### PR TITLE
Empty packages for `native_assets_cli` and `c_compiler`

### DIFF
--- a/.github/ISSUE_TEMPLATE/c_compiler.md
+++ b/.github/ISSUE_TEMPLATE/c_compiler.md
@@ -1,0 +1,5 @@
+---
+name: "package:c_compiler"
+about: "Create a bug or file a feature request against package:c_compiler."
+labels: "package:c_compiler"
+---

--- a/.github/ISSUE_TEMPLATE/native_assets_cli.md
+++ b/.github/ISSUE_TEMPLATE/native_assets_cli.md
@@ -1,0 +1,5 @@
+---
+name: "package:native_assets_cli"
+about: "Create a bug or file a feature request against package:native_assets_cli."
+labels: "package:native_assets_cli"
+---

--- a/.github/workflows/c_compiler.yaml
+++ b/.github/workflows/c_compiler.yaml
@@ -1,0 +1,57 @@
+name: package:c_compiler
+permissions: read-all
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/c_compiler.yml"
+      - "pkgs/c_compiler/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/c_compiler.yml"
+      - "pkgs/c_compiler/**"
+  schedule:
+    - cron: "0 0 * * 0" # weekly
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pkgs/c_compiler
+    strategy:
+      matrix:
+        sdk: [stable, dev] # {pkgs.versions}
+        include:
+          - sdk: stable
+            run-tests: true
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
+        with:
+          sdk: ${{matrix.sdk}}
+
+      - run: dart pub get
+
+      - run: dart analyze --fatal-infos
+
+      - run: dart format --output=none --set-exit-if-changed .
+        if: ${{matrix.run-tests}}
+
+      - run: dart test
+        if: ${{matrix.run-tests}}
+
+      - name: Install coverage
+        run: dart pub global activate coverage
+        if: ${{ matrix.sdk == 'stable' }}
+      - name: Collect coverage
+        run: dart pub global run coverage:test_with_coverage
+        if: ${{ matrix.sdk == 'stable' }}
+      - name: Upload coverage
+        uses: coverallsapp/github-action@50c33ad324a9902697adbf2f92c22cf5023eacf1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: c_compiler
+          path-to-lcov: ./pkgs/c_compiler/coverage/lcov.info

--- a/.github/workflows/c_compiler.yaml
+++ b/.github/workflows/c_compiler.yaml
@@ -55,3 +55,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: c_compiler
           path-to-lcov: ./pkgs/c_compiler/coverage/lcov.info
+        if: ${{ matrix.sdk == 'stable' }}

--- a/.github/workflows/native_assets_cli.yaml
+++ b/.github/workflows/native_assets_cli.yaml
@@ -55,3 +55,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: native_assets_cli
           path-to-lcov: ./pkgs/native_assets_cli/coverage/lcov.info
+        if: ${{ matrix.sdk == 'stable' }}

--- a/.github/workflows/native_assets_cli.yaml
+++ b/.github/workflows/native_assets_cli.yaml
@@ -1,0 +1,57 @@
+name: package:native_assets_cli
+permissions: read-all
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/native_assets_cli.yml"
+      - "pkgs/native_assets_cli/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/native_assets_cli.yml"
+      - "pkgs/native_assets_cli/**"
+  schedule:
+    - cron: "0 0 * * 0" # weekly
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pkgs/native_assets_cli
+    strategy:
+      matrix:
+        sdk: [stable, dev] # {pkgs.versions}
+        include:
+          - sdk: stable
+            run-tests: true
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
+        with:
+          sdk: ${{matrix.sdk}}
+
+      - run: dart pub get
+
+      - run: dart analyze --fatal-infos
+
+      - run: dart format --output=none --set-exit-if-changed .
+        if: ${{matrix.run-tests}}
+
+      - run: dart test
+        if: ${{matrix.run-tests}}
+
+      - name: Install coverage
+        run: dart pub global activate coverage
+        if: ${{ matrix.sdk == 'stable' }}
+      - name: Collect coverage
+        run: dart pub global run coverage:test_with_coverage
+        if: ${{ matrix.sdk == 'stable' }}
+      - name: Upload coverage
+        uses: coverallsapp/github-action@50c33ad324a9902697adbf2f92c22cf5023eacf1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: native_assets_cli
+          path-to-lcov: ./pkgs/native_assets_cli/coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ bundling.
 
 ## Packages
 
-| Package | Description | Version |
-| --- | --- | --- |
+| Package                                      | Description                                                                                 | Version |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------- | ------- |
+| [c_compiler](pkgs/c_compiler/)               | A library to invoke the native C compiler installed on the host machine.                    |         |
+| [native_assets_cli](pkgs/native_assets_cli/) | A library that contains the argument and file formats for implementing a native assets CLI. |         |
 
 <!-- ## Publishing automation
 

--- a/pkgs/c_compiler/.gitignore
+++ b/pkgs/c_compiler/.gitignore
@@ -1,0 +1,7 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/pkgs/c_compiler/.gitignore
+++ b/pkgs/c_compiler/.gitignore
@@ -5,3 +5,5 @@
 # Avoid committing pubspec.lock for library packages; see
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock
+
+coverage/

--- a/pkgs/c_compiler/CHANGELOG.md
+++ b/pkgs/c_compiler/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0
+
+- Initial version.

--- a/pkgs/c_compiler/CHANGELOG.md
+++ b/pkgs/c_compiler/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.1.0
+## 0.1.0-dev
 
 - Initial version.

--- a/pkgs/c_compiler/README.md
+++ b/pkgs/c_compiler/README.md
@@ -1,0 +1,6 @@
+[![package:c_compiler](https://github.com/dart-lang/native/actions/workflows/c_compiler.yml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/c_compiler.yml)
+[![pub package](https://img.shields.io/pub/v/c_compiler.svg)](https://pub.dev/packages/c_compiler)
+[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/tools?branch=main)
+<!-- [![package publisher](https://img.shields.io/pub/publisher/c_compiler.svg)](https://pub.dev/packages/c_compiler/publisher) -->
+
+A library to invoke the native C compiler installed on the host machine.

--- a/pkgs/c_compiler/analysis_options.yaml
+++ b/pkgs/c_compiler/analysis_options.yaml
@@ -1,0 +1,22 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml
+
+analyzer:
+  language:
+    strict-raw-types: true
+    strict-inference: true
+
+linter:
+  rules:
+    - always_declare_return_types
+    - avoid_dynamic_calls
+    - camel_case_types
+    - depend_on_referenced_packages
+    - directives_ordering
+    - prefer_const_declarations
+    - prefer_expression_function_bodies
+    - prefer_final_in_for_each
+    - prefer_final_locals
+    - prefer_relative_imports
+    - prefer_single_quotes
+    - sort_pub_dependencies
+    - unawaited_futures

--- a/pkgs/c_compiler/lib/c_compiler.dart
+++ b/pkgs/c_compiler/lib/c_compiler.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 /// A library to invoke the native C compiler installed on the host machine.
 library;
 

--- a/pkgs/c_compiler/lib/c_compiler.dart
+++ b/pkgs/c_compiler/lib/c_compiler.dart
@@ -1,0 +1,4 @@
+/// A library to invoke the native C compiler installed on the host machine.
+library;
+
+export 'src/c_compiler_base.dart';

--- a/pkgs/c_compiler/lib/src/c_compiler_base.dart
+++ b/pkgs/c_compiler/lib/src/c_compiler_base.dart
@@ -1,0 +1,6 @@
+// TODO: Put public facing types in this file.
+
+/// Checks if you are awesome. Spoiler: you are.
+class Awesome {
+  bool get isAwesome => true;
+}

--- a/pkgs/c_compiler/lib/src/c_compiler_base.dart
+++ b/pkgs/c_compiler/lib/src/c_compiler_base.dart
@@ -1,5 +1,3 @@
-// TODO: Put public facing types in this file.
-
 /// Checks if you are awesome. Spoiler: you are.
 class Awesome {
   bool get isAwesome => true;

--- a/pkgs/c_compiler/lib/src/c_compiler_base.dart
+++ b/pkgs/c_compiler/lib/src/c_compiler_base.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 /// Checks if you are awesome. Spoiler: you are.
 class Awesome {
   bool get isAwesome => true;

--- a/pkgs/c_compiler/pubspec.yaml
+++ b/pkgs/c_compiler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: c_compiler
 description: A library to invoke the native C compiler installed on the host machine.
-version: 0.1.0
+version: 0.1.0-dev
 repository: https://github.com/dart-lang/native/c_compiler
 
 environment:

--- a/pkgs/c_compiler/pubspec.yaml
+++ b/pkgs/c_compiler/pubspec.yaml
@@ -1,0 +1,11 @@
+name: c_compiler
+description: A library to invoke the native C compiler installed on the host machine.
+version: 0.1.0
+repository: https://github.com/dart-lang/native/c_compiler
+
+environment:
+  sdk: ">=2.19.3 <4.0.0"
+
+dev_dependencies:
+  dart_flutter_team_lints: ^1.0.0
+  test: ^1.21.0

--- a/pkgs/c_compiler/test/c_compiler_test.dart
+++ b/pkgs/c_compiler/test/c_compiler_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:c_compiler/c_compiler.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/c_compiler/test/c_compiler_test.dart
+++ b/pkgs/c_compiler/test/c_compiler_test.dart
@@ -1,0 +1,16 @@
+import 'package:c_compiler/c_compiler.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests', () {
+    final awesome = Awesome();
+
+    setUp(() {
+      // Additional setup goes here.
+    });
+
+    test('First Test', () {
+      expect(awesome.isAwesome, isTrue);
+    });
+  });
+}

--- a/pkgs/native_assets_cli/.gitignore
+++ b/pkgs/native_assets_cli/.gitignore
@@ -1,0 +1,7 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/pkgs/native_assets_cli/.gitignore
+++ b/pkgs/native_assets_cli/.gitignore
@@ -5,3 +5,5 @@
 # Avoid committing pubspec.lock for library packages; see
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock
+
+coverage/

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0
+
+- Initial version.

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.1.0
+## 0.1.0-dev
 
 - Initial version.

--- a/pkgs/native_assets_cli/README.md
+++ b/pkgs/native_assets_cli/README.md
@@ -1,0 +1,6 @@
+[![package:native_assets_cli](https://github.com/dart-lang/native/actions/workflows/native_assets_cli.yml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/native_assets_cli.yml)
+[![pub package](https://img.shields.io/pub/v/native_assets_cli.svg)](https://pub.dev/packages/native_assets_cli)
+[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/tools?branch=main)
+<!-- [![package publisher](https://img.shields.io/pub/publisher/native_assets_cli.svg)](https://pub.dev/packages/native_assets_cli/publisher) -->
+
+A library that contains the argument and file formats for implementing a native assets CLI.

--- a/pkgs/native_assets_cli/analysis_options.yaml
+++ b/pkgs/native_assets_cli/analysis_options.yaml
@@ -1,0 +1,22 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml
+
+analyzer:
+  language:
+    strict-raw-types: true
+    strict-inference: true
+
+linter:
+  rules:
+    - always_declare_return_types
+    - avoid_dynamic_calls
+    - camel_case_types
+    - depend_on_referenced_packages
+    - directives_ordering
+    - prefer_const_declarations
+    - prefer_expression_function_bodies
+    - prefer_final_in_for_each
+    - prefer_final_locals
+    - prefer_relative_imports
+    - prefer_single_quotes
+    - sort_pub_dependencies
+    - unawaited_futures

--- a/pkgs/native_assets_cli/lib/native_assets_cli.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli.dart
@@ -1,0 +1,4 @@
+/// A library that contains the argument and file formats for implementing a native assets CLI.
+library;
+
+export 'src/native_assets_cli_base.dart';

--- a/pkgs/native_assets_cli/lib/native_assets_cli.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 /// A library that contains the argument and file formats for implementing a
 /// native assets CLI.
 library;

--- a/pkgs/native_assets_cli/lib/native_assets_cli.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli.dart
@@ -1,4 +1,5 @@
-/// A library that contains the argument and file formats for implementing a native assets CLI.
+/// A library that contains the argument and file formats for implementing a
+/// native assets CLI.
 library;
 
 export 'src/native_assets_cli_base.dart';

--- a/pkgs/native_assets_cli/lib/src/native_assets_cli_base.dart
+++ b/pkgs/native_assets_cli/lib/src/native_assets_cli_base.dart
@@ -1,0 +1,6 @@
+// TODO: Put public facing types in this file.
+
+/// Checks if you are awesome. Spoiler: you are.
+class Awesome {
+  bool get isAwesome => true;
+}

--- a/pkgs/native_assets_cli/lib/src/native_assets_cli_base.dart
+++ b/pkgs/native_assets_cli/lib/src/native_assets_cli_base.dart
@@ -1,5 +1,3 @@
-// TODO: Put public facing types in this file.
-
 /// Checks if you are awesome. Spoiler: you are.
 class Awesome {
   bool get isAwesome => true;

--- a/pkgs/native_assets_cli/lib/src/native_assets_cli_base.dart
+++ b/pkgs/native_assets_cli/lib/src/native_assets_cli_base.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 /// Checks if you are awesome. Spoiler: you are.
 class Awesome {
   bool get isAwesome => true;

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: native_assets_cli
 description: A library that contains the argument and file formats for implementing a native assets CLI.
-version: 0.1.0
+version: 0.1.0-dev
 repository: https://github.com/dart-lang/native/native_assets_cli
 
 environment:

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -1,0 +1,11 @@
+name: native_assets_cli
+description: A library that contains the argument and file formats for implementing a native assets CLI.
+version: 0.1.0
+repository: https://github.com/dart-lang/native/native_assets_cli
+
+environment:
+  sdk: ">=2.19.3 <4.0.0"
+
+dev_dependencies:
+  dart_flutter_team_lints: ^1.0.0
+  test: ^1.21.0

--- a/pkgs/native_assets_cli/test/native_assets_cli_test.dart
+++ b/pkgs/native_assets_cli/test/native_assets_cli_test.dart
@@ -1,0 +1,16 @@
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests', () {
+    final awesome = Awesome();
+
+    setUp(() {
+      // Additional setup goes here.
+    });
+
+    test('First Test', () {
+      expect(awesome.isAwesome, isTrue);
+    });
+  });
+}

--- a/pkgs/native_assets_cli/test/native_assets_cli_test.dart
+++ b/pkgs/native_assets_cli/test/native_assets_cli_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/placeholder.txt
+++ b/pkgs/placeholder.txt
@@ -1,1 +1,0 @@
-remove once we have one package here


### PR DESCRIPTION
Based on discussions we introduce two packages.

1. `native_assets_cli` which contains the command-line interface for building native assets.
     * Named `native_assets_cli` as this is is part of the Native asset feature.
          * https://github.com/dart-lang/sdk/issues/50565
     * Could possibly be named something like `native_build_cli` if we'd like to connect this with `dart build` name-wise.
          * https://github.com/dart-lang/sdk/issues/51165
2. `c_compiler` which can compile C files with clang/msvc/xcodebuild/etc.
     * Named this way, so that a potential `rust_compiler` package can have consistent package naming.

Package names are not set in stone until we publish a first version of these packages.

This PR ensures we have the package layout, CI etc. set up correctly.

This PR mirrors the configuration from

* https://github.com/dart-lang/tools/pull/40