### PR TITLE
[native_assets_cli] Don't inherit test environment

### DIFF
--- a/pkgs/native_assets_cli/lib/src/model/build_config.dart
+++ b/pkgs/native_assets_cli/lib/src/model/build_config.dart
@@ -113,8 +113,28 @@ class BuildConfig {
     return result;
   }
 
-  static Future<BuildConfig> fromArgs(List<String> args) async {
-    final config = await Config.fromArgs(args: args);
+  /// Constructs a config by parsing CLI arguments and loading the config file.
+  ///
+  /// The [args] must be commandline arguments.
+  ///
+  /// If provided, [environment] must be a map containing environment variables.
+  /// If not provided, [environment] defaults to [Platform.environment].
+  ///
+  /// If provided, [workingDirectory] is used to resolves paths inside
+  /// [environment].
+  /// If not provided, [workingDirectory] defaults to [Directory.current].
+  ///
+  /// This async constructor is intended to be used directly in CLI files.
+  static Future<BuildConfig> fromArgs(
+    List<String> args, {
+    Map<String, String>? environment,
+    Uri? workingDirectory,
+  }) async {
+    final config = await Config.fromArgs(
+      args: args,
+      environment: environment,
+      workingDirectory: workingDirectory,
+    );
     return BuildConfig.fromConfig(config);
   }
 

--- a/pkgs/native_assets_cli/test/model/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_config_test.dart
@@ -245,8 +245,10 @@ target_ios_sdk: iphoneos''';
     final configUri = tempUri.resolve('config.yaml');
     final configFile = File.fromUri(configUri);
     await configFile.writeAsString(configFileContents);
-    final buildConfig2 =
-        await BuildConfig.fromArgs(['--config', configUri.toFilePath()]);
+    final buildConfig2 = await BuildConfig.fromArgs(
+      ['--config', configUri.toFilePath()],
+      environment: {}, // Don't inherit the test environment.
+    );
     expect(buildConfig2, buildConfig);
   });
 


### PR DESCRIPTION
On the Dart CI, we have defined the `CC` environment variable. This gets erronously picked up by the test.

[logs](https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8783571500596868353/+/u/test_results/new_test_failures__logs_)
