### PR TITLE
MacOS support

### DIFF
--- a/.github/workflows/c_compiler.yaml
+++ b/.github/workflows/c_compiler.yaml
@@ -7,16 +7,18 @@ on:
     paths:
       - ".github/workflows/c_compiler.yml"
       - "pkgs/c_compiler/**"
+      - "pkgs/native_assets_cli/**" # Direct import.
   push:
     branches: [main]
     paths:
       - ".github/workflows/c_compiler.yml"
       - "pkgs/c_compiler/**"
+      - "pkgs/native_assets_cli/**" # Direct import.
   schedule:
     - cron: "0 0 * * 0" # weekly
 
 jobs:
-  c_compiler:
+  build:
     strategy:
       matrix:
         os: [ubuntu-lastest, macos-latest]

--- a/.github/workflows/c_compiler.yaml
+++ b/.github/workflows/c_compiler.yaml
@@ -17,21 +17,19 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-lastest, macos-latest]
+        sdk: [stable, dev]
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: pkgs/c_compiler
-    strategy:
-      matrix:
-        sdk: [stable, dev] # {pkgs.versions}
-        include:
-          - sdk: stable
-            run-tests: true
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
-          sdk: ${{matrix.sdk}}
+          sdk: ${{ matrix.sdk }}
       - uses: nttld/setup-ndk@deccd078bf3db957dbdee9862f51955b35ac81dd
         with:
           ndk-version: r25b
@@ -39,26 +37,30 @@ jobs:
       - run: dart pub get
 
       - run: dart analyze --fatal-infos
+        # Run on dev to ensure we're not depending on deprecated SDK things.
 
       - run: dart format --output=none --set-exit-if-changed .
-        if: ${{matrix.run-tests}}
+        if: ${{ matrix.sdk == 'stable' }}
 
       - name: Install native toolchains
         run: sudo apt-get install clang-14 gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
+        if: ${{ matrix.sdk == 'stable' && matrix.os == 'ubuntu-latest' }}
 
       - run: dart test
-        if: ${{matrix.run-tests}}
+        if: ${{ matrix.sdk == 'stable' }}
 
       - name: Install coverage
         run: dart pub global activate coverage
         if: ${{ matrix.sdk == 'stable' }}
+
       - name: Collect coverage
         run: dart pub global run coverage:test_with_coverage
         if: ${{ matrix.sdk == 'stable' }}
+
       - name: Upload coverage
         uses: coverallsapp/github-action@67662d24394fd74bffcf7b462d1b432814159afd
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: c_compiler
+          flag-name: c_compiler-${{ matrix.os }}
           path-to-lcov: ./pkgs/c_compiler/coverage/lcov.info
         if: ${{ matrix.sdk == 'stable' }}

--- a/.github/workflows/c_compiler.yaml
+++ b/.github/workflows/c_compiler.yaml
@@ -72,8 +72,20 @@ jobs:
       - name: Upload coverage
         uses: coverallsapp/github-action@67662d24394fd74bffcf7b462d1b432814159afd
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          base-path: pkgs/c_compiler/
           flag-name: c_compiler-${{ matrix.os }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel: true
           path-to-lcov: ./pkgs/c_compiler/coverage/lcov.info
+        if: ${{ matrix.sdk == 'stable' }}
+
+  coverage-finished:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload coverage
+        uses: coverallsapp/github-action@67662d24394fd74bffcf7b462d1b432814159afd
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
         if: ${{ matrix.sdk == 'stable' }}

--- a/.github/workflows/c_compiler.yaml
+++ b/.github/workflows/c_compiler.yaml
@@ -16,7 +16,7 @@ on:
     - cron: "0 0 * * 0" # weekly
 
 jobs:
-  build:
+  c_compiler:
     strategy:
       matrix:
         os: [ubuntu-lastest, macos-latest]
@@ -27,12 +27,15 @@ jobs:
         working-directory: pkgs/c_compiler
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
           sdk: ${{ matrix.sdk }}
+
       - uses: nttld/setup-ndk@deccd078bf3db957dbdee9862f51955b35ac81dd
         with:
           ndk-version: r25b
+        if: ${{ matrix.sdk == 'stable' }}
 
       - run: dart pub get
 

--- a/.github/workflows/c_compiler.yaml
+++ b/.github/workflows/c_compiler.yaml
@@ -72,7 +72,6 @@ jobs:
       - name: Upload coverage
         uses: coverallsapp/github-action@67662d24394fd74bffcf7b462d1b432814159afd
         with:
-          base-path: pkgs/c_compiler/
           flag-name: c_compiler-${{ matrix.os }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel: true

--- a/.github/workflows/c_compiler.yaml
+++ b/.github/workflows/c_compiler.yaml
@@ -74,5 +74,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: c_compiler-${{ matrix.os }}
+          parallel: true
           path-to-lcov: ./pkgs/c_compiler/coverage/lcov.info
         if: ${{ matrix.sdk == 'stable' }}

--- a/.github/workflows/c_compiler.yaml
+++ b/.github/workflows/c_compiler.yaml
@@ -87,4 +87,3 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
-        if: ${{ matrix.sdk == 'stable' }}

--- a/.github/workflows/c_compiler.yaml
+++ b/.github/workflows/c_compiler.yaml
@@ -21,12 +21,19 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-lastest, macos-latest]
+        os: [ubuntu, macos]
         sdk: [stable, dev]
-    runs-on: ${{ matrix.os }}
+        exclude:
+          # Only run analyze against dev on one host.
+          - os: macos
+            sdk: dev
+
+    runs-on: ${{ matrix.os }}-latest
+
     defaults:
       run:
         working-directory: pkgs/c_compiler
+
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
 
@@ -49,7 +56,7 @@ jobs:
 
       - name: Install native toolchains
         run: sudo apt-get install clang-14 gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
-        if: ${{ matrix.sdk == 'stable' && matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.sdk == 'stable' && matrix.os == 'ubuntu' }}
 
       - run: dart test
         if: ${{ matrix.sdk == 'stable' }}

--- a/.github/workflows/native_assets_cli.yaml
+++ b/.github/workflows/native_assets_cli.yaml
@@ -74,8 +74,20 @@ jobs:
       - name: Upload coverage
         uses: coverallsapp/github-action@67662d24394fd74bffcf7b462d1b432814159afd
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          base-path: pkgs/native_assets_cli/
           flag-name: native_assets_cli-${{ matrix.os }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel: true
           path-to-lcov: ./pkgs/native_assets_cli/coverage/lcov.info
+        if: ${{ matrix.sdk == 'stable' }}
+
+  coverage-finished:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload coverage
+        uses: coverallsapp/github-action@67662d24394fd74bffcf7b462d1b432814159afd
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
         if: ${{ matrix.sdk == 'stable' }}

--- a/.github/workflows/native_assets_cli.yaml
+++ b/.github/workflows/native_assets_cli.yaml
@@ -89,4 +89,3 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
-        if: ${{ matrix.sdk == 'stable' }}

--- a/.github/workflows/native_assets_cli.yaml
+++ b/.github/workflows/native_assets_cli.yaml
@@ -21,12 +21,19 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu, macos]
         sdk: [stable, dev]
-    runs-on: ${{ matrix.os }}
+        exclude:
+          # Only run analyze against dev on one host.
+          - os: macos
+            sdk: dev
+
+    runs-on: ${{ matrix.os }}-latest
+
     defaults:
       run:
         working-directory: pkgs/native_assets_cli
+
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
 
@@ -51,7 +58,7 @@ jobs:
 
       - name: Install native toolchains
         run: sudo apt-get install clang-14 gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
-        if: ${{ matrix.sdk == 'stable' && matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.sdk == 'stable' && matrix.os == 'ubuntu' }}
 
       - run: dart test
         if: ${{ matrix.sdk == 'stable' }}
@@ -68,6 +75,6 @@ jobs:
         uses: coverallsapp/github-action@67662d24394fd74bffcf7b462d1b432814159afd
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: native_assets_cli-linux
+          flag-name: native_assets_cli-${{ matrix.os }}
           path-to-lcov: ./pkgs/native_assets_cli/coverage/lcov.info
         if: ${{ matrix.sdk == 'stable' }}

--- a/.github/workflows/native_assets_cli.yaml
+++ b/.github/workflows/native_assets_cli.yaml
@@ -76,5 +76,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: native_assets_cli-${{ matrix.os }}
+          parallel: true
           path-to-lcov: ./pkgs/native_assets_cli/coverage/lcov.info
         if: ${{ matrix.sdk == 'stable' }}

--- a/.github/workflows/native_assets_cli.yaml
+++ b/.github/workflows/native_assets_cli.yaml
@@ -6,17 +6,19 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/native_assets_cli.yml"
+      - "pkgs/c_compiler/**" # Direct import of example.
       - "pkgs/native_assets_cli/**"
   push:
     branches: [main]
     paths:
       - ".github/workflows/native_assets_cli.yml"
+      - "pkgs/c_compiler/**" # Direct import of example.
       - "pkgs/native_assets_cli/**"
   schedule:
     - cron: "0 0 * * 0" # weekly
 
 jobs:
-  native_assets_cli:
+  build:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/.github/workflows/native_assets_cli.yaml
+++ b/.github/workflows/native_assets_cli.yaml
@@ -17,16 +17,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        sdk: [stable, dev]
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: pkgs/native_assets_cli
-    strategy:
-      matrix:
-        sdk: [stable, dev] # {pkgs.versions}
-        include:
-          - sdk: stable
-            run-tests: true
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
@@ -41,26 +39,30 @@ jobs:
         working-directory: pkgs/native_assets_cli/example/native_add/
 
       - run: dart analyze --fatal-infos
+        # Run on dev to ensure we're not depending on deprecated SDK things.
 
       - run: dart format --output=none --set-exit-if-changed .
-        if: ${{matrix.run-tests}}
+        if: ${{ matrix.sdk == 'stable' }}
 
       - name: Install native toolchains
         run: sudo apt-get install clang-14 gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
+        if: ${{ matrix.sdk == 'stable' && matrix.os == 'ubuntu-latest' }}
 
       - run: dart test
-        if: ${{matrix.run-tests}}
+        if: ${{ matrix.sdk == 'stable' }}
 
       - name: Install coverage
         run: dart pub global activate coverage
         if: ${{ matrix.sdk == 'stable' }}
+
       - name: Collect coverage
         run: dart pub global run coverage:test_with_coverage
         if: ${{ matrix.sdk == 'stable' }}
+
       - name: Upload coverage
         uses: coverallsapp/github-action@67662d24394fd74bffcf7b462d1b432814159afd
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: native_assets_cli
+          flag-name: native_assets_cli-linux
           path-to-lcov: ./pkgs/native_assets_cli/coverage/lcov.info
         if: ${{ matrix.sdk == 'stable' }}

--- a/.github/workflows/native_assets_cli.yaml
+++ b/.github/workflows/native_assets_cli.yaml
@@ -74,7 +74,6 @@ jobs:
       - name: Upload coverage
         uses: coverallsapp/github-action@67662d24394fd74bffcf7b462d1b432814159afd
         with:
-          base-path: pkgs/native_assets_cli/
           flag-name: native_assets_cli-${{ matrix.os }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel: true

--- a/.github/workflows/native_assets_cli.yaml
+++ b/.github/workflows/native_assets_cli.yaml
@@ -16,7 +16,7 @@ on:
     - cron: "0 0 * * 0" # weekly
 
 jobs:
-  build:
+  native_assets_cli:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -27,12 +27,15 @@ jobs:
         working-directory: pkgs/native_assets_cli
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
-          sdk: ${{matrix.sdk}}
+          sdk: ${{ matrix.sdk }}
+
       - uses: nttld/setup-ndk@deccd078bf3db957dbdee9862f51955b35ac81dd
         with:
           ndk-version: r25b
+        if: ${{ matrix.sdk == 'stable' }}
 
       - run: dart pub get
       - run: dart pub get

--- a/pkgs/c_compiler/README.md
+++ b/pkgs/c_compiler/README.md
@@ -1,6 +1,6 @@
 [![package:c_compiler](https://github.com/dart-lang/native/actions/workflows/c_compiler.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/c_compiler.yaml)
-[![pub package](https://img.shields.io/pub/v/c_compiler.svg)](https://pub.dev/packages/c_compiler)
-[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/tools?branch=main)
+/[![pub package](https://img.shields.io/pub/v/c_compiler.svg)](https://pub.dev/packages/c_compiler)
+[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
 <!-- [![package publisher](https://img.shields.io/pub/publisher/c_compiler.svg)](https://pub.dev/packages/c_compiler/publisher) -->
 
 A library to invoke the native C compiler installed on the host machine.

--- a/pkgs/c_compiler/README.md
+++ b/pkgs/c_compiler/README.md
@@ -1,5 +1,5 @@
 [![package:c_compiler](https://github.com/dart-lang/native/actions/workflows/c_compiler.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/c_compiler.yaml)
-/[![pub package](https://img.shields.io/pub/v/c_compiler.svg)](https://pub.dev/packages/c_compiler)
+[![pub package](https://img.shields.io/pub/v/c_compiler.svg)](https://pub.dev/packages/c_compiler)
 [![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
 <!-- [![package publisher](https://img.shields.io/pub/publisher/c_compiler.svg)](https://pub.dev/packages/c_compiler/publisher) -->
 

--- a/pkgs/c_compiler/lib/c_compiler.dart
+++ b/pkgs/c_compiler/lib/c_compiler.dart
@@ -7,6 +7,7 @@ library;
 
 export 'src/cbuilder/cbuilder.dart';
 export 'src/native_toolchain/android_ndk.dart';
+export 'src/native_toolchain/apple_clang.dart';
 export 'src/native_toolchain/clang.dart';
 export 'src/native_toolchain/gcc.dart';
 export 'src/tool/tool.dart';

--- a/pkgs/c_compiler/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/cbuilder.dart
@@ -71,7 +71,6 @@ class CBuilder implements Builder {
     required BuildOutput buildOutput,
     Logger? logger,
   }) async {
-    logger ??= Logger('');
     final outDir = buildConfig.outDir;
     final packageRoot = buildConfig.packageRoot;
     await Directory.fromUri(outDir).create(recursive: true);

--- a/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
@@ -59,7 +59,7 @@ class CompilerResolver {
 
     // TODO(dacoharkes): Support falling back on other tools.
     if (target == host && host.os == OS.linux) return clang;
-    if (target == host && host.os == OS.macOS) return appleClang;
+    if (host.os == OS.macOS) return appleClang;
     if (target.os == OS.android) return androidNdkClang;
     if (host.os == OS.linux) {
       switch (target) {
@@ -127,7 +127,7 @@ class CompilerResolver {
 
     // TODO(dacoharkes): Support falling back on other tools.
     if (target == host && host.os == OS.linux) return llvmAr;
-    if (target == host && host.os == OS.macOS) return appleLd;
+    if (target.os == OS.macOS) return appleAr;
     if (target.os == OS.android) return androidNdkLlvmAr;
     if (host.os == OS.linux) {
       switch (target) {

--- a/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
@@ -7,8 +7,8 @@ import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 
-import '../../c_compiler.dart';
 import '../native_toolchain/android_ndk.dart';
+import '../native_toolchain/apple_clang.dart';
 import '../native_toolchain/clang.dart';
 import '../native_toolchain/gcc.dart';
 import '../native_toolchain/recognizer.dart';
@@ -59,7 +59,7 @@ class CompilerResolver {
 
     // TODO(dacoharkes): Support falling back on other tools.
     if (target == host && host.os == OS.linux) return clang;
-    if (host.os == OS.macOS) return appleClang;
+    if (target.os == OS.macOS || target.os == OS.iOS) return appleClang;
     if (target.os == OS.android) return androidNdkClang;
     if (host.os == OS.linux) {
       switch (target) {
@@ -127,7 +127,7 @@ class CompilerResolver {
 
     // TODO(dacoharkes): Support falling back on other tools.
     if (target == host && host.os == OS.linux) return llvmAr;
-    if (target.os == OS.macOS) return appleAr;
+    if (target.os == OS.macOS || target.os == OS.iOS) return appleAr;
     if (target.os == OS.android) return androidNdkLlvmAr;
     if (host.os == OS.linux) {
       switch (target) {

--- a/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 
+import '../../c_compiler.dart';
 import '../native_toolchain/android_ndk.dart';
 import '../native_toolchain/clang.dart';
 import '../native_toolchain/gcc.dart';
@@ -56,7 +57,9 @@ class CompilerResolver {
   Tool? _selectCompiler() {
     final target = buildConfig.target;
 
-    if (target == host) return clang;
+    // TODO(dacoharkes): Support falling back on other tools.
+    if (target == host && host.os == OS.linux) return clang;
+    if (target == host && host.os == OS.macOS) return appleClang;
     if (target.os == OS.android) return androidNdkClang;
     if (host.os == OS.linux) {
       switch (target) {
@@ -122,7 +125,9 @@ class CompilerResolver {
   Tool? _selectArchiver() {
     final target = buildConfig.target;
 
-    if (target == host) return llvmAr;
+    // TODO(dacoharkes): Support falling back on other tools.
+    if (target == host && host.os == OS.linux) return llvmAr;
+    if (target == host && host.os == OS.macOS) return appleLd;
     if (target.os == OS.android) return androidNdkLlvmAr;
     if (host.os == OS.linux) {
       switch (target) {

--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -11,7 +11,7 @@ import 'compiler_resolver.dart';
 
 class RunCBuilder {
   final BuildConfig buildConfig;
-  final Logger logger;
+  final Logger? logger;
   final List<Uri> sources;
   final Uri? executable;
   final Uri? dynamicLibrary;
@@ -21,7 +21,7 @@ class RunCBuilder {
 
   RunCBuilder({
     required this.buildConfig,
-    required this.logger,
+    this.logger,
     this.sources = const [],
     this.executable,
     this.dynamicLibrary,

--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -46,17 +46,22 @@ class RunCBuilder {
   Future<Uri> iosSdk(IOSSdk iosSdk, {Logger? logger}) async {
     if (iosSdk == IOSSdk.iPhoneOs) {
       return (await iPhoneOSSdk.defaultResolver!.resolve(logger: logger))
+          .where((i) => i.tool == iPhoneOSSdk)
           .first
           .uri;
     }
     assert(iosSdk == IOSSdk.iPhoneSimulator);
     return (await iPhoneSimulatorSdk.defaultResolver!.resolve(logger: logger))
+        .where((i) => i.tool == iPhoneSimulatorSdk)
         .first
         .uri;
   }
 
   Future<Uri> macosSdk({Logger? logger}) async =>
-      (await macosxSdk.defaultResolver!.resolve(logger: logger)).first.uri;
+      (await macosxSdk.defaultResolver!.resolve(logger: logger))
+          .where((i) => i.tool == macosxSdk)
+          .first
+          .uri;
 
   Future<void> run() async {
     final compiler_ = await compiler();

--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -55,6 +55,9 @@ class RunCBuilder {
         .uri;
   }
 
+  Future<Uri> macosSdk({Logger? logger}) async =>
+      (await macosxSdk.defaultResolver!.resolve(logger: logger)).first.uri;
+
   Future<void> run() async {
     final compiler_ = await compiler();
     final isStaticLib = staticLibrary != null;
@@ -80,6 +83,10 @@ class RunCBuilder {
           '-isysroot',
           (await iosSdk(buildConfig.targetIOSSdk!, logger: logger))
               .toFilePath(),
+        ],
+        if (target.os == OS.macOS) ...[
+          '-isysroot',
+          (await macosSdk(logger: logger)).toFilePath(),
         ],
         ...sources.map((e) => e.path),
         if (executable != null) ...[

--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -61,6 +61,7 @@ class RunCBuilder {
           if (dynamicLibrary != null) '-nostartfiles',
           '--target=${androidNdkClangTargetFlags[target]!}',
         ],
+        if (target.os == OS.macOS) '--target=${appleClangTargetFlags[target]!}',
         ...sources.map((e) => e.path),
         if (executable != null) ...[
           '-o',
@@ -98,5 +99,17 @@ class RunCBuilder {
     Target.androidArm64: 'aarch64-linux-android',
     Target.androidIA32: 'i686-linux-android',
     Target.androidX64: 'x86_64-linux-android',
+  };
+
+  static const appleClangArchFlags = {
+    Architecture.arm: 'arm',
+    Architecture.arm64: 'arm64',
+    Architecture.ia32: 'x86',
+    Architecture.x64: 'x86-64',
+  };
+
+  static const appleClangTargetFlags = {
+    Target.macOSArm64: 'arm64-apple-darwin',
+    Target.macOSX64: 'x86_64-apple-darwin',
   };
 }

--- a/pkgs/c_compiler/lib/src/native_toolchain/android_ndk.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/android_ndk.dart
@@ -50,6 +50,9 @@ class _AndroidNdkResolver implements ToolResolver {
             '\$HOME/Android/Sdk/ndk/*/',
             '\$HOME/Android/Sdk/ndk-bundle/',
           ],
+          if (Platform.isMacOS) ...[
+            '\$HOME/Library/Android/sdk/ndk/*/',
+          ],
         ],
       ),
     ]),

--- a/pkgs/c_compiler/lib/src/native_toolchain/apple_clang.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/apple_clang.dart
@@ -34,7 +34,7 @@ final Tool appleAr = Tool(
   ]),
 );
 
-/// The archiver belonging to [appleClang].
+/// The linker belonging to [appleClang].
 final Tool appleLd = Tool(
   name: 'Apple linker',
   defaultResolver: ToolResolvers([

--- a/pkgs/c_compiler/lib/src/native_toolchain/apple_clang.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/apple_clang.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../tool/tool.dart';
+import '../tool/tool_resolver.dart';
+
+/// The Clang variant inside XCode.
+///
+/// https://developer.apple.com/xcode/
+final Tool appleClang = Tool(
+  name: 'Apple Clang',
+  defaultResolver: CliVersionResolver(
+    wrappedResolver: CliFilter(
+      cliArguments: ['--version'],
+      keepIf: ({required String stdout}) => stdout.contains('Apple clang'),
+      wrappedResolver: PathToolResolver(
+        toolName: 'Apple Clang',
+        executableName: 'clang',
+      ),
+    ),
+  ),
+);
+
+/// The archiver belonging to [appleClang].
+final Tool appleAr = Tool(
+  name: 'Apple archiver',
+  defaultResolver: ToolResolvers([
+    RelativeToolResolver(
+      toolName: 'Apple archiver',
+      wrappedResolver: appleClang.defaultResolver!,
+      relativePath: Uri.file('ar'),
+    ),
+  ]),
+);
+
+/// The archiver belonging to [appleClang].
+final Tool appleLd = Tool(
+  name: 'Apple linker',
+  defaultResolver: ToolResolvers([
+    RelativeToolResolver(
+      toolName: 'Apple linker',
+      wrappedResolver: appleClang.defaultResolver!,
+      relativePath: Uri.file('ld'),
+    ),
+  ]),
+);

--- a/pkgs/c_compiler/lib/src/native_toolchain/clang.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/clang.dart
@@ -11,9 +11,14 @@ import '../tool/tool_resolver.dart';
 final Tool clang = Tool(
   name: 'Clang',
   defaultResolver: CliVersionResolver(
-    wrappedResolver: ToolResolvers([
-      PathToolResolver(toolName: 'Clang'),
-    ]),
+    wrappedResolver: CliFilter(
+      cliArguments: ['--version'],
+      keepIf: ({required String stdout}) => !stdout.contains('Apple clang'),
+      wrappedResolver: PathToolResolver(
+        toolName: 'Clang',
+        executableName: 'clang',
+      ),
+    ),
   ),
 );
 

--- a/pkgs/c_compiler/lib/src/native_toolchain/recognizer.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/recognizer.dart
@@ -7,6 +7,7 @@ import 'package:logging/logging.dart';
 import '../tool/tool.dart';
 import '../tool/tool_instance.dart';
 import '../tool/tool_resolver.dart';
+import 'apple_clang.dart';
 import 'clang.dart';
 import 'gcc.dart';
 
@@ -22,8 +23,14 @@ class CompilerRecognizer implements ToolResolver {
     Tool? tool;
     if (filePath.contains('-gcc')) {
       tool = gcc;
-    } else if (filePath.contains('clang')) {
-      tool = clang;
+    } else if (filePath.endsWith('clang')) {
+      final stdout = await CliFilter.executeCli(uri,
+          arguments: ['--version'], logger: logger);
+      if (stdout.contains('Apple clang')) {
+        tool = appleClang;
+      } else {
+        tool = clang;
+      }
     }
 
     if (tool != null) {
@@ -54,8 +61,10 @@ class LinkerRecognizer implements ToolResolver {
     Tool? tool;
     if (filePath.contains('-ld')) {
       tool = gnuLinker;
-    } else if (filePath.contains('ld.lld')) {
+    } else if (filePath.endsWith('ld.lld')) {
       tool = lld;
+    } else if (filePath.endsWith('ld')) {
+      tool = appleLd;
     }
 
     if (tool != null) {
@@ -89,8 +98,10 @@ class ArchiverRecognizer implements ToolResolver {
     Tool? tool;
     if (filePath.contains('-gcc-ar')) {
       tool = gnuArchiver;
-    } else if (filePath.contains('llvm-ar')) {
+    } else if (filePath.endsWith('llvm-ar')) {
       tool = llvmAr;
+    } else if (filePath.endsWith('ar')) {
+      tool = appleAr;
     }
 
     if (tool != null) {

--- a/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
@@ -30,7 +30,7 @@ final Tool iPhoneOSSdk = Tool(
   defaultResolver: _XCodeSdkResolver(),
 );
 
-/// The iPhoneOS SDK.
+/// The iPhoneSimulator SDK.
 final Tool iPhoneSimulatorSdk = Tool(
   name: 'iPhoneSimulator SDK',
   defaultResolver: _XCodeSdkResolver(),

--- a/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
@@ -27,22 +27,22 @@ final Tool xcrun = Tool(
 /// The MacOSX SDK.
 final Tool macosxSdk = Tool(
   name: 'MacOSX SDK',
-  defaultResolver: _XCodeSdkResolver(),
+  defaultResolver: XCodeSdkResolver(),
 );
 
 /// The iPhoneOS SDK.
 final Tool iPhoneOSSdk = Tool(
   name: 'iPhoneOS SDK',
-  defaultResolver: _XCodeSdkResolver(),
+  defaultResolver: XCodeSdkResolver(),
 );
 
 /// The iPhoneSimulator SDK.
 final Tool iPhoneSimulatorSdk = Tool(
   name: 'iPhoneSimulator SDK',
-  defaultResolver: _XCodeSdkResolver(),
+  defaultResolver: XCodeSdkResolver(),
 );
 
-class _XCodeSdkResolver implements ToolResolver {
+class XCodeSdkResolver implements ToolResolver {
   @override
   Future<List<ToolInstance>> resolve({Logger? logger}) async {
     final xcrunInstances = await xcrun.defaultResolver!.resolve(logger: logger);
@@ -72,7 +72,7 @@ class _XCodeSdkResolver implements ToolResolver {
     ];
   }
 
-  Future<List<ToolInstance>> tryResolveSdk({
+  static Future<List<ToolInstance>> tryResolveSdk({
     required ToolInstance xcrunInstance,
     required String sdk,
     required Tool tool,
@@ -83,6 +83,12 @@ class _XCodeSdkResolver implements ToolResolver {
       arguments: ['--sdk', sdk, '--show-sdk-path'],
       logger: logger,
     );
+    if (result.exitCode == 1) {
+      assert(result.stderr.contains('cannot be located'));
+      logger?.warning('SDK $sdk not installed.');
+      return [];
+    }
+    assert(result.exitCode == 0);
     final uriSymbolic = Uri.directory(result.stdout.trim());
     logger?.fine('Found $sdk at ${uriSymbolic.toFilePath()}}');
     final uri = Uri.directory(

--- a/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
@@ -1,0 +1,85 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:collection/collection.dart';
+import 'package:logging/logging.dart';
+
+import '../tool/tool.dart';
+import '../tool/tool_instance.dart';
+import '../tool/tool_resolver.dart';
+import '../utils/run_process.dart';
+
+/// The xcrun from XCode.
+///
+/// https://developer.apple.com/xcode/
+final Tool xcrun = Tool(
+  name: 'xcrun',
+  defaultResolver: CliVersionResolver(
+    wrappedResolver: PathToolResolver(
+      toolName: 'xcrun',
+      executableName: 'xcrun',
+    ),
+  ),
+);
+
+/// The iPhoneOS SDK.
+final Tool iPhoneOSSdk = Tool(
+  name: 'iPhoneOS SDK',
+  defaultResolver: _XCodeSdkResolver(),
+);
+
+/// The iPhoneOS SDK.
+final Tool iPhoneSimulatorSdk = Tool(
+  name: 'iPhoneSimulator SDK',
+  defaultResolver: _XCodeSdkResolver(),
+);
+
+class _XCodeSdkResolver implements ToolResolver {
+  @override
+  Future<List<ToolInstance>> resolve({Logger? logger}) async {
+    final xcrunInstances = await xcrun.defaultResolver!.resolve(logger: logger);
+    final xcrunInstance = xcrunInstances.firstOrNull;
+    if (xcrunInstance == null) {
+      return [];
+    }
+
+    return [
+      ...await tryResolveSdk(
+        xcrunInstance: xcrunInstance,
+        sdk: 'iphoneos',
+        tool: iPhoneOSSdk,
+        logger: logger,
+      ),
+      ...await tryResolveSdk(
+        xcrunInstance: xcrunInstance,
+        sdk: 'iphonesimulator',
+        tool: iPhoneSimulatorSdk,
+        logger: logger,
+      ),
+    ];
+  }
+
+  Future<List<ToolInstance>> tryResolveSdk({
+    required ToolInstance xcrunInstance,
+    required String sdk,
+    required Tool tool,
+    Logger? logger,
+  }) async {
+    final result = await runProcess(
+      executable: xcrunInstance.uri,
+      arguments: ['--sdk', sdk, '--show-sdk-path'],
+    );
+    final uri = Uri.directory(result.stdout.trim());
+    final directory = Directory.fromUri(uri);
+    if (await directory.exists()) {
+      logger?.fine('Found $sdk at ${uri.toFilePath()}}');
+      return [ToolInstance(tool: tool, uri: uri)];
+    }
+    logger?.severe(
+        '$sdk at ${uri.toFilePath()} reported by xcrun does not exist.');
+    return [];
+  }
+}

--- a/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
@@ -41,24 +41,22 @@ class _XCodeSdkResolver implements ToolResolver {
   @override
   Future<List<ToolInstance>> resolve({Logger? logger}) async {
     final xcrunInstances = await xcrun.defaultResolver!.resolve(logger: logger);
-    final xcrunInstance = xcrunInstances.firstOrNull;
-    if (xcrunInstance == null) {
-      return [];
-    }
 
     return [
-      ...await tryResolveSdk(
-        xcrunInstance: xcrunInstance,
-        sdk: 'iphoneos',
-        tool: iPhoneOSSdk,
-        logger: logger,
-      ),
-      ...await tryResolveSdk(
-        xcrunInstance: xcrunInstance,
-        sdk: 'iphonesimulator',
-        tool: iPhoneSimulatorSdk,
-        logger: logger,
-      ),
+      for (final xcrunInstance in xcrunInstances) ...[
+        ...await tryResolveSdk(
+          xcrunInstance: xcrunInstance,
+          sdk: 'iphoneos',
+          tool: iPhoneOSSdk,
+          logger: logger,
+        ),
+        ...await tryResolveSdk(
+          xcrunInstance: xcrunInstance,
+          sdk: 'iphonesimulator',
+          tool: iPhoneSimulatorSdk,
+          logger: logger,
+        ),
+      ],
     ];
   }
 

--- a/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
@@ -24,6 +24,12 @@ final Tool xcrun = Tool(
   ),
 );
 
+/// The MacOSX SDK.
+final Tool macosxSdk = Tool(
+  name: 'MacOSX SDK',
+  defaultResolver: _XCodeSdkResolver(),
+);
+
 /// The iPhoneOS SDK.
 final Tool iPhoneOSSdk = Tool(
   name: 'iPhoneOS SDK',
@@ -45,6 +51,12 @@ class _XCodeSdkResolver implements ToolResolver {
       for (final xcrunInstance in xcrunInstances) ...[
         ...await tryResolveSdk(
           xcrunInstance: xcrunInstance,
+          sdk: 'macosx',
+          tool: macosxSdk,
+          logger: logger,
+        ),
+        ...await tryResolveSdk(
+          xcrunInstance: xcrunInstance,
           sdk: 'iphoneos',
           tool: iPhoneOSSdk,
           logger: logger,
@@ -56,6 +68,7 @@ class _XCodeSdkResolver implements ToolResolver {
           logger: logger,
         ),
       ],
+      // xcrun --sdk macosx --show-sdk-path)
     ];
   }
 

--- a/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
@@ -4,7 +4,6 @@
 
 import 'dart:io';
 
-import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 
 import '../tool/tool.dart';

--- a/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
@@ -70,13 +70,8 @@ class _XCodeSdkResolver implements ToolResolver {
       arguments: ['--sdk', sdk, '--show-sdk-path'],
     );
     final uri = Uri.directory(result.stdout.trim());
-    final directory = Directory.fromUri(uri);
-    if (await directory.exists()) {
-      logger?.fine('Found $sdk at ${uri.toFilePath()}}');
-      return [ToolInstance(tool: tool, uri: uri)];
-    }
-    logger?.severe(
-        '$sdk at ${uri.toFilePath()} reported by xcrun does not exist.');
-    return [];
+    assert(await Directory.fromUri(uri).exists());
+    logger?.fine('Found $sdk at ${uri.toFilePath()}}');
+    return [ToolInstance(tool: tool, uri: uri)];
   }
 }

--- a/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
@@ -69,9 +69,14 @@ class _XCodeSdkResolver implements ToolResolver {
       executable: xcrunInstance.uri,
       arguments: ['--sdk', sdk, '--show-sdk-path'],
     );
-    final uri = Uri.directory(result.stdout.trim());
-    assert(await Directory.fromUri(uri).exists());
+    final uriSymbolic = Uri.directory(result.stdout.trim());
+    final uri = Uri.directory(
+        await Directory.fromUri(uriSymbolic).resolveSymbolicLinks());
+    if (uriSymbolic != uri) {
+      logger?.fine('Found $sdk at ${uriSymbolic.toFilePath()}}');
+    }
     logger?.fine('Found $sdk at ${uri.toFilePath()}}');
+    assert(await Directory.fromUri(uri).exists());
     return [ToolInstance(tool: tool, uri: uri)];
   }
 }

--- a/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
@@ -81,14 +81,15 @@ class _XCodeSdkResolver implements ToolResolver {
     final result = await runProcess(
       executable: xcrunInstance.uri,
       arguments: ['--sdk', sdk, '--show-sdk-path'],
+      logger: logger,
     );
     final uriSymbolic = Uri.directory(result.stdout.trim());
+    logger?.fine('Found $sdk at ${uriSymbolic.toFilePath()}}');
     final uri = Uri.directory(
         await Directory.fromUri(uriSymbolic).resolveSymbolicLinks());
     if (uriSymbolic != uri) {
-      logger?.fine('Found $sdk at ${uriSymbolic.toFilePath()}}');
+      logger?.fine('Found $sdk at ${uri.toFilePath()}}');
     }
-    logger?.fine('Found $sdk at ${uri.toFilePath()}}');
     assert(await Directory.fromUri(uri).exists());
     return [ToolInstance(tool: tool, uri: uri)];
   }

--- a/pkgs/c_compiler/lib/src/tool/tool_instance.dart
+++ b/pkgs/c_compiler/lib/src/tool/tool_instance.dart
@@ -24,7 +24,11 @@ class ToolInstance implements Comparable<ToolInstance> {
     this.version,
   });
 
-  ToolInstance copyWith({Uri? uri, Version? version}) => ToolInstance(
+  ToolInstance copyWith({
+    Uri? uri,
+    Version? version,
+  }) =>
+      ToolInstance(
         tool: tool,
         uri: uri ?? this.uri,
         version: version ?? this.version,

--- a/pkgs/c_compiler/lib/src/tool/tool_resolver.dart
+++ b/pkgs/c_compiler/lib/src/tool/tool_resolver.dart
@@ -300,12 +300,7 @@ class CliFilter implements ToolResolver {
       logger: logger,
     );
     final exitCode = process.exitCode;
-    if (exitCode != expectedExitCode) {
-      final executablePath = executable.toFilePath();
-      final invocationString = [executablePath, ...arguments].join(' ');
-      throw ToolError('`$invocationString` returned unexpected exit code: '
-          '$exitCode.');
-    }
+    assert(exitCode == expectedExitCode);
     return process.stdout;
   }
 }

--- a/pkgs/c_compiler/lib/src/utils/sem_version.dart
+++ b/pkgs/c_compiler/lib/src/utils/sem_version.dart
@@ -4,15 +4,39 @@
 
 import 'package:pub_semver/pub_semver.dart';
 
+/// Reads a version out of a string.
+///
+/// If no semantic version is found, tries to read find a version number
+/// that doesn't follow semantic versioning. It will default [Version.minor]
+/// and [Version.patch] to `0` if the relaxed version doesn't contain them.
 Version? versionFromString(String containsVersion) {
   final match = _semverRegex.firstMatch(containsVersion);
-  if (match == null) {
-    return null;
-  }
-  return Version(int.parse(match.group(1)!), int.parse(match.group(2)!),
+  if (match != null) {
+    return Version(
+      int.parse(match.group(1)!),
+      int.parse(match.group(2)!),
       int.parse(match.group(3)!),
-      pre: match.group(4), build: match.group(5));
+      pre: match.group(4),
+      build: match.group(5),
+    );
+  }
+
+  final relaxedMatch = _semverRegexReleaxed.firstMatch(containsVersion);
+  if (relaxedMatch != null) {
+    return Version(
+      int.parse(relaxedMatch.group(1)!),
+      int.parse(relaxedMatch.group(2) ?? '0'),
+      int.parse(relaxedMatch.group(3) ?? '0'),
+      pre: relaxedMatch.group(4),
+      build: relaxedMatch.group(5),
+    );
+  }
+
+  return null;
 }
 
 final _semverRegex = RegExp(
     r'(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?');
+
+final _semverRegexReleaxed = RegExp(
+    r'(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:\.(0|[1-9]\d*))?(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?');

--- a/pkgs/c_compiler/pubspec.yaml
+++ b/pkgs/c_compiler/pubspec.yaml
@@ -10,7 +10,6 @@ publish_to: none
 
 dependencies:
   cli_config: ^0.1.1
-  collection: ^1.17.1
   glob: ^2.1.1
   logging: ^1.1.1
   # TODO(dacoharkes): Publish native_assets_cli first.
@@ -19,5 +18,6 @@ dependencies:
   pub_semver: ^2.1.3
 
 dev_dependencies:
+  collection: ^1.17.1
   dart_flutter_team_lints: ^1.0.0
   test: ^1.21.0

--- a/pkgs/c_compiler/pubspec.yaml
+++ b/pkgs/c_compiler/pubspec.yaml
@@ -10,6 +10,7 @@ publish_to: none
 
 dependencies:
   cli_config: ^0.1.1
+  collection: ^1.17.1
   glob: ^2.1.1
   logging: ^1.1.1
   # TODO(dacoharkes): Publish native_assets_cli first.
@@ -18,6 +19,5 @@ dependencies:
   pub_semver: ^2.1.3
 
 dev_dependencies:
-  collection: ^1.17.1
   dart_flutter_team_lints: ^1.0.0
   test: ^1.21.0

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -5,6 +5,8 @@
 @TestOn('mac-os')
 library;
 
+import 'dart:io';
+
 import 'package:c_compiler/c_compiler.dart';
 import 'package:c_compiler/src/utils/run_process.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
@@ -13,6 +15,11 @@ import 'package:test/test.dart';
 import '../helpers.dart';
 
 void main() {
+  if (!Platform.isMacOS) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
+
   const targets = [
     Target.iOSArm64,
   ];

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -17,8 +17,9 @@ void main() {
     Target.iOSArm64,
   ];
 
+  // Dont include 'mach-o' or 'Mach-O', different spelling is used.
   const objdumpFileFormat = {
-    Target.iOSArm64: 'mach-o arm64',
+    Target.iOSArm64: 'arm64',
   };
 
   for (final packaging in Packaging.values) {

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('mac-os')
+library;
+
+import 'package:c_compiler/c_compiler.dart';
+import 'package:c_compiler/src/utils/run_process.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+
+void main() {
+  const targets = [
+    Target.iOSArm64,
+  ];
+
+  const objdumpFileFormat = {
+    Target.iOSArm64: 'mach-o arm64',
+  };
+
+  for (final packaging in Packaging.values) {
+    for (final targetIOSSdk in IOSSdk.values) {
+      for (final target in targets) {
+        test('Cbuilder $packaging library $targetIOSSdk $target', () async {
+          await inTempDir((tempUri) async {
+            final addCUri =
+                packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
+            const name = 'add';
+
+            final buildConfig = BuildConfig(
+              outDir: tempUri,
+              packageRoot: tempUri,
+              target: target,
+              packaging: packaging == Packaging.dynamic
+                  ? PackagingPreference.dynamic
+                  : PackagingPreference.static,
+              targetIOSSdk: targetIOSSdk,
+            );
+            final buildOutput = BuildOutput();
+
+            final cbuilder = CBuilder.library(
+              name: 'add',
+              assetName: 'add',
+              sources: [addCUri.toFilePath()],
+            );
+            await cbuilder.run(
+              buildConfig: buildConfig,
+              buildOutput: buildOutput,
+              logger: logger,
+            );
+
+            final libUri =
+                tempUri.resolve(target.os.libraryFileName(name, packaging));
+            final result = await runProcess(
+              executable: Uri.file('objdump'),
+              arguments: ['-t', libUri.path],
+              logger: logger,
+            );
+            expect(result.exitCode, 0);
+            final machine = result.stdout
+                .split('\n')
+                .firstWhere((e) => e.contains('file format'));
+            expect(machine, contains(objdumpFileFormat[target]));
+          });
+        });
+      }
+    }
+  }
+}

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -31,7 +31,7 @@ void main() {
 
   for (final packaging in Packaging.values) {
     for (final target in targets) {
-      test('Cbuilder $packaging library linux $target', () async {
+      test('Cbuilder $packaging library $target', () async {
         await inTempDir((tempUri) async {
           final addCUri =
               packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// TODO(dacoharkes): Make a MacOS cross compilation test.
-// Or make this test cross compilation on any host.
 @TestOn('linux')
 library;
 

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -5,6 +5,8 @@
 @TestOn('linux')
 library;
 
+import 'dart:io';
+
 import 'package:c_compiler/c_compiler.dart';
 import 'package:c_compiler/src/utils/run_process.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
@@ -13,6 +15,11 @@ import 'package:test/test.dart';
 import '../helpers.dart';
 
 void main() {
+  if (!Platform.isLinux) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
+
   const targets = [
     Target.linuxArm,
     Target.linuxArm64,

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -2,6 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// TODO(dacoharkes): Make a MacOS cross compilation test.
+// Or make this test cross compilation on any host.
+@TestOn('linux')
+library;
+
 import 'package:c_compiler/c_compiler.dart';
 import 'package:c_compiler/src/utils/run_process.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -25,7 +25,7 @@ void main() {
 
   for (final packaging in Packaging.values) {
     for (final target in targets) {
-      test('Cbuilder $packaging library linux $target', () async {
+      test('Cbuilder $packaging library $target', () async {
         await inTempDir((tempUri) async {
           final addCUri =
               packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -1,0 +1,71 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('mac-os')
+library;
+
+import 'package:c_compiler/c_compiler.dart';
+import 'package:c_compiler/src/utils/run_process.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+
+void main() {
+  const targets = [
+    Target.macOSArm64,
+    Target.macOSX64,
+  ];
+
+  const objdumpFileFormat = {
+    Target.macOSArm64: 'mach-o arm64',
+    Target.macOSX64: 'mach-o 64-bit x86-64',
+  };
+
+  for (final packaging in Packaging.values) {
+    for (final target in targets) {
+      test('Cbuilder $packaging library linux $target', () async {
+        await inTempDir((tempUri) async {
+          final addCUri =
+              packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
+          const name = 'add';
+
+          final buildConfig = BuildConfig(
+            outDir: tempUri,
+            packageRoot: tempUri,
+            target: target,
+            packaging: packaging == Packaging.dynamic
+                ? PackagingPreference.dynamic
+                : PackagingPreference.static,
+          );
+          final buildOutput = BuildOutput();
+
+          final cbuilder = CBuilder.library(
+            name: 'add',
+            assetName: 'add',
+            sources: [addCUri.toFilePath()],
+          );
+          await cbuilder.run(
+            buildConfig: buildConfig,
+            buildOutput: buildOutput,
+            logger: logger,
+          );
+
+          final libUri =
+              tempUri.resolve(target.os.libraryFileName(name, packaging));
+          final result = await runProcess(
+            executable: Uri.file('objdump'),
+            arguments: ['-t', libUri.path],
+            logger: logger,
+          );
+          expect(result.exitCode, 0);
+          final machine = result.stdout
+              .split('\n')
+              .firstWhere((e) => e.contains('file format'));
+          expect(machine, contains(objdumpFileFormat[target]));
+        });
+      });
+    }
+  }
+}

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -5,6 +5,8 @@
 @TestOn('mac-os')
 library;
 
+import 'dart:io';
+
 import 'package:c_compiler/c_compiler.dart';
 import 'package:c_compiler/src/utils/run_process.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
@@ -13,6 +15,11 @@ import 'package:test/test.dart';
 import '../helpers.dart';
 
 void main() {
+  if (!Platform.isMacOS) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
+
   const targets = [
     Target.macOSArm64,
     Target.macOSX64,

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -18,9 +18,10 @@ void main() {
     Target.macOSX64,
   ];
 
+  // Dont include 'mach-o' or 'Mach-O', different spelling is used.
   const objdumpFileFormat = {
-    Target.macOSArm64: 'mach-o arm64',
-    Target.macOSX64: 'mach-o 64-bit x86-64',
+    Target.macOSArm64: 'arm64',
+    Target.macOSX64: '64-bit x86-64',
   };
 
   for (final packaging in Packaging.values) {

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_test.dart
@@ -43,7 +43,10 @@ void main() {
       final executableUri =
           tempUri.resolve(Target.current.os.executableFileName(name));
       expect(await File.fromUri(executableUri).exists(), true);
-      final result = await runProcess(executable: executableUri);
+      final result = await runProcess(
+        executable: executableUri,
+        logger: logger,
+      );
       expect(result.exitCode, 0);
       expect(result.stdout, 'Hello world.\n');
     });

--- a/pkgs/c_compiler/test/cbuilder/compiler_resolver_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/compiler_resolver_test.dart
@@ -13,11 +13,18 @@ import '../helpers.dart';
 void main() {
   test('Config provided compiler', () async {
     await inTempDir((tempUri) async {
-      final ar =
-          (await llvmAr.defaultResolver!.resolve(logger: logger)).first.uri;
-      final cc =
-          (await clang.defaultResolver!.resolve(logger: logger)).first.uri;
-      final ld = (await lld.defaultResolver!.resolve(logger: logger)).first.uri;
+      final ar = [
+        ...await appleAr.defaultResolver!.resolve(logger: logger),
+        ...await llvmAr.defaultResolver!.resolve(logger: logger),
+      ].first.uri;
+      final cc = [
+        ...await appleClang.defaultResolver!.resolve(logger: logger),
+        ...await clang.defaultResolver!.resolve(logger: logger),
+      ].first.uri;
+      final ld = [
+        ...await appleLd.defaultResolver!.resolve(logger: logger),
+        ...await lld.defaultResolver!.resolve(logger: logger),
+      ].first.uri;
       final buildConfig = BuildConfig(
         outDir: tempUri,
         packageRoot: tempUri,

--- a/pkgs/c_compiler/test/native_toolchain/apple_clang_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/apple_clang_test.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('mac-os')
+library;
+
+import 'package:c_compiler/c_compiler.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+
+void main() {
+  test('smoke test', () async {
+    final requirement = ToolRequirement(appleClang,
+        minimumVersion: Version(14, 0, 0, pre: '0'));
+    final resolved = await appleClang.defaultResolver!.resolve(logger: logger);
+    expect(resolved.isNotEmpty, true);
+    final satisfied = requirement.satisfy(resolved);
+    expect(satisfied?.length, 1);
+  });
+
+  test('ar test', () async {
+    final requirement = ToolRequirement(appleAr);
+    final resolved = await appleAr.defaultResolver!.resolve(logger: logger);
+    expect(resolved.isNotEmpty, true);
+    final satisfied = requirement.satisfy(resolved);
+    expect(satisfied?.length, 1);
+  });
+
+  test('ld test', () async {
+    final requirement = ToolRequirement(appleLd);
+    final resolved = await appleLd.defaultResolver!.resolve(logger: logger);
+    expect(resolved.isNotEmpty, true);
+    final satisfied = requirement.satisfy(resolved);
+    expect(satisfied?.length, 1);
+  });
+}

--- a/pkgs/c_compiler/test/native_toolchain/apple_clang_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/apple_clang_test.dart
@@ -21,7 +21,7 @@ void main() {
 
   test('smoke test', () async {
     final requirement = ToolRequirement(appleClang,
-        minimumVersion: Version(14, 0, 0, pre: '0'));
+        minimumVersion: Version(12, 0, 0, pre: '0'));
     final resolved = await appleClang.defaultResolver!.resolve(logger: logger);
     expect(resolved.isNotEmpty, true);
     final satisfied = requirement.satisfy(resolved);

--- a/pkgs/c_compiler/test/native_toolchain/apple_clang_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/apple_clang_test.dart
@@ -5,6 +5,8 @@
 @TestOn('mac-os')
 library;
 
+import 'dart:io';
+
 import 'package:c_compiler/c_compiler.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
@@ -12,6 +14,11 @@ import 'package:test/test.dart';
 import '../helpers.dart';
 
 void main() {
+  if (!Platform.isMacOS) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
+
   test('smoke test', () async {
     final requirement = ToolRequirement(appleClang,
         minimumVersion: Version(14, 0, 0, pre: '0'));

--- a/pkgs/c_compiler/test/native_toolchain/clang_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/clang_test.dart
@@ -5,6 +5,8 @@
 @TestOn('linux')
 library;
 
+import 'dart:io';
+
 import 'package:c_compiler/src/native_toolchain/clang.dart';
 import 'package:c_compiler/src/tool/tool_instance.dart';
 import 'package:c_compiler/src/tool/tool_requirement.dart';
@@ -14,6 +16,11 @@ import 'package:test/test.dart';
 import '../helpers.dart';
 
 void main() {
+  if (!Platform.isLinux) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
+
   test('clang smoke test', () async {
     final requirement =
         ToolRequirement(clang, minimumVersion: Version(14, 0, 0, pre: '0'));

--- a/pkgs/c_compiler/test/native_toolchain/clang_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/clang_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn('linux')
+library;
+
 import 'package:c_compiler/src/native_toolchain/clang.dart';
 import 'package:c_compiler/src/tool/tool_instance.dart';
 import 'package:c_compiler/src/tool/tool_requirement.dart';

--- a/pkgs/c_compiler/test/native_toolchain/gcc_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/gcc_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn('linux')
+library;
+
 import 'package:c_compiler/src/native_toolchain/gcc.dart';
 import 'package:c_compiler/src/tool/tool.dart';
 import 'package:c_compiler/src/tool/tool_requirement.dart';

--- a/pkgs/c_compiler/test/native_toolchain/gcc_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/gcc_test.dart
@@ -5,6 +5,8 @@
 @TestOn('linux')
 library;
 
+import 'dart:io';
+
 import 'package:c_compiler/src/native_toolchain/gcc.dart';
 import 'package:c_compiler/src/tool/tool.dart';
 import 'package:c_compiler/src/tool/tool_requirement.dart';
@@ -14,6 +16,11 @@ import 'package:test/test.dart';
 import '../helpers.dart';
 
 void main() {
+  if (!Platform.isLinux) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
+
   void testToolSet(String name, List<Tool> tools) {
     test('gcc cross compilation $name smoke test', () async {
       final resolver = ToolResolvers([

--- a/pkgs/c_compiler/test/native_toolchain/recognizer_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/recognizer_test.dart
@@ -16,7 +16,6 @@ import 'package:test/test.dart';
 import '../helpers.dart';
 
 void main() async {
-  // TODO(dacoharkes): Add apple tools.
   final tests = [
     RecognizerTest(appleAr, ArchiverRecognizer.new),
     RecognizerTest(appleClang, CompilerRecognizer.new),

--- a/pkgs/c_compiler/test/native_toolchain/xcode_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/xcode_test.dart
@@ -23,6 +23,11 @@ void main() {
     expect(resolved.isNotEmpty, true);
   });
 
+  test('macosxSdk', () async {
+    final resolved = await macosxSdk.defaultResolver!.resolve(logger: logger);
+    expect(resolved.isNotEmpty, true);
+  });
+
   test('iPhoneOSSdk', () async {
     final resolved = await iPhoneOSSdk.defaultResolver!.resolve(logger: logger);
     expect(resolved.isNotEmpty, true);

--- a/pkgs/c_compiler/test/native_toolchain/xcode_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/xcode_test.dart
@@ -8,6 +8,8 @@ library;
 import 'dart:io';
 
 import 'package:c_compiler/src/native_toolchain/xcode.dart';
+import 'package:c_compiler/src/tool/tool.dart';
+import 'package:c_compiler/src/tool/tool_instance.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';
@@ -37,5 +39,18 @@ void main() {
     final resolved =
         await iPhoneSimulatorSdk.defaultResolver!.resolve(logger: logger);
     expect(resolved.isNotEmpty, true);
+  });
+
+  test('non-existing SDK', () async {
+    final xcrunInstance =
+        (await xcrun.defaultResolver!.resolve(logger: logger)).first;
+    final tool = Tool(name: 'non-tool');
+    final result = await XCodeSdkResolver.tryResolveSdk(
+      xcrunInstance: xcrunInstance,
+      sdk: 'doesnotexist',
+      tool: tool,
+      logger: logger,
+    );
+    expect(result, <ToolInstance>[]);
   });
 }

--- a/pkgs/c_compiler/test/native_toolchain/xcode_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/xcode_test.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('mac-os')
+library;
+
+import 'package:c_compiler/src/native_toolchain/xcode.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+
+void main() {
+  test('xcrun', () async {
+    final resolved = await xcrun.defaultResolver!.resolve(logger: logger);
+    expect(resolved.isNotEmpty, true);
+  });
+
+  test('iPhoneOSSdk', () async {
+    final resolved = await iPhoneOSSdk.defaultResolver!.resolve(logger: logger);
+    expect(resolved.isNotEmpty, true);
+  });
+
+  test('iPhoneSimulatorSdk', () async {
+    final resolved =
+        await iPhoneSimulatorSdk.defaultResolver!.resolve(logger: logger);
+    expect(resolved.isNotEmpty, true);
+  });
+}

--- a/pkgs/c_compiler/test/native_toolchain/xcode_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/xcode_test.dart
@@ -5,12 +5,19 @@
 @TestOn('mac-os')
 library;
 
+import 'dart:io';
+
 import 'package:c_compiler/src/native_toolchain/xcode.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';
 
 void main() {
+  if (!Platform.isMacOS) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
+
   test('xcrun', () async {
     final resolved = await xcrun.defaultResolver!.resolve(logger: logger);
     expect(resolved.isNotEmpty, true);

--- a/pkgs/c_compiler/test/native_toolchain/xcode_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/xcode_test.dart
@@ -21,23 +21,28 @@ void main() {
   }
 
   test('xcrun', () async {
-    final resolved = await xcrun.defaultResolver!.resolve(logger: logger);
+    final resolved = (await xcrun.defaultResolver!.resolve(logger: logger))
+        .where((i) => i.tool == xcrun);
     expect(resolved.isNotEmpty, true);
   });
 
   test('macosxSdk', () async {
-    final resolved = await macosxSdk.defaultResolver!.resolve(logger: logger);
+    final resolved = (await macosxSdk.defaultResolver!.resolve(logger: logger))
+        .where((i) => i.tool == macosxSdk);
     expect(resolved.isNotEmpty, true);
   });
 
   test('iPhoneOSSdk', () async {
-    final resolved = await iPhoneOSSdk.defaultResolver!.resolve(logger: logger);
+    final resolved =
+        (await iPhoneOSSdk.defaultResolver!.resolve(logger: logger))
+            .where((i) => i.tool == iPhoneOSSdk);
     expect(resolved.isNotEmpty, true);
   });
 
   test('iPhoneSimulatorSdk', () async {
     final resolved =
-        await iPhoneSimulatorSdk.defaultResolver!.resolve(logger: logger);
+        (await iPhoneSimulatorSdk.defaultResolver!.resolve(logger: logger))
+            .where((i) => i.tool == iPhoneSimulatorSdk);
     expect(resolved.isNotEmpty, true);
   });
 

--- a/pkgs/c_compiler/test/tool/tool_instance_test.dart
+++ b/pkgs/c_compiler/test/tool/tool_instance_test.dart
@@ -73,4 +73,15 @@ void main() {
     expect(instance.toString(), contains('1.0.0'));
     expect(instance.toString(), contains('path/to/bar'));
   });
+
+  test('copyWith', () {
+    final instance = ToolInstance(
+      tool: Tool(name: 'bar'),
+      version: Version(1, 0, 0),
+      uri: Uri.file('path/to/bar'),
+    );
+
+    expect(instance.copyWith(), instance);
+    expect(instance.copyWith(uri: Uri.file('foo/bar')) != instance, true);
+  });
 }

--- a/pkgs/c_compiler/test/tool/tool_resolver_test.dart
+++ b/pkgs/c_compiler/test/tool/tool_resolver_test.dart
@@ -4,11 +4,8 @@
 
 import 'dart:io';
 
-import 'package:c_compiler/src/native_toolchain/clang.dart';
-import 'package:c_compiler/src/tool/tool.dart';
+import 'package:c_compiler/c_compiler.dart';
 import 'package:c_compiler/src/tool/tool_error.dart';
-import 'package:c_compiler/src/tool/tool_instance.dart';
-import 'package:c_compiler/src/tool/tool_resolver.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
 
@@ -16,7 +13,10 @@ import '../helpers.dart';
 
 void main() {
   test('CliVersionResolver.executableVersion', () async {
-    final clangInstances = await clang.defaultResolver!.resolve(logger: logger);
+    final clangInstances = [
+      ...await appleClang.defaultResolver!.resolve(logger: logger),
+      ...await clang.defaultResolver!.resolve(logger: logger),
+    ];
     expect(clangInstances.isNotEmpty, true);
     final version =
         await CliVersionResolver.executableVersion(clangInstances.first.uri);

--- a/pkgs/native_assets_cli/README.md
+++ b/pkgs/native_assets_cli/README.md
@@ -1,6 +1,6 @@
 [![package:native_assets_cli](https://github.com/dart-lang/native/actions/workflows/native_assets_cli.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/native_assets_cli.yaml)
 [![pub package](https://img.shields.io/pub/v/native_assets_cli.svg)](https://pub.dev/packages/native_assets_cli)
-[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/tools?branch=main)
+[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
 <!-- [![package publisher](https://img.shields.io/pub/publisher/native_assets_cli.svg)](https://pub.dev/packages/native_assets_cli/publisher) -->
 
 A library that contains the argument and file formats for implementing a native assets CLI.


### PR DESCRIPTION
Adds support for using the `clang` on MacOS to compile for MacOS and iOS.
For iOS finds the relevant SDK using `xcrun --sdk ... --show-sdk-path`.
Uses the identical NDK setup as for Linux to cross compile to Android.

This PR modifies the workflows so that they are a matrix over OS as well.
The MacOS bots have XCode pre-installed. And the clang in xcode can cross-compile already, so no extra deps needed.
I'm not fully happy with the results yet, but lets see if this new setup + changing the settings on Coveralls to mono-repo will at least make it report coverage on both packages.
More discussion in:

* https://github.com/dart-lang/native/issues