### PR TITLE
[infra] fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![dart](https://github.com/dart-lang/native/actions/workflows/dart.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/dart.yaml)
+[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
+
 ## Overview
 
 This repository is home to Dart packages related to FFI and native assets

--- a/pkgs/c_compiler/README.md
+++ b/pkgs/c_compiler/README.md
@@ -1,4 +1,4 @@
-[![package:c_compiler](https://github.com/dart-lang/native/actions/workflows/c_compiler.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/c_compiler.yaml)
+[![dart](https://github.com/dart-lang/native/actions/workflows/dart.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/dart.yaml)
 [![pub package](https://img.shields.io/pub/v/c_compiler.svg)](https://pub.dev/packages/c_compiler)
 [![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
 <!-- [![package publisher](https://img.shields.io/pub/publisher/c_compiler.svg)](https://pub.dev/packages/c_compiler/publisher) -->

--- a/pkgs/native_assets_cli/README.md
+++ b/pkgs/native_assets_cli/README.md
@@ -1,4 +1,4 @@
-[![package:native_assets_cli](https://github.com/dart-lang/native/actions/workflows/native_assets_cli.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/native_assets_cli.yaml)
+[![package:native_assets_cli](https://github.com/dart-lang/native/actions/workflows/dart.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/dart.yaml)
 [![pub package](https://img.shields.io/pub/v/native_assets_cli.svg)](https://pub.dev/packages/native_assets_cli)
 [![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
 <!-- [![package publisher](https://img.shields.io/pub/publisher/native_assets_cli.svg)](https://pub.dev/packages/native_assets_cli/publisher) -->


### PR DESCRIPTION
Now that we have only one workflow, the badges can only link to that workflow instead of the per-package workflow.

We might as well add those badges to the top-level readme.