### PR TITLE
Windows & MSVC support

### DIFF
--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -80,7 +80,6 @@ jobs:
           flag-name: ${{ matrix.package }}-${{ matrix.os }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel: true
-          # path-to-lcov: ./pkgs/${{ matrix.package }}/coverage/lcov.info
         if: ${{ matrix.sdk == 'stable' }}
 
   coverage-finished:

--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -19,12 +19,14 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu, macos]
+        os: [ubuntu, macos, windows]
         sdk: [stable, dev]
         package: [c_compiler, native_assets_cli]
         exclude:
           # Only run analyze against dev on one host.
           - os: macos
+            sdk: dev
+          - os: windows
             sdk: dev
 
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -80,7 +80,7 @@ jobs:
           flag-name: ${{ matrix.package }}-${{ matrix.os }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel: true
-          path-to-lcov: ./pkgs/${{ matrix.package }}/coverage/lcov.info
+          # path-to-lcov: ./pkgs/${{ matrix.package }}/coverage/lcov.info
         if: ${{ matrix.sdk == 'stable' }}
 
   coverage-finished:

--- a/pkgs/c_compiler/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/cbuilder.dart
@@ -80,7 +80,8 @@ class CBuilder implements Builder {
     final exeUri =
         outDir.resolve(buildConfig.target.os.executableFileName(name));
     final sources = [
-      for (final source in this.sources) packageRoot.resolve(source),
+      for (final source in this.sources)
+        packageRoot.resolveUri(Uri.file(source)),
     ];
     final dartBuildFiles = [
       for (final source in this.dartBuildFiles) packageRoot.resolve(source),

--- a/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
@@ -80,7 +80,7 @@ class CompilerResolver {
     final configCcUri = getter(buildConfig);
     if (configCcUri != null) {
       assert(await File.fromUri(configCcUri).exists());
-      logger?.finer('Using compiler ${configCcUri.path} '
+      logger?.finer('Using compiler ${configCcUri.toFilePath()} '
           'from config[${BuildConfig.ccConfigKey}].');
       return (await CompilerRecognizer(configCcUri).resolve(logger: logger))
           .first;
@@ -148,7 +148,7 @@ class CompilerResolver {
     final configArUri = getter(buildConfig);
     if (configArUri != null) {
       assert(await File.fromUri(configArUri).exists());
-      logger?.finer('Using archiver ${configArUri.path} '
+      logger?.finer('Using archiver ${configArUri.toFilePath()} '
           'from config[${BuildConfig.arConfigKey}].');
       return (await ArchiverRecognizer(configArUri).resolve(logger: logger))
           .first;

--- a/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
@@ -72,9 +72,14 @@ class CompilerResolver {
           return i686LinuxGnuGcc;
       }
     }
-    if (host == Target.windowsX64 && target == Target.windowsX64) return cl;
-    if (host == Target.windowsX64 && target == Target.windowsIA32) {
-      return clIA32;
+
+    if (host.os == OS.windows) {
+      switch (target) {
+        case Target.windowsIA32:
+          return clIA32;
+        case Target.windowsX64:
+          return cl;
+      }
     }
 
     return null;
@@ -142,6 +147,14 @@ class CompilerResolver {
           return aarch64LinuxGnuGccAr;
         case Target.linuxIA32:
           return i686LinuxGnuGccAr;
+      }
+    }
+    if (host.os == OS.windows) {
+      switch (target) {
+        case Target.windowsIA32:
+          return libIA32;
+        case Target.windowsX64:
+          return lib;
       }
     }
 

--- a/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
@@ -11,6 +11,7 @@ import '../native_toolchain/android_ndk.dart';
 import '../native_toolchain/apple_clang.dart';
 import '../native_toolchain/clang.dart';
 import '../native_toolchain/gcc.dart';
+import '../native_toolchain/msvc.dart';
 import '../native_toolchain/recognizer.dart';
 import '../tool/tool.dart';
 import '../tool/tool_error.dart';
@@ -71,6 +72,7 @@ class CompilerResolver {
           return i686LinuxGnuGcc;
       }
     }
+    if (target.os == OS.windows && host.os == OS.windows) return cl;
 
     return null;
   }

--- a/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
@@ -72,7 +72,10 @@ class CompilerResolver {
           return i686LinuxGnuGcc;
       }
     }
-    if (target.os == OS.windows && host.os == OS.windows) return cl;
+    if (host == Target.windowsX64 && target == Target.windowsX64) return cl;
+    if (host == Target.windowsX64 && target == Target.windowsIA32) {
+      return clIA32;
+    }
 
     return null;
   }

--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -69,7 +69,9 @@ class RunCBuilder {
   Future<void> run() async {
     final compiler_ = await compiler();
     final compilerTool = compiler_.tool;
-    if (compilerTool == clang || compilerTool == gcc) {
+    if (compilerTool == appleClang ||
+        compilerTool == clang ||
+        compilerTool == gcc) {
       await runClangLike(compiler: compiler_.uri);
       return;
     }

--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -151,13 +151,18 @@ class RunCBuilder {
     final result = await runProcess(
       executable: compiler,
       arguments: [
-        '/LD',
+        if (dynamicLibrary != null) '/LD',
         ...sources.map((e) => e.toFilePath()),
         if (dynamicLibrary != null) ...[
           '/Fe',
           outDir.resolveUri(dynamicLibrary!).toFilePath(),
-        ]
+        ],
+        if (executable != null) ...[
+          '/link',
+          '/out:${outDir.resolveUri(executable!).toFilePath()}',
+        ],
       ],
+      workingDirectory: outDir,
       environment: environment,
       logger: logger,
       captureOutput: false,

--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -96,16 +96,16 @@ class RunCBuilder {
         ...sources.map((e) => e.path),
         if (executable != null) ...[
           '-o',
-          outDir.resolveUri(executable!).path,
+          outDir.resolveUri(executable!).toFilePath(),
         ],
         if (dynamicLibrary != null) ...[
           '--shared',
           '-o',
-          outDir.resolveUri(dynamicLibrary!).path,
+          outDir.resolveUri(dynamicLibrary!).toFilePath(),
         ] else if (staticLibrary != null) ...[
           '-c',
           '-o',
-          outDir.resolve('out.o').path,
+          outDir.resolve('out.o').toFilePath(),
         ],
       ],
       logger: logger,
@@ -116,8 +116,8 @@ class RunCBuilder {
         executable: archiver_!,
         arguments: [
           'rc',
-          outDir.resolveUri(staticLibrary!).path,
-          outDir.resolve('out.o').path,
+          outDir.resolveUri(staticLibrary!).toFilePath(),
+          outDir.resolve('out.o').toFilePath(),
         ],
         logger: logger,
         captureOutput: false,

--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -76,8 +76,9 @@ class RunCBuilder {
       return;
     }
     assert(compilerTool == cl);
-    final vcvars =
-        (await vcvars64.defaultResolver!.resolve(logger: logger)).first;
+    final vcvars = target == Target.windowsX64
+        ? (await vcvars64.defaultResolver!.resolve(logger: logger)).first
+        : (await vcvars32.defaultResolver!.resolve(logger: logger)).first;
     await runCl(
       compiler: compiler_.uri,
       vcvars: vcvars.uri,

--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -151,15 +151,15 @@ class RunCBuilder {
     final result = await runProcess(
       executable: compiler,
       arguments: [
-        if (dynamicLibrary != null) '/LD',
         ...sources.map((e) => e.toFilePath()),
-        if (dynamicLibrary != null) ...[
-          '/Fe',
-          outDir.resolveUri(dynamicLibrary!).toFilePath(),
-        ],
         if (executable != null) ...[
           '/link',
           '/out:${outDir.resolveUri(executable!).toFilePath()}',
+        ],
+        if (dynamicLibrary != null) ...[
+          '/link',
+          '/DLL',
+          '/out:${outDir.resolveUri(dynamicLibrary!).toFilePath()}',
         ],
       ],
       workingDirectory: outDir,

--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -8,6 +8,7 @@ import 'package:native_assets_cli/native_assets_cli.dart';
 import '../../c_compiler.dart';
 import '../native_toolchain/msvc.dart';
 import '../native_toolchain/xcode.dart';
+import '../utils/env_from_bat.dart';
 import '../utils/run_process.dart';
 import 'compiler_resolver.dart';
 
@@ -73,7 +74,12 @@ class RunCBuilder {
       return;
     }
     assert(compilerTool == cl);
-    await runCl(compiler: compiler_.uri);
+    final vcvars =
+        (await vcvars64.defaultResolver!.resolve(logger: logger)).first;
+    await runCl(
+      compiler: compiler_.uri,
+      vcvars: vcvars.uri,
+    );
   }
 
   Future<void> runClangLike({required Uri compiler}) async {
@@ -137,7 +143,11 @@ class RunCBuilder {
     }
   }
 
-  Future<void> runCl({required Uri compiler}) async {
+  Future<void> runCl({
+    required Uri compiler,
+    required Uri vcvars,
+  }) async {
+    final environment = await envFromBat(vcvars);
     final result = await runProcess(
       executable: compiler,
       arguments: [
@@ -148,6 +158,7 @@ class RunCBuilder {
           outDir.resolveUri(dynamicLibrary!).toFilePath(),
         ]
       ],
+      environment: environment,
       logger: logger,
       captureOutput: false,
     );

--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -76,12 +76,12 @@ class RunCBuilder {
       return;
     }
     assert(compilerTool == cl);
-    final vcvars = target == Target.windowsX64
-        ? (await vcvars64.defaultResolver!.resolve(logger: logger)).first
-        : (await vcvars32.defaultResolver!.resolve(logger: logger)).first;
+    final vcvarsScript =
+        (await vcvars(compiler_).defaultResolver!.resolve(logger: logger))
+            .first;
     await runCl(
       compiler: compiler_.uri,
-      vcvars: vcvars.uri,
+      vcvars: vcvarsScript.uri,
     );
   }
 

--- a/pkgs/c_compiler/lib/src/native_toolchain/android_ndk.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/android_ndk.dart
@@ -41,7 +41,7 @@ class _AndroidNdkResolver implements ToolResolver {
       RelativeToolResolver(
         toolName: 'Android NDK',
         wrappedResolver: PathToolResolver(toolName: 'ndk-build'),
-        relativePath: Uri(path: '.'),
+        relativePath: Uri(path: ''),
       ),
       InstallLocationResolver(
         toolName: 'Android NDK',

--- a/pkgs/c_compiler/lib/src/native_toolchain/android_ndk.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/android_ndk.dart
@@ -40,7 +40,10 @@ class _AndroidNdkResolver implements ToolResolver {
     wrappedResolver: ToolResolvers([
       RelativeToolResolver(
         toolName: 'Android NDK',
-        wrappedResolver: PathToolResolver(toolName: 'ndk-build'),
+        wrappedResolver: PathToolResolver(
+          toolName: 'ndk-build',
+          executableName: Platform.isWindows ? 'ndk-build.cmd' : 'ndk-build',
+        ),
         relativePath: Uri(path: ''),
       ),
       InstallLocationResolver(

--- a/pkgs/c_compiler/lib/src/native_toolchain/android_ndk.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/android_ndk.dart
@@ -53,6 +53,9 @@ class _AndroidNdkResolver implements ToolResolver {
           if (Platform.isMacOS) ...[
             '\$HOME/Library/Android/sdk/ndk/*/',
           ],
+          if (Platform.isWindows) ...[
+            '\$HOME/AppData/Local/Android/Sdk/ndk/*/',
+          ],
         ],
       ),
     ]),
@@ -79,21 +82,27 @@ class _AndroidNdkResolver implements ToolResolver {
     final hostArchDirs =
         (await prebuiltDir.list().toList()).whereType<Directory>().toList();
     for (final hostArchDir in hostArchDirs) {
-      final clangUri = hostArchDir.uri.resolve('bin/clang');
+      final clangUri = hostArchDir.uri
+          .resolve('bin/')
+          .resolve(Target.current.os.executableFileName('clang'));
       if (await File.fromUri(clangUri).exists()) {
         result.add(await CliVersionResolver.lookupVersion(ToolInstance(
           tool: androidNdkClang,
           uri: clangUri,
         )));
       }
-      final arUri = hostArchDir.uri.resolve('bin/llvm-ar');
+      final arUri = hostArchDir.uri
+          .resolve('bin/')
+          .resolve(Target.current.os.executableFileName('llvm-ar'));
       if (await File.fromUri(arUri).exists()) {
         result.add(await CliVersionResolver.lookupVersion(ToolInstance(
           tool: androidNdkLlvmAr,
           uri: arUri,
         )));
       }
-      final ldUri = hostArchDir.uri.resolve('bin/ld.lld');
+      final ldUri = hostArchDir.uri
+          .resolve('bin/')
+          .resolve(Target.current.os.executableFileName('ld.lld'));
       if (await File.fromUri(arUri).exists()) {
         result.add(await CliVersionResolver.lookupVersion(ToolInstance(
           tool: androidNdkLld,

--- a/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
@@ -45,6 +45,7 @@ final Tool visualStudio = Tool(
   defaultResolver: VisualStudioResolver(),
 );
 
+/// The C/C++ Optimizing Compiler.
 final Tool msvc = Tool(
   name: 'MSVC',
   defaultResolver: PathVersionResolver(
@@ -52,6 +53,20 @@ final Tool msvc = Tool(
       toolName: 'MSVC',
       wrappedResolver: visualStudio.defaultResolver!,
       relativePath: Uri(path: './VC/Tools/MSVC/*/'),
+    ),
+  ),
+);
+
+/// The C/C++ Optimizing Compiler main executable.
+final Tool cl = Tool(
+  name: 'cl.exe',
+  defaultResolver: CliVersionResolver(
+    arguments: [],
+    expectedExitCode: 0,
+    wrappedResolver: RelativeToolResolver(
+      toolName: 'cl.exe',
+      wrappedResolver: msvc.defaultResolver!,
+      relativePath: Uri(path: 'bin/Hostx64/x64/cl.exe'),
     ),
   ),
 );

--- a/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../tool/tool.dart';
+import '../tool/tool_resolver.dart';
+
+/// The Visual Studio Locator.
+///
+/// https://github.com/microsoft/vswhere
+final Tool vswhere = Tool(
+  name: 'Visual Studio Locator',
+  defaultResolver: CliVersionResolver(
+    arguments: [],
+    wrappedResolver: ToolResolvers(
+      [
+        PathToolResolver(
+          toolName: 'Visual Studio Locator',
+          executableName: 'vswhere.exe',
+        ),
+        InstallLocationResolver(
+          toolName: 'Visual Studio Locator',
+          paths: [
+            'C:/Program Files \\(x86\\)/Microsoft Visual Studio/Installer/vswhere.exe',
+            'C:/Program Files/Microsoft Visual Studio/Installer/vswhere.exe',
+          ],
+        ),
+      ],
+    ),
+  ),
+);
+
+/// Visual Studio.
+///
+/// https://visualstudio.microsoft.com/
+final Tool msvc = Tool(
+  name: 'Visual Studio',
+  defaultResolver: InstallLocationResolver(
+    toolName: 'Visual Studio',
+    paths: [
+      for (final edition in _visualStudioEditions) ...[
+        'C:/Program Files \\(x86\\)/Microsoft Visual Studio/*/$edition',
+        'C:/Program Files/Microsoft Visual Studio/*/$edition',
+      ],
+    ],
+  ),
+);
+
+final _visualStudioEditions = [
+  'Professional',
+  'Community',
+];

--- a/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
@@ -45,6 +45,17 @@ final Tool visualStudio = Tool(
   defaultResolver: VisualStudioResolver(),
 );
 
+final Tool msvc = Tool(
+  name: 'MSVC',
+  defaultResolver: PathVersionResolver(
+    wrappedResolver: RelativeToolResolver(
+      toolName: 'MSVC',
+      wrappedResolver: visualStudio.defaultResolver!,
+      relativePath: Uri(path: './VC/Tools/MSVC/*/'),
+    ),
+  ),
+);
+
 class VisualStudioResolver implements ToolResolver {
   @override
   Future<List<ToolInstance>> resolve({Logger? logger}) async {

--- a/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
@@ -57,6 +57,15 @@ final Tool msvc = Tool(
   ),
 );
 
+final Tool vcvars64 = Tool(
+  name: 'vcvars64.bat',
+  defaultResolver: RelativeToolResolver(
+    toolName: 'vcvars64.bat',
+    wrappedResolver: visualStudio.defaultResolver!,
+    relativePath: Uri(path: './VC/Auxiliary/Build/vcvars64.bat'),
+  ),
+);
+
 /// The C/C++ Optimizing Compiler main executable.
 final Tool cl = Tool(
   name: 'cl.exe',

--- a/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
@@ -2,8 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+
 import '../tool/tool.dart';
+import '../tool/tool_instance.dart';
 import '../tool/tool_resolver.dart';
+import '../utils/run_process.dart';
+import '../utils/sem_version.dart';
 
 /// The Visual Studio Locator.
 ///
@@ -35,18 +42,47 @@ final Tool vswhere = Tool(
 /// https://visualstudio.microsoft.com/
 final Tool msvc = Tool(
   name: 'Visual Studio',
-  defaultResolver: InstallLocationResolver(
-    toolName: 'Visual Studio',
-    paths: [
-      for (final edition in _visualStudioEditions) ...[
-        'C:/Program Files \\(x86\\)/Microsoft Visual Studio/*/$edition',
-        'C:/Program Files/Microsoft Visual Studio/*/$edition',
-      ],
-    ],
-  ),
+  defaultResolver: VisualStudioResolver(),
 );
 
-final _visualStudioEditions = [
-  'Professional',
-  'Community',
-];
+class VisualStudioResolver implements ToolResolver {
+  @override
+  Future<List<ToolInstance>> resolve({Logger? logger}) async {
+    final vswhereInstances =
+        await vswhere.defaultResolver!.resolve(logger: logger);
+
+    final result = <ToolInstance>[];
+    for (final vswhereInstance in vswhereInstances.take(1)) {
+      final vswhereResult = await runProcess(
+        executable: vswhereInstance.uri,
+        logger: logger,
+      );
+      final toolInfos = vswhereResult.stdout.split(_newLine * 2).skip(1);
+      for (final toolInfo in toolInfos) {
+        final toolInfoParsed = parseToolInfo(toolInfo);
+        final dir = Directory(toolInfoParsed['installationPath']!);
+        assert(await dir.exists());
+        final uri = dir.uri;
+        final version = versionFromString(toolInfoParsed['installationName']!);
+        final instance = ToolInstance(tool: msvc, uri: uri, version: version);
+        logger?.fine('Found $instance.');
+        result.add(instance);
+      }
+    }
+    return result;
+  }
+
+  static Map<String, String> parseToolInfo(String toolInfo) {
+    final result = <String, String>{};
+    final lines = toolInfo.split(_newLine);
+    for (final line in lines) {
+      final splitLine = line.split(': ');
+      final key = splitLine.first;
+      final value = splitLine.skip(1).join(': ');
+      result[key] = value;
+    }
+    return result;
+  }
+}
+
+const _newLine = '\r\n';

--- a/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
@@ -58,6 +58,25 @@ final Tool msvc = Tool(
   ),
 );
 
+Tool vcvars(ToolInstance toolInstance) {
+  final tool = toolInstance.tool;
+  assert(tool == cl || tool == link || tool == lib);
+  final vcDir = toolInstance.uri.resolve('../../../../../../');
+  final fileName = toolInstance.uri.toFilePath().contains('x86')
+      ? 'vcvars32.bat'
+      : 'vcvars64.bat';
+  final batchScript = vcDir.resolve('Auxiliary/Build/$fileName');
+  return Tool(
+    name: fileName,
+    defaultResolver: InstallLocationResolver(
+      toolName: fileName,
+      paths: [
+        batchScript.toFilePath().replaceAll('\\', '/'),
+      ],
+    ),
+  );
+}
+
 final Tool vcvars64 = Tool(
   name: 'vcvars64.bat',
   defaultResolver: RelativeToolResolver(

--- a/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
@@ -185,14 +185,14 @@ Tool _msvcTool({
   bool resolveVersion = true,
 }) {
   final executableName = OS.windows.executableFileName(name);
-  final hostArchName = _msvcArchNames[hostArchitecture];
-  final targetArchName = _msvcArchNames[targetArchitecture];
-  if (hostArchName == null || targetArchName == null) {
+  if (Target.current.os != OS.windows) {
     return Tool(
       name: executableName,
       defaultResolver: ToolResolvers([]),
     );
   }
+  final hostArchName = _msvcArchNames[hostArchitecture]!;
+  final targetArchName = _msvcArchNames[targetArchitecture]!;
   ToolResolver resolver = RelativeToolResolver(
     toolName: executableName,
     wrappedResolver: msvc.defaultResolver!,

--- a/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
@@ -116,14 +116,12 @@ final Tool clIA32 = _msvcTool(
 
 final Tool lib = _msvcTool(
   name: 'lib',
-  versionArguments: ['/version'],
   targetArchitecture: Architecture.x64,
   hostArchitecture: Target.current.architecture,
 );
 
 final Tool libIA32 = _msvcTool(
   name: 'lib',
-  versionArguments: ['/version'],
   targetArchitecture: Architecture.ia32,
   hostArchitecture: Target.current.architecture,
 );

--- a/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
@@ -116,12 +116,14 @@ final Tool clIA32 = _msvcTool(
 
 final Tool lib = _msvcTool(
   name: 'lib',
+  versionArguments: ['/version'],
   targetArchitecture: Architecture.x64,
   hostArchitecture: Target.current.architecture,
 );
 
 final Tool libIA32 = _msvcTool(
   name: 'lib',
+  versionArguments: ['/version'],
   targetArchitecture: Architecture.ia32,
   hostArchitecture: Target.current.architecture,
 );

--- a/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
@@ -94,6 +94,8 @@ final Tool vsDevCmd = Tool(
 );
 
 /// The C/C++ Optimizing Compiler main executable.
+///
+/// For targeting x64.
 final Tool cl = Tool(
   name: 'cl.exe',
   defaultResolver: CliVersionResolver(
@@ -103,6 +105,22 @@ final Tool cl = Tool(
       toolName: 'cl.exe',
       wrappedResolver: msvc.defaultResolver!,
       relativePath: Uri(path: 'bin/Hostx64/x64/cl.exe'),
+    ),
+  ),
+);
+
+/// The C/C++ Optimizing Compiler main executable.
+///
+/// For targeting ia32.
+final Tool clIA32 = Tool(
+  name: 'cl.exe',
+  defaultResolver: CliVersionResolver(
+    arguments: [],
+    expectedExitCode: 0,
+    wrappedResolver: RelativeToolResolver(
+      toolName: 'cl.exe',
+      wrappedResolver: msvc.defaultResolver!,
+      relativePath: Uri(path: 'bin/Hostx64/x86/cl.exe'),
     ),
   ),
 );

--- a/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
@@ -107,6 +107,18 @@ final Tool cl = Tool(
   ),
 );
 
+final Tool dumpbin = Tool(
+  name: 'dumpbin.exe',
+  defaultResolver: CliVersionResolver(
+    expectedExitCode: 0,
+    wrappedResolver: RelativeToolResolver(
+      toolName: 'dumpbin.exe',
+      wrappedResolver: msvc.defaultResolver!,
+      relativePath: Uri(path: 'bin/Hostx64/x64/dumpbin.exe'),
+    ),
+  ),
+);
+
 class VisualStudioResolver implements ToolResolver {
   @override
   Future<List<ToolInstance>> resolve({Logger? logger}) async {

--- a/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
@@ -66,6 +66,33 @@ final Tool vcvars64 = Tool(
   ),
 );
 
+final Tool vcvars32 = Tool(
+  name: 'vcvars32.bat',
+  defaultResolver: RelativeToolResolver(
+    toolName: 'vcvars32.bat',
+    wrappedResolver: visualStudio.defaultResolver!,
+    relativePath: Uri(path: './VC/Auxiliary/Build/vcvars32.bat'),
+  ),
+);
+
+final Tool vcvarsall = Tool(
+  name: 'vcvarsall.bat',
+  defaultResolver: RelativeToolResolver(
+    toolName: 'vcvars32.bat',
+    wrappedResolver: visualStudio.defaultResolver!,
+    relativePath: Uri(path: './VC/Auxiliary/Build/vcvarsall.bat'),
+  ),
+);
+
+final Tool vsDevCmd = Tool(
+  name: 'VsDevCmd.bat',
+  defaultResolver: RelativeToolResolver(
+    toolName: 'VsDevCmd.bat',
+    wrappedResolver: visualStudio.defaultResolver!,
+    relativePath: Uri(path: './Common7/Tools/VsDevCmd.bat'),
+  ),
+);
+
 /// The C/C++ Optimizing Compiler main executable.
 final Tool cl = Tool(
   name: 'cl.exe',

--- a/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
@@ -166,12 +166,19 @@ Tool _msvcTool({
   bool resolveVersion = true,
 }) {
   final executableName = OS.windows.executableFileName(name);
+  final hostArchName = _msvcArchNames[hostArchitecture];
+  final targetArchName = _msvcArchNames[targetArchitecture];
+  if (hostArchName == null || targetArchName == null) {
+    return Tool(
+      name: executableName,
+      defaultResolver: ToolResolvers([]),
+    );
+  }
   ToolResolver resolver = RelativeToolResolver(
     toolName: executableName,
     wrappedResolver: msvc.defaultResolver!,
     relativePath: Uri(
-      path: 'bin/Host${_msvcArchNames[hostArchitecture]!}/'
-          '${_msvcArchNames[targetArchitecture]!}/$executableName',
+      path: 'bin/Host$hostArchName/$targetArchName/$executableName',
     ),
   );
   if (resolveVersion) {

--- a/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
@@ -40,7 +40,7 @@ final Tool vswhere = Tool(
 /// Visual Studio.
 ///
 /// https://visualstudio.microsoft.com/
-final Tool msvc = Tool(
+final Tool visualStudio = Tool(
   name: 'Visual Studio',
   defaultResolver: VisualStudioResolver(),
 );
@@ -64,7 +64,8 @@ class VisualStudioResolver implements ToolResolver {
         assert(await dir.exists());
         final uri = dir.uri;
         final version = versionFromString(toolInfoParsed['installationName']!);
-        final instance = ToolInstance(tool: msvc, uri: uri, version: version);
+        final instance =
+            ToolInstance(tool: visualStudio, uri: uri, version: version);
         logger?.fine('Found $instance.');
         result.add(instance);
       }

--- a/pkgs/c_compiler/lib/src/native_toolchain/recognizer.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/recognizer.dart
@@ -139,14 +139,6 @@ class ArchiverRecognizer implements ToolResolver {
           ),
         ];
       }
-      if (tool == lib) {
-        return [
-          await CliVersionResolver.lookupVersion(
-            toolInstance,
-            logger: logger,
-          ),
-        ];
-      }
       return [toolInstance];
     }
 

--- a/pkgs/c_compiler/lib/src/native_toolchain/recognizer.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/recognizer.dart
@@ -144,7 +144,6 @@ class ArchiverRecognizer implements ToolResolver {
           await CliVersionResolver.lookupVersion(
             toolInstance,
             logger: logger,
-            arguments: ['/version'],
           ),
         ];
       }

--- a/pkgs/c_compiler/lib/src/native_toolchain/recognizer.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/recognizer.dart
@@ -74,6 +74,8 @@ class LinkerRecognizer implements ToolResolver {
       tool = lld;
     } else if (filePath.endsWith(os.executableFileName('ld'))) {
       tool = appleLd;
+    } else if (filePath.endsWith('link.exe')) {
+      tool = link;
     }
 
     if (tool != null) {
@@ -84,6 +86,16 @@ class LinkerRecognizer implements ToolResolver {
           await CliVersionResolver.lookupVersion(
             toolInstance,
             logger: logger,
+          ),
+        ];
+      }
+      if (tool == link) {
+        return [
+          await CliVersionResolver.lookupVersion(
+            toolInstance,
+            logger: logger,
+            arguments: ['/help'],
+            expectedExitCode: 1100,
           ),
         ];
       }
@@ -112,12 +124,22 @@ class ArchiverRecognizer implements ToolResolver {
       tool = llvmAr;
     } else if (filePath.endsWith(os.executableFileName('ar'))) {
       tool = appleAr;
+    } else if (filePath.endsWith('lib.exe')) {
+      tool = lib;
     }
 
     if (tool != null) {
       logger?.fine('Tool instance $uri is likely $tool.');
       final toolInstance = ToolInstance(tool: tool, uri: uri);
       if (tool == llvmAr) {
+        return [
+          await CliVersionResolver.lookupVersion(
+            toolInstance,
+            logger: logger,
+          ),
+        ];
+      }
+      if (tool == lib) {
         return [
           await CliVersionResolver.lookupVersion(
             toolInstance,

--- a/pkgs/c_compiler/lib/src/native_toolchain/recognizer.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/recognizer.dart
@@ -144,6 +144,7 @@ class ArchiverRecognizer implements ToolResolver {
           await CliVersionResolver.lookupVersion(
             toolInstance,
             logger: logger,
+            arguments: ['/version'],
           ),
         ];
       }

--- a/pkgs/c_compiler/lib/src/tool/tool_resolver.dart
+++ b/pkgs/c_compiler/lib/src/tool/tool_resolver.dart
@@ -213,7 +213,10 @@ class InstallLocationResolver implements ToolResolver {
     if (path.startsWith(home)) {
       final homeDir_ = homeDir;
       assert(homeDir_ != null);
-      path = path.replaceAll('$home/', homeDir!.path);
+      path = path.replaceAll('$home/', homeDir!.toFilePath());
+    }
+    if (Platform.isWindows) {
+      path = path.replaceAll('\\', '/');
     }
 
     final result = <Uri>[];

--- a/pkgs/c_compiler/lib/src/tool/tool_resolver.dart
+++ b/pkgs/c_compiler/lib/src/tool/tool_resolver.dart
@@ -252,14 +252,18 @@ class RelativeToolResolver implements ToolResolver {
 
     logger?.finer('Looking for $toolName relative to $otherToolInstances '
         'with $relativePath.');
-    final fileSystemEntities = [
+    final globs = [
       for (final toolInstance in otherToolInstances)
-        ...await Glob([
-          Glob.quote(toolInstance.uri.toFilePath().replaceAll('\\\\', '/')),
+        Glob([
+          Glob.quote(
+              toolInstance.uri.resolve('.').toFilePath().replaceAll('\\', '/')),
           relativePath.path
         ].join())
-            .list()
-            .toList(),
+    ];
+    // print(globs);
+    // exit(0);
+    final fileSystemEntities = [
+      for (final glob in globs) ...await glob.list().toList(),
     ];
 
     final result = [

--- a/pkgs/c_compiler/lib/src/tool/tool_resolver.dart
+++ b/pkgs/c_compiler/lib/src/tool/tool_resolver.dart
@@ -213,10 +213,8 @@ class InstallLocationResolver implements ToolResolver {
     if (path.startsWith(home)) {
       final homeDir_ = homeDir;
       assert(homeDir_ != null);
-      path = path.replaceAll('$home/', homeDir!.toFilePath());
-    }
-    if (Platform.isWindows) {
-      path = path.replaceAll('\\', '/');
+      path = path.replaceAll(
+          '$home/', homeDir!.toFilePath().replaceAll('\\', '/'));
     }
 
     final result = <Uri>[];

--- a/pkgs/c_compiler/lib/src/tool/tool_resolver.dart
+++ b/pkgs/c_compiler/lib/src/tool/tool_resolver.dart
@@ -242,13 +242,24 @@ class RelativeToolResolver implements ToolResolver {
 
     logger?.finer('Looking for $toolName relative to $otherToolInstances '
         'with $relativePath.');
-    final result = [
+    final fileSystemEntities = [
       for (final toolInstance in otherToolInstances)
+        ...await Glob([
+          Glob.quote(toolInstance.uri.toFilePath().replaceAll('\\\\', '/')),
+          relativePath.path
+        ].join())
+            .list()
+            .toList(),
+    ];
+
+    final result = [
+      for (final fileSystemEntity in fileSystemEntities)
         ToolInstance(
           tool: Tool(name: toolName),
-          uri: toolInstance.uri.resolveUri(relativePath),
+          uri: fileSystemEntity.uri,
         ),
     ];
+
     if (result.isNotEmpty) {
       logger?.fine('Found $result.');
     } else {

--- a/pkgs/c_compiler/lib/src/utils/env_from_bat.dart
+++ b/pkgs/c_compiler/lib/src/utils/env_from_bat.dart
@@ -4,17 +4,18 @@
 
 import 'dart:io';
 
-Future<Map<String, String>> envFromBat(Uri batchFile) async {
+Future<Map<String, String>> envFromBat(
+  Uri batchFile, {
+  List<String> arguments = const [],
+}) async {
   final fileName = batchFile.pathSegments.last;
   final dir = batchFile.resolve('.');
   const separator = '=======';
   final processResult = await Process.run(
-    'set && echo $separator && $fileName > nul && set',
+    'set && echo $separator && $fileName ${arguments.join(' ')} > nul && set',
     [],
     runInShell: true,
-    environment: {
-      'PATH': dir.toFilePath(),
-    },
+    workingDirectory: dir.toFilePath(),
   );
   assert(processResult.exitCode == 0);
   final resultSplit = (processResult.stdout as String).split(separator);

--- a/pkgs/c_compiler/lib/src/utils/env_from_bat.dart
+++ b/pkgs/c_compiler/lib/src/utils/env_from_bat.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+Future<Map<String, String>> envFromBat(Uri batchFile) async {
+  final fileName = batchFile.pathSegments.last;
+  final dir = batchFile.resolve('.');
+  const separator = '=======';
+  final processResult = await Process.run(
+    'set && echo $separator && $fileName > nul && set',
+    [],
+    runInShell: true,
+    environment: {
+      'PATH': dir.toFilePath(),
+    },
+  );
+  assert(processResult.exitCode == 0);
+  final resultSplit = (processResult.stdout as String).split(separator);
+  assert(resultSplit.length == 2);
+  final unmodifiedParsed = parseDefines(resultSplit.first.trim());
+  final modifiedParsed = parseDefines(resultSplit[1].trim());
+  final result = <String, String>{};
+  for (final entry in modifiedParsed.entries) {
+    final key = entry.key;
+    final value = entry.value;
+    if (!unmodifiedParsed.containsKey(key) || value != unmodifiedParsed[key]) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+Map<String, String> parseDefines(String defines) {
+  final result = <String, String>{};
+  final lines = defines.split('\r\n');
+  for (final line in lines) {
+    final lineSplit = line.split('=');
+    final key = lineSplit.first;
+    final value = lineSplit.skip(1).join('=');
+    result[key] = value;
+  }
+  return result;
+}

--- a/pkgs/c_compiler/lib/src/utils/run_process.dart
+++ b/pkgs/c_compiler/lib/src/utils/run_process.dart
@@ -27,7 +27,7 @@ Future<RunProcessResult> runProcess({
   final commandString = [
     if (printWorkingDir) '(cd ${workingDirectory.toFilePath()};',
     ...?environment?.entries.map((entry) => '${entry.key}=${entry.value}'),
-    executable,
+    executable.toFilePath(),
     ...arguments.map((a) => a.contains(' ') ? "'$a'" : a),
     if (printWorkingDir) ')',
   ].join(' ');

--- a/pkgs/c_compiler/lib/src/utils/run_process.dart
+++ b/pkgs/c_compiler/lib/src/utils/run_process.dart
@@ -25,7 +25,7 @@ Future<RunProcessResult> runProcess({
   final printWorkingDir =
       workingDirectory != null && workingDirectory != Directory.current.uri;
   final commandString = [
-    if (printWorkingDir) '(cd ${workingDirectory.path};',
+    if (printWorkingDir) '(cd ${workingDirectory.toFilePath()};',
     ...?environment?.entries.map((entry) => '${entry.key}=${entry.value}'),
     executable,
     ...arguments.map((a) => a.contains(' ') ? "'$a'" : a),

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -45,7 +45,8 @@ void main() {
 
   for (final packaging in Packaging.values) {
     for (final target in targets) {
-      test('Cbuilder $packaging library $target', () async {
+      test('Cbuilder $packaging library $target', timeout: Timeout.factor(2),
+          () async {
         await inTempDir((tempUri) async {
           final addCUri =
               packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -1,0 +1,95 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('windows')
+library;
+
+import 'dart:io';
+
+import 'package:c_compiler/c_compiler.dart';
+import 'package:c_compiler/src/native_toolchain/msvc.dart';
+import 'package:c_compiler/src/utils/run_process.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+
+void main() {
+  if (!Platform.isWindows) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
+
+  const targets = [
+    Target.windowsIA32,
+    Target.windowsX64,
+  ];
+
+  late Uri dumpbinUri;
+
+  setUp(() async {
+    dumpbinUri =
+        (await dumpbin.defaultResolver!.resolve(logger: logger)).first.uri;
+  });
+
+  const dumpbinMachine = {
+    Target.windowsIA32: 'x86',
+    Target.windowsX64: 'x64',
+  };
+
+  const dumpbinFileType = {
+    Packaging.dynamic: 'DLL',
+    Packaging.static: 'LIBRARY',
+  };
+
+  for (final packaging in Packaging.values) {
+    for (final target in targets) {
+      test('Cbuilder $packaging library $target', () async {
+        await inTempDir((tempUri) async {
+          final addCUri =
+              packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
+          const name = 'add';
+
+          final buildConfig = BuildConfig(
+            outDir: tempUri,
+            packageRoot: tempUri,
+            target: target,
+            packaging: packaging == Packaging.dynamic
+                ? PackagingPreference.dynamic
+                : PackagingPreference.static,
+          );
+          final buildOutput = BuildOutput();
+
+          final cbuilder = CBuilder.library(
+            name: 'add',
+            assetName: 'add',
+            sources: [addCUri.toFilePath()],
+          );
+          await cbuilder.run(
+            buildConfig: buildConfig,
+            buildOutput: buildOutput,
+            logger: logger,
+          );
+
+          final libUri =
+              tempUri.resolve(target.os.libraryFileName(name, packaging));
+          final result = await runProcess(
+            executable: dumpbinUri,
+            arguments: ['/HEADERS', libUri.toFilePath()],
+            logger: logger,
+          );
+          expect(result.exitCode, 0);
+          final machine = result.stdout
+              .split('\n')
+              .firstWhere((e) => e.contains('machine'));
+          expect(machine, contains(dumpbinMachine[target]));
+          final fileType = result.stdout
+              .split('\n')
+              .firstWhere((e) => e.contains('File Type'));
+          expect(fileType, contains(dumpbinFileType[packaging]));
+        });
+      });
+    }
+  }
+}

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -74,6 +74,7 @@ void main() {
 
           final libUri =
               tempUri.resolve(target.os.libraryFileName(name, packaging));
+          expect(await File.fromUri(libUri).exists(), true);
           final result = await runProcess(
             executable: dumpbinUri,
             arguments: ['/HEADERS', libUri.toFilePath()],

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_test.dart
@@ -79,6 +79,7 @@ void main() {
       );
 
       final dylibUri = tempUri.resolve(Target.current.os.dylibFileName(name));
+      expect(await File.fromUri(dylibUri).exists(), true);
       final dylib = DynamicLibrary.open(dylibUri.path);
       final add = dylib.lookupFunction<Int32 Function(Int32, Int32),
           int Function(int, int)>('add');

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_test.dart
@@ -48,7 +48,7 @@ void main() {
         logger: logger,
       );
       expect(result.exitCode, 0);
-      expect(result.stdout, 'Hello world.\n');
+      expect(result.stdout.trim(), 'Hello world.');
     });
   });
 

--- a/pkgs/c_compiler/test/cbuilder/compiler_resolver_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/compiler_resolver_test.dart
@@ -4,7 +4,9 @@
 
 import 'package:c_compiler/c_compiler.dart';
 import 'package:c_compiler/src/cbuilder/compiler_resolver.dart';
+import 'package:c_compiler/src/native_toolchain/msvc.dart';
 import 'package:c_compiler/src/tool/tool_error.dart';
+import 'package:collection/collection.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
 
@@ -16,15 +18,16 @@ void main() {
       final ar = [
         ...await appleAr.defaultResolver!.resolve(logger: logger),
         ...await llvmAr.defaultResolver!.resolve(logger: logger),
-      ].first.uri;
+      ].firstOrNull?.uri;
       final cc = [
         ...await appleClang.defaultResolver!.resolve(logger: logger),
         ...await clang.defaultResolver!.resolve(logger: logger),
+        ...await cl.defaultResolver!.resolve(logger: logger),
       ].first.uri;
       final ld = [
         ...await appleLd.defaultResolver!.resolve(logger: logger),
         ...await lld.defaultResolver!.resolve(logger: logger),
-      ].first.uri;
+      ].firstOrNull?.uri;
       final buildConfig = BuildConfig(
         outDir: tempUri,
         packageRoot: tempUri,
@@ -37,9 +40,9 @@ void main() {
       final resolver =
           CompilerResolver(buildConfig: buildConfig, logger: logger);
       final compiler = await resolver.resolveCompiler();
-      final archiver = await resolver.resolveArchiver();
+      final archiver = ar == null ? null : await resolver.resolveArchiver();
       expect(compiler.uri, buildConfig.cc);
-      expect(archiver.uri, buildConfig.ar);
+      expect(archiver?.uri, buildConfig.ar);
     });
   });
 

--- a/pkgs/c_compiler/test/cbuilder/compiler_resolver_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/compiler_resolver_test.dart
@@ -6,7 +6,6 @@ import 'package:c_compiler/c_compiler.dart';
 import 'package:c_compiler/src/cbuilder/compiler_resolver.dart';
 import 'package:c_compiler/src/native_toolchain/msvc.dart';
 import 'package:c_compiler/src/tool/tool_error.dart';
-import 'package:collection/collection.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
 
@@ -17,17 +16,19 @@ void main() {
     await inTempDir((tempUri) async {
       final ar = [
         ...await appleAr.defaultResolver!.resolve(logger: logger),
+        ...await lib.defaultResolver!.resolve(logger: logger),
         ...await llvmAr.defaultResolver!.resolve(logger: logger),
-      ].firstOrNull?.uri;
+      ].first.uri;
       final cc = [
         ...await appleClang.defaultResolver!.resolve(logger: logger),
-        ...await clang.defaultResolver!.resolve(logger: logger),
         ...await cl.defaultResolver!.resolve(logger: logger),
+        ...await clang.defaultResolver!.resolve(logger: logger),
       ].first.uri;
       final ld = [
         ...await appleLd.defaultResolver!.resolve(logger: logger),
+        ...await lib.defaultResolver!.resolve(logger: logger),
         ...await lld.defaultResolver!.resolve(logger: logger),
-      ].firstOrNull?.uri;
+      ].first.uri;
       final buildConfig = BuildConfig(
         outDir: tempUri,
         packageRoot: tempUri,
@@ -40,9 +41,9 @@ void main() {
       final resolver =
           CompilerResolver(buildConfig: buildConfig, logger: logger);
       final compiler = await resolver.resolveCompiler();
-      final archiver = ar == null ? null : await resolver.resolveArchiver();
+      final archiver = await resolver.resolveArchiver();
       expect(compiler.uri, buildConfig.cc);
-      expect(archiver?.uri, buildConfig.ar);
+      expect(archiver.uri, buildConfig.ar);
     });
   });
 

--- a/pkgs/c_compiler/test/cbuilder/testfiles/add/src/add.c
+++ b/pkgs/c_compiler/test/cbuilder/testfiles/add/src/add.c
@@ -4,6 +4,12 @@
 
 #include <stdint.h>
 
-int32_t add(int32_t a, int32_t b) {
+#if _WIN32
+#define FFI_EXPORT __declspec(dllexport)
+#else
+#define FFI_EXPORT
+#endif
+
+FFI_EXPORT int32_t add(int32_t a, int32_t b) {
    return a+b;
 }

--- a/pkgs/c_compiler/test/helpers.dart
+++ b/pkgs/c_compiler/test/helpers.dart
@@ -13,6 +13,7 @@ const keepTempKey = 'KEEP_TEMPORARY_DIRECTORIES';
 Future<void> inTempDir(
   Future<void> Function(Uri tempUri) fun, {
   String? prefix,
+  bool keepTemp = false,
 }) async {
   final tempDir = await Directory.systemTemp.createTemp(prefix);
   // Deal with Windows temp folder aliases.
@@ -21,8 +22,9 @@ Future<void> inTempDir(
   try {
     await fun(tempUri);
   } finally {
-    if (!Platform.environment.containsKey(keepTempKey) ||
-        Platform.environment[keepTempKey]!.isEmpty) {
+    if ((!Platform.environment.containsKey(keepTempKey) ||
+            Platform.environment[keepTempKey]!.isEmpty) &&
+        !keepTemp) {
       await tempDir.delete(recursive: true);
     }
   }

--- a/pkgs/c_compiler/test/helpers.dart
+++ b/pkgs/c_compiler/test/helpers.dart
@@ -15,8 +15,11 @@ Future<void> inTempDir(
   String? prefix,
 }) async {
   final tempDir = await Directory.systemTemp.createTemp(prefix);
+  // Deal with Windows temp folder aliases.
+  final tempUri =
+      Directory(await tempDir.resolveSymbolicLinks()).uri.normalizePath();
   try {
-    await fun(tempDir.uri);
+    await fun(tempUri);
   } finally {
     if (!Platform.environment.containsKey(keepTempKey) ||
         Platform.environment[keepTempKey]!.isEmpty) {

--- a/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
@@ -33,4 +33,9 @@ void main() {
     final instances = await msvc.defaultResolver!.resolve(logger: logger);
     expect(instances.isNotEmpty, true);
   });
+
+  test('cl', () async {
+    final instances = await cl.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+  });
 }

--- a/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
@@ -9,7 +9,6 @@ import 'dart:io';
 
 import 'package:c_compiler/src/native_toolchain/msvc.dart';
 import 'package:c_compiler/src/utils/env_from_bat.dart';
-import 'package:c_compiler/src/utils/run_process.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';
@@ -42,7 +41,10 @@ void main() {
   });
 
   test('vsvars64', () async {
-    print(await envFromBat(Uri.file(
-        'C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build/vcvars64.bat')));
+    final instances = await vcvars64.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+    final instance = instances.first;
+    final env = await envFromBat(instance.uri);
+    expect(env['INCLUDE'] != null, true);
   });
 }

--- a/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
@@ -71,7 +71,12 @@ void main() {
   });
 
   test('vcvars32', () async {
-    final instances = await vcvars32.defaultResolver!.resolve(logger: logger);
+    final clInstances = await clIA32.defaultResolver!.resolve(logger: logger);
+    expect(clInstances.isNotEmpty, true);
+
+    final instances = await vcvars(clInstances.first)
+        .defaultResolver!
+        .resolve(logger: logger);
     expect(instances.isNotEmpty, true);
     final instance = instances.first;
     final env = await envFromBat(instance.uri);
@@ -80,7 +85,12 @@ void main() {
   });
 
   test('vcvars64', () async {
-    final instances = await vcvars64.defaultResolver!.resolve(logger: logger);
+    final clInstances = await cl.defaultResolver!.resolve(logger: logger);
+    expect(clInstances.isNotEmpty, true);
+
+    final instances = await vcvars(clInstances.first)
+        .defaultResolver!
+        .resolve(logger: logger);
     expect(instances.isNotEmpty, true);
     final instance = instances.first;
     final env = await envFromBat(instance.uri);

--- a/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
@@ -40,6 +40,11 @@ void main() {
     expect(instances.isNotEmpty, true);
   });
 
+  test('dumpbin', () async {
+    final instances = await dumpbin.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+  });
+
   test('vcvars32', () async {
     final instances = await vcvars32.defaultResolver!.resolve(logger: logger);
     expect(instances.isNotEmpty, true);

--- a/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
@@ -40,6 +40,11 @@ void main() {
     expect(instances.isNotEmpty, true);
   });
 
+  test('clIa32', () async {
+    final instances = await clIA32.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+  });
+
   test('dumpbin', () async {
     final instances = await dumpbin.defaultResolver!.resolve(logger: logger);
     expect(instances.isNotEmpty, true);

--- a/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
@@ -40,11 +40,46 @@ void main() {
     expect(instances.isNotEmpty, true);
   });
 
-  test('vsvars64', () async {
+  test('vcvars32', () async {
+    final instances = await vcvars32.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+    final instance = instances.first;
+    final env = await envFromBat(instance.uri);
+    expect(env['INCLUDE'] != null, true);
+    expect(env['WindowsSdkDir'] != null, true); // stdio.h
+  });
+
+  test('vcvars64', () async {
     final instances = await vcvars64.defaultResolver!.resolve(logger: logger);
     expect(instances.isNotEmpty, true);
     final instance = instances.first;
     final env = await envFromBat(instance.uri);
     expect(env['INCLUDE'] != null, true);
+    expect(env['WindowsSdkDir'] != null, true); // stdio.h
+  });
+
+  test('vcvarsall', () async {
+    final instances = await vcvarsall.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+    final instance = instances.first;
+    final env = await envFromBat(
+      instance.uri,
+      arguments: [
+        'x64',
+        'uwp',
+        '10.0',
+      ],
+    );
+    expect(env['INCLUDE'] != null, true);
+    expect(env['WindowsSdkDir'] != null, true); // stdio.h
+  });
+
+  test('vsDevCmd', () async {
+    final instances = await vsDevCmd.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+    final instance = instances.first;
+    final env = await envFromBat(instance.uri);
+    expect(env['INCLUDE'] != null, true);
+    expect(env['WindowsSdkDir'] != null, true); // stdio.h
   });
 }

--- a/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
@@ -28,4 +28,9 @@ void main() {
         await visualStudio.defaultResolver!.resolve(logger: logger);
     expect(instances.isNotEmpty, true);
   });
+
+  test('msvc', () async {
+    final instances = await msvc.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+  });
 }

--- a/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
@@ -20,7 +20,11 @@ void main() {
 
   test('vswhere', () async {
     final instances = await vswhere.defaultResolver!.resolve(logger: logger);
-    print(instances);
-    // expect(1, 2);
+    expect(instances.isNotEmpty, true);
+  });
+
+  test('msvc', () async {
+    final instances = await msvc.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
   });
 }

--- a/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
@@ -70,7 +70,7 @@ void main() {
     expect(instances.isNotEmpty, true);
   });
 
-  test('vcvars32', () async {
+  test('vcvars32 from cl.exe', () async {
     final clInstances = await clIA32.defaultResolver!.resolve(logger: logger);
     expect(clInstances.isNotEmpty, true);
 
@@ -84,13 +84,31 @@ void main() {
     expect(env['WindowsSdkDir'] != null, true); // stdio.h
   });
 
-  test('vcvars64', () async {
+  test('vcvars64 from cl.exe', () async {
     final clInstances = await cl.defaultResolver!.resolve(logger: logger);
     expect(clInstances.isNotEmpty, true);
 
     final instances = await vcvars(clInstances.first)
         .defaultResolver!
         .resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+    final instance = instances.first;
+    final env = await envFromBat(instance.uri);
+    expect(env['INCLUDE'] != null, true);
+    expect(env['WindowsSdkDir'] != null, true); // stdio.h
+  });
+
+  test('vcvars32', () async {
+    final instances = await vcvars32.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+    final instance = instances.first;
+    final env = await envFromBat(instance.uri);
+    expect(env['INCLUDE'] != null, true);
+    expect(env['WindowsSdkDir'] != null, true); // stdio.h
+  });
+
+  test('vcvars64', () async {
+    final instances = await vcvars64.defaultResolver!.resolve(logger: logger);
     expect(instances.isNotEmpty, true);
     final instance = instances.first;
     final env = await envFromBat(instance.uri);

--- a/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
@@ -40,8 +40,28 @@ void main() {
     expect(instances.isNotEmpty, true);
   });
 
-  test('clIa32', () async {
+  test('clIA32', () async {
     final instances = await clIA32.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+  });
+
+  test('lib', () async {
+    final instances = await lib.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+  });
+
+  test('libIA32', () async {
+    final instances = await libIA32.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+  });
+
+  test('link', () async {
+    final instances = await link.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+  });
+
+  test('linkIA32', () async {
+    final instances = await linkIA32.defaultResolver!.resolve(logger: logger);
     expect(instances.isNotEmpty, true);
   });
 

--- a/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
@@ -8,6 +8,8 @@ library;
 import 'dart:io';
 
 import 'package:c_compiler/src/native_toolchain/msvc.dart';
+import 'package:c_compiler/src/utils/env_from_bat.dart';
+import 'package:c_compiler/src/utils/run_process.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';
@@ -37,5 +39,10 @@ void main() {
   test('cl', () async {
     final instances = await cl.defaultResolver!.resolve(logger: logger);
     expect(instances.isNotEmpty, true);
+  });
+
+  test('vsvars64', () async {
+    print(await envFromBat(Uri.file(
+        'C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build/vcvars64.bat')));
   });
 }

--- a/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
@@ -23,8 +23,9 @@ void main() {
     expect(instances.isNotEmpty, true);
   });
 
-  test('msvc', () async {
-    final instances = await msvc.defaultResolver!.resolve(logger: logger);
+  test('visualStudio', () async {
+    final instances =
+        await visualStudio.defaultResolver!.resolve(logger: logger);
     expect(instances.isNotEmpty, true);
   });
 }

--- a/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/msvc_test.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('windows')
+library;
+
+import 'dart:io';
+
+import 'package:c_compiler/src/native_toolchain/msvc.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+
+void main() {
+  if (!Platform.isWindows) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
+
+  test('vswhere', () async {
+    final instances = await vswhere.defaultResolver!.resolve(logger: logger);
+    print(instances);
+    // expect(1, 2);
+  });
+}

--- a/pkgs/c_compiler/test/native_toolchain/recognizer_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/recognizer_test.dart
@@ -35,6 +35,8 @@ void main() async {
     RecognizerTest(i686LinuxGnuGcc, CompilerRecognizer.new),
     RecognizerTest(i686LinuxGnuGccAr, ArchiverRecognizer.new),
     RecognizerTest(i686LinuxGnuLd, LinkerRecognizer.new),
+    RecognizerTest(lib, ArchiverRecognizer.new),
+    RecognizerTest(link, LinkerRecognizer.new),
     RecognizerTest(lld, LinkerRecognizer.new),
     RecognizerTest(llvmAr, ArchiverRecognizer.new),
   ];

--- a/pkgs/c_compiler/test/native_toolchain/recognizer_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/recognizer_test.dart
@@ -6,6 +6,7 @@ import 'package:c_compiler/src/native_toolchain/android_ndk.dart';
 import 'package:c_compiler/src/native_toolchain/apple_clang.dart';
 import 'package:c_compiler/src/native_toolchain/clang.dart';
 import 'package:c_compiler/src/native_toolchain/gcc.dart';
+import 'package:c_compiler/src/native_toolchain/msvc.dart';
 import 'package:c_compiler/src/native_toolchain/recognizer.dart';
 import 'package:c_compiler/src/tool/tool.dart';
 import 'package:c_compiler/src/tool/tool_instance.dart';
@@ -29,6 +30,7 @@ void main() async {
     RecognizerTest(armLinuxGnueabihfGcc, CompilerRecognizer.new),
     RecognizerTest(armLinuxGnueabihfGccAr, ArchiverRecognizer.new),
     RecognizerTest(armLinuxGnueabihfLd, LinkerRecognizer.new),
+    RecognizerTest(cl, CompilerRecognizer.new),
     RecognizerTest(clang, CompilerRecognizer.new),
     RecognizerTest(i686LinuxGnuGcc, CompilerRecognizer.new),
     RecognizerTest(i686LinuxGnuGccAr, ArchiverRecognizer.new),

--- a/pkgs/c_compiler/test/tool/tool_resolver_test.dart
+++ b/pkgs/c_compiler/test/tool/tool_resolver_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:c_compiler/c_compiler.dart';
+import 'package:c_compiler/src/native_toolchain/msvc.dart';
 import 'package:c_compiler/src/tool/tool_error.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
@@ -13,23 +14,39 @@ import '../helpers.dart';
 
 void main() {
   test('CliVersionResolver.executableVersion', () async {
-    final clangInstances = [
+    final toolInstances = [
       ...await appleClang.defaultResolver!.resolve(logger: logger),
       ...await clang.defaultResolver!.resolve(logger: logger),
+      ...await cl.defaultResolver!.resolve(logger: logger),
     ];
-    expect(clangInstances.isNotEmpty, true);
-    final version =
-        await CliVersionResolver.executableVersion(clangInstances.first.uri);
+    expect(toolInstances.isNotEmpty, true);
+    final toolInstance = toolInstances.first;
+    final versionArguments = [
+      if (toolInstance.tool != cl) '--version',
+    ];
+    final version = await CliVersionResolver.executableVersion(
+      toolInstance.uri,
+      arguments: versionArguments,
+      logger: logger,
+    );
     expect(version.major > 5, true);
     expect(
-      () => CliVersionResolver.executableVersion(clangInstances.first.uri,
-          expectedExitCode: 9999),
+      () => CliVersionResolver.executableVersion(
+        toolInstances.first.uri,
+        arguments: versionArguments,
+        expectedExitCode: 9999,
+        logger: logger,
+      ),
       throwsA(isA<ToolError>()),
     );
 
     try {
-      await CliVersionResolver.executableVersion(clangInstances.first.uri,
-          expectedExitCode: 9999);
+      await CliVersionResolver.executableVersion(
+        toolInstances.first.uri,
+        arguments: versionArguments,
+        expectedExitCode: 9999,
+        logger: logger,
+      );
       // ignore: avoid_catching_errors
     } on ToolError catch (e) {
       expect(e.toString(), contains('returned unexpected exit code'));
@@ -44,12 +61,21 @@ void main() {
       final bazExeUri = tempUri.resolve(bazExeName);
       await File.fromUri(barExeUri).writeAsString('dummy');
       await File.fromUri(bazExeUri).writeAsString('dummy');
+      expect(await File.fromUri(barExeUri).exists(), true);
+      expect(await File.fromUri(bazExeUri).exists(), true);
       final barResolver = InstallLocationResolver(
-          toolName: 'bar', paths: [barExeUri.toFilePath()]);
+        toolName: 'bar',
+        paths: [barExeUri.toFilePath().replaceAll('\\', '/')],
+      );
       final bazResolver = RelativeToolResolver(
         toolName: 'baz',
         wrappedResolver: barResolver,
-        relativePath: Uri(path: bazExeName),
+        relativePath: Uri.file(bazExeName),
+      );
+      final resolvedBarInstances = await barResolver.resolve(logger: logger);
+      expect(
+        resolvedBarInstances,
+        [ToolInstance(tool: Tool(name: 'bar'), uri: barExeUri)],
       );
       final resolvedBazInstances = await bazResolver.resolve(logger: logger);
       expect(
@@ -67,9 +93,11 @@ void main() {
       final bazExeUri = tempUri.resolve(bazExeName);
       await File.fromUri(barExeUri).writeAsString('dummy');
       final barResolver = InstallLocationResolver(
-          toolName: 'bar', paths: [barExeUri.toFilePath()]);
+          toolName: 'bar',
+          paths: [barExeUri.toFilePath().replaceAll('\\', '/')]);
       final bazResolver = InstallLocationResolver(
-          toolName: 'baz', paths: [bazExeUri.toFilePath()]);
+          toolName: 'baz',
+          paths: [bazExeUri.toFilePath().replaceAll('\\', '/')]);
       final barLogs = <String>[];
       final bazLogs = <String>[];
       await barResolver.resolve(logger: createCapturingLogger(barLogs));

--- a/pkgs/native_assets_cli/lib/src/model/build_config.dart
+++ b/pkgs/native_assets_cli/lib/src/model/build_config.dart
@@ -211,13 +211,13 @@ class BuildConfig {
   }
 
   Map<String, Object> toYaml() => {
-        outDirConfigKey: _outDir.path,
-        packageRootConfigKey: _packageRoot.path,
+        outDirConfigKey: _outDir.toFilePath(),
+        packageRootConfigKey: _packageRoot.toFilePath(),
         Target.configKey: _target.toString(),
         if (_targetIOSSdk != null) IOSSdk.configKey: _targetIOSSdk.toString(),
-        if (_ar != null) arConfigKey: _ar!.path,
-        if (_cc != null) ccConfigKey: _cc!.path,
-        if (_ld != null) ldConfigKey: _ld!.path,
+        if (_ar != null) arConfigKey: _ar!.toFilePath(),
+        if (_cc != null) ccConfigKey: _cc!.toFilePath(),
+        if (_ld != null) ldConfigKey: _ld!.toFilePath(),
         PackagingPreference.configKey: _packaging.toString(),
         if (_dependencyMetadata != null)
           dependencyMetadataConfigKey: {

--- a/pkgs/native_assets_cli/lib/src/model/dependencies.dart
+++ b/pkgs/native_assets_cli/lib/src/model/dependencies.dart
@@ -29,7 +29,7 @@ class Dependencies {
       ]);
 
   List<String> toYaml() => [
-        for (final dependency in dependencies) dependency.path,
+        for (final dependency in dependencies) dependency.toFilePath(),
       ];
 
   String toYamlString() => yamlEncode(toYaml());

--- a/pkgs/native_assets_cli/test/example/native_add_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_test.dart
@@ -20,7 +20,7 @@ void main() async {
     await Directory.fromUri(tempUri).delete(recursive: true);
   });
 
-  test('native_add build', () async {
+  test('native_add build', timeout: Timeout.factor(2), () async {
     final testTempUri = tempUri.resolve('test1/');
     await Directory.fromUri(testTempUri).create();
     final testPackageUri = packageUri.resolve('example/native_add/');

--- a/pkgs/native_assets_cli/test/example/native_add_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_test.dart
@@ -30,8 +30,8 @@ void main() async {
       dartUri.toFilePath(),
       [
         'build.dart',
-        '-Dout_dir=${tempUri.path}',
-        '-Dpackage_root=${testPackageUri.path}',
+        '-Dout_dir=${tempUri.toFilePath()}',
+        '-Dpackage_root=${testPackageUri.toFilePath()}',
         '-Dtarget=${Target.current}',
         '-Dpackaging=dynamic',
         if (cc != null) '-Dcc=${cc!.toFilePath()}',

--- a/pkgs/native_assets_cli/test/example/native_add_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_test.dart
@@ -27,7 +27,7 @@ void main() async {
     final dartUri = Uri.file(Platform.resolvedExecutable);
 
     final processResult = await Process.run(
-      dartUri.path,
+      dartUri.toFilePath(),
       [
         'build.dart',
         '-Dout_dir=${tempUri.path}',
@@ -36,7 +36,7 @@ void main() async {
         '-Dpackaging=dynamic',
         if (cc != null) '-Dcc=${cc!.toFilePath()}',
       ],
-      workingDirectory: testPackageUri.path,
+      workingDirectory: testPackageUri.toFilePath(),
     );
     if (processResult.exitCode != 0) {
       print(processResult.stdout);

--- a/pkgs/native_assets_cli/test/model/asset_test.dart
+++ b/pkgs/native_assets_cli/test/model/asset_test.dart
@@ -7,22 +7,27 @@ import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
 
 void main() {
+  final fooUri = Uri.file('path/to/libfoo.so');
+  final foo2Uri = Uri.file('path/to/libfoo2.so');
+  final foo3Uri = Uri(path: 'libfoo3.so');
+  final barUri = Uri(path: 'path/to/libbar.a');
+  final blaUri = Uri(path: 'path/with spaces/bla.dll');
   final assets = [
     Asset(
       name: 'foo',
-      path: AssetAbsolutePath(Uri(path: 'path/to/libfoo.so')),
+      path: AssetAbsolutePath(fooUri),
       target: Target.androidX64,
       packaging: Packaging.dynamic,
     ),
     Asset(
       name: 'foo2',
-      path: AssetRelativePath(Uri(path: 'path/to/libfoo2.so')),
+      path: AssetRelativePath(foo2Uri),
       target: Target.androidX64,
       packaging: Packaging.dynamic,
     ),
     Asset(
       name: 'foo3',
-      path: AssetSystemPath(Uri(path: 'libfoo3.so')),
+      path: AssetSystemPath(foo3Uri),
       target: Target.androidX64,
       packaging: Packaging.dynamic,
     ),
@@ -40,35 +45,35 @@ void main() {
     ),
     Asset(
       name: 'bar',
-      path: AssetAbsolutePath(Uri(path: 'path/to/libbar.a')),
+      path: AssetAbsolutePath(barUri),
       target: Target.linuxArm64,
       packaging: Packaging.static,
     ),
     Asset(
       name: 'bla',
-      path: AssetAbsolutePath(Uri(path: 'path/with spaces/bla.dll')),
+      path: AssetAbsolutePath(blaUri),
       target: Target.windowsX64,
       packaging: Packaging.dynamic,
     ),
   ];
 
-  const assetsYamlEncoding = '''- name: foo
+  final assetsYamlEncoding = '''- name: foo
   packaging: dynamic
   path:
     path_type: absolute
-    uri: path/to/libfoo.so
+    uri: ${fooUri.toFilePath()}
   target: android_x64
 - name: foo2
   packaging: dynamic
   path:
     path_type: relative
-    uri: path/to/libfoo2.so
+    uri: ${foo2Uri.toFilePath()}
   target: android_x64
 - name: foo3
   packaging: dynamic
   path:
     path_type: system
-    uri: libfoo3.so
+    uri: ${foo3Uri.toFilePath()}
   target: android_x64
 - name: foo4
   packaging: dynamic
@@ -84,16 +89,16 @@ void main() {
   packaging: static
   path:
     path_type: absolute
-    uri: path/to/libbar.a
+    uri: ${barUri.toFilePath()}
   target: linux_arm64
 - name: bla
   packaging: dynamic
   path:
     path_type: absolute
-    uri: path/with spaces/bla.dll
+    uri: ${blaUri.toFilePath()}
   target: windows_x64''';
 
-  const assetsDartEncoding = '''format-version:
+  final assetsDartEncoding = '''format-version:
   - 1
   - 0
   - 0
@@ -101,13 +106,13 @@ native-assets:
   android_x64:
     foo:
       - absolute
-      - path/to/libfoo.so
+      - ${fooUri.toFilePath()}
     foo2:
       - relative
-      - path/to/libfoo2.so
+      - ${foo2Uri.toFilePath()}
     foo3:
       - system
-      - libfoo3.so
+      - ${foo3Uri.toFilePath()}
     foo4:
       - executable
     foo5:
@@ -115,14 +120,14 @@ native-assets:
   linux_arm64:
     bar:
       - absolute
-      - path/to/libbar.a
+      - ${barUri.toFilePath()}
   windows_x64:
     bla:
       - absolute
-      - path/with spaces/bla.dll''';
+      - ${blaUri.toFilePath()}''';
 
   test('asset yaml', () {
-    final yaml = assets.toYamlString().replaceAll('\\', '/');
+    final yaml = assets.toYamlString();
     expect(yaml, assetsYamlEncoding);
     final assets2 = Asset.listFromYamlString(yaml);
     expect(assets, assets2);
@@ -130,7 +135,7 @@ native-assets:
 
   test('asset yaml', () async {
     final fileContents = assets.toNativeAssetsFile();
-    expect(fileContents.replaceAll('\\', '/'), assetsDartEncoding);
+    expect(fileContents, assetsDartEncoding);
   });
 
   test('AssetPath factory', () async {
@@ -173,7 +178,7 @@ name: foo
 packaging: dynamic
 path:
   path_type: absolute
-  uri: path/to/libfoo.so
+  uri: ${fooUri.toFilePath()}
 target: android_x64
 '''
             .trim());

--- a/pkgs/native_assets_cli/test/model/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_config_test.dart
@@ -155,7 +155,7 @@ void main() async {
       },
     );
     final yamlString = buildConfig1.toYamlString();
-    final expectedYamlString = '''cc: ${fakeClang.path}
+    final expectedYamlString = '''cc: ${fakeClang.toFilePath()}
 dependency_metadata:
   bar:
     key: value
@@ -164,9 +164,9 @@ dependency_metadata:
     z:
       - z
       - a
-ld: ${fakeLd.path}
-out_dir: ${outDir.path}
-package_root: ${tempUri.path}
+ld: ${fakeLd.toFilePath()}
+out_dir: ${outDir.toFilePath()}
+package_root: ${tempUri.toFilePath()}
 packaging: prefer-static
 target: ios_arm64
 target_ios_sdk: iphoneos''';

--- a/pkgs/native_assets_cli/test/model/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_config_test.dart
@@ -69,8 +69,8 @@ void main() async {
     );
 
     final config = Config(fileParsed: {
-      'out_dir': tempUri.resolve('out2/').path,
-      'package_root': tempUri.resolve('packageRoot/').path,
+      'out_dir': tempUri.resolve('out2/').toFilePath(),
+      'package_root': tempUri.resolve('packageRoot/').toFilePath(),
       'target': 'android_arm64',
       'packaging': 'prefer-static',
     });
@@ -187,7 +187,7 @@ target_ios_sdk: iphoneos''';
     );
     expect(
       () => BuildConfig.fromConfig(Config(fileParsed: {
-        'package_root': tempUri.resolve('packageRoot/').path,
+        'package_root': tempUri.resolve('packageRoot/').toFilePath(),
         'target': 'android_arm64',
         'packaging': 'prefer-static',
       })),
@@ -195,8 +195,8 @@ target_ios_sdk: iphoneos''';
     );
     expect(
       () => BuildConfig.fromConfig(Config(fileParsed: {
-        'out_dir': tempUri.resolve('out2/').path,
-        'package_root': tempUri.resolve('packageRoot/').path,
+        'out_dir': tempUri.resolve('out2/').toFilePath(),
+        'package_root': tempUri.resolve('packageRoot/').toFilePath(),
         'target': 'android_arm64',
         'packaging': 'prefer-static',
         'dependency_metadata': {
@@ -211,8 +211,8 @@ target_ios_sdk: iphoneos''';
   test('FormatExceptions contain full stack trace of wrapped exception', () {
     try {
       BuildConfig.fromConfig(Config(fileParsed: {
-        'out_dir': tempUri.resolve('out2/').path,
-        'package_root': tempUri.resolve('packageRoot/').path,
+        'out_dir': tempUri.resolve('out2/').toFilePath(),
+        'package_root': tempUri.resolve('packageRoot/').toFilePath(),
         'target': [1, 2, 3, 4, 5],
         'packaging': 'prefer-static',
       }));

--- a/pkgs/native_assets_cli/test/model/dependencies_test.dart
+++ b/pkgs/native_assets_cli/test/model/dependencies_test.dart
@@ -10,7 +10,10 @@ import 'package:test/test.dart';
 void main() {
   late Uri tempUri;
 
-  setUp(() async => tempUri = (await Directory.systemTemp.createTemp()).uri);
+  setUp(() async => tempUri = Directory(
+          await (await Directory.systemTemp.createTemp())
+              .resolveSymbolicLinks())
+      .uri);
 
   tearDown(
       () async => await Directory.fromUri(tempUri).delete(recursive: true));
@@ -54,6 +57,11 @@ void main() {
   });
 
   test('dependencies lastModified symlinks', () async {
+    if (Platform.isWindows) {
+      // Requires extra privilege, skip.
+      // "A required privilege is not held by the client"
+      return;
+    }
     final symlink = Link.fromUri(tempUri.resolve('my_link'));
     await symlink.create(tempUri.toFilePath());
 


### PR DESCRIPTION
Compilation on Windows with visual studio.

Closes:

* https://github.com/dart-lang/native/issues/15

Some more details:

* Visual studio installations can be found with https://github.com/microsoft/vswhere.
* This PR basically automates https://learn.microsoft.com/en-us/cpp/build/walkthrough-compile-a-c-program-on-the-command-line?view=msvc-170
  * The compiler itself is `cl.exe`, there are two, one for each target architecture.
  * In order to have the right include paths etc, a `vcvarsxxx.bat` has to be invoked. We capture the environment variables by looking at `set` before and after the batch script invocation.

This PR contains a lot of `.toFilePath()` refactorings to ensure paths are handled correctly on Windows.

Also in this PR, the `RelativePath` tool resolver now takes globs instead of uri's so that we can resolve relative paths with `/bla/*/` where `*` can be a version number for example.