### PR TITLE
Windows dart ci

### DIFF
--- a/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
@@ -174,4 +174,29 @@ class CompilerResolver {
     logger?.finer('No archiver set in config[${BuildConfig.arConfigKey}].');
     return null;
   }
+
+  Future<Uri?> toolchainEnvironmentScript(ToolInstance compiler) async {
+    final fromConfig = buildConfig.toolchainEnvScript;
+    if (fromConfig != null) {
+      logger?.fine('Using toolchainEnvScript from config: $fromConfig');
+      return fromConfig;
+    }
+
+    final compilerTool = compiler.tool;
+    assert(compilerTool == cl);
+    final vcvarsScript =
+        (await vcvars(compiler).defaultResolver!.resolve(logger: logger)).first;
+    return vcvarsScript.uri;
+  }
+
+  List<String>? toolchainEnvironmentScriptArguments(ToolInstance compiler) {
+    final fromConfig = buildConfig.toolchainEnvScriptArgs;
+    if (fromConfig != null) {
+      logger?.fine('Using toolchainEnvScriptArgs from config: $fromConfig');
+      return fromConfig;
+    }
+
+    // vcvars above already has x64 or x86 in the script name.
+    return null;
+  }
 }

--- a/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
@@ -189,7 +189,7 @@ class CompilerResolver {
     return vcvarsScript.uri;
   }
 
-  List<String>? toolchainEnvironmentScriptArguments(ToolInstance compiler) {
+  List<String>? toolchainEnvironmentScriptArguments() {
     final fromConfig = buildConfig.toolchainEnvScriptArgs;
     if (fromConfig != null) {
       logger?.fine('Using toolchainEnvScriptArgs from config: $fromConfig');

--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -139,7 +139,7 @@ class RunCBuilder {
 
   Future<void> runCl({required ToolInstance compiler}) async {
     final vcvars = (await _resolver.toolchainEnvironmentScript(compiler))!;
-    final vcvarsArgs = _resolver.toolchainEnvironmentScriptArguments(compiler);
+    final vcvarsArgs = _resolver.toolchainEnvironmentScriptArguments();
     final environment = await envFromBat(vcvars, arguments: vcvarsArgs ?? []);
 
     final isStaticLib = staticLibrary != null;

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_test.dart
@@ -28,6 +28,8 @@ void main() {
         target: Target.current,
         packaging: PackagingPreference.dynamic, // Ignored by executables.
         cc: cc,
+        toolchainEnvScript: toolchainEnvScript,
+        toolchainEnvScriptArgs: toolchainEnvScriptArgs,
       );
       final buildOutput = BuildOutput();
       final cbuilder = CBuilder.executable(
@@ -67,6 +69,8 @@ void main() {
           target: Target.current,
           packaging: PackagingPreference.dynamic,
           cc: cc,
+          toolchainEnvScript: toolchainEnvScript,
+          toolchainEnvScriptArgs: toolchainEnvScriptArgs,
         );
         final buildOutput = BuildOutput();
 

--- a/pkgs/c_compiler/test/cbuilder/compiler_resolver_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/compiler_resolver_test.dart
@@ -6,6 +6,7 @@ import 'package:c_compiler/c_compiler.dart';
 import 'package:c_compiler/src/cbuilder/compiler_resolver.dart';
 import 'package:c_compiler/src/native_toolchain/msvc.dart';
 import 'package:c_compiler/src/tool/tool_error.dart';
+import 'package:collection/collection.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
 
@@ -29,6 +30,9 @@ void main() {
         ...await lib.defaultResolver!.resolve(logger: logger),
         ...await lld.defaultResolver!.resolve(logger: logger),
       ].first.uri;
+      final toolchainEnvScript = [
+        ...await vcvars64.defaultResolver!.resolve(logger: logger)
+      ].firstOrNull?.uri;
       final buildConfig = BuildConfig(
         outDir: tempUri,
         packageRoot: tempUri,
@@ -37,6 +41,7 @@ void main() {
         ar: ar,
         cc: cc,
         ld: ld,
+        toolchainEnvScript: toolchainEnvScript,
       );
       final resolver =
           CompilerResolver(buildConfig: buildConfig, logger: logger);

--- a/pkgs/c_compiler/test/helpers.dart
+++ b/pkgs/c_compiler/test/helpers.dart
@@ -96,6 +96,16 @@ final Uri? cc = Platform.environment['CC']?.asFileUri();
 /// Linker provided by the environment.
 final Uri? ld = Platform.environment['LD']?.asFileUri();
 
+/// Path to script that sets environment variables for [cc], [ld], and [ar].
+///
+/// Provided by environment.
+final Uri? toolchainEnvScript =
+    Platform.environment['ToolchainEnvScript']?.asFileUri();
+
+/// Arguments for [toolchainEnvScript] provided by environment.
+final List<String>? toolchainEnvScriptArgs =
+    Platform.environment['ToolchainEnvScriptArguments']?.split(' ');
+
 extension on String {
   Uri asFileUri() => Uri.file(this);
 }

--- a/pkgs/native_assets_cli/test/example/native_add_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_test.dart
@@ -35,6 +35,12 @@ void main() async {
         '-Dtarget=${Target.current}',
         '-Dpackaging=dynamic',
         if (cc != null) '-Dcc=${cc!.toFilePath()}',
+        if (toolchainEnvScript != null)
+          '-D${BuildConfig.toolchainEnvScriptConfigKey}='
+              '${toolchainEnvScript!.toFilePath()}',
+        if (toolchainEnvScriptArgs != null)
+          '-D${BuildConfig.toolchainEnvScriptArgsConfigKey}='
+              '${toolchainEnvScriptArgs!.join(' ')}',
       ],
       workingDirectory: testPackageUri.toFilePath(),
     );

--- a/pkgs/native_assets_cli/test/helpers.dart
+++ b/pkgs/native_assets_cli/test/helpers.dart
@@ -56,6 +56,16 @@ final Uri? cc = Platform.environment['CC']?.asFileUri();
 /// Linker provided by the environment.
 final Uri? ld = Platform.environment['LD']?.asFileUri();
 
+/// Path to script that sets environment variables for [cc], [ld], and [ar].
+///
+/// Provided by environment.
+final Uri? toolchainEnvScript =
+    Platform.environment['ToolchainEnvScript']?.asFileUri();
+
+/// Arguments for [toolchainEnvScript] provided by environment.
+final List<String>? toolchainEnvScriptArgs =
+    Platform.environment['ToolchainEnvScriptArguments']?.split(' ');
+
 extension on String {
   Uri asFileUri() => Uri.file(this);
 }

--- a/pkgs/native_assets_cli/test/model/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_config_test.dart
@@ -13,6 +13,8 @@ void main() async {
   late Uri fakeClang;
   late Uri fakeLd;
   late Uri fakeAr;
+  late Uri fakeCl;
+  late Uri fakeVcVars;
 
   setUp(() async {
     tempUri = (await Directory.systemTemp.createTemp()).uri;
@@ -22,6 +24,10 @@ void main() async {
     await File.fromUri(fakeLd).create();
     fakeAr = tempUri.resolve('fake_ar');
     await File.fromUri(fakeAr).create();
+    fakeCl = tempUri.resolve('cl.exe');
+    await File.fromUri(fakeCl).create();
+    fakeVcVars = tempUri.resolve('vcvarsall.bat');
+    await File.fromUri(fakeVcVars).create();
   });
 
   tearDown(() async {
@@ -274,5 +280,22 @@ target_ios_sdk: iphoneos''';
       ].join('.')),
       'value',
     );
+  });
+
+  test('toolchainEnvScript', () {
+    final buildConfig1 = BuildConfig(
+      outDir: tempUri.resolve('out1/'),
+      packageRoot: tempUri.resolve('packageRoot/'),
+      target: Target.windowsX64,
+      cc: fakeCl,
+      toolchainEnvScript: fakeVcVars,
+      toolchainEnvScriptArgs: ['x64'],
+      packaging: PackagingPreference.dynamic,
+    );
+
+    final configFile = buildConfig1.toYaml();
+    final config = Config(fileParsed: configFile);
+    final fromConfig = BuildConfig.fromConfig(config);
+    expect(fromConfig, equals(buildConfig1));
   });
 }


### PR DESCRIPTION
When using MSVCs `cl.exe` an accompanying script sets the right environment variables, such as `INCLUDE`.
In visual studio this is `vcvarsall.bat`, `vcvars64.bat` or a similar script, which can be discovered in a relative path from `cl.exe`.

However, on the Dart CI bots, we use a custom script which serves the same purpose.
See https://chromium.googlesource.com/chromium/tools/depot_tools/+/master/win_toolchain/.

We might as well make the script configurable in general, as maybe more compilers require setting the right environment variables. (Side note: on the Dart CI we also use a `clang.exe` with this same environment variables script so that the `clang.exe` can also find the Windows implementations for `printf` etc.)

Dart CL: https://dart-review.googlesource.com/c/sdk/+/298580