### PR TITLE
[native_assets_cli] Nest `c_compiler` config

### DIFF
--- a/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
@@ -33,8 +33,8 @@ class CompilerResolver {
   Future<ToolInstance> resolveCompiler() async {
     // First, check if the launcher provided a direct path to the compiler.
     var result = await _tryLoadCompilerFromConfig(
-      BuildConfig.ccConfigKey,
-      (buildConfig) => buildConfig.cc,
+      CCompilerConfig.ccConfigKeyFull,
+      (buildConfig) => buildConfig.cCompiler.cc,
     );
 
     // Then, try to detect on the host machine.
@@ -91,11 +91,12 @@ class CompilerResolver {
     if (configCcUri != null) {
       assert(await File.fromUri(configCcUri).exists());
       logger?.finer('Using compiler ${configCcUri.toFilePath()} '
-          'from config[${BuildConfig.ccConfigKey}].');
+          'from config[${CCompilerConfig.ccConfigKeyFull}].');
       return (await CompilerRecognizer(configCcUri).resolve(logger: logger))
           .first;
     }
-    logger?.finer('No compiler set in config[${BuildConfig.ccConfigKey}].');
+    logger?.finer(
+        'No compiler set in config[${CCompilerConfig.ccConfigKeyFull}].');
     return null;
   }
 
@@ -110,8 +111,8 @@ class CompilerResolver {
   Future<ToolInstance> resolveArchiver() async {
     // First, check if the launcher provided a direct path to the compiler.
     var result = await _tryLoadArchiverFromConfig(
-      BuildConfig.arConfigKey,
-      (buildConfig) => buildConfig.ar,
+      CCompilerConfig.arConfigKeyFull,
+      (buildConfig) => buildConfig.cCompiler.ar,
     );
 
     // Then, try to detect on the host machine.
@@ -167,16 +168,17 @@ class CompilerResolver {
     if (configArUri != null) {
       assert(await File.fromUri(configArUri).exists());
       logger?.finer('Using archiver ${configArUri.toFilePath()} '
-          'from config[${BuildConfig.arConfigKey}].');
+          'from config[${CCompilerConfig.arConfigKeyFull}].');
       return (await ArchiverRecognizer(configArUri).resolve(logger: logger))
           .first;
     }
-    logger?.finer('No archiver set in config[${BuildConfig.arConfigKey}].');
+    logger?.finer(
+        'No archiver set in config[${CCompilerConfig.arConfigKeyFull}].');
     return null;
   }
 
   Future<Uri?> toolchainEnvironmentScript(ToolInstance compiler) async {
-    final fromConfig = buildConfig.toolchainEnvScript;
+    final fromConfig = buildConfig.cCompiler.toolchainEnvScript;
     if (fromConfig != null) {
       logger?.fine('Using toolchainEnvScript from config: $fromConfig');
       return fromConfig;
@@ -190,7 +192,7 @@ class CompilerResolver {
   }
 
   List<String>? toolchainEnvironmentScriptArguments() {
-    final fromConfig = buildConfig.toolchainEnvScriptArgs;
+    final fromConfig = buildConfig.cCompiler.toolchainEnvScriptArgs;
     if (fromConfig != null) {
       logger?.fine('Using toolchainEnvScriptArgs from config: $fromConfig');
       return fromConfig;

--- a/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/compiler_resolver.dart
@@ -178,9 +178,9 @@ class CompilerResolver {
   }
 
   Future<Uri?> toolchainEnvironmentScript(ToolInstance compiler) async {
-    final fromConfig = buildConfig.cCompiler.toolchainEnvScript;
+    final fromConfig = buildConfig.cCompiler.envScript;
     if (fromConfig != null) {
-      logger?.fine('Using toolchainEnvScript from config: $fromConfig');
+      logger?.fine('Using envScript from config: $fromConfig');
       return fromConfig;
     }
 
@@ -192,9 +192,9 @@ class CompilerResolver {
   }
 
   List<String>? toolchainEnvironmentScriptArguments() {
-    final fromConfig = buildConfig.cCompiler.toolchainEnvScriptArgs;
+    final fromConfig = buildConfig.cCompiler.envScriptArgs;
     if (fromConfig != null) {
-      logger?.fine('Using toolchainEnvScriptArgs from config: $fromConfig');
+      logger?.fine('Using envScriptArgs from config: $fromConfig');
       return fromConfig;
     }
 

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -46,8 +46,7 @@ void main() {
 
   for (final linkMode in LinkMode.values) {
     for (final target in targets) {
-      test('Cbuilder $linkMode library $target', timeout: Timeout.factor(2),
-          () async {
+      test('Cbuilder $linkMode library $target', () async {
         await inTempDir((tempUri) async {
           final addCUri =
               packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_test.dart
@@ -29,11 +29,13 @@ void main() {
         outDir: tempUri,
         packageRoot: tempUri,
         target: Target.current,
-        linkModePreference:
-            LinkModePreference.dynamic, // Ignored by executables.
-        cc: cc,
-        toolchainEnvScript: toolchainEnvScript,
-        toolchainEnvScriptArgs: toolchainEnvScriptArgs,
+        // Ignored by executables.
+        linkModePreference: LinkModePreference.dynamic,
+        cCompiler: CCompilerConfig(
+          cc: cc,
+          toolchainEnvScript: toolchainEnvScript,
+          toolchainEnvScriptArgs: toolchainEnvScriptArgs,
+        ),
       );
       final buildOutput = BuildOutput();
       final cbuilder = CBuilder.executable(
@@ -72,9 +74,11 @@ void main() {
           packageRoot: tempUri,
           target: Target.current,
           linkModePreference: LinkModePreference.dynamic,
-          cc: cc,
-          toolchainEnvScript: toolchainEnvScript,
-          toolchainEnvScriptArgs: toolchainEnvScriptArgs,
+          cCompiler: CCompilerConfig(
+            cc: cc,
+            toolchainEnvScript: toolchainEnvScript,
+            toolchainEnvScriptArgs: toolchainEnvScriptArgs,
+          ),
         );
         final buildOutput = BuildOutput();
 

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_test.dart
@@ -33,8 +33,8 @@ void main() {
         linkModePreference: LinkModePreference.dynamic,
         cCompiler: CCompilerConfig(
           cc: cc,
-          toolchainEnvScript: toolchainEnvScript,
-          toolchainEnvScriptArgs: toolchainEnvScriptArgs,
+          envScript: envScript,
+          envScriptArgs: envScriptArgs,
         ),
       );
       final buildOutput = BuildOutput();
@@ -76,8 +76,8 @@ void main() {
           linkModePreference: LinkModePreference.dynamic,
           cCompiler: CCompilerConfig(
             cc: cc,
-            toolchainEnvScript: toolchainEnvScript,
-            toolchainEnvScriptArgs: toolchainEnvScriptArgs,
+            envScript: envScript,
+            envScriptArgs: envScriptArgs,
           ),
         );
         final buildOutput = BuildOutput();

--- a/pkgs/c_compiler/test/cbuilder/compiler_resolver_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/compiler_resolver_test.dart
@@ -42,17 +42,19 @@ void main() {
         packageRoot: tempUri,
         target: Target.current,
         linkModePreference: LinkModePreference.dynamic,
-        ar: ar,
-        cc: cc,
-        ld: ld,
-        toolchainEnvScript: toolchainEnvScript,
+        cCompiler: CCompilerConfig(
+          ar: ar,
+          cc: cc,
+          ld: ld,
+          toolchainEnvScript: toolchainEnvScript,
+        ),
       );
       final resolver =
           CompilerResolver(buildConfig: buildConfig, logger: logger);
       final compiler = await resolver.resolveCompiler();
       final archiver = await resolver.resolveArchiver();
-      expect(compiler.uri, buildConfig.cc);
-      expect(archiver.uri, buildConfig.ar);
+      expect(compiler.uri, buildConfig.cCompiler.cc);
+      expect(archiver.uri, buildConfig.cCompiler.ar);
     });
   });
 

--- a/pkgs/c_compiler/test/cbuilder/compiler_resolver_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/compiler_resolver_test.dart
@@ -34,7 +34,7 @@ void main() {
         ...await lib.defaultResolver!.resolve(logger: logger),
         ...await lld.defaultResolver!.resolve(logger: logger),
       ].first.uri;
-      final toolchainEnvScript = [
+      final envScript = [
         ...await vcvars64.defaultResolver!.resolve(logger: logger)
       ].firstOrNull?.uri;
       final buildConfig = BuildConfig(
@@ -46,7 +46,7 @@ void main() {
           ar: ar,
           cc: cc,
           ld: ld,
-          toolchainEnvScript: toolchainEnvScript,
+          envScript: envScript,
         ),
       );
       final resolver =

--- a/pkgs/c_compiler/test/helpers.dart
+++ b/pkgs/c_compiler/test/helpers.dart
@@ -88,22 +88,23 @@ extension on Uri {
 }
 
 /// Archiver provided by the environment.
-final Uri? ar = Platform.environment['AR']?.asFileUri();
+final Uri? ar = Platform.environment['C_COMPILER__AR']?.asFileUri();
 
 /// Compiler provided by the environment.
-final Uri? cc = Platform.environment['CC']?.asFileUri();
+final Uri? cc = Platform.environment['C_COMPILER__CC']?.asFileUri();
 
 /// Linker provided by the environment.
-final Uri? ld = Platform.environment['LD']?.asFileUri();
+final Uri? ld = Platform.environment['C_COMPILER__LD']?.asFileUri();
 
 /// Path to script that sets environment variables for [cc], [ld], and [ar].
 ///
 /// Provided by environment.
-final Uri? envScript = Platform.environment['ToolchainEnvScript']?.asFileUri();
+final Uri? envScript =
+    Platform.environment['C_COMPILER__ENV_SCRIPT']?.asFileUri();
 
 /// Arguments for [envScript] provided by environment.
 final List<String>? envScriptArgs =
-    Platform.environment['ToolchainEnvScriptArguments']?.split(' ');
+    Platform.environment['C_COMPILER__ENV_SCRIPT_ARGS']?.split(' ');
 
 extension on String {
   Uri asFileUri() => Uri.file(this);

--- a/pkgs/c_compiler/test/helpers.dart
+++ b/pkgs/c_compiler/test/helpers.dart
@@ -99,11 +99,10 @@ final Uri? ld = Platform.environment['LD']?.asFileUri();
 /// Path to script that sets environment variables for [cc], [ld], and [ar].
 ///
 /// Provided by environment.
-final Uri? toolchainEnvScript =
-    Platform.environment['ToolchainEnvScript']?.asFileUri();
+final Uri? envScript = Platform.environment['ToolchainEnvScript']?.asFileUri();
 
-/// Arguments for [toolchainEnvScript] provided by environment.
-final List<String>? toolchainEnvScriptArgs =
+/// Arguments for [envScript] provided by environment.
+final List<String>? envScriptArgs =
     Platform.environment['ToolchainEnvScriptArguments']?.split(' ');
 
 extension on String {

--- a/pkgs/c_compiler/test/helpers.dart
+++ b/pkgs/c_compiler/test/helpers.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
 
 const keepTempKey = 'KEEP_TEMPORARY_DIRECTORIES';
@@ -87,24 +88,34 @@ extension on Uri {
   String get name => pathSegments.where((e) => e != '').last;
 }
 
+String unparseKey(String key) => key.replaceAll('.', '__').toUpperCase();
+
 /// Archiver provided by the environment.
-final Uri? ar = Platform.environment['C_COMPILER__AR']?.asFileUri();
+final Uri? ar = Platform
+    .environment[unparseKey(CCompilerConfig.arConfigKeyFull)]
+    ?.asFileUri();
 
 /// Compiler provided by the environment.
-final Uri? cc = Platform.environment['C_COMPILER__CC']?.asFileUri();
+final Uri? cc = Platform
+    .environment[unparseKey(CCompilerConfig.ccConfigKeyFull)]
+    ?.asFileUri();
 
 /// Linker provided by the environment.
-final Uri? ld = Platform.environment['C_COMPILER__LD']?.asFileUri();
+final Uri? ld = Platform
+    .environment[unparseKey(CCompilerConfig.ldConfigKeyFull)]
+    ?.asFileUri();
 
 /// Path to script that sets environment variables for [cc], [ld], and [ar].
 ///
 /// Provided by environment.
-final Uri? envScript =
-    Platform.environment['C_COMPILER__ENV_SCRIPT']?.asFileUri();
+final Uri? envScript = Platform
+    .environment[unparseKey(CCompilerConfig.envScriptConfigKeyFull)]
+    ?.asFileUri();
 
 /// Arguments for [envScript] provided by environment.
-final List<String>? envScriptArgs =
-    Platform.environment['C_COMPILER__ENV_SCRIPT_ARGS']?.split(' ');
+final List<String>? envScriptArgs = Platform
+    .environment[unparseKey(CCompilerConfig.envScriptArgsConfigKeyFull)]
+    ?.split(' ');
 
 extension on String {
   Uri asFileUri() => Uri.file(this);

--- a/pkgs/native_assets_cli/lib/src/model/build_config.dart
+++ b/pkgs/native_assets_cli/lib/src/model/build_config.dart
@@ -192,14 +192,13 @@ class BuildConfig {
       },
       (config) => cCompiler._ld =
           config.optionalPath(CCompilerConfig.ldConfigKeyFull, mustExist: true),
-      (config) => cCompiler._toolchainEnvScript = (ccSet &&
+      (config) => cCompiler._envScript = (ccSet &&
               cCompiler.cc != null &&
               cCompiler.cc!.toFilePath().endsWith('cl.exe'))
-          ? config.path(CCompilerConfig.toolchainEnvScriptConfigKeyFull,
-              mustExist: true)
+          ? config.path(CCompilerConfig.envScriptConfigKeyFull, mustExist: true)
           : null,
-      (config) => cCompiler._toolchainEnvScriptArgs = config.optionalStringList(
-            CCompilerConfig.toolchainEnvScriptArgsConfigKeyFull,
+      (config) => cCompiler._envScriptArgs = config.optionalStringList(
+            CCompilerConfig.envScriptArgsConfigKeyFull,
             splitEnvironmentPattern: ' ',
           ),
       (config) => _linkModePreference = LinkModePreference.fromString(
@@ -309,26 +308,26 @@ class CCompilerConfig {
   late final Uri? _ar;
 
   /// Path to script that sets environment variables for [cc], [ld], and [ar].
-  Uri? get toolchainEnvScript => _toolchainEnvScript;
-  late final Uri? _toolchainEnvScript;
+  Uri? get envScript => _envScript;
+  late final Uri? _envScript;
 
-  /// Arguments for [toolchainEnvScript].
-  List<String>? get toolchainEnvScriptArgs => _toolchainEnvScriptArgs;
-  late final List<String>? _toolchainEnvScriptArgs;
+  /// Arguments for [envScript].
+  List<String>? get envScriptArgs => _envScriptArgs;
+  late final List<String>? _envScriptArgs;
 
   factory CCompilerConfig({
     Uri? ar,
     Uri? cc,
     Uri? ld,
-    Uri? toolchainEnvScript,
-    List<String>? toolchainEnvScriptArgs,
+    Uri? envScript,
+    List<String>? envScriptArgs,
   }) =>
       CCompilerConfig._()
         .._ar = ar
         .._cc = cc
         .._ld = ld
-        .._toolchainEnvScript = toolchainEnvScript
-        .._toolchainEnvScriptArgs = toolchainEnvScriptArgs;
+        .._envScript = envScript
+        .._envScriptArgs = envScriptArgs;
 
   CCompilerConfig._();
 
@@ -339,22 +338,18 @@ class CCompilerConfig {
   static const ccConfigKeyFull = '$configKey.$ccConfigKey';
   static const ldConfigKey = 'ld';
   static const ldConfigKeyFull = '$configKey.$ldConfigKey';
-  static const toolchainEnvScriptConfigKey = 'toolchain_env_script';
-  static const toolchainEnvScriptConfigKeyFull =
-      '$configKey.$toolchainEnvScriptConfigKey';
-  static const toolchainEnvScriptArgsConfigKey =
-      'toolchain_env_script_arguments';
-  static const toolchainEnvScriptArgsConfigKeyFull =
-      '$configKey.$toolchainEnvScriptArgsConfigKey';
+  static const envScriptConfigKey = 'env_script';
+  static const envScriptConfigKeyFull = '$configKey.$envScriptConfigKey';
+  static const envScriptArgsConfigKey = 'env_script_arguments';
+  static const envScriptArgsConfigKeyFull =
+      '$configKey.$envScriptArgsConfigKey';
 
   Map<String, Object> toYaml() => {
         if (_ar != null) arConfigKey: _ar!.toFilePath(),
         if (_cc != null) ccConfigKey: _cc!.toFilePath(),
         if (_ld != null) ldConfigKey: _ld!.toFilePath(),
-        if (_toolchainEnvScript != null)
-          toolchainEnvScriptConfigKey: _toolchainEnvScript!.toFilePath(),
-        if (_toolchainEnvScriptArgs != null)
-          toolchainEnvScriptArgsConfigKey: _toolchainEnvScriptArgs!,
+        if (_envScript != null) envScriptConfigKey: _envScript!.toFilePath(),
+        if (_envScriptArgs != null) envScriptArgsConfigKey: _envScriptArgs!,
       }.sortOnKey();
 
   @override
@@ -365,9 +360,10 @@ class CCompilerConfig {
     if (other._ar != _ar) return false;
     if (other._cc != _cc) return false;
     if (other._ld != _ld) return false;
-    if (other.toolchainEnvScript != toolchainEnvScript) return false;
-    if (!ListEquality<String>().equals(
-        other.toolchainEnvScriptArgs, toolchainEnvScriptArgs)) return false;
+    if (other.envScript != envScript) return false;
+    if (!ListEquality<String>().equals(other.envScriptArgs, envScriptArgs)) {
+      return false;
+    }
     return true;
   }
 
@@ -376,7 +372,7 @@ class CCompilerConfig {
         _ar,
         _cc,
         _ld,
-        _toolchainEnvScript,
-        ListEquality<String>().hash(toolchainEnvScriptArgs),
+        _envScript,
+        ListEquality<String>().hash(envScriptArgs),
       );
 }

--- a/pkgs/native_assets_cli/lib/src/model/build_config.dart
+++ b/pkgs/native_assets_cli/lib/src/model/build_config.dart
@@ -36,29 +36,9 @@ class BuildConfig {
   IOSSdk? get targetIOSSdk => _targetIOSSdk;
   late final IOSSdk? _targetIOSSdk;
 
-  /// Path to a C compiler.
-  Uri? get cc => _cc;
-  late final Uri? _cc;
-
-  /// Path to a native linker.
-  Uri? get ld => _ld;
-  late final Uri? _ld;
-
-  /// Path to a native archiver.
-  Uri? get ar => _ar;
-  late final Uri? _ar;
-
   /// Preferred linkMode method for library.
   LinkModePreference get linkModePreference => _linkModePreference;
   late final LinkModePreference _linkModePreference;
-
-  /// Path to script that sets environment variables for [cc], [ld], and [ar].
-  Uri? get toolchainEnvScript => _toolchainEnvScript;
-  late final Uri? _toolchainEnvScript;
-
-  /// Arguments for [toolchainEnvScript].
-  List<String>? get toolchainEnvScriptArgs => _toolchainEnvScriptArgs;
-  late final List<String>? _toolchainEnvScriptArgs;
 
   /// Metadata from direct dependencies.
   ///
@@ -67,6 +47,10 @@ class BuildConfig {
   /// The key in the nested map is the key for the metadata from the dependency.
   Map<String, Metadata>? get dependencyMetadata => _dependencyMetadata;
   late final Map<String, Metadata>? _dependencyMetadata;
+
+  /// The configuration for invoking the C compiler.
+  CCompilerConfig get cCompiler => _cCompiler;
+  late final CCompilerConfig _cCompiler;
 
   /// The underlying config.
   ///
@@ -79,11 +63,7 @@ class BuildConfig {
     required Uri packageRoot,
     required Target target,
     IOSSdk? targetIOSSdk,
-    Uri? ar,
-    Uri? cc,
-    Uri? ld,
-    Uri? toolchainEnvScript,
-    List<String>? toolchainEnvScriptArgs,
+    CCompilerConfig? cCompiler,
     required LinkModePreference linkModePreference,
     Map<String, Metadata>? dependencyMetadata,
   }) {
@@ -92,12 +72,8 @@ class BuildConfig {
       .._packageRoot = packageRoot
       .._target = target
       .._targetIOSSdk = targetIOSSdk
-      .._ar = ar
-      .._cc = cc
-      .._ld = ld
+      .._cCompiler = cCompiler ?? CCompilerConfig()
       .._linkModePreference = linkModePreference
-      .._toolchainEnvScript = toolchainEnvScript
-      .._toolchainEnvScriptArgs = toolchainEnvScriptArgs
       .._dependencyMetadata = dependencyMetadata;
     final parsedConfigFile = nonValidated.toYaml();
     final config = Config(fileParsed: parsedConfigFile);
@@ -117,7 +93,7 @@ class BuildConfig {
   static Version version = Version(1, 0, 0);
 
   factory BuildConfig.fromConfig(Config config) {
-    final result = BuildConfig._();
+    final result = BuildConfig._().._cCompiler = CCompilerConfig._();
     final configExceptions = <Object>[];
     for (final f in result._readFieldsFromConfig()) {
       try {
@@ -163,12 +139,6 @@ class BuildConfig {
 
   static const outDirConfigKey = 'out_dir';
   static const packageRootConfigKey = 'package_root';
-  static const arConfigKey = 'ar';
-  static const ccConfigKey = 'cc';
-  static const ldConfigKey = 'ld';
-  static const toolchainEnvScriptConfigKey = 'toolchain_env_script';
-  static const toolchainEnvScriptArgsConfigKey =
-      'toolchain_env_script_arguments';
   static const dependencyMetadataConfigKey = 'dependency_metadata';
   static const _versionKey = 'version';
 
@@ -213,18 +183,23 @@ class BuildConfig {
               ),
             )
           : null,
-      (config) => _ar = config.optionalPath(arConfigKey, mustExist: true),
+      (config) => cCompiler._ar =
+          config.optionalPath(CCompilerConfig.arConfigKeyFull, mustExist: true),
       (config) {
-        _cc = config.optionalPath(ccConfigKey, mustExist: true);
+        cCompiler._cc = config.optionalPath(CCompilerConfig.ccConfigKeyFull,
+            mustExist: true);
         ccSet = true;
       },
-      (config) => _ld = config.optionalPath(ldConfigKey, mustExist: true),
-      (config) => _toolchainEnvScript =
-          (ccSet && cc != null && cc!.toFilePath().endsWith('cl.exe'))
-              ? config.path(toolchainEnvScriptConfigKey, mustExist: true)
-              : null,
-      (config) => _toolchainEnvScriptArgs = config.optionalStringList(
-            toolchainEnvScriptArgsConfigKey,
+      (config) => cCompiler._ld =
+          config.optionalPath(CCompilerConfig.ldConfigKeyFull, mustExist: true),
+      (config) => cCompiler._toolchainEnvScript = (ccSet &&
+              cCompiler.cc != null &&
+              cCompiler.cc!.toFilePath().endsWith('cl.exe'))
+          ? config.path(CCompilerConfig.toolchainEnvScriptConfigKeyFull,
+              mustExist: true)
+          : null,
+      (config) => cCompiler._toolchainEnvScriptArgs = config.optionalStringList(
+            CCompilerConfig.toolchainEnvScriptArgsConfigKeyFull,
             splitEnvironmentPattern: ' ',
           ),
       (config) => _linkModePreference = LinkModePreference.fromString(
@@ -266,26 +241,26 @@ class BuildConfig {
     return result.sortOnKey();
   }
 
-  Map<String, Object> toYaml() => {
-        outDirConfigKey: _outDir.toFilePath(),
-        packageRootConfigKey: _packageRoot.toFilePath(),
-        Target.configKey: _target.toString(),
-        if (_targetIOSSdk != null) IOSSdk.configKey: _targetIOSSdk.toString(),
-        if (_ar != null) arConfigKey: _ar!.toFilePath(),
-        if (_cc != null) ccConfigKey: _cc!.toFilePath(),
-        if (_ld != null) ldConfigKey: _ld!.toFilePath(),
-        if (_toolchainEnvScript != null)
-          toolchainEnvScriptConfigKey: _toolchainEnvScript!.toFilePath(),
-        if (_toolchainEnvScriptArgs != null)
-          toolchainEnvScriptArgsConfigKey: _toolchainEnvScriptArgs!,
-        LinkModePreference.configKey: _linkModePreference.toString(),
-        if (_dependencyMetadata != null)
-          dependencyMetadataConfigKey: {
-            for (final entry in _dependencyMetadata!.entries)
-              entry.key: entry.value.toYaml(),
-          },
-        _versionKey: version.toString(),
-      }.sortOnKey();
+  Map<String, Object> toYaml() {
+    final cCompilerYaml = _cCompiler.toYaml();
+    // print(cCompilerYaml);
+    // print(cCompilerYaml.isNotEmpty);
+
+    return {
+      outDirConfigKey: _outDir.toFilePath(),
+      packageRootConfigKey: _packageRoot.toFilePath(),
+      Target.configKey: _target.toString(),
+      if (_targetIOSSdk != null) IOSSdk.configKey: _targetIOSSdk.toString(),
+      if (cCompilerYaml.isNotEmpty) CCompilerConfig.configKey: cCompilerYaml,
+      LinkModePreference.configKey: _linkModePreference.toString(),
+      if (_dependencyMetadata != null)
+        dependencyMetadataConfigKey: {
+          for (final entry in _dependencyMetadata!.entries)
+            entry.key: entry.value.toYaml(),
+        },
+      _versionKey: version.toString(),
+    }.sortOnKey();
+  }
 
   String toYamlString() => yamlEncode(toYaml());
 
@@ -298,12 +273,7 @@ class BuildConfig {
     if (other._packageRoot != _packageRoot) return false;
     if (other._target != _target) return false;
     if (other._targetIOSSdk != _targetIOSSdk) return false;
-    if (other._ar != _ar) return false;
-    if (other._cc != _cc) return false;
-    if (other._ld != _ld) return false;
-    if (other.toolchainEnvScript != toolchainEnvScript) return false;
-    if (!ListEquality<String>().equals(
-        other.toolchainEnvScriptArgs, toolchainEnvScriptArgs)) return false;
+    if (other._cCompiler != _cCompiler) return false;
     if (other._linkModePreference != _linkModePreference) return false;
     if (!DeepCollectionEquality()
         .equals(other._dependencyMetadata, _dependencyMetadata)) return false;
@@ -316,15 +286,97 @@ class BuildConfig {
         _packageRoot,
         _target,
         _targetIOSSdk,
-        _ar,
-        _cc,
-        _ld,
-        _toolchainEnvScript,
-        ListEquality<String>().hash(toolchainEnvScriptArgs),
+        _cCompiler,
         _linkModePreference,
         DeepCollectionEquality().hash(_dependencyMetadata),
       );
 
   @override
   String toString() => 'BuildConfig(${toYaml()})';
+}
+
+class CCompilerConfig {
+  /// Path to a C compiler.
+  Uri? get cc => _cc;
+  late final Uri? _cc;
+
+  /// Path to a native linker.
+  Uri? get ld => _ld;
+  late final Uri? _ld;
+
+  /// Path to a native archiver.
+  Uri? get ar => _ar;
+  late final Uri? _ar;
+
+  /// Path to script that sets environment variables for [cc], [ld], and [ar].
+  Uri? get toolchainEnvScript => _toolchainEnvScript;
+  late final Uri? _toolchainEnvScript;
+
+  /// Arguments for [toolchainEnvScript].
+  List<String>? get toolchainEnvScriptArgs => _toolchainEnvScriptArgs;
+  late final List<String>? _toolchainEnvScriptArgs;
+
+  factory CCompilerConfig({
+    Uri? ar,
+    Uri? cc,
+    Uri? ld,
+    Uri? toolchainEnvScript,
+    List<String>? toolchainEnvScriptArgs,
+  }) =>
+      CCompilerConfig._()
+        .._ar = ar
+        .._cc = cc
+        .._ld = ld
+        .._toolchainEnvScript = toolchainEnvScript
+        .._toolchainEnvScriptArgs = toolchainEnvScriptArgs;
+
+  CCompilerConfig._();
+
+  static const configKey = 'c_compiler';
+  static const arConfigKey = 'ar';
+  static const arConfigKeyFull = '$configKey.$arConfigKey';
+  static const ccConfigKey = 'cc';
+  static const ccConfigKeyFull = '$configKey.$ccConfigKey';
+  static const ldConfigKey = 'ld';
+  static const ldConfigKeyFull = '$configKey.$ldConfigKey';
+  static const toolchainEnvScriptConfigKey = 'toolchain_env_script';
+  static const toolchainEnvScriptConfigKeyFull =
+      '$configKey.$toolchainEnvScriptConfigKey';
+  static const toolchainEnvScriptArgsConfigKey =
+      'toolchain_env_script_arguments';
+  static const toolchainEnvScriptArgsConfigKeyFull =
+      '$configKey.$toolchainEnvScriptArgsConfigKey';
+
+  Map<String, Object> toYaml() => {
+        if (_ar != null) arConfigKey: _ar!.toFilePath(),
+        if (_cc != null) ccConfigKey: _cc!.toFilePath(),
+        if (_ld != null) ldConfigKey: _ld!.toFilePath(),
+        if (_toolchainEnvScript != null)
+          toolchainEnvScriptConfigKey: _toolchainEnvScript!.toFilePath(),
+        if (_toolchainEnvScriptArgs != null)
+          toolchainEnvScriptArgsConfigKey: _toolchainEnvScriptArgs!,
+      }.sortOnKey();
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! CCompilerConfig) {
+      return false;
+    }
+    if (other._ar != _ar) return false;
+    if (other._cc != _cc) return false;
+    if (other._ld != _ld) return false;
+    if (other.toolchainEnvScript != toolchainEnvScript) return false;
+    if (!ListEquality<String>().equals(
+        other.toolchainEnvScriptArgs, toolchainEnvScriptArgs)) return false;
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        _ar,
+        _cc,
+        _ld,
+        _toolchainEnvScript,
+        ListEquality<String>().hash(toolchainEnvScriptArgs),
+      );
 }

--- a/pkgs/native_assets_cli/test/example/native_add_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_test.dart
@@ -35,12 +35,12 @@ void main() async {
         '-Dtarget=${Target.current}',
         '-Dlink_mode_preference=dynamic',
         if (cc != null) '-Dcc=${cc!.toFilePath()}',
-        if (toolchainEnvScript != null)
-          '-D${CCompilerConfig.toolchainEnvScriptConfigKeyFull}='
-              '${toolchainEnvScript!.toFilePath()}',
-        if (toolchainEnvScriptArgs != null)
-          '-D${CCompilerConfig.toolchainEnvScriptArgsConfigKeyFull}='
-              '${toolchainEnvScriptArgs!.join(' ')}',
+        if (envScript != null)
+          '-D${CCompilerConfig.envScriptConfigKeyFull}='
+              '${envScript!.toFilePath()}',
+        if (envScriptArgs != null)
+          '-D${CCompilerConfig.envScriptArgsConfigKeyFull}='
+              '${envScriptArgs!.join(' ')}',
         '-Dversion=${BuildConfig.version}',
       ],
       workingDirectory: testPackageUri.toFilePath(),

--- a/pkgs/native_assets_cli/test/example/native_add_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@OnPlatform({'windows': Timeout.factor(10)})
+library;
+
 import 'dart:io';
 
 import 'package:native_assets_cli/native_assets_cli.dart';
@@ -20,7 +23,7 @@ void main() async {
     await Directory.fromUri(tempUri).delete(recursive: true);
   });
 
-  test('native_add build', timeout: Timeout.factor(2), () async {
+  test('native_add build', () async {
     final testTempUri = tempUri.resolve('test1/');
     await Directory.fromUri(testTempUri).create();
     final testPackageUri = packageUri.resolve('example/native_add/');

--- a/pkgs/native_assets_cli/test/example/native_add_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_test.dart
@@ -36,10 +36,10 @@ void main() async {
         '-Dlink_mode_preference=dynamic',
         if (cc != null) '-Dcc=${cc!.toFilePath()}',
         if (toolchainEnvScript != null)
-          '-D${BuildConfig.toolchainEnvScriptConfigKey}='
+          '-D${CCompilerConfig.toolchainEnvScriptConfigKeyFull}='
               '${toolchainEnvScript!.toFilePath()}',
         if (toolchainEnvScriptArgs != null)
-          '-D${BuildConfig.toolchainEnvScriptArgsConfigKey}='
+          '-D${CCompilerConfig.toolchainEnvScriptArgsConfigKeyFull}='
               '${toolchainEnvScriptArgs!.join(' ')}',
         '-Dversion=${BuildConfig.version}',
       ],

--- a/pkgs/native_assets_cli/test/helpers.dart
+++ b/pkgs/native_assets_cli/test/helpers.dart
@@ -4,6 +4,8 @@
 
 import 'dart:io';
 
+import 'package:native_assets_cli/src/model/build_config.dart';
+
 /// Test files are run in a variety of ways, find this package root in all.
 ///
 /// Test files can be run from source from any working directory. The Dart SDK
@@ -47,24 +49,34 @@ extension on Uri {
   String get name => pathSegments.where((e) => e != '').last;
 }
 
+String unparseKey(String key) => key.replaceAll('.', '__').toUpperCase();
+
 /// Archiver provided by the environment.
-final Uri? ar = Platform.environment['C_COMPILER__AR']?.asFileUri();
+final Uri? ar = Platform
+    .environment[unparseKey(CCompilerConfig.arConfigKeyFull)]
+    ?.asFileUri();
 
 /// Compiler provided by the environment.
-final Uri? cc = Platform.environment['C_COMPILER__CC']?.asFileUri();
+final Uri? cc = Platform
+    .environment[unparseKey(CCompilerConfig.ccConfigKeyFull)]
+    ?.asFileUri();
 
 /// Linker provided by the environment.
-final Uri? ld = Platform.environment['C_COMPILER__LD']?.asFileUri();
+final Uri? ld = Platform
+    .environment[unparseKey(CCompilerConfig.ldConfigKeyFull)]
+    ?.asFileUri();
 
 /// Path to script that sets environment variables for [cc], [ld], and [ar].
 ///
 /// Provided by environment.
-final Uri? envScript =
-    Platform.environment['C_COMPILER__ENV_SCRIPT']?.asFileUri();
+final Uri? envScript = Platform
+    .environment[unparseKey(CCompilerConfig.envScriptConfigKeyFull)]
+    ?.asFileUri();
 
 /// Arguments for [envScript] provided by environment.
-final List<String>? envScriptArgs =
-    Platform.environment['C_COMPILER__ENV_SCRIPT_ARGS']?.split(' ');
+final List<String>? envScriptArgs = Platform
+    .environment[unparseKey(CCompilerConfig.envScriptArgsConfigKeyFull)]
+    ?.split(' ');
 
 extension on String {
   Uri asFileUri() => Uri.file(this);

--- a/pkgs/native_assets_cli/test/helpers.dart
+++ b/pkgs/native_assets_cli/test/helpers.dart
@@ -48,22 +48,23 @@ extension on Uri {
 }
 
 /// Archiver provided by the environment.
-final Uri? ar = Platform.environment['AR']?.asFileUri();
+final Uri? ar = Platform.environment['C_COMPILER__AR']?.asFileUri();
 
 /// Compiler provided by the environment.
-final Uri? cc = Platform.environment['CC']?.asFileUri();
+final Uri? cc = Platform.environment['C_COMPILER__CC']?.asFileUri();
 
 /// Linker provided by the environment.
-final Uri? ld = Platform.environment['LD']?.asFileUri();
+final Uri? ld = Platform.environment['C_COMPILER__LD']?.asFileUri();
 
 /// Path to script that sets environment variables for [cc], [ld], and [ar].
 ///
 /// Provided by environment.
-final Uri? envScript = Platform.environment['ToolchainEnvScript']?.asFileUri();
+final Uri? envScript =
+    Platform.environment['C_COMPILER__ENV_SCRIPT']?.asFileUri();
 
 /// Arguments for [envScript] provided by environment.
 final List<String>? envScriptArgs =
-    Platform.environment['ToolchainEnvScriptArguments']?.split(' ');
+    Platform.environment['C_COMPILER__ENV_SCRIPT_ARGS']?.split(' ');
 
 extension on String {
   Uri asFileUri() => Uri.file(this);

--- a/pkgs/native_assets_cli/test/helpers.dart
+++ b/pkgs/native_assets_cli/test/helpers.dart
@@ -59,11 +59,10 @@ final Uri? ld = Platform.environment['LD']?.asFileUri();
 /// Path to script that sets environment variables for [cc], [ld], and [ar].
 ///
 /// Provided by environment.
-final Uri? toolchainEnvScript =
-    Platform.environment['ToolchainEnvScript']?.asFileUri();
+final Uri? envScript = Platform.environment['ToolchainEnvScript']?.asFileUri();
 
-/// Arguments for [toolchainEnvScript] provided by environment.
-final List<String>? toolchainEnvScriptArgs =
+/// Arguments for [envScript] provided by environment.
+final List<String>? envScriptArgs =
     Platform.environment['ToolchainEnvScriptArguments']?.split(' ');
 
 extension on String {

--- a/pkgs/native_assets_cli/test/model/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_config_test.dart
@@ -293,15 +293,15 @@ version: ${BuildConfig.version}''';
     );
   });
 
-  test('toolchainEnvScript', () {
+  test('envScript', () {
     final buildConfig1 = BuildConfig(
       outDir: tempUri.resolve('out1/'),
       packageRoot: tempUri.resolve('packageRoot/'),
       target: Target.windowsX64,
       cCompiler: CCompilerConfig(
         cc: fakeCl,
-        toolchainEnvScript: fakeVcVars,
-        toolchainEnvScriptArgs: ['x64'],
+        envScript: fakeVcVars,
+        envScriptArgs: ['x64'],
       ),
       linkModePreference: LinkModePreference.dynamic,
     );

--- a/pkgs/native_assets_cli/test/model/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_config_test.dart
@@ -40,9 +40,11 @@ void main() async {
       packageRoot: tempUri,
       target: Target.iOSArm64,
       targetIOSSdk: IOSSdk.iPhoneOs,
-      cc: fakeClang,
-      ld: fakeLd,
-      ar: fakeAr,
+      cCompiler: CCompilerConfig(
+        cc: fakeClang,
+        ld: fakeLd,
+        ar: fakeAr,
+      ),
       linkModePreference: LinkModePreference.preferStatic,
     );
 
@@ -59,9 +61,9 @@ void main() async {
     expect(config1.packageRoot, config2.packageRoot);
     expect(config1.target != config2.target, true);
     expect(config1.targetIOSSdk != config2.targetIOSSdk, true);
-    expect(config1.cc != config2.cc, true);
-    expect(config1.ld != config2.ld, true);
-    expect(config1.ar != config2.ar, true);
+    expect(config1.cCompiler.cc != config2.cCompiler.cc, true);
+    expect(config1.cCompiler.ld != config2.cCompiler.ld, true);
+    expect(config1.cCompiler.ar != config2.cCompiler.ar, true);
     expect(config1.linkModePreference, config2.linkModePreference);
     expect(config1.dependencyMetadata, config2.dependencyMetadata);
   });
@@ -92,8 +94,10 @@ void main() async {
       packageRoot: tempUri.resolve('packageRoot/'),
       target: Target.iOSArm64,
       targetIOSSdk: IOSSdk.iPhoneOs,
-      cc: fakeClang,
-      ld: fakeLd,
+      cCompiler: CCompilerConfig(
+        cc: fakeClang,
+        ld: fakeLd,
+      ),
       linkModePreference: LinkModePreference.preferStatic,
     );
 
@@ -147,8 +151,10 @@ void main() async {
       packageRoot: tempUri,
       target: Target.iOSArm64,
       targetIOSSdk: IOSSdk.iPhoneOs,
-      cc: fakeClang,
-      ld: fakeLd,
+      cCompiler: CCompilerConfig(
+        cc: fakeClang,
+        ld: fakeLd,
+      ),
       linkModePreference: LinkModePreference.preferStatic,
       // This map should be sorted on key for two layers.
       dependencyMetadata: {
@@ -162,7 +168,9 @@ void main() async {
       },
     );
     final yamlString = buildConfig1.toYamlString();
-    final expectedYamlString = '''cc: ${fakeClang.toFilePath()}
+    final expectedYamlString = '''c_compiler:
+  cc: ${fakeClang.toFilePath()}
+  ld: ${fakeLd.toFilePath()}
 dependency_metadata:
   bar:
     key: value
@@ -171,7 +179,6 @@ dependency_metadata:
     z:
       - z
       - a
-ld: ${fakeLd.toFilePath()}
 link_mode_preference: prefer-static
 out_dir: ${outDir.toFilePath()}
 package_root: ${tempUri.toFilePath()}
@@ -235,8 +242,10 @@ version: ${BuildConfig.version}''';
       packageRoot: tempUri,
       target: Target.iOSArm64,
       targetIOSSdk: IOSSdk.iPhoneOs,
-      cc: fakeClang,
-      ld: fakeLd,
+      cCompiler: CCompilerConfig(
+        cc: fakeClang,
+        ld: fakeLd,
+      ),
       linkModePreference: LinkModePreference.preferStatic,
     );
     config.toString();
@@ -289,9 +298,11 @@ version: ${BuildConfig.version}''';
       outDir: tempUri.resolve('out1/'),
       packageRoot: tempUri.resolve('packageRoot/'),
       target: Target.windowsX64,
-      cc: fakeCl,
-      toolchainEnvScript: fakeVcVars,
-      toolchainEnvScriptArgs: ['x64'],
+      cCompiler: CCompilerConfig(
+        cc: fakeCl,
+        toolchainEnvScript: fakeVcVars,
+        toolchainEnvScriptArgs: ['x64'],
+      ),
       linkModePreference: LinkModePreference.dynamic,
     );
 

--- a/pkgs/native_assets_cli/test/model/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_config_test.dart
@@ -64,6 +64,10 @@ void main() async {
     expect(config1.cCompiler.cc != config2.cCompiler.cc, true);
     expect(config1.cCompiler.ld != config2.cCompiler.ld, true);
     expect(config1.cCompiler.ar != config2.cCompiler.ar, true);
+    expect(config1.cCompiler.envScript == config2.cCompiler.envScript, true);
+    expect(config1.cCompiler.envScriptArgs == config2.cCompiler.envScriptArgs,
+        true);
+    expect(config1.cCompiler != config2.cCompiler, true);
     expect(config1.linkModePreference, config2.linkModePreference);
     expect(config1.dependencyMetadata, config2.dependencyMetadata);
   });


### PR DESCRIPTION
Changes the format for the YAML/JSON `BuildConfig` to have a nested `c_compiler` key. Example config:

```yaml
c_compiler:
  ar: /tmp/MLTHBB/fake_ar
  cc: /tmp/MLTHBB/fake_clang
  env_script: /tmp/MLTHBB/fake_env_script.bat
  env_script_args: []
  ld: /tmp/MLTHBB/fake_ld
dependency_metadata:
  bar:
    key: value
  foo:
    a: 321
    z:
      - z
      - a
link_mode_preference: prefer-static
out_dir: /tmp/MLTHBB/out1/
package_root: /tmp/MLTHBB/
target: ios_arm64
target_ios_sdk: iphoneos
version: 1.0.0
```

This changes the environment variables to set if the compiler cannot be auto-detected on `PATH` or default install locations to:

* `C_COMPILER__AR`
* `C_COMPILER__CC`
* `C_COMPILER__LD`
* `C_COMPILER__ENV_SCRIPT`
* `C_COMPILER__ENV_SCRIPT_ARGS`

These will need to be updated in the Dart SDK: https://dart-review.googlesource.com/c/sdk/+/300221.

For reference [internal design doc for the protocol](http://goto.google.com/dart-native-assets-cli-v2).

Closes: https://github.com/dart-lang/native/issues/12