### PR TITLE
Prevent passing empty environment keys

### DIFF
--- a/pkgs/c_compiler/lib/src/utils/env_from_bat.dart
+++ b/pkgs/c_compiler/lib/src/utils/env_from_bat.dart
@@ -33,10 +33,12 @@ Future<Map<String, String>> envFromBat(
   return result;
 }
 
+// Ensures it doesn't return empty keys.
 Map<String, String> parseDefines(String defines) {
   final result = <String, String>{};
-  final lines = defines.split('\r\n');
+  final lines = defines.trim().split('\r\n');
   for (final line in lines) {
+    if (line.isEmpty) continue;
     final lineSplit = line.split('=');
     final key = lineSplit.first;
     final value = lineSplit.skip(1).join('=');


### PR DESCRIPTION
When trying to hermetic builds downstream by not passing any environment variables except the ones I explicitly set, I encountered empty environments, these weren't handled well.

The subsequent `Process.start` invocation with that environment lead to `ProcessException: The parameter is incorrect.` (it doesn't mention the environment at all 🙈 ).