### PR TITLE
[c_compiler] Propagate compilation failures as exceptions

### DIFF
--- a/pkgs/c_compiler/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/cbuilder.dart
@@ -65,6 +65,9 @@ class CBuilder implements Builder {
   })  : _type = _CBuilderType.executable,
         assetName = null;
 
+  /// Runs the C Compiler with on this C build spec.
+  ///
+  /// Completes with an error if the build fails.
   @override
   Future<void> run({
     required BuildConfig buildConfig,

--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -125,6 +125,7 @@ class RunCBuilder {
       ],
       logger: logger,
       captureOutput: false,
+      throwOnUnexpectedExitCode: true,
     );
     if (staticLibrary != null) {
       await runProcess(
@@ -136,6 +137,7 @@ class RunCBuilder {
         ],
         logger: logger,
         captureOutput: false,
+        throwOnUnexpectedExitCode: true,
       );
     }
   }
@@ -174,6 +176,7 @@ class RunCBuilder {
       environment: environment,
       logger: logger,
       captureOutput: false,
+      throwOnUnexpectedExitCode: true,
     );
 
     if (staticLibrary != null) {
@@ -187,6 +190,7 @@ class RunCBuilder {
         environment: environment,
         logger: logger,
         captureOutput: false,
+        throwOnUnexpectedExitCode: true,
       );
     }
 

--- a/pkgs/c_compiler/lib/src/utils/run_process.dart
+++ b/pkgs/c_compiler/lib/src/utils/run_process.dart
@@ -21,6 +21,8 @@ Future<RunProcessResult> runProcess({
   bool includeParentEnvironment = true,
   Logger? logger,
   bool captureOutput = true,
+  int expectedExitCode = 0,
+  bool throwOnUnexpectedExitCode = false,
 }) async {
   final printWorkingDir =
       workingDirectory != null && workingDirectory != Directory.current.uri;
@@ -70,6 +72,14 @@ Future<RunProcessResult> runProcess({
     stdout: stdoutBuffer.toString(),
     stderr: stderrBuffer.toString(),
   );
+  if (throwOnUnexpectedExitCode && expectedExitCode != exitCode) {
+    throw ProcessException(
+      executable.toFilePath(),
+      arguments,
+      "Full command string: '$commandString'."
+      'For the output of the process check the logger output.',
+    );
+  }
   return result;
 }
 

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_build_failure_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_build_failure_test.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@OnPlatform({'windows': Timeout.factor(10)})
+library;
+
+import 'dart:io';
+
+import 'package:c_compiler/c_compiler.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+
+void main() {
+  test('build failure', () async {
+    await inTempDir(
+      (tempUri) async {
+        final addCOriginalUri =
+            packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
+        final addCUri = tempUri.resolve('add.c');
+        final addCOriginalContents =
+            await File.fromUri(addCOriginalUri).readAsString();
+        final addCBrokenContents = addCOriginalContents.replaceAll(
+            'int32_t a, int32_t b', 'int64_t blabla');
+        await File.fromUri(addCUri).writeAsString(addCBrokenContents);
+        const name = 'add';
+
+        final buildConfig = BuildConfig(
+          outDir: tempUri,
+          packageRoot: tempUri,
+          target: Target.current,
+          linkModePreference: LinkModePreference.dynamic,
+          cCompiler: CCompilerConfig(
+            cc: cc,
+            envScript: envScript,
+            envScriptArgs: envScriptArgs,
+          ),
+        );
+        final buildOutput = BuildOutput();
+
+        final cbuilder = CBuilder.library(
+          sources: [addCUri.toFilePath()],
+          name: name,
+          assetName: name,
+        );
+        expect(
+          () => cbuilder.run(
+            buildConfig: buildConfig,
+            buildOutput: buildOutput,
+            logger: logger,
+          ),
+          throwsException,
+        );
+      },
+    );
+  });
+}

--- a/pkgs/c_compiler/test/cbuilder/testfiles/add/src/add.c
+++ b/pkgs/c_compiler/test/cbuilder/testfiles/add/src/add.c
@@ -11,5 +11,5 @@
 #endif
 
 FFI_EXPORT int32_t add(int32_t a, int32_t b) {
-   return a+b;
+   return a + b;
 }


### PR DESCRIPTION
The `CBuilder` will now throw `ProcessException`s.

That way `build.dart` invocations return a non-zero exit code if compilation fails.

The logs of the compiler itself are streamed to the `logger`.