### PR TITLE
[c_compiler] Make `logger` required

### DIFF
--- a/pkgs/c_compiler/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/cbuilder.dart
@@ -13,7 +13,7 @@ abstract class Builder {
   Future<void> run({
     required BuildConfig buildConfig,
     required BuildOutput buildOutput,
-    Logger? logger,
+    required Logger? logger,
   });
 }
 
@@ -72,7 +72,7 @@ class CBuilder implements Builder {
   Future<void> run({
     required BuildConfig buildConfig,
     required BuildOutput buildOutput,
-    Logger? logger,
+    required Logger? logger,
   }) async {
     final outDir = buildConfig.outDir;
     final packageRoot = buildConfig.packageRoot;

--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -46,7 +46,7 @@ class RunCBuilder {
 
   Future<Uri> archiver() async => (await _resolver.resolveArchiver()).uri;
 
-  Future<Uri> iosSdk(IOSSdk iosSdk, {Logger? logger}) async {
+  Future<Uri> iosSdk(IOSSdk iosSdk, {required Logger? logger}) async {
     if (iosSdk == IOSSdk.iPhoneOs) {
       return (await iPhoneOSSdk.defaultResolver!.resolve(logger: logger))
           .where((i) => i.tool == iPhoneOSSdk)
@@ -60,7 +60,7 @@ class RunCBuilder {
         .uri;
   }
 
-  Future<Uri> macosSdk({Logger? logger}) async =>
+  Future<Uri> macosSdk({required Logger? logger}) async =>
       (await macosxSdk.defaultResolver!.resolve(logger: logger))
           .where((i) => i.tool == macosxSdk)
           .first

--- a/pkgs/c_compiler/lib/src/native_toolchain/android_ndk.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/android_ndk.dart
@@ -65,19 +65,24 @@ class _AndroidNdkResolver implements ToolResolver {
   );
 
   @override
-  Future<List<ToolInstance>> resolve({Logger? logger}) async {
+  Future<List<ToolInstance>> resolve({required Logger? logger}) async {
     final ndkInstances = await installLocationResolver.resolve(logger: logger);
 
     return [
       for (final ndkInstance in ndkInstances) ...[
         ndkInstance,
-        ...await tryResolveClang(ndkInstance)
+        ...await tryResolveClang(
+          ndkInstance,
+          logger: logger,
+        )
       ]
     ];
   }
 
   Future<List<ToolInstance>> tryResolveClang(
-      ToolInstance androidNdkInstance) async {
+    ToolInstance androidNdkInstance, {
+    required Logger? logger,
+  }) async {
     final result = <ToolInstance>[];
     final prebuiltUri =
         androidNdkInstance.uri.resolve('toolchains/llvm/prebuilt/');
@@ -89,28 +94,37 @@ class _AndroidNdkResolver implements ToolResolver {
           .resolve('bin/')
           .resolve(Target.current.os.executableFileName('clang'));
       if (await File.fromUri(clangUri).exists()) {
-        result.add(await CliVersionResolver.lookupVersion(ToolInstance(
-          tool: androidNdkClang,
-          uri: clangUri,
-        )));
+        result.add(await CliVersionResolver.lookupVersion(
+          ToolInstance(
+            tool: androidNdkClang,
+            uri: clangUri,
+          ),
+          logger: logger,
+        ));
       }
       final arUri = hostArchDir.uri
           .resolve('bin/')
           .resolve(Target.current.os.executableFileName('llvm-ar'));
       if (await File.fromUri(arUri).exists()) {
-        result.add(await CliVersionResolver.lookupVersion(ToolInstance(
-          tool: androidNdkLlvmAr,
-          uri: arUri,
-        )));
+        result.add(await CliVersionResolver.lookupVersion(
+          ToolInstance(
+            tool: androidNdkLlvmAr,
+            uri: arUri,
+          ),
+          logger: logger,
+        ));
       }
       final ldUri = hostArchDir.uri
           .resolve('bin/')
           .resolve(Target.current.os.executableFileName('ld.lld'));
       if (await File.fromUri(arUri).exists()) {
-        result.add(await CliVersionResolver.lookupVersion(ToolInstance(
-          tool: androidNdkLld,
-          uri: ldUri,
-        )));
+        result.add(await CliVersionResolver.lookupVersion(
+          ToolInstance(
+            tool: androidNdkLld,
+            uri: ldUri,
+          ),
+          logger: logger,
+        ));
       }
     }
     return result;

--- a/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/msvc.dart
@@ -215,7 +215,7 @@ Tool _msvcTool({
 
 class VisualStudioResolver implements ToolResolver {
   @override
-  Future<List<ToolInstance>> resolve({Logger? logger}) async {
+  Future<List<ToolInstance>> resolve({required Logger? logger}) async {
     final vswhereInstances =
         await vswhere.defaultResolver!.resolve(logger: logger);
 

--- a/pkgs/c_compiler/lib/src/native_toolchain/recognizer.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/recognizer.dart
@@ -19,7 +19,7 @@ class CompilerRecognizer implements ToolResolver {
   CompilerRecognizer(this.uri);
 
   @override
-  Future<List<ToolInstance>> resolve({Logger? logger}) async {
+  Future<List<ToolInstance>> resolve({required Logger? logger}) async {
     final os = Target.current.os;
     logger?.finer('Trying to recognize $uri.');
     final filePath = uri.toFilePath();
@@ -63,7 +63,7 @@ class LinkerRecognizer implements ToolResolver {
   LinkerRecognizer(this.uri);
 
   @override
-  Future<List<ToolInstance>> resolve({Logger? logger}) async {
+  Future<List<ToolInstance>> resolve({required Logger? logger}) async {
     final os = Target.current.os;
     logger?.finer('Trying to recognize $uri.');
     final filePath = uri.toFilePath();
@@ -113,7 +113,7 @@ class ArchiverRecognizer implements ToolResolver {
   ArchiverRecognizer(this.uri);
 
   @override
-  Future<List<ToolInstance>> resolve({Logger? logger}) async {
+  Future<List<ToolInstance>> resolve({required Logger? logger}) async {
     logger?.finer('Trying to recognize $uri.');
     final os = Target.current.os;
     final filePath = uri.toFilePath();

--- a/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/xcode.dart
@@ -44,7 +44,7 @@ final Tool iPhoneSimulatorSdk = Tool(
 
 class XCodeSdkResolver implements ToolResolver {
   @override
-  Future<List<ToolInstance>> resolve({Logger? logger}) async {
+  Future<List<ToolInstance>> resolve({required Logger? logger}) async {
     final xcrunInstances = await xcrun.defaultResolver!.resolve(logger: logger);
 
     return [
@@ -76,7 +76,7 @@ class XCodeSdkResolver implements ToolResolver {
     required ToolInstance xcrunInstance,
     required String sdk,
     required Tool tool,
-    Logger? logger,
+    required Logger? logger,
   }) async {
     final result = await runProcess(
       executable: xcrunInstance.uri,

--- a/pkgs/c_compiler/lib/src/tool/tool_resolver.dart
+++ b/pkgs/c_compiler/lib/src/tool/tool_resolver.dart
@@ -19,7 +19,7 @@ import 'tool_instance.dart';
 
 abstract class ToolResolver {
   /// Resolves tools on the host system.
-  Future<List<ToolInstance>> resolve({Logger? logger});
+  Future<List<ToolInstance>> resolve({required Logger? logger});
 }
 
 /// Tries to resolve a tool on the `PATH`.
@@ -38,7 +38,7 @@ class PathToolResolver extends ToolResolver {
             Target.current.os.executableFileName(toolName.toLowerCase());
 
   @override
-  Future<List<ToolInstance>> resolve({Logger? logger}) async {
+  Future<List<ToolInstance>> resolve({required Logger? logger}) async {
     logger?.finer('Looking for $toolName on PATH.');
     final uri = await runWhich(logger: logger);
     if (uri == null) {
@@ -54,7 +54,7 @@ class PathToolResolver extends ToolResolver {
 
   static Uri get which => Uri.file(Platform.isWindows ? 'where' : 'which');
 
-  Future<Uri?> runWhich({Logger? logger}) async {
+  Future<Uri?> runWhich({required Logger? logger}) async {
     final process = await runProcess(
       executable: which,
       arguments: [executableName],
@@ -83,7 +83,7 @@ class CliVersionResolver implements ToolResolver {
   });
 
   @override
-  Future<List<ToolInstance>> resolve({Logger? logger}) async {
+  Future<List<ToolInstance>> resolve({required Logger? logger}) async {
     final toolInstances = await wrappedResolver.resolve(logger: logger);
     return [
       for (final toolInstance in toolInstances)
@@ -100,7 +100,7 @@ class CliVersionResolver implements ToolResolver {
     ToolInstance toolInstance, {
     List<String> arguments = const ['--version'],
     int expectedExitCode = 0,
-    Logger? logger,
+    required Logger? logger,
   }) async {
     if (toolInstance.version != null) return toolInstance;
     logger?.finer('Looking up version with --version for $toolInstance.');
@@ -119,7 +119,7 @@ class CliVersionResolver implements ToolResolver {
     Uri executable, {
     List<String> arguments = const ['--version'],
     int expectedExitCode = 0,
-    Logger? logger,
+    required Logger? logger,
   }) async {
     final process = await runProcess(
       executable: executable,
@@ -143,7 +143,7 @@ class PathVersionResolver implements ToolResolver {
   PathVersionResolver({required this.wrappedResolver});
 
   @override
-  Future<List<ToolInstance>> resolve({Logger? logger}) async {
+  Future<List<ToolInstance>> resolve({required Logger? logger}) async {
     final toolInstances = await wrappedResolver.resolve(logger: logger);
 
     return [
@@ -174,7 +174,7 @@ class ToolResolvers implements ToolResolver {
   ToolResolvers(this.resolvers);
 
   @override
-  Future<List<ToolInstance>> resolve({Logger? logger}) async => [
+  Future<List<ToolInstance>> resolve({required Logger? logger}) async => [
         for (final resolver in resolvers)
           ...await resolver.resolve(logger: logger)
       ];
@@ -192,7 +192,7 @@ class InstallLocationResolver implements ToolResolver {
   static const home = '\$HOME';
 
   @override
-  Future<List<ToolInstance>> resolve({Logger? logger}) async {
+  Future<List<ToolInstance>> resolve({required Logger? logger}) async {
     logger?.finer('Looking for $toolName in $paths.');
     final resolvedPaths = [
       for (final path in paths) ...await tryResolvePath(path)
@@ -247,7 +247,7 @@ class RelativeToolResolver implements ToolResolver {
   });
 
   @override
-  Future<List<ToolInstance>> resolve({Logger? logger}) async {
+  Future<List<ToolInstance>> resolve({required Logger? logger}) async {
     final otherToolInstances = await wrappedResolver.resolve(logger: logger);
 
     logger?.finer('Looking for $toolName relative to $otherToolInstances '
@@ -295,7 +295,7 @@ class CliFilter implements ToolResolver {
   });
 
   @override
-  Future<List<ToolInstance>> resolve({Logger? logger}) async {
+  Future<List<ToolInstance>> resolve({required Logger? logger}) async {
     final toolInstances = await wrappedResolver.resolve(logger: logger);
     return [
       for (final toolInstance in toolInstances)
@@ -305,7 +305,7 @@ class CliFilter implements ToolResolver {
 
   Future<ToolInstance?> filter(
     ToolInstance toolInstance, {
-    Logger? logger,
+    required Logger? logger,
   }) async {
     if (toolInstance.version != null) return toolInstance;
     logger?.finer('Checking if $toolInstance satisfies CLI filter.');
@@ -327,7 +327,7 @@ class CliFilter implements ToolResolver {
     Uri executable, {
     required List<String> arguments,
     int expectedExitCode = 0,
-    Logger? logger,
+    required Logger? logger,
   }) async {
     final process = await runProcess(
       executable: executable,

--- a/pkgs/c_compiler/lib/src/utils/run_process.dart
+++ b/pkgs/c_compiler/lib/src/utils/run_process.dart
@@ -19,7 +19,7 @@ Future<RunProcessResult> runProcess({
   Uri? workingDirectory,
   Map<String, String>? environment,
   bool includeParentEnvironment = true,
-  Logger? logger,
+  required Logger? logger,
   bool captureOutput = true,
   int expectedExitCode = 0,
   bool throwOnUnexpectedExitCode = false,

--- a/pkgs/c_compiler/test/native_toolchain/recognizer_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/recognizer_test.dart
@@ -82,7 +82,7 @@ class RecognizerTest {
   RecognizerTest(this.tool, this.recognizer);
 
   Future<void> setUp() async {
-    toolInstance = (await tool.defaultResolver!.resolve())
+    toolInstance = (await tool.defaultResolver!.resolve(logger: logger))
         .where((element) => element.tool == tool)
         .firstOrNull;
   }

--- a/pkgs/c_compiler/test/native_toolchain/recognizer_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/recognizer_test.dart
@@ -82,7 +82,9 @@ class RecognizerTest {
   RecognizerTest(this.tool, this.recognizer);
 
   Future<void> setUp() async {
-    toolInstance = (await tool.defaultResolver!.resolve(logger: logger))
+    toolInstance = (await tool.defaultResolver!.resolve(
+      logger: null /* no printOnFailure support in setup. */,
+    ))
         .where((element) => element.tool == tool)
         .firstOrNull;
   }

--- a/pkgs/native_assets_cli/example/native_add/build.dart
+++ b/pkgs/native_assets_cli/example/native_add/build.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:c_compiler/c_compiler.dart';
+import 'package:logging/logging.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 
 const packageName = 'native_add';
@@ -18,6 +19,10 @@ void main(List<String> args) async {
       'src/$packageName.c',
     ],
   );
-  await cbuilder.run(buildConfig: buildConfig, buildOutput: buildOutput);
+  await cbuilder.run(
+    buildConfig: buildConfig,
+    buildOutput: buildOutput,
+    logger: Logger('')..onRecord.listen((record) => print(record.message)),
+  );
   await buildOutput.writeToFile(outDir: buildConfig.outDir);
 }


### PR DESCRIPTION
Make the `Logger? logger` parameter `required` everywhere in the code.
This means it's a conscious decision of users to _not_ install a logger, leading to no log output from the wrapped C compiler.

We do the same in our internal code, so that we don't forget threading it through.