### PR TITLE
[c_compiler] Target ios_x64

### DIFF
--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -208,6 +208,7 @@ class RunCBuilder {
 
   static const appleClangTargetFlags = {
     Target.iOSArm64: 'arm64-apple-ios',
+    Target.iOSX64: 'x86_64-apple-ios',
     Target.macOSArm64: 'arm64-apple-darwin',
     Target.macOSX64: 'x86_64-apple-darwin',
   };

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -25,16 +25,21 @@ void main() {
 
   const targets = [
     Target.iOSArm64,
+    Target.iOSX64,
   ];
 
   // Dont include 'mach-o' or 'Mach-O', different spelling is used.
   const objdumpFileFormat = {
     Target.iOSArm64: 'arm64',
+    Target.iOSX64: '64-bit x86-64',
   };
 
   for (final linkMode in LinkMode.values) {
     for (final targetIOSSdk in IOSSdk.values) {
       for (final target in targets) {
+        if (target == Target.iOSX64 && targetIOSSdk == IOSSdk.iPhoneOs) {
+          continue;
+        }
         test('Cbuilder $linkMode library $targetIOSSdk $target', () async {
           await inTempDir((tempUri) async {
             final addCUri =

--- a/pkgs/native_assets_cli/lib/src/model/target.dart
+++ b/pkgs/native_assets_cli/lib/src/model/target.dart
@@ -249,6 +249,7 @@ class Target implements Comparable<Target> {
     fuchsiaX64,
     iOSArm,
     iOSArm64,
+    iOSX64,
     linuxArm,
     linuxArm64,
     linuxIA32,


### PR DESCRIPTION
I added the target in 3d891667678bfca9d672784d9cbcf9275bbf6594, but didn't actually try to run it on Apple clang. This PR fixes that.