### PR TITLE
[c_compiler] Support setting the install name of dylibs

### DIFF
--- a/pkgs/c_compiler/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/cbuilder.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 
 import 'run_cbuilder.dart';
@@ -51,7 +52,9 @@ class CBuilder implements Builder {
   /// Used to output the [BuildOutput.dependencies].
   final List<String> dartBuildFiles;
 
-  /// TODO(dacoharkes): Move to [BuildConfig].
+  /// TODO(https://github.com/dart-lang/native/issues/54): Move to [BuildConfig]
+  /// or hide in public API.
+  @visibleForTesting
   final Uri? installName;
 
   CBuilder.library({
@@ -59,7 +62,7 @@ class CBuilder implements Builder {
     required this.assetName,
     this.sources = const [],
     this.dartBuildFiles = const ['build.dart'],
-    this.installName,
+    @visibleForTesting this.installName,
   }) : _type = _CBuilderType.library;
 
   CBuilder.executable({

--- a/pkgs/c_compiler/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/cbuilder.dart
@@ -51,11 +51,15 @@ class CBuilder implements Builder {
   /// Used to output the [BuildOutput.dependencies].
   final List<String> dartBuildFiles;
 
+  /// TODO(dacoharkes): Move to [BuildConfig].
+  final Uri? installName;
+
   CBuilder.library({
     required this.name,
     required this.assetName,
     this.sources = const [],
     this.dartBuildFiles = const ['build.dart'],
+    this.installName,
   }) : _type = _CBuilderType.library;
 
   CBuilder.executable({
@@ -63,7 +67,8 @@ class CBuilder implements Builder {
     this.sources = const [],
     this.dartBuildFiles = const ['build.dart'],
   })  : _type = _CBuilderType.executable,
-        assetName = null;
+        assetName = null,
+        installName = null;
 
   /// Runs the C Compiler with on this C build spec.
   ///
@@ -103,6 +108,7 @@ class CBuilder implements Builder {
               ? libUri
               : null,
       executable: _type == _CBuilderType.executable ? exeUri : null,
+      installName: installName,
     );
     await task.run();
 

--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -25,6 +25,13 @@ class RunCBuilder {
   final Uri outDir;
   final Target target;
 
+  /// The install of the [dynamicLibrary].
+  ///
+  /// Can be inspected with `otool -D <path-to-dylib>`.
+  ///
+  /// Can be modified with `install_name_tool`.
+  final Uri? installName;
+
   RunCBuilder({
     required this.buildConfig,
     this.logger,
@@ -32,6 +39,7 @@ class RunCBuilder {
     this.executable,
     this.dynamicLibrary,
     this.staticLibrary,
+    this.installName,
   })  : outDir = buildConfig.outDir,
         target = buildConfig.target,
         assert([executable, dynamicLibrary, staticLibrary]
@@ -109,6 +117,10 @@ class RunCBuilder {
         if (target.os == OS.macOS) ...[
           '-isysroot',
           (await macosSdk(logger: logger)).toFilePath(),
+        ],
+        if (installName != null) ...[
+          '-install_name',
+          installName!.toFilePath(),
         ],
         ...sources.map((e) => e.toFilePath()),
         if (executable != null) ...[

--- a/pkgs/c_compiler/lib/src/native_toolchain/apple_clang.dart
+++ b/pkgs/c_compiler/lib/src/native_toolchain/apple_clang.dart
@@ -45,3 +45,16 @@ final Tool appleLd = Tool(
     ),
   ]),
 );
+
+/// The Mach-O dumping tool.
+///
+/// https://llvm.org/docs/CommandGuide/llvm-otool.html
+final Tool otool = Tool(
+  name: 'otool',
+  defaultResolver: CliVersionResolver(
+    wrappedResolver: PathToolResolver(
+      toolName: 'otool',
+      executableName: 'otool',
+    ),
+  ),
+);

--- a/pkgs/c_compiler/pubspec.yaml
+++ b/pkgs/c_compiler/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   cli_config: ^0.1.1
   glob: ^2.1.1
   logging: ^1.1.1
+  meta: ^1.9.1
   # TODO(dacoharkes): Publish native_assets_cli first.
   native_assets_cli:
     path: ../native_assets_cli/

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -92,9 +92,10 @@ void main() {
               expect(machine, contains(objdumpFileFormat[target]));
 
               if (linkMode == LinkMode.dynamic) {
-                final libInstallName = await otoolInstallName(libUri, libName);
+                final libInstallName =
+                    await runOtoolInstallName(libUri, libName);
                 if (installName == null) {
-                  // If no install path is passed, we will have an absolute path.
+                  // If no install path is passed, we have an absolute path.
                   final tempName =
                       tempUri.pathSegments.lastWhere((e) => e != '');
                   final pathEnding =

--- a/pkgs/c_compiler/test/helpers.dart
+++ b/pkgs/c_compiler/test/helpers.dart
@@ -126,7 +126,7 @@ extension on String {
 /// Looks up the install name of a dynamic library at [libraryUri].
 ///
 /// Because `otool` output multiple names, [libraryName] as search parameter.
-Future<String> otoolInstallName(Uri libraryUri, String libraryName) async {
+Future<String> runOtoolInstallName(Uri libraryUri, String libraryName) async {
   final otoolUri =
       (await otool.defaultResolver!.resolve(logger: logger)).first.uri;
   final otoolResult = await runProcess(
@@ -134,6 +134,7 @@ Future<String> otoolInstallName(Uri libraryUri, String libraryName) async {
     arguments: ['-l', libraryUri.path],
     logger: logger,
   );
+  expect(otoolResult.exitCode, 0);
   // Leading space on purpose to differentiate from other types of names.
   const installNameName = ' name ';
   final installName = otoolResult.stdout

--- a/pkgs/c_compiler/test/native_toolchain/apple_clang_test.dart
+++ b/pkgs/c_compiler/test/native_toolchain/apple_clang_test.dart
@@ -47,4 +47,12 @@ void main() {
     final satisfied = requirement.satisfy(resolved);
     expect(satisfied?.length, 1);
   });
+
+  test('otool test', () async {
+    final requirement = ToolRequirement(otool);
+    final resolved = await otool.defaultResolver!.resolve(logger: logger);
+    expect(resolved.isNotEmpty, true);
+    final satisfied = requirement.satisfy(resolved);
+    expect(satisfied?.length, 1);
+  });
 }


### PR DESCRIPTION
Exercises the logic discussed in https://github.com/dart-lang/native/issues/54.

We might not actually want to set the install name in package:c_compiler, but instead update it inside Flutter/Dart. See the discussion in https://github.com/dart-lang/native/issues/54. However, it is still useful to have the logic be exercised here so that we know we have the right process invocations and the tools available on CI.