### PR TITLE
[native_assets_cli] Add `dry_run` option

### DIFF
--- a/pkgs/c_compiler/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/cbuilder.dart
@@ -97,23 +97,24 @@ class CBuilder implements Builder {
     final dartBuildFiles = [
       for (final source in this.dartBuildFiles) packageRoot.resolve(source),
     ];
-
-    final task = RunCBuilder(
-      buildConfig: buildConfig,
-      logger: logger,
-      sources: sources,
-      dynamicLibrary:
-          _type == _CBuilderType.library && linkMode == LinkMode.dynamic
-              ? libUri
-              : null,
-      staticLibrary:
-          _type == _CBuilderType.library && linkMode == LinkMode.static
-              ? libUri
-              : null,
-      executable: _type == _CBuilderType.executable ? exeUri : null,
-      installName: installName,
-    );
-    await task.run();
+    if (!buildConfig.dryRun) {
+      final task = RunCBuilder(
+        buildConfig: buildConfig,
+        logger: logger,
+        sources: sources,
+        dynamicLibrary:
+            _type == _CBuilderType.library && linkMode == LinkMode.dynamic
+                ? libUri
+                : null,
+        staticLibrary:
+            _type == _CBuilderType.library && linkMode == LinkMode.static
+                ? libUri
+                : null,
+        executable: _type == _CBuilderType.executable ? exeUri : null,
+        installName: installName,
+      );
+      await task.run();
+    }
 
     if (assetName != null) {
       buildOutput.assets.add(Asset(
@@ -123,10 +124,12 @@ class CBuilder implements Builder {
         path: AssetAbsolutePath(libUri),
       ));
     }
-    buildOutput.dependencies.dependencies.addAll([
-      ...sources,
-      ...dartBuildFiles,
-    ]);
+    if (!buildConfig.dryRun) {
+      buildOutput.dependencies.dependencies.addAll([
+        ...sources,
+        ...dartBuildFiles,
+      ]);
+    }
   }
 }
 

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_test.dart
@@ -63,46 +63,53 @@ void main() {
     });
   });
 
-  test('Cbuilder dylib', () async {
-    await inTempDir(
-      // https://github.com/dart-lang/sdk/issues/40159
-      keepTemp: Platform.isWindows,
-      (tempUri) async {
-        final addCUri =
-            packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
-        const name = 'add';
+  for (final dryRun in [true, false]) {
+    final testSuffix = dryRun ? ' dry_run' : '';
+    test('Cbuilder dylib$testSuffix', () async {
+      await inTempDir(
+        // https://github.com/dart-lang/sdk/issues/40159
+        keepTemp: Platform.isWindows,
+        (tempUri) async {
+          final addCUri =
+              packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
+          const name = 'add';
 
-        final buildConfig = BuildConfig(
-          outDir: tempUri,
-          packageRoot: tempUri,
-          target: Target.current,
-          linkModePreference: LinkModePreference.dynamic,
-          cCompiler: CCompilerConfig(
-            cc: cc,
-            envScript: envScript,
-            envScriptArgs: envScriptArgs,
-          ),
-        );
-        final buildOutput = BuildOutput();
+          final buildConfig = BuildConfig(
+            outDir: tempUri,
+            packageRoot: tempUri,
+            target: Target.current,
+            linkModePreference: LinkModePreference.dynamic,
+            cCompiler: CCompilerConfig(
+              cc: cc,
+              envScript: envScript,
+              envScriptArgs: envScriptArgs,
+            ),
+            dryRun: dryRun,
+          );
+          final buildOutput = BuildOutput();
 
-        final cbuilder = CBuilder.library(
-          sources: [addCUri.toFilePath()],
-          name: name,
-          assetName: name,
-        );
-        await cbuilder.run(
-          buildConfig: buildConfig,
-          buildOutput: buildOutput,
-          logger: logger,
-        );
+          final cbuilder = CBuilder.library(
+            sources: [addCUri.toFilePath()],
+            name: name,
+            assetName: name,
+          );
+          await cbuilder.run(
+            buildConfig: buildConfig,
+            buildOutput: buildOutput,
+            logger: logger,
+          );
 
-        final dylibUri = tempUri.resolve(Target.current.os.dylibFileName(name));
-        expect(await File.fromUri(dylibUri).exists(), true);
-        final dylib = DynamicLibrary.open(dylibUri.toFilePath());
-        final add = dylib.lookupFunction<Int32 Function(Int32, Int32),
-            int Function(int, int)>('add');
-        expect(add(1, 2), 3);
-      },
-    );
-  });
+          final dylibUri =
+              tempUri.resolve(Target.current.os.dylibFileName(name));
+          expect(await File.fromUri(dylibUri).exists(), !dryRun);
+          if (!dryRun) {
+            final dylib = DynamicLibrary.open(dylibUri.toFilePath());
+            final add = dylib.lookupFunction<Int32 Function(Int32, Int32),
+                int Function(int, int)>('add');
+            expect(add(1, 2), 3);
+          }
+        },
+      );
+    });
+  }
 }

--- a/pkgs/native_assets_cli/test/model/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_config_test.dart
@@ -91,14 +91,16 @@ void main() async {
       target: Target.androidArm64,
       targetAndroidNdkApi: 30,
       linkModePreference: LinkModePreference.preferStatic,
+      dryRun: true,
     );
 
     final config = Config(fileParsed: {
+      'dry_run': true,
+      'link_mode_preference': 'prefer-static',
       'out_dir': outDirUri.toFilePath(),
       'package_root': packageRootUri.toFilePath(),
-      'target': 'android_arm64',
       'target_android_ndk_api': 30,
-      'link_mode_preference': 'prefer-static',
+      'target': 'android_arm64',
       'version': BuildOutput.version.toString(),
     });
 


### PR DESCRIPTION
Adds a `dry_run` option to the native assets CLI, and makes the c_compiler package respect it.

Issue:

* https://github.com/dart-lang/native/issues/51