### PR TITLE
Build-mode

### DIFF
--- a/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/c_compiler/lib/src/cbuilder/run_cbuilder.dart
@@ -136,6 +136,11 @@ class RunCBuilder {
           '-o',
           outDir.resolve('out.o').toFilePath(),
         ],
+        // TODO(https://github.com/dart-lang/native/issues/50): The defines
+        // should probably be configurable. That way, the mapping from
+        // build_mode to defines can be defined in a project-dependent way in
+        // each project build.dart.
+        '-D${buildConfig.buildMode.name.toUpperCase()}=1'
       ],
       logger: logger,
       captureOutput: false,
@@ -185,6 +190,11 @@ class RunCBuilder {
           '/c',
           ...sources.map((e) => e.toFilePath()),
         ],
+        // TODO(https://github.com/dart-lang/native/issues/50): The defines
+        // should probably be configurable. That way, the mapping from
+        // build_mode to defines can be defined in a project-dependent way in
+        // each project build.dart.
+        '/D${buildConfig.buildMode.name.toUpperCase()}=1'
       ],
       workingDirectory: outDir,
       environment: environment,

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_build_failure_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_build_failure_test.dart
@@ -35,6 +35,7 @@ void main() {
           packageRoot: tempUri,
           target: Target.current,
           linkModePreference: LinkModePreference.dynamic,
+          buildMode: BuildMode.release,
           cCompiler: CCompilerConfig(
             cc: cc,
             envScript: envScript,

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_android_test.dart
@@ -117,6 +117,7 @@ Future<Uri> buildLib(
     packageRoot: tempUri,
     target: target,
     targetAndroidNdkApi: androidNdkApi,
+    buildMode: BuildMode.release,
     linkModePreference: linkMode == LinkMode.dynamic
         ? LinkModePreference.dynamic
         : LinkModePreference.static,

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -60,6 +60,7 @@ void main() {
                 outDir: tempUri,
                 packageRoot: tempUri,
                 target: target,
+                buildMode: BuildMode.release,
                 linkModePreference: linkMode == LinkMode.dynamic
                     ? LinkModePreference.dynamic
                     : LinkModePreference.static,

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -46,6 +46,7 @@ void main() {
             outDir: tempUri,
             packageRoot: tempUri,
             target: target,
+            buildMode: BuildMode.release,
             linkModePreference: linkMode == LinkMode.dynamic
                 ? LinkModePreference.dynamic
                 : LinkModePreference.static,

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -46,6 +46,7 @@ void main() {
             outDir: tempUri,
             packageRoot: tempUri,
             target: target,
+            buildMode: BuildMode.release,
             linkModePreference: linkMode == LinkMode.dynamic
                 ? LinkModePreference.dynamic
                 : LinkModePreference.static,

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -58,6 +58,7 @@ void main() {
             outDir: tempUri,
             packageRoot: tempUri,
             target: target,
+            buildMode: BuildMode.release,
             linkModePreference: linkMode == LinkMode.dynamic
                 ? LinkModePreference.dynamic
                 : LinkModePreference.static,

--- a/pkgs/c_compiler/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/cbuilder_test.dart
@@ -32,6 +32,7 @@ void main() {
         outDir: tempUri,
         packageRoot: tempUri,
         target: Target.current,
+        buildMode: BuildMode.release,
         // Ignored by executables.
         linkModePreference: LinkModePreference.dynamic,
         cCompiler: CCompilerConfig(
@@ -78,6 +79,7 @@ void main() {
             outDir: tempUri,
             packageRoot: tempUri,
             target: Target.current,
+            buildMode: BuildMode.release,
             linkModePreference: LinkModePreference.dynamic,
             cCompiler: CCompilerConfig(
               cc: cc,

--- a/pkgs/c_compiler/test/cbuilder/compiler_resolver_test.dart
+++ b/pkgs/c_compiler/test/cbuilder/compiler_resolver_test.dart
@@ -44,6 +44,7 @@ void main() {
         outDir: tempUri,
         packageRoot: tempUri,
         target: Target.current,
+        buildMode: BuildMode.release,
         linkModePreference: LinkModePreference.dynamic,
         cCompiler: CCompilerConfig(
           ar: ar,
@@ -67,6 +68,7 @@ void main() {
         outDir: tempUri,
         packageRoot: tempUri,
         target: Target.windowsX64,
+        buildMode: BuildMode.release,
         linkModePreference: LinkModePreference.dynamic,
       );
       final resolver = CompilerResolver(

--- a/pkgs/c_compiler/test/cbuilder/testfiles/add/src/add.c
+++ b/pkgs/c_compiler/test/cbuilder/testfiles/add/src/add.c
@@ -4,6 +4,10 @@
 
 #include <stdint.h>
 
+#ifdef DEBUG
+#include <stdio.h>
+#endif
+
 #if _WIN32
 #define FFI_EXPORT __declspec(dllexport)
 #else
@@ -11,5 +15,8 @@
 #endif
 
 FFI_EXPORT int32_t add(int32_t a, int32_t b) {
-   return a + b;
+#ifdef DEBUG
+  printf("Adding %i and %i.\n", a, b);
+#endif
+  return a + b;
 }

--- a/pkgs/c_compiler/test/cbuilder/testfiles/hello_world/src/hello_world.c
+++ b/pkgs/c_compiler/test/cbuilder/testfiles/hello_world/src/hello_world.c
@@ -5,6 +5,9 @@
 #include <stdio.h>
 
 int main() {
-   printf("Hello world.\n");
-   return 0;
+#ifdef DEBUG
+  printf("Running in debug mode.\n");
+#endif
+  printf("Hello world.\n");
+  return 0;
 }

--- a/pkgs/native_assets_cli/example/native_add/src/native_add.c
+++ b/pkgs/native_assets_cli/example/native_add/src/native_add.c
@@ -4,6 +4,13 @@
 
 #include "native_add.h"
 
+#ifdef DEBUG
+#include <stdio.h>
+#endif
+
 int32_t add(int32_t a, int32_t b) {
-   return a + b;
+#ifdef DEBUG
+  printf("Adding %i and %i.\n", a, b);
+#endif
+  return a + b;
 }

--- a/pkgs/native_assets_cli/lib/native_assets_cli.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli.dart
@@ -8,6 +8,7 @@ library native_assets_cli;
 
 export 'src/model/asset.dart';
 export 'src/model/build_config.dart';
+export 'src/model/build_mode.dart';
 export 'src/model/build_output.dart';
 export 'src/model/dependencies.dart';
 export 'src/model/ios_sdk.dart';

--- a/pkgs/native_assets_cli/lib/src/model/build_config.dart
+++ b/pkgs/native_assets_cli/lib/src/model/build_config.dart
@@ -11,6 +11,7 @@ import 'package:pub_semver/pub_semver.dart';
 
 import '../utils/map.dart';
 import '../utils/yaml.dart';
+import 'build_mode.dart';
 import 'ios_sdk.dart';
 import 'link_mode_preference.dart';
 import 'metadata.dart';
@@ -65,6 +66,10 @@ class BuildConfig {
   bool get dryRun => _dryRun ?? false;
   late final bool? _dryRun;
 
+  /// The build mode that the code should be compiled in.
+  BuildMode get buildMode => _buildMode;
+  late final BuildMode _buildMode;
+
   /// The underlying config.
   ///
   /// Can be used for easier access to values on [dependencyMetadata].
@@ -74,6 +79,7 @@ class BuildConfig {
   factory BuildConfig({
     required Uri outDir,
     required Uri packageRoot,
+    required BuildMode buildMode,
     required Target target,
     IOSSdk? targetIOSSdk,
     int? targetAndroidNdkApi,
@@ -85,6 +91,7 @@ class BuildConfig {
     final nonValidated = BuildConfig._()
       .._outDir = outDir
       .._packageRoot = packageRoot
+      .._buildMode = buildMode
       .._target = target
       .._targetIOSSdk = targetIOSSdk
       .._targetAndroidNdkApi = targetAndroidNdkApi
@@ -107,6 +114,7 @@ class BuildConfig {
   static String checksum({
     required Uri packageRoot,
     required Target target,
+    required BuildMode buildMode,
     IOSSdk? targetIOSSdk,
     int? targetAndroidNdkApi,
     CCompilerConfig? cCompiler,
@@ -119,6 +127,7 @@ class BuildConfig {
       target.toString(),
       targetIOSSdk.toString(),
       targetAndroidNdkApi.toString(),
+      buildMode.toString(),
       linkModePreference.toString(),
       cCompiler?.ar.toString(),
       cCompiler?.cc.toString(),
@@ -228,6 +237,12 @@ class BuildConfig {
       (config) => _outDir = config.path(outDirConfigKey, mustExist: true),
       (config) =>
           _packageRoot = config.path(packageRootConfigKey, mustExist: true),
+      (config) => _buildMode = BuildMode.fromString(
+            config.string(
+              BuildMode.configKey,
+              validValues: BuildMode.values.map((e) => '$e'),
+            ),
+          ),
       (config) {
         _target = Target.fromString(
           config.string(
@@ -312,6 +327,7 @@ class BuildConfig {
     return {
       outDirConfigKey: _outDir.toFilePath(),
       packageRootConfigKey: _packageRoot.toFilePath(),
+      BuildMode.configKey: _buildMode.toString(),
       Target.configKey: _target.toString(),
       if (_targetIOSSdk != null) IOSSdk.configKey: _targetIOSSdk.toString(),
       if (_targetAndroidNdkApi != null)
@@ -337,6 +353,7 @@ class BuildConfig {
     }
     if (other._outDir != _outDir) return false;
     if (other._packageRoot != _packageRoot) return false;
+    if (other._buildMode != _buildMode) return false;
     if (other._target != _target) return false;
     if (other._targetIOSSdk != _targetIOSSdk) return false;
     if (other._targetAndroidNdkApi != _targetAndroidNdkApi) return false;
@@ -352,6 +369,7 @@ class BuildConfig {
   int get hashCode => Object.hash(
         _outDir,
         _packageRoot,
+        _buildMode,
         _target,
         _targetIOSSdk,
         _targetAndroidNdkApi,

--- a/pkgs/native_assets_cli/lib/src/model/build_mode.dart
+++ b/pkgs/native_assets_cli/lib/src/model/build_mode.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+class BuildMode {
+  final String name;
+
+  const BuildMode._(this.name);
+
+  static const debug = BuildMode._('debug');
+  static const release = BuildMode._('release');
+
+  static const values = [
+    debug,
+    release,
+  ];
+
+  factory BuildMode.fromString(String target) =>
+      values.firstWhere((e) => e.name == target);
+
+  /// The `package:config` key preferably used.
+  static const String configKey = 'build_mode';
+
+  @override
+  String toString() => name;
+}

--- a/pkgs/native_assets_cli/test/example/native_add_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_test.dart
@@ -41,6 +41,7 @@ void main() async {
           '-Dout_dir=${tempUri.toFilePath()}',
           '-Dpackage_root=${testPackageUri.toFilePath()}',
           '-Dtarget=${Target.current}',
+          '-Dbuild_mode=debug',
           '-Dlink_mode_preference=dynamic',
           if (cc != null) '-Dcc=${cc!.toFilePath()}',
           if (envScript != null)

--- a/pkgs/native_assets_cli/test/model/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_config_test.dart
@@ -56,6 +56,7 @@ void main() async {
         ld: fakeLd,
         ar: fakeAr,
       ),
+      buildMode: BuildMode.release,
       linkModePreference: LinkModePreference.preferStatic,
     );
 
@@ -64,6 +65,7 @@ void main() async {
       packageRoot: tempUri,
       target: Target.androidArm64,
       targetAndroidNdkApi: 30,
+      buildMode: BuildMode.release,
       linkModePreference: LinkModePreference.preferStatic,
     );
 
@@ -90,11 +92,13 @@ void main() async {
       packageRoot: packageRootUri,
       target: Target.androidArm64,
       targetAndroidNdkApi: 30,
+      buildMode: BuildMode.release,
       linkModePreference: LinkModePreference.preferStatic,
       dryRun: true,
     );
 
     final config = Config(fileParsed: {
+      'build_mode': 'release',
       'dry_run': true,
       'link_mode_preference': 'prefer-static',
       'out_dir': outDirUri.toFilePath(),
@@ -118,6 +122,7 @@ void main() async {
         cc: fakeClang,
         ld: fakeLd,
       ),
+      buildMode: BuildMode.release,
       linkModePreference: LinkModePreference.preferStatic,
     );
 
@@ -133,6 +138,7 @@ void main() async {
       packageRoot: tempUri,
       target: Target.androidArm64,
       targetAndroidNdkApi: 30,
+      buildMode: BuildMode.release,
       linkModePreference: LinkModePreference.preferStatic,
       dependencyMetadata: {
         'bar': Metadata({
@@ -150,6 +156,7 @@ void main() async {
       packageRoot: tempUri,
       target: Target.androidArm64,
       targetAndroidNdkApi: 30,
+      buildMode: BuildMode.release,
       linkModePreference: LinkModePreference.preferStatic,
       dependencyMetadata: {
         'bar': Metadata({
@@ -177,6 +184,7 @@ void main() async {
         cc: fakeClang,
         ld: fakeLd,
       ),
+      buildMode: BuildMode.release,
       linkModePreference: LinkModePreference.preferStatic,
       // This map should be sorted on key for two layers.
       dependencyMetadata: {
@@ -190,7 +198,8 @@ void main() async {
       },
     );
     final yamlString = buildConfig1.toYamlString();
-    final expectedYamlString = '''c_compiler:
+    final expectedYamlString = '''build_mode: release
+c_compiler:
   cc: ${fakeClang.toFilePath()}
   ld: ${fakeLd.toFilePath()}
 dependency_metadata:
@@ -307,6 +316,7 @@ version: ${BuildConfig.version}''';
         cc: fakeClang,
         ld: fakeLd,
       ),
+      buildMode: BuildMode.release,
       linkModePreference: LinkModePreference.preferStatic,
     );
     config.toString();
@@ -318,6 +328,7 @@ version: ${BuildConfig.version}''';
       packageRoot: tempUri,
       target: Target.androidArm64,
       targetAndroidNdkApi: 30,
+      buildMode: BuildMode.release,
       linkModePreference: LinkModePreference.preferStatic,
     );
     final configFileContents = buildConfig.toYamlString();
@@ -337,6 +348,7 @@ version: ${BuildConfig.version}''';
       packageRoot: tempUri,
       target: Target.androidArm64,
       targetAndroidNdkApi: 30,
+      buildMode: BuildMode.release,
       linkModePreference: LinkModePreference.preferStatic,
       dependencyMetadata: {
         'bar': Metadata({
@@ -366,6 +378,7 @@ version: ${BuildConfig.version}''';
         envScript: fakeVcVars,
         envScriptArgs: ['x64'],
       ),
+      buildMode: BuildMode.release,
       linkModePreference: LinkModePreference.dynamic,
     );
 
@@ -406,16 +419,18 @@ version: ${BuildConfig.version}''';
       final name1 = BuildConfig.checksum(
         packageRoot: nativeAddUri,
         target: Target.linuxX64,
+        buildMode: BuildMode.release,
         linkModePreference: LinkModePreference.dynamic,
       );
 
       // Using the checksum for a build folder should be stable.
-      expect(name1, '02dce8b58210deaf9f278772e892d01f');
+      expect(name1, '05b54381626750e570c92d255bb09390');
 
       // Build folder different due to metadata.
       final name2 = BuildConfig.checksum(
         packageRoot: nativeAddUri,
         target: Target.linuxX64,
+        buildMode: BuildMode.release,
         linkModePreference: LinkModePreference.dynamic,
         dependencyMetadata: {
           'foo': Metadata({'key': 'value'})
@@ -428,6 +443,7 @@ version: ${BuildConfig.version}''';
       final name3 = BuildConfig.checksum(
           packageRoot: nativeAddUri,
           target: Target.linuxX64,
+          buildMode: BuildMode.release,
           linkModePreference: LinkModePreference.dynamic,
           cCompiler: CCompilerConfig(
             cc: fakeClangUri,


### PR DESCRIPTION
Introduces `BuildMode` with `release` and `debug` values.

This is not an enum, but a collection with two opaque objects. (Similar to `Target`.) This way adding more values later will not be a breaking change.

Package c_compiler picks up the configuration and sets either the `DEBUG` or `RELEASE` macro to `1`.

We should probably do the mapping from `BuildMode` to defines in `build.dart` files, because it might be project specific. The defines should be added to the `CBuilder` constructors or `run` function.

Bug:

* https://github.com/dart-lang/native/issues/50