### PR TITLE
Handle errors from process output

### DIFF
--- a/pkgs/c_compiler/lib/src/utils/run_process.dart
+++ b/pkgs/c_compiler/lib/src/utils/run_process.dart
@@ -28,14 +28,11 @@ Future<RunProcessResult> runProcess({
     const winEnvKeys = [
       'SYSTEMROOT',
     ];
-    final newEnvironment = {
-      ...{
-        for (final winEnvKey in winEnvKeys)
-          winEnvKey: Platform.environment[winEnvKey]!,
-      },
-      if (environment != null) ...environment,
+    environment = {
+      for (final winEnvKey in winEnvKeys)
+        winEnvKey: Platform.environment[winEnvKey]!,
+      ...?environment,
     };
-    environment = newEnvironment;
   }
 
   final printWorkingDir =
@@ -51,8 +48,6 @@ Future<RunProcessResult> runProcess({
 
   final stdoutBuffer = StringBuffer();
   final stderrBuffer = StringBuffer();
-  final stdoutCompleter = Completer<Object?>();
-  final stderrCompleter = Completer<Object?>();
   final process = await Process.start(
     executable.toFilePath(),
     arguments,
@@ -62,24 +57,30 @@ Future<RunProcessResult> runProcess({
     runInShell: Platform.isWindows && !includeParentEnvironment,
   );
 
-  process.stdout.transform(utf8.decoder).transform(const LineSplitter()).listen(
-    (s) {
-      logger?.fine(s);
-      if (captureOutput) stdoutBuffer.writeln(s);
-    },
-    onDone: stdoutCompleter.complete,
-  );
-  process.stderr.transform(utf8.decoder).transform(const LineSplitter()).listen(
-    (s) {
-      logger?.severe(s);
-      if (captureOutput) stderrBuffer.writeln(s);
-    },
-    onDone: stderrCompleter.complete,
-  );
+  final stdoutSub = process.stdout
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .listen(captureOutput
+          ? (s) {
+              logger?.fine(s);
+              stdoutBuffer.writeln(s);
+            }
+          : logger?.fine);
+  final stderrSub = process.stderr
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .listen(captureOutput
+          ? (s) {
+              logger?.severe(s);
+              stderrBuffer.writeln(s);
+            }
+          : logger?.severe);
 
-  final exitCode = await process.exitCode;
-  await stdoutCompleter.future;
-  await stderrCompleter.future;
+  final (exitCode, _, _) = await (
+    process.exitCode,
+    stdoutSub.asFuture<void>(),
+    stderrSub.asFuture<void>()
+  ).wait;
   final result = RunProcessResult(
     pid: process.pid,
     command: commandString,


### PR DESCRIPTION
Remove the `stderrCompleter` and `stdoutCompleter` variables in favor of
holding the `StreamSubscription` and using `asFuture()`. This ensures
that any errors from the stream (for instance UTF8 decodign errors) are
captured by the awaited `Future` instead of bubbling up as unhandled
async errors.

Use the `.wait` extension for records so error handlers are eagerly
added for the `exitCode` and output futures instead of not listening to
the other futures until after the exit code has completed, and errors
may have already bubbled up unhandled.

Also refactor the use of a map literal - don't use an extra `...{}`
literal, move the for-in element to the outer collection literal and use
`...?` over a conditional element with a null check. Skip the extra
intermediate variable `newEnvironment`.

Check `captureOutput` eagerly and avoid a closure in favor of a tear-off
when it is false. When the logger is null this allows an ignorable
`null` callback instead of always invoking a callback that does nothing.
