### PR TITLE
[c_compiler] Pass the correct SDK for iOS simulator builds

### DIFF
--- a/pkgs/c_compiler/pubspec.yaml
+++ b/pkgs/c_compiler/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0-dev
 repository: https://github.com/dart-lang/native/tree/main/pkgs/c_compiler
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: '>=3.0.0 <4.0.0'
 
 publish_to: none
 
@@ -15,7 +15,10 @@ dependencies:
   meta: ^1.9.1
   # TODO(dacoharkes): Publish native_assets_cli first.
   native_assets_cli:
-    path: ../native_assets_cli/
+    git:
+      url: git@github.com:dart-lang/native.git
+      ref: 21d7270a9f629ec2c0eb0879d000b30bcbef6cfc
+      path: pkgs/native_assets_cli/
   pub_semver: ^2.1.3
 
 dev_dependencies:

--- a/pkgs/c_compiler/pubspec.yaml
+++ b/pkgs/c_compiler/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   # TODO(dacoharkes): Publish native_assets_cli first.
   native_assets_cli:
     git:
-      url: git@github.com:dart-lang/native.git
+      url: https://github.com/dart-lang/native.git
       ref: 21d7270a9f629ec2c0eb0879d000b30bcbef6cfc
       path: pkgs/native_assets_cli/
   pub_semver: ^2.1.3

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -11,7 +11,10 @@ dependencies:
   graphs: ^2.3.1
   logging: ^1.2.0
   native_assets_cli:
-    path: ../native_assets_cli/
+    git:
+      url: git@github.com:dart-lang/native.git
+      ref: 21d7270a9f629ec2c0eb0879d000b30bcbef6cfc
+      path: pkgs/native_assets_cli/
   package_config: ^2.1.0
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   logging: ^1.2.0
   native_assets_cli:
     git:
-      url: git@github.com:dart-lang/native.git
+      url: https://github.com/dart-lang/native.git
       ref: 21d7270a9f629ec2c0eb0879d000b30bcbef6cfc
       path: pkgs/native_assets_cli/
   package_config: ^2.1.0

--- a/pkgs/native_assets_cli/example/native_add/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/native_add/pubspec.yaml
@@ -20,3 +20,9 @@ dev_dependencies:
   ffigen: ^8.0.2
   lints: ^2.0.0
   test: ^1.21.0
+
+dependency_overrides:
+  c_compiler:
+    path: ../../../c_compiler/
+  native_assets_cli:
+    path: ../../


### PR DESCRIPTION
We were not passing the right SDK for iossimulator compilations. This only led to warnings which weren't checked in the tests. Trying to actually pass a dylib to iOS didn't work. The unit test now contains some `otool` checks to see that we're building the right thing.

The non-path dependencies in this PR are needed to make pub resolve things downstream:

* https://github.com/dart-lang/pub/issues/3343#issuecomment-1623935798

The messiness with dependencies should go away once we publish a v0.1 for each package. (Also, then we cannot have relative path dependencies anymore, and PRs that involve multiple packages will need to be stacked on top of each other.)