### PR TITLE
[native_assets_cli] Bump version to v0.1.0

### DIFF
--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.1.0-dev
+## 0.1.0
 
 - Initial version.

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -2,11 +2,11 @@ name: native_assets_cli
 description: >-
   A library that contains the argument and file formats for implementing a
   native assets CLI.
-version: 0.1.0-dev
+version: 0.1.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   cli_config: ^0.1.1


### PR DESCRIPTION
https://github.com/dart-lang/native/issues/71

This package needs to be published before the other two.