### PR TITLE
[infra] Remove the last path dependencies

### DIFF
--- a/pkgs/native_assets_builder/test/data/native_add/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/native_add/pubspec.yaml
@@ -11,8 +11,7 @@ dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
   native_assets_cli: ^0.1.0
-  native_toolchain_c:
-    path: ../../../../native_toolchain_c/
+  native_toolchain_c: ^0.1.0
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test/data/native_add_add_source/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/native_add_add_source/pubspec.yaml
@@ -11,8 +11,7 @@ dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
   native_assets_cli: ^0.1.0
-  native_toolchain_c:
-    path: ../../../../native_toolchain_c/
+  native_toolchain_c: ^0.1.0
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test/data/native_subtract/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/native_subtract/pubspec.yaml
@@ -11,8 +11,7 @@ dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
   native_assets_cli: ^0.1.0
-  native_toolchain_c:
-    path: ../../../../native_toolchain_c/
+  native_toolchain_c: ^0.1.0
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_cli/example/native_add_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/native_add_library/pubspec.yaml
@@ -12,14 +12,9 @@ dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
   native_assets_cli: ^0.1.0
-  native_toolchain_c:
-    path: ../../../native_toolchain_c/
+  native_toolchain_c: ^0.1.0
 
 dev_dependencies:
   ffigen: ^8.0.2
   lints: ^2.0.0
   test: ^1.21.0
-
-dependency_overrides:
-  native_toolchain_c:
-    path: ../../../native_toolchain_c/


### PR DESCRIPTION
After this PR, all examples and integration test projects also build against published versions of the packages.

This means we do not run tests against path dependencies at all anymore.  Testing this is tracked in https://github.com/dart-lang/native/issues/80.