### PR TITLE
[native_assets_builder] Stop throwing from BuildRunner

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 0.2.0-wip
 
-- **Breaking change** `NativeAssetsBuildRunner`s method now return an object
+- **Breaking change** `NativeAssetsBuildRunner`s methods now return an object
   ([#105](https://github.com/dart-lang/native/issues/105)).
+- **Breaking change** `NativeAssetsBuildRunner`s methods now return value now
+  contains a list of errors instead of it throwing
+  ([#106](https://github.com/dart-lang/native/issues/106)).
 - Use an `out/` sub directory for building native assets
   ([#98](https://github.com/dart-lang/native/issues/98)).
 - Check asset ids on having having a package uri with the owning package

--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -3,8 +3,9 @@
 - **Breaking change** `NativeAssetsBuildRunner`s methods now return an object
   ([#105](https://github.com/dart-lang/native/issues/105)).
 - **Breaking change** `NativeAssetsBuildRunner`s methods now return value now
-  contains a list of errors instead of it throwing
-  ([#106](https://github.com/dart-lang/native/issues/106)).
+  contain a success bool instead of throwing
+  ([#106](https://github.com/dart-lang/native/issues/106)). Error messages are
+  streamed to the logger.
 - Use an `out/` sub directory for building native assets
   ([#98](https://github.com/dart-lang/native/issues/98)).
 - Check asset ids on having having a package uri with the owning package

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_planner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_planner.dart
@@ -6,25 +6,27 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:graphs/graphs.dart' as graphs;
+import 'package:logging/logging.dart';
 import 'package:package_config/package_config.dart';
-
-import 'build_runner.dart';
 
 class NativeAssetsBuildPlanner {
   final PackageGraph packageGraph;
   final List<Package> packagesWithNativeAssets;
   final Uri dartExecutable;
+  final Logger logger;
 
   NativeAssetsBuildPlanner({
     required this.packageGraph,
     required this.packagesWithNativeAssets,
     required this.dartExecutable,
+    required this.logger,
   });
 
   static Future<NativeAssetsBuildPlanner> fromRootPackageRoot({
     required Uri rootPackageRoot,
     required List<Package> packagesWithNativeAssets,
     required Uri dartExecutable,
+    required Logger logger,
   }) async {
     final result = await Process.run(
       dartExecutable.toFilePath(),
@@ -41,33 +43,35 @@ class NativeAssetsBuildPlanner {
       packageGraph: packageGraph,
       packagesWithNativeAssets: packagesWithNativeAssets,
       dartExecutable: dartExecutable,
+      logger: logger,
     );
   }
 
-  ({List<Package> packages, List<NativeAssetsBuilderError> errors}) plan() {
+  ({List<Package> packages, bool success}) plan() {
     final packageMap = {
       for (final package in packagesWithNativeAssets) package.name: package
     };
     final packagesToBuild = packageMap.keys.toSet();
     final stronglyConnectedComponents = packageGraph.computeStrongComponents();
     final result = <Package>[];
-    final errors = <NativeAssetsBuilderError>[];
+    var success = true;
     for (final stronglyConnectedComponent in stronglyConnectedComponents) {
       final stronglyConnectedComponentWithNativeAssets = [
         for (final packageName in stronglyConnectedComponent)
           if (packagesToBuild.contains(packageName)) packageName
       ];
       if (stronglyConnectedComponentWithNativeAssets.length > 1) {
-        errors.add(NativeAssetsBuilderError(
+        logger.severe(
           'Cyclic dependency for native asset builds in the following '
           'packages: $stronglyConnectedComponentWithNativeAssets.',
-        ));
+        );
+        success = false;
       } else if (stronglyConnectedComponentWithNativeAssets.length == 1) {
         result.add(
             packageMap[stronglyConnectedComponentWithNativeAssets.single]!);
       }
     }
-    return (packages: result, errors: errors);
+    return (packages: result, success: success);
   }
 }
 

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_planner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_planner.dart
@@ -47,7 +47,7 @@ class NativeAssetsBuildPlanner {
     );
   }
 
-  ({List<Package> packages, bool success}) plan() {
+  (List<Package> packages, bool success) plan() {
     final packageMap = {
       for (final package in packagesWithNativeAssets) package.name: package
     };
@@ -71,7 +71,7 @@ class NativeAssetsBuildPlanner {
             packageMap[stronglyConnectedComponentWithNativeAssets.single]!);
       }
     }
-    return (packages: result, success: success);
+    return (result, success);
   }
 }
 

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -53,13 +53,13 @@ class NativeAssetsBuildRunner {
       dartExecutable: Uri.file(Platform.resolvedExecutable),
       logger: logger,
     );
-    final plan = planner.plan();
+    final (plan, planSuccess) = planner.plan();
     final assets = <Asset>[];
     final dependencies = <Uri>[];
     final metadata = <String, Metadata>{};
-    var success = plan.success;
-    if (plan.success) {
-      for (final package in plan.packages) {
+    var success = planSuccess;
+    if (planSuccess) {
+      for (final package in plan) {
         final dependencyMetadata = _metadataForPackage(
           packageGraph: planner.packageGraph,
           packageName: package.name,
@@ -124,11 +124,11 @@ class NativeAssetsBuildRunner {
       dartExecutable: Uri.file(Platform.resolvedExecutable),
       logger: logger,
     );
-    final plan = planner.plan();
+    final (plan, planSuccess) = planner.plan();
     final assets = <Asset>[];
-    var success = plan.success;
-    if (plan.success) {
-      for (final package in plan.packages) {
+    var success = planSuccess;
+    if (planSuccess) {
+      for (final package in plan) {
         final config = await _cliConfigDryRun(
           packageName: package.name,
           packageRoot: packageLayout.packageRoot(package.name),
@@ -153,7 +153,7 @@ class NativeAssetsBuildRunner {
     );
   }
 
-  Future<(List<Asset>, List<Uri>, Metadata?, bool)> _buildPackageCached(
+  Future<_PackageBuildRecord> _buildPackageCached(
     BuildConfig config,
     Uri packageConfigUri,
     Uri workingDirectory,
@@ -191,7 +191,7 @@ class NativeAssetsBuildRunner {
     );
   }
 
-  Future<(List<Asset>, List<Uri>, Metadata?, bool)> _buildPackage(
+  Future<_PackageBuildRecord> _buildPackage(
     BuildConfig config,
     Uri packageConfigUri,
     Uri workingDirectory,
@@ -366,6 +366,13 @@ build_output.yaml contained a format error.
     return success;
   }
 }
+
+typedef _PackageBuildRecord = (
+  List<Asset>,
+  List<Uri> dependencies,
+  Metadata?,
+  bool success,
+);
 
 /// The result from a [NativeAssetsBuildRunner.dryRun].
 abstract interface class DryRunResult {

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -258,6 +258,7 @@ Building native assets for package:${config.packageName} failed.
 build_output.yaml contained a format error.
 ${e.message}
         ''');
+      success = false;
       return (<Asset>[], <Uri>[], Metadata({}), false);
       // TODO(https://github.com/dart-lang/native/issues/109): Stop throwing
       // type errors in native_assets_cli, release a new version of that package
@@ -268,7 +269,16 @@ ${e.message}
 Building native assets for package:${config.packageName} failed.
 build_output.yaml contained a format error.
         ''');
+      success = false;
       return (<Asset>[], <Uri>[], Metadata({}), false);
+    } finally {
+      if (!success) {
+        final buildOutputFile =
+            File.fromUri(outDir.resolve(BuildOutput.fileName));
+        if (await buildOutputFile.exists()) {
+          await buildOutputFile.delete();
+        }
+      }
     }
   }
 

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -54,45 +54,50 @@ class NativeAssetsBuildRunner {
       logger: logger,
     );
     final (plan, planSuccess) = planner.plan();
+    if (!planSuccess) {
+      return _BuildResultImpl(
+        assets: [],
+        dependencies: [],
+        success: false,
+      );
+    }
     final assets = <Asset>[];
     final dependencies = <Uri>[];
     final metadata = <String, Metadata>{};
-    var success = planSuccess;
-    if (planSuccess) {
-      for (final package in plan) {
-        final dependencyMetadata = _metadataForPackage(
-          packageGraph: planner.packageGraph,
-          packageName: package.name,
-          targetMetadata: metadata,
-        );
-        final config = await _cliConfig(
-          packageRoot: packageLayout.packageRoot(package.name),
-          target: target,
-          buildMode: buildMode,
-          linkMode: linkModePreference,
-          buildParentDir: packageLayout.dartToolNativeAssetsBuilder,
-          dependencyMetadata: dependencyMetadata,
-          cCompilerConfig: cCompilerConfig,
-          targetIOSSdk: targetIOSSdk,
-          targetAndroidNdkApi: targetAndroidNdkApi,
-        );
-        final (
-          packageAssets,
-          packageDependencies,
-          packageMetadata,
-          packageSuccess,
-        ) = await _buildPackageCached(
-          config,
-          packageLayout.packageConfigUri,
-          workingDirectory,
-          includeParentEnvironment,
-        );
-        assets.addAll(packageAssets);
-        dependencies.addAll(packageDependencies);
-        success &= packageSuccess;
-        if (packageMetadata != null) {
-          metadata[config.packageName] = packageMetadata;
-        }
+    var success = true;
+    for (final package in plan) {
+      final dependencyMetadata = _metadataForPackage(
+        packageGraph: planner.packageGraph,
+        packageName: package.name,
+        targetMetadata: metadata,
+      );
+      final config = await _cliConfig(
+        packageRoot: packageLayout.packageRoot(package.name),
+        target: target,
+        buildMode: buildMode,
+        linkMode: linkModePreference,
+        buildParentDir: packageLayout.dartToolNativeAssetsBuilder,
+        dependencyMetadata: dependencyMetadata,
+        cCompilerConfig: cCompilerConfig,
+        targetIOSSdk: targetIOSSdk,
+        targetAndroidNdkApi: targetAndroidNdkApi,
+      );
+      final (
+        packageAssets,
+        packageDependencies,
+        packageMetadata,
+        packageSuccess,
+      ) = await _buildPackageCached(
+        config,
+        packageLayout.packageConfigUri,
+        workingDirectory,
+        includeParentEnvironment,
+      );
+      assets.addAll(packageAssets);
+      dependencies.addAll(packageDependencies);
+      success &= packageSuccess;
+      if (packageMetadata != null) {
+        metadata[config.packageName] = packageMetadata;
       }
     }
     return _BuildResultImpl(
@@ -125,27 +130,31 @@ class NativeAssetsBuildRunner {
       logger: logger,
     );
     final (plan, planSuccess) = planner.plan();
+    if (!planSuccess) {
+      return _DryRunResultImpl(
+        assets: [],
+        success: false,
+      );
+    }
     final assets = <Asset>[];
-    var success = planSuccess;
-    if (planSuccess) {
-      for (final package in plan) {
-        final config = await _cliConfigDryRun(
-          packageName: package.name,
-          packageRoot: packageLayout.packageRoot(package.name),
-          targetOs: targetOs,
-          linkMode: linkModePreference,
-          buildParentDir: packageLayout.dartToolNativeAssetsBuilder,
-        );
-        final (packageAssets, _, _, packageSuccess) = await _buildPackage(
-          config,
-          packageLayout.packageConfigUri,
-          workingDirectory,
-          includeParentEnvironment,
-          dryRun: true,
-        );
-        assets.addAll(packageAssets);
-        success &= packageSuccess;
-      }
+    var success = true;
+    for (final package in plan) {
+      final config = await _cliConfigDryRun(
+        packageName: package.name,
+        packageRoot: packageLayout.packageRoot(package.name),
+        targetOs: targetOs,
+        linkMode: linkModePreference,
+        buildParentDir: packageLayout.dartToolNativeAssetsBuilder,
+      );
+      final (packageAssets, _, _, packageSuccess) = await _buildPackage(
+        config,
+        packageLayout.packageConfigUri,
+        workingDirectory,
+        includeParentEnvironment,
+        dryRun: true,
+      );
+      assets.addAll(packageAssets);
+      success &= packageSuccess;
     }
     return _DryRunResultImpl(
       assets: assets,

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -231,7 +231,8 @@ class NativeAssetsBuildRunner {
         if (printWorkingDir) ')',
       ].join(' ');
       logger.severe(
-        '''Building native assets failed.
+        '''
+Building native assets for package:${config.packageName} failed.
 build.dart returned with exit code: ${result.exitCode}.
 To reproduce run:
 $commandString

--- a/pkgs/native_assets_builder/test/build_runner/build_planner_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_planner_test.dart
@@ -43,6 +43,7 @@ void main() async {
         packageGraph: graph,
         packagesWithNativeAssets: packagesWithNativeAssets,
         dartExecutable: Uri.file(Platform.resolvedExecutable),
+        logger: logger,
       );
       final buildPlan = planner.plan();
       expect(buildPlan.packages.length, 1);
@@ -65,6 +66,7 @@ void main() async {
         rootPackageRoot: nativeAddUri,
         packagesWithNativeAssets: packagesWithNativeAssets,
         dartExecutable: Uri.file(Platform.resolvedExecutable),
+        logger: logger,
       ))
           .plan();
       expect(buildPlan.packages.length, 1);

--- a/pkgs/native_assets_builder/test/build_runner/build_planner_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_planner_test.dart
@@ -45,8 +45,8 @@ void main() async {
         dartExecutable: Uri.file(Platform.resolvedExecutable),
       );
       final buildPlan = planner.plan();
-      expect(buildPlan.length, 1);
-      expect(buildPlan.single.name, 'native_add');
+      expect(buildPlan.packages.length, 1);
+      expect(buildPlan.packages.single.name, 'native_add');
     });
   });
   test('build dependency graph fromPackageRoot', () async {
@@ -67,8 +67,8 @@ void main() async {
         dartExecutable: Uri.file(Platform.resolvedExecutable),
       ))
           .plan();
-      expect(buildPlan.length, 1);
-      expect(buildPlan.single.name, 'native_add');
+      expect(buildPlan.packages.length, 1);
+      expect(buildPlan.packages.single.name, 'native_add');
     });
   });
 }

--- a/pkgs/native_assets_builder/test/build_runner/build_planner_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_planner_test.dart
@@ -45,9 +45,9 @@ void main() async {
         dartExecutable: Uri.file(Platform.resolvedExecutable),
         logger: logger,
       );
-      final buildPlan = planner.plan();
-      expect(buildPlan.packages.length, 1);
-      expect(buildPlan.packages.single.name, 'native_add');
+      final (buildPlan, _) = planner.plan();
+      expect(buildPlan.length, 1);
+      expect(buildPlan.single.name, 'native_add');
     });
   });
   test('build dependency graph fromPackageRoot', () async {
@@ -62,15 +62,16 @@ void main() async {
           await PackageLayout.fromRootPackageRoot(nativeAddUri);
       final packagesWithNativeAssets =
           await packageLayout.packagesWithNativeAssets;
-      final buildPlan = (await NativeAssetsBuildPlanner.fromRootPackageRoot(
+      final nativeAssetsBuildPlanner =
+          await NativeAssetsBuildPlanner.fromRootPackageRoot(
         rootPackageRoot: nativeAddUri,
         packagesWithNativeAssets: packagesWithNativeAssets,
         dartExecutable: Uri.file(Platform.resolvedExecutable),
         logger: logger,
-      ))
-          .plan();
-      expect(buildPlan.packages.length, 1);
-      expect(buildPlan.packages.single.name, 'native_add');
+      );
+      final (buildPlan, _) = nativeAssetsBuildPlanner.plan();
+      expect(buildPlan.length, 1);
+      expect(buildPlan.single.name, 'native_add');
     });
   });
 }

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_asset_id_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_asset_id_test.dart
@@ -22,7 +22,7 @@ void main() async {
 
       {
         final result = await build(packageUri, logger, dartExecutable);
-        expect(result.errors, isNotEmpty);
+        expect(result.success, false);
       }
     });
   });

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_asset_id_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_asset_id_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';
@@ -21,8 +22,21 @@ void main() async {
       );
 
       {
-        final result = await build(packageUri, logger, dartExecutable);
+        final logMessages = <String>[];
+        final result = await build(
+          packageUri,
+          createCapturingLogger(logMessages, level: Level.SEVERE),
+          dartExecutable,
+        );
+        final fullLog = logMessages.join('\n');
         expect(result.success, false);
+        expect(
+          fullLog,
+          contains(
+            '`package:wrong_namespace_asset` declares the following assets '
+            'which do not start with `package:wrong_namespace_asset/`:',
+          ),
+        );
       }
     });
   });

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_build_output_format_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_build_output_format_test.dart
@@ -26,7 +26,7 @@ void main() async {
 
         {
           final result = await build(packageUri, logger, dartExecutable);
-          expect(result.errors, isNotEmpty);
+          expect(result.success, false);
         }
       });
     });

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_build_output_format_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_build_output_format_test.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+import 'helpers.dart';
+
+const Timeout longTimeout = Timeout(Duration(minutes: 5));
+
+void main() async {
+  for (final package in [
+    'wrong_build_output',
+    'wrong_build_output_2',
+  ]) {
+    test('wrong version $package', timeout: longTimeout, () async {
+      await inTempDir((tempUri) async {
+        await copyTestProjects(targetUri: tempUri);
+        final packageUri = tempUri.resolve('$package/');
+
+        await runPubGet(
+          workingDirectory: packageUri,
+          logger: logger,
+        );
+
+        {
+          final result = await build(packageUri, logger, dartExecutable);
+          expect(result.errors, isNotEmpty);
+        }
+      });
+    });
+  }
+}

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_build_output_format_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_build_output_format_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';
@@ -25,8 +26,18 @@ void main() async {
         );
 
         {
-          final result = await build(packageUri, logger, dartExecutable);
+          final logMessages = <String>[];
+          final result = await build(
+            packageUri,
+            createCapturingLogger(logMessages, level: Level.SEVERE),
+            dartExecutable,
+          );
+          final fullLog = logMessages.join('\n');
           expect(result.success, false);
+          expect(
+            fullLog,
+            contains('build_output.yaml contained a format error.'),
+          );
         }
       });
     });

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_cycle_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_cycle_test.dart
@@ -22,12 +22,12 @@ void main() async {
 
       {
         final result = await dryRun(packageUri, logger, dartExecutable);
-        expect(result.errors, isNotEmpty);
+        expect(result.success, false);
       }
 
       {
         final result = await build(packageUri, logger, dartExecutable);
-        expect(result.errors, isNotEmpty);
+        expect(result.success, false);
       }
     });
   });

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_cycle_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_cycle_test.dart
@@ -10,15 +10,20 @@ import 'helpers.dart';
 const Timeout longTimeout = Timeout(Duration(minutes: 5));
 
 void main() async {
-  test('wrong asset id', timeout: longTimeout, () async {
+  test('cycle', timeout: longTimeout, () async {
     await inTempDir((tempUri) async {
       await copyTestProjects(targetUri: tempUri);
-      final packageUri = tempUri.resolve('wrong_namespace_asset/');
+      final packageUri = tempUri.resolve('cyclic_package_1/');
 
       await runPubGet(
         workingDirectory: packageUri,
         logger: logger,
       );
+
+      {
+        final result = await dryRun(packageUri, logger, dartExecutable);
+        expect(result.errors, isNotEmpty);
+      }
 
       {
         final result = await build(packageUri, logger, dartExecutable);

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_cycle_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_cycle_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';
@@ -19,15 +20,40 @@ void main() async {
         workingDirectory: packageUri,
         logger: logger,
       );
-
       {
-        final result = await dryRun(packageUri, logger, dartExecutable);
+        final logMessages = <String>[];
+        final result = await dryRun(
+          packageUri,
+          createCapturingLogger(logMessages, level: Level.SEVERE),
+          dartExecutable,
+        );
+        final fullLog = logMessages.join('\n');
         expect(result.success, false);
+        expect(
+          fullLog,
+          contains(
+            'Cyclic dependency for native asset builds in the following '
+            'packages: [cyclic_package_1, cyclic_package_2]',
+          ),
+        );
       }
 
       {
-        final result = await build(packageUri, logger, dartExecutable);
+        final logMessages = <String>[];
+        final result = await build(
+          packageUri,
+          createCapturingLogger(logMessages, level: Level.SEVERE),
+          dartExecutable,
+        );
+        final fullLog = logMessages.join('\n');
         expect(result.success, false);
+        expect(
+          fullLog,
+          contains(
+            'Cyclic dependency for native asset builds in the following '
+            'packages: [cyclic_package_1, cyclic_package_2]',
+          ),
+        );
       }
     });
   });

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_failure_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_failure_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';
@@ -43,9 +44,12 @@ void main() async {
       {
         final logMessages = <String>[];
         final result = await build(
-            packageUri, createCapturingLogger(logMessages), dartExecutable);
-        expect(result.success, false);
+          packageUri,
+          createCapturingLogger(logMessages, level: Level.SEVERE),
+          dartExecutable,
+        );
         final fullLog = logMessages.join('\n');
+        expect(result.success, false);
         expect(fullLog, contains('To reproduce run:'));
         final reproCommand = fullLog
             .split('\n')

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_failure_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_failure_test.dart
@@ -41,12 +41,13 @@ void main() async {
       );
 
       {
-        final result = await build(packageUri, logger, dartExecutable);
-        expect(result.errors, isNotEmpty);
-        expect(result.errors.length, 1);
-        final errorMessage = result.errors.first.message;
-        expect(errorMessage, contains('To reproduce run:'));
-        final reproCommand = errorMessage
+        final logMessages = <String>[];
+        final result = await build(
+            packageUri, createCapturingLogger(logMessages), dartExecutable);
+        expect(result.success, false);
+        final fullLog = logMessages.join('\n');
+        expect(fullLog, contains('To reproduce run:'));
+        final reproCommand = fullLog
             .split('\n')
             .skipWhile((l) => l != 'To reproduce run:')
             .skip(1)

--- a/pkgs/native_assets_builder/test/build_runner/helpers.dart
+++ b/pkgs/native_assets_builder/test/build_runner/helpers.dart
@@ -52,7 +52,9 @@ Future<BuildResult> build(
     cCompilerConfig: cCompilerConfig,
     includeParentEnvironment: includeParentEnvironment,
   );
-  await expectAssetsExist(result.assets);
+  if (result.errors.isEmpty) {
+    await expectAssetsExist(result.assets);
+  }
 
   if (subscription != null) {
     await subscription.cancel();

--- a/pkgs/native_assets_builder/test/build_runner/helpers.dart
+++ b/pkgs/native_assets_builder/test/build_runner/helpers.dart
@@ -52,7 +52,7 @@ Future<BuildResult> build(
     cCompilerConfig: cCompilerConfig,
     includeParentEnvironment: includeParentEnvironment,
   );
-  if (result.errors.isEmpty) {
+  if (result.success) {
     await expectAssetsExist(result.assets);
   }
 

--- a/pkgs/native_assets_builder/test/data/cyclic_package_1/build.dart
+++ b/pkgs/native_assets_builder/test/data/cyclic_package_1/build.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:native_assets_cli/native_assets_cli.dart';
+
+void main(List<String> args) async {
+  final buildConfig = await BuildConfig.fromArgs(args);
+  final buildOutput = BuildOutput();
+  await buildOutput.writeToFile(outDir: buildConfig.outDir);
+}

--- a/pkgs/native_assets_builder/test/data/cyclic_package_1/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/cyclic_package_1/pubspec.yaml
@@ -1,0 +1,19 @@
+name: cyclic_package_1
+description: Part of two packages with native assets that have a cycle.
+version: 0.1.0
+
+publish_to: none
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  cli_config: ^0.1.1
+  cyclic_package_2:
+    path: ../cyclic_package_2
+  native_assets_cli: ^0.1.0
+  yaml: ^3.1.1
+  yaml_edit: ^2.1.0
+
+dev_dependencies:
+  lints: ^2.0.0

--- a/pkgs/native_assets_builder/test/data/cyclic_package_2/build.dart
+++ b/pkgs/native_assets_builder/test/data/cyclic_package_2/build.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:native_assets_cli/native_assets_cli.dart';
+
+void main(List<String> args) async {
+  final buildConfig = await BuildConfig.fromArgs(args);
+  final buildOutput = BuildOutput();
+  await buildOutput.writeToFile(outDir: buildConfig.outDir);
+}

--- a/pkgs/native_assets_builder/test/data/cyclic_package_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/cyclic_package_2/pubspec.yaml
@@ -1,0 +1,19 @@
+name: cyclic_package_2
+description: Part of two packages with native assets that have a cycle.
+version: 0.1.0
+
+publish_to: none
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  cli_config: ^0.1.1
+  cyclic_package_1:
+    path: ../cyclic_package_1
+  native_assets_cli: ^0.1.0
+  yaml: ^3.1.1
+  yaml_edit: ^2.1.0
+
+dev_dependencies:
+  lints: ^2.0.0

--- a/pkgs/native_assets_builder/test/data/manifest.yaml
+++ b/pkgs/native_assets_builder/test/data/manifest.yaml
@@ -1,5 +1,9 @@
 # The list of files to copy to a temporary folder to ensure running tests from
 # a completely clean setup.
+- cyclic_package_1/build.dart
+- cyclic_package_1/pubspec.yaml
+- cyclic_package_2/build.dart
+- cyclic_package_2/pubspec.yaml
 - dart_app/bin/dart_app.dart
 - dart_app/pubspec.yaml
 - native_add/build.dart
@@ -23,5 +27,9 @@
 - package_reading_metadata/pubspec.yaml
 - package_with_metadata/build.dart
 - package_with_metadata/pubspec.yaml
+- wrong_build_output/build.dart
+- wrong_build_output/pubspec.yaml
+- wrong_build_output_2/build.dart
+- wrong_build_output_2/pubspec.yaml
 - wrong_namespace_asset/build.dart
 - wrong_namespace_asset/pubspec.yaml

--- a/pkgs/native_assets_builder/test/data/manifest.yaml
+++ b/pkgs/native_assets_builder/test/data/manifest.yaml
@@ -31,5 +31,7 @@
 - wrong_build_output/pubspec.yaml
 - wrong_build_output_2/build.dart
 - wrong_build_output_2/pubspec.yaml
+- wrong_build_output_3/build.dart
+- wrong_build_output_3/pubspec.yaml
 - wrong_namespace_asset/build.dart
 - wrong_namespace_asset/pubspec.yaml

--- a/pkgs/native_assets_builder/test/data/wrong_build_output/build.dart
+++ b/pkgs/native_assets_builder/test/data/wrong_build_output/build.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:native_assets_cli/native_assets_cli.dart';
+
+void main(List<String> args) async {
+  final buildConfig = await BuildConfig.fromArgs(args);
+  await File.fromUri(buildConfig.outDir.resolve(BuildOutput.fileName))
+      .writeAsString(_wrongContents);
+}
+
+const _wrongContents = '''
+timestamp: 2023-07-28 14:22:45.000
+assets: []
+dependencies: []
+metadata: {}
+version: 9001.0.0
+''';

--- a/pkgs/native_assets_builder/test/data/wrong_build_output/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/wrong_build_output/pubspec.yaml
@@ -1,0 +1,17 @@
+name: wrong_build_output
+description: Package that tries to add an asset with an id not prefixed by its package name.
+version: 0.1.0
+
+publish_to: none
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  cli_config: ^0.1.1
+  native_assets_cli: ^0.1.0
+  yaml: ^3.1.1
+  yaml_edit: ^2.1.0
+
+dev_dependencies:
+  lints: ^2.0.0

--- a/pkgs/native_assets_builder/test/data/wrong_build_output_2/build.dart
+++ b/pkgs/native_assets_builder/test/data/wrong_build_output_2/build.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:native_assets_cli/native_assets_cli.dart';
+
+void main(List<String> args) async {
+  final buildConfig = await BuildConfig.fromArgs(args);
+  await File.fromUri(buildConfig.outDir.resolve(BuildOutput.fileName))
+      .writeAsString(_wrongContents);
+}
+
+const _wrongContents = '''
+timestamp: 2023-07-28 14:22:45.000
+assets:
+  foo: 123
+dependencies: []
+metadata: {}
+version: 1.0.0
+''';

--- a/pkgs/native_assets_builder/test/data/wrong_build_output_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/wrong_build_output_2/pubspec.yaml
@@ -1,0 +1,17 @@
+name: wrong_build_output_2
+description: Package that tries to add an asset with an id not prefixed by its package name.
+version: 0.1.0
+
+publish_to: none
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  cli_config: ^0.1.1
+  native_assets_cli: ^0.1.0
+  yaml: ^3.1.1
+  yaml_edit: ^2.1.0
+
+dev_dependencies:
+  lints: ^2.0.0

--- a/pkgs/native_assets_builder/test/data/wrong_build_output_3/build.dart
+++ b/pkgs/native_assets_builder/test/data/wrong_build_output_3/build.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:native_assets_cli/native_assets_cli.dart';
+
+void main(List<String> args) async {
+  final buildConfig = await BuildConfig.fromArgs(args);
+  await File.fromUri(buildConfig.outDir.resolve(BuildOutput.fileName))
+      .writeAsString(_rightContents);
+  exit(1);
+}
+
+const _rightContents = '''
+timestamp: 2023-07-28 14:22:45.000
+assets: []
+dependencies: []
+metadata: {}
+version: 1.0.0
+''';

--- a/pkgs/native_assets_builder/test/data/wrong_build_output_3/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/wrong_build_output_3/pubspec.yaml
@@ -1,0 +1,17 @@
+name: wrong_build_output_3
+description: Package that outputs a valid build_output.yaml but a non-zero exit code.
+version: 0.1.0
+
+publish_to: none
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  cli_config: ^0.1.1
+  native_assets_cli: ^0.1.0
+  yaml: ^3.1.1
+  yaml_edit: ^2.1.0
+
+dev_dependencies:
+  lints: ^2.0.0

--- a/pkgs/native_assets_builder/test/helpers.dart
+++ b/pkgs/native_assets_builder/test/helpers.dart
@@ -163,11 +163,15 @@ final logger = Logger('')
     printOnFailure(record.message);
   });
 
-Logger createCapturingLogger(List<String> capturedMessages) => Logger('')
-  ..level = Level.ALL
-  ..onRecord.listen((record) {
-    printOnFailure(record.message);
-    capturedMessages.add(record.message);
-  });
+Logger createCapturingLogger(
+  List<String> capturedMessages, {
+  Level level = Level.ALL,
+}) =>
+    Logger('')
+      ..level = level
+      ..onRecord.listen((record) {
+        printOnFailure(record.message);
+        capturedMessages.add(record.message);
+      });
 
 final dartExecutable = File(Platform.resolvedExecutable).uri;

--- a/pkgs/native_assets_builder/test/helpers.dart
+++ b/pkgs/native_assets_builder/test/helpers.dart
@@ -160,7 +160,14 @@ Future<void> copyTestProjects({
 final logger = Logger('')
   ..level = Level.ALL
   ..onRecord.listen((record) {
-    printOnFailure('${record.level.name}: ${record.time}: ${record.message}');
+    printOnFailure(record.message);
+  });
+
+Logger createCapturingLogger(List<String> capturedMessages) => Logger('')
+  ..level = Level.ALL
+  ..onRecord.listen((record) {
+    printOnFailure(record.message);
+    capturedMessages.add(record.message);
   });
 
 final dartExecutable = File(Platform.resolvedExecutable).uri;


### PR DESCRIPTION
Closes #106.

* Streams errors to the logger.
* Returns a `success` boolean.

Closes #111.

* Deletes `build_output.yaml` to prevent caching on build failures. (See issue for alternative solutions.)