### PR TITLE
[native_toolchain_c] Rename `assetName` to `assetId`

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.1.1-wip
+## 0.2.0
 
 - Added topics.
+- *Breaking change* Rename `assetName` to `assetId`
+  ([#100](https://github.com/dart-lang/native/issues/100)).
 
 ## 0.1.0
 

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -36,7 +36,7 @@ class CBuilder implements Builder {
   /// Used to output the [BuildOutput.assets].
   ///
   /// If omitted, no asset will be added to the build output.
-  final String? assetName;
+  final String? assetId;
 
   /// Sources to build the library or executable.
   ///
@@ -59,7 +59,7 @@ class CBuilder implements Builder {
 
   CBuilder.library({
     required this.name,
-    required this.assetName,
+    required this.assetId,
     this.sources = const [],
     this.dartBuildFiles = const ['build.dart'],
     @visibleForTesting this.installName,
@@ -70,7 +70,7 @@ class CBuilder implements Builder {
     this.sources = const [],
     this.dartBuildFiles = const ['build.dart'],
   })  : _type = _CBuilderType.executable,
-        assetName = null,
+        assetId = null,
         installName = null;
 
   /// Runs the C Compiler with on this C build spec.
@@ -116,7 +116,7 @@ class CBuilder implements Builder {
       await task.run();
     }
 
-    if (assetName != null) {
+    if (assetId != null) {
       final targets = [
         if (!buildConfig.dryRun)
           buildConfig.target
@@ -126,7 +126,7 @@ class CBuilder implements Builder {
       ];
       for (final target in targets) {
         buildOutput.assets.add(Asset(
-          name: assetName!,
+          id: assetId!,
           linkMode: linkMode,
           target: target,
           path: AssetAbsolutePath(libUri),

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.1.1-wip
+version: 0.2.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:
@@ -19,7 +19,7 @@ dependencies:
   glob: ^2.1.1
   logging: ^1.1.1
   meta: ^1.9.1
-  native_assets_cli: ^0.1.0
+  native_assets_cli: ^0.2.0
   pub_semver: ^2.1.3
 
 dev_dependencies:

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
@@ -48,7 +48,7 @@ void main() {
         final cbuilder = CBuilder.library(
           sources: [addCUri.toFilePath()],
           name: name,
-          assetName: name,
+          assetId: name,
         );
         expect(
           () => cbuilder.run(

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -127,7 +127,7 @@ Future<Uri> buildLib(
 
   final cbuilder = CBuilder.library(
     name: name,
-    assetName: name,
+    assetId: name,
     sources: [addCUri.toFilePath()],
   );
   await cbuilder.run(

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -71,7 +71,7 @@ void main() {
 
               final cbuilder = CBuilder.library(
                 name: name,
-                assetName: name,
+                assetId: name,
                 sources: [addCUri.toFilePath()],
                 installName: installName,
               );

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -56,7 +56,7 @@ void main() {
 
           final cbuilder = CBuilder.library(
             name: name,
-            assetName: name,
+            assetId: name,
             sources: [addCUri.toFilePath()],
           );
           await cbuilder.run(

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -56,7 +56,7 @@ void main() {
 
           final cbuilder = CBuilder.library(
             name: name,
-            assetName: name,
+            assetId: name,
             sources: [addCUri.toFilePath()],
           );
           await cbuilder.run(

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -68,7 +68,7 @@ void main() {
 
           final cbuilder = CBuilder.library(
             name: name,
-            assetName: name,
+            assetId: name,
             sources: [addCUri.toFilePath()],
           );
           await cbuilder.run(

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -106,7 +106,7 @@ void main() {
           final cbuilder = CBuilder.library(
             sources: [addCUri.toFilePath()],
             name: name,
-            assetName: name,
+            assetId: name,
           );
           await cbuilder.run(
             buildConfig: buildConfig,


### PR DESCRIPTION
Bug https://github.com/dart-lang/native/issues/100.

1. This PR: Roll rename into `package:native_toolchain_c` and rename param.
2. Then publish native_toolchain_c.
3. Then a PR that rolls both native_toolchain_c and native_assets_cli into native_assets_builder.