### PR TITLE
[native_toolchain_c] Add support for configuring preprocessor macro defines

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.1
+
+- Added `defines` for specifying custom defines.
+- Added `buildModeDefine` to toggle define for current build mode.
+- Added `ndebugDefine` to toggle define of `NDEBUG` for non-debug builds.
+
 ## 0.2.0
 
 - **Breaking change** Rename `assetName` to `assetId`

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -32,6 +32,8 @@ class RunCBuilder {
   /// Can be modified with `install_name_tool`.
   final Uri? installName;
 
+  final Map<String, String?> defines;
+
   RunCBuilder({
     required this.buildConfig,
     this.logger,
@@ -40,6 +42,7 @@ class RunCBuilder {
     this.dynamicLibrary,
     this.staticLibrary,
     this.installName,
+    this.defines = const {},
   })  : outDir = buildConfig.outDir,
         target = buildConfig.target,
         assert([executable, dynamicLibrary, staticLibrary]
@@ -142,11 +145,8 @@ class RunCBuilder {
           '-o',
           outDir.resolve('out.o').toFilePath(),
         ],
-        // TODO(https://github.com/dart-lang/native/issues/50): The defines
-        // should probably be configurable. That way, the mapping from
-        // build_mode to defines can be defined in a project-dependent way in
-        // each project build.dart.
-        '-D${buildConfig.buildMode.name.toUpperCase()}'
+        for (final MapEntry(key: name, :value) in defines.entries)
+          if (value == null) '-D$name' else '-D$name=$value',
       ],
       logger: logger,
       captureOutput: false,
@@ -181,11 +181,8 @@ class RunCBuilder {
     final result = await runProcess(
       executable: compiler.uri,
       arguments: [
-        // TODO(https://github.com/dart-lang/native/issues/50): The defines
-        // should probably be configurable. That way, the mapping from
-        // build_mode to defines can be defined in a project-dependent way in
-        // each project build.dart.
-        '/D${buildConfig.buildMode.name.toUpperCase()}',
+        for (final MapEntry(key: name, :value) in defines.entries)
+          if (value == null) '/D$name' else '/D$name=$value',
         if (executable != null) ...[
           ...sources.map((e) => e.toFilePath()),
           '/link',

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.2.0
+version: 0.2.1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -127,4 +127,119 @@ void main() {
       );
     });
   }
+
+  for (final buildMode in BuildMode.values) {
+    for (final enabled in [true, false]) {
+      test(
+        'Cbuilder build mode defines ${enabled ? 'enabled' : 'disabled'} for '
+        '$buildMode',
+        () => testDefines(
+          buildMode: buildMode,
+          buildModeDefine: enabled,
+          ndebugDefine: enabled,
+        ),
+      );
+    }
+  }
+
+  for (final value in [true, false]) {
+    test(
+      'Cbuilder define ${value ? 'with' : 'without'} value',
+      () => testDefines(customDefineWithValue: value),
+    );
+  }
+}
+
+Future<void> testDefines({
+  BuildMode buildMode = BuildMode.debug,
+  bool buildModeDefine = false,
+  bool ndebugDefine = false,
+  bool? customDefineWithValue,
+}) async {
+  await inTempDir((tempUri) async {
+    final definesCUri =
+        packageUri.resolve('test/cbuilder/testfiles/defines/src/defines.c');
+    if (!await File.fromUri(definesCUri).exists()) {
+      throw Exception('Run the test from the root directory.');
+    }
+    const name = 'defines';
+
+    final buildConfig = BuildConfig(
+      outDir: tempUri,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.current,
+      targetOs: OS.current,
+      buildMode: buildMode,
+      // Ignored by executables.
+      linkModePreference: LinkModePreference.dynamic,
+      cCompiler: CCompilerConfig(
+        cc: cc,
+        envScript: envScript,
+        envScriptArgs: envScriptArgs,
+      ),
+    );
+    final buildOutput = BuildOutput();
+    final cbuilder = CBuilder.executable(
+      name: name,
+      sources: [definesCUri.toFilePath()],
+      defines: {
+        if (customDefineWithValue != null)
+          'FOO': customDefineWithValue ? 'BAR' : null,
+      },
+      buildModeDefine: buildModeDefine,
+      ndebugDefine: ndebugDefine,
+    );
+    await cbuilder.run(
+      buildConfig: buildConfig,
+      buildOutput: buildOutput,
+      logger: logger,
+    );
+
+    final executableUri =
+        tempUri.resolve(Target.current.os.executableFileName(name));
+    expect(await File.fromUri(executableUri).exists(), true);
+    final result = await runProcess(
+      executable: executableUri,
+      logger: logger,
+    );
+    expect(result.exitCode, 0);
+
+    if (buildModeDefine) {
+      expect(
+        result.stdout,
+        contains('Macro ${buildMode.name.toUpperCase()} is defined: 1'),
+      );
+    } else {
+      expect(
+        result.stdout,
+        contains('Macro ${buildMode.name.toUpperCase()} is undefined.'),
+      );
+    }
+
+    if (ndebugDefine && buildMode != BuildMode.debug) {
+      expect(
+        result.stdout,
+        contains('Macro NDEBUG is defined: 1'),
+      );
+    } else {
+      expect(
+        result.stdout,
+        contains('Macro NDEBUG is undefined.'),
+      );
+    }
+
+    if (customDefineWithValue != null) {
+      expect(
+        result.stdout,
+        contains(
+          'Macro FOO is defined: ${customDefineWithValue ? 'BAR' : '1'}',
+        ),
+      );
+    } else {
+      expect(
+        result.stdout,
+        contains('Macro FOO is undefined.'),
+      );
+    }
+  });
 }

--- a/pkgs/native_toolchain_c/test/cbuilder/testfiles/defines/src/defines.c
+++ b/pkgs/native_toolchain_c/test/cbuilder/testfiles/defines/src/defines.c
@@ -1,0 +1,38 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include <stdio.h>
+
+#define STRINGIFY(X) #X
+#define MACRO_IS_UNDEFINED(name) printf("Macro " #name " is undefined.\n");
+#define MACRO_IS_DEFINED(name)                                                 \
+  printf("Macro " #name " is defined: " STRINGIFY(name) "\n");
+
+int main() {
+#ifdef DEBUG
+  MACRO_IS_DEFINED(DEBUG);
+#else
+  MACRO_IS_UNDEFINED(DEBUG);
+#endif
+
+#ifdef RELEASE
+  MACRO_IS_DEFINED(RELEASE);
+#else
+  MACRO_IS_UNDEFINED(RELEASE);
+#endif
+
+#ifdef NDEBUG
+  MACRO_IS_DEFINED(NDEBUG);
+#else
+  MACRO_IS_UNDEFINED(NDEBUG);
+#endif
+
+#ifdef FOO
+  MACRO_IS_DEFINED(FOO);
+#else
+  MACRO_IS_UNDEFINED(FOO);
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
This PR adds `CBuilder.defines` which can be used to specify definitions for preprocessor macros. Providing a value for a macro is optional.

Whether a macro with the name of the current `BuildMode` is defined is now configurable through `CBuilder.buildModeDefine`. Per default, this option is enabled.

Additionally, the standard `NDEBUG` macro is now being defined when _not_ building with `BuildMode.debug`. This behavior is also configurable (`CBuilder.ndebugDefine`) and enabled by default.

Closes https://github.com/dart-lang/native/issues/61
