### PR TITLE
[native_toolchain_c] Default handling for PIC/PIE compiler flags

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Added `defines` for specifying custom defines.
 - Added `buildModeDefine` to toggle define for current build mode.
 - Added `ndebugDefine` to toggle define of `NDEBUG` for non-debug builds.
+- Generate position independent code for libraries by default and add
+  `pic` option to control this behavior.
 
 ## 0.2.0
 

--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,10 +1,13 @@
+## 0.2.2
+
+- Generate position independent code for libraries by default and add
+  `pic` option to control this behavior.
+
 ## 0.2.1
 
 - Added `defines` for specifying custom defines.
 - Added `buildModeDefine` to toggle define for current build mode.
 - Added `ndebugDefine` to toggle define of `NDEBUG` for non-debug builds.
-- Generate position independent code for libraries by default and add
-  `pic` option to control this behavior.
 
 ## 0.2.0
 

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -83,13 +83,14 @@ class CBuilder implements Builder {
 
   /// Whether the compiler will emit position independent code.
   ///
-  /// This option is set by the `pie` parameter for the [executable]
-  /// constructor.
-  ///
   /// When set to `true`, libraries will be compiled with `-fPIC` and
-  /// executables with `-fPIE`.
+  /// executables with `-fPIE`. Accordingly the corresponding parameter of the
+  /// [executable] constructor is named `pie`.
   ///
   /// When set to `null`, the default behavior of the compiler will be used.
+  ///
+  /// This option has no effect when building for Windows, where generation of
+  /// position independent code is not configurable.
   ///
   /// Defaults to `true` for libraries and `false` for executables.
   final bool? pic;

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -57,18 +57,27 @@ class CBuilder implements Builder {
   @visibleForTesting
   final Uri? installName;
 
+  /// Whether the compiler will emit position independent code.
+  ///
+  /// When set to `null`, the default behavior of the compiler will be used.
+  ///
+  /// Defaults to `true` for libraries and `false` for executables.
+  final bool? pic;
+
   CBuilder.library({
     required this.name,
     required this.assetId,
     this.sources = const [],
     this.dartBuildFiles = const ['build.dart'],
     @visibleForTesting this.installName,
+    this.pic = true,
   }) : _type = _CBuilderType.library;
 
   CBuilder.executable({
     required this.name,
     this.sources = const [],
     this.dartBuildFiles = const ['build.dart'],
+    this.pic = false,
   })  : _type = _CBuilderType.executable,
         assetId = null,
         installName = null;
@@ -112,6 +121,7 @@ class CBuilder implements Builder {
                 : null,
         executable: _type == _CBuilderType.executable ? exeUri : null,
         installName: installName,
+        pic: pic,
       );
       await task.run();
     }

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -59,6 +59,12 @@ class CBuilder implements Builder {
 
   /// Whether the compiler will emit position independent code.
   ///
+  /// This option is set by the `pie` parameter for the [executable]
+  /// constructor.
+  ///
+  /// When set to `true`, libraries will be compiled with `-fPIC` and
+  /// executables with `-fPIE`.
+  ///
   /// When set to `null`, the default behavior of the compiler will be used.
   ///
   /// Defaults to `true` for libraries and `false` for executables.
@@ -77,10 +83,11 @@ class CBuilder implements Builder {
     required this.name,
     this.sources = const [],
     this.dartBuildFiles = const ['build.dart'],
-    this.pic = false,
+    bool? pie = false,
   })  : _type = _CBuilderType.executable,
         assetId = null,
-        installName = null;
+        installName = null,
+        pic = pie;
 
   /// Runs the C Compiler with on this C build spec.
   ///

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -41,7 +41,7 @@ void main() {
 
   for (final linkMode in LinkMode.values) {
     for (final target in targets) {
-      test('Cbuilder $linkMode library $target', () async {
+      test('CBuilder $linkMode library $target', () async {
         await inTempDir((tempUri) async {
           final libUri = await buildLib(
             tempUri,
@@ -77,7 +77,7 @@ void main() {
     }
   }
 
-  test('Cbuilder API levels binary difference', () async {
+  test('CBuilder API levels binary difference', () async {
     const target = Target.androidArm64;
     const linkMode = LinkMode.dynamic;
     const apiLevel1 = flutterAndroidNdkVersionLowestSupported;

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -50,7 +50,7 @@ void main() {
             Uri.file('@executable_path/Frameworks/$libName'),
         ]) {
           test(
-              'Cbuilder $linkMode library $targetIOSSdk $target'
+              'CBuilder $linkMode library $targetIOSSdk $target'
                       ' ${installName ?? ''}'
                   .trim(), () async {
             await inTempDir((tempUri) async {

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -36,7 +36,7 @@ void main() {
 
   for (final linkMode in LinkMode.values) {
     for (final target in targets) {
-      test('Cbuilder $linkMode library $target', () async {
+      test('CBuilder $linkMode library $target', () async {
         await inTempDir((tempUri) async {
           final addCUri =
               packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -36,7 +36,7 @@ void main() {
 
   for (final linkMode in LinkMode.values) {
     for (final target in targets) {
-      test('Cbuilder $linkMode library $target', () async {
+      test('CBuilder $linkMode library $target', () async {
         await inTempDir((tempUri) async {
           final addCUri =
               packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -48,7 +48,7 @@ void main() {
 
   for (final linkMode in LinkMode.values) {
     for (final target in targets) {
-      test('Cbuilder $linkMode library $target', () async {
+      test('CBuilder $linkMode library $target', () async {
         await inTempDir((tempUri) async {
           final addCUri =
               packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -80,15 +80,16 @@ void main() {
           final compilerInvocation = logMessages.singleWhere(
             (message) => message.contains(helloWorldCUri.toFilePath()),
           );
-          switch (pic) {
-            case null:
+
+          switch ((buildConfig.targetOs, pic)) {
+            case (OS.windows, _) || (_, null):
               expect(compilerInvocation, isNot(contains('-fPIC')));
               expect(compilerInvocation, isNot(contains('-fPIE')));
               expect(compilerInvocation, isNot(contains('-fno-PIC')));
               expect(compilerInvocation, isNot(contains('-fno-PIE')));
-            case true:
+            case (_, true):
               expect(compilerInvocation, contains('-fPIE'));
-            case false:
+            case (_, false):
               expect(compilerInvocation, contains('-fno-PIC'));
               expect(compilerInvocation, contains('-fno-PIE'));
           }
@@ -157,15 +158,15 @@ void main() {
               final compilerInvocation = logMessages.singleWhere(
                 (message) => message.contains(addCUri.toFilePath()),
               );
-              switch (pic) {
-                case null:
+              switch ((buildConfig.targetOs, pic)) {
+                case (OS.windows, _) || (_, null):
                   expect(compilerInvocation, isNot(contains('-fPIC')));
                   expect(compilerInvocation, isNot(contains('-fPIE')));
                   expect(compilerInvocation, isNot(contains('-fno-PIC')));
                   expect(compilerInvocation, isNot(contains('-fno-PIE')));
-                case true:
+                case (_, true):
                   expect(compilerInvocation, contains('-fPIC'));
-                case false:
+                case (_, false):
                   expect(compilerInvocation, contains('-fno-PIC'));
                   expect(compilerInvocation, contains('-fno-PIE'));
               }

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -20,8 +20,13 @@ import '../helpers.dart';
 
 void main() {
   for (final pic in [null, true, false]) {
+    final picTag =
+        switch (pic) { null => 'auto-PIC', true => 'PIC', false => 'no-PIC' };
+
     for (final buildMode in BuildMode.values) {
-      test('Cbuilder executable $buildMode (pic: $pic)', () async {
+      final testSuffix = buildTestSuffix([buildMode.toString(), picTag]);
+
+      test('Cbuilder executable$testSuffix', () async {
         await inTempDir((tempUri) async {
           final helloWorldCUri = packageUri
               .resolve('test/cbuilder/testfiles/hello_world/src/hello_world.c');
@@ -48,7 +53,7 @@ void main() {
           final cbuilder = CBuilder.executable(
             name: name,
             sources: [helloWorldCUri.toFilePath()],
-            pic: pic,
+            pie: pic,
           );
           await cbuilder.run(
             buildConfig: buildConfig,
@@ -73,8 +78,9 @@ void main() {
     }
 
     for (final dryRun in [true, false]) {
-      final testSuffix = dryRun ? ' dry_run' : '';
-      test('Cbuilder dylib$testSuffix (pic: $pic)', () async {
+      final testSuffix = buildTestSuffix([if (dryRun) 'dry_run', picTag]);
+
+      test('Cbuilder dylib$testSuffix', () async {
         await inTempDir(
           // https://github.com/dart-lang/sdk/issues/40159
           keepTemp: Platform.isWindows,
@@ -132,3 +138,6 @@ void main() {
     }
   }
 }
+
+String buildTestSuffix(List<String> tags) =>
+    switch (tags) { [] => '', _ => ' (${tags.join(', ')})' };

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -19,94 +19,36 @@ import 'package:test/test.dart';
 import '../helpers.dart';
 
 void main() {
-  for (final buildMode in BuildMode.values) {
-    test('Cbuilder executable $buildMode', () async {
-      await inTempDir((tempUri) async {
-        final helloWorldCUri = packageUri
-            .resolve('test/cbuilder/testfiles/hello_world/src/hello_world.c');
-        if (!await File.fromUri(helloWorldCUri).exists()) {
-          throw Exception('Run the test from the root directory.');
-        }
-        const name = 'hello_world';
+  for (final pic in [null, true, false]) {
+    for (final buildMode in BuildMode.values) {
+      test('Cbuilder executable $buildMode (pic: $pic)', () async {
+        await inTempDir((tempUri) async {
+          final helloWorldCUri = packageUri
+              .resolve('test/cbuilder/testfiles/hello_world/src/hello_world.c');
+          if (!await File.fromUri(helloWorldCUri).exists()) {
+            throw Exception('Run the test from the root directory.');
+          }
+          const name = 'hello_world';
 
-        final buildConfig = BuildConfig(
-          outDir: tempUri,
-          packageRoot: tempUri,
-          targetArchitecture: Architecture.current,
-          targetOs: OS.current,
-          buildMode: buildMode,
-          // Ignored by executables.
-          linkModePreference: LinkModePreference.dynamic,
-          cCompiler: CCompilerConfig(
-            cc: cc,
-            envScript: envScript,
-            envScriptArgs: envScriptArgs,
-          ),
-        );
-        final buildOutput = BuildOutput();
-        final cbuilder = CBuilder.executable(
-          name: name,
-          sources: [helloWorldCUri.toFilePath()],
-        );
-        await cbuilder.run(
-          buildConfig: buildConfig,
-          buildOutput: buildOutput,
-          logger: logger,
-        );
-
-        final executableUri =
-            tempUri.resolve(Target.current.os.executableFileName(name));
-        expect(await File.fromUri(executableUri).exists(), true);
-        final result = await runProcess(
-          executable: executableUri,
-          logger: logger,
-        );
-        expect(result.exitCode, 0);
-        if (buildMode == BuildMode.debug) {
-          expect(result.stdout.trim(), startsWith('Running in debug mode.'));
-        }
-        expect(result.stdout.trim(), endsWith('Hello world.'));
-      });
-    });
-  }
-
-  for (final dryRun in [true, false]) {
-    final testSuffix = dryRun ? ' dry_run' : '';
-    test('Cbuilder dylib$testSuffix', () async {
-      await inTempDir(
-        // https://github.com/dart-lang/sdk/issues/40159
-        keepTemp: Platform.isWindows,
-        (tempUri) async {
-          final addCUri =
-              packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
-          const name = 'add';
-
-          final buildConfig = dryRun
-              ? BuildConfig.dryRun(
-                  outDir: tempUri,
-                  packageRoot: tempUri,
-                  targetOs: OS.current,
-                  linkModePreference: LinkModePreference.dynamic,
-                )
-              : BuildConfig(
-                  outDir: tempUri,
-                  packageRoot: tempUri,
-                  targetArchitecture: Architecture.current,
-                  targetOs: OS.current,
-                  buildMode: BuildMode.release,
-                  linkModePreference: LinkModePreference.dynamic,
-                  cCompiler: CCompilerConfig(
-                    cc: cc,
-                    envScript: envScript,
-                    envScriptArgs: envScriptArgs,
-                  ),
-                );
+          final buildConfig = BuildConfig(
+            outDir: tempUri,
+            packageRoot: tempUri,
+            targetArchitecture: Architecture.current,
+            targetOs: OS.current,
+            buildMode: buildMode,
+            // Ignored by executables.
+            linkModePreference: LinkModePreference.dynamic,
+            cCompiler: CCompilerConfig(
+              cc: cc,
+              envScript: envScript,
+              envScriptArgs: envScriptArgs,
+            ),
+          );
           final buildOutput = BuildOutput();
-
-          final cbuilder = CBuilder.library(
-            sources: [addCUri.toFilePath()],
+          final cbuilder = CBuilder.executable(
             name: name,
-            assetId: name,
+            sources: [helloWorldCUri.toFilePath()],
+            pic: pic,
           );
           await cbuilder.run(
             buildConfig: buildConfig,
@@ -114,17 +56,79 @@ void main() {
             logger: logger,
           );
 
-          final dylibUri =
-              tempUri.resolve(Target.current.os.dylibFileName(name));
-          expect(await File.fromUri(dylibUri).exists(), !dryRun);
-          if (!dryRun) {
-            final dylib = DynamicLibrary.open(dylibUri.toFilePath());
-            final add = dylib.lookupFunction<Int32 Function(Int32, Int32),
-                int Function(int, int)>('add');
-            expect(add(1, 2), 3);
+          final executableUri =
+              tempUri.resolve(Target.current.os.executableFileName(name));
+          expect(await File.fromUri(executableUri).exists(), true);
+          final result = await runProcess(
+            executable: executableUri,
+            logger: logger,
+          );
+          expect(result.exitCode, 0);
+          if (buildMode == BuildMode.debug) {
+            expect(result.stdout.trim(), startsWith('Running in debug mode.'));
           }
-        },
-      );
-    });
+          expect(result.stdout.trim(), endsWith('Hello world.'));
+        });
+      });
+    }
+
+    for (final dryRun in [true, false]) {
+      final testSuffix = dryRun ? ' dry_run' : '';
+      test('Cbuilder dylib$testSuffix (pic: $pic)', () async {
+        await inTempDir(
+          // https://github.com/dart-lang/sdk/issues/40159
+          keepTemp: Platform.isWindows,
+          (tempUri) async {
+            final addCUri =
+                packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
+            const name = 'add';
+
+            final buildConfig = dryRun
+                ? BuildConfig.dryRun(
+                    outDir: tempUri,
+                    packageRoot: tempUri,
+                    targetOs: OS.current,
+                    linkModePreference: LinkModePreference.dynamic,
+                  )
+                : BuildConfig(
+                    outDir: tempUri,
+                    packageRoot: tempUri,
+                    targetArchitecture: Architecture.current,
+                    targetOs: OS.current,
+                    buildMode: BuildMode.release,
+                    linkModePreference: LinkModePreference.dynamic,
+                    cCompiler: CCompilerConfig(
+                      cc: cc,
+                      envScript: envScript,
+                      envScriptArgs: envScriptArgs,
+                    ),
+                  );
+            final buildOutput = BuildOutput();
+
+            final cbuilder = CBuilder.library(
+              sources: [addCUri.toFilePath()],
+              name: name,
+              assetId: name,
+              pic: pic,
+            );
+            await cbuilder.run(
+              buildConfig: buildConfig,
+              buildOutput: buildOutput,
+              logger: logger,
+            );
+
+            final dylibUri =
+                tempUri.resolve(Target.current.os.dylibFileName(name));
+            expect(await File.fromUri(dylibUri).exists(), !dryRun);
+            if (!dryRun) {
+              final dylib = DynamicLibrary.open(dylibUri.toFilePath());
+              final add = dylib.lookupFunction<Int32 Function(Int32, Int32),
+                  int Function(int, int)>('add');
+              expect(add(1, 2), 3);
+            }
+          },
+        );
+      });
+    }
   }
 }

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -11,6 +11,32 @@ import 'package:native_toolchain_c/src/native_toolchain/apple_clang.dart';
 import 'package:native_toolchain_c/src/utils/run_process.dart';
 import 'package:test/test.dart';
 
+/// Returns a suffix for a test that is parameterized.
+///
+/// [tags] represent the current configuration of the test. Each element
+/// is converted to a string by calling [Object.toString].
+///
+/// ## Example
+///
+/// The instances of the test below will have the following descriptions:
+///
+/// - `My test`
+/// - `My test (dry_run)`
+///
+/// ```dart
+/// void main() {
+///   for (final dryRun in [true, false]) {
+///     final suffix = testSuffix([if (dryRun) 'dry_run']);
+///
+///     test('My test$suffix', () {});
+///   }
+/// }
+/// ```
+String testSuffix(List<Object> tags) => switch (tags) {
+      [] => '',
+      _ => ' (${tags.join(', ')})',
+    };
+
 const keepTempKey = 'KEEP_TEMPORARY_DIRECTORIES';
 
 Future<void> inTempDir(


### PR DESCRIPTION
The rust `cc` crate provides [defaults for passing `-fPIC`](https://docs.rs/cc/latest/cc/struct.Build.html#method.pic) to the compiler that simplify configuration for most use cases. This PR adapts this behavior for `CBuilder`.

Closes https://github.com/dart-lang/native/issues/119