### PR TITLE
Add `includes`, `flags`, `std`, `language`, `cppLinkStdLib` options

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.2.3
+
+- Added `includes` for specifying include directories.
+- Added `flags` for specifying arbitrary compiler flags.
+- Added `std` for specifying a language standard.
+- Added `cpp` for enabling C++ compilation.
+- Added `cppLinkStdLib` for specifying the C++ standard library to link against.
+
 ## 0.2.2
 
 - Generate position independent code for libraries by default and add

--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.3
+## 0.2.4
 
 - Added `includes` for specifying include directories.
 - Added `flags` for specifying arbitrary compiler flags.

--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Added `includes` for specifying include directories.
 - Added `flags` for specifying arbitrary compiler flags.
 - Added `std` for specifying a language standard.
-- Added `cpp` for enabling C++ compilation.
+- Added `language` for selecting the language (`c` and `cpp`) to compile source files as.
 - Added `cppLinkStdLib` for specifying the C++ standard library to link against.
 
 ## 0.2.3

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -189,7 +189,8 @@ class CBuilder implements Builder {
         packageRoot.resolveUri(Uri.file(source)),
     ];
     final includes = [
-      for (final include in this.includes) packageRoot.resolve(include),
+      for (final directory in this.includes)
+        packageRoot.resolveUri(Uri.file(directory)),
     ];
     final dartBuildFiles = [
       for (final source in this.dartBuildFiles) packageRoot.resolve(source),

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -18,7 +18,9 @@ abstract class Builder {
   });
 }
 
-/// A programming language.
+/// A programming language that can be selected for compilation of source files.
+///
+/// See [CBuilder.language] for more information.
 class Language {
   /// The name of the language.
   final String name;

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -18,6 +18,23 @@ abstract class Builder {
   });
 }
 
+/// A programming language.
+class Language {
+  /// The name of the language.
+  final String name;
+
+  const Language._(this.name);
+
+  static const Language c = Language._('c');
+  static const Language cpp = Language._('c++');
+
+  /// Known values for [Language].
+  static const List<Language> values = [c, cpp];
+
+  @override
+  String toString() => name;
+}
+
 /// Specification for building an artifact with a C compiler.
 class CBuilder implements Builder {
   /// What kind of artifact to build.
@@ -110,15 +127,16 @@ class CBuilder implements Builder {
   /// When set to `null`, the default behavior of the compiler will be used.
   final String? std;
 
-  /// Whether to compile sources as C++.
+  /// The language to compile [sources] as.
   ///
-  /// [cppLinkStdLib] only has an effect when this is `true`.
-  final bool cpp;
+  /// [cppLinkStdLib] only has an effect when this option is set to
+  /// [Langauge.cpp].
+  final Language language;
 
   /// The C++ standard library to link against.
   ///
-  /// This option has no effect when [cpp] is `false` or when compiling for
-  /// Windows.
+  /// This option has no effect when [language] is not set to [Language.cpp] or
+  /// when compiling for Windows.
   ///
   /// When set to `null`, the following defaults will be used, based on the
   /// target OS:
@@ -145,7 +163,7 @@ class CBuilder implements Builder {
     this.ndebugDefine = true,
     this.pic = true,
     this.std,
-    this.cpp = false,
+    this.language = Language.c,
     this.cppLinkStdLib,
   }) : _type = _CBuilderType.library;
 
@@ -160,7 +178,7 @@ class CBuilder implements Builder {
     this.ndebugDefine = true,
     bool? pie = false,
     this.std,
-    this.cpp = false,
+    this.language = Language.c,
     this.cppLinkStdLib,
   })  : _type = _CBuilderType.executable,
         assetId = null,
@@ -220,7 +238,7 @@ class CBuilder implements Builder {
         },
         pic: pic,
         std: std,
-        cpp: cpp,
+        language: language,
         cppLinkStdLib: cppLinkStdLib,
       );
       await task.run();

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -13,6 +13,7 @@ import '../native_toolchain/xcode.dart';
 import '../tool/tool_instance.dart';
 import '../utils/env_from_bat.dart';
 import '../utils/run_process.dart';
+import 'cbuilder.dart';
 import 'compiler_resolver.dart';
 
 class RunCBuilder {
@@ -37,7 +38,7 @@ class RunCBuilder {
   final Map<String, String?> defines;
   final bool? pic;
   final String? std;
-  final bool cpp;
+  final Language language;
   final String? cppLinkStdLib;
 
   RunCBuilder({
@@ -53,7 +54,7 @@ class RunCBuilder {
     this.defines = const {},
     this.pic,
     this.std,
-    this.cpp = false,
+    this.language = Language.c,
     this.cppLinkStdLib,
   })  : outDir = buildConfig.outDir,
         target = buildConfig.target,
@@ -158,7 +159,7 @@ class RunCBuilder {
             '-fno-PIE',
           ],
         if (std != null) '-std=$std',
-        if (cpp) ...[
+        if (language == Language.cpp) ...[
           '-x',
           'c++',
           '-l',
@@ -217,7 +218,7 @@ class RunCBuilder {
       executable: compiler.uri,
       arguments: [
         if (std != null) '/std:$std',
-        if (cpp) '/TP',
+        if (language == Language.cpp) '/TP',
         ...flags,
         for (final MapEntry(key: name, :value) in defines.entries)
           if (value == null) '/D$name' else '/D$name=$value',

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -61,7 +61,15 @@ class RunCBuilder {
         assert([executable, dynamicLibrary, staticLibrary]
                 .whereType<Uri>()
                 .length ==
-            1);
+            1) {
+    if (target.os == OS.windows && cppLinkStdLib != null) {
+      throw ArgumentError.value(
+        cppLinkStdLib,
+        'cppLinkStdLib',
+        'is not supported when targeting Windows',
+      );
+    }
+  }
 
   late final _resolver =
       CompilerResolver(buildConfig: buildConfig, logger: logger);

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -221,7 +221,7 @@ class RunCBuilder {
         ...flags,
         for (final MapEntry(key: name, :value) in defines.entries)
           if (value == null) '/D$name' else '/D$name=$value',
-        for (final include in includes) '/I${include.toFilePath()}',
+        for (final directory in includes) '/I${directory.toFilePath()}',
         if (executable != null) ...[
           ...sources.map((e) => e.toFilePath()),
           '/link',

--- a/pkgs/native_toolchain_c/lib/src/native_toolchain/xcode.dart
+++ b/pkgs/native_toolchain_c/lib/src/native_toolchain/xcode.dart
@@ -90,11 +90,11 @@ class XCodeSdkResolver implements ToolResolver {
     }
     assert(result.exitCode == 0);
     final uriSymbolic = Uri.directory(result.stdout.trim());
-    logger?.fine('Found $sdk at ${uriSymbolic.toFilePath()}}');
+    logger?.fine('Found $sdk at ${uriSymbolic.toFilePath()}');
     final uri = Uri.directory(
         await Directory.fromUri(uriSymbolic).resolveSymbolicLinks());
     if (uriSymbolic != uri) {
-      logger?.fine('Found $sdk at ${uri.toFilePath()}}');
+      logger?.fine('Found $sdk at ${uri.toFilePath()}');
     }
     assert(await Directory.fromUri(uri).exists());
     return [ToolInstance(tool: tool, uri: uri)];

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - native-toolchain
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.1.0 <4.0.0'
 
 dependencies:
   cli_config: ^0.1.1

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.2.3
+version: 0.2.4
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.2.2
+version: 0.2.3
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
@@ -18,45 +18,44 @@ import '../helpers.dart';
 
 void main() {
   test('build failure', () async {
-    await inTempDir((tempUri) async {
-      final addCOriginalUri =
-          packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
-      final addCUri = tempUri.resolve('add.c');
-      final addCOriginalContents =
-          await File.fromUri(addCOriginalUri).readAsString();
-      final addCBrokenContents = addCOriginalContents.replaceAll(
-          'int32_t a, int32_t b', 'int64_t blabla');
-      await File.fromUri(addCUri).writeAsString(addCBrokenContents);
-      const name = 'add';
+    final tempUri = await tempDirForTest();
+    final addCOriginalUri =
+        packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
+    final addCUri = tempUri.resolve('add.c');
+    final addCOriginalContents =
+        await File.fromUri(addCOriginalUri).readAsString();
+    final addCBrokenContents = addCOriginalContents.replaceAll(
+        'int32_t a, int32_t b', 'int64_t blabla');
+    await File.fromUri(addCUri).writeAsString(addCBrokenContents);
+    const name = 'add';
 
-      final buildConfig = BuildConfig(
-        outDir: tempUri,
-        packageRoot: tempUri,
-        targetArchitecture: Architecture.current,
-        targetOs: OS.current,
-        linkModePreference: LinkModePreference.dynamic,
-        buildMode: BuildMode.release,
-        cCompiler: CCompilerConfig(
-          cc: cc,
-          envScript: envScript,
-          envScriptArgs: envScriptArgs,
-        ),
-      );
-      final buildOutput = BuildOutput();
+    final buildConfig = BuildConfig(
+      outDir: tempUri,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.current,
+      targetOs: OS.current,
+      linkModePreference: LinkModePreference.dynamic,
+      buildMode: BuildMode.release,
+      cCompiler: CCompilerConfig(
+        cc: cc,
+        envScript: envScript,
+        envScriptArgs: envScriptArgs,
+      ),
+    );
+    final buildOutput = BuildOutput();
 
-      final cbuilder = CBuilder.library(
-        sources: [addCUri.toFilePath()],
-        name: name,
-        assetId: name,
-      );
-      expect(
-        () => cbuilder.run(
-          buildConfig: buildConfig,
-          buildOutput: buildOutput,
-          logger: logger,
-        ),
-        throwsException,
-      );
-    });
+    final cbuilder = CBuilder.library(
+      sources: [addCUri.toFilePath()],
+      name: name,
+      assetId: name,
+    );
+    expect(
+      () => cbuilder.run(
+        buildConfig: buildConfig,
+        buildOutput: buildOutput,
+        logger: logger,
+      ),
+      throwsException,
+    );
   });
 }

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
@@ -18,47 +18,45 @@ import '../helpers.dart';
 
 void main() {
   test('build failure', () async {
-    await inTempDir(
-      (tempUri) async {
-        final addCOriginalUri =
-            packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
-        final addCUri = tempUri.resolve('add.c');
-        final addCOriginalContents =
-            await File.fromUri(addCOriginalUri).readAsString();
-        final addCBrokenContents = addCOriginalContents.replaceAll(
-            'int32_t a, int32_t b', 'int64_t blabla');
-        await File.fromUri(addCUri).writeAsString(addCBrokenContents);
-        const name = 'add';
+    await inTempDir((tempUri) async {
+      final addCOriginalUri =
+          packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
+      final addCUri = tempUri.resolve('add.c');
+      final addCOriginalContents =
+          await File.fromUri(addCOriginalUri).readAsString();
+      final addCBrokenContents = addCOriginalContents.replaceAll(
+          'int32_t a, int32_t b', 'int64_t blabla');
+      await File.fromUri(addCUri).writeAsString(addCBrokenContents);
+      const name = 'add';
 
-        final buildConfig = BuildConfig(
-          outDir: tempUri,
-          packageRoot: tempUri,
-          targetArchitecture: Architecture.current,
-          targetOs: OS.current,
-          linkModePreference: LinkModePreference.dynamic,
-          buildMode: BuildMode.release,
-          cCompiler: CCompilerConfig(
-            cc: cc,
-            envScript: envScript,
-            envScriptArgs: envScriptArgs,
-          ),
-        );
-        final buildOutput = BuildOutput();
+      final buildConfig = BuildConfig(
+        outDir: tempUri,
+        packageRoot: tempUri,
+        targetArchitecture: Architecture.current,
+        targetOs: OS.current,
+        linkModePreference: LinkModePreference.dynamic,
+        buildMode: BuildMode.release,
+        cCompiler: CCompilerConfig(
+          cc: cc,
+          envScript: envScript,
+          envScriptArgs: envScriptArgs,
+        ),
+      );
+      final buildOutput = BuildOutput();
 
-        final cbuilder = CBuilder.library(
-          sources: [addCUri.toFilePath()],
-          name: name,
-          assetId: name,
-        );
-        expect(
-          () => cbuilder.run(
-            buildConfig: buildConfig,
-            buildOutput: buildOutput,
-            logger: logger,
-          ),
-          throwsException,
-        );
-      },
-    );
+      final cbuilder = CBuilder.library(
+        sources: [addCUri.toFilePath()],
+        name: name,
+        assetId: name,
+      );
+      expect(
+        () => cbuilder.run(
+          buildConfig: buildConfig,
+          buildOutput: buildOutput,
+          logger: logger,
+        ),
+        throwsException,
+      );
+    });
   });
 }

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -42,37 +42,36 @@ void main() {
   for (final linkMode in LinkMode.values) {
     for (final target in targets) {
       test('CBuilder $linkMode library $target', () async {
-        await inTempDir((tempUri) async {
-          final libUri = await buildLib(
-            tempUri,
-            target,
-            flutterAndroidNdkVersionLowestSupported,
-            linkMode,
+        final tempUri = await tempDirForTest();
+        final libUri = await buildLib(
+          tempUri,
+          target,
+          flutterAndroidNdkVersionLowestSupported,
+          linkMode,
+        );
+        if (Platform.isLinux) {
+          final result = await runProcess(
+            executable: Uri.file('readelf'),
+            arguments: ['-h', libUri.path],
+            logger: logger,
           );
-          if (Platform.isLinux) {
-            final result = await runProcess(
-              executable: Uri.file('readelf'),
-              arguments: ['-h', libUri.path],
-              logger: logger,
-            );
-            expect(result.exitCode, 0);
-            final machine = result.stdout
-                .split('\n')
-                .firstWhere((e) => e.contains('Machine:'));
-            expect(machine, contains(readElfMachine[target]));
-          } else if (Platform.isMacOS) {
-            final result = await runProcess(
-              executable: Uri.file('objdump'),
-              arguments: ['-T', libUri.path],
-              logger: logger,
-            );
-            expect(result.exitCode, 0);
-            final machine = result.stdout
-                .split('\n')
-                .firstWhere((e) => e.contains('file format'));
-            expect(machine, contains(objdumpFileFormat[target]));
-          }
-        });
+          expect(result.exitCode, 0);
+          final machine = result.stdout
+              .split('\n')
+              .firstWhere((e) => e.contains('Machine:'));
+          expect(machine, contains(readElfMachine[target]));
+        } else if (Platform.isMacOS) {
+          final result = await runProcess(
+            executable: Uri.file('objdump'),
+            arguments: ['-T', libUri.path],
+            logger: logger,
+          );
+          expect(result.exitCode, 0);
+          final machine = result.stdout
+              .split('\n')
+              .firstWhere((e) => e.contains('file format'));
+          expect(machine, contains(objdumpFileFormat[target]));
+        }
       });
     }
   }
@@ -82,24 +81,23 @@ void main() {
     const linkMode = LinkMode.dynamic;
     const apiLevel1 = flutterAndroidNdkVersionLowestSupported;
     const apiLevel2 = flutterAndroidNdkVersionHighestSupported;
-    await inTempDir((tempUri) async {
-      final out1Uri = tempUri.resolve('out1/');
-      final out2Uri = tempUri.resolve('out2/');
-      final out3Uri = tempUri.resolve('out3/');
-      await Directory.fromUri(out1Uri).create();
-      await Directory.fromUri(out2Uri).create();
-      await Directory.fromUri(out3Uri).create();
-      final lib1Uri = await buildLib(out1Uri, target, apiLevel1, linkMode);
-      final lib2Uri = await buildLib(out2Uri, target, apiLevel2, linkMode);
-      final lib3Uri = await buildLib(out3Uri, target, apiLevel2, linkMode);
-      final bytes1 = await File.fromUri(lib1Uri).readAsBytes();
-      final bytes2 = await File.fromUri(lib2Uri).readAsBytes();
-      final bytes3 = await File.fromUri(lib3Uri).readAsBytes();
-      // Different API levels should lead to a different binary.
-      expect(bytes1, isNot(bytes2));
-      // Identical API levels should lead to an identical binary.
-      expect(bytes2, bytes3);
-    });
+    final tempUri = await tempDirForTest();
+    final out1Uri = tempUri.resolve('out1/');
+    final out2Uri = tempUri.resolve('out2/');
+    final out3Uri = tempUri.resolve('out3/');
+    await Directory.fromUri(out1Uri).create();
+    await Directory.fromUri(out2Uri).create();
+    await Directory.fromUri(out3Uri).create();
+    final lib1Uri = await buildLib(out1Uri, target, apiLevel1, linkMode);
+    final lib2Uri = await buildLib(out2Uri, target, apiLevel2, linkMode);
+    final lib3Uri = await buildLib(out3Uri, target, apiLevel2, linkMode);
+    final bytes1 = await File.fromUri(lib1Uri).readAsBytes();
+    final bytes2 = await File.fromUri(lib2Uri).readAsBytes();
+    final bytes3 = await File.fromUri(lib3Uri).readAsBytes();
+    // Different API levels should lead to a different binary.
+    expect(bytes1, isNot(bytes2));
+    // Identical API levels should lead to an identical binary.
+    expect(bytes2, bytes3);
   });
 }
 

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -37,48 +37,46 @@ void main() {
   for (final linkMode in LinkMode.values) {
     for (final target in targets) {
       test('CBuilder $linkMode library $target', () async {
-        await inTempDir((tempUri) async {
-          final addCUri =
-              packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
-          const name = 'add';
+        final tempUri = await tempDirForTest();
+        final addCUri =
+            packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
+        const name = 'add';
 
-          final buildConfig = BuildConfig(
-            outDir: tempUri,
-            packageRoot: tempUri,
-            targetArchitecture: target.architecture,
-            targetOs: target.os,
-            buildMode: BuildMode.release,
-            linkModePreference: linkMode == LinkMode.dynamic
-                ? LinkModePreference.dynamic
-                : LinkModePreference.static,
-          );
-          final buildOutput = BuildOutput();
+        final buildConfig = BuildConfig(
+          outDir: tempUri,
+          packageRoot: tempUri,
+          targetArchitecture: target.architecture,
+          targetOs: target.os,
+          buildMode: BuildMode.release,
+          linkModePreference: linkMode == LinkMode.dynamic
+              ? LinkModePreference.dynamic
+              : LinkModePreference.static,
+        );
+        final buildOutput = BuildOutput();
 
-          final cbuilder = CBuilder.library(
-            name: name,
-            assetId: name,
-            sources: [addCUri.toFilePath()],
-          );
-          await cbuilder.run(
-            buildConfig: buildConfig,
-            buildOutput: buildOutput,
-            logger: logger,
-          );
+        final cbuilder = CBuilder.library(
+          name: name,
+          assetId: name,
+          sources: [addCUri.toFilePath()],
+        );
+        await cbuilder.run(
+          buildConfig: buildConfig,
+          buildOutput: buildOutput,
+          logger: logger,
+        );
 
-          final libUri =
-              tempUri.resolve(target.os.libraryFileName(name, linkMode));
-          final result = await runProcess(
-            executable: Uri.file('readelf'),
-            arguments: ['-h', libUri.path],
-            logger: logger,
-          );
-          expect(result.exitCode, 0);
-          final machine = result.stdout
-              .split('\n')
-              .firstWhere((e) => e.contains('Machine:'));
-          expect(machine, contains(readElfMachine[target]));
-          expect(result.exitCode, 0);
-        });
+        final libUri =
+            tempUri.resolve(target.os.libraryFileName(name, linkMode));
+        final result = await runProcess(
+          executable: Uri.file('readelf'),
+          arguments: ['-h', libUri.path],
+          logger: logger,
+        );
+        expect(result.exitCode, 0);
+        final machine =
+            result.stdout.split('\n').firstWhere((e) => e.contains('Machine:'));
+        expect(machine, contains(readElfMachine[target]));
+        expect(result.exitCode, 0);
       });
     }
   }

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -37,47 +37,46 @@ void main() {
   for (final linkMode in LinkMode.values) {
     for (final target in targets) {
       test('CBuilder $linkMode library $target', () async {
-        await inTempDir((tempUri) async {
-          final addCUri =
-              packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
-          const name = 'add';
+        final tempUri = await tempDirForTest();
+        final addCUri =
+            packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
+        const name = 'add';
 
-          final buildConfig = BuildConfig(
-            outDir: tempUri,
-            packageRoot: tempUri,
-            targetArchitecture: target.architecture,
-            targetOs: target.os,
-            buildMode: BuildMode.release,
-            linkModePreference: linkMode == LinkMode.dynamic
-                ? LinkModePreference.dynamic
-                : LinkModePreference.static,
-          );
-          final buildOutput = BuildOutput();
+        final buildConfig = BuildConfig(
+          outDir: tempUri,
+          packageRoot: tempUri,
+          targetArchitecture: target.architecture,
+          targetOs: target.os,
+          buildMode: BuildMode.release,
+          linkModePreference: linkMode == LinkMode.dynamic
+              ? LinkModePreference.dynamic
+              : LinkModePreference.static,
+        );
+        final buildOutput = BuildOutput();
 
-          final cbuilder = CBuilder.library(
-            name: name,
-            assetId: name,
-            sources: [addCUri.toFilePath()],
-          );
-          await cbuilder.run(
-            buildConfig: buildConfig,
-            buildOutput: buildOutput,
-            logger: logger,
-          );
+        final cbuilder = CBuilder.library(
+          name: name,
+          assetId: name,
+          sources: [addCUri.toFilePath()],
+        );
+        await cbuilder.run(
+          buildConfig: buildConfig,
+          buildOutput: buildOutput,
+          logger: logger,
+        );
 
-          final libUri =
-              tempUri.resolve(target.os.libraryFileName(name, linkMode));
-          final result = await runProcess(
-            executable: Uri.file('objdump'),
-            arguments: ['-t', libUri.path],
-            logger: logger,
-          );
-          expect(result.exitCode, 0);
-          final machine = result.stdout
-              .split('\n')
-              .firstWhere((e) => e.contains('file format'));
-          expect(machine, contains(objdumpFileFormat[target]));
-        });
+        final libUri =
+            tempUri.resolve(target.os.libraryFileName(name, linkMode));
+        final result = await runProcess(
+          executable: Uri.file('objdump'),
+          arguments: ['-t', libUri.path],
+          logger: logger,
+        );
+        expect(result.exitCode, 0);
+        final machine = result.stdout
+            .split('\n')
+            .firstWhere((e) => e.contains('file format'));
+        expect(machine, contains(objdumpFileFormat[target]));
       });
     }
   }

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -49,52 +49,50 @@ void main() {
   for (final linkMode in LinkMode.values) {
     for (final target in targets) {
       test('CBuilder $linkMode library $target', () async {
-        await inTempDir((tempUri) async {
-          final addCUri =
-              packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
-          const name = 'add';
+        final tempUri = await tempDirForTest();
+        final addCUri =
+            packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
+        const name = 'add';
 
-          final buildConfig = BuildConfig(
-            outDir: tempUri,
-            packageRoot: tempUri,
-            targetOs: target.os,
-            targetArchitecture: target.architecture,
-            buildMode: BuildMode.release,
-            linkModePreference: linkMode == LinkMode.dynamic
-                ? LinkModePreference.dynamic
-                : LinkModePreference.static,
-          );
-          final buildOutput = BuildOutput();
+        final buildConfig = BuildConfig(
+          outDir: tempUri,
+          packageRoot: tempUri,
+          targetOs: target.os,
+          targetArchitecture: target.architecture,
+          buildMode: BuildMode.release,
+          linkModePreference: linkMode == LinkMode.dynamic
+              ? LinkModePreference.dynamic
+              : LinkModePreference.static,
+        );
+        final buildOutput = BuildOutput();
 
-          final cbuilder = CBuilder.library(
-            name: name,
-            assetId: name,
-            sources: [addCUri.toFilePath()],
-          );
-          await cbuilder.run(
-            buildConfig: buildConfig,
-            buildOutput: buildOutput,
-            logger: logger,
-          );
+        final cbuilder = CBuilder.library(
+          name: name,
+          assetId: name,
+          sources: [addCUri.toFilePath()],
+        );
+        await cbuilder.run(
+          buildConfig: buildConfig,
+          buildOutput: buildOutput,
+          logger: logger,
+        );
 
-          final libUri =
-              tempUri.resolve(target.os.libraryFileName(name, linkMode));
-          expect(await File.fromUri(libUri).exists(), true);
-          final result = await runProcess(
-            executable: dumpbinUri,
-            arguments: ['/HEADERS', libUri.toFilePath()],
-            logger: logger,
-          );
-          expect(result.exitCode, 0);
-          final machine = result.stdout
-              .split('\n')
-              .firstWhere((e) => e.contains('machine'));
-          expect(machine, contains(dumpbinMachine[target]));
-          final fileType = result.stdout
-              .split('\n')
-              .firstWhere((e) => e.contains('File Type'));
-          expect(fileType, contains(dumpbinFileType[linkMode]));
-        });
+        final libUri =
+            tempUri.resolve(target.os.libraryFileName(name, linkMode));
+        expect(await File.fromUri(libUri).exists(), true);
+        final result = await runProcess(
+          executable: dumpbinUri,
+          arguments: ['/HEADERS', libUri.toFilePath()],
+          logger: logger,
+        );
+        expect(result.exitCode, 0);
+        final machine =
+            result.stdout.split('\n').firstWhere((e) => e.contains('machine'));
+        expect(machine, contains(dumpbinMachine[target]));
+        final fileType = result.stdout
+            .split('\n')
+            .firstWhere((e) => e.contains('File Type'));
+        expect(fileType, contains(dumpbinFileType[linkMode]));
       });
     }
   }

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -106,78 +106,74 @@ void main() {
       final suffix = testSuffix([if (dryRun) 'dry_run', picTag]);
 
       test('CBuilder dylib$suffix', () async {
-        await inTempDir(
-          // https://github.com/dart-lang/sdk/issues/40159
-          keepTemp: Platform.isWindows,
-          (tempUri) async {
-            final addCUri =
-                packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
-            const name = 'add';
+        await inTempDir((tempUri) async {
+          final addCUri =
+              packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
+          const name = 'add';
 
-            final logMessages = <String>[];
-            final logger = createCapturingLogger(logMessages);
+          final logMessages = <String>[];
+          final logger = createCapturingLogger(logMessages);
 
-            final buildConfig = dryRun
-                ? BuildConfig.dryRun(
-                    outDir: tempUri,
-                    packageRoot: tempUri,
-                    targetOs: OS.current,
-                    linkModePreference: LinkModePreference.dynamic,
-                  )
-                : BuildConfig(
-                    outDir: tempUri,
-                    packageRoot: tempUri,
-                    targetArchitecture: Architecture.current,
-                    targetOs: OS.current,
-                    buildMode: BuildMode.release,
-                    linkModePreference: LinkModePreference.dynamic,
-                    cCompiler: CCompilerConfig(
-                      cc: cc,
-                      envScript: envScript,
-                      envScriptArgs: envScriptArgs,
-                    ),
-                  );
-            final buildOutput = BuildOutput();
+          final buildConfig = dryRun
+              ? BuildConfig.dryRun(
+                  outDir: tempUri,
+                  packageRoot: tempUri,
+                  targetOs: OS.current,
+                  linkModePreference: LinkModePreference.dynamic,
+                )
+              : BuildConfig(
+                  outDir: tempUri,
+                  packageRoot: tempUri,
+                  targetArchitecture: Architecture.current,
+                  targetOs: OS.current,
+                  buildMode: BuildMode.release,
+                  linkModePreference: LinkModePreference.dynamic,
+                  cCompiler: CCompilerConfig(
+                    cc: cc,
+                    envScript: envScript,
+                    envScriptArgs: envScriptArgs,
+                  ),
+                );
+          final buildOutput = BuildOutput();
 
-            final cbuilder = CBuilder.library(
-              sources: [addCUri.toFilePath()],
-              name: name,
-              assetId: name,
-              pic: pic,
+          final cbuilder = CBuilder.library(
+            sources: [addCUri.toFilePath()],
+            name: name,
+            assetId: name,
+            pic: pic,
+          );
+          await cbuilder.run(
+            buildConfig: buildConfig,
+            buildOutput: buildOutput,
+            logger: logger,
+          );
+
+          final dylibUri =
+              tempUri.resolve(Target.current.os.dylibFileName(name));
+          expect(await File.fromUri(dylibUri).exists(), !dryRun);
+          if (!dryRun) {
+            final dylib = openDynamicLibraryForTest(dylibUri.toFilePath());
+            final add = dylib.lookupFunction<Int32 Function(Int32, Int32),
+                int Function(int, int)>('add');
+            expect(add(1, 2), 3);
+
+            final compilerInvocation = logMessages.singleWhere(
+              (message) => message.contains(addCUri.toFilePath()),
             );
-            await cbuilder.run(
-              buildConfig: buildConfig,
-              buildOutput: buildOutput,
-              logger: logger,
-            );
-
-            final dylibUri =
-                tempUri.resolve(Target.current.os.dylibFileName(name));
-            expect(await File.fromUri(dylibUri).exists(), !dryRun);
-            if (!dryRun) {
-              final dylib = DynamicLibrary.open(dylibUri.toFilePath());
-              final add = dylib.lookupFunction<Int32 Function(Int32, Int32),
-                  int Function(int, int)>('add');
-              expect(add(1, 2), 3);
-
-              final compilerInvocation = logMessages.singleWhere(
-                (message) => message.contains(addCUri.toFilePath()),
-              );
-              switch ((buildConfig.targetOs, pic)) {
-                case (OS.windows, _) || (_, null):
-                  expect(compilerInvocation, isNot(contains('-fPIC')));
-                  expect(compilerInvocation, isNot(contains('-fPIE')));
-                  expect(compilerInvocation, isNot(contains('-fno-PIC')));
-                  expect(compilerInvocation, isNot(contains('-fno-PIE')));
-                case (_, true):
-                  expect(compilerInvocation, contains('-fPIC'));
-                case (_, false):
-                  expect(compilerInvocation, contains('-fno-PIC'));
-                  expect(compilerInvocation, contains('-fno-PIE'));
-              }
+            switch ((buildConfig.targetOs, pic)) {
+              case (OS.windows, _) || (_, null):
+                expect(compilerInvocation, isNot(contains('-fPIC')));
+                expect(compilerInvocation, isNot(contains('-fPIE')));
+                expect(compilerInvocation, isNot(contains('-fno-PIC')));
+                expect(compilerInvocation, isNot(contains('-fno-PIE')));
+              case (_, true):
+                expect(compilerInvocation, contains('-fPIC'));
+              case (_, false):
+                expect(compilerInvocation, contains('-fno-PIC'));
+                expect(compilerInvocation, contains('-fno-PIE'));
             }
-          },
-        );
+          }
+        });
       });
     }
   }
@@ -268,113 +264,105 @@ void main() {
   });
 
   test('CBuilder includes', () async {
-    await inTempDir(
-      // https://github.com/dart-lang/sdk/issues/40159
-      keepTemp: Platform.isWindows,
-      (tempUri) async {
-        final includeDirectoryUri =
-            packageUri.resolve('test/cbuilder/testfiles/includes/include');
-        final includesHUri = packageUri
-            .resolve('test/cbuilder/testfiles/includes/include/includes.h');
-        final includesCUri = packageUri
-            .resolve('test/cbuilder/testfiles/includes/src/includes.c');
-        const name = 'includes';
+    await inTempDir((tempUri) async {
+      final includeDirectoryUri =
+          packageUri.resolve('test/cbuilder/testfiles/includes/include');
+      final includesHUri = packageUri
+          .resolve('test/cbuilder/testfiles/includes/include/includes.h');
+      final includesCUri =
+          packageUri.resolve('test/cbuilder/testfiles/includes/src/includes.c');
+      const name = 'includes';
 
-        final buildConfig = BuildConfig(
-          outDir: tempUri,
-          packageRoot: tempUri,
-          targetArchitecture: Architecture.current,
-          targetOs: OS.current,
-          buildMode: BuildMode.release,
-          linkModePreference: LinkModePreference.dynamic,
-          cCompiler: CCompilerConfig(
-            cc: cc,
-            envScript: envScript,
-            envScriptArgs: envScriptArgs,
-          ),
-        );
-        final buildOutput = BuildOutput();
+      final buildConfig = BuildConfig(
+        outDir: tempUri,
+        packageRoot: tempUri,
+        targetArchitecture: Architecture.current,
+        targetOs: OS.current,
+        buildMode: BuildMode.release,
+        linkModePreference: LinkModePreference.dynamic,
+        cCompiler: CCompilerConfig(
+          cc: cc,
+          envScript: envScript,
+          envScriptArgs: envScriptArgs,
+        ),
+      );
+      final buildOutput = BuildOutput();
 
-        final cbuilder = CBuilder.library(
-          name: name,
-          assetId: name,
-          includes: [includeDirectoryUri.toFilePath()],
-          sources: [includesCUri.toFilePath()],
-        );
-        await cbuilder.run(
-          buildConfig: buildConfig,
-          buildOutput: buildOutput,
-          logger: logger,
-        );
+      final cbuilder = CBuilder.library(
+        name: name,
+        assetId: name,
+        includes: [includeDirectoryUri.toFilePath()],
+        sources: [includesCUri.toFilePath()],
+      );
+      await cbuilder.run(
+        buildConfig: buildConfig,
+        buildOutput: buildOutput,
+        logger: logger,
+      );
 
-        expect(buildOutput.dependencies.dependencies, contains(includesHUri));
+      expect(buildOutput.dependencies.dependencies, contains(includesHUri));
 
-        final dylibUri = tempUri.resolve(Target.current.os.dylibFileName(name));
-        final dylib = DynamicLibrary.open(dylibUri.toFilePath());
-        final x = dylib.lookup<Int>('x');
-        expect(x.value, 42);
-      },
-    );
+      final dylibUri = tempUri.resolve(Target.current.os.dylibFileName(name));
+      final dylib = openDynamicLibraryForTest(dylibUri.toFilePath());
+      final x = dylib.lookup<Int>('x');
+      expect(x.value, 42);
+    });
   });
 
   test('CBuilder std', () async {
-    await inTempDir(
-      // https://github.com/dart-lang/sdk/issues/40159
-      keepTemp: Platform.isWindows,
-      (tempUri) async {
-        final addCUri =
-            packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
-        const name = 'add';
-        const std = 'c99';
+    await inTempDir((tempUri) async {
+      final addCUri =
+          packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
+      const name = 'add';
+      const std = 'c99';
 
-        final logMessages = <String>[];
-        final logger = createCapturingLogger(logMessages);
+      final logMessages = <String>[];
+      final logger = createCapturingLogger(logMessages);
 
-        final buildConfig = BuildConfig(
-          outDir: tempUri,
-          packageRoot: tempUri,
-          targetArchitecture: Architecture.current,
-          targetOs: OS.current,
-          buildMode: BuildMode.release,
-          linkModePreference: LinkModePreference.dynamic,
-          cCompiler: CCompilerConfig(
-            cc: cc,
-            envScript: envScript,
-            envScriptArgs: envScriptArgs,
-          ),
-        );
-        final buildOutput = BuildOutput();
+      final buildConfig = BuildConfig(
+        outDir: tempUri,
+        packageRoot: tempUri,
+        targetArchitecture: Architecture.current,
+        targetOs: OS.current,
+        buildMode: BuildMode.release,
+        linkModePreference: LinkModePreference.dynamic,
+        cCompiler: CCompilerConfig(
+          cc: cc,
+          envScript: envScript,
+          envScriptArgs: envScriptArgs,
+        ),
+      );
+      final buildOutput = BuildOutput();
 
-        final stdFlag = switch (buildConfig.targetOs) {
-          OS.windows => '/std:$std',
-          _ => '-std=$std',
-        };
+      final stdFlag = switch (buildConfig.targetOs) {
+        OS.windows => '/std:$std',
+        _ => '-std=$std',
+      };
 
-        final cbuilder = CBuilder.library(
-          sources: [addCUri.toFilePath()],
-          name: name,
-          assetId: name,
-          std: std,
-        );
-        await cbuilder.run(
-          buildConfig: buildConfig,
-          buildOutput: buildOutput,
-          logger: logger,
-        );
+      final cbuilder = CBuilder.library(
+        sources: [addCUri.toFilePath()],
+        name: name,
+        assetId: name,
+        std: std,
+      );
+      await cbuilder.run(
+        buildConfig: buildConfig,
+        buildOutput: buildOutput,
+        logger: logger,
+      );
 
-        final dylibUri = tempUri.resolve(Target.current.os.dylibFileName(name));
+      final dylibUri = tempUri.resolve(Target.current.os.dylibFileName(name));
 
-        final dylib = DynamicLibrary.open(dylibUri.toFilePath());
-        final add = dylib.lookupFunction<Int32 Function(Int32, Int32),
-            int Function(int, int)>('add');
-        expect(add(1, 2), 3);
+      final dylib = openDynamicLibraryForTest(dylibUri.toFilePath());
+      final add = dylib.lookupFunction<Int32 Function(Int32, Int32),
+          int Function(int, int)>('add');
+      expect(add(1, 2), 3);
 
-        final compilerInvocation = logMessages.singleWhere(
-          (message) => message.contains(addCUri.toFilePath()),
-        );
-        expect(compilerInvocation, contains(stdFlag));
-      },
-    );
+      final compilerInvocation = logMessages.singleWhere(
+        (message) => message.contains(addCUri.toFilePath()),
+      );
+      expect(compilerInvocation, contains(stdFlag));
+    });
   });
 
   test('CBuilder compile c++', () async {

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -370,7 +370,7 @@ void main() {
     );
   });
 
-  test('CBuilder cpp', () async {
+  test('CBuilder compile c++', () async {
     await inTempDir((tempUri) async {
       final helloWorldCppUri = packageUri.resolve(
           'test/cbuilder/testfiles/hello_world_cpp/src/hello_world_cpp.cc');
@@ -397,7 +397,7 @@ void main() {
       final cbuilder = CBuilder.executable(
         name: name,
         sources: [helloWorldCppUri.toFilePath()],
-        cpp: true,
+        language: Language.cpp,
       );
       await cbuilder.run(
         buildConfig: buildConfig,

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -32,73 +32,72 @@ void main() {
       final suffix = testSuffix([buildMode, picTag]);
 
       test('CBuilder executable$suffix', () async {
-        await inTempDir((tempUri) async {
-          final helloWorldCUri = packageUri
-              .resolve('test/cbuilder/testfiles/hello_world/src/hello_world.c');
-          if (!await File.fromUri(helloWorldCUri).exists()) {
-            throw Exception('Run the test from the root directory.');
-          }
-          const name = 'hello_world';
+        final tempUri = await tempDirForTest();
+        final helloWorldCUri = packageUri
+            .resolve('test/cbuilder/testfiles/hello_world/src/hello_world.c');
+        if (!await File.fromUri(helloWorldCUri).exists()) {
+          throw Exception('Run the test from the root directory.');
+        }
+        const name = 'hello_world';
 
-          final logMessages = <String>[];
-          final logger = createCapturingLogger(logMessages);
+        final logMessages = <String>[];
+        final logger = createCapturingLogger(logMessages);
 
-          final buildConfig = BuildConfig(
-            outDir: tempUri,
-            packageRoot: tempUri,
-            targetArchitecture: Architecture.current,
-            targetOs: OS.current,
-            buildMode: buildMode,
-            // Ignored by executables.
-            linkModePreference: LinkModePreference.dynamic,
-            cCompiler: CCompilerConfig(
-              cc: cc,
-              envScript: envScript,
-              envScriptArgs: envScriptArgs,
-            ),
-          );
-          final buildOutput = BuildOutput();
-          final cbuilder = CBuilder.executable(
-            name: name,
-            sources: [helloWorldCUri.toFilePath()],
-            pie: pic,
-          );
-          await cbuilder.run(
-            buildConfig: buildConfig,
-            buildOutput: buildOutput,
-            logger: logger,
-          );
+        final buildConfig = BuildConfig(
+          outDir: tempUri,
+          packageRoot: tempUri,
+          targetArchitecture: Architecture.current,
+          targetOs: OS.current,
+          buildMode: buildMode,
+          // Ignored by executables.
+          linkModePreference: LinkModePreference.dynamic,
+          cCompiler: CCompilerConfig(
+            cc: cc,
+            envScript: envScript,
+            envScriptArgs: envScriptArgs,
+          ),
+        );
+        final buildOutput = BuildOutput();
+        final cbuilder = CBuilder.executable(
+          name: name,
+          sources: [helloWorldCUri.toFilePath()],
+          pie: pic,
+        );
+        await cbuilder.run(
+          buildConfig: buildConfig,
+          buildOutput: buildOutput,
+          logger: logger,
+        );
 
-          final executableUri =
-              tempUri.resolve(Target.current.os.executableFileName(name));
-          expect(await File.fromUri(executableUri).exists(), true);
-          final result = await runProcess(
-            executable: executableUri,
-            logger: logger,
-          );
-          expect(result.exitCode, 0);
-          if (buildMode == BuildMode.debug) {
-            expect(result.stdout.trim(), startsWith('Running in debug mode.'));
-          }
-          expect(result.stdout.trim(), endsWith('Hello world.'));
+        final executableUri =
+            tempUri.resolve(Target.current.os.executableFileName(name));
+        expect(await File.fromUri(executableUri).exists(), true);
+        final result = await runProcess(
+          executable: executableUri,
+          logger: logger,
+        );
+        expect(result.exitCode, 0);
+        if (buildMode == BuildMode.debug) {
+          expect(result.stdout.trim(), startsWith('Running in debug mode.'));
+        }
+        expect(result.stdout.trim(), endsWith('Hello world.'));
 
-          final compilerInvocation = logMessages.singleWhere(
-            (message) => message.contains(helloWorldCUri.toFilePath()),
-          );
+        final compilerInvocation = logMessages.singleWhere(
+          (message) => message.contains(helloWorldCUri.toFilePath()),
+        );
 
-          switch ((buildConfig.targetOs, pic)) {
-            case (OS.windows, _) || (_, null):
-              expect(compilerInvocation, isNot(contains('-fPIC')));
-              expect(compilerInvocation, isNot(contains('-fPIE')));
-              expect(compilerInvocation, isNot(contains('-fno-PIC')));
-              expect(compilerInvocation, isNot(contains('-fno-PIE')));
-            case (_, true):
-              expect(compilerInvocation, contains('-fPIE'));
-            case (_, false):
-              expect(compilerInvocation, contains('-fno-PIC'));
-              expect(compilerInvocation, contains('-fno-PIE'));
-          }
-        });
+        switch ((buildConfig.targetOs, pic)) {
+          case (OS.windows, _) || (_, null):
+            expect(compilerInvocation, isNot(contains('-fPIC')));
+            expect(compilerInvocation, isNot(contains('-fPIE')));
+            expect(compilerInvocation, isNot(contains('-fno-PIC')));
+            expect(compilerInvocation, isNot(contains('-fno-PIE')));
+          case (_, true):
+            expect(compilerInvocation, contains('-fPIE'));
+          case (_, false):
+            expect(compilerInvocation, contains('-fno-PIC'));
+            expect(compilerInvocation, contains('-fno-PIE'));
+        }
       });
     }
 
@@ -106,74 +105,72 @@ void main() {
       final suffix = testSuffix([if (dryRun) 'dry_run', picTag]);
 
       test('CBuilder dylib$suffix', () async {
-        await inTempDir((tempUri) async {
-          final addCUri =
-              packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
-          const name = 'add';
+        final tempUri = await tempDirForTest();
+        final addCUri =
+            packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
+        const name = 'add';
 
-          final logMessages = <String>[];
-          final logger = createCapturingLogger(logMessages);
+        final logMessages = <String>[];
+        final logger = createCapturingLogger(logMessages);
 
-          final buildConfig = dryRun
-              ? BuildConfig.dryRun(
-                  outDir: tempUri,
-                  packageRoot: tempUri,
-                  targetOs: OS.current,
-                  linkModePreference: LinkModePreference.dynamic,
-                )
-              : BuildConfig(
-                  outDir: tempUri,
-                  packageRoot: tempUri,
-                  targetArchitecture: Architecture.current,
-                  targetOs: OS.current,
-                  buildMode: BuildMode.release,
-                  linkModePreference: LinkModePreference.dynamic,
-                  cCompiler: CCompilerConfig(
-                    cc: cc,
-                    envScript: envScript,
-                    envScriptArgs: envScriptArgs,
-                  ),
-                );
-          final buildOutput = BuildOutput();
+        final buildConfig = dryRun
+            ? BuildConfig.dryRun(
+                outDir: tempUri,
+                packageRoot: tempUri,
+                targetOs: OS.current,
+                linkModePreference: LinkModePreference.dynamic,
+              )
+            : BuildConfig(
+                outDir: tempUri,
+                packageRoot: tempUri,
+                targetArchitecture: Architecture.current,
+                targetOs: OS.current,
+                buildMode: BuildMode.release,
+                linkModePreference: LinkModePreference.dynamic,
+                cCompiler: CCompilerConfig(
+                  cc: cc,
+                  envScript: envScript,
+                  envScriptArgs: envScriptArgs,
+                ),
+              );
+        final buildOutput = BuildOutput();
 
-          final cbuilder = CBuilder.library(
-            sources: [addCUri.toFilePath()],
-            name: name,
-            assetId: name,
-            pic: pic,
+        final cbuilder = CBuilder.library(
+          sources: [addCUri.toFilePath()],
+          name: name,
+          assetId: name,
+          pic: pic,
+        );
+        await cbuilder.run(
+          buildConfig: buildConfig,
+          buildOutput: buildOutput,
+          logger: logger,
+        );
+
+        final dylibUri = tempUri.resolve(Target.current.os.dylibFileName(name));
+        expect(await File.fromUri(dylibUri).exists(), !dryRun);
+        if (!dryRun) {
+          final dylib = openDynamicLibraryForTest(dylibUri.toFilePath());
+          final add = dylib.lookupFunction<Int32 Function(Int32, Int32),
+              int Function(int, int)>('add');
+          expect(add(1, 2), 3);
+
+          final compilerInvocation = logMessages.singleWhere(
+            (message) => message.contains(addCUri.toFilePath()),
           );
-          await cbuilder.run(
-            buildConfig: buildConfig,
-            buildOutput: buildOutput,
-            logger: logger,
-          );
-
-          final dylibUri =
-              tempUri.resolve(Target.current.os.dylibFileName(name));
-          expect(await File.fromUri(dylibUri).exists(), !dryRun);
-          if (!dryRun) {
-            final dylib = openDynamicLibraryForTest(dylibUri.toFilePath());
-            final add = dylib.lookupFunction<Int32 Function(Int32, Int32),
-                int Function(int, int)>('add');
-            expect(add(1, 2), 3);
-
-            final compilerInvocation = logMessages.singleWhere(
-              (message) => message.contains(addCUri.toFilePath()),
-            );
-            switch ((buildConfig.targetOs, pic)) {
-              case (OS.windows, _) || (_, null):
-                expect(compilerInvocation, isNot(contains('-fPIC')));
-                expect(compilerInvocation, isNot(contains('-fPIE')));
-                expect(compilerInvocation, isNot(contains('-fno-PIC')));
-                expect(compilerInvocation, isNot(contains('-fno-PIE')));
-              case (_, true):
-                expect(compilerInvocation, contains('-fPIC'));
-              case (_, false):
-                expect(compilerInvocation, contains('-fno-PIC'));
-                expect(compilerInvocation, contains('-fno-PIE'));
-            }
+          switch ((buildConfig.targetOs, pic)) {
+            case (OS.windows, _) || (_, null):
+              expect(compilerInvocation, isNot(contains('-fPIC')));
+              expect(compilerInvocation, isNot(contains('-fPIE')));
+              expect(compilerInvocation, isNot(contains('-fno-PIC')));
+              expect(compilerInvocation, isNot(contains('-fno-PIE')));
+            case (_, true):
+              expect(compilerInvocation, contains('-fPIC'));
+            case (_, false):
+              expect(compilerInvocation, contains('-fno-PIC'));
+              expect(compilerInvocation, contains('-fno-PIE'));
           }
-        });
+        }
       });
     }
   }
@@ -203,208 +200,272 @@ void main() {
   }
 
   test('CBuilder flags', () async {
-    await inTempDir((tempUri) async {
-      final definesCUri =
-          packageUri.resolve('test/cbuilder/testfiles/defines/src/defines.c');
-      if (!await File.fromUri(definesCUri).exists()) {
-        throw Exception('Run the test from the root directory.');
-      }
-      const name = 'defines';
+    final tempUri = await tempDirForTest();
+    final definesCUri =
+        packageUri.resolve('test/cbuilder/testfiles/defines/src/defines.c');
+    if (!await File.fromUri(definesCUri).exists()) {
+      throw Exception('Run the test from the root directory.');
+    }
+    const name = 'defines';
 
-      final logMessages = <String>[];
-      final logger = createCapturingLogger(logMessages);
+    final logMessages = <String>[];
+    final logger = createCapturingLogger(logMessages);
 
-      final buildConfig = BuildConfig(
-        outDir: tempUri,
-        packageRoot: tempUri,
-        targetArchitecture: Architecture.current,
-        targetOs: OS.current,
-        buildMode: BuildMode.release,
-        // Ignored by executables.
-        linkModePreference: LinkModePreference.dynamic,
-        cCompiler: CCompilerConfig(
-          cc: cc,
-          envScript: envScript,
-          envScriptArgs: envScriptArgs,
-        ),
-      );
-      final buildOutput = BuildOutput();
+    final buildConfig = BuildConfig(
+      outDir: tempUri,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.current,
+      targetOs: OS.current,
+      buildMode: BuildMode.release,
+      // Ignored by executables.
+      linkModePreference: LinkModePreference.dynamic,
+      cCompiler: CCompilerConfig(
+        cc: cc,
+        envScript: envScript,
+        envScriptArgs: envScriptArgs,
+      ),
+    );
+    final buildOutput = BuildOutput();
 
-      final flag = switch (buildConfig.targetOs) {
-        OS.windows => '/DFOO=USER_FLAG',
-        _ => '-DFOO=USER_FLAG',
-      };
+    final flag = switch (buildConfig.targetOs) {
+      OS.windows => '/DFOO=USER_FLAG',
+      _ => '-DFOO=USER_FLAG',
+    };
 
-      final cbuilder = CBuilder.executable(
-        name: name,
-        sources: [definesCUri.toFilePath()],
-        flags: [flag],
-      );
-      await cbuilder.run(
-        buildConfig: buildConfig,
-        buildOutput: buildOutput,
-        logger: logger,
-      );
+    final cbuilder = CBuilder.executable(
+      name: name,
+      sources: [definesCUri.toFilePath()],
+      flags: [flag],
+    );
+    await cbuilder.run(
+      buildConfig: buildConfig,
+      buildOutput: buildOutput,
+      logger: logger,
+    );
 
-      final executableUri =
-          tempUri.resolve(Target.current.os.executableFileName(name));
-      expect(await File.fromUri(executableUri).exists(), true);
-      final result = await runProcess(
-        executable: executableUri,
-        logger: logger,
-      );
-      expect(result.exitCode, 0);
-      expect(result.stdout, contains('Macro FOO is defined: USER_FLAG'));
+    final executableUri =
+        tempUri.resolve(Target.current.os.executableFileName(name));
+    expect(await File.fromUri(executableUri).exists(), true);
+    final result = await runProcess(
+      executable: executableUri,
+      logger: logger,
+    );
+    expect(result.exitCode, 0);
+    expect(result.stdout, contains('Macro FOO is defined: USER_FLAG'));
 
-      final compilerInvocation = logMessages.singleWhere(
-        (message) => message.contains(definesCUri.toFilePath()),
-      );
-      expect(compilerInvocation, contains(flag));
-    });
+    final compilerInvocation = logMessages.singleWhere(
+      (message) => message.contains(definesCUri.toFilePath()),
+    );
+    expect(compilerInvocation, contains(flag));
   });
 
   test('CBuilder includes', () async {
-    await inTempDir((tempUri) async {
-      final includeDirectoryUri =
-          packageUri.resolve('test/cbuilder/testfiles/includes/include');
-      final includesHUri = packageUri
-          .resolve('test/cbuilder/testfiles/includes/include/includes.h');
-      final includesCUri =
-          packageUri.resolve('test/cbuilder/testfiles/includes/src/includes.c');
-      const name = 'includes';
+    final tempUri = await tempDirForTest();
+    final includeDirectoryUri =
+        packageUri.resolve('test/cbuilder/testfiles/includes/include');
+    final includesHUri = packageUri
+        .resolve('test/cbuilder/testfiles/includes/include/includes.h');
+    final includesCUri =
+        packageUri.resolve('test/cbuilder/testfiles/includes/src/includes.c');
+    const name = 'includes';
 
-      final buildConfig = BuildConfig(
-        outDir: tempUri,
-        packageRoot: tempUri,
-        targetArchitecture: Architecture.current,
-        targetOs: OS.current,
-        buildMode: BuildMode.release,
-        linkModePreference: LinkModePreference.dynamic,
-        cCompiler: CCompilerConfig(
-          cc: cc,
-          envScript: envScript,
-          envScriptArgs: envScriptArgs,
-        ),
-      );
-      final buildOutput = BuildOutput();
+    final buildConfig = BuildConfig(
+      outDir: tempUri,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.current,
+      targetOs: OS.current,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.dynamic,
+      cCompiler: CCompilerConfig(
+        cc: cc,
+        envScript: envScript,
+        envScriptArgs: envScriptArgs,
+      ),
+    );
+    final buildOutput = BuildOutput();
 
-      final cbuilder = CBuilder.library(
-        name: name,
-        assetId: name,
-        includes: [includeDirectoryUri.toFilePath()],
-        sources: [includesCUri.toFilePath()],
-      );
-      await cbuilder.run(
-        buildConfig: buildConfig,
-        buildOutput: buildOutput,
-        logger: logger,
-      );
+    final cbuilder = CBuilder.library(
+      name: name,
+      assetId: name,
+      includes: [includeDirectoryUri.toFilePath()],
+      sources: [includesCUri.toFilePath()],
+    );
+    await cbuilder.run(
+      buildConfig: buildConfig,
+      buildOutput: buildOutput,
+      logger: logger,
+    );
 
-      expect(buildOutput.dependencies.dependencies, contains(includesHUri));
+    expect(buildOutput.dependencies.dependencies, contains(includesHUri));
 
-      final dylibUri = tempUri.resolve(Target.current.os.dylibFileName(name));
-      final dylib = openDynamicLibraryForTest(dylibUri.toFilePath());
-      final x = dylib.lookup<Int>('x');
-      expect(x.value, 42);
-    });
+    final dylibUri = tempUri.resolve(Target.current.os.dylibFileName(name));
+    final dylib = openDynamicLibraryForTest(dylibUri.toFilePath());
+    final x = dylib.lookup<Int>('x');
+    expect(x.value, 42);
   });
 
   test('CBuilder std', () async {
-    await inTempDir((tempUri) async {
-      final addCUri =
-          packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
-      const name = 'add';
-      const std = 'c99';
+    final tempUri = await tempDirForTest();
+    final addCUri = packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
+    const name = 'add';
+    const std = 'c99';
 
-      final logMessages = <String>[];
-      final logger = createCapturingLogger(logMessages);
+    final logMessages = <String>[];
+    final logger = createCapturingLogger(logMessages);
 
-      final buildConfig = BuildConfig(
-        outDir: tempUri,
-        packageRoot: tempUri,
-        targetArchitecture: Architecture.current,
-        targetOs: OS.current,
-        buildMode: BuildMode.release,
-        linkModePreference: LinkModePreference.dynamic,
-        cCompiler: CCompilerConfig(
-          cc: cc,
-          envScript: envScript,
-          envScriptArgs: envScriptArgs,
-        ),
-      );
-      final buildOutput = BuildOutput();
+    final buildConfig = BuildConfig(
+      outDir: tempUri,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.current,
+      targetOs: OS.current,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.dynamic,
+      cCompiler: CCompilerConfig(
+        cc: cc,
+        envScript: envScript,
+        envScriptArgs: envScriptArgs,
+      ),
+    );
+    final buildOutput = BuildOutput();
 
-      final stdFlag = switch (buildConfig.targetOs) {
-        OS.windows => '/std:$std',
-        _ => '-std=$std',
-      };
+    final stdFlag = switch (buildConfig.targetOs) {
+      OS.windows => '/std:$std',
+      _ => '-std=$std',
+    };
 
-      final cbuilder = CBuilder.library(
-        sources: [addCUri.toFilePath()],
-        name: name,
-        assetId: name,
-        std: std,
-      );
-      await cbuilder.run(
-        buildConfig: buildConfig,
-        buildOutput: buildOutput,
-        logger: logger,
-      );
+    final cbuilder = CBuilder.library(
+      sources: [addCUri.toFilePath()],
+      name: name,
+      assetId: name,
+      std: std,
+    );
+    await cbuilder.run(
+      buildConfig: buildConfig,
+      buildOutput: buildOutput,
+      logger: logger,
+    );
 
-      final dylibUri = tempUri.resolve(Target.current.os.dylibFileName(name));
+    final dylibUri = tempUri.resolve(Target.current.os.dylibFileName(name));
 
-      final dylib = openDynamicLibraryForTest(dylibUri.toFilePath());
-      final add = dylib.lookupFunction<Int32 Function(Int32, Int32),
-          int Function(int, int)>('add');
-      expect(add(1, 2), 3);
+    final dylib = openDynamicLibraryForTest(dylibUri.toFilePath());
+    final add = dylib.lookupFunction<Int32 Function(Int32, Int32),
+        int Function(int, int)>('add');
+    expect(add(1, 2), 3);
 
-      final compilerInvocation = logMessages.singleWhere(
-        (message) => message.contains(addCUri.toFilePath()),
-      );
-      expect(compilerInvocation, contains(stdFlag));
-    });
+    final compilerInvocation = logMessages.singleWhere(
+      (message) => message.contains(addCUri.toFilePath()),
+    );
+    expect(compilerInvocation, contains(stdFlag));
   });
 
   test('CBuilder compile c++', () async {
-    await inTempDir((tempUri) async {
-      final helloWorldCppUri = packageUri.resolve(
-          'test/cbuilder/testfiles/hello_world_cpp/src/hello_world_cpp.cc');
-      if (!await File.fromUri(helloWorldCppUri).exists()) {
-        throw Exception('Run the test from the root directory.');
-      }
-      const name = 'hello_world_cpp';
+    final tempUri = await tempDirForTest();
+    final helloWorldCppUri = packageUri.resolve(
+        'test/cbuilder/testfiles/hello_world_cpp/src/hello_world_cpp.cc');
+    if (!await File.fromUri(helloWorldCppUri).exists()) {
+      throw Exception('Run the test from the root directory.');
+    }
+    const name = 'hello_world_cpp';
 
-      final logMessages = <String>[];
-      final logger = createCapturingLogger(logMessages);
+    final logMessages = <String>[];
+    final logger = createCapturingLogger(logMessages);
 
-      final buildConfig = BuildConfig(
-        buildMode: BuildMode.release,
-        outDir: tempUri,
-        packageRoot: tempUri,
-        targetArchitecture: Architecture.current,
-        targetOs: OS.current,
-        // Ignored by executables.
-        linkModePreference: LinkModePreference.dynamic,
-        cCompiler: CCompilerConfig(
-          cc: cc,
-          envScript: envScript,
-          envScriptArgs: envScriptArgs,
+    final buildConfig = BuildConfig(
+      buildMode: BuildMode.release,
+      outDir: tempUri,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.current,
+      targetOs: OS.current,
+      // Ignored by executables.
+      linkModePreference: LinkModePreference.dynamic,
+      cCompiler: CCompilerConfig(
+        cc: cc,
+        envScript: envScript,
+        envScriptArgs: envScriptArgs,
+      ),
+    );
+    final buildOutput = BuildOutput();
+
+    final defaultStdLibLinkFlag = switch (buildConfig.targetOs) {
+      OS.windows => null,
+      OS.linux => '-l stdc++',
+      OS.macOS => '-l c++',
+      _ => throw UnimplementedError(),
+    };
+
+    final cbuilder = CBuilder.executable(
+      name: name,
+      sources: [helloWorldCppUri.toFilePath()],
+      language: Language.cpp,
+    );
+    await cbuilder.run(
+      buildConfig: buildConfig,
+      buildOutput: buildOutput,
+      logger: logger,
+    );
+
+    final executableUri =
+        tempUri.resolve(Target.current.os.executableFileName(name));
+    expect(await File.fromUri(executableUri).exists(), true);
+    final result = await runProcess(
+      executable: executableUri,
+      logger: logger,
+    );
+    expect(result.exitCode, 0);
+    expect(result.stdout.trim(), endsWith('Hello world.'));
+
+    if (defaultStdLibLinkFlag != null) {
+      final compilerInvocation = logMessages.singleWhere(
+        (message) => message.contains(helloWorldCppUri.toFilePath()),
+      );
+      expect(compilerInvocation, contains(defaultStdLibLinkFlag));
+    }
+  });
+
+  test('CBuilder cppLinkStdLib', () async {
+    final tempUri = await tempDirForTest();
+    final helloWorldCppUri = packageUri.resolve(
+        'test/cbuilder/testfiles/hello_world_cpp/src/hello_world_cpp.cc');
+    if (!await File.fromUri(helloWorldCppUri).exists()) {
+      throw Exception('Run the test from the root directory.');
+    }
+    const name = 'hello_world_cpp';
+
+    final logMessages = <String>[];
+    final logger = createCapturingLogger(logMessages);
+
+    final buildConfig = BuildConfig(
+      buildMode: BuildMode.release,
+      outDir: tempUri,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.current,
+      targetOs: OS.current,
+      // Ignored by executables.
+      linkModePreference: LinkModePreference.dynamic,
+      cCompiler: CCompilerConfig(
+        cc: cc,
+        envScript: envScript,
+        envScriptArgs: envScriptArgs,
+      ),
+    );
+    final buildOutput = BuildOutput();
+    final cbuilder = CBuilder.executable(
+      name: name,
+      sources: [helloWorldCppUri.toFilePath()],
+      language: Language.cpp,
+      cppLinkStdLib: 'stdc++',
+    );
+
+    if (buildConfig.targetOs == OS.windows) {
+      await expectLater(
+        () => cbuilder.run(
+          buildConfig: buildConfig,
+          buildOutput: buildOutput,
+          logger: logger,
         ),
+        throwsArgumentError,
       );
-      final buildOutput = BuildOutput();
-
-      final defaultStdLibLinkFlag = switch (buildConfig.targetOs) {
-        OS.windows => null,
-        OS.linux => '-l stdc++',
-        OS.macOS => '-l c++',
-        _ => throw UnimplementedError(),
-      };
-
-      final cbuilder = CBuilder.executable(
-        name: name,
-        sources: [helloWorldCppUri.toFilePath()],
-        language: Language.cpp,
-      );
+    } else {
       await cbuilder.run(
         buildConfig: buildConfig,
         buildOutput: buildOutput,
@@ -421,81 +482,11 @@ void main() {
       expect(result.exitCode, 0);
       expect(result.stdout.trim(), endsWith('Hello world.'));
 
-      if (defaultStdLibLinkFlag != null) {
-        final compilerInvocation = logMessages.singleWhere(
-          (message) => message.contains(helloWorldCppUri.toFilePath()),
-        );
-        expect(compilerInvocation, contains(defaultStdLibLinkFlag));
-      }
-    });
-  });
-
-  test('CBuilder cppLinkStdLib', () async {
-    await inTempDir((tempUri) async {
-      final helloWorldCppUri = packageUri.resolve(
-          'test/cbuilder/testfiles/hello_world_cpp/src/hello_world_cpp.cc');
-      if (!await File.fromUri(helloWorldCppUri).exists()) {
-        throw Exception('Run the test from the root directory.');
-      }
-      const name = 'hello_world_cpp';
-
-      final logMessages = <String>[];
-      final logger = createCapturingLogger(logMessages);
-
-      final buildConfig = BuildConfig(
-        buildMode: BuildMode.release,
-        outDir: tempUri,
-        packageRoot: tempUri,
-        targetArchitecture: Architecture.current,
-        targetOs: OS.current,
-        // Ignored by executables.
-        linkModePreference: LinkModePreference.dynamic,
-        cCompiler: CCompilerConfig(
-          cc: cc,
-          envScript: envScript,
-          envScriptArgs: envScriptArgs,
-        ),
+      final compilerInvocation = logMessages.singleWhere(
+        (message) => message.contains(helloWorldCppUri.toFilePath()),
       );
-      final buildOutput = BuildOutput();
-      final cbuilder = CBuilder.executable(
-        name: name,
-        sources: [helloWorldCppUri.toFilePath()],
-        language: Language.cpp,
-        cppLinkStdLib: 'stdc++',
-      );
-
-      if (buildConfig.targetOs == OS.windows) {
-        await expectLater(
-          () => cbuilder.run(
-            buildConfig: buildConfig,
-            buildOutput: buildOutput,
-            logger: logger,
-          ),
-          throwsArgumentError,
-        );
-      } else {
-        await cbuilder.run(
-          buildConfig: buildConfig,
-          buildOutput: buildOutput,
-          logger: logger,
-        );
-
-        final executableUri =
-            tempUri.resolve(Target.current.os.executableFileName(name));
-        expect(await File.fromUri(executableUri).exists(), true);
-        final result = await runProcess(
-          executable: executableUri,
-          logger: logger,
-        );
-        expect(result.exitCode, 0);
-        expect(result.stdout.trim(), endsWith('Hello world.'));
-
-        final compilerInvocation = logMessages.singleWhere(
-          (message) => message.contains(helloWorldCppUri.toFilePath()),
-        );
-        expect(compilerInvocation, contains('-l stdc++'));
-      }
-    });
+      expect(compilerInvocation, contains('-l stdc++'));
+    }
   });
 }
 
@@ -505,90 +496,89 @@ Future<void> testDefines({
   bool ndebugDefine = false,
   bool? customDefineWithValue,
 }) async {
-  await inTempDir((tempUri) async {
-    final definesCUri =
-        packageUri.resolve('test/cbuilder/testfiles/defines/src/defines.c');
-    if (!await File.fromUri(definesCUri).exists()) {
-      throw Exception('Run the test from the root directory.');
-    }
-    const name = 'defines';
+  final tempUri = await tempDirForTest();
+  final definesCUri =
+      packageUri.resolve('test/cbuilder/testfiles/defines/src/defines.c');
+  if (!await File.fromUri(definesCUri).exists()) {
+    throw Exception('Run the test from the root directory.');
+  }
+  const name = 'defines';
 
-    final buildConfig = BuildConfig(
-      outDir: tempUri,
-      packageRoot: tempUri,
-      targetArchitecture: Architecture.current,
-      targetOs: OS.current,
-      buildMode: buildMode,
-      // Ignored by executables.
-      linkModePreference: LinkModePreference.dynamic,
-      cCompiler: CCompilerConfig(
-        cc: cc,
-        envScript: envScript,
-        envScriptArgs: envScriptArgs,
+  final buildConfig = BuildConfig(
+    outDir: tempUri,
+    packageRoot: tempUri,
+    targetArchitecture: Architecture.current,
+    targetOs: OS.current,
+    buildMode: buildMode,
+    // Ignored by executables.
+    linkModePreference: LinkModePreference.dynamic,
+    cCompiler: CCompilerConfig(
+      cc: cc,
+      envScript: envScript,
+      envScriptArgs: envScriptArgs,
+    ),
+  );
+  final buildOutput = BuildOutput();
+  final cbuilder = CBuilder.executable(
+    name: name,
+    sources: [definesCUri.toFilePath()],
+    defines: {
+      if (customDefineWithValue != null)
+        'FOO': customDefineWithValue ? 'BAR' : null,
+    },
+    buildModeDefine: buildModeDefine,
+    ndebugDefine: ndebugDefine,
+  );
+  await cbuilder.run(
+    buildConfig: buildConfig,
+    buildOutput: buildOutput,
+    logger: logger,
+  );
+
+  final executableUri =
+      tempUri.resolve(Target.current.os.executableFileName(name));
+  expect(await File.fromUri(executableUri).exists(), true);
+  final result = await runProcess(
+    executable: executableUri,
+    logger: logger,
+  );
+  expect(result.exitCode, 0);
+
+  if (buildModeDefine) {
+    expect(
+      result.stdout,
+      contains('Macro ${buildMode.name.toUpperCase()} is defined: 1'),
+    );
+  } else {
+    expect(
+      result.stdout,
+      contains('Macro ${buildMode.name.toUpperCase()} is undefined.'),
+    );
+  }
+
+  if (ndebugDefine && buildMode != BuildMode.debug) {
+    expect(
+      result.stdout,
+      contains('Macro NDEBUG is defined: 1'),
+    );
+  } else {
+    expect(
+      result.stdout,
+      contains('Macro NDEBUG is undefined.'),
+    );
+  }
+
+  if (customDefineWithValue != null) {
+    expect(
+      result.stdout,
+      contains(
+        'Macro FOO is defined: ${customDefineWithValue ? 'BAR' : '1'}',
       ),
     );
-    final buildOutput = BuildOutput();
-    final cbuilder = CBuilder.executable(
-      name: name,
-      sources: [definesCUri.toFilePath()],
-      defines: {
-        if (customDefineWithValue != null)
-          'FOO': customDefineWithValue ? 'BAR' : null,
-      },
-      buildModeDefine: buildModeDefine,
-      ndebugDefine: ndebugDefine,
+  } else {
+    expect(
+      result.stdout,
+      contains('Macro FOO is undefined.'),
     );
-    await cbuilder.run(
-      buildConfig: buildConfig,
-      buildOutput: buildOutput,
-      logger: logger,
-    );
-
-    final executableUri =
-        tempUri.resolve(Target.current.os.executableFileName(name));
-    expect(await File.fromUri(executableUri).exists(), true);
-    final result = await runProcess(
-      executable: executableUri,
-      logger: logger,
-    );
-    expect(result.exitCode, 0);
-
-    if (buildModeDefine) {
-      expect(
-        result.stdout,
-        contains('Macro ${buildMode.name.toUpperCase()} is defined: 1'),
-      );
-    } else {
-      expect(
-        result.stdout,
-        contains('Macro ${buildMode.name.toUpperCase()} is undefined.'),
-      );
-    }
-
-    if (ndebugDefine && buildMode != BuildMode.debug) {
-      expect(
-        result.stdout,
-        contains('Macro NDEBUG is defined: 1'),
-      );
-    } else {
-      expect(
-        result.stdout,
-        contains('Macro NDEBUG is undefined.'),
-      );
-    }
-
-    if (customDefineWithValue != null) {
-      expect(
-        result.stdout,
-        contains(
-          'Macro FOO is defined: ${customDefineWithValue ? 'BAR' : '1'}',
-        ),
-      );
-    } else {
-      expect(
-        result.stdout,
-        contains('Macro FOO is undefined.'),
-      );
-    }
-  });
+  }
 }

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -19,6 +19,11 @@ import 'package:test/test.dart';
 import '../helpers.dart';
 
 void main() {
+  test('Langauge.toString', () {
+    expect(Language.c.toString(), 'c');
+    expect(Language.cpp.toString(), 'c++');
+  });
+
   for (final pic in [null, true, false]) {
     final picTag =
         switch (pic) { null => 'auto_pic', true => 'pic', false => 'no_pic' };

--- a/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
@@ -21,65 +21,62 @@ import '../helpers.dart';
 
 void main() {
   test('Config provided compiler', () async {
-    await inTempDir((tempUri) async {
-      final ar = [
-        ...await appleAr.defaultResolver!.resolve(logger: logger),
-        ...await lib.defaultResolver!.resolve(logger: logger),
-        ...await llvmAr.defaultResolver!.resolve(logger: logger),
-      ].first.uri;
-      final cc = [
-        ...await appleClang.defaultResolver!.resolve(logger: logger),
-        ...await cl.defaultResolver!.resolve(logger: logger),
-        ...await clang.defaultResolver!.resolve(logger: logger),
-      ].first.uri;
-      final ld = [
-        ...await appleLd.defaultResolver!.resolve(logger: logger),
-        ...await lib.defaultResolver!.resolve(logger: logger),
-        ...await lld.defaultResolver!.resolve(logger: logger),
-      ].first.uri;
-      final envScript = [
-        ...await vcvars64.defaultResolver!.resolve(logger: logger)
-      ].firstOrNull?.uri;
-      final buildConfig = BuildConfig(
-        outDir: tempUri,
-        packageRoot: tempUri,
-        targetArchitecture: Architecture.current,
-        targetOs: OS.current,
-        buildMode: BuildMode.release,
-        linkModePreference: LinkModePreference.dynamic,
-        cCompiler: CCompilerConfig(
-          ar: ar,
-          cc: cc,
-          ld: ld,
-          envScript: envScript,
-        ),
-      );
-      final resolver =
-          CompilerResolver(buildConfig: buildConfig, logger: logger);
-      final compiler = await resolver.resolveCompiler();
-      final archiver = await resolver.resolveArchiver();
-      expect(compiler.uri, buildConfig.cCompiler.cc);
-      expect(archiver.uri, buildConfig.cCompiler.ar);
-    });
+    final tempUri = await tempDirForTest();
+    final ar = [
+      ...await appleAr.defaultResolver!.resolve(logger: logger),
+      ...await lib.defaultResolver!.resolve(logger: logger),
+      ...await llvmAr.defaultResolver!.resolve(logger: logger),
+    ].first.uri;
+    final cc = [
+      ...await appleClang.defaultResolver!.resolve(logger: logger),
+      ...await cl.defaultResolver!.resolve(logger: logger),
+      ...await clang.defaultResolver!.resolve(logger: logger),
+    ].first.uri;
+    final ld = [
+      ...await appleLd.defaultResolver!.resolve(logger: logger),
+      ...await lib.defaultResolver!.resolve(logger: logger),
+      ...await lld.defaultResolver!.resolve(logger: logger),
+    ].first.uri;
+    final envScript = [
+      ...await vcvars64.defaultResolver!.resolve(logger: logger)
+    ].firstOrNull?.uri;
+    final buildConfig = BuildConfig(
+      outDir: tempUri,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.current,
+      targetOs: OS.current,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.dynamic,
+      cCompiler: CCompilerConfig(
+        ar: ar,
+        cc: cc,
+        ld: ld,
+        envScript: envScript,
+      ),
+    );
+    final resolver = CompilerResolver(buildConfig: buildConfig, logger: logger);
+    final compiler = await resolver.resolveCompiler();
+    final archiver = await resolver.resolveArchiver();
+    expect(compiler.uri, buildConfig.cCompiler.cc);
+    expect(archiver.uri, buildConfig.cCompiler.ar);
   });
 
   test('No compiler found', () async {
-    await inTempDir((tempUri) async {
-      final buildConfig = BuildConfig(
-        outDir: tempUri,
-        packageRoot: tempUri,
-        targetArchitecture: Architecture.arm64,
-        targetOs: OS.windows,
-        buildMode: BuildMode.release,
-        linkModePreference: LinkModePreference.dynamic,
-      );
-      final resolver = CompilerResolver(
-        buildConfig: buildConfig,
-        logger: logger,
-        host: Target.androidArm64, // This is never a host.
-      );
-      expect(resolver.resolveCompiler, throwsA(isA<ToolError>()));
-      expect(resolver.resolveArchiver, throwsA(isA<ToolError>()));
-    });
+    final tempUri = await tempDirForTest();
+    final buildConfig = BuildConfig(
+      outDir: tempUri,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.arm64,
+      targetOs: OS.windows,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.dynamic,
+    );
+    final resolver = CompilerResolver(
+      buildConfig: buildConfig,
+      logger: logger,
+      host: Target.androidArm64, // This is never a host.
+    );
+    expect(resolver.resolveCompiler, throwsA(isA<ToolError>()));
+    expect(resolver.resolveArchiver, throwsA(isA<ToolError>()));
   });
 }

--- a/pkgs/native_toolchain_c/test/cbuilder/testfiles/hello_world_cpp/src/hello_world_cpp.cc
+++ b/pkgs/native_toolchain_c/test/cbuilder/testfiles/hello_world_cpp/src/hello_world_cpp.cc
@@ -1,0 +1,13 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include <iostream>
+
+int main() {
+#ifdef DEBUG
+  std::cout << "Running in debug mode." << std::endl;
+#endif
+  std::cout << "Hello world." << std::endl;
+  return 0;
+}

--- a/pkgs/native_toolchain_c/test/cbuilder/testfiles/hello_world_cpp/src/hello_world_cpp.cc
+++ b/pkgs/native_toolchain_c/test/cbuilder/testfiles/hello_world_cpp/src/hello_world_cpp.cc
@@ -11,3 +11,4 @@ int main() {
   std::cout << "Hello world." << std::endl;
   return 0;
 }
+

--- a/pkgs/native_toolchain_c/test/cbuilder/testfiles/includes/include/includes.h
+++ b/pkgs/native_toolchain_c/test/cbuilder/testfiles/includes/include/includes.h
@@ -1,0 +1,11 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#if _WIN32
+#define FFI_EXPORT __declspec(dllexport)
+#else
+#define FFI_EXPORT
+#endif
+
+FFI_EXPORT int x = 42;

--- a/pkgs/native_toolchain_c/test/cbuilder/testfiles/includes/include/includes.h
+++ b/pkgs/native_toolchain_c/test/cbuilder/testfiles/includes/include/includes.h
@@ -9,3 +9,4 @@
 #endif
 
 FFI_EXPORT int x = 42;
+

--- a/pkgs/native_toolchain_c/test/cbuilder/testfiles/includes/src/includes.c
+++ b/pkgs/native_toolchain_c/test/cbuilder/testfiles/includes/src/includes.c
@@ -1,0 +1,5 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include "includes.h"

--- a/pkgs/native_toolchain_c/test/cbuilder/testfiles/includes/src/includes.c
+++ b/pkgs/native_toolchain_c/test/cbuilder/testfiles/includes/src/includes.c
@@ -3,3 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 #include "includes.h"
+

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:ffi';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
@@ -169,4 +170,14 @@ Future<String> runOtoolInstallName(Uri libraryUri, String libraryName) async {
       .trim()
       .split(' ')[1];
   return installName;
+}
+
+/// Opens the [DynamicLibrary] at [path] and register a tear down hook to close
+/// it when the current test is done.
+DynamicLibrary openDynamicLibraryForTest(String path) {
+  final library = DynamicLibrary.open(path);
+  // TODO: Remove this ignore when sdk is >=3.1.0.
+  // ignore: sdk_version_since
+  addTearDown(library.close);
+  return library;
 }

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -49,15 +49,12 @@ Future<void> inTempDir(
   // Deal with Windows temp folder aliases.
   final tempUri =
       Directory(await tempDir.resolveSymbolicLinks()).uri.normalizePath();
-  try {
-    await fun(tempUri);
-  } finally {
-    if ((!Platform.environment.containsKey(keepTempKey) ||
-            Platform.environment[keepTempKey]!.isEmpty) &&
-        !keepTemp) {
-      addTearDown(() => tempDir.delete(recursive: true));
-    }
+  if ((!Platform.environment.containsKey(keepTempKey) ||
+          Platform.environment[keepTempKey]!.isEmpty) &&
+      !keepTemp) {
+    addTearDown(() => tempDir.delete(recursive: true));
   }
+  await fun(tempUri);
 }
 
 /// Logger that outputs the full trace when a test fails.

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -169,8 +169,6 @@ Future<String> runOtoolInstallName(Uri libraryUri, String libraryName) async {
 /// it when the current test is done.
 DynamicLibrary openDynamicLibraryForTest(String path) {
   final library = DynamicLibrary.open(path);
-  // TODO: Remove this ignore when sdk is >=3.1.0.
-  // ignore: sdk_version_since
   addTearDown(library.close);
   return library;
 }

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -55,7 +55,7 @@ Future<void> inTempDir(
     if ((!Platform.environment.containsKey(keepTempKey) ||
             Platform.environment[keepTempKey]!.isEmpty) &&
         !keepTemp) {
-      await tempDir.delete(recursive: true);
+      addTearDown(() => tempDir.delete(recursive: true));
     }
   }
 }

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -40,11 +40,7 @@ String testSuffix(List<Object> tags) => switch (tags) {
 
 const keepTempKey = 'KEEP_TEMPORARY_DIRECTORIES';
 
-Future<void> inTempDir(
-  Future<void> Function(Uri tempUri) fun, {
-  String? prefix,
-  bool keepTemp = false,
-}) async {
+Future<Uri> tempDirForTest({String? prefix, bool keepTemp = false}) async {
   final tempDir = await Directory.systemTemp.createTemp(prefix);
   // Deal with Windows temp folder aliases.
   final tempUri =
@@ -54,7 +50,7 @@ Future<void> inTempDir(
       !keepTemp) {
     addTearDown(() => tempDir.delete(recursive: true));
   }
-  await fun(tempUri);
+  return tempUri;
 }
 
 /// Logger that outputs the full trace when a test fails.

--- a/pkgs/native_toolchain_c/test/native_toolchain/recognizer_test.dart
+++ b/pkgs/native_toolchain_c/test/native_toolchain/recognizer_test.dart
@@ -50,27 +50,24 @@ void main() async {
   }
 
   test('compiler does not exist', () async {
-    await inTempDir((tempUri) async {
-      final recognizer = CompilerRecognizer(tempUri.resolve('asdf'));
-      final result = await recognizer.resolve(logger: logger);
-      expect(result, <ToolInstance>[]);
-    });
+    final tempUri = await tempDirForTest();
+    final recognizer = CompilerRecognizer(tempUri.resolve('asdf'));
+    final result = await recognizer.resolve(logger: logger);
+    expect(result, <ToolInstance>[]);
   });
 
   test('linker does not exist', () async {
-    await inTempDir((tempUri) async {
-      final recognizer = LinkerRecognizer(tempUri.resolve('asdf'));
-      final result = await recognizer.resolve(logger: logger);
-      expect(result, <ToolInstance>[]);
-    });
+    final tempUri = await tempDirForTest();
+    final recognizer = LinkerRecognizer(tempUri.resolve('asdf'));
+    final result = await recognizer.resolve(logger: logger);
+    expect(result, <ToolInstance>[]);
   });
 
   test('archiver does not exist', () async {
-    await inTempDir((tempUri) async {
-      final recognizer = ArchiverRecognizer(tempUri.resolve('asdf'));
-      final result = await recognizer.resolve(logger: logger);
-      expect(result, <ToolInstance>[]);
-    });
+    final tempUri = await tempDirForTest();
+    final recognizer = ArchiverRecognizer(tempUri.resolve('asdf'));
+    final result = await recognizer.resolve(logger: logger);
+    expect(result, <ToolInstance>[]);
   });
 }
 

--- a/pkgs/native_toolchain_c/test/tool/tool_resolver_test.dart
+++ b/pkgs/native_toolchain_c/test/tool/tool_resolver_test.dart
@@ -58,56 +58,52 @@ void main() {
   });
 
   test('RelativeToolResolver', () async {
-    await inTempDir((tempUri) async {
-      final barExeUri =
-          tempUri.resolve(Target.current.os.executableFileName('bar'));
-      final bazExeName = Target.current.os.executableFileName('baz');
-      final bazExeUri = tempUri.resolve(bazExeName);
-      await File.fromUri(barExeUri).writeAsString('dummy');
-      await File.fromUri(bazExeUri).writeAsString('dummy');
-      expect(await File.fromUri(barExeUri).exists(), true);
-      expect(await File.fromUri(bazExeUri).exists(), true);
-      final barResolver = InstallLocationResolver(
-        toolName: 'bar',
-        paths: [barExeUri.toFilePath().replaceAll('\\', '/')],
-      );
-      final bazResolver = RelativeToolResolver(
-        toolName: 'baz',
-        wrappedResolver: barResolver,
-        relativePath: Uri.file(bazExeName),
-      );
-      final resolvedBarInstances = await barResolver.resolve(logger: logger);
-      expect(
-        resolvedBarInstances,
-        [ToolInstance(tool: Tool(name: 'bar'), uri: barExeUri)],
-      );
-      final resolvedBazInstances = await bazResolver.resolve(logger: logger);
-      expect(
-        resolvedBazInstances,
-        [ToolInstance(tool: Tool(name: 'baz'), uri: bazExeUri)],
-      );
-    });
+    final tempUri = await tempDirForTest();
+    final barExeUri =
+        tempUri.resolve(Target.current.os.executableFileName('bar'));
+    final bazExeName = Target.current.os.executableFileName('baz');
+    final bazExeUri = tempUri.resolve(bazExeName);
+    await File.fromUri(barExeUri).writeAsString('dummy');
+    await File.fromUri(bazExeUri).writeAsString('dummy');
+    expect(await File.fromUri(barExeUri).exists(), true);
+    expect(await File.fromUri(bazExeUri).exists(), true);
+    final barResolver = InstallLocationResolver(
+      toolName: 'bar',
+      paths: [barExeUri.toFilePath().replaceAll('\\', '/')],
+    );
+    final bazResolver = RelativeToolResolver(
+      toolName: 'baz',
+      wrappedResolver: barResolver,
+      relativePath: Uri.file(bazExeName),
+    );
+    final resolvedBarInstances = await barResolver.resolve(logger: logger);
+    expect(
+      resolvedBarInstances,
+      [ToolInstance(tool: Tool(name: 'bar'), uri: barExeUri)],
+    );
+    final resolvedBazInstances = await bazResolver.resolve(logger: logger);
+    expect(
+      resolvedBazInstances,
+      [ToolInstance(tool: Tool(name: 'baz'), uri: bazExeUri)],
+    );
   });
 
   test('logger', () async {
-    await inTempDir((tempUri) async {
-      final barExeUri =
-          tempUri.resolve(Target.current.os.executableFileName('bar'));
-      final bazExeName = Target.current.os.executableFileName('baz');
-      final bazExeUri = tempUri.resolve(bazExeName);
-      await File.fromUri(barExeUri).writeAsString('dummy');
-      final barResolver = InstallLocationResolver(
-          toolName: 'bar',
-          paths: [barExeUri.toFilePath().replaceAll('\\', '/')]);
-      final bazResolver = InstallLocationResolver(
-          toolName: 'baz',
-          paths: [bazExeUri.toFilePath().replaceAll('\\', '/')]);
-      final barLogs = <String>[];
-      final bazLogs = <String>[];
-      await barResolver.resolve(logger: createCapturingLogger(barLogs));
-      await bazResolver.resolve(logger: createCapturingLogger(bazLogs));
-      expect(barLogs.join('\n'), contains('Found [ToolInstance(bar'));
-      expect(bazLogs.join('\n'), contains('Found no baz'));
-    });
+    final tempUri = await tempDirForTest();
+    final barExeUri =
+        tempUri.resolve(Target.current.os.executableFileName('bar'));
+    final bazExeName = Target.current.os.executableFileName('baz');
+    final bazExeUri = tempUri.resolve(bazExeName);
+    await File.fromUri(barExeUri).writeAsString('dummy');
+    final barResolver = InstallLocationResolver(
+        toolName: 'bar', paths: [barExeUri.toFilePath().replaceAll('\\', '/')]);
+    final bazResolver = InstallLocationResolver(
+        toolName: 'baz', paths: [bazExeUri.toFilePath().replaceAll('\\', '/')]);
+    final barLogs = <String>[];
+    final bazLogs = <String>[];
+    await barResolver.resolve(logger: createCapturingLogger(barLogs));
+    await bazResolver.resolve(logger: createCapturingLogger(bazLogs));
+    expect(barLogs.join('\n'), contains('Found [ToolInstance(bar'));
+    expect(bazLogs.join('\n'), contains('Found no baz'));
   });
 }

--- a/pkgs/native_toolchain_c/test/utils/run_process_test.dart
+++ b/pkgs/native_toolchain_c/test/utils/run_process_test.dart
@@ -13,15 +13,14 @@ void main() {
   final whichUri = Uri.file(Platform.isWindows ? 'where' : 'which');
 
   test('log contains working dir', () async {
-    await inTempDir((tempUri) async {
-      final messages = <String>[];
-      await runProcess(
-        executable: whichUri,
-        workingDirectory: tempUri,
-        logger: createCapturingLogger(messages),
-      );
-      expect(messages.join('\n'), contains('cd'));
-    });
+    final tempUri = await tempDirForTest();
+    final messages = <String>[];
+    await runProcess(
+      executable: whichUri,
+      workingDirectory: tempUri,
+      logger: createCapturingLogger(messages),
+    );
+    expect(messages.join('\n'), contains('cd'));
   });
 
   test('log contains env', () async {


### PR DESCRIPTION
This PR adds a few more options to `CBuilder` that are commonly useful. 
The `flags` option allows users to accomplish most things, even if `CBuilder` does support the specific use case.

The added options follow the example set by the [`cc` crate](https://docs.rs/cc/latest/cc/struct.Build.html).