### PR TITLE
`PackageLayout` constructor for already parsed `PackageConfig`

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.1
+
+- Provide a `PackageLayout` constructor for already parsed `PackageConfig`
+  [flutter#134427](https://github.com/flutter/flutter/issues/134427).
+
 ## 0.2.0
 
 - **Breaking change** `NativeAssetsBuildRunner`s methods now return an object

--- a/pkgs/native_assets_builder/lib/src/package_layout/package_layout.dart
+++ b/pkgs/native_assets_builder/lib/src/package_layout/package_layout.dart
@@ -31,6 +31,16 @@ class PackageLayout {
   PackageLayout._(
       this.rootPackageRoot, this.packageConfig, this.packageConfigUri);
 
+  factory PackageLayout.fromPackageConfig(
+    PackageConfig packageConfig,
+    Uri packageConfigUri,
+  ) {
+    assert(File.fromUri(packageConfigUri).existsSync());
+    packageConfigUri = packageConfigUri.normalizePath();
+    final rootPackageRoot = packageConfigUri.resolve('../');
+    return PackageLayout._(rootPackageRoot, packageConfig, packageConfigUri);
+  }
+
   static Future<PackageLayout> fromRootPackageRoot(Uri rootPackageRoot) async {
     rootPackageRoot = rootPackageRoot.normalizePath();
     final packageConfigUri =

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_assets_builder
 description: >-
   This package is the backend that invokes top-level `build.dart` scripts.
-version: 0.2.0
+version: 0.2.1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_builder
 
 environment:

--- a/pkgs/native_assets_builder/test/build_runner/package_layout_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/package_layout_test.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:native_assets_builder/native_assets_builder.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+import 'helpers.dart';
+
+void main() async {
+  test('fromRootPackageRoot', () async {
+    await inTempDir((tempUri) async {
+      await copyTestProjects(targetUri: tempUri);
+      final nativeAddUri = tempUri.resolve('native_add/');
+
+      // First, run `pub get`, we need pub to resolve our dependencies.
+      await runPubGet(workingDirectory: nativeAddUri, logger: logger);
+
+      final packageLayout =
+          await PackageLayout.fromRootPackageRoot(nativeAddUri);
+      final packageLayout2 = PackageLayout.fromPackageConfig(
+        packageLayout.packageConfig,
+        packageLayout.packageConfigUri,
+      );
+      expect(packageLayout.rootPackageRoot, packageLayout2.rootPackageRoot);
+    });
+  });
+}


### PR DESCRIPTION
Provide a constructor for `PackageLayout` that does not require reading and reparsing the package config file.

Context:

* https://github.com/flutter/flutter/issues/134427