### PR TITLE
[native_assets_builder] Take packageLayout for build and dryRun

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.2
+
+- Take a `PackageLayout` argument for `build` and `dryRun`
+  [flutter#134427](https://github.com/flutter/flutter/issues/134427).
+
 ## 0.2.1
 
 - Provide a `PackageLayout` constructor for already parsed `PackageConfig`

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -42,9 +42,9 @@ class NativeAssetsBuildRunner {
     IOSSdk? targetIOSSdk,
     int? targetAndroidNdkApi,
     required bool includeParentEnvironment,
+    PackageLayout? packageLayout,
   }) async {
-    final packageLayout =
-        await PackageLayout.fromRootPackageRoot(workingDirectory);
+    packageLayout ??= await PackageLayout.fromRootPackageRoot(workingDirectory);
     final packagesWithNativeAssets =
         await packageLayout.packagesWithNativeAssets;
     final planner = await NativeAssetsBuildPlanner.fromRootPackageRoot(
@@ -118,9 +118,9 @@ class NativeAssetsBuildRunner {
     required OS targetOs,
     required Uri workingDirectory,
     required bool includeParentEnvironment,
+    PackageLayout? packageLayout,
   }) async {
-    final packageLayout =
-        await PackageLayout.fromRootPackageRoot(workingDirectory);
+    packageLayout ??= await PackageLayout.fromRootPackageRoot(workingDirectory);
     final packagesWithNativeAssets =
         await packageLayout.packagesWithNativeAssets;
     final planner = await NativeAssetsBuildPlanner.fromRootPackageRoot(

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_assets_builder
 description: >-
   This package is the backend that invokes top-level `build.dart` scripts.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_builder
 
 environment:

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:native_assets_builder/native_assets_builder.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';
@@ -36,15 +37,25 @@ void main() async {
       }
 
       // Trigger a build, should not invoke anything.
-      {
+      for (final passPackageLayout in [true, false]) {
+        PackageLayout? packageLayout;
+        if (passPackageLayout) {
+          packageLayout = await PackageLayout.fromRootPackageRoot(packageUri);
+        }
         final logMessages = <String>[];
-        final result = await build(packageUri, logger, dartExecutable,
-            capturedLogs: logMessages);
+        final result = await build(
+          packageUri,
+          logger,
+          dartExecutable,
+          capturedLogs: logMessages,
+          packageLayout: packageLayout,
+        );
         expect(
-            false,
-            logMessages
-                .join('\n')
-                .contains('native_add${Platform.pathSeparator}build.dart'));
+          false,
+          logMessages
+              .join('\n')
+              .contains('native_add${Platform.pathSeparator}build.dart'),
+        );
         expect(result.assets.length, 1);
       }
     });

--- a/pkgs/native_assets_builder/test/build_runner/helpers.dart
+++ b/pkgs/native_assets_builder/test/build_runner/helpers.dart
@@ -34,6 +34,7 @@ Future<BuildResult> build(
   CCompilerConfig? cCompilerConfig,
   bool includeParentEnvironment = true,
   List<String>? capturedLogs,
+  PackageLayout? packageLayout,
 }) async {
   StreamSubscription<LogRecord>? subscription;
   if (capturedLogs != null) {
@@ -51,6 +52,7 @@ Future<BuildResult> build(
     workingDirectory: packageUri,
     cCompilerConfig: cCompilerConfig,
     includeParentEnvironment: includeParentEnvironment,
+    packageLayout: packageLayout,
   );
   if (result.success) {
     await expectAssetsExist(result.assets);
@@ -71,6 +73,7 @@ Future<DryRunResult> dryRun(
   CCompilerConfig? cCompilerConfig,
   bool includeParentEnvironment = true,
   List<String>? capturedLogs,
+  PackageLayout? packageLayout,
 }) async {
   StreamSubscription<LogRecord>? subscription;
   if (capturedLogs != null) {
@@ -86,6 +89,7 @@ Future<DryRunResult> dryRun(
     targetOs: Target.current.os,
     workingDirectory: packageUri,
     includeParentEnvironment: includeParentEnvironment,
+    packageLayout: packageLayout,
   );
 
   if (subscription != null) {


### PR DESCRIPTION
Enable using `PackageLayout` in `build` and `run` from `NativeAssetsBuildRunner`, so that does not require reading and reparsing the package config file.

Follow up of:

* https://github.com/dart-lang/native/pull/126

That PR only covered the code paths in flutter_tools using `PackageLayout.packagesWithNativeAssets`, this also should cover the paths doing the actual builds.

(Note that flutter_tools requires published dependencies, hence we just land small PRs here and publish right away.)

Context:

* https://github.com/flutter/flutter/issues/134427

