### PR TITLE
[CI] Bump clang to newer version

### DIFF
--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -82,7 +82,7 @@ jobs:
         if: ${{ matrix.sdk == 'stable' }}
 
       - name: Install native toolchains
-        run: sudo add-apt-repository 'deb http://apt.llvm.org/unstable/ llvm-toolchain-16 main' && sudo apt-get update && sudo apt-get install clang-16 gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
+        run: sudo apt-get update && sudo apt-get install clang-15 gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
         if: ${{ matrix.sdk == 'stable' && matrix.os == 'ubuntu' }}
 
       - run: dart test

--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -82,7 +82,7 @@ jobs:
         if: ${{ matrix.sdk == 'stable' }}
 
       - name: Install native toolchains
-        run: sudo apt-get update && sudo apt-get install clang-16 gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
+        run: add-apt-repository 'deb http://apt.llvm.org/unstable/ llvm-toolchain-16 main' && sudo apt-get update && sudo apt-get install clang-16 gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
         if: ${{ matrix.sdk == 'stable' && matrix.os == 'ubuntu' }}
 
       - run: dart test

--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -82,7 +82,7 @@ jobs:
         if: ${{ matrix.sdk == 'stable' }}
 
       - name: Install native toolchains
-        run: add-apt-repository 'deb http://apt.llvm.org/unstable/ llvm-toolchain-16 main' && sudo apt-get update && sudo apt-get install clang-16 gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
+        run: sudo add-apt-repository 'deb http://apt.llvm.org/unstable/ llvm-toolchain-16 main' && sudo apt-get update && sudo apt-get install clang-16 gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
         if: ${{ matrix.sdk == 'stable' && matrix.os == 'ubuntu' }}
 
       - run: dart test

--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -82,7 +82,7 @@ jobs:
         if: ${{ matrix.sdk == 'stable' }}
 
       - name: Install native toolchains
-        run: sudo apt-get update && sudo apt-get install clang-14 gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
+        run: sudo apt-get update && sudo apt-get install clang-17 gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
         if: ${{ matrix.sdk == 'stable' && matrix.os == 'ubuntu' }}
 
       - run: dart test

--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -82,7 +82,7 @@ jobs:
         if: ${{ matrix.sdk == 'stable' }}
 
       - name: Install native toolchains
-        run: sudo apt-get update && sudo apt-get install clang-17 gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
+        run: sudo apt-get update && sudo apt-get install clang-16 gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
         if: ${{ matrix.sdk == 'stable' && matrix.os == 'ubuntu' }}
 
       - run: dart test


### PR DESCRIPTION
Brings clang slightly closer to the one pinned in the Dart SDK (which is bleeding edge).

Unfortunately, we can't easily use unstable clang versions on the CI here. So Clang 16 and 17 are not available yet. https://github.com/dart-lang/native/issues/131#issuecomment-1720742490