### PR TITLE
[native_toolchain_c] Explicitly tell linker to create position dependent or position independent executable

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.4+1
+
+- Explicitly tell linker to create position dependent or position independent executable
+  ([#113](https://github.com/dart-lang/native/issues/133)).
+
 ## 0.2.4
 
 - Added `includes` for specifying include directories.

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -161,15 +161,18 @@ class RunCBuilder {
             // which the static library is linked is PIC, PIE or neither. Then
             // we could use the same option for the static library.
             if (staticLibrary != null) '-fPIC',
-            if (executable != null) '-fPIE',
+            if (executable != null) ...[
+              // Generate position-independent code for executables.
+              '-fPIE',
+              // Tell the linker to generate a position-independent executable.
+              '-pie',
+            ],
           ] else ...[
+            // Disable generation of any kind of position-independent code.
             '-fno-PIC',
             '-fno-PIE',
-            if (compiler.tool == clang) ...[
-              '-z',
-              'notext',
-              if (executable != null) '-no-pie',
-            ]
+            // Tell the linker to generate a position-dependent executable.
+            if (executable != null) '-no-pie',
           ],
         if (std != null) '-std=$std',
         if (language == Language.cpp) ...[

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -168,6 +168,7 @@ class RunCBuilder {
             if (compiler.tool == clang) ...[
               '-z',
               'notext',
+              if (executable != null) '-no-pie',
             ]
           ],
         if (std != null) '-std=$std',

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.2.4
+version: 0.2.4+1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -19,7 +19,6 @@ import 'package:test/test.dart';
 import '../helpers.dart';
 
 void main() {
-  // TODO: Fix
   test('Langauge.toString', () {
     expect(Language.c.toString(), 'c');
     expect(Language.cpp.toString(), 'c++');

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -19,6 +19,7 @@ import 'package:test/test.dart';
 import '../helpers.dart';
 
 void main() {
+  // TODO: Fix
   test('Langauge.toString', () {
     expect(Language.c.toString(), 'c');
     expect(Language.cpp.toString(), 'c++');


### PR DESCRIPTION
I assumed that `-fPIE` also affect the linking stage. This is not the case. It only affects code generation. Whether a position dependent or independent executable is generated depends on the `-pie` and `-no-pie` options. Compilers and compiler versions can have different defaults for creating position dependent or independent executables (apparently clang changed its default somewhere between 16 and 18). With this PR, we now pass `-pie` and `-no-pie` in addition to `-fPIE`/`-fno-PIE`, when compiling an executable.