### PR TITLE
[native_toolchain_c] Bump version

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.4+1
+## 0.2.5
 
 - Explicitly tell linker to create position dependent or position independent executable
   ([#113](https://github.com/dart-lang/native/issues/133)).

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.2.4+1
+version: 0.2.5
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:


### PR DESCRIPTION
It looks like the auto-publisher doesn't pick up on semantic versions with `+x`, so bump from 0.2.4+1 to 0.2.5.