### PR TITLE
fix: Header filename mismatch causing ffigen to produce empty output

### DIFF
--- a/pkgs/native_assets_cli/example/native_add_library/ffigen.yaml
+++ b/pkgs/native_assets_cli/example/native_add_library/ffigen.yaml
@@ -7,9 +7,9 @@ description: |
 output: 'lib/native_add_library.dart'
 headers:
   entry-points:
-    - 'src/native_add.h'
+    - 'src/native_add_library.h'
   include-directives:
-    - 'src/native_add.h'
+    - 'src/native_add_library.h'
 preamble: |
   // Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
   // for details. All rights reserved. Use of this source code is governed by a


### PR DESCRIPTION
# Description
<details>

<summary>
Some minor context how I got here:
</summary>
Been fighting with ffigen for about a week now to get a project called `llama_cpp` ported over to Dart as a convenient package. I've got ffi working in a side project of mine (shady.ai) but creating a plugin_ffi package has been troublesome.
</details>

Before this PR, upon checking out the repository, things seemed to work at first glance. No compile errors. I was able to execute the `test` and `run` commands with success in the `native_add_library` package.

However, I was unable to re-generate Dart code from the native header (specified in `ffigen.yaml`), turns out it's due to a typo in the [headers] section.

Steps I had taken prior this PR:
1. Navigate to `dart_lang_native/pkgs/native_assets_cli/example/native_add_library`
2. Execute `dart --enable-experiment=native-assets test`
3. Test passed.
4. Happy me
5. Added new C code
6. Ran ffigen tooling
7. Analyzer will show some syntax errors here and there due to the missing missing references 
8. `native_add_library.dart` seems to be an empty file now aside from the file comments.

## Before
Result of `lib/native_add_library.dart`:
```Dart
// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
// for details. All rights reserved. Use of this source code is governed by a
// BSD-style license that can be found in the LICENSE file.

// AUTO GENERATED FILE, DO NOT EDIT.
//
// Generated by `package:ffigen`.
// ignore_for_file: type=lint

```

## After
Now, with this PR, the file (`lib/native_add_library.dart`) is looking good again.
```Dart
// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
// for details. All rights reserved. Use of this source code is governed by a
// BSD-style license that can be found in the LICENSE file.

// AUTO GENERATED FILE, DO NOT EDIT.
//
// Generated by `package:ffigen`.
// ignore_for_file: type=lint
import 'dart:ffi' as ffi;

@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>(symbol: 'add')
external int add(
  int a,
  int b,
);

```
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
