### PR TITLE
Fix printing of log messages on test failures

### DIFF
--- a/pkgs/native_assets_builder/test/helpers.dart
+++ b/pkgs/native_assets_builder/test/helpers.dart
@@ -156,7 +156,10 @@ Future<void> copyTestProjects({
   }
 }
 
+/// Logger that outputs the full trace when a test fails.
 Logger get logger => _logger ??= () {
+      // We lazily create a new logger for each test so that the messages
+      // captured by printOnFailure are scoped to the correct test.
       addTearDown(() => _logger = null);
       return _createTestLogger();
     }();

--- a/pkgs/native_assets_builder/test/helpers.dart
+++ b/pkgs/native_assets_builder/test/helpers.dart
@@ -156,22 +156,30 @@ Future<void> copyTestProjects({
   }
 }
 
-/// Logger that outputs the full trace when a test fails.
-final logger = Logger('')
-  ..level = Level.ALL
-  ..onRecord.listen((record) {
-    printOnFailure(record.message);
-  });
+Logger get logger => _logger ??= () {
+      addTearDown(() => _logger = null);
+      return _createTestLogger();
+    }();
+
+Logger? _logger;
 
 Logger createCapturingLogger(
   List<String> capturedMessages, {
   Level level = Level.ALL,
 }) =>
+    _createTestLogger(capturedMessages: capturedMessages, level: level);
+
+Logger _createTestLogger({
+  List<String>? capturedMessages,
+  Level level = Level.ALL,
+}) =>
     Logger('')
       ..level = level
       ..onRecord.listen((record) {
-        printOnFailure(record.message);
-        capturedMessages.add(record.message);
+        printOnFailure(
+          '${record.level.name}: ${record.time}: ${record.message}',
+        );
+        capturedMessages?.add(record.message);
       });
 
 final dartExecutable = File(Platform.resolvedExecutable).uri;

--- a/pkgs/native_assets_builder/test/helpers.dart
+++ b/pkgs/native_assets_builder/test/helpers.dart
@@ -158,7 +158,7 @@ Future<void> copyTestProjects({
 
 /// Logger that outputs the full trace when a test fails.
 Logger get logger => _logger ??= () {
-      // We lazily create a new logger for each test so that the messages
+      // A new logger is lazily created for each test so that the messages
       // captured by printOnFailure are scoped to the correct test.
       addTearDown(() => _logger = null);
       return _createTestLogger();

--- a/pkgs/native_assets_cli/example/native_add_library/build.dart
+++ b/pkgs/native_assets_cli/example/native_add_library/build.dart
@@ -28,7 +28,9 @@ void main(List<String> args) async {
     // `package:native_toolchain_c` will output the dynamic or static libraries it built,
     // what files it accessed (for caching the build), etc.
     buildOutput: buildOutput,
-    logger: Logger('')..onRecord.listen((record) => print(record.message)),
+    logger: Logger('')
+      ..level = Level.ALL
+      ..onRecord.listen((record) => print(record.message)),
   );
 
   // Write the output according to the native assets protocol so that Dart or

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -55,7 +55,7 @@ Future<Uri> tempDirForTest({String? prefix, bool keepTemp = false}) async {
 
 /// Logger that outputs the full trace when a test fails.
 Logger get logger => _logger ??= () {
-      // We lazily create a new logger for each test so that the messages
+      // A new logger is lazily created for each test so that the messages
       // captured by printOnFailure are scoped to the correct test.
       addTearDown(() => _logger = null);
       return _createTestLogger();

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -53,6 +53,7 @@ Future<Uri> tempDirForTest({String? prefix, bool keepTemp = false}) async {
   return tempUri;
 }
 
+/// Logger that outputs the full trace when a test fails.
 Logger get logger => _logger ??= () {
       // We lazily create a new logger for each test so that the messages
       // captured by printOnFailure are scoped to the correct test.

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -53,18 +53,23 @@ Future<Uri> tempDirForTest({String? prefix, bool keepTemp = false}) async {
   return tempUri;
 }
 
-/// Logger that outputs the full trace when a test fails.
-final logger = Logger('')
-  ..level = Level.ALL
-  ..onRecord.listen((record) {
-    printOnFailure('${record.level.name}: ${record.time}: ${record.message}');
-  });
+Logger get logger => _logger ??= () {
+      // We lazily create a new logger for each test so that the messages
+      // captured by printOnFailure are scoped to the correct test.
+      addTearDown(() => _logger = null);
+      return _createTestLogger();
+    }();
 
-Logger createCapturingLogger(List<String> capturedMessages) => Logger('')
+Logger? _logger;
+
+Logger createCapturingLogger(List<String> capturedMessages) =>
+    _createTestLogger(capturedMessages: capturedMessages);
+
+Logger _createTestLogger({List<String>? capturedMessages}) => Logger('')
   ..level = Level.ALL
   ..onRecord.listen((record) {
     printOnFailure('${record.level.name}: ${record.time}: ${record.message}');
-    capturedMessages.add(record.message);
+    capturedMessages?.add(record.message);
   });
 
 /// Test files are run in a variety of ways, find this package root in all.


### PR DESCRIPTION
The global singleton `logger` that was used before associated all log messages with the first test that accessed it. 

The issue was that calling `onRecord.listen()` captured the `Zone` of the first access of `logger` and thus of the first test that uses `logger`. `printOnFailure` in turn uses `Zone`s to associate messages with a specific test.