### PR TITLE
[native_toolchain_c] Bump deps

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- Bump `package:native_assets_cli` to 0.3.0.
+
 ## 0.2.5
 
 - Explicitly tell linker to create position dependent or position independent executable

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.2.5
+version: 0.3.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:
@@ -19,7 +19,7 @@ dependencies:
   glob: ^2.1.1
   logging: ^1.1.1
   meta: ^1.9.1
-  native_assets_cli: ^0.2.0
+  native_assets_cli: ^0.3.0
   pub_semver: ^2.1.3
 
 dev_dependencies:

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
@@ -31,6 +31,7 @@ void main() {
 
     final buildConfig = BuildConfig(
       outDir: tempUri,
+      packageName: name,
       packageRoot: tempUri,
       targetArchitecture: Architecture.current,
       targetOs: OS.current,

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -112,6 +112,7 @@ Future<Uri> buildLib(
 
   final buildConfig = BuildConfig(
     outDir: tempUri,
+    packageName: name,
     packageRoot: tempUri,
     targetArchitecture: target.architecture,
     targetOs: target.os,

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -58,6 +58,7 @@ void main() {
                 packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
             final buildConfig = BuildConfig(
               outDir: tempUri,
+              packageName: name,
               packageRoot: tempUri,
               targetArchitecture: target.architecture,
               targetOs: target.os,

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -44,6 +44,7 @@ void main() {
 
         final buildConfig = BuildConfig(
           outDir: tempUri,
+          packageName: name,
           packageRoot: tempUri,
           targetArchitecture: target.architecture,
           targetOs: target.os,

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -44,6 +44,7 @@ void main() {
 
         final buildConfig = BuildConfig(
           outDir: tempUri,
+          packageName: name,
           packageRoot: tempUri,
           targetArchitecture: target.architecture,
           targetOs: target.os,

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -56,6 +56,7 @@ void main() {
 
         final buildConfig = BuildConfig(
           outDir: tempUri,
+          packageName: name,
           packageRoot: tempUri,
           targetOs: target.os,
           targetArchitecture: target.architecture,

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -45,6 +45,7 @@ void main() {
 
         final buildConfig = BuildConfig(
           outDir: tempUri,
+          packageName: name,
           packageRoot: tempUri,
           targetArchitecture: Architecture.current,
           targetOs: OS.current,
@@ -116,12 +117,14 @@ void main() {
         final buildConfig = dryRun
             ? BuildConfig.dryRun(
                 outDir: tempUri,
+                packageName: name,
                 packageRoot: tempUri,
                 targetOs: OS.current,
                 linkModePreference: LinkModePreference.dynamic,
               )
             : BuildConfig(
                 outDir: tempUri,
+                packageName: name,
                 packageRoot: tempUri,
                 targetArchitecture: Architecture.current,
                 targetOs: OS.current,
@@ -213,6 +216,7 @@ void main() {
 
     final buildConfig = BuildConfig(
       outDir: tempUri,
+      packageName: name,
       packageRoot: tempUri,
       targetArchitecture: Architecture.current,
       targetOs: OS.current,
@@ -271,6 +275,7 @@ void main() {
 
     final buildConfig = BuildConfig(
       outDir: tempUri,
+      packageName: name,
       packageRoot: tempUri,
       targetArchitecture: Architecture.current,
       targetOs: OS.current,
@@ -315,6 +320,7 @@ void main() {
 
     final buildConfig = BuildConfig(
       outDir: tempUri,
+      packageName: name,
       packageRoot: tempUri,
       targetArchitecture: Architecture.current,
       targetOs: OS.current,
@@ -373,6 +379,7 @@ void main() {
     final buildConfig = BuildConfig(
       buildMode: BuildMode.release,
       outDir: tempUri,
+      packageName: name,
       packageRoot: tempUri,
       targetArchitecture: Architecture.current,
       targetOs: OS.current,
@@ -437,6 +444,7 @@ void main() {
     final buildConfig = BuildConfig(
       buildMode: BuildMode.release,
       outDir: tempUri,
+      packageName: name,
       packageRoot: tempUri,
       targetArchitecture: Architecture.current,
       targetOs: OS.current,
@@ -506,6 +514,7 @@ Future<void> testDefines({
 
   final buildConfig = BuildConfig(
     outDir: tempUri,
+    packageName: name,
     packageRoot: tempUri,
     targetArchitecture: Architecture.current,
     targetOs: OS.current,

--- a/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
@@ -42,6 +42,7 @@ void main() {
     ].firstOrNull?.uri;
     final buildConfig = BuildConfig(
       outDir: tempUri,
+      packageName: 'dummy',
       packageRoot: tempUri,
       targetArchitecture: Architecture.current,
       targetOs: OS.current,
@@ -65,6 +66,7 @@ void main() {
     final tempUri = await tempDirForTest();
     final buildConfig = BuildConfig(
       outDir: tempUri,
+      packageName: 'dummy',
       packageRoot: tempUri,
       targetArchitecture: Architecture.arm64,
       targetOs: OS.windows,


### PR DESCRIPTION
native_assets_builder's tests use native_toolchain_c, so we need to roll this first.

* https://github.com/dart-lang/native/issues/142