### PR TITLE
Use `Logger.detached` for test loggers

### DIFF
--- a/pkgs/native_assets_builder/test/helpers.dart
+++ b/pkgs/native_assets_builder/test/helpers.dart
@@ -176,7 +176,7 @@ Logger _createTestLogger({
   List<String>? capturedMessages,
   Level level = Level.ALL,
 }) =>
-    Logger('')
+    Logger.detached('')
       ..level = level
       ..onRecord.listen((record) {
         printOnFailure(

--- a/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
@@ -34,7 +34,7 @@ void main() {
     ].first.uri;
     final ld = [
       ...await appleLd.defaultResolver!.resolve(logger: logger),
-      ...await lib.defaultResolver!.resolve(logger: logger),
+      ...await link.defaultResolver!.resolve(logger: logger),
       ...await lld.defaultResolver!.resolve(logger: logger),
     ].first.uri;
     final envScript = [

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -66,12 +66,14 @@ Logger? _logger;
 Logger createCapturingLogger(List<String> capturedMessages) =>
     _createTestLogger(capturedMessages: capturedMessages);
 
-Logger _createTestLogger({List<String>? capturedMessages}) => Logger('')
-  ..level = Level.ALL
-  ..onRecord.listen((record) {
-    printOnFailure('${record.level.name}: ${record.time}: ${record.message}');
-    capturedMessages?.add(record.message);
-  });
+Logger _createTestLogger({List<String>? capturedMessages}) =>
+    Logger.detached('')
+      ..level = Level.ALL
+      ..onRecord.listen((record) {
+        printOnFailure(
+            '${record.level.name}: ${record.time}: ${record.message}');
+        capturedMessages?.add(record.message);
+      });
 
 /// Test files are run in a variety of ways, find this package root in all.
 ///


### PR DESCRIPTION
The primary `Logger` constructor returns the same instance when given the same string. This meant that all tests effectively used the same instance, breaking the separation of log messages printed in case of a test failure.

By using `Logger.detached` every test actually gets its own logger.

Also, a drive by change in `compiler_resolver_test.dart` to correct what looks like a typo.