### PR TITLE
Update all `lints` and `dart_flutter_team_lints` dependencies

### DIFF
--- a/pkgs/native_assets_builder/analysis_options.yaml
+++ b/pkgs/native_assets_builder/analysis_options.yaml
@@ -3,23 +3,13 @@ include: package:dart_flutter_team_lints/analysis_options.yaml
 analyzer:
   language:
     strict-raw-types: true
-    strict-inference: true
   exclude:
     # TODO(https://github.com/dart-lang/ecosystem/issues/150): Remove this.
     - test/data/
 
 linter:
   rules:
-    - always_declare_return_types
-    - avoid_dynamic_calls
-    - camel_case_types
-    - depend_on_referenced_packages
-    - directives_ordering
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_in_for_each
     - prefer_final_locals
-    - prefer_relative_imports
-    - prefer_single_quotes
-    - sort_pub_dependencies
-    - unawaited_futures

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -287,7 +287,7 @@ build_output.yaml contained a format error.
 ${e.message}
         ''');
       success = false;
-      return (<Asset>[], <Uri>[], Metadata({}), false);
+      return (<Asset>[], <Uri>[], const Metadata({}), false);
       // TODO(https://github.com/dart-lang/native/issues/109): Stop throwing
       // type errors in native_assets_cli, release a new version of that package
       // and then remove this.
@@ -298,7 +298,7 @@ Building native assets for package:${config.packageName} failed.
 build_output.yaml contained a format error.
         ''');
       success = false;
-      return (<Asset>[], <Uri>[], Metadata({}), false);
+      return (<Asset>[], <Uri>[], const Metadata({}), false);
     } finally {
       if (!success) {
         final buildOutputFile =
@@ -472,7 +472,7 @@ final class _BuildResultImpl implements BuildResult {
 extension on DateTime {
   DateTime roundDownToSeconds() =>
       DateTime.fromMillisecondsSinceEpoch(millisecondsSinceEpoch -
-          millisecondsSinceEpoch % Duration(seconds: 1).inMilliseconds);
+          millisecondsSinceEpoch % const Duration(seconds: 1).inMilliseconds);
 }
 
 int _uriCompare(Uri u1, Uri u2) => u1.toString().compareTo(u2.toString());

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   package_config: ^2.1.0
 
 dev_dependencies:
-  dart_flutter_team_lints: ^1.0.0
+  dart_flutter_team_lints: ^2.1.1
   file_testing: ^3.0.0
   test: ^1.24.3
   yaml: ^3.1.2

--- a/pkgs/native_assets_builder/test/data/cyclic_package_1/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/cyclic_package_1/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
   yaml_edit: ^2.1.0
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0

--- a/pkgs/native_assets_builder/test/data/cyclic_package_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/cyclic_package_2/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
   yaml_edit: ^2.1.0
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0

--- a/pkgs/native_assets_builder/test/data/native_add/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/native_add/pubspec.yaml
@@ -15,5 +15,5 @@ dependencies:
 
 dev_dependencies:
   ffigen: ^8.0.2
-  lints: ^2.0.0
+  lints: ^3.0.0
   test: ^1.23.1

--- a/pkgs/native_assets_builder/test/data/native_add_add_source/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/native_add_add_source/pubspec.yaml
@@ -15,5 +15,5 @@ dependencies:
 
 dev_dependencies:
   ffigen: ^8.0.2
-  lints: ^2.0.0
+  lints: ^3.0.0
   test: ^1.23.1

--- a/pkgs/native_assets_builder/test/data/native_subtract/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/native_subtract/pubspec.yaml
@@ -15,5 +15,5 @@ dependencies:
 
 dev_dependencies:
   ffigen: ^8.0.2
-  lints: ^2.0.0
+  lints: ^3.0.0
   test: ^1.23.1

--- a/pkgs/native_assets_builder/test/data/package_reading_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/package_reading_metadata/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
   yaml_edit: ^2.1.0
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0

--- a/pkgs/native_assets_builder/test/data/package_with_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/package_with_metadata/pubspec.yaml
@@ -14,4 +14,4 @@ dependencies:
   yaml_edit: ^2.1.0
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0

--- a/pkgs/native_assets_builder/test/data/wrong_build_output/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/wrong_build_output/pubspec.yaml
@@ -14,4 +14,4 @@ dependencies:
   yaml_edit: ^2.1.0
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0

--- a/pkgs/native_assets_builder/test/data/wrong_build_output_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/wrong_build_output_2/pubspec.yaml
@@ -14,4 +14,4 @@ dependencies:
   yaml_edit: ^2.1.0
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0

--- a/pkgs/native_assets_builder/test/data/wrong_build_output_3/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/wrong_build_output_3/pubspec.yaml
@@ -14,4 +14,4 @@ dependencies:
   yaml_edit: ^2.1.0
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0

--- a/pkgs/native_assets_builder/test/data/wrong_namespace_asset/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/wrong_namespace_asset/pubspec.yaml
@@ -14,4 +14,4 @@ dependencies:
   yaml_edit: ^2.1.0
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0

--- a/pkgs/native_assets_cli/analysis_options.yaml
+++ b/pkgs/native_assets_cli/analysis_options.yaml
@@ -3,20 +3,10 @@ include: package:dart_flutter_team_lints/analysis_options.yaml
 analyzer:
   language:
     strict-raw-types: true
-    strict-inference: true
 
 linter:
   rules:
-    - always_declare_return_types
-    - avoid_dynamic_calls
-    - camel_case_types
-    - depend_on_referenced_packages
-    - directives_ordering
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_in_for_each
     - prefer_final_locals
-    - prefer_relative_imports
-    - prefer_single_quotes
-    - sort_pub_dependencies
-    - unawaited_futures

--- a/pkgs/native_assets_cli/example/native_add_app/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/native_add_app/pubspec.yaml
@@ -13,5 +13,5 @@ dependencies:
     path: ../native_add_library/
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0
   test: ^1.21.0

--- a/pkgs/native_assets_cli/example/native_add_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/native_add_library/pubspec.yaml
@@ -16,5 +16,5 @@ dependencies:
 
 dev_dependencies:
   ffigen: ^8.0.2
-  lints: ^2.0.0
+  lints: ^3.0.0
   test: ^1.21.0

--- a/pkgs/native_assets_cli/lib/src/model/build_config.dart
+++ b/pkgs/native_assets_cli/lib/src/model/build_config.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:cli_config/cli_config.dart';
 import 'package:collection/collection.dart';
@@ -525,7 +526,7 @@ class BuildConfig {
       if (other.targetIOSSdk != targetIOSSdk) return false;
       if (other.targetAndroidNdkApi != targetAndroidNdkApi) return false;
       if (other.cCompiler != cCompiler) return false;
-      if (!DeepCollectionEquality()
+      if (!const DeepCollectionEquality()
           .equals(other.dependencyMetadata, _dependencyMetadata)) return false;
     }
     return true;
@@ -541,7 +542,7 @@ class BuildConfig {
         dryRun,
         if (!dryRun) ...[
           buildMode,
-          DeepCollectionEquality().hash(dependencyMetadata),
+          const DeepCollectionEquality().hash(dependencyMetadata),
           targetArchitecture,
           targetIOSSdk,
           targetAndroidNdkApi,
@@ -564,7 +565,7 @@ can _only_ depend on OS.''');
   void _throwIfNotNullInDryRun<T>(String key) {
     final object = config.valueOf<T?>(key);
     if (object != null) {
-      throw FormatException('''This field is not available in dry runs.
+      throw const FormatException('''This field is not available in dry runs.
 In Flutter projects, native builds are generated per OS which target multiple
 architectures, build modes, etc. Therefore, the list of native assets produced
 can _only_ depend on OS.''');
@@ -639,7 +640,8 @@ class CCompilerConfig {
     if (other.cc != cc) return false;
     if (other.ld != ld) return false;
     if (other.envScript != envScript) return false;
-    if (!ListEquality<String>().equals(other.envScriptArgs, envScriptArgs)) {
+    if (!const ListEquality<String>()
+        .equals(other.envScriptArgs, envScriptArgs)) {
       return false;
     }
     return true;
@@ -651,6 +653,6 @@ class CCompilerConfig {
         _cc,
         _ld,
         _envScript,
-        ListEquality<String>().hash(envScriptArgs),
+        const ListEquality<String>().hash(envScriptArgs),
       );
 }

--- a/pkgs/native_assets_cli/lib/src/model/build_output.dart
+++ b/pkgs/native_assets_cli/lib/src/model/build_output.dart
@@ -33,8 +33,8 @@ class BuildOutput {
     Metadata? metadata,
   })  : timestamp = (timestamp ?? DateTime.now()).roundDownToSeconds(),
         assets = assets ?? [],
-        dependencies = dependencies ?? Dependencies([]),
-        metadata = metadata ?? Metadata({});
+        dependencies = dependencies ?? const Dependencies([]),
+        metadata = metadata ?? const Metadata({});
 
   static const _assetsKey = 'assets';
   static const _dependenciesKey = 'dependencies';
@@ -121,7 +121,7 @@ class BuildOutput {
       return false;
     }
     return other.timestamp == timestamp &&
-        ListEquality<Asset>().equals(other.assets, assets) &&
+        const ListEquality<Asset>().equals(other.assets, assets) &&
         other.dependencies == dependencies &&
         other.metadata == metadata;
   }
@@ -129,7 +129,7 @@ class BuildOutput {
   @override
   int get hashCode => Object.hash(
         timestamp.hashCode,
-        ListEquality<Asset>().hash(assets),
+        const ListEquality<Asset>().hash(assets),
         dependencies,
         metadata,
       );

--- a/pkgs/native_assets_cli/lib/src/model/dependencies.dart
+++ b/pkgs/native_assets_cli/lib/src/model/dependencies.dart
@@ -19,7 +19,7 @@ class Dependencies {
     if (yaml is YamlList) {
       return Dependencies.fromYaml(yaml);
     }
-    return Dependencies([]);
+    return const Dependencies([]);
   }
 
   factory Dependencies.fromYaml(YamlList? yamlList) => Dependencies([
@@ -45,9 +45,9 @@ class Dependencies {
     if (other is! Dependencies) {
       return false;
     }
-    return ListEquality<Uri>().equals(other.dependencies, dependencies);
+    return const ListEquality<Uri>().equals(other.dependencies, dependencies);
   }
 
   @override
-  int get hashCode => ListEquality<Uri>().hash(dependencies);
+  int get hashCode => const ListEquality<Uri>().hash(dependencies);
 }

--- a/pkgs/native_assets_cli/lib/src/model/metadata.dart
+++ b/pkgs/native_assets_cli/lib/src/model/metadata.dart
@@ -30,11 +30,11 @@ class Metadata {
     if (other is! Metadata) {
       return false;
     }
-    return DeepCollectionEquality().equals(other.metadata, metadata);
+    return const DeepCollectionEquality().equals(other.metadata, metadata);
   }
 
   @override
-  int get hashCode => DeepCollectionEquality().hash(metadata);
+  int get hashCode => const DeepCollectionEquality().hash(metadata);
 
   @override
   String toString() => 'Metadata(${toYaml()})';

--- a/pkgs/native_assets_cli/lib/src/utils/datetime.dart
+++ b/pkgs/native_assets_cli/lib/src/utils/datetime.dart
@@ -5,5 +5,5 @@
 extension DateTimeExtension on DateTime {
   DateTime roundDownToSeconds() =>
       DateTime.fromMillisecondsSinceEpoch(millisecondsSinceEpoch -
-          millisecondsSinceEpoch % Duration(seconds: 1).inMilliseconds);
+          millisecondsSinceEpoch % const Duration(seconds: 1).inMilliseconds);
 }

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -22,5 +22,5 @@ dependencies:
   yaml_edit: ^2.1.0
 
 dev_dependencies:
-  dart_flutter_team_lints: ^1.0.0
+  dart_flutter_team_lints: ^2.1.1
   test: ^1.21.0

--- a/pkgs/native_assets_cli/test/model/asset_test.dart
+++ b/pkgs/native_assets_cli/test/model/asset_test.dart
@@ -158,7 +158,7 @@ native-assets:
 
   test('List<Asset> hashCode', () async {
     final assets2 = assets.take(3).toList();
-    final equality = ListEquality<Asset>();
+    const equality = ListEquality<Asset>();
     expect(equality.hash(assets) != equality.hash(assets2), true);
   });
 

--- a/pkgs/native_assets_cli/test/model/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_config_test.dart
@@ -178,11 +178,11 @@ void main() async {
       buildMode: BuildMode.release,
       linkModePreference: LinkModePreference.preferStatic,
       dependencyMetadata: {
-        'bar': Metadata({
+        'bar': const Metadata({
           'key': 'value',
           'foo': ['asdf', 'fdsa'],
         }),
-        'foo': Metadata({
+        'foo': const Metadata({
           'key': 321,
         }),
       },
@@ -198,10 +198,10 @@ void main() async {
       buildMode: BuildMode.release,
       linkModePreference: LinkModePreference.preferStatic,
       dependencyMetadata: {
-        'bar': Metadata({
+        'bar': const Metadata({
           'key': 'value',
         }),
-        'foo': Metadata({
+        'foo': const Metadata({
           'key': 123,
         }),
       },
@@ -229,11 +229,11 @@ void main() async {
       linkModePreference: LinkModePreference.preferStatic,
       // This map should be sorted on key for two layers.
       dependencyMetadata: {
-        'foo': Metadata({
+        'foo': const Metadata({
           'z': ['z', 'a'],
           'a': 321,
         }),
-        'bar': Metadata({
+        'bar': const Metadata({
           'key': 'value',
         }),
       },
@@ -406,7 +406,7 @@ version: ${BuildConfig.version}''';
       buildMode: BuildMode.release,
       linkModePreference: LinkModePreference.preferStatic,
       dependencyMetadata: {
-        'bar': Metadata({
+        'bar': const Metadata({
           'key': {'key2': 'value'},
         }),
       },
@@ -495,7 +495,7 @@ version: ${BuildConfig.version}''';
         buildMode: BuildMode.release,
         linkModePreference: LinkModePreference.dynamic,
         dependencyMetadata: {
-          'foo': Metadata({'key': 'value'})
+          'foo': const Metadata({'key': 'value'})
         },
       );
       printOnFailure([name1, name2].toString());

--- a/pkgs/native_assets_cli/test/model/build_output_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_output_test.dart
@@ -37,7 +37,7 @@ void main() {
     dependencies: Dependencies([
       Uri.file('path/to/file.ext'),
     ]),
-    metadata: Metadata({
+    metadata: const Metadata({
       'key': 'value',
     }),
   );

--- a/pkgs/native_assets_cli/test/model/dependencies_test.dart
+++ b/pkgs/native_assets_cli/test/model/dependencies_test.dart
@@ -42,7 +42,7 @@ void main() {
 
   test('dependencies fromYamlString', () {
     final dependencies = Dependencies.fromYamlString('');
-    expect(dependencies, Dependencies([]));
+    expect(dependencies, const Dependencies([]));
   });
 
   test('dependencies lastModified', () async {

--- a/pkgs/native_assets_cli/test/model/metadata_test.dart
+++ b/pkgs/native_assets_cli/test/model/metadata_test.dart
@@ -6,7 +6,7 @@ import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final metadata = Metadata({
+  const metadata = Metadata({
     'key': 'value',
     'my_list': [1, 2, 3],
     'my_map': {

--- a/pkgs/native_toolchain_c/analysis_options.yaml
+++ b/pkgs/native_toolchain_c/analysis_options.yaml
@@ -3,20 +3,10 @@ include: package:dart_flutter_team_lints/analysis_options.yaml
 analyzer:
   language:
     strict-raw-types: true
-    strict-inference: true
 
 linter:
   rules:
-    - always_declare_return_types
-    - avoid_dynamic_calls
-    - camel_case_types
-    - depend_on_referenced_packages
-    - directives_ordering
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_in_for_each
     - prefer_final_locals
-    - prefer_relative_imports
-    - prefer_single_quotes
-    - sort_pub_dependencies
-    - unawaited_futures

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -114,7 +114,7 @@ class CBuilder implements Builder {
   ///
   /// When set to `true`, libraries will be compiled with `-fPIC` and
   /// executables with `-fPIE`. Accordingly the corresponding parameter of the
-  /// [executable] constructor is named `pie`.
+  /// [CBuilder.executable] constructor is named `pie`.
   ///
   /// When set to `null`, the default behavior of the compiler will be used.
   ///
@@ -132,7 +132,7 @@ class CBuilder implements Builder {
   /// The language to compile [sources] as.
   ///
   /// [cppLinkStdLib] only has an effect when this option is set to
-  /// [Langauge.cpp].
+  /// [Language.cpp].
   final Language language;
 
   /// The C++ standard library to link against.

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -24,5 +24,5 @@ dependencies:
 
 dev_dependencies:
   collection: ^1.17.1
-  dart_flutter_team_lints: ^1.0.0
+  dart_flutter_team_lints: ^2.1.1
   test: ^1.21.0

--- a/pkgs/native_toolchain_c/test/tool/tool_instance_test.dart
+++ b/pkgs/native_toolchain_c/test/tool/tool_instance_test.dart
@@ -59,8 +59,10 @@ void main() {
     ];
 
     final toolInstancesSorted = [...toolInstances]..sort();
-    expect(DeepCollectionEquality().equals(toolInstancesSorted, toolInstances),
-        true);
+    expect(
+      const DeepCollectionEquality().equals(toolInstancesSorted, toolInstances),
+      true,
+    );
   });
 
   test('toString', () {


### PR DESCRIPTION
- Updates dependency constraints on `package:dart_flutter_team_lints` and `package:lints`.
- Removes now duplicated/unnecessary entries from the `analysis_options.yaml` files
- Applies the few fixes for new lints 