### PR TITLE
[native_toolchain_c] Support MSVC arm64 toolchain

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+- Added MSVC arm64 toolchain.
+
 ## 0.3.0
 
 - Bump `package:native_assets_cli` to 0.3.0.

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/compiler_resolver.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/compiler_resolver.dart
@@ -85,6 +85,8 @@ class CompilerResolver {
       switch (targetArch) {
         case Architecture.ia32:
           return clIA32;
+        case Architecture.arm64:
+          return clArm64;
         case Architecture.x64:
           return cl;
       }
@@ -172,6 +174,8 @@ class CompilerResolver {
       switch (targetArchitecture) {
         case Architecture.ia32:
           return libIA32;
+        case Architecture.arm64:
+          return libArm64;
         case Architecture.x64:
           return lib;
       }

--- a/pkgs/native_toolchain_c/lib/src/native_toolchain/msvc.dart
+++ b/pkgs/native_toolchain_c/lib/src/native_toolchain/msvc.dart
@@ -63,9 +63,19 @@ Tool vcvars(ToolInstance toolInstance) {
   final tool = toolInstance.tool;
   assert(tool == cl || tool == link || tool == lib);
   final vcDir = toolInstance.uri.resolve('../../../../../../');
-  final fileName = toolInstance.uri.toFilePath().contains('x86')
-      ? 'vcvars32.bat'
-      : 'vcvars64.bat';
+  final String fileName;
+  if (toolInstance.uri.toFilePath().contains('\\x86\\')) {
+    fileName = 'vcvars32.bat';
+  } else if (toolInstance.uri.toFilePath().contains('\\arm64\\')) {
+    // TODO(https://github.com/dart-lang/native/issues/170): Support native
+    // windows-arm64 MSVC toolchain.
+    // vcvarsarm64 only works on native windows-arm64. In case of cross
+    // compilation, it's better to stick to cross toolchain, which works under
+    // emulation on windows-arm64.
+    fileName = 'vcvarsamd64_arm64.bat';
+  } else {
+    fileName = 'vcvars64.bat';
+  }
   final batchScript = vcDir.resolve('Auxiliary/Build/$fileName');
   return Tool(
     name: fileName,
@@ -96,6 +106,20 @@ final Tool vcvars32 = Tool(
   ),
 );
 
+final Tool vcvarsarm64 = Tool(
+  // TODO(https://github.com/dart-lang/native/issues/170): Support native
+  // windows-arm64 MSVC toolchain.
+  // vcvarsarm64 only works on native windows-arm64. In case of cross
+  // compilation, it's better to stick to cross toolchain, which works under
+  // emulation on windows-arm64.
+  name: 'vcvarsamd64_arm64.bat',
+  defaultResolver: RelativeToolResolver(
+    toolName: 'vcvarsamd64_arm64.bat',
+    wrappedResolver: visualStudio.defaultResolver!,
+    relativePath: Uri(path: './VC/Auxiliary/Build/vcvarsamd64_arm64.bat'),
+  ),
+);
+
 final Tool vcvarsall = Tool(
   name: 'vcvarsall.bat',
   defaultResolver: RelativeToolResolver(
@@ -116,7 +140,7 @@ final Tool vsDevCmd = Tool(
 
 /// The C/C++ Optimizing Compiler main executable.
 ///
-/// For targeting x64.
+/// For targeting [Architecture.x64].
 final Tool cl = _msvcTool(
   name: 'cl',
   versionArguments: [],
@@ -126,11 +150,21 @@ final Tool cl = _msvcTool(
 
 /// The C/C++ Optimizing Compiler main executable.
 ///
-/// For targeting ia32.
+/// For targeting [Architecture.ia32].
 final Tool clIA32 = _msvcTool(
   name: 'cl',
   versionArguments: [],
   targetArchitecture: Architecture.ia32,
+  hostArchitecture: Target.current.architecture,
+);
+
+/// The C/C++ Optimizing Compiler main executable.
+///
+/// For targeting [Architecture.arm64].
+final Tool clArm64 = _msvcTool(
+  name: 'cl',
+  versionArguments: [],
+  targetArchitecture: Architecture.arm64,
   hostArchitecture: Target.current.architecture,
 );
 
@@ -145,6 +179,14 @@ final Tool lib = _msvcTool(
 final Tool libIA32 = _msvcTool(
   name: 'lib',
   targetArchitecture: Architecture.ia32,
+  hostArchitecture: Target.current.architecture,
+  // https://github.com/dart-lang/native/issues/18
+  resolveVersion: false,
+);
+
+final Tool libArm64 = _msvcTool(
+  name: 'lib',
+  targetArchitecture: Architecture.arm64,
   hostArchitecture: Target.current.architecture,
   // https://github.com/dart-lang/native/issues/18
   resolveVersion: false,
@@ -166,6 +208,14 @@ final Tool linkIA32 = _msvcTool(
   hostArchitecture: Target.current.architecture,
 );
 
+final Tool linkArm64 = _msvcTool(
+  name: 'link',
+  versionArguments: ['/help'],
+  versionExitCode: 1100,
+  targetArchitecture: Architecture.arm64,
+  hostArchitecture: Target.current.architecture,
+);
+
 final Tool dumpbin = _msvcTool(
   name: 'dumpbin',
   targetArchitecture: Architecture.x64,
@@ -175,6 +225,7 @@ final Tool dumpbin = _msvcTool(
 const _msvcArchNames = {
   Architecture.ia32: 'x86',
   Architecture.x64: 'x64',
+  Architecture.arm64: 'arm64',
 };
 
 Tool _msvcTool({

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.3.0
+version: 0.3.1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:

--- a/pkgs/native_toolchain_c/test/native_toolchain/msvc_test.dart
+++ b/pkgs/native_toolchain_c/test/native_toolchain/msvc_test.dart
@@ -48,6 +48,11 @@ void main() {
     expect(instances.isNotEmpty, true);
   });
 
+  test('clArm64', () async {
+    final instances = await clArm64.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+  });
+
   test('lib', () async {
     final instances = await lib.defaultResolver!.resolve(logger: logger);
     expect(instances.isNotEmpty, true);
@@ -58,6 +63,11 @@ void main() {
     expect(instances.isNotEmpty, true);
   });
 
+  test('libArm64', () async {
+    final instances = await libArm64.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+  });
+
   test('link', () async {
     final instances = await link.defaultResolver!.resolve(logger: logger);
     expect(instances.isNotEmpty, true);
@@ -65,6 +75,11 @@ void main() {
 
   test('linkIA32', () async {
     final instances = await linkIA32.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+  });
+
+  test('linkArm64', () async {
+    final instances = await linkArm64.defaultResolver!.resolve(logger: logger);
     expect(instances.isNotEmpty, true);
   });
 
@@ -82,6 +97,7 @@ void main() {
         .resolve(logger: logger);
     expect(instances.isNotEmpty, true);
     final instance = instances.first;
+    expect(instance.tool, vcvars32);
     final env = await envFromBat(instance.uri);
     expect(env['INCLUDE'] != null, true);
     expect(env['WindowsSdkDir'] != null, true); // stdio.h
@@ -96,6 +112,22 @@ void main() {
         .resolve(logger: logger);
     expect(instances.isNotEmpty, true);
     final instance = instances.first;
+    expect(instance.tool, vcvars64);
+    final env = await envFromBat(instance.uri);
+    expect(env['INCLUDE'] != null, true);
+    expect(env['WindowsSdkDir'] != null, true); // stdio.h
+  });
+
+  test('vcvarsarm64 from cl.exe', () async {
+    final clInstances = await clArm64.defaultResolver!.resolve(logger: logger);
+    expect(clInstances.isNotEmpty, true);
+
+    final instances = await vcvars(clInstances.first)
+        .defaultResolver!
+        .resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+    final instance = instances.first;
+    expect(instance.tool, vcvarsarm64);
     final env = await envFromBat(instance.uri);
     expect(env['INCLUDE'] != null, true);
     expect(env['WindowsSdkDir'] != null, true); // stdio.h
@@ -112,6 +144,16 @@ void main() {
 
   test('vcvars64', () async {
     final instances = await vcvars64.defaultResolver!.resolve(logger: logger);
+    expect(instances.isNotEmpty, true);
+    final instance = instances.first;
+    final env = await envFromBat(instance.uri);
+    expect(env['INCLUDE'] != null, true);
+    expect(env['WindowsSdkDir'] != null, true); // stdio.h
+  });
+
+  test('vcvarsarm64', () async {
+    final instances =
+        await vcvarsarm64.defaultResolver!.resolve(logger: logger);
     expect(instances.isNotEmpty, true);
     final instance = instances.first;
     final env = await envFromBat(instance.uri);


### PR DESCRIPTION
This PR adds support to be able to compile native-assets on windows-arm64.

It seems to be what is needed to compile windows-arm64 flutter apps, as discussed initially [here](https://github.com/flutter/flutter/issues/129807#issuecomment-1778949427).

@dcharkes I'm not sure which tests to update exactly. Since windows-arm64 runners are not available for this repository, will we still be able to test this? In more, do existing x64 runners have installed msvc arm64 toolchain?