### PR TITLE
Temporarily allow modification of a BuildOutput's raw dependencies

### DIFF
--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.2
+
+- Fixed an issue where `Depenendencies.dependencies` could not be
+  modified when expected to.
+  **Note:** Avoid modifying `Dependencies.dependencies` directly,
+  the property will likely return an `Iterable` in a future release.
+
 ## 0.3.1
 
 - Added `Target.androidRiscv64`.

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 - Fixed an issue where `Depenendencies.dependencies` could not be
   modified when expected to.
-  **Note:** Avoid modifying `Dependencies.dependencies` directly,
-  the property will likely return an `Iterable` in a future release.
 
 ## 0.3.1
 

--- a/pkgs/native_assets_cli/lib/src/model/build_output.dart
+++ b/pkgs/native_assets_cli/lib/src/model/build_output.dart
@@ -33,8 +33,10 @@ class BuildOutput {
     Metadata? metadata,
   })  : timestamp = (timestamp ?? DateTime.now()).roundDownToSeconds(),
         assets = assets ?? [],
-        dependencies = dependencies ?? const Dependencies([]),
-        metadata = metadata ?? const Metadata({});
+        // ignore: prefer_const_constructors
+        dependencies = dependencies ?? Dependencies([]),
+        // ignore: prefer_const_constructors
+        metadata = metadata ?? Metadata({});
 
   static const _assetsKey = 'assets';
   static const _dependenciesKey = 'dependencies';

--- a/pkgs/native_assets_cli/lib/src/model/dependencies.dart
+++ b/pkgs/native_assets_cli/lib/src/model/dependencies.dart
@@ -11,9 +11,6 @@ import '../utils/yaml.dart';
 
 class Dependencies {
   /// The dependencies a build relied on.
-  ///
-  /// NOTE: Do not modify this list. In a future release,
-  /// the [dependencies] property will likely return an [Iterable].
   final List<Uri> dependencies;
 
   const Dependencies(this.dependencies);

--- a/pkgs/native_assets_cli/lib/src/model/dependencies.dart
+++ b/pkgs/native_assets_cli/lib/src/model/dependencies.dart
@@ -10,6 +10,10 @@ import '../utils/uri.dart';
 import '../utils/yaml.dart';
 
 class Dependencies {
+  /// The dependencies a build relied on.
+  ///
+  /// NOTE: Do not modify this list. In a future release,
+  /// the [dependencies] property will likely return an [Iterable].
   final List<Uri> dependencies;
 
   const Dependencies(this.dependencies);
@@ -19,7 +23,8 @@ class Dependencies {
     if (yaml is YamlList) {
       return Dependencies.fromYaml(yaml);
     }
-    return const Dependencies([]);
+    // ignore: prefer_const_constructors
+    return Dependencies([]);
   }
 
   factory Dependencies.fromYaml(YamlList? yamlList) => Dependencies([

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -2,7 +2,7 @@ name: native_assets_cli
 description: >-
   A library that contains the argument and file formats for implementing a
   native assets CLI.
-version: 0.3.1
+version: 0.3.2
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
 topics:

--- a/pkgs/native_assets_cli/test/model/build_output_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_output_test.dart
@@ -161,7 +161,7 @@ version: ${BuildOutput.version}'''),
   });
 
   test('BuildOutput dependencies can be modified', () {
-    // TODO(https://github.com/dart-lang/native/issues/168):
+    // TODO(https://github.com/dart-lang/native/issues/25):
     // Remove once dependencies are made immutable.
     final buildOutput = BuildOutput();
     expect(

--- a/pkgs/native_assets_cli/test/model/build_output_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_output_test.dart
@@ -159,4 +159,15 @@ version: ${BuildOutput.version}'''),
       throwsFormatException,
     );
   });
+
+  test('BuildOutput dependencies can be modified', () {
+    // TODO(https://github.com/dart-lang/native/issues/168):
+    // Remove once dependencies are made immutable.
+    final buildOutput = BuildOutput();
+    expect(
+      () => buildOutput.dependencies.dependencies
+          .add(Uri.file('path/to/file.ext')),
+      returnsNormally,
+    );
+  });
 }


### PR DESCRIPTION
The issue in https://github.com/dart-lang/native/issues/168 was not caught due to the packages depending on each through through pub rather than as path dependencies. It was the `native_toolchain_c` tests that failed which earlier on CI depended on a version of `native_assets_cli` during test.

The core issue here is that `Dependencies` should likely be properly immutable (as indicated by its `const` constructor that's always been there) and its `dependencies` property should instead be exposed as an `Iterable` or not at all directly. 

Since making those changes is a breaking change, I will instead follow-up with those changes as part of a `0.4.0` release. This fix removes the const lists/maps that the depending packages are not currently expecting.


Fixes https://github.com/dart-lang/native/issues/168