### PR TITLE
[infra] Rename `dart.yaml` to `native.yaml`

### DIFF
--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -1,17 +1,25 @@
-name: dart
+# CI for the native_* packages.
+#
+# Combined into a single workflow so that deps are configured and installed once.
+
+name: native
 permissions: read-all
 
 on:
   pull_request:
     branches: [main]
     paths:
-      - ".github/workflows/dart.yaml"
-      - "pkgs/**"
+      - ".github/workflows/native.yaml"
+      - "pkgs/native_assets_builder/**"
+      - "pkgs/native_assets_cli/**"
+      - "pkgs/native_toolchain_c/**"
   push:
     branches: [main]
     paths:
-      - ".github/workflows/dart.yaml"
-      - "pkgs/**"
+      - ".github/workflows/native.yaml"
+      - "pkgs/native_assets_builder/**"
+      - "pkgs/native_assets_cli/**"
+      - "pkgs/native_toolchain_c/**"
   schedule:
     - cron: "0 0 * * 0" # weekly
 

--- a/.github/workflows/native_toolchain_c.yaml
+++ b/.github/workflows/native_toolchain_c.yaml
@@ -1,3 +1,5 @@
+# Workflow that runs relevant tests with the clang from the Dart SDK.
+
 name: native_toolchain_c
 permissions: read-all
 

--- a/pkgs/native_assets_builder/README.md
+++ b/pkgs/native_assets_builder/README.md
@@ -1,4 +1,4 @@
-[![dart](https://github.com/dart-lang/native/actions/workflows/dart.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/dart.yaml)
+[![dart](https://github.com/dart-lang/native/actions/workflows/native.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/native.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
 [![pub package](https://img.shields.io/pub/v/native_assets_builder.svg)](https://pub.dev/packages/native_assets_builder)
 [![package publisher](https://img.shields.io/pub/publisher/native_assets_builder.svg)](https://pub.dev/packages/native_assets_builder/publisher)

--- a/pkgs/native_assets_cli/README.md
+++ b/pkgs/native_assets_cli/README.md
@@ -1,4 +1,4 @@
-[![package:native_assets_cli](https://github.com/dart-lang/native/actions/workflows/dart.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/dart.yaml)
+[![package:native_assets_cli](https://github.com/dart-lang/native/actions/workflows/native.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/native.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
 [![pub package](https://img.shields.io/pub/v/native_assets_cli.svg)](https://pub.dev/packages/native_assets_cli)
 [![package publisher](https://img.shields.io/pub/publisher/native_assets_cli.svg)](https://pub.dev/packages/native_assets_cli/publisher)

--- a/pkgs/native_toolchain_c/README.md
+++ b/pkgs/native_toolchain_c/README.md
@@ -1,4 +1,4 @@
-[![dart](https://github.com/dart-lang/native/actions/workflows/dart.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/dart.yaml)
+[![dart](https://github.com/dart-lang/native/actions/workflows/native.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/native.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
 [![pub package](https://img.shields.io/pub/v/native_toolchain_c.svg)](https://pub.dev/packages/native_toolchain_c)
 [![package publisher](https://img.shields.io/pub/publisher/native_toolchain_c.svg)](https://pub.dev/packages/native_toolchain_c/publisher)


### PR DESCRIPTION
When we're going to merge in more packages into this repo, they'll have their own workflows.

So rename the current workflow to something more specific.

Context:

* https://github.com/dart-lang/jnigen/issues/410
* https://github.com/dart-lang/ffigen/issues/612#issuecomment-1787499895
* https://github.com/dart-lang/ffi/issues/218