### PR TITLE
[native_toolchain_c] Use sysroot on Android

### DIFF
--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -98,6 +98,9 @@ class RunCBuilder {
           .first
           .uri;
 
+  Uri androidSysroot(ToolInstance compiler) =>
+      compiler.uri.resolve('../sysroot/');
+
   Future<void> run() async {
     final compiler_ = await compiler();
     final compilerTool = compiler_.tool;
@@ -127,14 +130,10 @@ class RunCBuilder {
       executable: compiler.uri,
       arguments: [
         if (target.os == OS.android) ...[
-          // TODO(dacoharkes): How to solve linking issues?
-          // Non-working fix: --sysroot=$NDKPATH/toolchains/llvm/prebuilt/linux-x86_64/sysroot.
-          // The sysroot should be discovered automatically after NDK 22.
-          // Workaround:
-          if (dynamicLibrary != null) '-nostartfiles',
           '--target='
               '${androidNdkClangTargetFlags[target]!}'
               '${buildConfig.targetAndroidNdkApi!}',
+          '--sysroot=${androidSysroot(compiler).toFilePath()}',
         ],
         if (target.os == OS.macOS)
           '--target=${appleClangMacosTargetFlags[target]!}',


### PR DESCRIPTION
Addresses: https://github.com/dart-lang/native/pull/165#discussion_r1375048853

This is in line with what CMake does, so it's probably a more reasonable thing to do than `-nostartfiles`.

The documentation says the sysroot should be auto-discovered on NDKs newer than 22, but it doesn't seem to break the newer versions, so maybe lets just keep the logic consistent for various NDK versions.

We probably need a workaround for https://github.com/dart-lang/native/pull/165 temporarily.