### PR TITLE
[native_toolchain_c] Bump highest tested NDK version to 34

### DIFF
--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -37,7 +37,7 @@ void main() {
   const flutterAndroidNdkVersionLowestSupported = 21;
 
   /// From https://docs.flutter.dev/reference/supported-platforms.
-  const flutterAndroidNdkVersionHighestSupported = 30;
+  const flutterAndroidNdkVersionHighestSupported = 34;
 
   for (final linkMode in LinkMode.values) {
     for (final target in targets) {


### PR DESCRIPTION
https://docs.flutter.dev/reference/supported-platforms now lists 34 instead of 30.

Update our testing to cover this.