### PR TITLE
[infra] Bump NDK version

### DIFF
--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: nttld/setup-ndk@3354316c3285ea90da09d047280dd79d00d5a37a
         with:
-          ndk-version: r25b
+          ndk-version: r26b
         if: ${{ matrix.sdk == 'stable' }}
 
       - run: dart pub get

--- a/.github/workflows/native_toolchain_c.yaml
+++ b/.github/workflows/native_toolchain_c.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: nttld/setup-ndk@3354316c3285ea90da09d047280dd79d00d5a37a
         with:
-          ndk-version: r25b
+          ndk-version: r26b
         if: ${{ matrix.sdk == 'stable' }}
 
       - run: dart pub get


### PR DESCRIPTION
It looks like the CI didn't run the sysroot and minSdkVersion against each other and merged them both.