### PR TITLE
[native_assets_builder] Don't use FFIgen in test

### DIFF
--- a/pkgs/native_assets_builder/test/build_runner/build_runner_asset_id_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_asset_id_test.dart
@@ -45,6 +45,9 @@ void main() async {
     await inTempDir((tempUri) async {
       final packageUri = tempUri.resolve('different_root_dir/');
       await copyTestProjects(
+        targetUri: tempUri,
+      );
+      await copyTestProjects(
         sourceUri: testDataUri.resolve('native_add/'),
         targetUri: packageUri,
       );

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_non_root_package_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_non_root_package_test.dart
@@ -29,7 +29,7 @@ void main() async {
           logger,
           dartExecutable,
           capturedLogs: logMessages,
-          runPackageName: 'ffigen',
+          runPackageName: 'some_dev_dep',
         );
         expect(result.assets, isEmpty);
         expect(result.dependencies, isEmpty);

--- a/pkgs/native_assets_builder/test/data/manifest.yaml
+++ b/pkgs/native_assets_builder/test/data/manifest.yaml
@@ -27,6 +27,8 @@
 - package_reading_metadata/pubspec.yaml
 - package_with_metadata/build.dart
 - package_with_metadata/pubspec.yaml
+- some_dev_dep/bin/some_dev_dep.dart
+- some_dev_dep/pubspec.yaml
 - wrong_build_output/build.dart
 - wrong_build_output/pubspec.yaml
 - wrong_build_output_2/build.dart

--- a/pkgs/native_assets_builder/test/data/native_add/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/native_add/pubspec.yaml
@@ -16,4 +16,6 @@ dependencies:
 dev_dependencies:
   ffigen: ^8.0.2
   lints: ^3.0.0
+  some_dev_dep:
+    path: ../some_dev_dep/
   test: ^1.23.1

--- a/pkgs/native_assets_builder/test/data/some_dev_dep/bin/some_dev_dep.dart
+++ b/pkgs/native_assets_builder/test/data/some_dev_dep/bin/some_dev_dep.dart
@@ -2,6 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-main() {
+void main() {
   print('Hello world!');
 }

--- a/pkgs/native_assets_builder/test/data/some_dev_dep/bin/some_dev_dep.dart
+++ b/pkgs/native_assets_builder/test/data/some_dev_dep/bin/some_dev_dep.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+main() {
+  print('Hello world!');
+}

--- a/pkgs/native_assets_builder/test/data/some_dev_dep/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/some_dev_dep/pubspec.yaml
@@ -1,0 +1,8 @@
+name: some_dev_dep
+description: Has a bin script that can be run from the context of other root packages.
+version: 0.1.0
+
+publish_to: none
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
The Windows bots on the Dart SDK CI don't have libclang installed:

https://dart-review.googlesource.com/c/sdk/+/339124 -> https://dart-ci.firebaseapp.com/cl/339124/5 -> https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8762986001033204401/+/u/test_results/new_test_failures__logs_

This test does not need to use FFIgen, we can use some other package with a bin script.