### PR TITLE
[native_assets_builder] Handle non-existing package names

### DIFF
--- a/pkgs/native_assets_builder/lib/src/build_runner/build_planner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_planner.dart
@@ -115,6 +115,11 @@ class PackageGraph {
       graphs.stronglyConnectedComponents(vertices, neighborsOf);
 
   PackageGraph subGraph(String rootPackageName) {
+    if (!vertices.contains(rootPackageName)) {
+      // Some downstream tooling requested a package that doesn't exist.
+      // This will likely lead to an error, so avoid building native assets.
+      return PackageGraph({});
+    }
     final subgraphVertices = [
       ...graphs.transitiveClosure(vertices, neighborsOf)[rootPackageName]!,
       rootPackageName,

--- a/pkgs/native_assets_builder/test/build_runner/build_planner_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_planner_test.dart
@@ -76,29 +76,32 @@ void main() async {
     });
   });
 
-  test('runPackageName', () async {
-    await inTempDir((tempUri) async {
-      await copyTestProjects(targetUri: tempUri);
-      final nativeAddUri = tempUri.resolve('native_add/');
+  for (final existing in [true, false]) {
+    final runPackageName = existing ? 'ffigen' : 'does_not_exist';
+    test('runPackageName $runPackageName', () async {
+      await inTempDir((tempUri) async {
+        await copyTestProjects(targetUri: tempUri);
+        final nativeAddUri = tempUri.resolve('native_add/');
 
-      // First, run `pub get`, we need pub to resolve our dependencies.
-      await runPubGet(workingDirectory: nativeAddUri, logger: logger);
+        // First, run `pub get`, we need pub to resolve our dependencies.
+        await runPubGet(workingDirectory: nativeAddUri, logger: logger);
 
-      final packageLayout =
-          await PackageLayout.fromRootPackageRoot(nativeAddUri);
-      final packagesWithNativeAssets =
-          await packageLayout.packagesWithNativeAssets;
-      final nativeAssetsBuildPlanner =
-          await NativeAssetsBuildPlanner.fromRootPackageRoot(
-        rootPackageRoot: nativeAddUri,
-        packagesWithNativeAssets: packagesWithNativeAssets,
-        dartExecutable: Uri.file(Platform.resolvedExecutable),
-        logger: logger,
-      );
-      final (buildPlan, _) = nativeAssetsBuildPlanner.plan(
-        runPackageName: 'ffigen',
-      );
-      expect(buildPlan.length, 0);
+        final packageLayout =
+            await PackageLayout.fromRootPackageRoot(nativeAddUri);
+        final packagesWithNativeAssets =
+            await packageLayout.packagesWithNativeAssets;
+        final nativeAssetsBuildPlanner =
+            await NativeAssetsBuildPlanner.fromRootPackageRoot(
+          rootPackageRoot: nativeAddUri,
+          packagesWithNativeAssets: packagesWithNativeAssets,
+          dartExecutable: Uri.file(Platform.resolvedExecutable),
+          logger: logger,
+        );
+        final (buildPlan, _) = nativeAssetsBuildPlanner.plan(
+          runPackageName: runPackageName,
+        );
+        expect(buildPlan.length, 0);
+      });
     });
-  });
+  }
 }


### PR DESCRIPTION
With `dart/flutter run dont_exist`, dartdev or flutter_tools might pass a package name to `runPackageName` that is not in the package graph.