### PR TITLE
[ffigen] Run ffigen CI less often on Apple silicon

### DIFF
--- a/.github/workflows/ffigen.yml
+++ b/.github/workflows/ffigen.yml
@@ -68,12 +68,7 @@ jobs:
 
   test-mac:
     needs: analyze
-    strategy:
-      matrix:
-        host: 
-          - 'macos-latest'
-          - 'macos-latest-xlarge' # Arm64.
-    runs-on: ${{ matrix.host }}
+    runs-on: 'macos-latest'
     defaults:
       run:
         working-directory: pkgs/ffigen/
@@ -90,7 +85,6 @@ jobs:
         run: dart test --platform vm --concurrency=1
       - name: Collect coverage
         run: ./tool/coverage.sh
-        if: ${{ matrix.host == 'macos-latest' }}
       - name: Upload coverage
         uses: coverallsapp/github-action@3dfc5567390f6fa9267c0ee9c251e4c8c3f18949
         with:
@@ -98,14 +92,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel: true
           path-to-lcov: pkgs/ffigen/lcov.info
-        if: ${{ matrix.host == 'macos-latest' }}
       - name: Upload coverage
         uses: coverallsapp/github-action@3dfc5567390f6fa9267c0ee9c251e4c8c3f18949
         with:
           carryforward: "jnigen_tests,jni_tests,native_assets_builder_macos,native_assets_builder_ubuntu,native_assets_builder_windows,native_assets_cli_macos,native_assets_cli_ubuntu,native_assets_cli_windows,native_toolchain_c_macos,native_toolchain_c_ubuntu,native_toolchain_c_windows"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
-        if: ${{ matrix.host == 'macos-latest' }}
 
   test-windows:
     needs: analyze

--- a/.github/workflows/ffigen.yml
+++ b/.github/workflows/ffigen.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Run VM tests
         run: dart test --platform vm --concurrency=1
 
+  # Keep in sync with ffigen_weekly.yaml:test-mac-arm64
   test-mac:
     needs: analyze
     runs-on: 'macos-latest'

--- a/.github/workflows/ffigen_weekly.yml
+++ b/.github/workflows/ffigen_weekly.yml
@@ -1,0 +1,30 @@
+# Run the ffigen tests on apple silicon once a week. Unlike the other GitHub
+# CI hosts, this one isn't free, so we don't run it on every commit.
+
+name: ffigen_weekly
+
+on:
+  # Run once a week.
+  schedule:
+    - cron: "0 0 * * 0"
+
+env:
+  PUB_ENVIRONMENT: bot.github
+
+jobs:
+  test-mac:
+    runs-on: 'macos-latest-xlarge' # Arm64.
+    defaults:
+      run:
+        working-directory: pkgs/ffigen/
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        with:
+          sdk: 3.2.0
+      - name: Install dependencies
+        run: dart pub get
+      - name: Build test dylib and bindings
+        run: dart test/setup.dart
+      - name: Run VM tests
+        run: dart test --platform vm --concurrency=1

--- a/.github/workflows/ffigen_weekly.yml
+++ b/.github/workflows/ffigen_weekly.yml
@@ -12,7 +12,8 @@ env:
   PUB_ENVIRONMENT: bot.github
 
 jobs:
-  test-mac:
+  # Keep in sync with ffigen.yaml:test-mac
+  test-mac-arm64:
     runs-on: 'macos-latest-xlarge' # Arm64.
     defaults:
       run:


### PR DESCRIPTION
The mac arm64 bot isn't free, so we'll just run it once a week, rather than on every PR. CPU specific bugs don't come up very often, so this should be sufficient.

Fixes #845