### PR TITLE
[infra] Skip coverage in health check

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -8,7 +8,7 @@ jobs:
     uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
     with:
       coverage_web: false
-      checks: "version,changelog,license,coverage,do-not-submit,breaking"
+      checks: "version,changelog,license,do-not-submit,breaking"
       use-flutter: true
     permissions:
       pull-requests: write


### PR DESCRIPTION
We already have coveralls check coverage for the various packages.

The coverage check is blocking various PRs on this repo:

- https://github.com/dart-lang/native/pull/861
- https://github.com/dart-lang/native/pull/858