### PR TITLE
Fix clang "sometimes-uninitialized" and "unused-variable" warnings

### DIFF
--- a/pkgs/jni/src/dartjni.c
+++ b/pkgs/jni/src/dartjni.c
@@ -453,6 +453,7 @@ JniResult newPrimitiveArray(jsize length, int type) {
       // This error should have been handled in dart.
       // is there a way to mark this as unreachable?
       // or throw exception in Dart using Dart's C API.
+      array = NULL;
       break;
   }
   return to_global_ref_result(array);
@@ -468,7 +469,6 @@ JniResult newObjectArray(jsize length,
 }
 
 JniResult getArrayElement(jarray array, int index, int type) {
-  JniResult result = {{.l = NULL}, NULL};
   attach_thread();
   jvalue value;
   switch (type) {


### PR DESCRIPTION
- Fix clang errors when compiled with `-Werror -Wunused-variable -Wsometimes-uninitialized`

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
