### PR TITLE
[native_assets_cli] Move non-`build.dart` code to `package:native_assets_builder`

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -8,7 +8,7 @@ jobs:
     uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
     with:
       coverage_web: false
-      checks: "version,changelog,license,do-not-submit,breaking"
+      checks: "version,changelog,license,do-not-submit,breaking,coverage"
       use-flutter: true
       sdk: master
     permissions:

--- a/pkgs/native_assets_builder/dart_test.yaml
+++ b/pkgs/native_assets_builder/dart_test.yaml
@@ -1,2 +1,3 @@
 paths:
   - test/build_runner/
+  - test/model/

--- a/pkgs/native_assets_builder/lib/native_assets_builder.dart
+++ b/pkgs/native_assets_builder/lib/native_assets_builder.dart
@@ -3,4 +3,5 @@
 // BSD-style license that can be found in the LICENSE file.
 
 export 'package:native_assets_builder/src/build_runner/build_runner.dart';
+export 'package:native_assets_builder/src/model/asset.dart';
 export 'package:native_assets_builder/src/package_layout/package_layout.dart';

--- a/pkgs/native_assets_builder/lib/src/model/asset.dart
+++ b/pkgs/native_assets_builder/lib/src/model/asset.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/pkgs/native_assets_builder/lib/src/model/asset.dart
+++ b/pkgs/native_assets_builder/lib/src/model/asset.dart
@@ -6,35 +6,27 @@ import 'package:native_assets_cli/native_assets_cli.dart';
 
 import '../utils/yaml.dart';
 
-/// Asset is avaliable on a relative path.
-///
-/// If [LinkMode] of an [Asset] is [LinkMode.dynamic],
-/// `Platform.script.resolve(uri)` will be used to load the asset at runtime.
-class AssetRelativePath implements AssetPath {
-  final Uri uri;
+extension on Asset {
+  Map<String, List<String>> toDartConst() => {
+        id: path.toDartConst(),
+      };
+}
 
-  AssetRelativePath(this.uri);
-
-  static const _pathTypeValue = 'relative';
-
-  @override
-  Map<String, Object> toYaml() => throw UnimplementedError();
-  @override
-  List<String> toDartConst() => [_pathTypeValue, uri.toFilePath()];
-
-  @override
-  int get hashCode => Object.hash(uri, 133717);
-
-  @override
-  bool operator ==(Object other) {
-    if (other is! AssetRelativePath) {
-      return false;
+extension on AssetPath {
+  List<String> toDartConst() {
+    final this_ = this;
+    switch (this_) {
+      case AssetAbsolutePath _:
+        return ['absolute', this_.uri.toFilePath()];
+      case AssetSystemPath _:
+        return ['system', this_.uri.toFilePath()];
+      case AssetInProcess _:
+        return ['process'];
+      default:
+        assert(this_ is AssetInExecutable);
+        return ['executable'];
     }
-    return uri == other.uri;
   }
-
-  @override
-  Future<bool> exists() => throw UnimplementedError();
 }
 
 extension AssetIterable on Iterable<Asset> {

--- a/pkgs/native_assets_builder/lib/src/model/asset.dart
+++ b/pkgs/native_assets_builder/lib/src/model/asset.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:native_assets_cli/native_assets_cli.dart';
+
+import '../utils/yaml.dart';
+
+/// Asset is avaliable on a relative path.
+///
+/// If [LinkMode] of an [Asset] is [LinkMode.dynamic],
+/// `Platform.script.resolve(uri)` will be used to load the asset at runtime.
+class AssetRelativePath implements AssetPath {
+  final Uri uri;
+
+  AssetRelativePath(this.uri);
+
+  static const _pathTypeValue = 'relative';
+
+  @override
+  Map<String, Object> toYaml() => throw UnimplementedError();
+  @override
+  List<String> toDartConst() => [_pathTypeValue, uri.toFilePath()];
+
+  @override
+  int get hashCode => Object.hash(uri, 133717);
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! AssetRelativePath) {
+      return false;
+    }
+    return uri == other.uri;
+  }
+
+  @override
+  Future<bool> exists() => throw UnimplementedError();
+}
+
+extension AssetIterable on Iterable<Asset> {
+  Iterable<Asset> whereLinkMode(LinkMode linkMode) =>
+      where((e) => e.linkMode == linkMode);
+
+  Map<Target, List<Asset>> get assetsPerTarget {
+    final result = <Target, List<Asset>>{};
+    for (final asset in this) {
+      final assets = result[asset.target] ?? [];
+      assets.add(asset);
+      result[asset.target] = assets;
+    }
+    return result;
+  }
+
+  Map<String, Map<String, List<String>>> toDartConst() => {
+        for (final entry in assetsPerTarget.entries)
+          entry.key.toString():
+              _combineMaps(entry.value.map((e) => e.toDartConst()).toList())
+      };
+
+  Map<Object, Object> toNativeAssetsFileEncoding() => {
+        'format-version': [1, 0, 0],
+        'native-assets': toDartConst(),
+      };
+
+  String toNativeAssetsFile() => yamlEncode(toNativeAssetsFileEncoding());
+}
+
+Map<X, Y> _combineMaps<X, Y>(Iterable<Map<X, Y>> maps) {
+  final result = <X, Y>{};
+  for (final map in maps) {
+    result.addAll(map);
+  }
+  return result;
+}

--- a/pkgs/native_assets_builder/lib/src/model/asset.dart
+++ b/pkgs/native_assets_builder/lib/src/model/asset.dart
@@ -6,28 +6,7 @@ import 'package:native_assets_cli/native_assets_cli.dart';
 
 import '../utils/yaml.dart';
 
-extension on Asset {
-  Map<String, List<String>> toDartConst() => {
-        id: path.toDartConst(),
-      };
-}
-
-extension on AssetPath {
-  List<String> toDartConst() {
-    final this_ = this;
-    switch (this_) {
-      case AssetAbsolutePath _:
-        return ['absolute', this_.uri.toFilePath()];
-      case AssetSystemPath _:
-        return ['system', this_.uri.toFilePath()];
-      case AssetInProcess _:
-        return ['process'];
-      default:
-        assert(this_ is AssetInExecutable);
-        return ['executable'];
-    }
-  }
-}
+extension on AssetPath {}
 
 extension AssetIterable on Iterable<Asset> {
   Iterable<Asset> whereLinkMode(LinkMode linkMode) =>
@@ -45,8 +24,11 @@ extension AssetIterable on Iterable<Asset> {
 
   Map<String, Map<String, List<String>>> toDartConst() => {
         for (final entry in assetsPerTarget.entries)
-          entry.key.toString():
-              _combineMaps(entry.value.map((e) => e.toDartConst()).toList())
+          entry.key.toString(): _combineMaps(entry.value
+              .map((e) => {
+                    e.id: _toDartConst(e.path),
+                  })
+              .toList())
       };
 
   Map<Object, Object> toNativeAssetsFileEncoding() => {
@@ -55,6 +37,20 @@ extension AssetIterable on Iterable<Asset> {
       };
 
   String toNativeAssetsFile() => yamlEncode(toNativeAssetsFileEncoding());
+}
+
+List<String> _toDartConst(AssetPath path) {
+  switch (path) {
+    case AssetAbsolutePath _:
+      return ['absolute', path.uri.toFilePath()];
+    case AssetSystemPath _:
+      return ['system', path.uri.toFilePath()];
+    case AssetInProcess _:
+      return ['process'];
+    default:
+      assert(path is AssetInExecutable);
+      return ['executable'];
+  }
 }
 
 Map<X, Y> _combineMaps<X, Y>(Iterable<Map<X, Y>> maps) {

--- a/pkgs/native_assets_builder/lib/src/utils/yaml.dart
+++ b/pkgs/native_assets_builder/lib/src/utils/yaml.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/pkgs/native_assets_builder/lib/src/utils/yaml.dart
+++ b/pkgs/native_assets_builder/lib/src/utils/yaml.dart
@@ -16,12 +16,3 @@ String yamlEncode(Object yamlEncoding) {
   );
   return editor.toString();
 }
-
-T as<T>(Object? object) {
-  if (object is T) {
-    return object;
-  }
-  throw FormatException(
-    "Unexpected value '$object' in YAML. Expected a $T.",
-  );
-}

--- a/pkgs/native_assets_builder/lib/src/utils/yaml.dart
+++ b/pkgs/native_assets_builder/lib/src/utils/yaml.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:yaml/yaml.dart';
+import 'package:yaml_edit/yaml_edit.dart';
+
+String yamlEncode(Object yamlEncoding) {
+  final editor = YamlEditor('');
+  editor.update(
+    [],
+    wrapAsYamlNode(
+      yamlEncoding,
+      collectionStyle: CollectionStyle.BLOCK,
+    ),
+  );
+  return editor.toString();
+}
+
+T as<T>(Object? object) {
+  if (object is T) {
+    return object;
+  }
+  throw FormatException(
+    "Unexpected value '$object' in YAML. Expected a $T.",
+  );
+}

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -12,9 +12,10 @@ dependencies:
   logging: ^1.2.0
   native_assets_cli: ^0.3.2
   package_config: ^2.1.0
+  yaml: ^3.1.2
+  yaml_edit: ^2.1.0
 
 dev_dependencies:
   dart_flutter_team_lints: ^2.1.1
   file_testing: ^3.0.0
   test: ^1.24.3
-  yaml: ^3.1.2

--- a/pkgs/native_assets_builder/test/model/asset_test.dart
+++ b/pkgs/native_assets_builder/test/model/asset_test.dart
@@ -1,0 +1,97 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:native_assets_builder/src/model/asset.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final fooUri = Uri.file('path/to/libfoo.so');
+  final foo2Uri = Uri.file('path/to/libfoo2.so');
+  final foo3Uri = Uri(path: 'libfoo3.so');
+  final barUri = Uri(path: 'path/to/libbar.a');
+  final blaUri = Uri(path: 'path/with spaces/bla.dll');
+  final assets = [
+    Asset(
+      id: 'foo',
+      path: AssetAbsolutePath(fooUri),
+      target: Target.androidX64,
+      linkMode: LinkMode.dynamic,
+    ),
+    Asset(
+      id: 'foo2',
+      path: AssetRelativePath(foo2Uri),
+      target: Target.androidX64,
+      linkMode: LinkMode.dynamic,
+    ),
+    Asset(
+      id: 'foo3',
+      path: AssetSystemPath(foo3Uri),
+      target: Target.androidX64,
+      linkMode: LinkMode.dynamic,
+    ),
+    Asset(
+      id: 'foo4',
+      path: AssetInExecutable(),
+      target: Target.androidX64,
+      linkMode: LinkMode.dynamic,
+    ),
+    Asset(
+      id: 'foo5',
+      path: AssetInProcess(),
+      target: Target.androidX64,
+      linkMode: LinkMode.dynamic,
+    ),
+    Asset(
+      id: 'bar',
+      path: AssetAbsolutePath(barUri),
+      target: Target.linuxArm64,
+      linkMode: LinkMode.static,
+    ),
+    Asset(
+      id: 'bla',
+      path: AssetAbsolutePath(blaUri),
+      target: Target.windowsX64,
+      linkMode: LinkMode.dynamic,
+    ),
+  ];
+
+  final assetsDartEncoding = '''format-version:
+  - 1
+  - 0
+  - 0
+native-assets:
+  android_x64:
+    foo:
+      - absolute
+      - ${fooUri.toFilePath()}
+    foo2:
+      - relative
+      - ${foo2Uri.toFilePath()}
+    foo3:
+      - system
+      - ${foo3Uri.toFilePath()}
+    foo4:
+      - executable
+    foo5:
+      - process
+  linux_arm64:
+    bar:
+      - absolute
+      - ${barUri.toFilePath()}
+  windows_x64:
+    bla:
+      - absolute
+      - ${blaUri.toFilePath()}''';
+
+  test('asset yaml', () async {
+    final fileContents = assets.toNativeAssetsFile();
+    expect(fileContents, assetsDartEncoding);
+  });
+
+  test('List<Asset> whereLinkMode', () async {
+    final assets2 = assets.whereLinkMode(LinkMode.dynamic);
+    expect(assets2.length, 6);
+  });
+}

--- a/pkgs/native_assets_builder/test/model/asset_test.dart
+++ b/pkgs/native_assets_builder/test/model/asset_test.dart
@@ -2,8 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: undefined_hidden_name
+
 import 'package:native_assets_builder/src/model/asset.dart';
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli.dart'
+    hide AssetIterable, AssetRelativePath;
 import 'package:test/test.dart';
 
 void main() {

--- a/pkgs/native_assets_builder/test/model/asset_test.dart
+++ b/pkgs/native_assets_builder/test/model/asset_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -11,7 +11,6 @@ import 'package:test/test.dart';
 
 void main() {
   final fooUri = Uri.file('path/to/libfoo.so');
-  final foo2Uri = Uri.file('path/to/libfoo2.so');
   final foo3Uri = Uri(path: 'libfoo3.so');
   final barUri = Uri(path: 'path/to/libbar.a');
   final blaUri = Uri(path: 'path/with spaces/bla.dll');
@@ -19,12 +18,6 @@ void main() {
     Asset(
       id: 'foo',
       path: AssetAbsolutePath(fooUri),
-      target: Target.androidX64,
-      linkMode: LinkMode.dynamic,
-    ),
-    Asset(
-      id: 'foo2',
-      path: AssetRelativePath(foo2Uri),
       target: Target.androidX64,
       linkMode: LinkMode.dynamic,
     ),
@@ -69,9 +62,6 @@ native-assets:
     foo:
       - absolute
       - ${fooUri.toFilePath()}
-    foo2:
-      - relative
-      - ${foo2Uri.toFilePath()}
     foo3:
       - system
       - ${foo3Uri.toFilePath()}
@@ -95,6 +85,6 @@ native-assets:
 
   test('List<Asset> whereLinkMode', () async {
     final assets2 = assets.whereLinkMode(LinkMode.dynamic);
-    expect(assets2.length, 6);
+    expect(assets2.length, 5);
   });
 }

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,7 +1,12 @@
-## 0.3.3-wip
+## 0.4.0-wip
 
 - Added [example/use_dart_api/](example/use_dart_api/) detailing how to use
   `dart_api_dl.h` from the Dart SDK in native code.
+- **Breaking change** Moved code not used in `build.dart` to
+  `package:native_assets_builder`.
+  `AssetRelativePath` is only defined inside `toNativeAssetsFile()` which is
+  passed to the VM, not inside `build.dart` output.
+
 
 ## 0.3.2
 

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -4,8 +4,6 @@
   `dart_api_dl.h` from the Dart SDK in native code.
 - **Breaking change** Moved code not used in `build.dart` to
   `package:native_assets_builder`.
-  `AssetRelativePath` is only defined inside `toNativeAssetsFile()` which is
-  passed to the VM, not inside `build.dart` output.
 
 
 ## 0.3.2

--- a/pkgs/native_assets_cli/lib/src/model/asset.dart
+++ b/pkgs/native_assets_cli/lib/src/model/asset.dart
@@ -14,8 +14,6 @@ abstract class AssetPath {
     switch (pathType) {
       case AssetAbsolutePath._pathTypeValue:
         return AssetAbsolutePath(uri!);
-      case AssetRelativePath._pathTypeValue:
-        return AssetRelativePath(uri!);
       case AssetSystemPath._pathTypeValue:
         return AssetSystemPath(uri!);
       case AssetInExecutable._pathTypeValue:
@@ -65,41 +63,6 @@ class AssetAbsolutePath implements AssetPath {
   @override
   bool operator ==(Object other) {
     if (other is! AssetAbsolutePath) {
-      return false;
-    }
-    return uri == other.uri;
-  }
-
-  @override
-  Future<bool> exists() => uri.fileSystemEntity.exists();
-}
-
-/// Asset is avaliable on a relative path.
-///
-/// If [LinkMode] of an [Asset] is [LinkMode.dynamic],
-/// `Platform.script.resolve(uri)` will be used to load the asset at runtime.
-class AssetRelativePath implements AssetPath {
-  final Uri uri;
-
-  AssetRelativePath(this.uri);
-
-  static const _pathTypeValue = 'relative';
-
-  @override
-  Map<String, Object> toYaml() => {
-        AssetPath._pathTypeKey: _pathTypeValue,
-        AssetPath._uriKey: uri.toFilePath(),
-      };
-
-  @override
-  List<String> toDartConst() => [_pathTypeValue, uri.toFilePath()];
-
-  @override
-  int get hashCode => Object.hash(uri, 133717);
-
-  @override
-  bool operator ==(Object other) {
-    if (other is! AssetRelativePath) {
       return false;
     }
     return uri == other.uri;
@@ -263,8 +226,6 @@ class Asset {
         id: path.toDartConst(),
       };
 
-  String toYamlString() => yamlEncode(toYaml());
-
   static const _idKey = 'id';
   static const _linkModeKey = 'link_mode';
   static const _pathKey = 'path';
@@ -280,44 +241,4 @@ extension AssetIterable on Iterable<Asset> {
   List<Object> toYaml() => [for (final item in this) item.toYaml()];
 
   String toYamlString() => yamlEncode(toYaml());
-
-  Iterable<Asset> whereLinkMode(LinkMode linkMode) =>
-      where((e) => e.linkMode == linkMode);
-
-  Map<Target, List<Asset>> get assetsPerTarget {
-    final result = <Target, List<Asset>>{};
-    for (final asset in this) {
-      final assets = result[asset.target] ?? [];
-      assets.add(asset);
-      result[asset.target] = assets;
-    }
-    return result;
-  }
-
-  Map<String, Map<String, List<String>>> toDartConst() => {
-        for (final entry in assetsPerTarget.entries)
-          entry.key.toString():
-              _combineMaps(entry.value.map((e) => e.toDartConst()).toList())
-      };
-
-  Map<Object, Object> toNativeAssetsFileEncoding() => {
-        'format-version': [1, 0, 0],
-        'native-assets': toDartConst(),
-      };
-
-  String toNativeAssetsFile() => yamlEncode(toNativeAssetsFileEncoding());
-
-  Future<bool> allExist() async {
-    final allResults = await Future.wait(map((e) => e.exists()));
-    final missing = allResults.contains(false);
-    return !missing;
-  }
-}
-
-Map<X, Y> _combineMaps<X, Y>(Iterable<Map<X, Y>> maps) {
-  final result = <X, Y>{};
-  for (final map in maps) {
-    result.addAll(map);
-  }
-  return result;
 }

--- a/pkgs/native_assets_cli/lib/src/model/asset.dart
+++ b/pkgs/native_assets_cli/lib/src/model/asset.dart
@@ -4,7 +4,6 @@
 
 import 'package:yaml/yaml.dart';
 
-import '../utils/uri.dart';
 import '../utils/yaml.dart';
 import 'link_mode.dart';
 import 'target.dart';
@@ -32,12 +31,9 @@ abstract class AssetPath {
   }
 
   Map<String, Object> toYaml();
-  List<String> toDartConst();
 
   static const _pathTypeKey = 'path_type';
   static const _uriKey = 'uri';
-
-  Future<bool> exists();
 }
 
 /// Asset at absolute path [uri].
@@ -55,9 +51,6 @@ class AssetAbsolutePath implements AssetPath {
       };
 
   @override
-  List<String> toDartConst() => [_pathTypeValue, uri.toFilePath()];
-
-  @override
   int get hashCode => Object.hash(uri, 133711);
 
   @override
@@ -67,9 +60,6 @@ class AssetAbsolutePath implements AssetPath {
     }
     return uri == other.uri;
   }
-
-  @override
-  Future<bool> exists() => uri.fileSystemEntity.exists();
 }
 
 /// Asset is avaliable on the system `PATH`.
@@ -89,9 +79,6 @@ class AssetSystemPath implements AssetPath {
       };
 
   @override
-  List<String> toDartConst() => [_pathTypeValue, uri.toFilePath()];
-
-  @override
   int get hashCode => Object.hash(uri, 133723);
 
   @override
@@ -101,9 +88,6 @@ class AssetSystemPath implements AssetPath {
     }
     return uri == other.uri;
   }
-
-  @override
-  Future<bool> exists() => Future.value(true);
 }
 
 /// Asset is loaded in the process and symbols are available through
@@ -121,12 +105,6 @@ class AssetInProcess implements AssetPath {
   Map<String, Object> toYaml() => {
         AssetPath._pathTypeKey: _pathTypeValue,
       };
-
-  @override
-  List<String> toDartConst() => [_pathTypeValue];
-
-  @override
-  Future<bool> exists() => Future.value(true);
 }
 
 /// Asset is embedded in executable and symbols are available through
@@ -144,12 +122,6 @@ class AssetInExecutable implements AssetPath {
   Map<String, Object> toYaml() => {
         AssetPath._pathTypeKey: _pathTypeValue,
       };
-
-  @override
-  List<String> toDartConst() => [_pathTypeValue];
-
-  @override
-  Future<bool> exists() => Future.value(true);
 }
 
 class Asset {
@@ -222,16 +194,12 @@ class Asset {
         _targetKey: target.toString(),
       };
 
-  Map<String, List<String>> toDartConst() => {
-        id: path.toDartConst(),
-      };
-
   static const _idKey = 'id';
   static const _linkModeKey = 'link_mode';
   static const _pathKey = 'path';
   static const _targetKey = 'target';
 
-  Future<bool> exists() => path.exists();
+  // Future<bool> exists() => path.exists();
 
   @override
   String toString() => 'Asset(${toYaml()})';

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   native assets CLI.
 
 # Note: Bump BuildConfig.version and BuildOutput.version on breaking changes!
-version: 0.3.3-wip
+version: 0.4.0-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
 topics:
@@ -13,7 +13,7 @@ topics:
   - native-assets
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   cli_config: ^0.1.1

--- a/pkgs/native_assets_cli/test/example/native_add_library_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_library_test.dart
@@ -74,7 +74,10 @@ void main() async {
       final dependencies = buildOutput.dependencies;
       if (dryRun) {
         expect(assets.length, greaterThanOrEqualTo(1));
-        expect(await assets.first.exists(), false);
+        expect(
+            await File.fromUri((assets.first.path as AssetAbsolutePath).uri)
+                .exists(),
+            false);
         expect(dependencies.dependencies, <Uri>[]);
       } else {
         expect(assets.length, 1);

--- a/pkgs/native_assets_cli/test/helpers.dart
+++ b/pkgs/native_assets_cli/test/helpers.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:native_assets_cli/src/model/asset.dart';
 import 'package:native_assets_cli/src/model/build_config.dart';
 
 const keepTempKey = 'KEEP_TEMPORARY_DIRECTORIES';
@@ -102,4 +103,12 @@ final List<String>? envScriptArgs = Platform
 
 extension on String {
   Uri asFileUri() => Uri.file(this);
+}
+
+extension AssetIterable on Iterable<Asset> {
+  Future<bool> allExist() async {
+    final allResults = await Future.wait(map((e) => e.exists()));
+    final missing = allResults.contains(false);
+    return !missing;
+  }
 }

--- a/pkgs/native_assets_cli/test/helpers.dart
+++ b/pkgs/native_assets_cli/test/helpers.dart
@@ -4,8 +4,7 @@
 
 import 'dart:io';
 
-import 'package:native_assets_cli/src/model/asset.dart';
-import 'package:native_assets_cli/src/model/build_config.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 const keepTempKey = 'KEEP_TEMPORARY_DIRECTORIES';
 
@@ -110,5 +109,24 @@ extension AssetIterable on Iterable<Asset> {
     final allResults = await Future.wait(map((e) => e.exists()));
     final missing = allResults.contains(false);
     return !missing;
+  }
+}
+
+extension on Asset {
+  Future<bool> exists() async {
+    final path_ = path;
+    return switch (path_) {
+      AssetAbsolutePath _ => await path_.uri.fileSystemEntity.exists(),
+      _ => true,
+    };
+  }
+}
+
+extension UriExtension on Uri {
+  FileSystemEntity get fileSystemEntity {
+    if (path.endsWith(Platform.pathSeparator) || path.endsWith('/')) {
+      return Directory.fromUri(this);
+    }
+    return File.fromUri(this);
   }
 }

--- a/pkgs/native_assets_cli/test/model/asset_test.dart
+++ b/pkgs/native_assets_cli/test/model/asset_test.dart
@@ -8,7 +8,6 @@ import 'package:test/test.dart';
 
 void main() {
   final fooUri = Uri.file('path/to/libfoo.so');
-  final foo2Uri = Uri.file('path/to/libfoo2.so');
   final foo3Uri = Uri(path: 'libfoo3.so');
   final barUri = Uri(path: 'path/to/libbar.a');
   final blaUri = Uri(path: 'path/with spaces/bla.dll');
@@ -16,12 +15,6 @@ void main() {
     Asset(
       id: 'foo',
       path: AssetAbsolutePath(fooUri),
-      target: Target.androidX64,
-      linkMode: LinkMode.dynamic,
-    ),
-    Asset(
-      id: 'foo2',
-      path: AssetRelativePath(foo2Uri),
       target: Target.androidX64,
       linkMode: LinkMode.dynamic,
     ),
@@ -63,12 +56,6 @@ void main() {
     path_type: absolute
     uri: ${fooUri.toFilePath()}
   target: android_x64
-- id: foo2
-  link_mode: dynamic
-  path:
-    path_type: relative
-    uri: ${foo2Uri.toFilePath()}
-  target: android_x64
 - id: foo3
   link_mode: dynamic
   path:
@@ -98,44 +85,11 @@ void main() {
     uri: ${blaUri.toFilePath()}
   target: windows_x64''';
 
-  final assetsDartEncoding = '''format-version:
-  - 1
-  - 0
-  - 0
-native-assets:
-  android_x64:
-    foo:
-      - absolute
-      - ${fooUri.toFilePath()}
-    foo2:
-      - relative
-      - ${foo2Uri.toFilePath()}
-    foo3:
-      - system
-      - ${foo3Uri.toFilePath()}
-    foo4:
-      - executable
-    foo5:
-      - process
-  linux_arm64:
-    bar:
-      - absolute
-      - ${barUri.toFilePath()}
-  windows_x64:
-    bla:
-      - absolute
-      - ${blaUri.toFilePath()}''';
-
   test('asset yaml', () {
     final yaml = assets.toYamlString();
     expect(yaml, assetsYamlEncoding);
     final assets2 = Asset.listFromYamlString(yaml);
     expect(assets, assets2);
-  });
-
-  test('asset yaml', () async {
-    final fileContents = assets.toNativeAssetsFile();
-    expect(fileContents, assetsDartEncoding);
   });
 
   test('AssetPath factory', () async {
@@ -162,31 +116,8 @@ native-assets:
     expect(equality.hash(assets) != equality.hash(assets2), true);
   });
 
-  test('List<Asset> whereLinkMode', () async {
-    final assets2 = assets.whereLinkMode(LinkMode.dynamic);
-    expect(assets2.length, 6);
-  });
-
   test('Asset toString', () async {
     assets.toString();
-  });
-
-  test('Asset toString', () async {
-    expect(await assets.allExist(), false);
-  });
-
-  test('Asset toYaml', () async {
-    expect(
-        assets.first.toYamlString(),
-        '''
-id: foo
-link_mode: dynamic
-path:
-  path_type: absolute
-  uri: ${fooUri.toFilePath()}
-target: android_x64
-'''
-            .trim());
   });
 
   test('Asset listFromYamlString', () async {

--- a/pkgs/native_assets_cli/test/model/build_output_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_output_test.dart
@@ -29,7 +29,7 @@ void main() {
       ),
       Asset(
         id: 'foo2',
-        path: AssetRelativePath(Uri(path: 'path/to/libfoo2.so')),
+        path: AssetSystemPath(Uri(path: 'path/to/libfoo2.so')),
         target: Target.androidX64,
         linkMode: LinkMode.dynamic,
       ),
@@ -53,7 +53,7 @@ assets:
   - id: foo2
     link_mode: dynamic
     path:
-      path_type: relative
+      path_type: system
       uri: path/to/libfoo2.so
     target: android_x64
 dependencies:


### PR DESCRIPTION
Classes/methods that are not used in writing `build.dart` scripts, should not be part of `package:native_assets_cli`.

This PR moves code to `package:native_assets_builder` or deletes it entirely.

This PR will likely need to be manually rolled into Dart and Flutter to fix imports.

Issues:

* https://github.com/dart-lang/native/issues/882