### PR TITLE
[ffigen] Use `-wip` instead of `-dev` semantic versioning

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 12.0.0-dev
+## 12.0.0-wip
 
 - Global variables are now compatible with the `ffi-native` option.
 - Exposing symbol addresses of functions and globals is now compatible with the

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 12.0.0-dev
+version: 12.0.0-wip
 description: >
   Generator for FFI bindings, using LibClang to parse C, Objective-C, and Swift
   files.


### PR DESCRIPTION
I believe `-wip` is the new normal.

'wip' indicates something that will not be released until the version number is changed.
'dev' can be released as a dev release.