### PR TITLE
[native_assets_cli] Separate out public API

### DIFF
--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:package_config/package_config.dart';
 
 import '../package_layout/package_layout.dart';

--- a/pkgs/native_assets_builder/lib/src/model/asset.dart
+++ b/pkgs/native_assets_builder/lib/src/model/asset.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 
 import '../utils/yaml.dart';
 

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   graphs: ^2.3.1
   logging: ^1.2.0
-  native_assets_cli: ^0.3.2
+  native_assets_cli: ^0.4.0
   package_config: ^2.1.0
   yaml: ^3.1.2
   yaml_edit: ^2.1.0

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_dry_run_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_dry_run_test.dart
@@ -5,7 +5,7 @@
 import 'dart:io';
 
 import 'package:file_testing/file_testing.dart';
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:native_assets_builder/src/build_runner/build_runner.dart';
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_run_in_isolation_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_run_in_isolation_test.dart
@@ -4,7 +4,7 @@
 
 import 'dart:io';
 
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_builder/test/build_runner/helpers.dart
+++ b/pkgs/native_assets_builder/test/build_runner/helpers.dart
@@ -8,7 +8,7 @@ import 'dart:io';
 import 'package:file_testing/file_testing.dart';
 import 'package:logging/logging.dart';
 import 'package:native_assets_builder/native_assets_builder.dart';
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_builder/test/build_runner/packaging_preference_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/packaging_preference_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_builder/test/data/cyclic_package_1/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/cyclic_package_1/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   cli_config: ^0.1.1
   cyclic_package_2:
     path: ../cyclic_package_2
-  native_assets_cli: ^0.3.2
+  native_assets_cli: ^0.4.0
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test/data/cyclic_package_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/cyclic_package_2/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   cli_config: ^0.1.1
   cyclic_package_1:
     path: ../cyclic_package_1
-  native_assets_cli: ^0.3.2
+  native_assets_cli: ^0.4.0
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test/data/native_add/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/native_add/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
-  native_assets_cli: ^0.3.2
+  native_assets_cli: ^0.4.0
   native_toolchain_c: ^0.3.2
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test/data/native_add/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/native_add/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
   native_assets_cli: ^0.4.0
-  native_toolchain_c: ^0.3.2
+  native_toolchain_c: ^0.3.4
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test/data/native_add_add_source/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/native_add_add_source/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
-  native_assets_cli: ^0.3.2
+  native_assets_cli: ^0.4.0
   native_toolchain_c: ^0.3.2
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test/data/native_add_add_source/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/native_add_add_source/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
   native_assets_cli: ^0.4.0
-  native_toolchain_c: ^0.3.2
+  native_toolchain_c: ^0.3.4
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test/data/native_subtract/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/native_subtract/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
-  native_assets_cli: ^0.3.2
+  native_assets_cli: ^0.4.0
   native_toolchain_c: ^0.3.2
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test/data/native_subtract/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/native_subtract/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
   native_assets_cli: ^0.4.0
-  native_toolchain_c: ^0.3.2
+  native_toolchain_c: ^0.3.4
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test/data/package_reading_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/package_reading_metadata/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   cli_config: ^0.1.1
-  native_assets_cli: ^0.3.2
+  native_assets_cli: ^0.4.0
   package_with_metadata:
     path: ../package_with_metadata/
   yaml: ^3.1.1

--- a/pkgs/native_assets_builder/test/data/package_with_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/package_with_metadata/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   cli_config: ^0.1.1
-  native_assets_cli: ^0.3.2
+  native_assets_cli: ^0.4.0
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test/data/wrong_build_output/build.dart
+++ b/pkgs/native_assets_builder/test/data/wrong_build_output/build.dart
@@ -4,7 +4,7 @@
 
 import 'dart:io';
 
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 
 void main(List<String> args) async {
   final buildConfig = await BuildConfig.fromArgs(args);

--- a/pkgs/native_assets_builder/test/data/wrong_build_output/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/wrong_build_output/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   cli_config: ^0.1.1
-  native_assets_cli: ^0.3.2
+  native_assets_cli: ^0.4.0
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test/data/wrong_build_output_2/build.dart
+++ b/pkgs/native_assets_builder/test/data/wrong_build_output_2/build.dart
@@ -4,7 +4,7 @@
 
 import 'dart:io';
 
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 
 void main(List<String> args) async {
   final buildConfig = await BuildConfig.fromArgs(args);

--- a/pkgs/native_assets_builder/test/data/wrong_build_output_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/wrong_build_output_2/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   cli_config: ^0.1.1
-  native_assets_cli: ^0.3.2
+  native_assets_cli: ^0.4.0
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test/data/wrong_build_output_3/build.dart
+++ b/pkgs/native_assets_builder/test/data/wrong_build_output_3/build.dart
@@ -4,7 +4,7 @@
 
 import 'dart:io';
 
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 
 void main(List<String> args) async {
   final buildConfig = await BuildConfig.fromArgs(args);

--- a/pkgs/native_assets_builder/test/data/wrong_build_output_3/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/wrong_build_output_3/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   cli_config: ^0.1.1
-  native_assets_cli: ^0.3.2
+  native_assets_cli: ^0.4.0
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test/data/wrong_namespace_asset/pubspec.yaml
+++ b/pkgs/native_assets_builder/test/data/wrong_namespace_asset/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   cli_config: ^0.1.1
-  native_assets_cli: ^0.3.2
+  native_assets_cli: ^0.4.0
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 - Added [example/use_dart_api/](example/use_dart_api/) detailing how to use
   `dart_api_dl.h` from the Dart SDK in native code.
-- **Breaking change** Moved code not used in `build.dart` to
-  `package:native_assets_builder`.
+- **Breaking change** Removed all code not used in `build.dart` scripts out of
+  the public API.
+
 
 
 ## 0.3.2

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,9 +1,15 @@
+## 0.4.1-wip
+
+- **Breaking change** Removed all code not used in `build.dart` scripts out of
+  the public API.
+
 ## 0.4.0
 
 - Added [example/use_dart_api/](example/use_dart_api/) detailing how to use
   `dart_api_dl.h` from the Dart SDK in native code.
-- **Breaking change** Removed all code not used in `build.dart` scripts out of
-  the public API.
+- **Breaking change** Moved code not used in `build.dart` to
+  `package:native_assets_builder`.
+
 
 
 ## 0.3.2

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -10,8 +10,6 @@
 - **Breaking change** Moved code not used in `build.dart` to
   `package:native_assets_builder`.
 
-
-
 ## 0.3.2
 
 - Fixed an issue where `Depenendencies.dependencies` could not be

--- a/pkgs/native_assets_cli/example/native_add_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/native_add_library/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
   native_assets_cli: ^0.4.0
-  native_toolchain_c: ^0.3.2
+  native_toolchain_c: ^0.3.4
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_cli/example/native_add_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/native_add_library/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
-  native_assets_cli: ^0.3.2
+  native_assets_cli: ^0.4.0
   native_toolchain_c: ^0.3.2
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/use_dart_api/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/use_dart_api/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
-  native_assets_cli: ^0.3.2
+  native_assets_cli: ^0.4.0
   native_toolchain_c: ^0.3.2
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/use_dart_api/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/use_dart_api/pubspec.yaml
@@ -5,13 +5,13 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
   native_assets_cli: ^0.4.0
-  native_toolchain_c: ^0.3.2
+  native_toolchain_c: ^0.3.4
 
 dev_dependencies:
   ffigen: ^10.0.0

--- a/pkgs/native_assets_cli/lib/native_assets_cli.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli.dart
@@ -6,13 +6,13 @@
 /// native assets CLI.
 library native_assets_cli;
 
-export 'src/model/asset.dart';
-export 'src/model/build_config.dart';
-export 'src/model/build_mode.dart';
-export 'src/model/build_output.dart';
-export 'src/model/dependencies.dart';
-export 'src/model/ios_sdk.dart';
-export 'src/model/link_mode.dart';
-export 'src/model/link_mode_preference.dart';
-export 'src/model/metadata.dart';
-export 'src/model/target.dart';
+export 'src/api/asset.dart';
+export 'src/api/build_config.dart';
+export 'src/api/build_mode.dart';
+export 'src/api/build_output.dart';
+export 'src/api/dependencies.dart';
+export 'src/api/ios_sdk.dart';
+export 'src/api/link_mode.dart';
+export 'src/api/link_mode_preference.dart';
+export 'src/api/metadata.dart';
+export 'src/api/target.dart';

--- a/pkgs/native_assets_cli/lib/native_assets_cli_internal.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli_internal.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// These files should not be accessed from `build.dart`.
+library native_assets_cli_internal;
+
+export 'src/model/asset.dart';
+export 'src/model/build_config.dart';
+export 'src/model/build_mode.dart';
+export 'src/model/build_output.dart';
+export 'src/model/dependencies.dart';
+export 'src/model/ios_sdk.dart';
+export 'src/model/link_mode.dart';
+export 'src/model/link_mode_preference.dart';
+export 'src/model/metadata.dart';
+export 'src/model/target.dart';

--- a/pkgs/native_assets_cli/lib/src/api/asset.dart
+++ b/pkgs/native_assets_cli/lib/src/api/asset.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../model/asset.dart' as model;
+import '../model/link_mode.dart' as model;
+import '../model/target.dart' as model;
+import 'link_mode.dart';
+import 'target.dart';
+
+abstract class AssetPath {}
+
+/// Asset at absolute path [uri].
+abstract class AssetAbsolutePath implements AssetPath {
+  Uri get uri;
+
+  factory AssetAbsolutePath(Uri uri) = model.AssetAbsolutePath;
+}
+
+/// Asset is avaliable on the system `PATH`.
+///
+/// [uri] only contains a file name.
+abstract class AssetSystemPath implements AssetPath {
+  Uri get uri;
+
+  factory AssetSystemPath(Uri uri) = model.AssetSystemPath;
+}
+
+/// Asset is loaded in the process and symbols are available through
+/// `DynamicLibrary.process()`.
+abstract class AssetInProcess implements AssetPath {
+  factory AssetInProcess() = model.AssetInProcess;
+}
+
+/// Asset is embedded in executable and symbols are available through
+/// `DynamicLibrary.executable()`.
+abstract class AssetInExecutable implements AssetPath {
+  factory AssetInExecutable() = model.AssetInExecutable;
+}
+
+abstract class Asset {
+  LinkMode get linkMode;
+  String get id;
+  Target get target;
+  AssetPath get path;
+
+  factory Asset({
+    required String id,
+    required LinkMode linkMode,
+    required Target target,
+    required AssetPath path,
+  }) =>
+      model.Asset(
+        id: id,
+        linkMode: linkMode as model.LinkMode,
+        target: target as model.Target,
+        path: path as model.AssetPath,
+      );
+}

--- a/pkgs/native_assets_cli/lib/src/api/build_config.dart
+++ b/pkgs/native_assets_cli/lib/src/api/build_config.dart
@@ -1,0 +1,199 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:cli_config/cli_config.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+import '../model/build_config.dart' as model;
+import '../model/build_mode.dart' as model;
+import '../model/ios_sdk.dart' as model;
+import '../model/link_mode_preference.dart' as model;
+import '../model/target.dart' as model;
+import 'build_mode.dart';
+import 'ios_sdk.dart';
+import 'link_mode_preference.dart';
+import 'metadata.dart';
+import 'target.dart';
+
+abstract class BuildConfig {
+  /// The folder in which all output and intermediate artifacts should be
+  /// placed.
+  Uri get outDir;
+
+  /// The name of the package the native assets are built for.
+  String get packageName;
+
+  /// The root of the package the native assets are built for.
+  ///
+  /// Often a package's native assets are built because a package is a
+  /// dependency of another. For this it is convenient to know the packageRoot.
+  Uri get packageRoot;
+
+  /// The target being compiled for.
+  ///
+  /// Not available in [dryRun].
+  Target get target;
+
+  /// The architecture being compiled for.
+  ///
+  /// Not available in [dryRun].
+  Architecture get targetArchitecture;
+
+  /// The operating system being compiled for.
+  OS get targetOs;
+
+  /// When compiling for iOS, whether to target device or simulator.
+  ///
+  /// Required when [targetOs] equals [OS.iOS].
+  ///
+  /// Not available in [dryRun].s
+  IOSSdk? get targetIOSSdk;
+
+  /// When compiling for Android, the minimum Android SDK API version to that
+  /// the compiled code will be compatible with.
+  ///
+  /// Required when [targetOs] equals [OS.android].
+  ///
+  /// Not available in [dryRun].
+  ///
+  /// For more information about the Android API version, refer to
+  /// [`minSdkVersion`](https://developer.android.com/ndk/guides/sdk-versions#minsdkversion)
+  /// in the Android documentation.
+  int? get targetAndroidNdkApi;
+
+  /// Preferred linkMode method for library.
+  LinkModePreference get linkModePreference;
+
+  /// Metadata from direct dependencies.
+  ///
+  /// The key in the map is the package name of the dependency.
+  ///
+  /// The key in the nested map is the key for the metadata from the dependency.
+  ///
+  /// Not available in [dryRun].
+  Map<String, Metadata>? get dependencyMetadata;
+
+  /// The configuration for invoking the C compiler.
+  ///
+  /// Not available in [dryRun].
+  CCompilerConfig get cCompiler;
+
+  /// Don't run the build, only report the native assets produced.
+  bool get dryRun;
+
+  /// The build mode that the code should be compiled in.
+  ///
+  /// Not available in [dryRun].
+  BuildMode get buildMode;
+
+  /// The underlying config.
+  ///
+  /// Can be used for easier access to values on [dependencyMetadata].
+  Config get config;
+
+  /// The version of [BuildConfig].
+  ///
+  /// This class is used in the protocol between the Dart and Flutter SDKs
+  /// and packages through `build.dart` invocations.
+  ///
+  /// If we ever were to make breaking changes, it would be useful to give
+  /// proper error messages rather than just fail to parse the YAML
+  /// representation in the protocol.
+  static Version get version => model.BuildConfig.version;
+
+  factory BuildConfig({
+    required Uri outDir,
+    required String packageName,
+    required Uri packageRoot,
+    required BuildMode buildMode,
+    required Architecture targetArchitecture,
+    required OS targetOs,
+    IOSSdk? targetIOSSdk,
+    int? targetAndroidNdkApi,
+    CCompilerConfig? cCompiler,
+    required LinkModePreference linkModePreference,
+    Map<String, Metadata>? dependencyMetadata,
+  }) =>
+      model.BuildConfig(
+        outDir: outDir,
+        packageName: packageName,
+        packageRoot: packageRoot,
+        buildMode: buildMode as model.BuildMode,
+        targetArchitecture: targetArchitecture as model.Architecture,
+        targetOs: targetOs as model.OS,
+        targetIOSSdk: targetIOSSdk as model.IOSSdk?,
+        targetAndroidNdkApi: targetAndroidNdkApi,
+        cCompiler: cCompiler as model.CCompilerConfig?,
+        linkModePreference: linkModePreference as model.LinkModePreference,
+        dependencyMetadata: dependencyMetadata?.cast(),
+      );
+
+  factory BuildConfig.dryRun({
+    required Uri outDir,
+    required String packageName,
+    required Uri packageRoot,
+    required OS targetOs,
+    required LinkModePreference linkModePreference,
+  }) =>
+      model.BuildConfig.dryRun(
+        outDir: outDir,
+        packageName: packageName,
+        packageRoot: packageRoot,
+        targetOs: targetOs as model.OS,
+        linkModePreference: linkModePreference as model.LinkModePreference,
+      );
+
+  factory BuildConfig.fromConfig(Config config) =>
+      model.BuildConfig.fromConfig(config);
+
+  /// Constructs a config by parsing CLI arguments and loading the config file.
+  ///
+  /// The [args] must be commandline arguments.
+  ///
+  /// If provided, [environment] must be a map containing environment variables.
+  /// If not provided, [environment] defaults to [Platform.environment].
+  ///
+  /// If provided, [workingDirectory] is used to resolves paths inside
+  /// [environment].
+  /// If not provided, [workingDirectory] defaults to [Directory.current].
+  ///
+  /// This async constructor is intended to be used directly in CLI files.
+  static Future<BuildConfig> fromArgs(
+    List<String> args, {
+    Map<String, String>? environment,
+    Uri? workingDirectory,
+  }) =>
+      model.BuildConfig.fromArgs(
+        args,
+        environment: environment,
+        workingDirectory: workingDirectory,
+      );
+}
+
+abstract class CCompilerConfig {
+  /// Path to a C compiler.
+  Uri? get cc;
+
+  /// Path to a native linker.
+  Uri? get ld;
+
+  /// Path to a native archiver.
+  Uri? get ar;
+
+  /// Path to script that sets environment variables for [cc], [ld], and [ar].
+  Uri? get envScript;
+
+  /// Arguments for [envScript].
+  List<String>? get envScriptArgs;
+
+  factory CCompilerConfig({
+    Uri? ar,
+    Uri? cc,
+    Uri? ld,
+    Uri? envScript,
+    List<String>? envScriptArgs,
+  }) = model.CCompilerConfig;
+}

--- a/pkgs/native_assets_cli/lib/src/api/build_mode.dart
+++ b/pkgs/native_assets_cli/lib/src/api/build_mode.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../model/build_mode.dart' as model;
+
+abstract class BuildMode {
+  String get name;
+
+  static const BuildMode debug = model.BuildMode.debug;
+  static const BuildMode release = model.BuildMode.release;
+
+  static const values = <BuildMode>[
+    debug,
+    release,
+  ];
+}

--- a/pkgs/native_assets_cli/lib/src/api/build_output.dart
+++ b/pkgs/native_assets_cli/lib/src/api/build_output.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:pub_semver/pub_semver.dart';
+
+import '../model/asset.dart' as model;
+import '../model/build_output.dart' as model;
+import '../model/dependencies.dart' as model;
+import '../model/metadata.dart' as model;
+import 'asset.dart';
+import 'dependencies.dart';
+import 'metadata.dart';
+
+abstract class BuildOutput {
+  /// Time the build this output belongs to started.
+  ///
+  /// Rounded down to whole seconds, because [File.lastModified] is rounded
+  /// to whole seconds and caching logic compares these timestamps.
+  DateTime get timestamp;
+  List<Asset> get assets;
+  Dependencies get dependencies;
+  Metadata get metadata;
+
+  factory BuildOutput({
+    DateTime? timestamp,
+    List<Asset>? assets,
+    Dependencies? dependencies,
+    Metadata? metadata,
+  }) =>
+      model.BuildOutput(
+        timestamp: timestamp,
+        assets: assets?.map((e) => e as model.Asset).toList(),
+        dependencies: dependencies as model.Dependencies?,
+        metadata: metadata as model.Metadata?,
+      );
+
+  /// The version of [BuildOutput].
+  ///
+  /// This class is used in the protocol between the Dart and Flutter SDKs
+  /// and packages through `build.dart` invocations.
+  ///
+  /// If we ever were to make breaking changes, it would be useful to give
+  /// proper error messages rather than just fail to parse the YAML
+  /// representation in the protocol.
+  static Version get version => model.BuildOutput.version;
+
+  Future<void> writeToFile({required Uri outDir});
+}

--- a/pkgs/native_assets_cli/lib/src/api/dependencies.dart
+++ b/pkgs/native_assets_cli/lib/src/api/dependencies.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../model/dependencies.dart' as model;
+
+abstract class Dependencies {
+  /// The dependencies a build relied on.
+  List<Uri> get dependencies;
+
+  const factory Dependencies(List<Uri> dependencies) = model.Dependencies;
+}

--- a/pkgs/native_assets_cli/lib/src/api/ios_sdk.dart
+++ b/pkgs/native_assets_cli/lib/src/api/ios_sdk.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../model/ios_sdk.dart' as model;
+
+/// For an iOS target, a build is either done for the device or the simulator.
+///
+/// Only fat binaries or xcframeworks can contain both targets.
+abstract class IOSSdk {
+  static const IOSSdk iPhoneOs = model.IOSSdk.iPhoneOs;
+  static const IOSSdk iPhoneSimulator = model.IOSSdk.iPhoneSimulator;
+
+  static const values = <IOSSdk>[
+    iPhoneOs,
+    iPhoneSimulator,
+  ];
+}

--- a/pkgs/native_assets_cli/lib/src/api/link_mode.dart
+++ b/pkgs/native_assets_cli/lib/src/api/link_mode.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../model/link_mode.dart' as model;
+
+abstract class LinkMode {
+  static const LinkMode dynamic = model.LinkMode.dynamic;
+  static const LinkMode static = model.LinkMode.static;
+
+  /// Known values for [LinkMode].
+  static const List<LinkMode> values = [
+    dynamic,
+    static,
+  ];
+}

--- a/pkgs/native_assets_cli/lib/src/api/link_mode_preference.dart
+++ b/pkgs/native_assets_cli/lib/src/api/link_mode_preference.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../model/link_mode_preference.dart' as model;
+import 'link_mode.dart';
+
+abstract class LinkModePreference {
+  String get name;
+
+  LinkMode get preferredLinkMode;
+
+  List<LinkMode> get potentialLinkMode;
+
+  /// Provide native assets as dynamic libraries.
+  ///
+  /// Fails if not all native assets can only be provided as static library.
+  /// Required to run Dart in JIT mode.
+  static const LinkModePreference dynamic = model.LinkModePreference.dynamic;
+
+  /// Provide native assets as static libraries.
+  ///
+  /// Fails if not all native assets can only be provided as dynamic library.
+  /// Required for potential link-time tree-shaking of native code.
+  /// Therefore, preferred to in Dart AOT mode.
+  static const LinkModePreference static = model.LinkModePreference.static;
+
+  /// Provide native assets as dynamic libraries, if possible.
+  ///
+  /// Otherwise, build native assets as static libraries
+  static const LinkModePreference preferDynamic =
+      model.LinkModePreference.preferDynamic;
+
+  /// Provide native assets as static libraries, if possible.
+  ///
+  /// Otherwise, build native assets as dynamic libraries. Preferred for AOT
+  /// compilation, if there are any native assets which can only be provided as
+  /// dynamic libraries.
+  static const LinkModePreference preferStatic =
+      model.LinkModePreference.preferStatic;
+
+  static const values = <LinkModePreference>[
+    dynamic,
+    static,
+    preferDynamic,
+    preferStatic,
+  ];
+}

--- a/pkgs/native_assets_cli/lib/src/api/metadata.dart
+++ b/pkgs/native_assets_cli/lib/src/api/metadata.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../model/metadata.dart' as model;
+
+abstract class Metadata {
+  Map<String, Object> get metadata;
+
+  const factory Metadata(Map<String, Object> metadata) = model.Metadata;
+}

--- a/pkgs/native_assets_cli/lib/src/api/target.dart
+++ b/pkgs/native_assets_cli/lib/src/api/target.dart
@@ -1,0 +1,134 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import '../model/target.dart' as model;
+import 'link_mode.dart';
+
+/// The hardware architectures the Dart VM runs on.
+abstract class Architecture {
+  static const Architecture arm = model.Architecture.arm;
+  static const Architecture arm64 = model.Architecture.arm64;
+  static const Architecture ia32 = model.Architecture.ia32;
+  static const Architecture riscv32 = model.Architecture.riscv32;
+  static const Architecture riscv64 = model.Architecture.riscv64;
+  static const Architecture x64 = model.Architecture.x64;
+
+  /// Known values for [Architecture].
+  static const List<Architecture> values = [
+    arm,
+    arm64,
+    ia32,
+    riscv32,
+    riscv64,
+    x64,
+  ];
+
+  /// The current [Architecture].
+  ///
+  /// Read from the [Platform.version] string.
+  static Architecture get current => model.Architecture.current;
+}
+
+/// The operating systems the Dart VM runs on.
+abstract class OS {
+  static const OS android = model.OS.android;
+  static const OS fuchsia = model.OS.fuchsia;
+  static const OS iOS = model.OS.iOS;
+  static const OS linux = model.OS.linux;
+  static const OS macOS = model.OS.macOS;
+  static const OS windows = model.OS.windows;
+
+  /// Known values for [OS].
+  static const List<OS> values = [
+    android,
+    fuchsia,
+    iOS,
+    linux,
+    macOS,
+    windows,
+  ];
+
+  /// The default dynamic library file name on this [OS].
+  String dylibFileName(String name);
+
+  /// The default static library file name on this [OS].
+  String staticlibFileName(String name);
+
+  String libraryFileName(String name, LinkMode linkMode);
+
+  /// The default executable file name on this [OS].
+  String executableFileName(String name);
+
+  /// The current [OS].
+  ///
+  /// Read from the [Platform.version] string.
+  static OS get current => model.OS.current;
+}
+
+/// Application binary interface.
+///
+/// The Dart VM can run on a variety of [Target]s, see [Target.values].
+abstract class Target implements Comparable<Target> {
+  static const Target androidArm = model.Target.androidArm;
+  static const Target androidArm64 = model.Target.androidArm64;
+  static const Target androidIA32 = model.Target.androidIA32;
+  static const Target androidX64 = model.Target.androidX64;
+  static const Target androidRiscv64 = model.Target.androidRiscv64;
+  static const Target fuchsiaArm64 = model.Target.fuchsiaArm64;
+  static const Target fuchsiaX64 = model.Target.fuchsiaX64;
+  static const Target iOSArm = model.Target.iOSArm;
+  static const Target iOSArm64 = model.Target.iOSArm64;
+  static const Target iOSX64 = model.Target.iOSX64;
+  static const Target linuxArm = model.Target.linuxArm;
+  static const Target linuxArm64 = model.Target.linuxArm64;
+  static const Target linuxIA32 = model.Target.linuxIA32;
+  static const Target linuxRiscv32 = model.Target.linuxRiscv32;
+  static const Target linuxRiscv64 = model.Target.linuxRiscv64;
+  static const Target linuxX64 = model.Target.linuxX64;
+  static const Target macOSArm64 = model.Target.macOSArm64;
+  static const Target macOSX64 = model.Target.macOSX64;
+  static const Target windowsArm64 = model.Target.windowsArm64;
+  static const Target windowsIA32 = model.Target.windowsIA32;
+  static const Target windowsX64 = model.Target.windowsX64;
+
+  /// All Targets that native assets can be built for.
+  ///
+  /// Note that for some of these a Dart SDK is not available and they are only
+  /// used as target architectures for Flutter apps.
+  static const values = <Target>{
+    androidArm,
+    androidArm64,
+    androidIA32,
+    androidX64,
+    androidRiscv64,
+    fuchsiaArm64,
+    fuchsiaX64,
+    iOSArm,
+    iOSArm64,
+    iOSX64,
+    linuxArm,
+    linuxArm64,
+    linuxIA32,
+    linuxRiscv32,
+    linuxRiscv64,
+    linuxX64,
+    macOSArm64,
+    macOSX64,
+    windowsArm64,
+    windowsIA32,
+    windowsX64,
+    // TODO(dacoharkes): Add support for `wasm`.
+  };
+
+  /// The current [Target].
+  ///
+  /// Read from the [Platform.version] string.
+  static Target get current => model.Target.current;
+
+  Architecture get architecture;
+
+  OS get os;
+}

--- a/pkgs/native_assets_cli/lib/src/model/asset.dart
+++ b/pkgs/native_assets_cli/lib/src/model/asset.dart
@@ -4,11 +4,12 @@
 
 import 'package:yaml/yaml.dart';
 
+import '../api/asset.dart' as api;
 import '../utils/yaml.dart';
 import 'link_mode.dart';
 import 'target.dart';
 
-abstract class AssetPath {
+abstract class AssetPath implements api.AssetPath {
   factory AssetPath(String pathType, Uri? uri) {
     switch (pathType) {
       case AssetAbsolutePath._pathTypeValue:
@@ -37,7 +38,8 @@ abstract class AssetPath {
 }
 
 /// Asset at absolute path [uri].
-class AssetAbsolutePath implements AssetPath {
+class AssetAbsolutePath implements AssetPath, api.AssetAbsolutePath {
+  @override
   final Uri uri;
 
   AssetAbsolutePath(this.uri);
@@ -65,7 +67,8 @@ class AssetAbsolutePath implements AssetPath {
 /// Asset is avaliable on the system `PATH`.
 ///
 /// [uri] only contains a file name.
-class AssetSystemPath implements AssetPath {
+class AssetSystemPath implements AssetPath, api.AssetSystemPath {
+  @override
   final Uri uri;
 
   AssetSystemPath(this.uri);
@@ -92,7 +95,7 @@ class AssetSystemPath implements AssetPath {
 
 /// Asset is loaded in the process and symbols are available through
 /// `DynamicLibrary.process()`.
-class AssetInProcess implements AssetPath {
+class AssetInProcess implements AssetPath, api.AssetInProcess {
   AssetInProcess._();
 
   static final AssetInProcess _singleton = AssetInProcess._();
@@ -109,7 +112,7 @@ class AssetInProcess implements AssetPath {
 
 /// Asset is embedded in executable and symbols are available through
 /// `DynamicLibrary.executable()`.
-class AssetInExecutable implements AssetPath {
+class AssetInExecutable implements AssetPath, api.AssetInExecutable {
   AssetInExecutable._();
 
   static final AssetInExecutable _singleton = AssetInExecutable._();
@@ -124,10 +127,14 @@ class AssetInExecutable implements AssetPath {
       };
 }
 
-class Asset {
+class Asset implements api.Asset {
+  @override
   final LinkMode linkMode;
+  @override
   final String id;
+  @override
   final Target target;
+  @override
   final AssetPath path;
 
   Asset({

--- a/pkgs/native_assets_cli/lib/src/model/build_config.dart
+++ b/pkgs/native_assets_cli/lib/src/model/build_config.dart
@@ -10,6 +10,7 @@ import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart';
 import 'package:pub_semver/pub_semver.dart';
 
+import '../api/build_config.dart' as api;
 import '../utils/map.dart';
 import '../utils/yaml.dart';
 import 'build_mode.dart';
@@ -18,13 +19,15 @@ import 'link_mode_preference.dart';
 import 'metadata.dart';
 import 'target.dart';
 
-class BuildConfig {
+class BuildConfig implements api.BuildConfig {
   /// The folder in which all output and intermediate artifacts should be
   /// placed.
+  @override
   Uri get outDir => _outDir;
   late final Uri _outDir;
 
   /// The name of the package the native assets are built for.
+  @override
   String get packageName => _packageName;
   late final String _packageName;
 
@@ -32,18 +35,21 @@ class BuildConfig {
   ///
   /// Often a package's native assets are built because a package is a
   /// dependency of another. For this it is convenient to know the packageRoot.
+  @override
   Uri get packageRoot => _packageRoot;
   late final Uri _packageRoot;
 
   /// The target being compiled for.
   ///
   /// Not available in [dryRun].
+  @override
   late final Target target =
       Target.fromArchitectureAndOs(targetArchitecture, targetOs);
 
   /// The architecture being compiled for.
   ///
   /// Not available in [dryRun].
+  @override
   Architecture get targetArchitecture {
     _ensureNotDryRun();
     return _targetArchitecture;
@@ -52,6 +58,7 @@ class BuildConfig {
   late final Architecture _targetArchitecture;
 
   /// The operating system being compiled for.
+  @override
   OS get targetOs => _targetOs;
   late final OS _targetOs;
 
@@ -60,6 +67,7 @@ class BuildConfig {
   /// Required when [targetOs] equals [OS.iOS].
   ///
   /// Not available in [dryRun].s
+  @override
   IOSSdk? get targetIOSSdk {
     _ensureNotDryRun();
     return _targetIOSSdk;
@@ -77,6 +85,7 @@ class BuildConfig {
   /// For more information about the Android API version, refer to
   /// [`minSdkVersion`](https://developer.android.com/ndk/guides/sdk-versions#minsdkversion)
   /// in the Android documentation.
+  @override
   int? get targetAndroidNdkApi {
     _ensureNotDryRun();
     return _targetAndroidNdkApi;
@@ -85,6 +94,7 @@ class BuildConfig {
   late final int? _targetAndroidNdkApi;
 
   /// Preferred linkMode method for library.
+  @override
   LinkModePreference get linkModePreference => _linkModePreference;
   late final LinkModePreference _linkModePreference;
 
@@ -95,6 +105,7 @@ class BuildConfig {
   /// The key in the nested map is the key for the metadata from the dependency.
   ///
   /// Not available in [dryRun].
+  @override
   Map<String, Metadata>? get dependencyMetadata {
     _ensureNotDryRun();
     return _dependencyMetadata;
@@ -105,6 +116,7 @@ class BuildConfig {
   /// The configuration for invoking the C compiler.
   ///
   /// Not available in [dryRun].
+  @override
   CCompilerConfig get cCompiler {
     _ensureNotDryRun();
     return _cCompiler;
@@ -113,12 +125,14 @@ class BuildConfig {
   late final CCompilerConfig _cCompiler;
 
   /// Don't run the build, only report the native assets produced.
+  @override
   bool get dryRun => _dryRun ?? false;
   late final bool? _dryRun;
 
   /// The build mode that the code should be compiled in.
   ///
   /// Not available in [dryRun].
+  @override
   BuildMode get buildMode {
     _ensureNotDryRun();
     return _buildMode;
@@ -129,6 +143,7 @@ class BuildConfig {
   /// The underlying config.
   ///
   /// Can be used for easier access to values on [dependencyMetadata].
+  @override
   Config get config => _config;
   late final Config _config;
 
@@ -573,24 +588,29 @@ can _only_ depend on OS.''');
   }
 }
 
-class CCompilerConfig {
+class CCompilerConfig implements api.CCompilerConfig {
   /// Path to a C compiler.
+  @override
   Uri? get cc => _cc;
   late final Uri? _cc;
 
   /// Path to a native linker.
+  @override
   Uri? get ld => _ld;
   late final Uri? _ld;
 
   /// Path to a native archiver.
+  @override
   Uri? get ar => _ar;
   late final Uri? _ar;
 
   /// Path to script that sets environment variables for [cc], [ld], and [ar].
+  @override
   Uri? get envScript => _envScript;
   late final Uri? _envScript;
 
   /// Arguments for [envScript].
+  @override
   List<String>? get envScriptArgs => _envScriptArgs;
   late final List<String>? _envScriptArgs;
 

--- a/pkgs/native_assets_cli/lib/src/model/build_mode.dart
+++ b/pkgs/native_assets_cli/lib/src/model/build_mode.dart
@@ -2,7 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-class BuildMode {
+import '../api/build_mode.dart' as api;
+
+class BuildMode implements api.BuildMode {
+  @override
   final String name;
 
   const BuildMode._(this.name);

--- a/pkgs/native_assets_cli/lib/src/model/build_output.dart
+++ b/pkgs/native_assets_cli/lib/src/model/build_output.dart
@@ -8,6 +8,7 @@ import 'package:collection/collection.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
 
+import '../api/build_output.dart' as api;
 import '../utils/datetime.dart';
 import '../utils/file.dart';
 import '../utils/map.dart';
@@ -16,14 +17,18 @@ import 'asset.dart';
 import 'dependencies.dart';
 import 'metadata.dart';
 
-class BuildOutput {
+class BuildOutput implements api.BuildOutput {
   /// Time the build this output belongs to started.
   ///
   /// Rounded down to whole seconds, because [File.lastModified] is rounded
   /// to whole seconds and caching logic compares these timestamps.
+  @override
   final DateTime timestamp;
+  @override
   final List<Asset> assets;
+  @override
   final Dependencies dependencies;
+  @override
   final Metadata metadata;
 
   BuildOutput({
@@ -108,6 +113,7 @@ class BuildOutput {
   }
 
   /// Writes the [toYamlString] to [outDir]/[fileName].
+  @override
   Future<void> writeToFile({required Uri outDir}) async {
     final buildOutputUri = outDir.resolve(fileName);
     await File.fromUri(buildOutputUri)

--- a/pkgs/native_assets_cli/lib/src/model/dependencies.dart
+++ b/pkgs/native_assets_cli/lib/src/model/dependencies.dart
@@ -5,12 +5,14 @@
 import 'package:collection/collection.dart';
 import 'package:yaml/yaml.dart';
 
+import '../api/dependencies.dart' as api;
 import '../utils/file.dart';
 import '../utils/uri.dart';
 import '../utils/yaml.dart';
 
-class Dependencies {
+class Dependencies implements api.Dependencies {
   /// The dependencies a build relied on.
+  @override
   final List<Uri> dependencies;
 
   const Dependencies(this.dependencies);

--- a/pkgs/native_assets_cli/lib/src/model/ios_sdk.dart
+++ b/pkgs/native_assets_cli/lib/src/model/ios_sdk.dart
@@ -2,10 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../api/ios_sdk.dart' as api;
+
 /// For an iOS target, a build is either done for the device or the simulator.
 ///
 /// Only fat binaries or xcframeworks can contain both targets.
-class IOSSdk {
+class IOSSdk implements api.IOSSdk {
   final String xcodebuildSdk;
 
   const IOSSdk._(this.xcodebuildSdk);

--- a/pkgs/native_assets_cli/lib/src/model/link_mode.dart
+++ b/pkgs/native_assets_cli/lib/src/model/link_mode.dart
@@ -2,7 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-class LinkMode {
+import '../api/link_mode.dart' as api;
+
+class LinkMode implements api.LinkMode {
   final String name;
 
   const LinkMode._(this.name);

--- a/pkgs/native_assets_cli/lib/src/model/link_mode_preference.dart
+++ b/pkgs/native_assets_cli/lib/src/model/link_mode_preference.dart
@@ -2,17 +2,21 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../api/link_mode_preference.dart' as api;
 import 'link_mode.dart';
 
-class LinkModePreference {
+class LinkModePreference implements api.LinkModePreference {
+  @override
   final String name;
-  final String description;
+
+  @override
   final LinkMode preferredLinkMode;
+
+  @override
   final List<LinkMode> potentialLinkMode;
 
   const LinkModePreference(
-    this.name,
-    this.description, {
+    this.name, {
     required this.preferredLinkMode,
     required this.potentialLinkMode,
   });
@@ -22,37 +26,24 @@ class LinkModePreference {
 
   static const dynamic = LinkModePreference(
     'dynamic',
-    '''Provide native assets as dynamic libraries.
-Fails if not all native assets can only be provided as static library.
-Required to run Dart in JIT mode.''',
     preferredLinkMode: LinkMode.dynamic,
     potentialLinkMode: [LinkMode.dynamic],
   );
 
   static const static = LinkModePreference(
     'static',
-    '''Provide native assets as static libraries.
-Fails if not all native assets can only be provided as dynamic library.
-Required for potential link-time tree-shaking of native code.
-Therefore, preferred to in Dart AOT mode.''',
     preferredLinkMode: LinkMode.static,
     potentialLinkMode: [LinkMode.static],
   );
 
   static const preferDynamic = LinkModePreference(
     'prefer-dynamic',
-    '''Provide native assets as dynamic libraries, if possible.
-Otherwise, build native assets as static libraries.''',
     preferredLinkMode: LinkMode.dynamic,
     potentialLinkMode: LinkMode.values,
   );
 
   static const preferStatic = LinkModePreference(
     'prefer-static',
-    '''Provide native assets as static libraries, if possible.
-Otherwise, build native assets as dynamic libraries.
-Preferred for AOT compilation, if there are any native assets which can only be
-provided as dynamic libraries.''',
     preferredLinkMode: LinkMode.static,
     potentialLinkMode: LinkMode.values,
   );

--- a/pkgs/native_assets_cli/lib/src/model/metadata.dart
+++ b/pkgs/native_assets_cli/lib/src/model/metadata.dart
@@ -5,10 +5,12 @@
 import 'package:collection/collection.dart';
 import 'package:yaml/yaml.dart';
 
+import '../api/metadata.dart' as api;
 import '../utils/map.dart';
 import '../utils/yaml.dart';
 
-class Metadata {
+class Metadata implements api.Metadata {
+  @override
   final Map<String, Object> metadata;
 
   const Metadata(this.metadata);

--- a/pkgs/native_assets_cli/lib/src/model/target.dart
+++ b/pkgs/native_assets_cli/lib/src/model/target.dart
@@ -5,10 +5,12 @@
 import 'dart:ffi' show Abi;
 import 'dart:io';
 
+import '../api/link_mode.dart' as api;
+import '../api/target.dart' as api;
 import 'link_mode.dart';
 
 /// The hardware architectures the Dart VM runs on.
-class Architecture {
+class Architecture implements api.Architecture {
   /// This architecture as used in [Platform.version].
   final String dartPlatform;
 
@@ -79,7 +81,7 @@ class Architecture {
 }
 
 /// The operating systems the Dart VM runs on.
-class OS {
+class OS implements api.OS {
   /// This OS as used in [Platform.version]
   final String dartPlatform;
 
@@ -136,6 +138,7 @@ class OS {
   };
 
   /// The default dynamic library file name on this [OS].
+  @override
   String dylibFileName(String name) {
     final prefix = _dylibPrefix[this]!;
     final extension = _dylibExtension[this]!;
@@ -143,13 +146,15 @@ class OS {
   }
 
   /// The default static library file name on this [OS].
+  @override
   String staticlibFileName(String name) {
     final prefix = _staticlibPrefix[this]!;
     final extension = _staticlibExtension[this]!;
     return '$prefix$name.$extension';
   }
 
-  String libraryFileName(String name, LinkMode linkMode) {
+  @override
+  String libraryFileName(String name, api.LinkMode linkMode) {
     if (linkMode == LinkMode.dynamic) {
       return dylibFileName(name);
     }
@@ -158,6 +163,7 @@ class OS {
   }
 
   /// The default executable file name on this [OS].
+  @override
   String executableFileName(String name) {
     final extension = _executableExtension[this]!;
     final dot = extension.isNotEmpty ? '.' : '';
@@ -229,7 +235,7 @@ class OS {
 /// Application binary interface.
 ///
 /// The Dart VM can run on a variety of [Target]s, see [Target.values].
-class Target implements Comparable<Target> {
+class Target implements api.Target {
   final Abi abi;
 
   const Target._(this.abi);
@@ -331,8 +337,10 @@ class Target implements Comparable<Target> {
   /// Read from the [Platform.version] string.
   static final Target current = Target.fromDartPlatform(Platform.version);
 
+  @override
   Architecture get architecture => Architecture.fromAbi(abi);
 
+  @override
   OS get os => OS.fromAbi(abi);
 
   String get _architectureString => architecture.dartPlatform;
@@ -350,7 +358,7 @@ class Target implements Comparable<Target> {
   ///
   /// If [other] is also an [Target], consistent with sorting on [toString].
   @override
-  int compareTo(Target other) => toString().compareTo(other.toString());
+  int compareTo(api.Target other) => toString().compareTo(other.toString());
 
   /// A list of supported target [Target]s from this host [os].
   List<Target> supportedTargetTargets(

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   native assets CLI.
 
 # Note: Bump BuildConfig.version and BuildOutput.version on breaking changes!
-version: 0.4.0
+version: 0.4.1-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
 topics:

--- a/pkgs/native_assets_cli/test/api/asset_test.dart
+++ b/pkgs/native_assets_cli/test/api/asset_test.dart
@@ -1,12 +1,8 @@
-// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: undefined_hidden_name
-
-import 'package:native_assets_builder/src/model/asset.dart';
-import 'package:native_assets_cli/native_assets_cli_internal.dart'
-    hide AssetIterable, AssetRelativePath;
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -53,38 +49,7 @@ void main() {
     ),
   ];
 
-  final assetsDartEncoding = '''format-version:
-  - 1
-  - 0
-  - 0
-native-assets:
-  android_x64:
-    foo:
-      - absolute
-      - ${fooUri.toFilePath()}
-    foo3:
-      - system
-      - ${foo3Uri.toFilePath()}
-    foo4:
-      - executable
-    foo5:
-      - process
-  linux_arm64:
-    bar:
-      - absolute
-      - ${barUri.toFilePath()}
-  windows_x64:
-    bla:
-      - absolute
-      - ${blaUri.toFilePath()}''';
-
-  test('asset yaml', () async {
-    final fileContents = assets.toNativeAssetsFile();
-    expect(fileContents, assetsDartEncoding);
-  });
-
-  test('List<Asset> whereLinkMode', () async {
-    final assets2 = assets.whereLinkMode(LinkMode.dynamic);
-    expect(assets2.length, 5);
+  test('Asset toString', () async {
+    assets.toString();
   });
 }

--- a/pkgs/native_assets_cli/test/api/asset_test.dart
+++ b/pkgs/native_assets_cli/test/api/asset_test.dart
@@ -6,50 +6,45 @@ import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final fooUri = Uri.file('path/to/libfoo.so');
-  final foo3Uri = Uri(path: 'libfoo3.so');
-  final barUri = Uri(path: 'path/to/libbar.a');
-  final blaUri = Uri(path: 'path/with spaces/bla.dll');
-  final assets = [
-    Asset(
-      id: 'foo',
-      path: AssetAbsolutePath(fooUri),
-      target: Target.androidX64,
-      linkMode: LinkMode.dynamic,
-    ),
-    Asset(
-      id: 'foo3',
-      path: AssetSystemPath(foo3Uri),
-      target: Target.androidX64,
-      linkMode: LinkMode.dynamic,
-    ),
-    Asset(
-      id: 'foo4',
-      path: AssetInExecutable(),
-      target: Target.androidX64,
-      linkMode: LinkMode.dynamic,
-    ),
-    Asset(
-      id: 'foo5',
-      path: AssetInProcess(),
-      target: Target.androidX64,
-      linkMode: LinkMode.dynamic,
-    ),
-    Asset(
-      id: 'bar',
-      path: AssetAbsolutePath(barUri),
-      target: Target.linuxArm64,
-      linkMode: LinkMode.static,
-    ),
-    Asset(
-      id: 'bla',
-      path: AssetAbsolutePath(blaUri),
-      target: Target.windowsX64,
-      linkMode: LinkMode.dynamic,
-    ),
-  ];
-
-  test('Asset toString', () async {
+  test('Asset constructors', () async {
+    final assets = [
+      Asset(
+        id: 'foo',
+        path: AssetAbsolutePath(Uri.file('path/to/libfoo.so')),
+        target: Target.androidX64,
+        linkMode: LinkMode.dynamic,
+      ),
+      Asset(
+        id: 'foo3',
+        path: AssetSystemPath(Uri(path: 'libfoo3.so')),
+        target: Target.androidX64,
+        linkMode: LinkMode.dynamic,
+      ),
+      Asset(
+        id: 'foo4',
+        path: AssetInExecutable(),
+        target: Target.androidX64,
+        linkMode: LinkMode.dynamic,
+      ),
+      Asset(
+        id: 'foo5',
+        path: AssetInProcess(),
+        target: Target.androidX64,
+        linkMode: LinkMode.dynamic,
+      ),
+      Asset(
+        id: 'bar',
+        path: AssetAbsolutePath(Uri(path: 'path/to/libbar.a')),
+        target: Target.linuxArm64,
+        linkMode: LinkMode.static,
+      ),
+      Asset(
+        id: 'bla',
+        path: AssetAbsolutePath(Uri(path: 'path/with spaces/bla.dll')),
+        target: Target.windowsX64,
+        linkMode: LinkMode.dynamic,
+      ),
+    ];
     assets.toString();
   });
 }

--- a/pkgs/native_assets_cli/test/api/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/api/build_config_test.dart
@@ -205,11 +205,11 @@ void main() async {
     final configUri = tempUri.resolve('config.yaml');
     final configFile = File.fromUri(configUri);
     await configFile.writeAsString(configFileContents);
-    final buildConfig2 = await BuildConfig.fromArgs(
+    final buildConfigFromArgs = await BuildConfig.fromArgs(
       ['--config', configUri.toFilePath()],
       environment: {}, // Don't inherit the test environment.
     );
-    expect(buildConfig2, buildConfig);
+    expect(buildConfigFromArgs, buildConfig);
   });
 
   test('BuildConfig.version', () {

--- a/pkgs/native_assets_cli/test/api/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/api/build_config_test.dart
@@ -1,0 +1,218 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:cli_config/cli_config.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart' as internal;
+import 'package:test/test.dart';
+
+void main() async {
+  late Uri tempUri;
+  late Uri outDirUri;
+  late Uri outDir2Uri;
+  late String packageName;
+  late Uri packageRootUri;
+  late Uri fakeClang;
+  late Uri fakeLd;
+  late Uri fakeAr;
+  late Uri fakeCl;
+  late Uri fakeVcVars;
+
+  setUp(() async {
+    tempUri = (await Directory.systemTemp.createTemp()).uri;
+    outDirUri = tempUri.resolve('out1/');
+    await Directory.fromUri(outDirUri).create();
+    outDir2Uri = tempUri.resolve('out2/');
+    packageName = 'my_package';
+    await Directory.fromUri(outDir2Uri).create();
+    packageRootUri = tempUri.resolve('$packageName/');
+    await Directory.fromUri(packageRootUri).create();
+    fakeClang = tempUri.resolve('fake_clang');
+    await File.fromUri(fakeClang).create();
+    fakeLd = tempUri.resolve('fake_ld');
+    await File.fromUri(fakeLd).create();
+    fakeAr = tempUri.resolve('fake_ar');
+    await File.fromUri(fakeAr).create();
+    fakeCl = tempUri.resolve('cl.exe');
+    await File.fromUri(fakeCl).create();
+    fakeVcVars = tempUri.resolve('vcvarsall.bat');
+    await File.fromUri(fakeVcVars).create();
+  });
+
+  tearDown(() async {
+    await Directory.fromUri(tempUri).delete(recursive: true);
+  });
+
+  test('BuildConfig ==', () {
+    final config1 = BuildConfig(
+      outDir: outDirUri,
+      packageName: packageName,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.arm64,
+      targetOs: OS.iOS,
+      targetIOSSdk: IOSSdk.iPhoneOs,
+      cCompiler: CCompilerConfig(
+        cc: fakeClang,
+        ld: fakeLd,
+        ar: fakeAr,
+      ),
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.preferStatic,
+    );
+
+    final config2 = BuildConfig(
+      outDir: outDir2Uri,
+      packageName: packageName,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.arm64,
+      targetOs: OS.android,
+      targetAndroidNdkApi: 30,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.preferStatic,
+    );
+
+    expect(config1, equals(config1));
+    expect(config1 == config2, false);
+    expect(config1.outDir != config2.outDir, true);
+    expect(config1.packageRoot, config2.packageRoot);
+    expect(config1.targetArchitecture == config2.targetArchitecture, true);
+    expect(config1.targetOs != config2.targetOs, true);
+    expect(config1.targetIOSSdk != config2.targetIOSSdk, true);
+    expect(config1.cCompiler.cc != config2.cCompiler.cc, true);
+    expect(config1.cCompiler.ld != config2.cCompiler.ld, true);
+    expect(config1.cCompiler.ar != config2.cCompiler.ar, true);
+    expect(config1.cCompiler.envScript == config2.cCompiler.envScript, true);
+    expect(config1.cCompiler.envScriptArgs == config2.cCompiler.envScriptArgs,
+        true);
+    expect(config1.cCompiler != config2.cCompiler, true);
+    expect(config1.linkModePreference, config2.linkModePreference);
+    expect(config1.dependencyMetadata, config2.dependencyMetadata);
+  });
+
+  test('BuildConfig fromConfig', () {
+    final buildConfig2 = BuildConfig(
+      outDir: outDirUri,
+      packageName: packageName,
+      packageRoot: packageRootUri,
+      targetArchitecture: Architecture.arm64,
+      targetOs: OS.android,
+      targetAndroidNdkApi: 30,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.preferStatic,
+    );
+
+    final config = Config(fileParsed: {
+      'build_mode': 'release',
+      'dry_run': false,
+      'link_mode_preference': 'prefer-static',
+      'out_dir': outDirUri.toFilePath(),
+      'package_name': packageName,
+      'package_root': packageRootUri.toFilePath(),
+      'target_android_ndk_api': 30,
+      'target_architecture': 'arm64',
+      'target_os': 'android',
+      'version': BuildOutput.version.toString(),
+    });
+
+    final fromConfig = BuildConfig.fromConfig(config);
+    expect(fromConfig, equals(buildConfig2));
+  });
+
+  test('BuildConfig.dryRun', () {
+    final buildConfig2 = BuildConfig.dryRun(
+      outDir: outDirUri,
+      packageName: packageName,
+      packageRoot: packageRootUri,
+      targetOs: OS.android,
+      linkModePreference: LinkModePreference.preferStatic,
+    );
+
+    final config = Config(fileParsed: {
+      'dry_run': true,
+      'link_mode_preference': 'prefer-static',
+      'out_dir': outDirUri.toFilePath(),
+      'package_name': packageName,
+      'package_root': packageRootUri.toFilePath(),
+      'target_os': 'android',
+      'version': BuildOutput.version.toString(),
+    });
+
+    final fromConfig = BuildConfig.fromConfig(config);
+    expect(fromConfig, equals(buildConfig2));
+  });
+
+  test('BuildConfig == dependency metadata', () {
+    final buildConfig1 = BuildConfig(
+      outDir: outDirUri,
+      packageName: packageName,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.arm64,
+      targetOs: OS.android,
+      targetAndroidNdkApi: 30,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.preferStatic,
+      dependencyMetadata: {
+        'bar': const Metadata({
+          'key': 'value',
+          'foo': ['asdf', 'fdsa'],
+        }),
+        'foo': const Metadata({
+          'key': 321,
+        }),
+      },
+    );
+
+    final buildConfig2 = BuildConfig(
+      outDir: outDirUri,
+      packageName: packageName,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.arm64,
+      targetOs: OS.android,
+      targetAndroidNdkApi: 30,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.preferStatic,
+      dependencyMetadata: {
+        'bar': const Metadata({
+          'key': 'value',
+        }),
+        'foo': const Metadata({
+          'key': 123,
+        }),
+      },
+    );
+
+    expect(buildConfig1, equals(buildConfig1));
+    expect(buildConfig1 == buildConfig2, false);
+    expect(buildConfig1.hashCode == buildConfig2.hashCode, false);
+  });
+
+  test('BuildConfig fromArgs', () async {
+    final buildConfig = BuildConfig(
+      outDir: outDirUri,
+      packageName: packageName,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.arm64,
+      targetOs: OS.android,
+      targetAndroidNdkApi: 30,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.preferStatic,
+    );
+    final configFileContents =
+        (buildConfig as internal.BuildConfig).toYamlString();
+    final configUri = tempUri.resolve('config.yaml');
+    final configFile = File.fromUri(configUri);
+    await configFile.writeAsString(configFileContents);
+    final buildConfig2 = await BuildConfig.fromArgs(
+      ['--config', configUri.toFilePath()],
+      environment: {}, // Don't inherit the test environment.
+    );
+    expect(buildConfig2, buildConfig);
+  });
+
+  test('BuildConfig.version', () {
+    BuildConfig.version.toString();
+  });
+}

--- a/pkgs/native_assets_cli/test/api/build_output_test.dart
+++ b/pkgs/native_assets_cli/test/api/build_output_test.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Uri tempUri;
+
+  setUp(() async {
+    tempUri = (await Directory.systemTemp.createTemp()).uri;
+  });
+
+  tearDown(() async {
+    await Directory.fromUri(tempUri).delete(recursive: true);
+  });
+
+  test('BuildOutput constructor', () {
+    BuildOutput(
+      timestamp: DateTime.parse('2022-11-10 13:25:01.000'),
+      assets: [
+        Asset(
+          id: 'foo',
+          path: AssetAbsolutePath(Uri(path: 'path/to/libfoo.so')),
+          target: Target.androidX64,
+          linkMode: LinkMode.dynamic,
+        ),
+        Asset(
+          id: 'foo2',
+          path: AssetSystemPath(Uri(path: 'path/to/libfoo2.so')),
+          target: Target.androidX64,
+          linkMode: LinkMode.dynamic,
+        ),
+      ],
+      dependencies: Dependencies([
+        Uri.file('path/to/file.ext'),
+      ]),
+      metadata: const Metadata({
+        'key': 'value',
+      }),
+    );
+  });
+}

--- a/pkgs/native_assets_cli/test/api/target_test.dart
+++ b/pkgs/native_assets_cli/test/api/target_test.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:ffi';
+
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Target current', () async {
+    final current = Target.current;
+    expect(current.toString(), Abi.current().toString());
+  });
+
+  test('OS current', () async {
+    final current = OS.current;
+    expect(current.toString(), Abi.current().toString().split('_').first);
+  });
+
+  test('Architecture current', () async {
+    final current = Architecture.current;
+    expect(current.toString(), Abi.current().toString().split('_')[1]);
+  });
+}

--- a/pkgs/native_assets_cli/test/example/native_add_library_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_library_test.dart
@@ -10,7 +10,7 @@ library;
 
 import 'dart:io';
 
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_cli/test/helpers.dart
+++ b/pkgs/native_assets_cli/test/helpers.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart' as internal;
 
 const keepTempKey = 'KEEP_TEMPORARY_DIRECTORIES';
 
@@ -74,30 +75,38 @@ extension on Uri {
 String unparseKey(String key) => key.replaceAll('.', '__').toUpperCase();
 
 /// Archiver provided by the environment.
+///
+/// Provided on Dart CI.
 final Uri? ar = Platform
-    .environment[unparseKey(CCompilerConfig.arConfigKeyFull)]
+    .environment[unparseKey(internal.CCompilerConfig.arConfigKeyFull)]
     ?.asFileUri();
 
 /// Compiler provided by the environment.
+///
+/// Provided on Dart CI.
 final Uri? cc = Platform
-    .environment[unparseKey(CCompilerConfig.ccConfigKeyFull)]
+    .environment[unparseKey(internal.CCompilerConfig.ccConfigKeyFull)]
     ?.asFileUri();
 
 /// Linker provided by the environment.
+///
+/// Provided on Dart CI.
 final Uri? ld = Platform
-    .environment[unparseKey(CCompilerConfig.ldConfigKeyFull)]
+    .environment[unparseKey(internal.CCompilerConfig.ldConfigKeyFull)]
     ?.asFileUri();
 
 /// Path to script that sets environment variables for [cc], [ld], and [ar].
 ///
-/// Provided by environment.
+/// Provided on Dart CI.
 final Uri? envScript = Platform
-    .environment[unparseKey(CCompilerConfig.envScriptConfigKeyFull)]
+    .environment[unparseKey(internal.CCompilerConfig.envScriptConfigKeyFull)]
     ?.asFileUri();
 
 /// Arguments for [envScript] provided by environment.
-final List<String>? envScriptArgs = Platform
-    .environment[unparseKey(CCompilerConfig.envScriptArgsConfigKeyFull)]
+///
+/// Provided on Dart CI.
+final List<String>? envScriptArgs = Platform.environment[
+        unparseKey(internal.CCompilerConfig.envScriptArgsConfigKeyFull)]
     ?.split(' ');
 
 extension on String {

--- a/pkgs/native_assets_cli/test/model/asset_test.dart
+++ b/pkgs/native_assets_cli/test/model/asset_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:collection/collection.dart';
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -99,15 +99,6 @@ void main() {
         (e) => e is FormatException && e.message.contains('Unknown pathType'),
       )),
     );
-  });
-
-  test('Asset hashCode copyWith', () async {
-    final asset = assets.first;
-    final asset2 = asset.copyWith(id: 'foo321');
-    expect(asset.hashCode != asset2.hashCode, true);
-
-    final asset3 = asset.copyWith();
-    expect(asset.hashCode, asset3.hashCode);
   });
 
   test('List<Asset> hashCode', () async {

--- a/pkgs/native_assets_cli/test/model/asset_test.dart
+++ b/pkgs/native_assets_cli/test/model/asset_test.dart
@@ -101,6 +101,15 @@ void main() {
     );
   });
 
+  test('Asset hashCode copyWith', () async {
+    final asset = assets.first;
+    final asset2 = asset.copyWith(id: 'foo321');
+    expect(asset.hashCode != asset2.hashCode, true);
+
+    final asset3 = asset.copyWith();
+    expect(asset.hashCode, asset3.hashCode);
+  });
+
   test('List<Asset> hashCode', () async {
     final assets2 = assets.take(3).toList();
     const equality = ListEquality<Asset>();

--- a/pkgs/native_assets_cli/test/model/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_config_test.dart
@@ -5,7 +5,7 @@
 import 'dart:io';
 
 import 'package:cli_config/cli_config.dart';
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_cli/test/model/build_output_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_output_test.dart
@@ -4,7 +4,7 @@
 
 import 'dart:io';
 
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/pkgs/native_assets_cli/test/model/dependencies_test.dart
+++ b/pkgs/native_assets_cli/test/model/dependencies_test.dart
@@ -4,7 +4,7 @@
 
 import 'dart:io';
 
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/pkgs/native_assets_cli/test/model/metadata_test.dart
+++ b/pkgs/native_assets_cli/test/model/metadata_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/pkgs/native_assets_cli/test/model/target_test.dart
+++ b/pkgs/native_assets_cli/test/model/target_test.dart
@@ -5,7 +5,7 @@
 import 'dart:ffi';
 import 'dart:io';
 
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/compiler_resolver.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/compiler_resolver.dart
@@ -32,10 +32,7 @@ class CompilerResolver {
 
   Future<ToolInstance> resolveCompiler() async {
     // First, check if the launcher provided a direct path to the compiler.
-    var result = await _tryLoadCompilerFromConfig(
-      CCompilerConfig.ccConfigKeyFull,
-      (buildConfig) => buildConfig.cCompiler.cc,
-    );
+    var result = await _tryLoadCompilerFromConfig();
 
     // Then, try to detect on the host machine.
     final tool = _selectCompiler();
@@ -95,18 +92,16 @@ class CompilerResolver {
     return null;
   }
 
-  Future<ToolInstance?> _tryLoadCompilerFromConfig(
-      String configKey, Uri? Function(BuildConfig) getter) async {
-    final configCcUri = getter(buildConfig);
+  Future<ToolInstance?> _tryLoadCompilerFromConfig() async {
+    final configCcUri = buildConfig.cCompiler.cc;
     if (configCcUri != null) {
       assert(await File.fromUri(configCcUri).exists());
       logger?.finer('Using compiler ${configCcUri.toFilePath()} '
-          'from config[${CCompilerConfig.ccConfigKeyFull}].');
+          'from BuildConfig.cCompiler.cc.');
       return (await CompilerRecognizer(configCcUri).resolve(logger: logger))
           .first;
     }
-    logger?.finer(
-        'No compiler set in config[${CCompilerConfig.ccConfigKeyFull}].');
+    logger?.finer('No compiler set in BuildConfig.cCompiler.cc.');
     return null;
   }
 
@@ -120,10 +115,7 @@ class CompilerResolver {
 
   Future<ToolInstance> resolveArchiver() async {
     // First, check if the launcher provided a direct path to the compiler.
-    var result = await _tryLoadArchiverFromConfig(
-      CCompilerConfig.arConfigKeyFull,
-      (buildConfig) => buildConfig.cCompiler.ar,
-    );
+    var result = await _tryLoadArchiverFromConfig();
 
     // Then, try to detect on the host machine.
     final tool = _selectArchiver();
@@ -184,18 +176,16 @@ class CompilerResolver {
     return null;
   }
 
-  Future<ToolInstance?> _tryLoadArchiverFromConfig(
-      String configKey, Uri? Function(BuildConfig) getter) async {
-    final configArUri = getter(buildConfig);
+  Future<ToolInstance?> _tryLoadArchiverFromConfig() async {
+    final configArUri = buildConfig.cCompiler.ar;
     if (configArUri != null) {
       assert(await File.fromUri(configArUri).exists());
       logger?.finer('Using archiver ${configArUri.toFilePath()} '
-          'from config[${CCompilerConfig.arConfigKeyFull}].');
+          'from BuildConfig.cCompiler.ar.');
       return (await ArchiverRecognizer(configArUri).resolve(logger: logger))
           .first;
     }
-    logger?.finer(
-        'No archiver set in config[${CCompilerConfig.arConfigKeyFull}].');
+    logger?.finer('No compiler set in BuildConfig.cCompiler.ar.');
     return null;
   }
 

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   glob: ^2.1.1
   logging: ^1.1.1
   meta: ^1.9.1
-  native_assets_cli: ^0.3.2
+  native_assets_cli: ^0.4.0
   pub_semver: ^2.1.3
 
 dev_dependencies:

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -7,7 +7,6 @@ import 'dart:ffi';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
-import 'package:native_assets_cli/native_assets_cli_internal.dart' as internal;
 import 'package:native_toolchain_c/src/native_toolchain/apple_clang.dart';
 import 'package:native_toolchain_c/src/utils/run_process.dart';
 import 'package:test/test.dart';
@@ -123,36 +122,29 @@ String unparseKey(String key) => key.replaceAll('.', '__').toUpperCase();
 /// Archiver provided by the environment.
 ///
 /// Provided on Dart CI.
-final Uri? ar = Platform
-    .environment[unparseKey(internal.CCompilerConfig.arConfigKeyFull)]
-    ?.asFileUri();
+final Uri? ar = Platform.environment[unparseKey('c_compiler.ar')]?.asFileUri();
 
 /// Compiler provided by the environment.
 ///
 /// Provided on Dart CI.
-final Uri? cc = Platform
-    .environment[unparseKey(internal.CCompilerConfig.ccConfigKeyFull)]
-    ?.asFileUri();
+final Uri? cc = Platform.environment[unparseKey('c_compiler.cc')]?.asFileUri();
 
 /// Linker provided by the environment.
 ///
 /// Provided on Dart CI.
-final Uri? ld = Platform
-    .environment[unparseKey(internal.CCompilerConfig.ldConfigKeyFull)]
-    ?.asFileUri();
+final Uri? ld = Platform.environment[unparseKey('c_compiler.ld')]?.asFileUri();
 
 /// Path to script that sets environment variables for [cc], [ld], and [ar].
 ///
 /// Provided on Dart CI.
-final Uri? envScript = Platform
-    .environment[unparseKey(internal.CCompilerConfig.envScriptConfigKeyFull)]
-    ?.asFileUri();
+final Uri? envScript =
+    Platform.environment[unparseKey('c_compiler.env_script')]?.asFileUri();
 
 /// Arguments for [envScript] provided by environment.
 ///
 /// Provided on Dart CI.
-final List<String>? envScriptArgs = Platform.environment[
-        unparseKey(internal.CCompilerConfig.envScriptArgsConfigKeyFull)]
+final List<String>? envScriptArgs = Platform
+    .environment[unparseKey('c_compiler.env_script_arguments')]
     ?.split(' ');
 
 extension on String {

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -7,7 +7,7 @@ import 'dart:ffi';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart' as internal;
 import 'package:native_toolchain_c/src/native_toolchain/apple_clang.dart';
 import 'package:native_toolchain_c/src/utils/run_process.dart';
 import 'package:test/test.dart';
@@ -121,30 +121,38 @@ extension on Uri {
 String unparseKey(String key) => key.replaceAll('.', '__').toUpperCase();
 
 /// Archiver provided by the environment.
+///
+/// Provided on Dart CI.
 final Uri? ar = Platform
-    .environment[unparseKey(CCompilerConfig.arConfigKeyFull)]
+    .environment[unparseKey(internal.CCompilerConfig.arConfigKeyFull)]
     ?.asFileUri();
 
 /// Compiler provided by the environment.
+///
+/// Provided on Dart CI.
 final Uri? cc = Platform
-    .environment[unparseKey(CCompilerConfig.ccConfigKeyFull)]
+    .environment[unparseKey(internal.CCompilerConfig.ccConfigKeyFull)]
     ?.asFileUri();
 
 /// Linker provided by the environment.
+///
+/// Provided on Dart CI.
 final Uri? ld = Platform
-    .environment[unparseKey(CCompilerConfig.ldConfigKeyFull)]
+    .environment[unparseKey(internal.CCompilerConfig.ldConfigKeyFull)]
     ?.asFileUri();
 
 /// Path to script that sets environment variables for [cc], [ld], and [ar].
 ///
-/// Provided by environment.
+/// Provided on Dart CI.
 final Uri? envScript = Platform
-    .environment[unparseKey(CCompilerConfig.envScriptConfigKeyFull)]
+    .environment[unparseKey(internal.CCompilerConfig.envScriptConfigKeyFull)]
     ?.asFileUri();
 
 /// Arguments for [envScript] provided by environment.
-final List<String>? envScriptArgs = Platform
-    .environment[unparseKey(CCompilerConfig.envScriptArgsConfigKeyFull)]
+///
+/// Provided on Dart CI.
+final List<String>? envScriptArgs = Platform.environment[
+        unparseKey(internal.CCompilerConfig.envScriptArgsConfigKeyFull)]
     ?.split(' ');
 
 extension on String {


### PR DESCRIPTION
This does not change any of the public API yet, but it slims down the API surface of `package:native_assets_cli` to the bare minimum.

Internal details may be accessed in `package:native_assets_builder` via:

```dart
import 'package:native_assets_cli/native_assets_cli_internal.dart';
```

This enables the yaml serialization/deserialization to live in one place and be unit tested as one.

One hack is that we also access `package:native_assets_cli/native_assets_cli_internal.dart` in `package:native_toolchain_c` in the unit tests to depend on the C compilers provided on the Dart CI.