### PR TITLE
[native_assets_cli] v0.4.0

### DIFF
--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,10 +1,9 @@
-## 0.4.0-wip
+## 0.4.0
 
 - Added [example/use_dart_api/](example/use_dart_api/) detailing how to use
   `dart_api_dl.h` from the Dart SDK in native code.
 - **Breaking change** Moved code not used in `build.dart` to
   `package:native_assets_builder`.
-
 
 ## 0.3.2
 

--- a/pkgs/native_assets_cli/lib/native_assets_cli_internal.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli_internal.dart
@@ -2,8 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// A library that contains the argument and file formats for implementing a
-/// native assets CLI, e.g. a `build.dart` script.
+/// This library should not be used by `build.dart` scripts.
+///
+/// Only `package:native_assets_builder` should use this.
 library native_assets_cli;
 
 export 'src/model/asset.dart';

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   native assets CLI.
 
 # Note: Bump BuildConfig.version and BuildOutput.version on breaking changes!
-version: 0.4.0-wip
+version: 0.4.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
 topics:


### PR DESCRIPTION
Introduces `pkg/native_assets_cli/native_assets_cli_internal.dart` and bumps the version.

* https://github.com/dart-lang/native/pull/885#issuecomment-1885284368