### PR TITLE
[native_toolchain_c] Bump native_assets_cli to 0.4.0

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4
+
+- Bump `package:native_assets_cli` to 0.4.0.
+
 ## 0.3.3
 
 - Export `environmentFromBatchFile`.

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.3.3
+version: 0.3.4
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:
@@ -12,14 +12,14 @@ topics:
   - native-toolchain
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
+  sdk: '>=3.1.0 <4.0.0'
 
 dependencies:
   cli_config: ^0.1.1
   glob: ^2.1.1
   logging: ^1.1.1
   meta: ^1.9.1
-  native_assets_cli: ^0.3.2
+  native_assets_cli: ^0.4.0
   pub_semver: ^2.1.3
 
 dev_dependencies:


### PR DESCRIPTION
This is needed before we can bump `native_assets_cli` in any packages using `native_toolchain_c`.