### PR TITLE
[native_assets_cli] Release 0.4.1

### DIFF
--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.1-wip
+## 0.4.1
 
 - **Breaking change** Removed all code not used in `build.dart` scripts out of
   the public API.

--- a/pkgs/native_assets_cli/lib/src/api/build_output.dart
+++ b/pkgs/native_assets_cli/lib/src/api/build_output.dart
@@ -15,6 +15,15 @@ import 'dependencies.dart';
 import 'metadata.dart';
 
 abstract class BuildOutput {
+  /// Time the build this output belongs to started.
+  ///
+  /// Rounded down to whole seconds, because [File.lastModified] is rounded
+  /// to whole seconds and caching logic compares these timestamps.
+  DateTime get timestamp;
+  List<Asset> get assets;
+  Dependencies get dependencies;
+  Metadata get metadata;
+
   factory BuildOutput({
     DateTime? timestamp,
     List<Asset>? assets,

--- a/pkgs/native_assets_cli/lib/src/api/build_output.dart
+++ b/pkgs/native_assets_cli/lib/src/api/build_output.dart
@@ -15,15 +15,6 @@ import 'dependencies.dart';
 import 'metadata.dart';
 
 abstract class BuildOutput {
-  /// Time the build this output belongs to started.
-  ///
-  /// Rounded down to whole seconds, because [File.lastModified] is rounded
-  /// to whole seconds and caching logic compares these timestamps.
-  DateTime get timestamp;
-  List<Asset> get assets;
-  Dependencies get dependencies;
-  Metadata get metadata;
-
   factory BuildOutput({
     DateTime? timestamp,
     List<Asset>? assets,

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   native assets CLI.
 
 # Note: Bump BuildConfig.version and BuildOutput.version on breaking changes!
-version: 0.4.1-wip
+version: 0.4.1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
 topics:


### PR DESCRIPTION
Release a version with a smaller API before starting to do breaking changes to the API.