### PR TITLE
[native_toolchain_c] Remove private dependency use

### DIFF
--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -63,6 +63,8 @@ jobs:
           ndk-version: r26b
         if: ${{ matrix.sdk == 'stable' }}
 
+      - run: dart run ../../tools/check_pubspec_overrides.dart
+
       - run: dart run ../../tools/delete_pubspec_overrides.dart
         if: ${{ matrix.dependencies == 'published' }}
 

--- a/pkgs/native_assets_builder/test/data/dart_app/pubspec_overrides.yaml
+++ b/pkgs/native_assets_builder/test/data/dart_app/pubspec_overrides.yaml
@@ -1,0 +1,5 @@
+dependency_overrides:
+  native_assets_cli:
+    path: ../../../../native_assets_cli/
+  native_toolchain_c:
+    path: ../../../../native_toolchain_c/

--- a/pkgs/native_assets_builder/test/data/manifest.yaml
+++ b/pkgs/native_assets_builder/test/data/manifest.yaml
@@ -8,6 +8,7 @@
 - cyclic_package_2/pubspec_overrides.yaml
 - dart_app/bin/dart_app.dart
 - dart_app/pubspec.yaml
+- dart_app/pubspec_overrides.yaml
 - native_add/build.dart
 - native_add/ffigen.yaml
 - native_add/lib/native_add.dart

--- a/pkgs/native_assets_builder/test/data/some_dev_dep/pubspec_overrides.yaml
+++ b/pkgs/native_assets_builder/test/data/some_dev_dep/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  native_assets_cli:
+    path: ../../../../native_assets_cli/

--- a/pkgs/native_assets_cli/example/native_add_app/pubspec_overrides.yaml
+++ b/pkgs/native_assets_cli/example/native_add_app/pubspec_overrides.yaml
@@ -1,0 +1,5 @@
+dependency_overrides:
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+  native_toolchain_c:
+    path: ../../../native_toolchain_c/

--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4+1
+
+- Stop depending on private `package:native_assets_cli` `CCompilerConfig` fields.
+
 ## 0.3.4
 
 - Bump `package:native_assets_cli` to 0.4.0.

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.3.4
+version: 0.3.4+1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:

--- a/tools/check_pubspec_overrides.dart
+++ b/tools/check_pubspec_overrides.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+void main(List<String> arguments) async {
+  final allPubspecs = await Directory.current
+      .list(recursive: true)
+      .where((f) => f.path.endsWith('pubspec.yaml'))
+      .map((f) => f as File)
+      .toList();
+  final nativePubspecs =
+      allPubspecs.where((f) => f.path.contains('pkgs/native_')).toList();
+  final missingOverrides = nativePubspecs
+      .map((element) =>
+          File.fromUri(element.uri.resolve('pubspec_overrides.yaml')))
+      .where((f) => !f.existsSync())
+      .where((f) =>
+          !f.path.endsWith('pkgs/native_assets_cli/pubspec_overrides.yaml'))
+      .toList()
+      .join('\n');
+  if (missingOverrides.isEmpty) {
+    print('No missing overrides.');
+  } else {
+    print('Missing overrides:');
+    print(missingOverrides);
+    exit(1);
+  }
+}


### PR DESCRIPTION
I probably should not have used 'skip-breaking-change' on https://github.com/dart-lang/native/pull/885. 🤓 

```
  SEVERE: 2024-01-15 10:29:49.412987: /home/runner/.pub-cache/hosted/pub.dev/native_toolchain_c-0.3.4/lib/src/cbuilder/compiler_resolver.dart:36:23: Error: Member not found: 'ccConfigKeyFull'.
  
  SEVERE: 2024-01-15 10:29:49.413145:       CCompilerConfig.ccConfigKeyFull,
```

Creating a patch release to patch this up.

Probably the CI will keep failing until we hit merge and then publish.