### PR TITLE
[ffi] Cleanup after move and bump to v2.1.2

### DIFF
--- a/.github/workflows/ffi.yaml
+++ b/.github/workflows/ffi.yaml
@@ -1,4 +1,4 @@
-name: Dart CI
+name: ffi
 
 on:
   # Run on PRs and pushes to the default branch.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ building and bundling.
 
 | Package | Description | Version |
 | --- | --- | --- |
+| [ffi](pkgs/ffi/) | Utilities for working with Foreign Function Interface (FFI) code. | [![pub package](https://img.shields.io/pub/v/ffi.svg)](https://pub.dev/packages/ffi) |
 | [ffigen](pkgs/ffigen/) | Generator for FFI bindings, using LibClang to parse C, Objective-C, and Swift files. | [![pub package](https://img.shields.io/pub/v/ffigen.svg)](https://pub.dev/packages/ffigen) |
 | [jni](pkgs/jni/) | A library to access JNI from Dart and Flutter that acts as a support library for `package:jnigen`. | [![pub package](https://img.shields.io/pub/v/jni.svg)](https://pub.dev/packages/jni) |
 | [jnigen](pkgs/jnigen/) | A Dart bindings generator for Java and Kotlin that uses JNI under the hood to interop with Java virtual machine. | [![pub package](https://img.shields.io/pub/v/jnigen.svg)](https://pub.dev/packages/jnigen) |

--- a/pkgs/ffi/CHANGELOG.md
+++ b/pkgs/ffi/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.2
+
+- Update repository to point to dart-lang/native.
+
 ## 2.1.1
 
 - Require Dart 3.3.0 or greater.

--- a/pkgs/ffi/README.md
+++ b/pkgs/ffi/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://github.com/dart-lang/ffi/workflows/Dart%20CI/badge.svg)](https://github.com/dart-lang/ffi/actions?query=workflow%3A"Dart+CI")
+[![Build Status](https://github.com/dart-lang/native/actions/workflows/ffi.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/ffi.yaml)
+[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
 [![pub package](https://img.shields.io/pub/v/ffi.svg)](https://pub.dev/packages/ffi)
 [![package publisher](https://img.shields.io/pub/publisher/ffi.svg)](https://pub.dev/packages/ffi/publisher)
 

--- a/pkgs/ffi/pubspec.yaml
+++ b/pkgs/ffi/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ffi
-version: 2.1.1
+version: 2.1.2
 description: Utilities for working with Foreign Function Interface (FFI) code.
-repository: https://github.com/dart-lang/ffi
+repository: https://github.com/dart-lang/native/tree/main/pkgs/ffi
 
 topics:
   - interop


### PR DESCRIPTION
* Update repository in pubspec.yaml to point to the new location.
* Bump version so we can release to pub so the readme there points to this repo.
* Add to toplevel readme
* Update badge urls
* Fix workflow name
* Add issue template