### PR TITLE
[native_assets_builder] Add `AssetRelativePath` back in

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+- Reintroduce `AssetRelativePath`, it's used in `dart build`.
+
 ## 0.3.1
 
 - Add support for `runPackageName` to avoid native assets for packages that

--- a/pkgs/native_assets_builder/lib/src/model/asset.dart
+++ b/pkgs/native_assets_builder/lib/src/model/asset.dart
@@ -6,7 +6,16 @@ import 'package:native_assets_cli/native_assets_cli_internal.dart';
 
 import '../utils/yaml.dart';
 
-extension on AssetPath {}
+/// Asset at absolute path [uri].
+class AssetRelativePath implements AssetPath {
+  final Uri uri;
+
+  AssetRelativePath(this.uri);
+
+  // Never used in native_assets_cli, but the interface must be implemented.
+  @override
+  Map<String, Object> toYaml() => throw UnimplementedError();
+}
 
 extension AssetIterable on Iterable<Asset> {
   Iterable<Asset> whereLinkMode(LinkMode linkMode) =>
@@ -43,6 +52,8 @@ List<String> _toDartConst(AssetPath path) {
   switch (path) {
     case AssetAbsolutePath _:
       return ['absolute', path.uri.toFilePath()];
+    case AssetRelativePath _:
+      return ['relative', path.uri.toFilePath()];
     case AssetSystemPath _:
       return ['system', path.uri.toFilePath()];
     case AssetInProcess _:

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_assets_builder
 description: >-
   This package is the backend that invokes top-level `build.dart` scripts.
-version: 0.3.1
+version: 0.3.2
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_builder
 
 environment:

--- a/pkgs/native_assets_builder/test/model/asset_test.dart
+++ b/pkgs/native_assets_builder/test/model/asset_test.dart
@@ -11,6 +11,7 @@ import 'package:test/test.dart';
 
 void main() {
   final fooUri = Uri.file('path/to/libfoo.so');
+  final foo2Uri = Uri.file('path/to/libfoo2.so');
   final foo3Uri = Uri(path: 'libfoo3.so');
   final barUri = Uri(path: 'path/to/libbar.a');
   final blaUri = Uri(path: 'path/with spaces/bla.dll');
@@ -18,6 +19,12 @@ void main() {
     Asset(
       id: 'foo',
       path: AssetAbsolutePath(fooUri),
+      target: Target.androidX64,
+      linkMode: LinkMode.dynamic,
+    ),
+    Asset(
+      id: 'foo2',
+      path: AssetRelativePath(foo2Uri),
       target: Target.androidX64,
       linkMode: LinkMode.dynamic,
     ),
@@ -62,6 +69,9 @@ native-assets:
     foo:
       - absolute
       - ${fooUri.toFilePath()}
+    foo2:
+      - relative
+      - ${foo2Uri.toFilePath()}
     foo3:
       - system
       - ${foo3Uri.toFilePath()}
@@ -85,6 +95,10 @@ native-assets:
 
   test('List<Asset> whereLinkMode', () async {
     final assets2 = assets.whereLinkMode(LinkMode.dynamic);
-    expect(assets2.length, 5);
+    expect(assets2.length, 6);
+  });
+
+  test('satisfy coverage', () async {
+    expect(() => assets[1].toYaml(), throwsUnimplementedError);
   });
 }


### PR DESCRIPTION
It's being used in the Dart SDK, which I forgot about when deleting it. (It was deleted in https://github.com/dart-lang/native/pull/881, rather than moved.)

We need it back in order to roll.