### PR TITLE
[native_assets_cli] Fix dartdoc generation

### DIFF
--- a/pkgs/native_assets_cli/.gitignore
+++ b/pkgs/native_assets_cli/.gitignore
@@ -12,3 +12,6 @@ coverage/
 *.dylib
 *.exe
 *.so
+
+# Dartdoc dir
+doc/

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2
+
+- Fix dartdoc generation. Hide the implementation details.
+
 ## 0.4.1
 
 - **Breaking change** Removed all code not used in `build.dart` scripts out of

--- a/pkgs/native_assets_cli/dartdoc_options.yaml
+++ b/pkgs/native_assets_cli/dartdoc_options.yaml
@@ -1,0 +1,3 @@
+dartdoc:
+  nodoc:
+    - 'lib/native_assets_cli_internal.dart'

--- a/pkgs/native_assets_cli/lib/native_assets_cli_internal.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli_internal.dart
@@ -5,7 +5,7 @@
 /// This library should not be used by `build.dart` scripts.
 ///
 /// Only `package:native_assets_builder` should use this.
-library native_assets_cli;
+library native_assets_cli_internal;
 
 export 'src/model/asset.dart';
 export 'src/model/build_config.dart';

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   native assets CLI.
 
 # Note: Bump BuildConfig.version and BuildOutput.version on breaking changes!
-version: 0.4.1
+version: 0.4.2
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
 topics:


### PR DESCRIPTION
Both the internal library and the public one had the same name, confusing API doc generation.

This PR fixes the library name.

Moreover, this PR removes the API docs for the internal API so that users don't see it at all.

This should fix https://pub.dev/documentation/native_assets_cli/latest/ after merging.

I've run `dart doc` locally to verify.