### PR TITLE
[native_assets_cli] Better fix for dartdoc

### DIFF
--- a/pkgs/native_assets_cli/dartdoc_options.yaml
+++ b/pkgs/native_assets_cli/dartdoc_options.yaml
@@ -1,3 +1,0 @@
-dartdoc:
-  nodoc:
-    - 'lib/native_assets_cli_internal.dart'

--- a/pkgs/native_assets_cli/lib/native_assets_cli_internal.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli_internal.dart
@@ -5,6 +5,7 @@
 /// This library should not be used by `build.dart` scripts.
 ///
 /// Only `package:native_assets_builder` should use this.
+/// @nodoc
 library native_assets_cli_internal;
 
 export 'src/model/asset.dart';


### PR DESCRIPTION
Turns out that `@nodoc` is supposed to be in the comment, not an annotation.