### PR TITLE
[native_assets_builder] Publish v0.4.0

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,7 +1,6 @@
-## 0.4.0-wip
+## 0.4.0
 
 - **Breaking change**: Split out the `KernelAsset`s from normal `Asset`s.
-- Bump `package:native_assets_cli` to path dependency.
 
 ## 0.3.2
 

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -1,20 +1,18 @@
 name: native_assets_builder
 description: >-
   This package is the backend that invokes top-level `build.dart` scripts.
-version: 0.4.0-wip
+version: 0.4.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_builder
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
 
-publish_to: none
-
 dependencies:
   graphs: ^2.3.1
   logging: ^1.2.0
-  # native_assets_cli: ^0.4.1
-  native_assets_cli:
-    path: ../native_assets_cli/
+  native_assets_cli: ^0.4.2
+  # native_assets_cli:
+  #   path: ../native_assets_cli/
   package_config: ^2.1.0
   yaml: ^3.1.2
   yaml_edit: ^2.1.0

--- a/pkgs/native_assets_builder/test_data/cyclic_package_1/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/cyclic_package_1/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
   cli_config: ^0.1.1
   cyclic_package_2:
     path: ../cyclic_package_2
-  # native_assets_cli: ^0.4.1
   native_assets_cli:
     path: ../../../native_assets_cli/
   yaml: ^3.1.1

--- a/pkgs/native_assets_builder/test_data/cyclic_package_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/cyclic_package_2/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
   cli_config: ^0.1.1
   cyclic_package_1:
     path: ../cyclic_package_1
-  # native_assets_cli: ^0.4.1
   native_assets_cli:
     path: ../../../native_assets_cli/
   yaml: ^3.1.1

--- a/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
-  # native_assets_cli: ^0.4.1
   native_assets_cli:
     path: ../../../native_assets_cli/
   # native_toolchain_c: ^0.3.4+1

--- a/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
-  # native_assets_cli: ^0.4.1
   native_assets_cli:
     path: ../../../native_assets_cli/
   # native_toolchain_c: ^0.3.4+1

--- a/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
-  # native_assets_cli: ^0.4.1
   native_assets_cli:
     path: ../../../native_assets_cli/
   # native_toolchain_c: ^0.3.4+1

--- a/pkgs/native_assets_builder/test_data/package_reading_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/package_reading_metadata/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 
 dependencies:
   cli_config: ^0.1.1
-  # native_assets_cli: ^0.4.1
   native_assets_cli:
     path: ../../../native_assets_cli/
   package_with_metadata:

--- a/pkgs/native_assets_builder/test_data/package_with_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/package_with_metadata/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 
 dependencies:
   cli_config: ^0.1.1
-  # native_assets_cli: ^0.4.1
   native_assets_cli:
     path: ../../../native_assets_cli/
   yaml: ^3.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_build_output/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 
 dependencies:
   cli_config: ^0.1.1
-  # native_assets_cli: ^0.4.1
   native_assets_cli:
     path: ../../../native_assets_cli/
   yaml: ^3.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_build_output_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output_2/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 
 dependencies:
   cli_config: ^0.1.1
-  # native_assets_cli: ^0.4.1
   native_assets_cli:
     path: ../../../native_assets_cli/
   yaml: ^3.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_build_output_3/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output_3/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 
 dependencies:
   cli_config: ^0.1.1
-  # native_assets_cli: ^0.4.1
   native_assets_cli:
     path: ../../../native_assets_cli/
   yaml: ^3.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_namespace_asset/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_namespace_asset/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 
 dependencies:
   cli_config: ^0.1.1
-  # native_assets_cli: ^0.4.1
   native_assets_cli:
     path: ../../../native_assets_cli/
   yaml: ^3.1.1

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.3-wip
 
-- Bump examples dependencies to path dependencies.
+- Bump examples dependencies to path dependencies. (2x)
 
 ## 0.4.2
 

--- a/pkgs/native_assets_cli/example/native_add_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/native_add_library/pubspec.yaml
@@ -11,10 +11,8 @@ environment:
 dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
-  # native_assets_cli: ^0.4.1
   native_assets_cli:
     path: ../../../native_assets_cli/
-  # native_toolchain_c: ^0.3.4+1
   native_toolchain_c:
     path: ../../../native_toolchain_c/
 

--- a/pkgs/native_assets_cli/example/use_dart_api/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/use_dart_api/pubspec.yaml
@@ -10,10 +10,8 @@ environment:
 dependencies:
   cli_config: ^0.1.1
   logging: ^1.1.1
-  # native_assets_cli: ^0.4.1
   native_assets_cli:
     path: ../../../native_assets_cli/
-  # native_toolchain_c: ^0.3.4+1
   native_toolchain_c:
     path: ../../../native_toolchain_c/
 


### PR DESCRIPTION
Bumps native_assets_cli dependency back to 0.4.2 (0.4.3-wip only has example pubspec changes).

Also removes all the example stable versions of dependencies. I think we probably only want to support running the examples with path dependencies.
