### PR TITLE
[native_assets_builder] Hide `KernelAssets` field

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0
+
+- **Breaking change**: Hide implementation of `KernelAssets`.
+
 ## 0.4.0
 
 - **Breaking change**: Split out the `KernelAsset`s from normal `Asset`s.

--- a/pkgs/native_assets_builder/lib/src/model/kernel_assets.dart
+++ b/pkgs/native_assets_builder/lib/src/model/kernel_assets.dart
@@ -19,13 +19,13 @@ import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import '../utils/yaml.dart';
 
 class KernelAssets {
-  final List<KernelAsset> assets;
+  final List<KernelAsset> _assets;
 
-  KernelAssets(this.assets);
+  KernelAssets(Iterable<KernelAsset> assets) : _assets = [...assets];
 
   String toNativeAssetsFile() {
     final assetsPerTarget = <Target, List<KernelAsset>>{};
-    for (final asset in assets) {
+    for (final asset in _assets) {
       final assets = assetsPerTarget[asset.target] ?? [];
       assets.add(asset);
       assetsPerTarget[asset.target] = assets;

--- a/pkgs/native_assets_builder/lib/src/model/kernel_assets.dart
+++ b/pkgs/native_assets_builder/lib/src/model/kernel_assets.dart
@@ -21,7 +21,7 @@ import '../utils/yaml.dart';
 class KernelAssets {
   final List<KernelAsset> _assets;
 
-  KernelAssets(Iterable<KernelAsset> assets) : _assets = [...assets];
+  KernelAssets([Iterable<KernelAsset>? assets]) : _assets = [...?assets];
 
   String toNativeAssetsFile() {
     final assetsPerTarget = <Target, List<KernelAsset>>{};

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_assets_builder
 description: >-
   This package is the backend that invokes top-level `build.dart` scripts.
-version: 0.4.0
+version: 0.5.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_builder
 
 environment:


### PR DESCRIPTION
Some cleanup of the last PR that will make the Flutter PR https://github.com/flutter/flutter/pull/143472 slightly cleaner.

Changes the constructor to take an optional iterable instead of a required list.