### PR TITLE
[infra] Remove broken breaking bot from jnigen

### DIFF
--- a/.github/workflows/health_jnigen.yaml
+++ b/.github/workflows/health_jnigen.yaml
@@ -2,20 +2,17 @@ name: Health
 on:
   pull_request:
     branches: [ main ]
-    # Remove paths after https://github.com/bmw-tech/dart_apitool/issues/177 is addressed.
+    # Merge back into health.yaml after https://github.com/bmw-tech/dart_apitool/issues/177 is addressed.
     paths:
-      - "pkgs/ffi/**"
-      - "pkgs/ffigen/**"
-      - "pkgs/native_assets_builder/**"
-      - "pkgs/native_assets_cli/**"
-      - "pkgs/native_toolchain_c/**"
+      - "pkgs/jni/**"
+      - "pkgs/jnigen/**"
     types: [opened, synchronize, reopened, labeled, unlabeled]
 jobs:
   health:
     uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
     with:
       coverage_web: false
-      checks: "version,changelog,license,do-not-submit,breaking,coverage"
+      checks: "version,changelog,license,do-not-submit,coverage"
       use-flutter: true
       sdk: master
     permissions:


### PR DESCRIPTION
Due to https://github.com/bmw-tech/dart_apitool/issues/177, every PR on JNIgen is currently failing. This is causing noise.

This PR removes the breaking change check from JNIgen and JNI.