### PR TITLE
Fix getID bug

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -44,6 +44,11 @@
 - **Breaking Change**: `JArray.filled` now uses the generated type class of the
   `fill` object and not its Java runtime type.
 
+## 0.7.3
+
+- Fixed a bug where `get(Static)MethodID` and `get(Static)FieldID` could access
+  null and throw.
+
 ## 0.7.2
 
 - Fixed a bug where reading non-null terminated strings would overflow.

--- a/pkgs/jni/src/dartjni.c
+++ b/pkgs/jni/src/dartjni.c
@@ -207,25 +207,28 @@ static inline JniPointerResult _getId(MemberGetter getter,
                                       char* name,
                                       char* sig) {
   JniPointerResult result = {NULL, NULL};
-  attach_thread();
   result.value = getter(jniEnv, cls, name, sig);
   result.exception = check_exception();
   return result;
 }
 
 JniPointerResult getMethodID(jclass cls, char* name, char* sig) {
+  attach_thread();
   return _getId((MemberGetter)(*jniEnv)->GetMethodID, cls, name, sig);
 }
 
 JniPointerResult getStaticMethodID(jclass cls, char* name, char* sig) {
+  attach_thread();
   return _getId((MemberGetter)(*jniEnv)->GetStaticMethodID, cls, name, sig);
 }
 
 JniPointerResult getFieldID(jclass cls, char* name, char* sig) {
+  attach_thread();
   return _getId((MemberGetter)(*jniEnv)->GetFieldID, cls, name, sig);
 }
 
 JniPointerResult getStaticFieldID(jclass cls, char* name, char* sig) {
+  attach_thread();
   return _getId((MemberGetter)(*jniEnv)->GetStaticFieldID, cls, name, sig);
 }
 


### PR DESCRIPTION
`jniEnv` could be null before calling `attachThread`, even for getting the function pointer.

Might fix https://github.com/dart-lang/http/issues/1152.
