### PR TITLE
Add assert to castTo

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -43,6 +43,8 @@
 - **Breaking Change**: Primitive types and their type classes are now `final`.
 - **Breaking Change**: `JArray.filled` now uses the generated type class of the
   `fill` object and not its Java runtime type.
+- `JObject`s now check the types using `instanceof` in debug mode when using
+  `castTo`.
 
 ## 0.7.2
 

--- a/pkgs/jni/lib/src/errors.dart
+++ b/pkgs/jni/lib/src/errors.dart
@@ -4,7 +4,7 @@
 
 import 'package:jni/src/third_party/generated_bindings.dart';
 
-// TODO(#393): Add the fact that [JException] is now a [JObject] to the
+// TODO(#567): Add the fact that [JException] is now a [JObject] to the
 // CHANGELOG.
 
 final class UseAfterReleaseError extends Error {
@@ -14,7 +14,7 @@ final class UseAfterReleaseError extends Error {
   }
 }
 
-// TODO(#393): Use NullPointerError once it's available.
+// TODO(#567): Use NullPointerError once it's available.
 final class JNullError extends Error {
   @override
   String toString() => 'The reference was null';
@@ -85,7 +85,7 @@ final class NoJvmInstanceError extends Error {
   String toString() => 'No JNI instance is available';
 }
 
-// TODO(#393): Remove this class in favor of `JThrowable`.
+// TODO(#567): Remove this class in favor of `JThrowable`.
 class JniException implements Exception {
   /// Error message from Java exception.
   final String message;

--- a/pkgs/jni/lib/src/jobject.dart
+++ b/pkgs/jni/lib/src/jobject.dart
@@ -77,6 +77,10 @@ class JObject {
     JObjType<T> type, {
     bool releaseOriginal = false,
   }) {
+    assert(
+      Jni.env.IsInstanceOf(reference.pointer, type.jClass.reference.pointer),
+      'The object must be of type "${type.signature}".',
+    );
     if (releaseOriginal) {
       final ret = type.fromReference(JGlobalReference(reference.pointer));
       reference.setAsReleased();

--- a/pkgs/jni/test/jobject_test.dart
+++ b/pkgs/jni/test/jobject_test.dart
@@ -288,4 +288,18 @@ void run({required TestRunnerCallback testRunner}) {
         longClass.staticFieldId("MAX_VALUE", "J").get(longClass, jlong.type);
     expect(maxLong, maxLongInJava);
   });
+
+  testRunner('Casting correctly succeeds', () {
+    final long = JLong(1);
+    final long2 = long.castTo(JLong.type, releaseOriginal: true);
+    expect(long2.longValue(releaseOriginal: true), 1);
+  });
+
+  testRunner('Casting incorrectly fails', () {
+    final long = JLong(1);
+    expect(
+      () => long.castTo(JInteger.type, releaseOriginal: true),
+      throwsA(isA<AssertionError>()),
+    );
+  });
 }


### PR DESCRIPTION
Alternative considered:

Instead of assertion, we could add a `unsafe = false` named parameter to `castTo` and throw an `JClassCastError` instead.

Reason against going with it: This forcefully adds a call to `instanceof` but with assertion, we don't have any overhead in production while still getting the benefit while development.

Closes #986.