### PR TITLE
[native_assets_cli] Examples `build.dart` -> `hook/build.dart`

### DIFF
--- a/pkgs/native_assets_cli/example/local_asset/hook/build.dart
+++ b/pkgs/native_assets_cli/example/local_asset/hook/build.dart
@@ -27,9 +27,7 @@ void main(List<String> args) async {
 
       output.addDependencies([
         assetSourcePath,
-        // TODO(https://github.com/dart-lang/native/issues/823): Update after
-        // change is rolled into Dart SDK.
-        config.packageRoot.resolve('build.dart'),
+        config.packageRoot.resolve('hook/build.dart'),
       ]);
     }
 

--- a/pkgs/native_assets_cli/example/native_add_library/hook/build.dart
+++ b/pkgs/native_assets_cli/example/native_add_library/hook/build.dart
@@ -6,29 +6,23 @@ import 'package:logging/logging.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
-const packageName = 'use_dart_api';
-
-void main(List<String> arguments) async {
-  await build(arguments, (config, output) async {
+void main(List<String> args) async {
+  await build(args, (config, output) async {
+    final packageName = config.packageName;
     final cbuilder = CBuilder.library(
       name: packageName,
-      assetName: 'src/${packageName}_bindings_generated.dart',
+      assetName: '$packageName.dart',
       sources: [
         'src/$packageName.c',
-        'src/dart_api_dl.c',
       ],
-      // TODO(https://github.com/dart-lang/native/issues/823): Update after
-      // change is rolled into Dart SDK.
-      dartBuildFiles: ['build.dart'],
+      dartBuildFiles: ['hook/build.dart'],
     );
     await cbuilder.run(
       buildConfig: config,
       buildOutput: output,
       logger: Logger('')
         ..level = Level.ALL
-        ..onRecord.listen((record) {
-          print('${record.level.name}: ${record.time}: ${record.message}');
-        }),
+        ..onRecord.listen((record) => print(record.message)),
     );
   });
 }

--- a/pkgs/native_assets_cli/example/use_dart_api/hook/build.dart
+++ b/pkgs/native_assets_cli/example/use_dart_api/hook/build.dart
@@ -6,25 +6,27 @@ import 'package:logging/logging.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
-void main(List<String> args) async {
-  await build(args, (config, output) async {
-    final packageName = config.packageName;
+const packageName = 'use_dart_api';
+
+void main(List<String> arguments) async {
+  await build(arguments, (config, output) async {
     final cbuilder = CBuilder.library(
       name: packageName,
-      assetName: '$packageName.dart',
+      assetName: 'src/${packageName}_bindings_generated.dart',
       sources: [
         'src/$packageName.c',
+        'src/dart_api_dl.c',
       ],
-      // TODO(https://github.com/dart-lang/native/issues/823): Update after
-      // change is rolled into Dart SDK.
-      dartBuildFiles: ['build.dart'],
+      dartBuildFiles: ['hook/build.dart'],
     );
     await cbuilder.run(
       buildConfig: config,
       buildOutput: output,
       logger: Logger('')
         ..level = Level.ALL
-        ..onRecord.listen((record) => print(record.message)),
+        ..onRecord.listen((record) {
+          print('${record.level.name}: ${record.time}: ${record.message}');
+        }),
     );
   });
 }

--- a/pkgs/native_assets_cli/test/example/local_asset_test.dart
+++ b/pkgs/native_assets_cli/test/example/local_asset_test.dart
@@ -38,9 +38,7 @@ void main() async {
       final processResult = await Process.run(
         dartUri.toFilePath(),
         [
-          // TODO(https://github.com/dart-lang/native/issues/823): Update after
-          // change is rolled into Dart SDK.
-          'build.dart',
+          'hook/build.dart',
           '-Dout_dir=${tempUri.toFilePath()}',
           '-Dpackage_name=$name',
           '-Dpackage_root=${testPackageUri.toFilePath()}',
@@ -85,9 +83,7 @@ void main() async {
           dependencies,
           [
             testPackageUri.resolve('data/asset.txt'),
-            // TODO(https://github.com/dart-lang/native/issues/823): Update after
-            // change is rolled into Dart SDK.
-            testPackageUri.resolve('build.dart'),
+            testPackageUri.resolve('hook/build.dart'),
           ],
         );
       }

--- a/pkgs/native_assets_cli/test/example/native_add_library_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_library_test.dart
@@ -38,9 +38,7 @@ void main() async {
       final processResult = await Process.run(
         dartUri.toFilePath(),
         [
-          // TODO(https://github.com/dart-lang/native/issues/823): Update after
-          // change is rolled into Dart SDK.
-          'build.dart',
+          'hook/build.dart',
           '-Dout_dir=${tempUri.toFilePath()}',
           '-Dpackage_name=$name',
           '-Dpackage_root=${testPackageUri.toFilePath()}',
@@ -85,9 +83,7 @@ void main() async {
           dependencies,
           [
             testPackageUri.resolve('src/$name.c'),
-            // TODO(https://github.com/dart-lang/native/issues/823): Update after
-            // change is rolled into Dart SDK.
-            testPackageUri.resolve('build.dart'),
+            testPackageUri.resolve('hook/build.dart'),
           ],
         );
       }


### PR DESCRIPTION
The changes rolled into the Dart SDK, so we can now update the examples.

(The changes have not yet been rolled into Flutter, so the examples will fail in Flutter until we do.)

* https://github.com/dart-lang/native/issues/823