### PR TITLE
[native_toolchain_c] Output an `Asset.file` in dry run

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.1
+
+- Output an `Asset.file` in dry run.
+  https://github.com/dart-lang/native/issues/1049
+
 ## 0.4.0
 
 - **Breaking change** Completely rewritten API in `native_assets_cli`.

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -251,7 +251,7 @@ class CBuilder implements Builder {
         NativeCodeAsset(
           package: buildConfig.packageName,
           name: assetName!,
-          file: buildConfig.dryRun ? null : libUri,
+          file: libUri,
           linkMode: linkMode,
           os: buildConfig.targetOS,
           architecture:

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.4.0
+version: 0.4.1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:


### PR DESCRIPTION
* https://github.com/dart-lang/native/issues/1049