### PR TITLE
Fix tests

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1
+
+- Fix test.
+
 ## 0.6.0
 
 - **Breaking change** Completely rewritten API in `native_assets_cli`.

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_assets_builder
 description: >-
   This package is the backend that invokes `build.dart` hooks.
-version: 0.6.0
+version: 0.6.1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_builder
 
 environment:

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_dry_run_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_dry_run_test.dart
@@ -44,7 +44,6 @@ void main() async {
         expect(dryRunAsset.id, buildAsset.id);
         // The build runner expands NativeCodeAssets to all architectures.
         expect(buildAsset.file, isNotNull);
-        expect(dryRunAsset.file, isNull);
         if (dryRunAsset is NativeCodeAssetImpl &&
             buildAsset is NativeCodeAssetImpl) {
           expect(dryRunAsset.architecture, isNotNull);

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2
+
+- Fix test.
+
 ## 0.5.1
 
 - Update documentation about providing `NativeCodeAsset.file` in dry runs.

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   native assets CLI.
 
 # Note: Bump BuildConfig.version and BuildOutput.version on breaking changes!
-version: 0.5.1
+version: 0.5.2
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
 topics:

--- a/pkgs/native_assets_cli/test/example/native_add_library_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_library_test.dart
@@ -74,7 +74,6 @@ void main() async {
       final dependencies = buildOutput.dependencies;
       if (dryRun) {
         expect(assets.length, greaterThanOrEqualTo(1));
-        expect(assets.first.file, isNull);
         expect(dependencies, <Uri>[]);
       } else {
         expect(assets.length, 1);


### PR DESCRIPTION
Stop expecting dry run to have `Asset.file == null`.

(When publishing packages we don't have path dependencies, and so we don't see test failures until packages are published. Introduced in https://github.com/dart-lang/native/pull/1050.)