### PR TITLE
[jnigen] Expand cli_config constraint

### DIFF
--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1-wip
+
+- Expand constraint on `package:cli_config` to allow `^0.2.0`.
+
 ## 0.8.0
 
 - **Breaking Change** ([#981](https://github.com/dart-lang/native/issues/981)):

--- a/pkgs/jnigen/pubspec.yaml
+++ b/pkgs/jnigen/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jnigen
 description: A Dart bindings generator for Java and Kotlin that uses JNI under the hood to interop with Java virtual machine.
-version: 0.8.0
+version: 0.8.1-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jnigen
 
 environment:
@@ -26,7 +26,7 @@ dependencies:
   yaml: ^3.1.0
   logging: ^1.0.2
   meta: ^1.8.0
-  cli_config: ^0.1.0
+  cli_config: '>=0.1.0 <0.3.0'
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
The [0.2.0 release](https://pub.dev/packages/cli_config/changelog#020) didn't change anything that jnigen depends on.