### PR TITLE
Remove `brew install llvm` instruction from mac setup

### DIFF
--- a/pkgs/ffigen/README.md
+++ b/pkgs/ffigen/README.md
@@ -78,7 +78,6 @@ Jump to [FAQ](#faq).
 #### MacOS
 1. Install Xcode.
 2. Install Xcode command line tools - `xcode-select --install`.
-3. Install LLVM - `brew install llvm`.
 
 ## Configurations
 Configurations can be provided in 2 ways-


### PR DESCRIPTION
That instruction is unnecessary, and can lead to version skew: https://github.com/dart-lang/native/issues/1075
