### PR TITLE
[jnigen] Use varargs for dartonly method calls

### DIFF
--- a/pkgs/jni/example/pubspec.lock
+++ b/pkgs/jni/example/pubspec.lock
@@ -200,7 +200,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.8.0-wip"
+    version: "0.8.0"
   js:
     dependency: transitive
     description:

--- a/pkgs/jni/ffigen.yaml
+++ b/pkgs/jni/ffigen.yaml
@@ -34,6 +34,10 @@ functions:
     - 'GetJniContextPtr'
     - 'setJniGetters'
     - 'jni_log'
+    # Exclude functions with VarArgs, jnigen will generate them based on the 
+    # exact arguments needed.
+    - 'globalEnv_NewObject'
+    - 'globalEnv_Call(Static|Nonvirtual|)[A-Z][a-z]+Method'
     # Inline functions
     # keep-sorted start
     - 'acquire_lock'

--- a/pkgs/jni/lib/src/jni.dart
+++ b/pkgs/jni/lib/src/jni.dart
@@ -300,6 +300,9 @@ extension ProtectedJniExtensions on Jni {
     Jni._ensureInitialized();
     Jni._bindings.deleteFinalizableHandle(finalizableHandle, object);
   }
+
+  static Pointer<T> Function<T extends NativeType>(String) get lookup =>
+      Jni._dylib.lookup;
 }
 
 extension AdditionalEnvMethods on GlobalJniEnv {

--- a/pkgs/jni/src/third_party/global_jni_env.c
+++ b/pkgs/jni/src/third_party/global_jni_env.c
@@ -272,9 +272,14 @@ JniResult globalEnv_AllocObject(jclass clazz) {
   return (JniResult){.value = {.l = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_NewObject(jclass clazz, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_NewObject(jclass clazz,
+                                                jmethodID methodID,
+                                                ...) {
   attach_thread();
-  jobject _result = (*jniEnv)->NewObject(jniEnv, clazz, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jobject _result = (*jniEnv)->NewObjectV(jniEnv, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -325,9 +330,14 @@ JniPointerResult globalEnv_GetMethodID(jclass clazz, char* name, char* sig) {
   return (JniPointerResult){.value = _result, .exception = NULL};
 }
 
-JniResult globalEnv_CallObjectMethod(jobject obj, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallObjectMethod(jobject obj,
+                                                       jmethodID methodID,
+                                                       ...) {
   attach_thread();
-  jobject _result = (*jniEnv)->CallObjectMethod(jniEnv, obj, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jobject _result = (*jniEnv)->CallObjectMethodV(jniEnv, obj, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -349,9 +359,14 @@ JniResult globalEnv_CallObjectMethodA(jobject obj,
   return (JniResult){.value = {.l = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallBooleanMethod(jobject obj, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallBooleanMethod(jobject obj,
+                                                        jmethodID methodID,
+                                                        ...) {
   attach_thread();
-  jboolean _result = (*jniEnv)->CallBooleanMethod(jniEnv, obj, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jboolean _result = (*jniEnv)->CallBooleanMethodV(jniEnv, obj, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -371,9 +386,14 @@ JniResult globalEnv_CallBooleanMethodA(jobject obj,
   return (JniResult){.value = {.z = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallByteMethod(jobject obj, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallByteMethod(jobject obj,
+                                                     jmethodID methodID,
+                                                     ...) {
   attach_thread();
-  jbyte _result = (*jniEnv)->CallByteMethod(jniEnv, obj, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jbyte _result = (*jniEnv)->CallByteMethodV(jniEnv, obj, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -393,9 +413,14 @@ JniResult globalEnv_CallByteMethodA(jobject obj,
   return (JniResult){.value = {.b = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallCharMethod(jobject obj, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallCharMethod(jobject obj,
+                                                     jmethodID methodID,
+                                                     ...) {
   attach_thread();
-  jchar _result = (*jniEnv)->CallCharMethod(jniEnv, obj, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jchar _result = (*jniEnv)->CallCharMethodV(jniEnv, obj, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -415,9 +440,14 @@ JniResult globalEnv_CallCharMethodA(jobject obj,
   return (JniResult){.value = {.c = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallShortMethod(jobject obj, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallShortMethod(jobject obj,
+                                                      jmethodID methodID,
+                                                      ...) {
   attach_thread();
-  jshort _result = (*jniEnv)->CallShortMethod(jniEnv, obj, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jshort _result = (*jniEnv)->CallShortMethodV(jniEnv, obj, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -437,9 +467,14 @@ JniResult globalEnv_CallShortMethodA(jobject obj,
   return (JniResult){.value = {.s = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallIntMethod(jobject obj, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallIntMethod(jobject obj,
+                                                    jmethodID methodID,
+                                                    ...) {
   attach_thread();
-  jint _result = (*jniEnv)->CallIntMethod(jniEnv, obj, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jint _result = (*jniEnv)->CallIntMethodV(jniEnv, obj, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -459,9 +494,14 @@ JniResult globalEnv_CallIntMethodA(jobject obj,
   return (JniResult){.value = {.i = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallLongMethod(jobject obj, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallLongMethod(jobject obj,
+                                                     jmethodID methodID,
+                                                     ...) {
   attach_thread();
-  jlong _result = (*jniEnv)->CallLongMethod(jniEnv, obj, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jlong _result = (*jniEnv)->CallLongMethodV(jniEnv, obj, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -481,9 +521,14 @@ JniResult globalEnv_CallLongMethodA(jobject obj,
   return (JniResult){.value = {.j = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallFloatMethod(jobject obj, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallFloatMethod(jobject obj,
+                                                      jmethodID methodID,
+                                                      ...) {
   attach_thread();
-  jfloat _result = (*jniEnv)->CallFloatMethod(jniEnv, obj, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jfloat _result = (*jniEnv)->CallFloatMethodV(jniEnv, obj, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -503,9 +548,14 @@ JniResult globalEnv_CallFloatMethodA(jobject obj,
   return (JniResult){.value = {.f = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallDoubleMethod(jobject obj, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallDoubleMethod(jobject obj,
+                                                       jmethodID methodID,
+                                                       ...) {
   attach_thread();
-  jdouble _result = (*jniEnv)->CallDoubleMethod(jniEnv, obj, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jdouble _result = (*jniEnv)->CallDoubleMethodV(jniEnv, obj, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -525,9 +575,14 @@ JniResult globalEnv_CallDoubleMethodA(jobject obj,
   return (JniResult){.value = {.d = _result}, .exception = NULL};
 }
 
-jthrowable globalEnv_CallVoidMethod(jobject obj, jmethodID methodID) {
+FFI_PLUGIN_EXPORT jthrowable globalEnv_CallVoidMethod(jobject obj,
+                                                      jmethodID methodID,
+                                                      ...) {
   attach_thread();
-  (*jniEnv)->CallVoidMethod(jniEnv, obj, methodID);
+  va_list args;
+  va_start(args, methodID);
+  (*jniEnv)->CallVoidMethodV(jniEnv, obj, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return _exception;
@@ -547,12 +602,17 @@ jthrowable globalEnv_CallVoidMethodA(jobject obj,
   return NULL;
 }
 
-JniResult globalEnv_CallNonvirtualObjectMethod(jobject obj,
-                                               jclass clazz,
-                                               jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualObjectMethod(jobject obj,
+                                     jclass clazz,
+                                     jmethodID methodID,
+                                     ...) {
   attach_thread();
-  jobject _result =
-      (*jniEnv)->CallNonvirtualObjectMethod(jniEnv, obj, clazz, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jobject _result = (*jniEnv)->CallNonvirtualObjectMethodV(jniEnv, obj, clazz,
+                                                           methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -576,12 +636,17 @@ JniResult globalEnv_CallNonvirtualObjectMethodA(jobject obj,
   return (JniResult){.value = {.l = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallNonvirtualBooleanMethod(jobject obj,
-                                                jclass clazz,
-                                                jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualBooleanMethod(jobject obj,
+                                      jclass clazz,
+                                      jmethodID methodID,
+                                      ...) {
   attach_thread();
-  jboolean _result =
-      (*jniEnv)->CallNonvirtualBooleanMethod(jniEnv, obj, clazz, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jboolean _result = (*jniEnv)->CallNonvirtualBooleanMethodV(jniEnv, obj, clazz,
+                                                             methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -603,12 +668,17 @@ JniResult globalEnv_CallNonvirtualBooleanMethodA(jobject obj,
   return (JniResult){.value = {.z = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallNonvirtualByteMethod(jobject obj,
-                                             jclass clazz,
-                                             jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualByteMethod(jobject obj,
+                                   jclass clazz,
+                                   jmethodID methodID,
+                                   ...) {
   attach_thread();
+  va_list args;
+  va_start(args, methodID);
   jbyte _result =
-      (*jniEnv)->CallNonvirtualByteMethod(jniEnv, obj, clazz, methodID);
+      (*jniEnv)->CallNonvirtualByteMethodV(jniEnv, obj, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -630,12 +700,17 @@ JniResult globalEnv_CallNonvirtualByteMethodA(jobject obj,
   return (JniResult){.value = {.b = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallNonvirtualCharMethod(jobject obj,
-                                             jclass clazz,
-                                             jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualCharMethod(jobject obj,
+                                   jclass clazz,
+                                   jmethodID methodID,
+                                   ...) {
   attach_thread();
+  va_list args;
+  va_start(args, methodID);
   jchar _result =
-      (*jniEnv)->CallNonvirtualCharMethod(jniEnv, obj, clazz, methodID);
+      (*jniEnv)->CallNonvirtualCharMethodV(jniEnv, obj, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -657,12 +732,17 @@ JniResult globalEnv_CallNonvirtualCharMethodA(jobject obj,
   return (JniResult){.value = {.c = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallNonvirtualShortMethod(jobject obj,
-                                              jclass clazz,
-                                              jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualShortMethod(jobject obj,
+                                    jclass clazz,
+                                    jmethodID methodID,
+                                    ...) {
   attach_thread();
+  va_list args;
+  va_start(args, methodID);
   jshort _result =
-      (*jniEnv)->CallNonvirtualShortMethod(jniEnv, obj, clazz, methodID);
+      (*jniEnv)->CallNonvirtualShortMethodV(jniEnv, obj, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -684,12 +764,17 @@ JniResult globalEnv_CallNonvirtualShortMethodA(jobject obj,
   return (JniResult){.value = {.s = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallNonvirtualIntMethod(jobject obj,
-                                            jclass clazz,
-                                            jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualIntMethod(jobject obj,
+                                  jclass clazz,
+                                  jmethodID methodID,
+                                  ...) {
   attach_thread();
+  va_list args;
+  va_start(args, methodID);
   jint _result =
-      (*jniEnv)->CallNonvirtualIntMethod(jniEnv, obj, clazz, methodID);
+      (*jniEnv)->CallNonvirtualIntMethodV(jniEnv, obj, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -711,12 +796,17 @@ JniResult globalEnv_CallNonvirtualIntMethodA(jobject obj,
   return (JniResult){.value = {.i = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallNonvirtualLongMethod(jobject obj,
-                                             jclass clazz,
-                                             jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualLongMethod(jobject obj,
+                                   jclass clazz,
+                                   jmethodID methodID,
+                                   ...) {
   attach_thread();
+  va_list args;
+  va_start(args, methodID);
   jlong _result =
-      (*jniEnv)->CallNonvirtualLongMethod(jniEnv, obj, clazz, methodID);
+      (*jniEnv)->CallNonvirtualLongMethodV(jniEnv, obj, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -738,12 +828,17 @@ JniResult globalEnv_CallNonvirtualLongMethodA(jobject obj,
   return (JniResult){.value = {.j = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallNonvirtualFloatMethod(jobject obj,
-                                              jclass clazz,
-                                              jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualFloatMethod(jobject obj,
+                                    jclass clazz,
+                                    jmethodID methodID,
+                                    ...) {
   attach_thread();
+  va_list args;
+  va_start(args, methodID);
   jfloat _result =
-      (*jniEnv)->CallNonvirtualFloatMethod(jniEnv, obj, clazz, methodID);
+      (*jniEnv)->CallNonvirtualFloatMethodV(jniEnv, obj, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -765,12 +860,17 @@ JniResult globalEnv_CallNonvirtualFloatMethodA(jobject obj,
   return (JniResult){.value = {.f = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallNonvirtualDoubleMethod(jobject obj,
-                                               jclass clazz,
-                                               jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualDoubleMethod(jobject obj,
+                                     jclass clazz,
+                                     jmethodID methodID,
+                                     ...) {
   attach_thread();
-  jdouble _result =
-      (*jniEnv)->CallNonvirtualDoubleMethod(jniEnv, obj, clazz, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jdouble _result = (*jniEnv)->CallNonvirtualDoubleMethodV(jniEnv, obj, clazz,
+                                                           methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -792,11 +892,16 @@ JniResult globalEnv_CallNonvirtualDoubleMethodA(jobject obj,
   return (JniResult){.value = {.d = _result}, .exception = NULL};
 }
 
-jthrowable globalEnv_CallNonvirtualVoidMethod(jobject obj,
-                                              jclass clazz,
-                                              jmethodID methodID) {
+FFI_PLUGIN_EXPORT jthrowable
+globalEnv_CallNonvirtualVoidMethod(jobject obj,
+                                   jclass clazz,
+                                   jmethodID methodID,
+                                   ...) {
   attach_thread();
-  (*jniEnv)->CallNonvirtualVoidMethod(jniEnv, obj, clazz, methodID);
+  va_list args;
+  va_start(args, methodID);
+  (*jniEnv)->CallNonvirtualVoidMethodV(jniEnv, obj, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return _exception;
@@ -1026,9 +1131,15 @@ JniPointerResult globalEnv_GetStaticMethodID(jclass clazz,
   return (JniPointerResult){.value = _result, .exception = NULL};
 }
 
-JniResult globalEnv_CallStaticObjectMethod(jclass clazz, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallStaticObjectMethod(jclass clazz,
+                                                             jmethodID methodID,
+                                                             ...) {
   attach_thread();
-  jobject _result = (*jniEnv)->CallStaticObjectMethod(jniEnv, clazz, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jobject _result =
+      (*jniEnv)->CallStaticObjectMethodV(jniEnv, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -1051,10 +1162,14 @@ JniResult globalEnv_CallStaticObjectMethodA(jclass clazz,
   return (JniResult){.value = {.l = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallStaticBooleanMethod(jclass clazz, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallStaticBooleanMethod(jclass clazz, jmethodID methodID, ...) {
   attach_thread();
+  va_list args;
+  va_start(args, methodID);
   jboolean _result =
-      (*jniEnv)->CallStaticBooleanMethod(jniEnv, clazz, methodID);
+      (*jniEnv)->CallStaticBooleanMethodV(jniEnv, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -1075,9 +1190,15 @@ JniResult globalEnv_CallStaticBooleanMethodA(jclass clazz,
   return (JniResult){.value = {.z = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallStaticByteMethod(jclass clazz, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallStaticByteMethod(jclass clazz,
+                                                           jmethodID methodID,
+                                                           ...) {
   attach_thread();
-  jbyte _result = (*jniEnv)->CallStaticByteMethod(jniEnv, clazz, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jbyte _result =
+      (*jniEnv)->CallStaticByteMethodV(jniEnv, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -1098,9 +1219,15 @@ JniResult globalEnv_CallStaticByteMethodA(jclass clazz,
   return (JniResult){.value = {.b = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallStaticCharMethod(jclass clazz, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallStaticCharMethod(jclass clazz,
+                                                           jmethodID methodID,
+                                                           ...) {
   attach_thread();
-  jchar _result = (*jniEnv)->CallStaticCharMethod(jniEnv, clazz, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jchar _result =
+      (*jniEnv)->CallStaticCharMethodV(jniEnv, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -1121,9 +1248,15 @@ JniResult globalEnv_CallStaticCharMethodA(jclass clazz,
   return (JniResult){.value = {.c = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallStaticShortMethod(jclass clazz, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallStaticShortMethod(jclass clazz,
+                                                            jmethodID methodID,
+                                                            ...) {
   attach_thread();
-  jshort _result = (*jniEnv)->CallStaticShortMethod(jniEnv, clazz, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jshort _result =
+      (*jniEnv)->CallStaticShortMethodV(jniEnv, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -1144,9 +1277,14 @@ JniResult globalEnv_CallStaticShortMethodA(jclass clazz,
   return (JniResult){.value = {.s = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallStaticIntMethod(jclass clazz, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallStaticIntMethod(jclass clazz,
+                                                          jmethodID methodID,
+                                                          ...) {
   attach_thread();
-  jint _result = (*jniEnv)->CallStaticIntMethod(jniEnv, clazz, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jint _result = (*jniEnv)->CallStaticIntMethodV(jniEnv, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -1166,9 +1304,15 @@ JniResult globalEnv_CallStaticIntMethodA(jclass clazz,
   return (JniResult){.value = {.i = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallStaticLongMethod(jclass clazz, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallStaticLongMethod(jclass clazz,
+                                                           jmethodID methodID,
+                                                           ...) {
   attach_thread();
-  jlong _result = (*jniEnv)->CallStaticLongMethod(jniEnv, clazz, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jlong _result =
+      (*jniEnv)->CallStaticLongMethodV(jniEnv, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -1189,9 +1333,15 @@ JniResult globalEnv_CallStaticLongMethodA(jclass clazz,
   return (JniResult){.value = {.j = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallStaticFloatMethod(jclass clazz, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallStaticFloatMethod(jclass clazz,
+                                                            jmethodID methodID,
+                                                            ...) {
   attach_thread();
-  jfloat _result = (*jniEnv)->CallStaticFloatMethod(jniEnv, clazz, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jfloat _result =
+      (*jniEnv)->CallStaticFloatMethodV(jniEnv, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -1212,9 +1362,15 @@ JniResult globalEnv_CallStaticFloatMethodA(jclass clazz,
   return (JniResult){.value = {.f = _result}, .exception = NULL};
 }
 
-JniResult globalEnv_CallStaticDoubleMethod(jclass clazz, jmethodID methodID) {
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallStaticDoubleMethod(jclass clazz,
+                                                             jmethodID methodID,
+                                                             ...) {
   attach_thread();
-  jdouble _result = (*jniEnv)->CallStaticDoubleMethod(jniEnv, clazz, methodID);
+  va_list args;
+  va_start(args, methodID);
+  jdouble _result =
+      (*jniEnv)->CallStaticDoubleMethodV(jniEnv, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return (JniResult){.value = {.j = 0}, .exception = _exception};
@@ -1235,9 +1391,14 @@ JniResult globalEnv_CallStaticDoubleMethodA(jclass clazz,
   return (JniResult){.value = {.d = _result}, .exception = NULL};
 }
 
-jthrowable globalEnv_CallStaticVoidMethod(jclass clazz, jmethodID methodID) {
+FFI_PLUGIN_EXPORT jthrowable globalEnv_CallStaticVoidMethod(jclass clazz,
+                                                            jmethodID methodID,
+                                                            ...) {
   attach_thread();
-  (*jniEnv)->CallStaticVoidMethod(jniEnv, clazz, methodID);
+  va_list args;
+  va_start(args, methodID);
+  (*jniEnv)->CallStaticVoidMethodV(jniEnv, clazz, methodID, args);
+  va_end(args);
   jthrowable _exception = check_exception();
   if (_exception != NULL) {
     return _exception;

--- a/pkgs/jni/src/third_party/global_jni_env.h
+++ b/pkgs/jni/src/third_party/global_jni_env.h
@@ -65,47 +65,48 @@ typedef struct GlobalJniEnvStruct {
   JniResult (*NewLocalRef)(jobject obj);
   JniResult (*EnsureLocalCapacity)(jint capacity);
   JniResult (*AllocObject)(jclass clazz);
-  JniResult (*NewObject)(jclass clazz, jmethodID methodID);
+  JniResult (*NewObject)(jclass clazz, jmethodID methodID, ...);
   JniResult (*NewObjectV)(jclass, jmethodID, void*);
   JniResult (*NewObjectA)(jclass clazz, jmethodID methodID, jvalue* args);
   JniClassLookupResult (*GetObjectClass)(jobject obj);
   JniResult (*IsInstanceOf)(jobject obj, jclass clazz);
   JniPointerResult (*GetMethodID)(jclass clazz, char* name, char* sig);
-  JniResult (*CallObjectMethod)(jobject obj, jmethodID methodID);
+  JniResult (*CallObjectMethod)(jobject obj, jmethodID methodID, ...);
   JniResult (*CallObjectMethodV)(jobject, jmethodID, void*);
   JniResult (*CallObjectMethodA)(jobject obj, jmethodID methodID, jvalue* args);
-  JniResult (*CallBooleanMethod)(jobject obj, jmethodID methodID);
+  JniResult (*CallBooleanMethod)(jobject obj, jmethodID methodID, ...);
   JniResult (*CallBooleanMethodV)(jobject, jmethodID, void*);
   JniResult (*CallBooleanMethodA)(jobject obj,
                                   jmethodID methodId,
                                   jvalue* args);
-  JniResult (*CallByteMethod)(jobject obj, jmethodID methodID);
+  JniResult (*CallByteMethod)(jobject obj, jmethodID methodID, ...);
   JniResult (*CallByteMethodV)(jobject, jmethodID, void*);
   JniResult (*CallByteMethodA)(jobject obj, jmethodID methodID, jvalue* args);
-  JniResult (*CallCharMethod)(jobject obj, jmethodID methodID);
+  JniResult (*CallCharMethod)(jobject obj, jmethodID methodID, ...);
   JniResult (*CallCharMethodV)(jobject, jmethodID, void*);
   JniResult (*CallCharMethodA)(jobject obj, jmethodID methodID, jvalue* args);
-  JniResult (*CallShortMethod)(jobject obj, jmethodID methodID);
+  JniResult (*CallShortMethod)(jobject obj, jmethodID methodID, ...);
   JniResult (*CallShortMethodV)(jobject, jmethodID, void*);
   JniResult (*CallShortMethodA)(jobject obj, jmethodID methodID, jvalue* args);
-  JniResult (*CallIntMethod)(jobject obj, jmethodID methodID);
+  JniResult (*CallIntMethod)(jobject obj, jmethodID methodID, ...);
   JniResult (*CallIntMethodV)(jobject, jmethodID, void*);
   JniResult (*CallIntMethodA)(jobject obj, jmethodID methodID, jvalue* args);
-  JniResult (*CallLongMethod)(jobject obj, jmethodID methodID);
+  JniResult (*CallLongMethod)(jobject obj, jmethodID methodID, ...);
   JniResult (*CallLongMethodV)(jobject, jmethodID, void*);
   JniResult (*CallLongMethodA)(jobject obj, jmethodID methodID, jvalue* args);
-  JniResult (*CallFloatMethod)(jobject obj, jmethodID methodID);
+  JniResult (*CallFloatMethod)(jobject obj, jmethodID methodID, ...);
   JniResult (*CallFloatMethodV)(jobject, jmethodID, void*);
   JniResult (*CallFloatMethodA)(jobject obj, jmethodID methodID, jvalue* args);
-  JniResult (*CallDoubleMethod)(jobject obj, jmethodID methodID);
+  JniResult (*CallDoubleMethod)(jobject obj, jmethodID methodID, ...);
   JniResult (*CallDoubleMethodV)(jobject, jmethodID, void*);
   JniResult (*CallDoubleMethodA)(jobject obj, jmethodID methodID, jvalue* args);
-  jthrowable (*CallVoidMethod)(jobject obj, jmethodID methodID);
+  jthrowable (*CallVoidMethod)(jobject obj, jmethodID methodID, ...);
   jthrowable (*CallVoidMethodV)(jobject, jmethodID, void*);
   jthrowable (*CallVoidMethodA)(jobject obj, jmethodID methodID, jvalue* args);
   JniResult (*CallNonvirtualObjectMethod)(jobject obj,
                                           jclass clazz,
-                                          jmethodID methodID);
+                                          jmethodID methodID,
+                                          ...);
   JniResult (*CallNonvirtualObjectMethodV)(jobject, jclass, jmethodID, void*);
   JniResult (*CallNonvirtualObjectMethodA)(jobject obj,
                                            jclass clazz,
@@ -113,7 +114,8 @@ typedef struct GlobalJniEnvStruct {
                                            jvalue* args);
   JniResult (*CallNonvirtualBooleanMethod)(jobject obj,
                                            jclass clazz,
-                                           jmethodID methodID);
+                                           jmethodID methodID,
+                                           ...);
   JniResult (*CallNonvirtualBooleanMethodV)(jobject, jclass, jmethodID, void*);
   JniResult (*CallNonvirtualBooleanMethodA)(jobject obj,
                                             jclass clazz,
@@ -121,7 +123,8 @@ typedef struct GlobalJniEnvStruct {
                                             jvalue* args);
   JniResult (*CallNonvirtualByteMethod)(jobject obj,
                                         jclass clazz,
-                                        jmethodID methodID);
+                                        jmethodID methodID,
+                                        ...);
   JniResult (*CallNonvirtualByteMethodV)(jobject, jclass, jmethodID, void*);
   JniResult (*CallNonvirtualByteMethodA)(jobject obj,
                                          jclass clazz,
@@ -129,7 +132,8 @@ typedef struct GlobalJniEnvStruct {
                                          jvalue* args);
   JniResult (*CallNonvirtualCharMethod)(jobject obj,
                                         jclass clazz,
-                                        jmethodID methodID);
+                                        jmethodID methodID,
+                                        ...);
   JniResult (*CallNonvirtualCharMethodV)(jobject, jclass, jmethodID, void*);
   JniResult (*CallNonvirtualCharMethodA)(jobject obj,
                                          jclass clazz,
@@ -137,7 +141,8 @@ typedef struct GlobalJniEnvStruct {
                                          jvalue* args);
   JniResult (*CallNonvirtualShortMethod)(jobject obj,
                                          jclass clazz,
-                                         jmethodID methodID);
+                                         jmethodID methodID,
+                                         ...);
   JniResult (*CallNonvirtualShortMethodV)(jobject, jclass, jmethodID, void*);
   JniResult (*CallNonvirtualShortMethodA)(jobject obj,
                                           jclass clazz,
@@ -145,7 +150,8 @@ typedef struct GlobalJniEnvStruct {
                                           jvalue* args);
   JniResult (*CallNonvirtualIntMethod)(jobject obj,
                                        jclass clazz,
-                                       jmethodID methodID);
+                                       jmethodID methodID,
+                                       ...);
   JniResult (*CallNonvirtualIntMethodV)(jobject, jclass, jmethodID, void*);
   JniResult (*CallNonvirtualIntMethodA)(jobject obj,
                                         jclass clazz,
@@ -153,7 +159,8 @@ typedef struct GlobalJniEnvStruct {
                                         jvalue* args);
   JniResult (*CallNonvirtualLongMethod)(jobject obj,
                                         jclass clazz,
-                                        jmethodID methodID);
+                                        jmethodID methodID,
+                                        ...);
   JniResult (*CallNonvirtualLongMethodV)(jobject, jclass, jmethodID, void*);
   JniResult (*CallNonvirtualLongMethodA)(jobject obj,
                                          jclass clazz,
@@ -161,7 +168,8 @@ typedef struct GlobalJniEnvStruct {
                                          jvalue* args);
   JniResult (*CallNonvirtualFloatMethod)(jobject obj,
                                          jclass clazz,
-                                         jmethodID methodID);
+                                         jmethodID methodID,
+                                         ...);
   JniResult (*CallNonvirtualFloatMethodV)(jobject, jclass, jmethodID, void*);
   JniResult (*CallNonvirtualFloatMethodA)(jobject obj,
                                           jclass clazz,
@@ -169,7 +177,8 @@ typedef struct GlobalJniEnvStruct {
                                           jvalue* args);
   JniResult (*CallNonvirtualDoubleMethod)(jobject obj,
                                           jclass clazz,
-                                          jmethodID methodID);
+                                          jmethodID methodID,
+                                          ...);
   JniResult (*CallNonvirtualDoubleMethodV)(jobject, jclass, jmethodID, void*);
   JniResult (*CallNonvirtualDoubleMethodA)(jobject obj,
                                            jclass clazz,
@@ -177,7 +186,8 @@ typedef struct GlobalJniEnvStruct {
                                            jvalue* args);
   jthrowable (*CallNonvirtualVoidMethod)(jobject obj,
                                          jclass clazz,
-                                         jmethodID methodID);
+                                         jmethodID methodID,
+                                         ...);
   jthrowable (*CallNonvirtualVoidMethodV)(jobject, jclass, jmethodID, void*);
   jthrowable (*CallNonvirtualVoidMethodA)(jobject obj,
                                           jclass clazz,
@@ -203,52 +213,52 @@ typedef struct GlobalJniEnvStruct {
   jthrowable (*SetFloatField)(jobject obj, jfieldID fieldID, jfloat val);
   jthrowable (*SetDoubleField)(jobject obj, jfieldID fieldID, jdouble val);
   JniPointerResult (*GetStaticMethodID)(jclass clazz, char* name, char* sig);
-  JniResult (*CallStaticObjectMethod)(jclass clazz, jmethodID methodID);
+  JniResult (*CallStaticObjectMethod)(jclass clazz, jmethodID methodID, ...);
   JniResult (*CallStaticObjectMethodV)(jclass, jmethodID, void*);
   JniResult (*CallStaticObjectMethodA)(jclass clazz,
                                        jmethodID methodID,
                                        jvalue* args);
-  JniResult (*CallStaticBooleanMethod)(jclass clazz, jmethodID methodID);
+  JniResult (*CallStaticBooleanMethod)(jclass clazz, jmethodID methodID, ...);
   JniResult (*CallStaticBooleanMethodV)(jclass, jmethodID, void*);
   JniResult (*CallStaticBooleanMethodA)(jclass clazz,
                                         jmethodID methodID,
                                         jvalue* args);
-  JniResult (*CallStaticByteMethod)(jclass clazz, jmethodID methodID);
+  JniResult (*CallStaticByteMethod)(jclass clazz, jmethodID methodID, ...);
   JniResult (*CallStaticByteMethodV)(jclass, jmethodID, void*);
   JniResult (*CallStaticByteMethodA)(jclass clazz,
                                      jmethodID methodID,
                                      jvalue* args);
-  JniResult (*CallStaticCharMethod)(jclass clazz, jmethodID methodID);
+  JniResult (*CallStaticCharMethod)(jclass clazz, jmethodID methodID, ...);
   JniResult (*CallStaticCharMethodV)(jclass, jmethodID, void*);
   JniResult (*CallStaticCharMethodA)(jclass clazz,
                                      jmethodID methodID,
                                      jvalue* args);
-  JniResult (*CallStaticShortMethod)(jclass clazz, jmethodID methodID);
+  JniResult (*CallStaticShortMethod)(jclass clazz, jmethodID methodID, ...);
   JniResult (*CallStaticShortMethodV)(jclass, jmethodID, void*);
   JniResult (*CallStaticShortMethodA)(jclass clazz,
                                       jmethodID methodID,
                                       jvalue* args);
-  JniResult (*CallStaticIntMethod)(jclass clazz, jmethodID methodID);
+  JniResult (*CallStaticIntMethod)(jclass clazz, jmethodID methodID, ...);
   JniResult (*CallStaticIntMethodV)(jclass, jmethodID, void*);
   JniResult (*CallStaticIntMethodA)(jclass clazz,
                                     jmethodID methodID,
                                     jvalue* args);
-  JniResult (*CallStaticLongMethod)(jclass clazz, jmethodID methodID);
+  JniResult (*CallStaticLongMethod)(jclass clazz, jmethodID methodID, ...);
   JniResult (*CallStaticLongMethodV)(jclass, jmethodID, void*);
   JniResult (*CallStaticLongMethodA)(jclass clazz,
                                      jmethodID methodID,
                                      jvalue* args);
-  JniResult (*CallStaticFloatMethod)(jclass clazz, jmethodID methodID);
+  JniResult (*CallStaticFloatMethod)(jclass clazz, jmethodID methodID, ...);
   JniResult (*CallStaticFloatMethodV)(jclass, jmethodID, void*);
   JniResult (*CallStaticFloatMethodA)(jclass clazz,
                                       jmethodID methodID,
                                       jvalue* args);
-  JniResult (*CallStaticDoubleMethod)(jclass clazz, jmethodID methodID);
+  JniResult (*CallStaticDoubleMethod)(jclass clazz, jmethodID methodID, ...);
   JniResult (*CallStaticDoubleMethodV)(jclass, jmethodID, void*);
   JniResult (*CallStaticDoubleMethodA)(jclass clazz,
                                        jmethodID methodID,
                                        jvalue* args);
-  jthrowable (*CallStaticVoidMethod)(jclass clazz, jmethodID methodID);
+  jthrowable (*CallStaticVoidMethod)(jclass clazz, jmethodID methodID, ...);
   jthrowable (*CallStaticVoidMethodV)(jclass, jmethodID, void*);
   jthrowable (*CallStaticVoidMethodA)(jclass clazz,
                                       jmethodID methodID,
@@ -432,3 +442,115 @@ typedef struct GlobalJniEnvStruct {
   JniResult (*GetObjectRefType)(jobject obj);
 } GlobalJniEnvStruct;
 FFI_PLUGIN_EXPORT GlobalJniEnvStruct* GetGlobalEnv();
+FFI_PLUGIN_EXPORT JniResult globalEnv_NewObject(jclass clazz,
+                                                jmethodID methodID,
+                                                ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallObjectMethod(jobject obj,
+                                                       jmethodID methodID,
+                                                       ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallBooleanMethod(jobject obj,
+                                                        jmethodID methodID,
+                                                        ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallByteMethod(jobject obj,
+                                                     jmethodID methodID,
+                                                     ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallCharMethod(jobject obj,
+                                                     jmethodID methodID,
+                                                     ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallShortMethod(jobject obj,
+                                                      jmethodID methodID,
+                                                      ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallIntMethod(jobject obj,
+                                                    jmethodID methodID,
+                                                    ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallLongMethod(jobject obj,
+                                                     jmethodID methodID,
+                                                     ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallFloatMethod(jobject obj,
+                                                      jmethodID methodID,
+                                                      ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallDoubleMethod(jobject obj,
+                                                       jmethodID methodID,
+                                                       ...);
+FFI_PLUGIN_EXPORT jthrowable globalEnv_CallVoidMethod(jobject obj,
+                                                      jmethodID methodID,
+                                                      ...);
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualObjectMethod(jobject obj,
+                                     jclass clazz,
+                                     jmethodID methodID,
+                                     ...);
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualBooleanMethod(jobject obj,
+                                      jclass clazz,
+                                      jmethodID methodID,
+                                      ...);
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualByteMethod(jobject obj,
+                                   jclass clazz,
+                                   jmethodID methodID,
+                                   ...);
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualCharMethod(jobject obj,
+                                   jclass clazz,
+                                   jmethodID methodID,
+                                   ...);
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualShortMethod(jobject obj,
+                                    jclass clazz,
+                                    jmethodID methodID,
+                                    ...);
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualIntMethod(jobject obj,
+                                  jclass clazz,
+                                  jmethodID methodID,
+                                  ...);
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualLongMethod(jobject obj,
+                                   jclass clazz,
+                                   jmethodID methodID,
+                                   ...);
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualFloatMethod(jobject obj,
+                                    jclass clazz,
+                                    jmethodID methodID,
+                                    ...);
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallNonvirtualDoubleMethod(jobject obj,
+                                     jclass clazz,
+                                     jmethodID methodID,
+                                     ...);
+FFI_PLUGIN_EXPORT jthrowable
+globalEnv_CallNonvirtualVoidMethod(jobject obj,
+                                   jclass clazz,
+                                   jmethodID methodID,
+                                   ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallStaticObjectMethod(jclass clazz,
+                                                             jmethodID methodID,
+                                                             ...);
+FFI_PLUGIN_EXPORT JniResult
+globalEnv_CallStaticBooleanMethod(jclass clazz, jmethodID methodID, ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallStaticByteMethod(jclass clazz,
+                                                           jmethodID methodID,
+                                                           ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallStaticCharMethod(jclass clazz,
+                                                           jmethodID methodID,
+                                                           ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallStaticShortMethod(jclass clazz,
+                                                            jmethodID methodID,
+                                                            ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallStaticIntMethod(jclass clazz,
+                                                          jmethodID methodID,
+                                                          ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallStaticLongMethod(jclass clazz,
+                                                           jmethodID methodID,
+                                                           ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallStaticFloatMethod(jclass clazz,
+                                                            jmethodID methodID,
+                                                            ...);
+FFI_PLUGIN_EXPORT JniResult globalEnv_CallStaticDoubleMethod(jclass clazz,
+                                                             jmethodID methodID,
+                                                             ...);
+FFI_PLUGIN_EXPORT jthrowable globalEnv_CallStaticVoidMethod(jclass clazz,
+                                                            jmethodID methodID,
+                                                            ...);

--- a/pkgs/jnigen/example/in_app_java/lib/android_utils.dart
+++ b/pkgs/jnigen/example/in_app_java/lib/android_utils.dart
@@ -369,10 +369,14 @@ class EmojiCompat_Config extends jni.JObject {
   }
 
   static final _getMetadataRepoLoader = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "EmojiCompat_Config__getMetadataRepoLoader")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("EmojiCompat_Config__getMetadataRepoLoader")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: protected final androidx.emoji2.text.EmojiCompat.MetadataRepoLoader getMetadataRepoLoader()
   /// The returned object must be released after use, by calling the [release] method.
@@ -610,10 +614,14 @@ class EmojiCompat_InitCallback extends jni.JObject {
   }
 
   static final _onInitialized = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "EmojiCompat_InitCallback__onInitialized")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("EmojiCompat_InitCallback__onInitialized")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public void onInitialized()
   ///
@@ -1385,10 +1393,14 @@ class EmojiCompat extends jni.JObject {
   }
 
   static final _load = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "EmojiCompat__load")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("EmojiCompat__load")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public void load()
   ///
@@ -1456,10 +1468,14 @@ class EmojiCompat extends jni.JObject {
   }
 
   static final _getLoadState = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "EmojiCompat__getLoadState")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("EmojiCompat__getLoadState")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int getLoadState()
   ///
@@ -1472,10 +1488,14 @@ class EmojiCompat extends jni.JObject {
   }
 
   static final _isEmojiSpanIndicatorEnabled = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "EmojiCompat__isEmojiSpanIndicatorEnabled")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("EmojiCompat__isEmojiSpanIndicatorEnabled")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean isEmojiSpanIndicatorEnabled()
   ///
@@ -1486,10 +1506,14 @@ class EmojiCompat extends jni.JObject {
   }
 
   static final _getEmojiSpanIndicatorColor = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "EmojiCompat__getEmojiSpanIndicatorColor")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("EmojiCompat__getEmojiSpanIndicatorColor")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int getEmojiSpanIndicatorColor()
   ///
@@ -1897,10 +1921,14 @@ class EmojiCompat extends jni.JObject {
   }
 
   static final _getAssetSignature = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "EmojiCompat__getAssetSignature")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("EmojiCompat__getAssetSignature")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getAssetSignature()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2509,10 +2537,14 @@ class Build_Partition extends jni.JObject {
       _get_PARTITION_NAME_SYSTEM().object(const jni.JStringType());
 
   static final _getName = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Build_Partition__getName")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Build_Partition__getName")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getName()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2521,10 +2553,14 @@ class Build_Partition extends jni.JObject {
   }
 
   static final _getFingerprint = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Build_Partition__getFingerprint")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Build_Partition__getFingerprint")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getFingerprint()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2533,10 +2569,14 @@ class Build_Partition extends jni.JObject {
   }
 
   static final _getBuildTimeMillis = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Build_Partition__getBuildTimeMillis")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Build_Partition__getBuildTimeMillis")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public long getBuildTimeMillis()
   int getBuildTimeMillis() {
@@ -2559,10 +2599,14 @@ class Build_Partition extends jni.JObject {
   }
 
   static final _hashCode1 = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Build_Partition__hashCode1")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Build_Partition__hashCode1")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int hashCode()
   int hashCode1() {
@@ -3336,8 +3380,13 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
 
   static final _size = jniLookup<
           ffi.NativeFunction<
-              jni.JniResult Function(ffi.Pointer<ffi.Void>)>>("HashMap__size")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("HashMap__size")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int size()
   int size() {
@@ -3345,10 +3394,14 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
   }
 
   static final _isEmpty = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "HashMap__isEmpty")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("HashMap__isEmpty")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean isEmpty()
   bool isEmpty() {
@@ -3440,8 +3493,13 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
 
   static final _clear = jniLookup<
           ffi.NativeFunction<
-              jni.JniResult Function(ffi.Pointer<ffi.Void>)>>("HashMap__clear")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("HashMap__clear")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public void clear()
   void clear() {
@@ -3465,8 +3523,13 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
 
   static final _keySet = jniLookup<
           ffi.NativeFunction<
-              jni.JniResult Function(ffi.Pointer<ffi.Void>)>>("HashMap__keySet")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("HashMap__keySet")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.util.Set keySet()
   /// The returned object must be released after use, by calling the [release] method.
@@ -3476,8 +3539,13 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
 
   static final _values = jniLookup<
           ffi.NativeFunction<
-              jni.JniResult Function(ffi.Pointer<ffi.Void>)>>("HashMap__values")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("HashMap__values")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.util.Collection values()
   /// The returned object must be released after use, by calling the [release] method.
@@ -3486,10 +3554,14 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
   }
 
   static final _entrySet = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "HashMap__entrySet")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("HashMap__entrySet")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.util.Set entrySet()
   /// The returned object must be released after use, by calling the [release] method.
@@ -3721,8 +3793,13 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
 
   static final _clone = jniLookup<
           ffi.NativeFunction<
-              jni.JniResult Function(ffi.Pointer<ffi.Void>)>>("HashMap__clone")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("HashMap__clone")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.Object clone()
   /// The returned object must be released after use, by calling the [release] method.

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
@@ -406,10 +406,14 @@ class PDDocument extends jni.JObject {
   }
 
   static final _getDocument = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocument__getDocument")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocument__getDocument")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public org.apache.pdfbox.cos.COSDocument getDocument()
   /// The returned object must be released after use, by calling the [release] method.
@@ -421,10 +425,14 @@ class PDDocument extends jni.JObject {
   }
 
   static final _getDocumentInformation = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocument__getDocumentInformation")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocument__getDocumentInformation")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public org.apache.pdfbox.pdmodel.PDDocumentInformation getDocumentInformation()
   /// The returned object must be released after use, by calling the [release] method.
@@ -464,10 +472,14 @@ class PDDocument extends jni.JObject {
   }
 
   static final _getDocumentCatalog = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocument__getDocumentCatalog")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocument__getDocumentCatalog")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public org.apache.pdfbox.pdmodel.PDDocumentCatalog getDocumentCatalog()
   /// The returned object must be released after use, by calling the [release] method.
@@ -480,10 +492,14 @@ class PDDocument extends jni.JObject {
   }
 
   static final _isEncrypted = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocument__isEncrypted")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocument__isEncrypted")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean isEncrypted()
   ///
@@ -494,10 +510,14 @@ class PDDocument extends jni.JObject {
   }
 
   static final _getEncryption = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocument__getEncryption")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocument__getEncryption")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public org.apache.pdfbox.pdmodel.encryption.PDEncryption getEncryption()
   /// The returned object must be released after use, by calling the [release] method.
@@ -533,10 +553,14 @@ class PDDocument extends jni.JObject {
   }
 
   static final _getLastSignatureDictionary = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocument__getLastSignatureDictionary")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocument__getLastSignatureDictionary")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature getLastSignatureDictionary()
   /// The returned object must be released after use, by calling the [release] method.
@@ -551,10 +575,14 @@ class PDDocument extends jni.JObject {
   }
 
   static final _getSignatureFields = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocument__getSignatureFields")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocument__getSignatureFields")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.util.List<org.apache.pdfbox.pdmodel.interactive.form.PDSignatureField> getSignatureFields()
   /// The returned object must be released after use, by calling the [release] method.
@@ -568,10 +596,14 @@ class PDDocument extends jni.JObject {
   }
 
   static final _getSignatureDictionaries = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocument__getSignatureDictionaries")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocument__getSignatureDictionaries")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.util.List<org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature> getSignatureDictionaries()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1304,10 +1336,14 @@ class PDDocument extends jni.JObject {
   }
 
   static final _getPages = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocument__getPages")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocument__getPages")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public org.apache.pdfbox.pdmodel.PDPageTree getPages()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1319,10 +1355,14 @@ class PDDocument extends jni.JObject {
   }
 
   static final _getNumberOfPages = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocument__getNumberOfPages")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocument__getNumberOfPages")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int getNumberOfPages()
   ///
@@ -1333,10 +1373,14 @@ class PDDocument extends jni.JObject {
   }
 
   static final _close = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocument__close")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocument__close")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public void close()
   ///
@@ -1373,10 +1417,14 @@ class PDDocument extends jni.JObject {
   }
 
   static final _getCurrentAccessPermission = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocument__getCurrentAccessPermission")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocument__getCurrentAccessPermission")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public org.apache.pdfbox.pdmodel.encryption.AccessPermission getCurrentAccessPermission()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1392,10 +1440,14 @@ class PDDocument extends jni.JObject {
   }
 
   static final _isAllSecurityToBeRemoved = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocument__isAllSecurityToBeRemoved")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocument__isAllSecurityToBeRemoved")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean isAllSecurityToBeRemoved()
   ///
@@ -1423,10 +1475,14 @@ class PDDocument extends jni.JObject {
   }
 
   static final _getDocumentId = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocument__getDocumentId")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocument__getDocumentId")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.Long getDocumentId()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1456,10 +1512,14 @@ class PDDocument extends jni.JObject {
   }
 
   static final _getVersion = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocument__getVersion")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocument__getVersion")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public float getVersion()
   ///
@@ -1486,10 +1546,14 @@ class PDDocument extends jni.JObject {
   }
 
   static final _getResourceCache = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocument__getResourceCache")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocument__getResourceCache")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public org.apache.pdfbox.pdmodel.ResourceCache getResourceCache()
   /// The returned object must be released after use, by calling the [release] method.

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocumentInformation.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocumentInformation.dart
@@ -91,10 +91,14 @@ class PDDocumentInformation extends jni.JObject {
   }
 
   static final _getCOSObject = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocumentInformation__getCOSObject")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocumentInformation__getCOSObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public org.apache.pdfbox.cos.COSDictionary getCOSObject()
   /// The returned object must be released after use, by calling the [release] method.
@@ -134,10 +138,14 @@ class PDDocumentInformation extends jni.JObject {
   }
 
   static final _getTitle = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocumentInformation__getTitle")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocumentInformation__getTitle")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getTitle()
   /// The returned object must be released after use, by calling the [release] method.
@@ -167,10 +175,14 @@ class PDDocumentInformation extends jni.JObject {
   }
 
   static final _getAuthor = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocumentInformation__getAuthor")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocumentInformation__getAuthor")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getAuthor()
   /// The returned object must be released after use, by calling the [release] method.
@@ -200,10 +212,14 @@ class PDDocumentInformation extends jni.JObject {
   }
 
   static final _getSubject = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocumentInformation__getSubject")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocumentInformation__getSubject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getSubject()
   /// The returned object must be released after use, by calling the [release] method.
@@ -233,10 +249,14 @@ class PDDocumentInformation extends jni.JObject {
   }
 
   static final _getKeywords = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocumentInformation__getKeywords")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocumentInformation__getKeywords")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getKeywords()
   /// The returned object must be released after use, by calling the [release] method.
@@ -266,10 +286,14 @@ class PDDocumentInformation extends jni.JObject {
   }
 
   static final _getCreator = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocumentInformation__getCreator")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocumentInformation__getCreator")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getCreator()
   /// The returned object must be released after use, by calling the [release] method.
@@ -299,10 +323,14 @@ class PDDocumentInformation extends jni.JObject {
   }
 
   static final _getProducer = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocumentInformation__getProducer")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocumentInformation__getProducer")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getProducer()
   /// The returned object must be released after use, by calling the [release] method.
@@ -332,10 +360,14 @@ class PDDocumentInformation extends jni.JObject {
   }
 
   static final _getCreationDate = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocumentInformation__getCreationDate")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocumentInformation__getCreationDate")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.util.Calendar getCreationDate()
   /// The returned object must be released after use, by calling the [release] method.
@@ -366,10 +398,14 @@ class PDDocumentInformation extends jni.JObject {
   }
 
   static final _getModificationDate = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocumentInformation__getModificationDate")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocumentInformation__getModificationDate")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.util.Calendar getModificationDate()
   /// The returned object must be released after use, by calling the [release] method.
@@ -401,10 +437,14 @@ class PDDocumentInformation extends jni.JObject {
   }
 
   static final _getTrapped = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocumentInformation__getTrapped")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocumentInformation__getTrapped")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getTrapped()
   /// The returned object must be released after use, by calling the [release] method.
@@ -417,10 +457,14 @@ class PDDocumentInformation extends jni.JObject {
   }
 
   static final _getMetadataKeys = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDDocumentInformation__getMetadataKeys")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDDocumentInformation__getMetadataKeys")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.util.Set<java.lang.String> getMetadataKeys()
   /// The returned object must be released after use, by calling the [release] method.

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/text/PDFTextStripper.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/text/PDFTextStripper.dart
@@ -334,10 +334,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _startArticle = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__startArticle")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__startArticle")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: protected void startArticle()
   ///
@@ -368,10 +372,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _endArticle = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__endArticle")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__endArticle")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: protected void endArticle()
   ///
@@ -420,10 +428,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _writePage = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__writePage")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__writePage")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: protected void writePage()
   ///
@@ -436,10 +448,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _writeLineSeparator = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__writeLineSeparator")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__writeLineSeparator")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: protected void writeLineSeparator()
   ///
@@ -450,10 +466,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _writeWordSeparator = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__writeWordSeparator")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__writeWordSeparator")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: protected void writeWordSeparator()
   ///
@@ -548,10 +568,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getStartPage = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getStartPage")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getStartPage")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int getStartPage()
   ///
@@ -580,10 +604,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getEndPage = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getEndPage")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getEndPage")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int getEndPage()
   ///
@@ -631,10 +659,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getLineSeparator = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getLineSeparator")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getLineSeparator")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getLineSeparator()
   /// The returned object must be released after use, by calling the [release] method.
@@ -646,10 +678,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getWordSeparator = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getWordSeparator")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getWordSeparator")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getWordSeparator()
   /// The returned object must be released after use, by calling the [release] method.
@@ -682,10 +718,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getSuppressDuplicateOverlappingText = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getSuppressDuplicateOverlappingText")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getSuppressDuplicateOverlappingText")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean getSuppressDuplicateOverlappingText()
   ///
@@ -695,10 +735,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getCurrentPageNo = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getCurrentPageNo")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getCurrentPageNo")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: protected int getCurrentPageNo()
   ///
@@ -709,10 +753,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getOutput = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getOutput")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getOutput")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: protected java.io.Writer getOutput()
   /// The returned object must be released after use, by calling the [release] method.
@@ -724,10 +772,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getCharactersByArticle = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getCharactersByArticle")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getCharactersByArticle")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: protected java.util.List<java.util.List<org.apache.pdfbox.text.TextPosition>> getCharactersByArticle()
   /// The returned object must be released after use, by calling the [release] method.
@@ -761,10 +813,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getSeparateByBeads = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getSeparateByBeads")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getSeparateByBeads")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean getSeparateByBeads()
   ///
@@ -792,10 +848,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getEndBookmark = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getEndBookmark")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getEndBookmark")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem getEndBookmark()
   /// The returned object must be released after use, by calling the [release] method.
@@ -825,10 +885,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getStartBookmark = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getStartBookmark")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getStartBookmark")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem getStartBookmark()
   /// The returned object must be released after use, by calling the [release] method.
@@ -859,10 +923,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getAddMoreFormatting = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getAddMoreFormatting")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getAddMoreFormatting")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean getAddMoreFormatting()
   ///
@@ -890,10 +958,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getSortByPosition = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getSortByPosition")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getSortByPosition")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean getSortByPosition()
   ///
@@ -926,10 +998,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getSpacingTolerance = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getSpacingTolerance")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getSpacingTolerance")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public float getSpacingTolerance()
   ///
@@ -959,10 +1035,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getAverageCharTolerance = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getAverageCharTolerance")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getAverageCharTolerance")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public float getAverageCharTolerance()
   ///
@@ -993,10 +1073,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getIndentThreshold = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getIndentThreshold")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getIndentThreshold")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public float getIndentThreshold()
   ///
@@ -1026,10 +1110,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getDropThreshold = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getDropThreshold")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getDropThreshold")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public float getDropThreshold()
   ///
@@ -1059,10 +1147,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getParagraphStart = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getParagraphStart")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getParagraphStart")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getParagraphStart()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1093,10 +1185,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getParagraphEnd = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getParagraphEnd")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getParagraphEnd")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getParagraphEnd()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1126,10 +1222,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getPageStart = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getPageStart")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getPageStart")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getPageStart()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1159,10 +1259,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getPageEnd = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getPageEnd")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getPageEnd")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getPageEnd()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1192,10 +1296,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getArticleStart = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getArticleStart")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getArticleStart")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getArticleStart()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1226,10 +1334,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getArticleEnd = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getArticleEnd")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getArticleEnd")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getArticleEnd()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1260,10 +1372,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _writeParagraphSeparator = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__writeParagraphSeparator")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__writeParagraphSeparator")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: protected void writeParagraphSeparator()
   ///
@@ -1274,10 +1390,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _writeParagraphStart = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__writeParagraphStart")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__writeParagraphStart")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: protected void writeParagraphStart()
   ///
@@ -1288,10 +1408,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _writeParagraphEnd = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__writeParagraphEnd")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__writeParagraphEnd")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: protected void writeParagraphEnd()
   ///
@@ -1302,10 +1426,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _writePageStart = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__writePageStart")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__writePageStart")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: protected void writePageStart()
   ///
@@ -1316,10 +1444,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _writePageEnd = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__writePageEnd")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__writePageEnd")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: protected void writePageEnd()
   ///
@@ -1349,10 +1481,14 @@ class PDFTextStripper extends jni.JObject {
   }
 
   static final _getListItemPatterns = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "PDFTextStripper__getListItemPatterns")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("PDFTextStripper__getListItemPatterns")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: protected java.util.List<java.util.regex.Pattern> getListItemPatterns()
   /// The returned object must be released after use, by calling the [release] method.

--- a/pkgs/jnigen/test/jackson_core_test/third_party/c_based/dart_bindings/com/fasterxml/jackson/core/JsonFactory.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/c_based/dart_bindings/com/fasterxml/jackson/core/JsonFactory.dart
@@ -98,10 +98,14 @@ class JsonFactory_Feature extends jni.JObject {
   }
 
   static final _enabledByDefault = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory_Feature__enabledByDefault")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory_Feature__enabledByDefault")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean enabledByDefault()
   bool enabledByDefault() {
@@ -122,10 +126,14 @@ class JsonFactory_Feature extends jni.JObject {
   }
 
   static final _getMask = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory_Feature__getMask")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory_Feature__getMask")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int getMask()
   int getMask() {
@@ -343,10 +351,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _rebuild = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__rebuild")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__rebuild")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.TSFBuilder<?,?> rebuild()
   /// The returned object must be released after use, by calling the [release] method.
@@ -380,10 +392,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _copy = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__copy")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__copy")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.JsonFactory copy()
   /// The returned object must be released after use, by calling the [release] method.
@@ -405,10 +421,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _readResolve = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__readResolve")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__readResolve")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: protected java.lang.Object readResolve()
   /// The returned object must be released after use, by calling the [release] method.
@@ -424,10 +444,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _requiresPropertyOrdering = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__requiresPropertyOrdering")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__requiresPropertyOrdering")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean requiresPropertyOrdering()
   ///
@@ -450,10 +474,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _canHandleBinaryNatively = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__canHandleBinaryNatively")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__canHandleBinaryNatively")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean canHandleBinaryNatively()
   ///
@@ -473,10 +501,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _canUseCharArrays = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__canUseCharArrays")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__canUseCharArrays")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean canUseCharArrays()
   ///
@@ -496,10 +528,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _canParseAsync = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__canParseAsync")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__canParseAsync")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean canParseAsync()
   ///
@@ -515,10 +551,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _getFormatReadFeatureType = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__getFormatReadFeatureType")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__getFormatReadFeatureType")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.Class<? extends com.fasterxml.jackson.core.FormatFeature> getFormatReadFeatureType()
   /// The returned object must be released after use, by calling the [release] method.
@@ -528,10 +568,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _getFormatWriteFeatureType = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__getFormatWriteFeatureType")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__getFormatWriteFeatureType")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.Class<? extends com.fasterxml.jackson.core.FormatFeature> getFormatWriteFeatureType()
   /// The returned object must be released after use, by calling the [release] method.
@@ -566,10 +610,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _getFormatName = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__getFormatName")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__getFormatName")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getFormatName()
   /// The returned object must be released after use, by calling the [release] method.
@@ -602,10 +650,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _requiresCustomCodec = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__requiresCustomCodec")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__requiresCustomCodec")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean requiresCustomCodec()
   ///
@@ -640,10 +692,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _version = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__version")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__version")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.Version version()
   /// The returned object must be released after use, by calling the [release] method.
@@ -742,10 +798,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _getParserFeatures = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__getParserFeatures")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__getParserFeatures")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public final int getParserFeatures()
   int getParserFeatures() {
@@ -753,10 +813,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _getGeneratorFeatures = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__getGeneratorFeatures")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__getGeneratorFeatures")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public final int getGeneratorFeatures()
   int getGeneratorFeatures() {
@@ -764,10 +828,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _getFormatParserFeatures = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__getFormatParserFeatures")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__getFormatParserFeatures")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int getFormatParserFeatures()
   int getFormatParserFeatures() {
@@ -775,10 +843,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _getFormatGeneratorFeatures = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__getFormatGeneratorFeatures")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__getFormatGeneratorFeatures")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int getFormatGeneratorFeatures()
   int getFormatGeneratorFeatures() {
@@ -893,10 +965,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _getInputDecorator = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__getInputDecorator")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__getInputDecorator")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.io.InputDecorator getInputDecorator()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1039,10 +1115,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _getCharacterEscapes = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__getCharacterEscapes")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__getCharacterEscapes")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.io.CharacterEscapes getCharacterEscapes()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1078,10 +1158,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _getOutputDecorator = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__getOutputDecorator")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__getOutputDecorator")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.io.OutputDecorator getOutputDecorator()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1141,10 +1225,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _getRootValueSeparator = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__getRootValueSeparator")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__getRootValueSeparator")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getRootValueSeparator()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1181,10 +1269,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _getCodec = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__getCodec")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__getCodec")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.ObjectCodec getCodec()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1465,10 +1557,14 @@ class JsonFactory extends jni.JObject {
   }
 
   static final _createNonBlockingByteArrayParser = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonFactory__createNonBlockingByteArrayParser")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonFactory__createNonBlockingByteArrayParser")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createNonBlockingByteArrayParser()
   /// The returned object must be released after use, by calling the [release] method.

--- a/pkgs/jnigen/test/jackson_core_test/third_party/c_based/dart_bindings/com/fasterxml/jackson/core/JsonParser.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/c_based/dart_bindings/com/fasterxml/jackson/core/JsonParser.dart
@@ -97,10 +97,14 @@ class JsonParser_Feature extends jni.JObject {
   }
 
   static final _enabledByDefault = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser_Feature__enabledByDefault")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser_Feature__enabledByDefault")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean enabledByDefault()
   bool enabledByDefault() {
@@ -121,10 +125,14 @@ class JsonParser_Feature extends jni.JObject {
   }
 
   static final _getMask = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser_Feature__getMask")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser_Feature__getMask")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int getMask()
   int getMask() {
@@ -281,10 +289,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getCodec = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getCodec")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getCodec")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.ObjectCodec getCodec()
   /// The returned object must be released after use, by calling the [release] method.
@@ -318,10 +330,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getInputSource = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getInputSource")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getInputSource")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.Object getInputSource()
   /// The returned object must be released after use, by calling the [release] method.
@@ -437,10 +453,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getSchema = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getSchema")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getSchema")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.FormatSchema getSchema()
   /// The returned object must be released after use, by calling the [release] method.
@@ -474,10 +494,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _requiresCustomCodec = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__requiresCustomCodec")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__requiresCustomCodec")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean requiresCustomCodec()
   ///
@@ -494,10 +518,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _canParseAsync = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__canParseAsync")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__canParseAsync")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean canParseAsync()
   ///
@@ -517,10 +545,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getNonBlockingInputFeeder = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getNonBlockingInputFeeder")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getNonBlockingInputFeeder")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.async.NonBlockingInputFeeder getNonBlockingInputFeeder()
   /// The returned object must be released after use, by calling the [release] method.
@@ -536,10 +568,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getReadCapabilities = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getReadCapabilities")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getReadCapabilities")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.util.JacksonFeatureSet<com.fasterxml.jackson.core.StreamReadCapability> getReadCapabilities()
   /// The returned object must be released after use, by calling the [release] method.
@@ -554,10 +590,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _version = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__version")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__version")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.Version version()
   /// The returned object must be released after use, by calling the [release] method.
@@ -571,10 +611,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _close = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__close")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__close")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract void close()
   ///
@@ -597,10 +641,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _isClosed = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__isClosed")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__isClosed")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract boolean isClosed()
   ///
@@ -616,10 +664,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getParsingContext = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getParsingContext")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getParsingContext")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonStreamContext getParsingContext()
   /// The returned object must be released after use, by calling the [release] method.
@@ -639,10 +691,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _currentLocation = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__currentLocation")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__currentLocation")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.JsonLocation currentLocation()
   /// The returned object must be released after use, by calling the [release] method.
@@ -664,10 +720,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _currentTokenLocation = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__currentTokenLocation")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__currentTokenLocation")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.JsonLocation currentTokenLocation()
   /// The returned object must be released after use, by calling the [release] method.
@@ -690,10 +750,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getCurrentLocation = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getCurrentLocation")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getCurrentLocation")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonLocation getCurrentLocation()
   /// The returned object must be released after use, by calling the [release] method.
@@ -707,10 +771,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getTokenLocation = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getTokenLocation")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getTokenLocation")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonLocation getTokenLocation()
   /// The returned object must be released after use, by calling the [release] method.
@@ -723,10 +791,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _currentValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__currentValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__currentValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.Object currentValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -769,10 +841,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getCurrentValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getCurrentValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getCurrentValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.Object getCurrentValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -966,10 +1042,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getFeatureMask = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getFeatureMask")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getFeatureMask")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int getFeatureMask()
   ///
@@ -1031,10 +1111,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getFormatFeatures = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getFormatFeatures")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getFormatFeatures")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int getFormatFeatures()
   ///
@@ -1074,10 +1158,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _nextToken = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__nextToken")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__nextToken")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonToken nextToken()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1096,10 +1184,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _nextValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__nextValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__nextValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonToken nextValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1157,10 +1249,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _nextFieldName1 = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__nextFieldName1")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__nextFieldName1")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String nextFieldName()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1178,10 +1274,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _nextTextValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__nextTextValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__nextTextValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String nextTextValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1266,10 +1366,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _nextBooleanValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__nextBooleanValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__nextBooleanValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.Boolean nextBooleanValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1296,10 +1400,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _skipChildren = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__skipChildren")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__skipChildren")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonParser skipChildren()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1324,10 +1432,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _finishToken = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__finishToken")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__finishToken")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public void finishToken()
   ///
@@ -1349,10 +1461,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _currentToken = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__currentToken")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__currentToken")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.JsonToken currentToken()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1372,10 +1488,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _currentTokenId = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__currentTokenId")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__currentTokenId")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int currentTokenId()
   ///
@@ -1393,10 +1513,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getCurrentToken = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getCurrentToken")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getCurrentToken")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonToken getCurrentToken()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1411,10 +1535,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getCurrentTokenId = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getCurrentTokenId")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getCurrentTokenId")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract int getCurrentTokenId()
   ///
@@ -1426,10 +1554,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _hasCurrentToken = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__hasCurrentToken")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__hasCurrentToken")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract boolean hasCurrentToken()
   ///
@@ -1500,10 +1632,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _isExpectedStartArrayToken = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__isExpectedStartArrayToken")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__isExpectedStartArrayToken")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean isExpectedStartArrayToken()
   ///
@@ -1528,10 +1664,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _isExpectedStartObjectToken = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__isExpectedStartObjectToken")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__isExpectedStartObjectToken")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean isExpectedStartObjectToken()
   ///
@@ -1546,10 +1686,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _isExpectedNumberIntToken = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__isExpectedNumberIntToken")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__isExpectedNumberIntToken")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean isExpectedNumberIntToken()
   ///
@@ -1567,10 +1711,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _isNaN = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__isNaN")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__isNaN")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean isNaN()
   ///
@@ -1591,10 +1739,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _clearCurrentToken = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__clearCurrentToken")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__clearCurrentToken")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract void clearCurrentToken()
   ///
@@ -1613,10 +1765,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getLastClearedToken = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getLastClearedToken")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getLastClearedToken")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonToken getLastClearedToken()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1657,10 +1813,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getCurrentName = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getCurrentName")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getCurrentName")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract java.lang.String getCurrentName()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1674,10 +1834,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _currentName = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__currentName")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__currentName")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String currentName()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1696,10 +1860,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getText = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getText")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getText")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract java.lang.String getText()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1748,10 +1916,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getTextCharacters = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getTextCharacters")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getTextCharacters")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract char[] getTextCharacters()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1789,10 +1961,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getTextLength = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getTextLength")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getTextLength")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract int getTextLength()
   ///
@@ -1808,10 +1984,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getTextOffset = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getTextOffset")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getTextOffset")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract int getTextOffset()
   ///
@@ -1827,10 +2007,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _hasTextCharacters = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__hasTextCharacters")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__hasTextCharacters")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract boolean hasTextCharacters()
   ///
@@ -1853,10 +2037,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getNumberValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getNumberValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getNumberValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract java.lang.Number getNumberValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1876,10 +2064,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getNumberValueExact = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getNumberValueExact")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getNumberValueExact")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.Number getNumberValueExact()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1904,10 +2096,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getNumberType = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getNumberType")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getNumberType")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonParser.NumberType getNumberType()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1925,10 +2121,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getByteValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getByteValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getByteValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public byte getByteValue()
   ///
@@ -1958,10 +2158,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getShortValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getShortValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getShortValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public short getShortValue()
   ///
@@ -1985,10 +2189,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getIntValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getIntValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getIntValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract int getIntValue()
   ///
@@ -2012,10 +2220,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getLongValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getLongValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getLongValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract long getLongValue()
   ///
@@ -2039,10 +2251,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getBigIntegerValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getBigIntegerValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getBigIntegerValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract java.math.BigInteger getBigIntegerValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2064,10 +2280,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getFloatValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getFloatValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getFloatValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract float getFloatValue()
   ///
@@ -2091,10 +2311,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getDoubleValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getDoubleValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getDoubleValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract double getDoubleValue()
   ///
@@ -2118,10 +2342,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getDecimalValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getDecimalValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getDecimalValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract java.math.BigDecimal getDecimalValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2139,10 +2367,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getBooleanValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getBooleanValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getBooleanValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean getBooleanValue()
   ///
@@ -2162,10 +2394,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getEmbeddedObject = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getEmbeddedObject")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getEmbeddedObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.Object getEmbeddedObject()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2228,10 +2464,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getBinaryValue1 = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getBinaryValue1")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getBinaryValue1")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public byte[] getBinaryValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2304,10 +2544,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getValueAsInt = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getValueAsInt")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getValueAsInt")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int getValueAsInt()
   ///
@@ -2356,10 +2600,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getValueAsLong = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getValueAsLong")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getValueAsLong")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public long getValueAsLong()
   ///
@@ -2408,10 +2656,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getValueAsDouble = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getValueAsDouble")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getValueAsDouble")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public double getValueAsDouble()
   ///
@@ -2460,10 +2712,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getValueAsBoolean = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getValueAsBoolean")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getValueAsBoolean")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean getValueAsBoolean()
   ///
@@ -2512,10 +2768,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getValueAsString = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getValueAsString")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getValueAsString")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getValueAsString()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2566,10 +2826,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _canReadObjectId = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__canReadObjectId")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__canReadObjectId")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean canReadObjectId()
   ///
@@ -2589,10 +2853,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _canReadTypeId = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__canReadTypeId")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__canReadTypeId")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean canReadTypeId()
   ///
@@ -2612,10 +2880,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getObjectId = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getObjectId")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getObjectId")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.Object getObjectId()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2638,10 +2910,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _getTypeId = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__getTypeId")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__getTypeId")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.Object getTypeId()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2803,10 +3079,14 @@ class JsonParser extends jni.JObject {
   }
 
   static final _readValueAsTree = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonParser__readValueAsTree")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonParser__readValueAsTree")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public T readValueAsTree()
   /// The returned object must be released after use, by calling the [release] method.

--- a/pkgs/jnigen/test/jackson_core_test/third_party/c_based/dart_bindings/com/fasterxml/jackson/core/JsonToken.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/c_based/dart_bindings/com/fasterxml/jackson/core/JsonToken.dart
@@ -83,8 +83,13 @@ class JsonToken extends jni.JObject {
 
   static final _id = jniLookup<
           ffi.NativeFunction<
-              jni.JniResult Function(ffi.Pointer<ffi.Void>)>>("JsonToken__id")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonToken__id")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public final int id()
   int id() {
@@ -92,10 +97,14 @@ class JsonToken extends jni.JObject {
   }
 
   static final _asString = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonToken__asString")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonToken__asString")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public final java.lang.String asString()
   /// The returned object must be released after use, by calling the [release] method.
@@ -104,10 +113,14 @@ class JsonToken extends jni.JObject {
   }
 
   static final _asCharArray = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonToken__asCharArray")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonToken__asCharArray")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public final char[] asCharArray()
   /// The returned object must be released after use, by calling the [release] method.
@@ -117,10 +130,14 @@ class JsonToken extends jni.JObject {
   }
 
   static final _asByteArray = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonToken__asByteArray")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonToken__asByteArray")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public final byte[] asByteArray()
   /// The returned object must be released after use, by calling the [release] method.
@@ -130,10 +147,14 @@ class JsonToken extends jni.JObject {
   }
 
   static final _isNumeric = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonToken__isNumeric")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonToken__isNumeric")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public final boolean isNumeric()
   ///
@@ -144,10 +165,14 @@ class JsonToken extends jni.JObject {
   }
 
   static final _isStructStart = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonToken__isStructStart")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonToken__isStructStart")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public final boolean isStructStart()
   ///
@@ -163,10 +188,14 @@ class JsonToken extends jni.JObject {
   }
 
   static final _isStructEnd = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonToken__isStructEnd")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonToken__isStructEnd")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public final boolean isStructEnd()
   ///
@@ -182,10 +211,14 @@ class JsonToken extends jni.JObject {
   }
 
   static final _isScalarValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonToken__isScalarValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonToken__isScalarValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public final boolean isScalarValue()
   ///
@@ -200,10 +233,14 @@ class JsonToken extends jni.JObject {
   }
 
   static final _isBoolean = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonToken__isBoolean")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonToken__isBoolean")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public final boolean isBoolean()
   ///

--- a/pkgs/jnigen/test/jackson_core_test/third_party/dart_only/dart_bindings/com/fasterxml/jackson/core/JsonFactory.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/dart_only/dart_bindings/com/fasterxml/jackson/core/JsonFactory.dart
@@ -64,11 +64,23 @@ class JsonFactory_Feature extends jni.JObject {
     r"()[Lcom/fasterxml/jackson/core/JsonFactory$Feature;",
   );
 
+  static final _values = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public com.fasterxml.jackson.core.JsonFactory.Feature[] values()
   /// The returned object must be released after use, by calling the [release] method.
   static jni.JArray<JsonFactory_Feature> values() {
-    return _id_values(
-        _class, const jni.JArrayType($JsonFactory_FeatureType()), []);
+    return _values(_class.reference.pointer, _id_values as jni.JMethodIDPtr)
+        .object(const jni.JArrayType($JsonFactory_FeatureType()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -76,13 +88,25 @@ class JsonFactory_Feature extends jni.JObject {
     r"(Ljava/lang/String;)Lcom/fasterxml/jackson/core/JsonFactory$Feature;",
   );
 
+  static final _valueOf = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: static public com.fasterxml.jackson.core.JsonFactory.Feature valueOf(java.lang.String name)
   /// The returned object must be released after use, by calling the [release] method.
   static JsonFactory_Feature valueOf(
     jni.JString name,
   ) {
-    return _id_valueOf(
-        _class, const $JsonFactory_FeatureType(), [name.reference.pointer]);
+    return _valueOf(_class.reference.pointer, _id_valueOf as jni.JMethodIDPtr,
+            name.reference.pointer)
+        .object(const $JsonFactory_FeatureType());
   }
 
   static final _id_collectDefaults = _class.staticMethodId(
@@ -90,13 +114,27 @@ class JsonFactory_Feature extends jni.JObject {
     r"()I",
   );
 
+  static final _collectDefaults = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public int collectDefaults()
   ///
   /// Method that calculates bit set (flags) of all features that
   /// are enabled by default.
   ///@return Bit field of features enabled by default
   static int collectDefaults() {
-    return _id_collectDefaults(_class, const jni.jintType(), []);
+    return _collectDefaults(
+            _class.reference.pointer, _id_collectDefaults as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_enabledByDefault = _class.instanceMethodId(
@@ -104,9 +142,23 @@ class JsonFactory_Feature extends jni.JObject {
     r"()Z",
   );
 
+  static final _enabledByDefault = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public boolean enabledByDefault()
   bool enabledByDefault() {
-    return _id_enabledByDefault(this, const jni.jbooleanType(), []);
+    return _enabledByDefault(
+            reference.pointer, _id_enabledByDefault as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_enabledIn = _class.instanceMethodId(
@@ -114,12 +166,21 @@ class JsonFactory_Feature extends jni.JObject {
     r"(I)Z",
   );
 
+  static final _enabledIn = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
+
   /// from: public boolean enabledIn(int flags)
   bool enabledIn(
     int flags,
   ) {
-    return _id_enabledIn(
-        this, const jni.jbooleanType(), [jni.JValueInt(flags)]);
+    return _enabledIn(
+            reference.pointer, _id_enabledIn as jni.JMethodIDPtr, flags)
+        .boolean;
   }
 
   static final _id_getMask = _class.instanceMethodId(
@@ -127,9 +188,21 @@ class JsonFactory_Feature extends jni.JObject {
     r"()I",
   );
 
+  static final _getMask = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public int getMask()
   int getMask() {
-    return _id_getMask(this, const jni.jintType(), []);
+    return _getMask(reference.pointer, _id_getMask as jni.JMethodIDPtr).integer;
   }
 }
 
@@ -253,6 +326,18 @@ class JsonFactory extends jni.JObject {
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   ///
@@ -265,25 +350,53 @@ class JsonFactory extends jni.JObject {
   /// and this reuse only works within context of a single
   /// factory instance.
   factory JsonFactory() {
-    return JsonFactory.fromReference(_id_new0(_class, referenceType, []));
+    return JsonFactory.fromReference(
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 
   static final _id_new1 = _class.constructorId(
     r"(Lcom/fasterxml/jackson/core/ObjectCodec;)V",
   );
 
+  static final _new1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public void <init>(com.fasterxml.jackson.core.ObjectCodec oc)
   /// The returned object must be released after use, by calling the [release] method.
   factory JsonFactory.new1(
     jni.JObject oc,
   ) {
-    return JsonFactory.fromReference(
-        _id_new1(_class, referenceType, [oc.reference.pointer]));
+    return JsonFactory.fromReference(_new1(_class.reference.pointer,
+            _id_new1 as jni.JMethodIDPtr, oc.reference.pointer)
+        .reference);
   }
 
   static final _id_new2 = _class.constructorId(
     r"(Lcom/fasterxml/jackson/core/JsonFactory;Lcom/fasterxml/jackson/core/ObjectCodec;)V",
   );
+
+  static final _new2 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
 
   /// from: protected void <init>(com.fasterxml.jackson.core.JsonFactory src, com.fasterxml.jackson.core.ObjectCodec codec)
   /// The returned object must be released after use, by calling the [release] method.
@@ -296,13 +409,28 @@ class JsonFactory extends jni.JObject {
     JsonFactory src,
     jni.JObject codec,
   ) {
-    return JsonFactory.fromReference(_id_new2(_class, referenceType,
-        [src.reference.pointer, codec.reference.pointer]));
+    return JsonFactory.fromReference(_new2(
+            _class.reference.pointer,
+            _id_new2 as jni.JMethodIDPtr,
+            src.reference.pointer,
+            codec.reference.pointer)
+        .reference);
   }
 
   static final _id_new3 = _class.constructorId(
     r"(Lcom/fasterxml/jackson/core/JsonFactoryBuilder;)V",
   );
+
+  static final _new3 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public void <init>(com.fasterxml.jackson.core.JsonFactoryBuilder b)
   /// The returned object must be released after use, by calling the [release] method.
@@ -313,13 +441,25 @@ class JsonFactory extends jni.JObject {
   factory JsonFactory.new3(
     jni.JObject b,
   ) {
-    return JsonFactory.fromReference(
-        _id_new3(_class, referenceType, [b.reference.pointer]));
+    return JsonFactory.fromReference(_new3(_class.reference.pointer,
+            _id_new3 as jni.JMethodIDPtr, b.reference.pointer)
+        .reference);
   }
 
   static final _id_new4 = _class.constructorId(
     r"(Lcom/fasterxml/jackson/core/TSFBuilder;Z)V",
   );
+
+  static final _new4 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, ffi.Int64)>)>>(
+          "globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, int)>();
 
   /// from: protected void <init>(com.fasterxml.jackson.core.TSFBuilder<?,?> b, boolean bogus)
   /// The returned object must be released after use, by calling the [release] method.
@@ -333,14 +473,27 @@ class JsonFactory extends jni.JObject {
     jni.JObject b,
     bool bogus,
   ) {
-    return JsonFactory.fromReference(
-        _id_new4(_class, referenceType, [b.reference.pointer, bogus ? 1 : 0]));
+    return JsonFactory.fromReference(_new4(_class.reference.pointer,
+            _id_new4 as jni.JMethodIDPtr, b.reference.pointer, bogus ? 1 : 0)
+        .reference);
   }
 
   static final _id_rebuild = _class.instanceMethodId(
     r"rebuild",
     r"()Lcom/fasterxml/jackson/core/TSFBuilder;",
   );
+
+  static final _rebuild = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.TSFBuilder<?,?> rebuild()
   /// The returned object must be released after use, by calling the [release] method.
@@ -350,13 +503,26 @@ class JsonFactory extends jni.JObject {
   ///@return Builder instance to use
   ///@since 2.10
   jni.JObject rebuild() {
-    return _id_rebuild(this, const jni.JObjectType(), []);
+    return _rebuild(reference.pointer, _id_rebuild as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_builder = _class.staticMethodId(
     r"builder",
     r"()Lcom/fasterxml/jackson/core/TSFBuilder;",
   );
+
+  static final _builder = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: static public com.fasterxml.jackson.core.TSFBuilder<?,?> builder()
   /// The returned object must be released after use, by calling the [release] method.
@@ -370,13 +536,26 @@ class JsonFactory extends jni.JObject {
   /// will be fixed in 3.0.
   ///@return Builder instance to use
   static jni.JObject builder() {
-    return _id_builder(_class, const jni.JObjectType(), []);
+    return _builder(_class.reference.pointer, _id_builder as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_copy = _class.instanceMethodId(
     r"copy",
     r"()Lcom/fasterxml/jackson/core/JsonFactory;",
   );
+
+  static final _copy = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.JsonFactory copy()
   /// The returned object must be released after use, by calling the [release] method.
@@ -394,13 +573,26 @@ class JsonFactory extends jni.JObject {
   ///@return Copy of this factory instance
   ///@since 2.1
   JsonFactory copy() {
-    return _id_copy(this, const $JsonFactoryType(), []);
+    return _copy(reference.pointer, _id_copy as jni.JMethodIDPtr)
+        .object(const $JsonFactoryType());
   }
 
   static final _id_readResolve = _class.instanceMethodId(
     r"readResolve",
     r"()Ljava/lang/Object;",
   );
+
+  static final _readResolve = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: protected java.lang.Object readResolve()
   /// The returned object must be released after use, by calling the [release] method.
@@ -412,13 +604,26 @@ class JsonFactory extends jni.JObject {
   /// Note: must be overridden by sub-classes as well.
   ///@return Newly constructed instance
   jni.JObject readResolve() {
-    return _id_readResolve(this, const jni.JObjectType(), []);
+    return _readResolve(reference.pointer, _id_readResolve as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_requiresPropertyOrdering = _class.instanceMethodId(
     r"requiresPropertyOrdering",
     r"()Z",
   );
+
+  static final _requiresPropertyOrdering = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public boolean requiresPropertyOrdering()
   ///
@@ -437,13 +642,27 @@ class JsonFactory extends jni.JObject {
   ///   requires Object properties to be ordered.
   ///@since 2.3
   bool requiresPropertyOrdering() {
-    return _id_requiresPropertyOrdering(this, const jni.jbooleanType(), []);
+    return _requiresPropertyOrdering(
+            reference.pointer, _id_requiresPropertyOrdering as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_canHandleBinaryNatively = _class.instanceMethodId(
     r"canHandleBinaryNatively",
     r"()Z",
   );
+
+  static final _canHandleBinaryNatively = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public boolean canHandleBinaryNatively()
   ///
@@ -459,13 +678,27 @@ class JsonFactory extends jni.JObject {
   ///    supports native binary content
   ///@since 2.3
   bool canHandleBinaryNatively() {
-    return _id_canHandleBinaryNatively(this, const jni.jbooleanType(), []);
+    return _canHandleBinaryNatively(
+            reference.pointer, _id_canHandleBinaryNatively as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_canUseCharArrays = _class.instanceMethodId(
     r"canUseCharArrays",
     r"()Z",
   );
+
+  static final _canUseCharArrays = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public boolean canUseCharArrays()
   ///
@@ -481,13 +714,27 @@ class JsonFactory extends jni.JObject {
   ///   accessed using parser method {@code getTextCharacters()}.
   ///@since 2.4
   bool canUseCharArrays() {
-    return _id_canUseCharArrays(this, const jni.jbooleanType(), []);
+    return _canUseCharArrays(
+            reference.pointer, _id_canUseCharArrays as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_canParseAsync = _class.instanceMethodId(
     r"canParseAsync",
     r"()Z",
   );
+
+  static final _canParseAsync = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public boolean canParseAsync()
   ///
@@ -499,7 +746,9 @@ class JsonFactory extends jni.JObject {
   ///    not (and consequently whether {@code createNonBlockingXxx()} method(s) work)
   ///@since 2.9
   bool canParseAsync() {
-    return _id_canParseAsync(this, const jni.jbooleanType(), []);
+    return _canParseAsync(
+            reference.pointer, _id_canParseAsync as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_getFormatReadFeatureType = _class.instanceMethodId(
@@ -507,10 +756,24 @@ class JsonFactory extends jni.JObject {
     r"()Ljava/lang/Class;",
   );
 
+  static final _getFormatReadFeatureType = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public java.lang.Class<? extends com.fasterxml.jackson.core.FormatFeature> getFormatReadFeatureType()
   /// The returned object must be released after use, by calling the [release] method.
   jni.JObject getFormatReadFeatureType() {
-    return _id_getFormatReadFeatureType(this, const jni.JObjectType(), []);
+    return _getFormatReadFeatureType(
+            reference.pointer, _id_getFormatReadFeatureType as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_getFormatWriteFeatureType = _class.instanceMethodId(
@@ -518,16 +781,41 @@ class JsonFactory extends jni.JObject {
     r"()Ljava/lang/Class;",
   );
 
+  static final _getFormatWriteFeatureType = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public java.lang.Class<? extends com.fasterxml.jackson.core.FormatFeature> getFormatWriteFeatureType()
   /// The returned object must be released after use, by calling the [release] method.
   jni.JObject getFormatWriteFeatureType() {
-    return _id_getFormatWriteFeatureType(this, const jni.JObjectType(), []);
+    return _getFormatWriteFeatureType(reference.pointer,
+            _id_getFormatWriteFeatureType as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_canUseSchema = _class.instanceMethodId(
     r"canUseSchema",
     r"(Lcom/fasterxml/jackson/core/FormatSchema;)Z",
   );
+
+  static final _canUseSchema = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public boolean canUseSchema(com.fasterxml.jackson.core.FormatSchema schema)
   ///
@@ -543,14 +831,27 @@ class JsonFactory extends jni.JObject {
   bool canUseSchema(
     jni.JObject schema,
   ) {
-    return _id_canUseSchema(
-        this, const jni.jbooleanType(), [schema.reference.pointer]);
+    return _canUseSchema(reference.pointer,
+            _id_canUseSchema as jni.JMethodIDPtr, schema.reference.pointer)
+        .boolean;
   }
 
   static final _id_getFormatName = _class.instanceMethodId(
     r"getFormatName",
     r"()Ljava/lang/String;",
   );
+
+  static final _getFormatName = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public java.lang.String getFormatName()
   /// The returned object must be released after use, by calling the [release] method.
@@ -562,7 +863,9 @@ class JsonFactory extends jni.JObject {
   /// implementation will return null for all sub-classes
   ///@return Name of the format handled by parsers, generators this factory creates
   jni.JString getFormatName() {
-    return _id_getFormatName(this, const jni.JStringType(), []);
+    return _getFormatName(
+            reference.pointer, _id_getFormatName as jni.JMethodIDPtr)
+        .object(const jni.JStringType());
   }
 
   static final _id_hasFormat = _class.instanceMethodId(
@@ -570,19 +873,43 @@ class JsonFactory extends jni.JObject {
     r"(Lcom/fasterxml/jackson/core/format/InputAccessor;)Lcom/fasterxml/jackson/core/format/MatchStrength;",
   );
 
+  static final _hasFormat = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public com.fasterxml.jackson.core.format.MatchStrength hasFormat(com.fasterxml.jackson.core.format.InputAccessor acc)
   /// The returned object must be released after use, by calling the [release] method.
   jni.JObject hasFormat(
     jni.JObject acc,
   ) {
-    return _id_hasFormat(
-        this, const jni.JObjectType(), [acc.reference.pointer]);
+    return _hasFormat(reference.pointer, _id_hasFormat as jni.JMethodIDPtr,
+            acc.reference.pointer)
+        .object(const jni.JObjectType());
   }
 
   static final _id_requiresCustomCodec = _class.instanceMethodId(
     r"requiresCustomCodec",
     r"()Z",
   );
+
+  static final _requiresCustomCodec = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public boolean requiresCustomCodec()
   ///
@@ -596,7 +923,9 @@ class JsonFactory extends jni.JObject {
   ///   ObjectCodec is enough
   ///@since 2.1
   bool requiresCustomCodec() {
-    return _id_requiresCustomCodec(this, const jni.jbooleanType(), []);
+    return _requiresCustomCodec(
+            reference.pointer, _id_requiresCustomCodec as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_hasJSONFormat = _class.instanceMethodId(
@@ -604,13 +933,25 @@ class JsonFactory extends jni.JObject {
     r"(Lcom/fasterxml/jackson/core/format/InputAccessor;)Lcom/fasterxml/jackson/core/format/MatchStrength;",
   );
 
+  static final _hasJSONFormat = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: protected com.fasterxml.jackson.core.format.MatchStrength hasJSONFormat(com.fasterxml.jackson.core.format.InputAccessor acc)
   /// The returned object must be released after use, by calling the [release] method.
   jni.JObject hasJSONFormat(
     jni.JObject acc,
   ) {
-    return _id_hasJSONFormat(
-        this, const jni.JObjectType(), [acc.reference.pointer]);
+    return _hasJSONFormat(reference.pointer,
+            _id_hasJSONFormat as jni.JMethodIDPtr, acc.reference.pointer)
+        .object(const jni.JObjectType());
   }
 
   static final _id_version = _class.instanceMethodId(
@@ -618,16 +959,40 @@ class JsonFactory extends jni.JObject {
     r"()Lcom/fasterxml/jackson/core/Version;",
   );
 
+  static final _version = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public com.fasterxml.jackson.core.Version version()
   /// The returned object must be released after use, by calling the [release] method.
   jni.JObject version() {
-    return _id_version(this, const jni.JObjectType(), []);
+    return _version(reference.pointer, _id_version as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_configure = _class.instanceMethodId(
     r"configure",
     r"(Lcom/fasterxml/jackson/core/JsonFactory$Feature;Z)Lcom/fasterxml/jackson/core/JsonFactory;",
   );
+
+  static final _configure = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, ffi.Int64)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, int)>();
 
   /// from: public final com.fasterxml.jackson.core.JsonFactory configure(com.fasterxml.jackson.core.JsonFactory.Feature f, boolean state)
   /// The returned object must be released after use, by calling the [release] method.
@@ -642,14 +1007,26 @@ class JsonFactory extends jni.JObject {
     JsonFactory_Feature f,
     bool state,
   ) {
-    return _id_configure(
-        this, const $JsonFactoryType(), [f.reference.pointer, state ? 1 : 0]);
+    return _configure(reference.pointer, _id_configure as jni.JMethodIDPtr,
+            f.reference.pointer, state ? 1 : 0)
+        .object(const $JsonFactoryType());
   }
 
   static final _id_enable = _class.instanceMethodId(
     r"enable",
     r"(Lcom/fasterxml/jackson/core/JsonFactory$Feature;)Lcom/fasterxml/jackson/core/JsonFactory;",
   );
+
+  static final _enable = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonFactory enable(com.fasterxml.jackson.core.JsonFactory.Feature f)
   /// The returned object must be released after use, by calling the [release] method.
@@ -662,13 +1039,26 @@ class JsonFactory extends jni.JObject {
   JsonFactory enable(
     JsonFactory_Feature f,
   ) {
-    return _id_enable(this, const $JsonFactoryType(), [f.reference.pointer]);
+    return _enable(reference.pointer, _id_enable as jni.JMethodIDPtr,
+            f.reference.pointer)
+        .object(const $JsonFactoryType());
   }
 
   static final _id_disable = _class.instanceMethodId(
     r"disable",
     r"(Lcom/fasterxml/jackson/core/JsonFactory$Feature;)Lcom/fasterxml/jackson/core/JsonFactory;",
   );
+
+  static final _disable = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonFactory disable(com.fasterxml.jackson.core.JsonFactory.Feature f)
   /// The returned object must be released after use, by calling the [release] method.
@@ -681,13 +1071,26 @@ class JsonFactory extends jni.JObject {
   JsonFactory disable(
     JsonFactory_Feature f,
   ) {
-    return _id_disable(this, const $JsonFactoryType(), [f.reference.pointer]);
+    return _disable(reference.pointer, _id_disable as jni.JMethodIDPtr,
+            f.reference.pointer)
+        .object(const $JsonFactoryType());
   }
 
   static final _id_isEnabled = _class.instanceMethodId(
     r"isEnabled",
     r"(Lcom/fasterxml/jackson/core/JsonFactory$Feature;)Z",
   );
+
+  static final _isEnabled = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public final boolean isEnabled(com.fasterxml.jackson.core.JsonFactory.Feature f)
   ///
@@ -697,7 +1100,9 @@ class JsonFactory extends jni.JObject {
   bool isEnabled(
     JsonFactory_Feature f,
   ) {
-    return _id_isEnabled(this, const jni.jbooleanType(), [f.reference.pointer]);
+    return _isEnabled(reference.pointer, _id_isEnabled as jni.JMethodIDPtr,
+            f.reference.pointer)
+        .boolean;
   }
 
   static final _id_getParserFeatures = _class.instanceMethodId(
@@ -705,9 +1110,23 @@ class JsonFactory extends jni.JObject {
     r"()I",
   );
 
+  static final _getParserFeatures = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public final int getParserFeatures()
   int getParserFeatures() {
-    return _id_getParserFeatures(this, const jni.jintType(), []);
+    return _getParserFeatures(
+            reference.pointer, _id_getParserFeatures as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_getGeneratorFeatures = _class.instanceMethodId(
@@ -715,9 +1134,23 @@ class JsonFactory extends jni.JObject {
     r"()I",
   );
 
+  static final _getGeneratorFeatures = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public final int getGeneratorFeatures()
   int getGeneratorFeatures() {
-    return _id_getGeneratorFeatures(this, const jni.jintType(), []);
+    return _getGeneratorFeatures(
+            reference.pointer, _id_getGeneratorFeatures as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_getFormatParserFeatures = _class.instanceMethodId(
@@ -725,9 +1158,23 @@ class JsonFactory extends jni.JObject {
     r"()I",
   );
 
+  static final _getFormatParserFeatures = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public int getFormatParserFeatures()
   int getFormatParserFeatures() {
-    return _id_getFormatParserFeatures(this, const jni.jintType(), []);
+    return _getFormatParserFeatures(
+            reference.pointer, _id_getFormatParserFeatures as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_getFormatGeneratorFeatures = _class.instanceMethodId(
@@ -735,15 +1182,40 @@ class JsonFactory extends jni.JObject {
     r"()I",
   );
 
+  static final _getFormatGeneratorFeatures = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public int getFormatGeneratorFeatures()
   int getFormatGeneratorFeatures() {
-    return _id_getFormatGeneratorFeatures(this, const jni.jintType(), []);
+    return _getFormatGeneratorFeatures(reference.pointer,
+            _id_getFormatGeneratorFeatures as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_configure1 = _class.instanceMethodId(
     r"configure",
     r"(Lcom/fasterxml/jackson/core/JsonParser$Feature;Z)Lcom/fasterxml/jackson/core/JsonFactory;",
   );
+
+  static final _configure1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, ffi.Int64)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, int)>();
 
   /// from: public final com.fasterxml.jackson.core.JsonFactory configure(com.fasterxml.jackson.core.JsonParser.Feature f, boolean state)
   /// The returned object must be released after use, by calling the [release] method.
@@ -757,14 +1229,26 @@ class JsonFactory extends jni.JObject {
     jsonparser_.JsonParser_Feature f,
     bool state,
   ) {
-    return _id_configure1(
-        this, const $JsonFactoryType(), [f.reference.pointer, state ? 1 : 0]);
+    return _configure1(reference.pointer, _id_configure1 as jni.JMethodIDPtr,
+            f.reference.pointer, state ? 1 : 0)
+        .object(const $JsonFactoryType());
   }
 
   static final _id_enable1 = _class.instanceMethodId(
     r"enable",
     r"(Lcom/fasterxml/jackson/core/JsonParser$Feature;)Lcom/fasterxml/jackson/core/JsonFactory;",
   );
+
+  static final _enable1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonFactory enable(com.fasterxml.jackson.core.JsonParser.Feature f)
   /// The returned object must be released after use, by calling the [release] method.
@@ -776,13 +1260,26 @@ class JsonFactory extends jni.JObject {
   JsonFactory enable1(
     jsonparser_.JsonParser_Feature f,
   ) {
-    return _id_enable1(this, const $JsonFactoryType(), [f.reference.pointer]);
+    return _enable1(reference.pointer, _id_enable1 as jni.JMethodIDPtr,
+            f.reference.pointer)
+        .object(const $JsonFactoryType());
   }
 
   static final _id_disable1 = _class.instanceMethodId(
     r"disable",
     r"(Lcom/fasterxml/jackson/core/JsonParser$Feature;)Lcom/fasterxml/jackson/core/JsonFactory;",
   );
+
+  static final _disable1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonFactory disable(com.fasterxml.jackson.core.JsonParser.Feature f)
   /// The returned object must be released after use, by calling the [release] method.
@@ -794,13 +1291,26 @@ class JsonFactory extends jni.JObject {
   JsonFactory disable1(
     jsonparser_.JsonParser_Feature f,
   ) {
-    return _id_disable1(this, const $JsonFactoryType(), [f.reference.pointer]);
+    return _disable1(reference.pointer, _id_disable1 as jni.JMethodIDPtr,
+            f.reference.pointer)
+        .object(const $JsonFactoryType());
   }
 
   static final _id_isEnabled1 = _class.instanceMethodId(
     r"isEnabled",
     r"(Lcom/fasterxml/jackson/core/JsonParser$Feature;)Z",
   );
+
+  static final _isEnabled1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public final boolean isEnabled(com.fasterxml.jackson.core.JsonParser.Feature f)
   ///
@@ -810,14 +1320,26 @@ class JsonFactory extends jni.JObject {
   bool isEnabled1(
     jsonparser_.JsonParser_Feature f,
   ) {
-    return _id_isEnabled1(
-        this, const jni.jbooleanType(), [f.reference.pointer]);
+    return _isEnabled1(reference.pointer, _id_isEnabled1 as jni.JMethodIDPtr,
+            f.reference.pointer)
+        .boolean;
   }
 
   static final _id_isEnabled2 = _class.instanceMethodId(
     r"isEnabled",
     r"(Lcom/fasterxml/jackson/core/StreamReadFeature;)Z",
   );
+
+  static final _isEnabled2 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public final boolean isEnabled(com.fasterxml.jackson.core.StreamReadFeature f)
   ///
@@ -828,14 +1350,27 @@ class JsonFactory extends jni.JObject {
   bool isEnabled2(
     jni.JObject f,
   ) {
-    return _id_isEnabled2(
-        this, const jni.jbooleanType(), [f.reference.pointer]);
+    return _isEnabled2(reference.pointer, _id_isEnabled2 as jni.JMethodIDPtr,
+            f.reference.pointer)
+        .boolean;
   }
 
   static final _id_getInputDecorator = _class.instanceMethodId(
     r"getInputDecorator",
     r"()Lcom/fasterxml/jackson/core/io/InputDecorator;",
   );
+
+  static final _getInputDecorator = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.io.InputDecorator getInputDecorator()
   /// The returned object must be released after use, by calling the [release] method.
@@ -844,13 +1379,26 @@ class JsonFactory extends jni.JObject {
   /// there is no default decorator).
   ///@return InputDecorator configured, if any
   jni.JObject getInputDecorator() {
-    return _id_getInputDecorator(this, const jni.JObjectType(), []);
+    return _getInputDecorator(
+            reference.pointer, _id_getInputDecorator as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_setInputDecorator = _class.instanceMethodId(
     r"setInputDecorator",
     r"(Lcom/fasterxml/jackson/core/io/InputDecorator;)Lcom/fasterxml/jackson/core/JsonFactory;",
   );
+
+  static final _setInputDecorator = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonFactory setInputDecorator(com.fasterxml.jackson.core.io.InputDecorator d)
   /// The returned object must be released after use, by calling the [release] method.
@@ -862,14 +1410,26 @@ class JsonFactory extends jni.JObject {
   JsonFactory setInputDecorator(
     jni.JObject d,
   ) {
-    return _id_setInputDecorator(
-        this, const $JsonFactoryType(), [d.reference.pointer]);
+    return _setInputDecorator(reference.pointer,
+            _id_setInputDecorator as jni.JMethodIDPtr, d.reference.pointer)
+        .object(const $JsonFactoryType());
   }
 
   static final _id_configure2 = _class.instanceMethodId(
     r"configure",
     r"(Lcom/fasterxml/jackson/core/JsonGenerator$Feature;Z)Lcom/fasterxml/jackson/core/JsonFactory;",
   );
+
+  static final _configure2 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, ffi.Int64)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, int)>();
 
   /// from: public final com.fasterxml.jackson.core.JsonFactory configure(com.fasterxml.jackson.core.JsonGenerator.Feature f, boolean state)
   /// The returned object must be released after use, by calling the [release] method.
@@ -883,14 +1443,26 @@ class JsonFactory extends jni.JObject {
     jni.JObject f,
     bool state,
   ) {
-    return _id_configure2(
-        this, const $JsonFactoryType(), [f.reference.pointer, state ? 1 : 0]);
+    return _configure2(reference.pointer, _id_configure2 as jni.JMethodIDPtr,
+            f.reference.pointer, state ? 1 : 0)
+        .object(const $JsonFactoryType());
   }
 
   static final _id_enable2 = _class.instanceMethodId(
     r"enable",
     r"(Lcom/fasterxml/jackson/core/JsonGenerator$Feature;)Lcom/fasterxml/jackson/core/JsonFactory;",
   );
+
+  static final _enable2 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonFactory enable(com.fasterxml.jackson.core.JsonGenerator.Feature f)
   /// The returned object must be released after use, by calling the [release] method.
@@ -902,13 +1474,26 @@ class JsonFactory extends jni.JObject {
   JsonFactory enable2(
     jni.JObject f,
   ) {
-    return _id_enable2(this, const $JsonFactoryType(), [f.reference.pointer]);
+    return _enable2(reference.pointer, _id_enable2 as jni.JMethodIDPtr,
+            f.reference.pointer)
+        .object(const $JsonFactoryType());
   }
 
   static final _id_disable2 = _class.instanceMethodId(
     r"disable",
     r"(Lcom/fasterxml/jackson/core/JsonGenerator$Feature;)Lcom/fasterxml/jackson/core/JsonFactory;",
   );
+
+  static final _disable2 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonFactory disable(com.fasterxml.jackson.core.JsonGenerator.Feature f)
   /// The returned object must be released after use, by calling the [release] method.
@@ -920,13 +1505,26 @@ class JsonFactory extends jni.JObject {
   JsonFactory disable2(
     jni.JObject f,
   ) {
-    return _id_disable2(this, const $JsonFactoryType(), [f.reference.pointer]);
+    return _disable2(reference.pointer, _id_disable2 as jni.JMethodIDPtr,
+            f.reference.pointer)
+        .object(const $JsonFactoryType());
   }
 
   static final _id_isEnabled3 = _class.instanceMethodId(
     r"isEnabled",
     r"(Lcom/fasterxml/jackson/core/JsonGenerator$Feature;)Z",
   );
+
+  static final _isEnabled3 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public final boolean isEnabled(com.fasterxml.jackson.core.JsonGenerator.Feature f)
   ///
@@ -936,14 +1534,26 @@ class JsonFactory extends jni.JObject {
   bool isEnabled3(
     jni.JObject f,
   ) {
-    return _id_isEnabled3(
-        this, const jni.jbooleanType(), [f.reference.pointer]);
+    return _isEnabled3(reference.pointer, _id_isEnabled3 as jni.JMethodIDPtr,
+            f.reference.pointer)
+        .boolean;
   }
 
   static final _id_isEnabled4 = _class.instanceMethodId(
     r"isEnabled",
     r"(Lcom/fasterxml/jackson/core/StreamWriteFeature;)Z",
   );
+
+  static final _isEnabled4 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public final boolean isEnabled(com.fasterxml.jackson.core.StreamWriteFeature f)
   ///
@@ -954,14 +1564,27 @@ class JsonFactory extends jni.JObject {
   bool isEnabled4(
     jni.JObject f,
   ) {
-    return _id_isEnabled4(
-        this, const jni.jbooleanType(), [f.reference.pointer]);
+    return _isEnabled4(reference.pointer, _id_isEnabled4 as jni.JMethodIDPtr,
+            f.reference.pointer)
+        .boolean;
   }
 
   static final _id_getCharacterEscapes = _class.instanceMethodId(
     r"getCharacterEscapes",
     r"()Lcom/fasterxml/jackson/core/io/CharacterEscapes;",
   );
+
+  static final _getCharacterEscapes = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.io.CharacterEscapes getCharacterEscapes()
   /// The returned object must be released after use, by calling the [release] method.
@@ -970,13 +1593,26 @@ class JsonFactory extends jni.JObject {
   /// it creates.
   ///@return Configured {@code CharacterEscapes}, if any; {@code null} if none
   jni.JObject getCharacterEscapes() {
-    return _id_getCharacterEscapes(this, const jni.JObjectType(), []);
+    return _getCharacterEscapes(
+            reference.pointer, _id_getCharacterEscapes as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_setCharacterEscapes = _class.instanceMethodId(
     r"setCharacterEscapes",
     r"(Lcom/fasterxml/jackson/core/io/CharacterEscapes;)Lcom/fasterxml/jackson/core/JsonFactory;",
   );
+
+  static final _setCharacterEscapes = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonFactory setCharacterEscapes(com.fasterxml.jackson.core.io.CharacterEscapes esc)
   /// The returned object must be released after use, by calling the [release] method.
@@ -988,14 +1624,27 @@ class JsonFactory extends jni.JObject {
   JsonFactory setCharacterEscapes(
     jni.JObject esc,
   ) {
-    return _id_setCharacterEscapes(
-        this, const $JsonFactoryType(), [esc.reference.pointer]);
+    return _setCharacterEscapes(reference.pointer,
+            _id_setCharacterEscapes as jni.JMethodIDPtr, esc.reference.pointer)
+        .object(const $JsonFactoryType());
   }
 
   static final _id_getOutputDecorator = _class.instanceMethodId(
     r"getOutputDecorator",
     r"()Lcom/fasterxml/jackson/core/io/OutputDecorator;",
   );
+
+  static final _getOutputDecorator = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.io.OutputDecorator getOutputDecorator()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1005,13 +1654,26 @@ class JsonFactory extends jni.JObject {
   ///@return OutputDecorator configured for generators factory creates, if any;
   ///    {@code null} if none.
   jni.JObject getOutputDecorator() {
-    return _id_getOutputDecorator(this, const jni.JObjectType(), []);
+    return _getOutputDecorator(
+            reference.pointer, _id_getOutputDecorator as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_setOutputDecorator = _class.instanceMethodId(
     r"setOutputDecorator",
     r"(Lcom/fasterxml/jackson/core/io/OutputDecorator;)Lcom/fasterxml/jackson/core/JsonFactory;",
   );
+
+  static final _setOutputDecorator = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonFactory setOutputDecorator(com.fasterxml.jackson.core.io.OutputDecorator d)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1023,14 +1685,26 @@ class JsonFactory extends jni.JObject {
   JsonFactory setOutputDecorator(
     jni.JObject d,
   ) {
-    return _id_setOutputDecorator(
-        this, const $JsonFactoryType(), [d.reference.pointer]);
+    return _setOutputDecorator(reference.pointer,
+            _id_setOutputDecorator as jni.JMethodIDPtr, d.reference.pointer)
+        .object(const $JsonFactoryType());
   }
 
   static final _id_setRootValueSeparator = _class.instanceMethodId(
     r"setRootValueSeparator",
     r"(Ljava/lang/String;)Lcom/fasterxml/jackson/core/JsonFactory;",
   );
+
+  static final _setRootValueSeparator = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonFactory setRootValueSeparator(java.lang.String sep)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1043,8 +1717,11 @@ class JsonFactory extends jni.JObject {
   JsonFactory setRootValueSeparator(
     jni.JString sep,
   ) {
-    return _id_setRootValueSeparator(
-        this, const $JsonFactoryType(), [sep.reference.pointer]);
+    return _setRootValueSeparator(
+            reference.pointer,
+            _id_setRootValueSeparator as jni.JMethodIDPtr,
+            sep.reference.pointer)
+        .object(const $JsonFactoryType());
   }
 
   static final _id_getRootValueSeparator = _class.instanceMethodId(
@@ -1052,18 +1729,43 @@ class JsonFactory extends jni.JObject {
     r"()Ljava/lang/String;",
   );
 
+  static final _getRootValueSeparator = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public java.lang.String getRootValueSeparator()
   /// The returned object must be released after use, by calling the [release] method.
   ///
   /// @return Root value separator configured, if any
   jni.JString getRootValueSeparator() {
-    return _id_getRootValueSeparator(this, const jni.JStringType(), []);
+    return _getRootValueSeparator(
+            reference.pointer, _id_getRootValueSeparator as jni.JMethodIDPtr)
+        .object(const jni.JStringType());
   }
 
   static final _id_setCodec = _class.instanceMethodId(
     r"setCodec",
     r"(Lcom/fasterxml/jackson/core/ObjectCodec;)Lcom/fasterxml/jackson/core/JsonFactory;",
   );
+
+  static final _setCodec = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonFactory setCodec(com.fasterxml.jackson.core.ObjectCodec oc)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1078,7 +1780,9 @@ class JsonFactory extends jni.JObject {
   JsonFactory setCodec(
     jni.JObject oc,
   ) {
-    return _id_setCodec(this, const $JsonFactoryType(), [oc.reference.pointer]);
+    return _setCodec(reference.pointer, _id_setCodec as jni.JMethodIDPtr,
+            oc.reference.pointer)
+        .object(const $JsonFactoryType());
   }
 
   static final _id_getCodec = _class.instanceMethodId(
@@ -1086,16 +1790,40 @@ class JsonFactory extends jni.JObject {
     r"()Lcom/fasterxml/jackson/core/ObjectCodec;",
   );
 
+  static final _getCodec = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public com.fasterxml.jackson.core.ObjectCodec getCodec()
   /// The returned object must be released after use, by calling the [release] method.
   jni.JObject getCodec() {
-    return _id_getCodec(this, const jni.JObjectType(), []);
+    return _getCodec(reference.pointer, _id_getCodec as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_createParser = _class.instanceMethodId(
     r"createParser",
     r"(Ljava/io/File;)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createParser = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createParser(java.io.File f)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1119,14 +1847,26 @@ class JsonFactory extends jni.JObject {
   jsonparser_.JsonParser createParser(
     jni.JObject f,
   ) {
-    return _id_createParser(
-        this, const jsonparser_.$JsonParserType(), [f.reference.pointer]);
+    return _createParser(reference.pointer,
+            _id_createParser as jni.JMethodIDPtr, f.reference.pointer)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createParser1 = _class.instanceMethodId(
     r"createParser",
     r"(Ljava/net/URL;)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createParser1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createParser(java.net.URL url)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1148,14 +1888,26 @@ class JsonFactory extends jni.JObject {
   jsonparser_.JsonParser createParser1(
     jni.JObject url,
   ) {
-    return _id_createParser1(
-        this, const jsonparser_.$JsonParserType(), [url.reference.pointer]);
+    return _createParser1(reference.pointer,
+            _id_createParser1 as jni.JMethodIDPtr, url.reference.pointer)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createParser2 = _class.instanceMethodId(
     r"createParser",
     r"(Ljava/io/InputStream;)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createParser2 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createParser(java.io.InputStream in)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1180,14 +1932,26 @@ class JsonFactory extends jni.JObject {
   jsonparser_.JsonParser createParser2(
     jni.JObject in0,
   ) {
-    return _id_createParser2(
-        this, const jsonparser_.$JsonParserType(), [in0.reference.pointer]);
+    return _createParser2(reference.pointer,
+            _id_createParser2 as jni.JMethodIDPtr, in0.reference.pointer)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createParser3 = _class.instanceMethodId(
     r"createParser",
     r"(Ljava/io/Reader;)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createParser3 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createParser(java.io.Reader r)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1205,14 +1969,26 @@ class JsonFactory extends jni.JObject {
   jsonparser_.JsonParser createParser3(
     jni.JObject r,
   ) {
-    return _id_createParser3(
-        this, const jsonparser_.$JsonParserType(), [r.reference.pointer]);
+    return _createParser3(reference.pointer,
+            _id_createParser3 as jni.JMethodIDPtr, r.reference.pointer)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createParser4 = _class.instanceMethodId(
     r"createParser",
     r"([B)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createParser4 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createParser(byte[] data)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1223,14 +1999,30 @@ class JsonFactory extends jni.JObject {
   jsonparser_.JsonParser createParser4(
     jni.JArray<jni.jbyte> data,
   ) {
-    return _id_createParser4(
-        this, const jsonparser_.$JsonParserType(), [data.reference.pointer]);
+    return _createParser4(reference.pointer,
+            _id_createParser4 as jni.JMethodIDPtr, data.reference.pointer)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createParser5 = _class.instanceMethodId(
     r"createParser",
     r"([BII)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createParser5 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Int64,
+                        ffi.Int64
+                      )>)>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, int, int)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createParser(byte[] data, int offset, int len)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1246,14 +2038,30 @@ class JsonFactory extends jni.JObject {
     int offset,
     int len,
   ) {
-    return _id_createParser5(this, const jsonparser_.$JsonParserType(),
-        [data.reference.pointer, jni.JValueInt(offset), jni.JValueInt(len)]);
+    return _createParser5(
+            reference.pointer,
+            _id_createParser5 as jni.JMethodIDPtr,
+            data.reference.pointer,
+            offset,
+            len)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createParser6 = _class.instanceMethodId(
     r"createParser",
     r"(Ljava/lang/String;)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createParser6 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createParser(java.lang.String content)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1264,14 +2072,26 @@ class JsonFactory extends jni.JObject {
   jsonparser_.JsonParser createParser6(
     jni.JString content,
   ) {
-    return _id_createParser6(
-        this, const jsonparser_.$JsonParserType(), [content.reference.pointer]);
+    return _createParser6(reference.pointer,
+            _id_createParser6 as jni.JMethodIDPtr, content.reference.pointer)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createParser7 = _class.instanceMethodId(
     r"createParser",
     r"([C)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createParser7 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createParser(char[] content)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1282,14 +2102,30 @@ class JsonFactory extends jni.JObject {
   jsonparser_.JsonParser createParser7(
     jni.JArray<jni.jchar> content,
   ) {
-    return _id_createParser7(
-        this, const jsonparser_.$JsonParserType(), [content.reference.pointer]);
+    return _createParser7(reference.pointer,
+            _id_createParser7 as jni.JMethodIDPtr, content.reference.pointer)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createParser8 = _class.instanceMethodId(
     r"createParser",
     r"([CII)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createParser8 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Int64,
+                        ffi.Int64
+                      )>)>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, int, int)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createParser(char[] content, int offset, int len)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1301,14 +2137,30 @@ class JsonFactory extends jni.JObject {
     int offset,
     int len,
   ) {
-    return _id_createParser8(this, const jsonparser_.$JsonParserType(),
-        [content.reference.pointer, jni.JValueInt(offset), jni.JValueInt(len)]);
+    return _createParser8(
+            reference.pointer,
+            _id_createParser8 as jni.JMethodIDPtr,
+            content.reference.pointer,
+            offset,
+            len)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createParser9 = _class.instanceMethodId(
     r"createParser",
     r"(Ljava/io/DataInput;)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createParser9 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createParser(java.io.DataInput in)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1322,14 +2174,28 @@ class JsonFactory extends jni.JObject {
   jsonparser_.JsonParser createParser9(
     jni.JObject in0,
   ) {
-    return _id_createParser9(
-        this, const jsonparser_.$JsonParserType(), [in0.reference.pointer]);
+    return _createParser9(reference.pointer,
+            _id_createParser9 as jni.JMethodIDPtr, in0.reference.pointer)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createNonBlockingByteArrayParser = _class.instanceMethodId(
     r"createNonBlockingByteArrayParser",
     r"()Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createNonBlockingByteArrayParser =
+      ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                    ffi.Pointer<ffi.Void>,
+                    jni.JMethodIDPtr,
+                  )>>("globalEnv_CallObjectMethod")
+          .asFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createNonBlockingByteArrayParser()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1348,14 +2214,29 @@ class JsonFactory extends jni.JObject {
   /// at this point.
   ///@since 2.9
   jsonparser_.JsonParser createNonBlockingByteArrayParser() {
-    return _id_createNonBlockingByteArrayParser(
-        this, const jsonparser_.$JsonParserType(), []);
+    return _createNonBlockingByteArrayParser(reference.pointer,
+            _id_createNonBlockingByteArrayParser as jni.JMethodIDPtr)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createGenerator = _class.instanceMethodId(
     r"createGenerator",
     r"(Ljava/io/OutputStream;Lcom/fasterxml/jackson/core/JsonEncoding;)Lcom/fasterxml/jackson/core/JsonGenerator;",
   );
+
+  static final _createGenerator = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonGenerator createGenerator(java.io.OutputStream out, com.fasterxml.jackson.core.JsonEncoding enc)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1382,14 +2263,29 @@ class JsonFactory extends jni.JObject {
     jni.JObject out,
     jni.JObject enc,
   ) {
-    return _id_createGenerator(this, const jni.JObjectType(),
-        [out.reference.pointer, enc.reference.pointer]);
+    return _createGenerator(
+            reference.pointer,
+            _id_createGenerator as jni.JMethodIDPtr,
+            out.reference.pointer,
+            enc.reference.pointer)
+        .object(const jni.JObjectType());
   }
 
   static final _id_createGenerator1 = _class.instanceMethodId(
     r"createGenerator",
     r"(Ljava/io/OutputStream;)Lcom/fasterxml/jackson/core/JsonGenerator;",
   );
+
+  static final _createGenerator1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonGenerator createGenerator(java.io.OutputStream out)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1402,14 +2298,26 @@ class JsonFactory extends jni.JObject {
   jni.JObject createGenerator1(
     jni.JObject out,
   ) {
-    return _id_createGenerator1(
-        this, const jni.JObjectType(), [out.reference.pointer]);
+    return _createGenerator1(reference.pointer,
+            _id_createGenerator1 as jni.JMethodIDPtr, out.reference.pointer)
+        .object(const jni.JObjectType());
   }
 
   static final _id_createGenerator2 = _class.instanceMethodId(
     r"createGenerator",
     r"(Ljava/io/Writer;)Lcom/fasterxml/jackson/core/JsonGenerator;",
   );
+
+  static final _createGenerator2 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonGenerator createGenerator(java.io.Writer w)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1428,14 +2336,29 @@ class JsonFactory extends jni.JObject {
   jni.JObject createGenerator2(
     jni.JObject w,
   ) {
-    return _id_createGenerator2(
-        this, const jni.JObjectType(), [w.reference.pointer]);
+    return _createGenerator2(reference.pointer,
+            _id_createGenerator2 as jni.JMethodIDPtr, w.reference.pointer)
+        .object(const jni.JObjectType());
   }
 
   static final _id_createGenerator3 = _class.instanceMethodId(
     r"createGenerator",
     r"(Ljava/io/File;Lcom/fasterxml/jackson/core/JsonEncoding;)Lcom/fasterxml/jackson/core/JsonGenerator;",
   );
+
+  static final _createGenerator3 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonGenerator createGenerator(java.io.File f, com.fasterxml.jackson.core.JsonEncoding enc)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1456,14 +2379,32 @@ class JsonFactory extends jni.JObject {
     jni.JObject f,
     jni.JObject enc,
   ) {
-    return _id_createGenerator3(this, const jni.JObjectType(),
-        [f.reference.pointer, enc.reference.pointer]);
+    return _createGenerator3(
+            reference.pointer,
+            _id_createGenerator3 as jni.JMethodIDPtr,
+            f.reference.pointer,
+            enc.reference.pointer)
+        .object(const jni.JObjectType());
   }
 
   static final _id_createGenerator4 = _class.instanceMethodId(
     r"createGenerator",
     r"(Ljava/io/DataOutput;Lcom/fasterxml/jackson/core/JsonEncoding;)Lcom/fasterxml/jackson/core/JsonGenerator;",
   );
+
+  static final _createGenerator4 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonGenerator createGenerator(java.io.DataOutput out, com.fasterxml.jackson.core.JsonEncoding enc)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1475,14 +2416,29 @@ class JsonFactory extends jni.JObject {
     jni.JObject out,
     jni.JObject enc,
   ) {
-    return _id_createGenerator4(this, const jni.JObjectType(),
-        [out.reference.pointer, enc.reference.pointer]);
+    return _createGenerator4(
+            reference.pointer,
+            _id_createGenerator4 as jni.JMethodIDPtr,
+            out.reference.pointer,
+            enc.reference.pointer)
+        .object(const jni.JObjectType());
   }
 
   static final _id_createGenerator5 = _class.instanceMethodId(
     r"createGenerator",
     r"(Ljava/io/DataOutput;)Lcom/fasterxml/jackson/core/JsonGenerator;",
   );
+
+  static final _createGenerator5 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonGenerator createGenerator(java.io.DataOutput out)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1495,14 +2451,26 @@ class JsonFactory extends jni.JObject {
   jni.JObject createGenerator5(
     jni.JObject out,
   ) {
-    return _id_createGenerator5(
-        this, const jni.JObjectType(), [out.reference.pointer]);
+    return _createGenerator5(reference.pointer,
+            _id_createGenerator5 as jni.JMethodIDPtr, out.reference.pointer)
+        .object(const jni.JObjectType());
   }
 
   static final _id_createJsonParser = _class.instanceMethodId(
     r"createJsonParser",
     r"(Ljava/io/File;)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createJsonParser = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createJsonParser(java.io.File f)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1528,14 +2496,26 @@ class JsonFactory extends jni.JObject {
   jsonparser_.JsonParser createJsonParser(
     jni.JObject f,
   ) {
-    return _id_createJsonParser(
-        this, const jsonparser_.$JsonParserType(), [f.reference.pointer]);
+    return _createJsonParser(reference.pointer,
+            _id_createJsonParser as jni.JMethodIDPtr, f.reference.pointer)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createJsonParser1 = _class.instanceMethodId(
     r"createJsonParser",
     r"(Ljava/net/URL;)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createJsonParser1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createJsonParser(java.net.URL url)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1560,14 +2540,26 @@ class JsonFactory extends jni.JObject {
   jsonparser_.JsonParser createJsonParser1(
     jni.JObject url,
   ) {
-    return _id_createJsonParser1(
-        this, const jsonparser_.$JsonParserType(), [url.reference.pointer]);
+    return _createJsonParser1(reference.pointer,
+            _id_createJsonParser1 as jni.JMethodIDPtr, url.reference.pointer)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createJsonParser2 = _class.instanceMethodId(
     r"createJsonParser",
     r"(Ljava/io/InputStream;)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createJsonParser2 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createJsonParser(java.io.InputStream in)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1595,14 +2587,26 @@ class JsonFactory extends jni.JObject {
   jsonparser_.JsonParser createJsonParser2(
     jni.JObject in0,
   ) {
-    return _id_createJsonParser2(
-        this, const jsonparser_.$JsonParserType(), [in0.reference.pointer]);
+    return _createJsonParser2(reference.pointer,
+            _id_createJsonParser2 as jni.JMethodIDPtr, in0.reference.pointer)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createJsonParser3 = _class.instanceMethodId(
     r"createJsonParser",
     r"(Ljava/io/Reader;)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createJsonParser3 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createJsonParser(java.io.Reader r)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1623,14 +2627,26 @@ class JsonFactory extends jni.JObject {
   jsonparser_.JsonParser createJsonParser3(
     jni.JObject r,
   ) {
-    return _id_createJsonParser3(
-        this, const jsonparser_.$JsonParserType(), [r.reference.pointer]);
+    return _createJsonParser3(reference.pointer,
+            _id_createJsonParser3 as jni.JMethodIDPtr, r.reference.pointer)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createJsonParser4 = _class.instanceMethodId(
     r"createJsonParser",
     r"([B)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createJsonParser4 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createJsonParser(byte[] data)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1644,14 +2660,30 @@ class JsonFactory extends jni.JObject {
   jsonparser_.JsonParser createJsonParser4(
     jni.JArray<jni.jbyte> data,
   ) {
-    return _id_createJsonParser4(
-        this, const jsonparser_.$JsonParserType(), [data.reference.pointer]);
+    return _createJsonParser4(reference.pointer,
+            _id_createJsonParser4 as jni.JMethodIDPtr, data.reference.pointer)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createJsonParser5 = _class.instanceMethodId(
     r"createJsonParser",
     r"([BII)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createJsonParser5 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Int64,
+                        ffi.Int64
+                      )>)>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, int, int)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createJsonParser(byte[] data, int offset, int len)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1670,14 +2702,30 @@ class JsonFactory extends jni.JObject {
     int offset,
     int len,
   ) {
-    return _id_createJsonParser5(this, const jsonparser_.$JsonParserType(),
-        [data.reference.pointer, jni.JValueInt(offset), jni.JValueInt(len)]);
+    return _createJsonParser5(
+            reference.pointer,
+            _id_createJsonParser5 as jni.JMethodIDPtr,
+            data.reference.pointer,
+            offset,
+            len)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createJsonParser6 = _class.instanceMethodId(
     r"createJsonParser",
     r"(Ljava/lang/String;)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _createJsonParser6 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser createJsonParser(java.lang.String content)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1692,14 +2740,31 @@ class JsonFactory extends jni.JObject {
   jsonparser_.JsonParser createJsonParser6(
     jni.JString content,
   ) {
-    return _id_createJsonParser6(
-        this, const jsonparser_.$JsonParserType(), [content.reference.pointer]);
+    return _createJsonParser6(
+            reference.pointer,
+            _id_createJsonParser6 as jni.JMethodIDPtr,
+            content.reference.pointer)
+        .object(const jsonparser_.$JsonParserType());
   }
 
   static final _id_createJsonGenerator = _class.instanceMethodId(
     r"createJsonGenerator",
     r"(Ljava/io/OutputStream;Lcom/fasterxml/jackson/core/JsonEncoding;)Lcom/fasterxml/jackson/core/JsonGenerator;",
   );
+
+  static final _createJsonGenerator = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonGenerator createJsonGenerator(java.io.OutputStream out, com.fasterxml.jackson.core.JsonEncoding enc)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1728,14 +2793,29 @@ class JsonFactory extends jni.JObject {
     jni.JObject out,
     jni.JObject enc,
   ) {
-    return _id_createJsonGenerator(this, const jni.JObjectType(),
-        [out.reference.pointer, enc.reference.pointer]);
+    return _createJsonGenerator(
+            reference.pointer,
+            _id_createJsonGenerator as jni.JMethodIDPtr,
+            out.reference.pointer,
+            enc.reference.pointer)
+        .object(const jni.JObjectType());
   }
 
   static final _id_createJsonGenerator1 = _class.instanceMethodId(
     r"createJsonGenerator",
     r"(Ljava/io/Writer;)Lcom/fasterxml/jackson/core/JsonGenerator;",
   );
+
+  static final _createJsonGenerator1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonGenerator createJsonGenerator(java.io.Writer out)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1756,14 +2836,26 @@ class JsonFactory extends jni.JObject {
   jni.JObject createJsonGenerator1(
     jni.JObject out,
   ) {
-    return _id_createJsonGenerator1(
-        this, const jni.JObjectType(), [out.reference.pointer]);
+    return _createJsonGenerator1(reference.pointer,
+            _id_createJsonGenerator1 as jni.JMethodIDPtr, out.reference.pointer)
+        .object(const jni.JObjectType());
   }
 
   static final _id_createJsonGenerator2 = _class.instanceMethodId(
     r"createJsonGenerator",
     r"(Ljava/io/OutputStream;)Lcom/fasterxml/jackson/core/JsonGenerator;",
   );
+
+  static final _createJsonGenerator2 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonGenerator createJsonGenerator(java.io.OutputStream out)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1779,8 +2871,9 @@ class JsonFactory extends jni.JObject {
   jni.JObject createJsonGenerator2(
     jni.JObject out,
   ) {
-    return _id_createJsonGenerator2(
-        this, const jni.JObjectType(), [out.reference.pointer]);
+    return _createJsonGenerator2(reference.pointer,
+            _id_createJsonGenerator2 as jni.JMethodIDPtr, out.reference.pointer)
+        .object(const jni.JObjectType());
   }
 }
 

--- a/pkgs/jnigen/test/jackson_core_test/third_party/dart_only/dart_bindings/com/fasterxml/jackson/core/JsonParser.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/dart_only/dart_bindings/com/fasterxml/jackson/core/JsonParser.dart
@@ -63,11 +63,23 @@ class JsonParser_Feature extends jni.JObject {
     r"()[Lcom/fasterxml/jackson/core/JsonParser$Feature;",
   );
 
+  static final _values = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public com.fasterxml.jackson.core.JsonParser.Feature[] values()
   /// The returned object must be released after use, by calling the [release] method.
   static jni.JArray<JsonParser_Feature> values() {
-    return _id_values(
-        _class, const jni.JArrayType($JsonParser_FeatureType()), []);
+    return _values(_class.reference.pointer, _id_values as jni.JMethodIDPtr)
+        .object(const jni.JArrayType($JsonParser_FeatureType()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -75,13 +87,25 @@ class JsonParser_Feature extends jni.JObject {
     r"(Ljava/lang/String;)Lcom/fasterxml/jackson/core/JsonParser$Feature;",
   );
 
+  static final _valueOf = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: static public com.fasterxml.jackson.core.JsonParser.Feature valueOf(java.lang.String name)
   /// The returned object must be released after use, by calling the [release] method.
   static JsonParser_Feature valueOf(
     jni.JString name,
   ) {
-    return _id_valueOf(
-        _class, const $JsonParser_FeatureType(), [name.reference.pointer]);
+    return _valueOf(_class.reference.pointer, _id_valueOf as jni.JMethodIDPtr,
+            name.reference.pointer)
+        .object(const $JsonParser_FeatureType());
   }
 
   static final _id_collectDefaults = _class.staticMethodId(
@@ -89,13 +113,27 @@ class JsonParser_Feature extends jni.JObject {
     r"()I",
   );
 
+  static final _collectDefaults = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public int collectDefaults()
   ///
   /// Method that calculates bit set (flags) of all features that
   /// are enabled by default.
   ///@return Bit mask of all features that are enabled by default
   static int collectDefaults() {
-    return _id_collectDefaults(_class, const jni.jintType(), []);
+    return _collectDefaults(
+            _class.reference.pointer, _id_collectDefaults as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_enabledByDefault = _class.instanceMethodId(
@@ -103,9 +141,23 @@ class JsonParser_Feature extends jni.JObject {
     r"()Z",
   );
 
+  static final _enabledByDefault = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public boolean enabledByDefault()
   bool enabledByDefault() {
-    return _id_enabledByDefault(this, const jni.jbooleanType(), []);
+    return _enabledByDefault(
+            reference.pointer, _id_enabledByDefault as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_enabledIn = _class.instanceMethodId(
@@ -113,12 +165,21 @@ class JsonParser_Feature extends jni.JObject {
     r"(I)Z",
   );
 
+  static final _enabledIn = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
+
   /// from: public boolean enabledIn(int flags)
   bool enabledIn(
     int flags,
   ) {
-    return _id_enabledIn(
-        this, const jni.jbooleanType(), [jni.JValueInt(flags)]);
+    return _enabledIn(
+            reference.pointer, _id_enabledIn as jni.JMethodIDPtr, flags)
+        .boolean;
   }
 
   static final _id_getMask = _class.instanceMethodId(
@@ -126,9 +187,21 @@ class JsonParser_Feature extends jni.JObject {
     r"()I",
   );
 
+  static final _getMask = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public int getMask()
   int getMask() {
-    return _id_getMask(this, const jni.jintType(), []);
+    return _getMask(reference.pointer, _id_getMask as jni.JMethodIDPtr).integer;
   }
 }
 
@@ -180,11 +253,23 @@ class JsonParser_NumberType extends jni.JObject {
     r"()[Lcom/fasterxml/jackson/core/JsonParser$NumberType;",
   );
 
+  static final _values = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public com.fasterxml.jackson.core.JsonParser.NumberType[] values()
   /// The returned object must be released after use, by calling the [release] method.
   static jni.JArray<JsonParser_NumberType> values() {
-    return _id_values(
-        _class, const jni.JArrayType($JsonParser_NumberTypeType()), []);
+    return _values(_class.reference.pointer, _id_values as jni.JMethodIDPtr)
+        .object(const jni.JArrayType($JsonParser_NumberTypeType()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -192,13 +277,25 @@ class JsonParser_NumberType extends jni.JObject {
     r"(Ljava/lang/String;)Lcom/fasterxml/jackson/core/JsonParser$NumberType;",
   );
 
+  static final _valueOf = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: static public com.fasterxml.jackson.core.JsonParser.NumberType valueOf(java.lang.String name)
   /// The returned object must be released after use, by calling the [release] method.
   static JsonParser_NumberType valueOf(
     jni.JString name,
   ) {
-    return _id_valueOf(
-        _class, const $JsonParser_NumberTypeType(), [name.reference.pointer]);
+    return _valueOf(_class.reference.pointer, _id_valueOf as jni.JMethodIDPtr,
+            name.reference.pointer)
+        .object(const $JsonParser_NumberTypeType());
   }
 }
 
@@ -267,15 +364,37 @@ class JsonParser extends jni.JObject {
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: protected void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory JsonParser() {
-    return JsonParser.fromReference(_id_new0(_class, referenceType, []));
+    return JsonParser.fromReference(
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 
   static final _id_new1 = _class.constructorId(
     r"(I)V",
   );
+
+  static final _new1 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
 
   /// from: protected void <init>(int features)
   /// The returned object must be released after use, by calling the [release] method.
@@ -283,13 +402,26 @@ class JsonParser extends jni.JObject {
     int features,
   ) {
     return JsonParser.fromReference(
-        _id_new1(_class, referenceType, [jni.JValueInt(features)]));
+        _new1(_class.reference.pointer, _id_new1 as jni.JMethodIDPtr, features)
+            .reference);
   }
 
   static final _id_getCodec = _class.instanceMethodId(
     r"getCodec",
     r"()Lcom/fasterxml/jackson/core/ObjectCodec;",
   );
+
+  static final _getCodec = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.ObjectCodec getCodec()
   /// The returned object must be released after use, by calling the [release] method.
@@ -299,13 +431,25 @@ class JsonParser extends jni.JObject {
   /// method (and its variants).
   ///@return Codec assigned to this parser, if any; {@code null} if none
   jni.JObject getCodec() {
-    return _id_getCodec(this, const jni.JObjectType(), []);
+    return _getCodec(reference.pointer, _id_getCodec as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_setCodec = _class.instanceMethodId(
     r"setCodec",
     r"(Lcom/fasterxml/jackson/core/ObjectCodec;)V",
   );
+
+  static final _setCodec = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JThrowablePtr Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public abstract void setCodec(com.fasterxml.jackson.core.ObjectCodec oc)
   ///
@@ -316,13 +460,27 @@ class JsonParser extends jni.JObject {
   void setCodec(
     jni.JObject oc,
   ) {
-    _id_setCodec(this, const jni.jvoidType(), [oc.reference.pointer]);
+    _setCodec(reference.pointer, _id_setCodec as jni.JMethodIDPtr,
+            oc.reference.pointer)
+        .check();
   }
 
   static final _id_getInputSource = _class.instanceMethodId(
     r"getInputSource",
     r"()Ljava/lang/Object;",
   );
+
+  static final _getInputSource = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public java.lang.Object getInputSource()
   /// The returned object must be released after use, by calling the [release] method.
@@ -342,13 +500,26 @@ class JsonParser extends jni.JObject {
   /// "last effort", i.e. only used if no other mechanism is applicable.
   ///@return Input source this parser was configured with
   jni.JObject getInputSource() {
-    return _id_getInputSource(this, const jni.JObjectType(), []);
+    return _getInputSource(
+            reference.pointer, _id_getInputSource as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_setRequestPayloadOnError = _class.instanceMethodId(
     r"setRequestPayloadOnError",
     r"(Lcom/fasterxml/jackson/core/util/RequestPayload;)V",
   );
+
+  static final _setRequestPayloadOnError = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JThrowablePtr Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public void setRequestPayloadOnError(com.fasterxml.jackson.core.util.RequestPayload payload)
   ///
@@ -358,14 +529,31 @@ class JsonParser extends jni.JObject {
   void setRequestPayloadOnError(
     jni.JObject payload,
   ) {
-    _id_setRequestPayloadOnError(
-        this, const jni.jvoidType(), [payload.reference.pointer]);
+    _setRequestPayloadOnError(
+            reference.pointer,
+            _id_setRequestPayloadOnError as jni.JMethodIDPtr,
+            payload.reference.pointer)
+        .check();
   }
 
   static final _id_setRequestPayloadOnError1 = _class.instanceMethodId(
     r"setRequestPayloadOnError",
     r"([BLjava/lang/String;)V",
   );
+
+  static final _setRequestPayloadOnError1 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
 
   /// from: public void setRequestPayloadOnError(byte[] payload, java.lang.String charset)
   ///
@@ -377,14 +565,29 @@ class JsonParser extends jni.JObject {
     jni.JArray<jni.jbyte> payload,
     jni.JString charset,
   ) {
-    _id_setRequestPayloadOnError1(this, const jni.jvoidType(),
-        [payload.reference.pointer, charset.reference.pointer]);
+    _setRequestPayloadOnError1(
+            reference.pointer,
+            _id_setRequestPayloadOnError1 as jni.JMethodIDPtr,
+            payload.reference.pointer,
+            charset.reference.pointer)
+        .check();
   }
 
   static final _id_setRequestPayloadOnError2 = _class.instanceMethodId(
     r"setRequestPayloadOnError",
     r"(Ljava/lang/String;)V",
   );
+
+  static final _setRequestPayloadOnError2 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JThrowablePtr Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public void setRequestPayloadOnError(java.lang.String payload)
   ///
@@ -394,14 +597,28 @@ class JsonParser extends jni.JObject {
   void setRequestPayloadOnError2(
     jni.JString payload,
   ) {
-    _id_setRequestPayloadOnError2(
-        this, const jni.jvoidType(), [payload.reference.pointer]);
+    _setRequestPayloadOnError2(
+            reference.pointer,
+            _id_setRequestPayloadOnError2 as jni.JMethodIDPtr,
+            payload.reference.pointer)
+        .check();
   }
 
   static final _id_setSchema = _class.instanceMethodId(
     r"setSchema",
     r"(Lcom/fasterxml/jackson/core/FormatSchema;)V",
   );
+
+  static final _setSchema = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JThrowablePtr Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public void setSchema(com.fasterxml.jackson.core.FormatSchema schema)
   ///
@@ -418,13 +635,27 @@ class JsonParser extends jni.JObject {
   void setSchema(
     jni.JObject schema,
   ) {
-    _id_setSchema(this, const jni.jvoidType(), [schema.reference.pointer]);
+    _setSchema(reference.pointer, _id_setSchema as jni.JMethodIDPtr,
+            schema.reference.pointer)
+        .check();
   }
 
   static final _id_getSchema = _class.instanceMethodId(
     r"getSchema",
     r"()Lcom/fasterxml/jackson/core/FormatSchema;",
   );
+
+  static final _getSchema = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.FormatSchema getSchema()
   /// The returned object must be released after use, by calling the [release] method.
@@ -434,13 +665,25 @@ class JsonParser extends jni.JObject {
   ///@return Schema in use by this parser, if any; {@code null} if none
   ///@since 2.1
   jni.JObject getSchema() {
-    return _id_getSchema(this, const jni.JObjectType(), []);
+    return _getSchema(reference.pointer, _id_getSchema as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_canUseSchema = _class.instanceMethodId(
     r"canUseSchema",
     r"(Lcom/fasterxml/jackson/core/FormatSchema;)Z",
   );
+
+  static final _canUseSchema = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public boolean canUseSchema(com.fasterxml.jackson.core.FormatSchema schema)
   ///
@@ -451,14 +694,27 @@ class JsonParser extends jni.JObject {
   bool canUseSchema(
     jni.JObject schema,
   ) {
-    return _id_canUseSchema(
-        this, const jni.jbooleanType(), [schema.reference.pointer]);
+    return _canUseSchema(reference.pointer,
+            _id_canUseSchema as jni.JMethodIDPtr, schema.reference.pointer)
+        .boolean;
   }
 
   static final _id_requiresCustomCodec = _class.instanceMethodId(
     r"requiresCustomCodec",
     r"()Z",
   );
+
+  static final _requiresCustomCodec = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public boolean requiresCustomCodec()
   ///
@@ -471,13 +727,27 @@ class JsonParser extends jni.JObject {
   ///   ObjectCodec is enough
   ///@since 2.1
   bool requiresCustomCodec() {
-    return _id_requiresCustomCodec(this, const jni.jbooleanType(), []);
+    return _requiresCustomCodec(
+            reference.pointer, _id_requiresCustomCodec as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_canParseAsync = _class.instanceMethodId(
     r"canParseAsync",
     r"()Z",
   );
+
+  static final _canParseAsync = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public boolean canParseAsync()
   ///
@@ -493,13 +763,27 @@ class JsonParser extends jni.JObject {
   ///@return True if this is a non-blocking ("asynchronous") parser
   ///@since 2.9
   bool canParseAsync() {
-    return _id_canParseAsync(this, const jni.jbooleanType(), []);
+    return _canParseAsync(
+            reference.pointer, _id_canParseAsync as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_getNonBlockingInputFeeder = _class.instanceMethodId(
     r"getNonBlockingInputFeeder",
     r"()Lcom/fasterxml/jackson/core/async/NonBlockingInputFeeder;",
   );
+
+  static final _getNonBlockingInputFeeder = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.async.NonBlockingInputFeeder getNonBlockingInputFeeder()
   /// The returned object must be released after use, by calling the [release] method.
@@ -510,13 +794,27 @@ class JsonParser extends jni.JObject {
   ///@return Input feeder to use with non-blocking (async) parsing
   ///@since 2.9
   jni.JObject getNonBlockingInputFeeder() {
-    return _id_getNonBlockingInputFeeder(this, const jni.JObjectType(), []);
+    return _getNonBlockingInputFeeder(reference.pointer,
+            _id_getNonBlockingInputFeeder as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_getReadCapabilities = _class.instanceMethodId(
     r"getReadCapabilities",
     r"()Lcom/fasterxml/jackson/core/util/JacksonFeatureSet;",
   );
+
+  static final _getReadCapabilities = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.util.JacksonFeatureSet<com.fasterxml.jackson.core.StreamReadCapability> getReadCapabilities()
   /// The returned object must be released after use, by calling the [release] method.
@@ -526,13 +824,27 @@ class JsonParser extends jni.JObject {
   ///@return Set of read capabilities for content to read via this parser
   ///@since 2.12
   jni.JObject getReadCapabilities() {
-    return _id_getReadCapabilities(this, const jni.JObjectType(), []);
+    return _getReadCapabilities(
+            reference.pointer, _id_getReadCapabilities as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_version = _class.instanceMethodId(
     r"version",
     r"()Lcom/fasterxml/jackson/core/Version;",
   );
+
+  static final _version = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.Version version()
   /// The returned object must be released after use, by calling the [release] method.
@@ -542,13 +854,26 @@ class JsonParser extends jni.JObject {
   ///@return Version of this generator (derived from version declared for
   ///   {@code jackson-core} jar that contains the class
   jni.JObject version() {
-    return _id_version(this, const jni.JObjectType(), []);
+    return _version(reference.pointer, _id_version as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_close = _class.instanceMethodId(
     r"close",
     r"()V",
   );
+
+  static final _close = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract void close()
   ///
@@ -567,13 +892,25 @@ class JsonParser extends jni.JObject {
   /// stream or reader it does own them.
   ///@throws IOException if there is either an underlying I/O problem
   void close() {
-    _id_close(this, const jni.jvoidType(), []);
+    _close(reference.pointer, _id_close as jni.JMethodIDPtr).check();
   }
 
   static final _id_isClosed = _class.instanceMethodId(
     r"isClosed",
     r"()Z",
   );
+
+  static final _isClosed = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract boolean isClosed()
   ///
@@ -585,13 +922,26 @@ class JsonParser extends jni.JObject {
   /// end of input.
   ///@return {@code True} if this parser instance has been closed
   bool isClosed() {
-    return _id_isClosed(this, const jni.jbooleanType(), []);
+    return _isClosed(reference.pointer, _id_isClosed as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_getParsingContext = _class.instanceMethodId(
     r"getParsingContext",
     r"()Lcom/fasterxml/jackson/core/JsonStreamContext;",
   );
+
+  static final _getParsingContext = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonStreamContext getParsingContext()
   /// The returned object must be released after use, by calling the [release] method.
@@ -606,13 +956,27 @@ class JsonParser extends jni.JObject {
   /// input, if so desired.
   ///@return Stream input context (JsonStreamContext) associated with this parser
   jni.JObject getParsingContext() {
-    return _id_getParsingContext(this, const jni.JObjectType(), []);
+    return _getParsingContext(
+            reference.pointer, _id_getParsingContext as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_currentLocation = _class.instanceMethodId(
     r"currentLocation",
     r"()Lcom/fasterxml/jackson/core/JsonLocation;",
   );
+
+  static final _currentLocation = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.JsonLocation currentLocation()
   /// The returned object must be released after use, by calling the [release] method.
@@ -630,13 +994,27 @@ class JsonParser extends jni.JObject {
   ///@return Location of the last processed input unit (byte or character)
   ///@since 2.13
   jni.JObject currentLocation() {
-    return _id_currentLocation(this, const jni.JObjectType(), []);
+    return _currentLocation(
+            reference.pointer, _id_currentLocation as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_currentTokenLocation = _class.instanceMethodId(
     r"currentTokenLocation",
     r"()Lcom/fasterxml/jackson/core/JsonLocation;",
   );
+
+  static final _currentTokenLocation = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.JsonLocation currentTokenLocation()
   /// The returned object must be released after use, by calling the [release] method.
@@ -654,13 +1032,27 @@ class JsonParser extends jni.JObject {
   ///@return Starting location of the token parser currently points to
   ///@since 2.13 (will eventually replace \#getTokenLocation)
   jni.JObject currentTokenLocation() {
-    return _id_currentTokenLocation(this, const jni.JObjectType(), []);
+    return _currentTokenLocation(
+            reference.pointer, _id_currentTokenLocation as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_getCurrentLocation = _class.instanceMethodId(
     r"getCurrentLocation",
     r"()Lcom/fasterxml/jackson/core/JsonLocation;",
   );
+
+  static final _getCurrentLocation = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonLocation getCurrentLocation()
   /// The returned object must be released after use, by calling the [release] method.
@@ -669,13 +1061,27 @@ class JsonParser extends jni.JObject {
   /// Jackson 2.x versions (and removed from Jackson 3.0).
   ///@return Location of the last processed input unit (byte or character)
   jni.JObject getCurrentLocation() {
-    return _id_getCurrentLocation(this, const jni.JObjectType(), []);
+    return _getCurrentLocation(
+            reference.pointer, _id_getCurrentLocation as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_getTokenLocation = _class.instanceMethodId(
     r"getTokenLocation",
     r"()Lcom/fasterxml/jackson/core/JsonLocation;",
   );
+
+  static final _getTokenLocation = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonLocation getTokenLocation()
   /// The returned object must be released after use, by calling the [release] method.
@@ -684,13 +1090,27 @@ class JsonParser extends jni.JObject {
   /// Jackson 2.x versions (and removed from Jackson 3.0).
   ///@return Starting location of the token parser currently points to
   jni.JObject getTokenLocation() {
-    return _id_getTokenLocation(this, const jni.JObjectType(), []);
+    return _getTokenLocation(
+            reference.pointer, _id_getTokenLocation as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_currentValue = _class.instanceMethodId(
     r"currentValue",
     r"()Ljava/lang/Object;",
   );
+
+  static final _currentValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public java.lang.Object currentValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -707,13 +1127,26 @@ class JsonParser extends jni.JObject {
   ///@return "Current value" associated with the current input context (state) of this parser
   ///@since 2.13 (added as replacement for older \#getCurrentValue()
   jni.JObject currentValue() {
-    return _id_currentValue(this, const jni.JObjectType(), []);
+    return _currentValue(
+            reference.pointer, _id_currentValue as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_assignCurrentValue = _class.instanceMethodId(
     r"assignCurrentValue",
     r"(Ljava/lang/Object;)V",
   );
+
+  static final _assignCurrentValue = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JThrowablePtr Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public void assignCurrentValue(java.lang.Object v)
   ///
@@ -726,13 +1159,27 @@ class JsonParser extends jni.JObject {
   void assignCurrentValue(
     jni.JObject v,
   ) {
-    _id_assignCurrentValue(this, const jni.jvoidType(), [v.reference.pointer]);
+    _assignCurrentValue(reference.pointer,
+            _id_assignCurrentValue as jni.JMethodIDPtr, v.reference.pointer)
+        .check();
   }
 
   static final _id_getCurrentValue = _class.instanceMethodId(
     r"getCurrentValue",
     r"()Ljava/lang/Object;",
   );
+
+  static final _getCurrentValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public java.lang.Object getCurrentValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -741,13 +1188,26 @@ class JsonParser extends jni.JObject {
   /// Jackson 2.x versions (and removed from Jackson 3.0).
   ///@return Location of the last processed input unit (byte or character)
   jni.JObject getCurrentValue() {
-    return _id_getCurrentValue(this, const jni.JObjectType(), []);
+    return _getCurrentValue(
+            reference.pointer, _id_getCurrentValue as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_setCurrentValue = _class.instanceMethodId(
     r"setCurrentValue",
     r"(Ljava/lang/Object;)V",
   );
+
+  static final _setCurrentValue = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JThrowablePtr Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public void setCurrentValue(java.lang.Object v)
   ///
@@ -757,13 +1217,26 @@ class JsonParser extends jni.JObject {
   void setCurrentValue(
     jni.JObject v,
   ) {
-    _id_setCurrentValue(this, const jni.jvoidType(), [v.reference.pointer]);
+    _setCurrentValue(reference.pointer, _id_setCurrentValue as jni.JMethodIDPtr,
+            v.reference.pointer)
+        .check();
   }
 
   static final _id_releaseBuffered = _class.instanceMethodId(
     r"releaseBuffered",
     r"(Ljava/io/OutputStream;)I",
   );
+
+  static final _releaseBuffered = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public int releaseBuffered(java.io.OutputStream out)
   ///
@@ -781,14 +1254,26 @@ class JsonParser extends jni.JObject {
   int releaseBuffered(
     jni.JObject out,
   ) {
-    return _id_releaseBuffered(
-        this, const jni.jintType(), [out.reference.pointer]);
+    return _releaseBuffered(reference.pointer,
+            _id_releaseBuffered as jni.JMethodIDPtr, out.reference.pointer)
+        .integer;
   }
 
   static final _id_releaseBuffered1 = _class.instanceMethodId(
     r"releaseBuffered",
     r"(Ljava/io/Writer;)I",
   );
+
+  static final _releaseBuffered1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public int releaseBuffered(java.io.Writer w)
   ///
@@ -807,14 +1292,26 @@ class JsonParser extends jni.JObject {
   int releaseBuffered1(
     jni.JObject w,
   ) {
-    return _id_releaseBuffered1(
-        this, const jni.jintType(), [w.reference.pointer]);
+    return _releaseBuffered1(reference.pointer,
+            _id_releaseBuffered1 as jni.JMethodIDPtr, w.reference.pointer)
+        .integer;
   }
 
   static final _id_enable = _class.instanceMethodId(
     r"enable",
     r"(Lcom/fasterxml/jackson/core/JsonParser$Feature;)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _enable = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser enable(com.fasterxml.jackson.core.JsonParser.Feature f)
   /// The returned object must be released after use, by calling the [release] method.
@@ -826,13 +1323,26 @@ class JsonParser extends jni.JObject {
   JsonParser enable(
     JsonParser_Feature f,
   ) {
-    return _id_enable(this, const $JsonParserType(), [f.reference.pointer]);
+    return _enable(reference.pointer, _id_enable as jni.JMethodIDPtr,
+            f.reference.pointer)
+        .object(const $JsonParserType());
   }
 
   static final _id_disable = _class.instanceMethodId(
     r"disable",
     r"(Lcom/fasterxml/jackson/core/JsonParser$Feature;)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _disable = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser disable(com.fasterxml.jackson.core.JsonParser.Feature f)
   /// The returned object must be released after use, by calling the [release] method.
@@ -844,13 +1354,26 @@ class JsonParser extends jni.JObject {
   JsonParser disable(
     JsonParser_Feature f,
   ) {
-    return _id_disable(this, const $JsonParserType(), [f.reference.pointer]);
+    return _disable(reference.pointer, _id_disable as jni.JMethodIDPtr,
+            f.reference.pointer)
+        .object(const $JsonParserType());
   }
 
   static final _id_configure = _class.instanceMethodId(
     r"configure",
     r"(Lcom/fasterxml/jackson/core/JsonParser$Feature;Z)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _configure = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, ffi.Int64)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, int)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser configure(com.fasterxml.jackson.core.JsonParser.Feature f, boolean state)
   /// The returned object must be released after use, by calling the [release] method.
@@ -864,14 +1387,26 @@ class JsonParser extends jni.JObject {
     JsonParser_Feature f,
     bool state,
   ) {
-    return _id_configure(
-        this, const $JsonParserType(), [f.reference.pointer, state ? 1 : 0]);
+    return _configure(reference.pointer, _id_configure as jni.JMethodIDPtr,
+            f.reference.pointer, state ? 1 : 0)
+        .object(const $JsonParserType());
   }
 
   static final _id_isEnabled = _class.instanceMethodId(
     r"isEnabled",
     r"(Lcom/fasterxml/jackson/core/JsonParser$Feature;)Z",
   );
+
+  static final _isEnabled = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public boolean isEnabled(com.fasterxml.jackson.core.JsonParser.Feature f)
   ///
@@ -881,13 +1416,26 @@ class JsonParser extends jni.JObject {
   bool isEnabled(
     JsonParser_Feature f,
   ) {
-    return _id_isEnabled(this, const jni.jbooleanType(), [f.reference.pointer]);
+    return _isEnabled(reference.pointer, _id_isEnabled as jni.JMethodIDPtr,
+            f.reference.pointer)
+        .boolean;
   }
 
   static final _id_isEnabled1 = _class.instanceMethodId(
     r"isEnabled",
     r"(Lcom/fasterxml/jackson/core/StreamReadFeature;)Z",
   );
+
+  static final _isEnabled1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public boolean isEnabled(com.fasterxml.jackson.core.StreamReadFeature f)
   ///
@@ -898,8 +1446,9 @@ class JsonParser extends jni.JObject {
   bool isEnabled1(
     jni.JObject f,
   ) {
-    return _id_isEnabled1(
-        this, const jni.jbooleanType(), [f.reference.pointer]);
+    return _isEnabled1(reference.pointer, _id_isEnabled1 as jni.JMethodIDPtr,
+            f.reference.pointer)
+        .boolean;
   }
 
   static final _id_getFeatureMask = _class.instanceMethodId(
@@ -907,19 +1456,41 @@ class JsonParser extends jni.JObject {
     r"()I",
   );
 
+  static final _getFeatureMask = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public int getFeatureMask()
   ///
   /// Bulk access method for getting state of all standard Features.
   ///@return Bit mask that defines current states of all standard Features.
   ///@since 2.3
   int getFeatureMask() {
-    return _id_getFeatureMask(this, const jni.jintType(), []);
+    return _getFeatureMask(
+            reference.pointer, _id_getFeatureMask as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_setFeatureMask = _class.instanceMethodId(
     r"setFeatureMask",
     r"(I)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _setFeatureMask = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser setFeatureMask(int mask)
   /// The returned object must be released after use, by calling the [release] method.
@@ -932,14 +1503,24 @@ class JsonParser extends jni.JObject {
   JsonParser setFeatureMask(
     int mask,
   ) {
-    return _id_setFeatureMask(
-        this, const $JsonParserType(), [jni.JValueInt(mask)]);
+    return _setFeatureMask(
+            reference.pointer, _id_setFeatureMask as jni.JMethodIDPtr, mask)
+        .object(const $JsonParserType());
   }
 
   static final _id_overrideStdFeatures = _class.instanceMethodId(
     r"overrideStdFeatures",
     r"(II)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _overrideStdFeatures = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr, ffi.VarArgs<(ffi.Int64, ffi.Int64)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int, int)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser overrideStdFeatures(int values, int mask)
   /// The returned object must be released after use, by calling the [release] method.
@@ -960,14 +1541,27 @@ class JsonParser extends jni.JObject {
     int values,
     int mask,
   ) {
-    return _id_overrideStdFeatures(this, const $JsonParserType(),
-        [jni.JValueInt(values), jni.JValueInt(mask)]);
+    return _overrideStdFeatures(reference.pointer,
+            _id_overrideStdFeatures as jni.JMethodIDPtr, values, mask)
+        .object(const $JsonParserType());
   }
 
   static final _id_getFormatFeatures = _class.instanceMethodId(
     r"getFormatFeatures",
     r"()I",
   );
+
+  static final _getFormatFeatures = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public int getFormatFeatures()
   ///
@@ -976,13 +1570,24 @@ class JsonParser extends jni.JObject {
   ///@return Bit mask that defines current states of all standard FormatFeatures.
   ///@since 2.6
   int getFormatFeatures() {
-    return _id_getFormatFeatures(this, const jni.jintType(), []);
+    return _getFormatFeatures(
+            reference.pointer, _id_getFormatFeatures as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_overrideFormatFeatures = _class.instanceMethodId(
     r"overrideFormatFeatures",
     r"(II)Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _overrideFormatFeatures = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr, ffi.VarArgs<(ffi.Int64, ffi.Int64)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int, int)>();
 
   /// from: public com.fasterxml.jackson.core.JsonParser overrideFormatFeatures(int values, int mask)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1001,14 +1606,27 @@ class JsonParser extends jni.JObject {
     int values,
     int mask,
   ) {
-    return _id_overrideFormatFeatures(this, const $JsonParserType(),
-        [jni.JValueInt(values), jni.JValueInt(mask)]);
+    return _overrideFormatFeatures(reference.pointer,
+            _id_overrideFormatFeatures as jni.JMethodIDPtr, values, mask)
+        .object(const $JsonParserType());
   }
 
   static final _id_nextToken = _class.instanceMethodId(
     r"nextToken",
     r"()Lcom/fasterxml/jackson/core/JsonToken;",
   );
+
+  static final _nextToken = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonToken nextToken()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1022,13 +1640,26 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jsontoken_.JsonToken nextToken() {
-    return _id_nextToken(this, const jsontoken_.$JsonTokenType(), []);
+    return _nextToken(reference.pointer, _id_nextToken as jni.JMethodIDPtr)
+        .object(const jsontoken_.$JsonTokenType());
   }
 
   static final _id_nextValue = _class.instanceMethodId(
     r"nextValue",
     r"()Lcom/fasterxml/jackson/core/JsonToken;",
   );
+
+  static final _nextValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonToken nextValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1050,13 +1681,25 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jsontoken_.JsonToken nextValue() {
-    return _id_nextValue(this, const jsontoken_.$JsonTokenType(), []);
+    return _nextValue(reference.pointer, _id_nextValue as jni.JMethodIDPtr)
+        .object(const jsontoken_.$JsonTokenType());
   }
 
   static final _id_nextFieldName = _class.instanceMethodId(
     r"nextFieldName",
     r"(Lcom/fasterxml/jackson/core/SerializableString;)Z",
   );
+
+  static final _nextFieldName = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public boolean nextFieldName(com.fasterxml.jackson.core.SerializableString str)
   ///
@@ -1078,14 +1721,27 @@ class JsonParser extends jni.JObject {
   bool nextFieldName(
     jni.JObject str,
   ) {
-    return _id_nextFieldName(
-        this, const jni.jbooleanType(), [str.reference.pointer]);
+    return _nextFieldName(reference.pointer,
+            _id_nextFieldName as jni.JMethodIDPtr, str.reference.pointer)
+        .boolean;
   }
 
   static final _id_nextFieldName1 = _class.instanceMethodId(
     r"nextFieldName",
     r"()Ljava/lang/String;",
   );
+
+  static final _nextFieldName1 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public java.lang.String nextFieldName()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1099,13 +1755,27 @@ class JsonParser extends jni.JObject {
   ///   JsonParseException for decoding problems
   ///@since 2.5
   jni.JString nextFieldName1() {
-    return _id_nextFieldName1(this, const jni.JStringType(), []);
+    return _nextFieldName1(
+            reference.pointer, _id_nextFieldName1 as jni.JMethodIDPtr)
+        .object(const jni.JStringType());
   }
 
   static final _id_nextTextValue = _class.instanceMethodId(
     r"nextTextValue",
     r"()Ljava/lang/String;",
   );
+
+  static final _nextTextValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public java.lang.String nextTextValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1124,13 +1794,23 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni.JString nextTextValue() {
-    return _id_nextTextValue(this, const jni.JStringType(), []);
+    return _nextTextValue(
+            reference.pointer, _id_nextTextValue as jni.JMethodIDPtr)
+        .object(const jni.JStringType());
   }
 
   static final _id_nextIntValue = _class.instanceMethodId(
     r"nextIntValue",
     r"(I)I",
   );
+
+  static final _nextIntValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
 
   /// from: public int nextIntValue(int defaultValue)
   ///
@@ -1154,14 +1834,23 @@ class JsonParser extends jni.JObject {
   int nextIntValue(
     int defaultValue,
   ) {
-    return _id_nextIntValue(
-        this, const jni.jintType(), [jni.JValueInt(defaultValue)]);
+    return _nextIntValue(reference.pointer,
+            _id_nextIntValue as jni.JMethodIDPtr, defaultValue)
+        .integer;
   }
 
   static final _id_nextLongValue = _class.instanceMethodId(
     r"nextLongValue",
     r"(J)J",
   );
+
+  static final _nextLongValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_CallLongMethod")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
 
   /// from: public long nextLongValue(long defaultValue)
   ///
@@ -1185,13 +1874,27 @@ class JsonParser extends jni.JObject {
   int nextLongValue(
     int defaultValue,
   ) {
-    return _id_nextLongValue(this, const jni.jlongType(), [defaultValue]);
+    return _nextLongValue(reference.pointer,
+            _id_nextLongValue as jni.JMethodIDPtr, defaultValue)
+        .long;
   }
 
   static final _id_nextBooleanValue = _class.instanceMethodId(
     r"nextBooleanValue",
     r"()Ljava/lang/Boolean;",
   );
+
+  static final _nextBooleanValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public java.lang.Boolean nextBooleanValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1213,13 +1916,27 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni.JBoolean nextBooleanValue() {
-    return _id_nextBooleanValue(this, const jni.JBooleanType(), []);
+    return _nextBooleanValue(
+            reference.pointer, _id_nextBooleanValue as jni.JMethodIDPtr)
+        .object(const jni.JBooleanType());
   }
 
   static final _id_skipChildren = _class.instanceMethodId(
     r"skipChildren",
     r"()Lcom/fasterxml/jackson/core/JsonParser;",
   );
+
+  static final _skipChildren = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonParser skipChildren()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1240,13 +1957,27 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   JsonParser skipChildren() {
-    return _id_skipChildren(this, const $JsonParserType(), []);
+    return _skipChildren(
+            reference.pointer, _id_skipChildren as jni.JMethodIDPtr)
+        .object(const $JsonParserType());
   }
 
   static final _id_finishToken = _class.instanceMethodId(
     r"finishToken",
     r"()V",
   );
+
+  static final _finishToken = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public void finishToken()
   ///
@@ -1264,13 +1995,26 @@ class JsonParser extends jni.JObject {
   ///   JsonParseException for decoding problems
   ///@since 2.8
   void finishToken() {
-    _id_finishToken(this, const jni.jvoidType(), []);
+    _finishToken(reference.pointer, _id_finishToken as jni.JMethodIDPtr)
+        .check();
   }
 
   static final _id_currentToken = _class.instanceMethodId(
     r"currentToken",
     r"()Lcom/fasterxml/jackson/core/JsonToken;",
   );
+
+  static final _currentToken = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public com.fasterxml.jackson.core.JsonToken currentToken()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1285,13 +2029,27 @@ class JsonParser extends jni.JObject {
   ///   if the current token has been explicitly cleared.
   ///@since 2.8
   jsontoken_.JsonToken currentToken() {
-    return _id_currentToken(this, const jsontoken_.$JsonTokenType(), []);
+    return _currentToken(
+            reference.pointer, _id_currentToken as jni.JMethodIDPtr)
+        .object(const jsontoken_.$JsonTokenType());
   }
 
   static final _id_currentTokenId = _class.instanceMethodId(
     r"currentTokenId",
     r"()I",
   );
+
+  static final _currentTokenId = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public int currentTokenId()
   ///
@@ -1305,13 +2063,27 @@ class JsonParser extends jni.JObject {
   ///@since 2.8
   ///@return {@code int} matching one of constants from JsonTokenId.
   int currentTokenId() {
-    return _id_currentTokenId(this, const jni.jintType(), []);
+    return _currentTokenId(
+            reference.pointer, _id_currentTokenId as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_getCurrentToken = _class.instanceMethodId(
     r"getCurrentToken",
     r"()Lcom/fasterxml/jackson/core/JsonToken;",
   );
+
+  static final _getCurrentToken = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonToken getCurrentToken()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1321,7 +2093,9 @@ class JsonParser extends jni.JObject {
   ///@return Type of the token this parser currently points to,
   ///   if any: null before any tokens have been read, and
   jsontoken_.JsonToken getCurrentToken() {
-    return _id_getCurrentToken(this, const jsontoken_.$JsonTokenType(), []);
+    return _getCurrentToken(
+            reference.pointer, _id_getCurrentToken as jni.JMethodIDPtr)
+        .object(const jsontoken_.$JsonTokenType());
   }
 
   static final _id_getCurrentTokenId = _class.instanceMethodId(
@@ -1329,19 +2103,45 @@ class JsonParser extends jni.JObject {
     r"()I",
   );
 
+  static final _getCurrentTokenId = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public abstract int getCurrentTokenId()
   ///
   /// Deprecated alias for \#currentTokenId().
   ///@return {@code int} matching one of constants from JsonTokenId.
   ///@deprecated Since 2.12 use \#currentTokenId instead
   int getCurrentTokenId() {
-    return _id_getCurrentTokenId(this, const jni.jintType(), []);
+    return _getCurrentTokenId(
+            reference.pointer, _id_getCurrentTokenId as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_hasCurrentToken = _class.instanceMethodId(
     r"hasCurrentToken",
     r"()Z",
   );
+
+  static final _hasCurrentToken = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract boolean hasCurrentToken()
   ///
@@ -1354,13 +2154,23 @@ class JsonParser extends jni.JObject {
   ///   and returned null from \#nextToken, or the token
   ///   has been consumed)
   bool hasCurrentToken() {
-    return _id_hasCurrentToken(this, const jni.jbooleanType(), []);
+    return _hasCurrentToken(
+            reference.pointer, _id_hasCurrentToken as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_hasTokenId = _class.instanceMethodId(
     r"hasTokenId",
     r"(I)Z",
   );
+
+  static final _hasTokenId = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
 
   /// from: public abstract boolean hasTokenId(int id)
   ///
@@ -1379,13 +2189,26 @@ class JsonParser extends jni.JObject {
   bool hasTokenId(
     int id,
   ) {
-    return _id_hasTokenId(this, const jni.jbooleanType(), [jni.JValueInt(id)]);
+    return _hasTokenId(
+            reference.pointer, _id_hasTokenId as jni.JMethodIDPtr, id)
+        .boolean;
   }
 
   static final _id_hasToken = _class.instanceMethodId(
     r"hasToken",
     r"(Lcom/fasterxml/jackson/core/JsonToken;)Z",
   );
+
+  static final _hasToken = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public abstract boolean hasToken(com.fasterxml.jackson.core.JsonToken t)
   ///
@@ -1404,13 +2227,27 @@ class JsonParser extends jni.JObject {
   bool hasToken(
     jsontoken_.JsonToken t,
   ) {
-    return _id_hasToken(this, const jni.jbooleanType(), [t.reference.pointer]);
+    return _hasToken(reference.pointer, _id_hasToken as jni.JMethodIDPtr,
+            t.reference.pointer)
+        .boolean;
   }
 
   static final _id_isExpectedStartArrayToken = _class.instanceMethodId(
     r"isExpectedStartArrayToken",
     r"()Z",
   );
+
+  static final _isExpectedStartArrayToken = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public boolean isExpectedStartArrayToken()
   ///
@@ -1431,13 +2268,27 @@ class JsonParser extends jni.JObject {
   ///   start-array marker (such JsonToken\#START_ARRAY);
   ///   {@code false} if not
   bool isExpectedStartArrayToken() {
-    return _id_isExpectedStartArrayToken(this, const jni.jbooleanType(), []);
+    return _isExpectedStartArrayToken(reference.pointer,
+            _id_isExpectedStartArrayToken as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_isExpectedStartObjectToken = _class.instanceMethodId(
     r"isExpectedStartObjectToken",
     r"()Z",
   );
+
+  static final _isExpectedStartObjectToken = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public boolean isExpectedStartObjectToken()
   ///
@@ -1448,13 +2299,27 @@ class JsonParser extends jni.JObject {
   ///   {@code false} if not
   ///@since 2.5
   bool isExpectedStartObjectToken() {
-    return _id_isExpectedStartObjectToken(this, const jni.jbooleanType(), []);
+    return _isExpectedStartObjectToken(reference.pointer,
+            _id_isExpectedStartObjectToken as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_isExpectedNumberIntToken = _class.instanceMethodId(
     r"isExpectedNumberIntToken",
     r"()Z",
   );
+
+  static final _isExpectedNumberIntToken = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public boolean isExpectedNumberIntToken()
   ///
@@ -1468,13 +2333,27 @@ class JsonParser extends jni.JObject {
   ///   {@code false} if not
   ///@since 2.12
   bool isExpectedNumberIntToken() {
-    return _id_isExpectedNumberIntToken(this, const jni.jbooleanType(), []);
+    return _isExpectedNumberIntToken(
+            reference.pointer, _id_isExpectedNumberIntToken as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_isNaN = _class.instanceMethodId(
     r"isNaN",
     r"()Z",
   );
+
+  static final _isNaN = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public boolean isNaN()
   ///
@@ -1491,13 +2370,25 @@ class JsonParser extends jni.JObject {
   ///   JsonParseException for decoding problems
   ///@since 2.9
   bool isNaN() {
-    return _id_isNaN(this, const jni.jbooleanType(), []);
+    return _isNaN(reference.pointer, _id_isNaN as jni.JMethodIDPtr).boolean;
   }
 
   static final _id_clearCurrentToken = _class.instanceMethodId(
     r"clearCurrentToken",
     r"()V",
   );
+
+  static final _clearCurrentToken = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract void clearCurrentToken()
   ///
@@ -1512,13 +2403,27 @@ class JsonParser extends jni.JObject {
   /// it has to be able to consume last token used for binding (so that
   /// it will not be used again).
   void clearCurrentToken() {
-    _id_clearCurrentToken(this, const jni.jvoidType(), []);
+    _clearCurrentToken(
+            reference.pointer, _id_clearCurrentToken as jni.JMethodIDPtr)
+        .check();
   }
 
   static final _id_getLastClearedToken = _class.instanceMethodId(
     r"getLastClearedToken",
     r"()Lcom/fasterxml/jackson/core/JsonToken;",
   );
+
+  static final _getLastClearedToken = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonToken getLastClearedToken()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1530,13 +2435,26 @@ class JsonParser extends jni.JObject {
   /// or if parser has been closed.
   ///@return Last cleared token, if any; {@code null} otherwise
   jsontoken_.JsonToken getLastClearedToken() {
-    return _id_getLastClearedToken(this, const jsontoken_.$JsonTokenType(), []);
+    return _getLastClearedToken(
+            reference.pointer, _id_getLastClearedToken as jni.JMethodIDPtr)
+        .object(const jsontoken_.$JsonTokenType());
   }
 
   static final _id_overrideCurrentName = _class.instanceMethodId(
     r"overrideCurrentName",
     r"(Ljava/lang/String;)V",
   );
+
+  static final _overrideCurrentName = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JThrowablePtr Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public abstract void overrideCurrentName(java.lang.String name)
   ///
@@ -1551,14 +2469,27 @@ class JsonParser extends jni.JObject {
   void overrideCurrentName(
     jni.JString name,
   ) {
-    _id_overrideCurrentName(
-        this, const jni.jvoidType(), [name.reference.pointer]);
+    _overrideCurrentName(reference.pointer,
+            _id_overrideCurrentName as jni.JMethodIDPtr, name.reference.pointer)
+        .check();
   }
 
   static final _id_getCurrentName = _class.instanceMethodId(
     r"getCurrentName",
     r"()Ljava/lang/String;",
   );
+
+  static final _getCurrentName = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract java.lang.String getCurrentName()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1568,13 +2499,27 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni.JString getCurrentName() {
-    return _id_getCurrentName(this, const jni.JStringType(), []);
+    return _getCurrentName(
+            reference.pointer, _id_getCurrentName as jni.JMethodIDPtr)
+        .object(const jni.JStringType());
   }
 
   static final _id_currentName = _class.instanceMethodId(
     r"currentName",
     r"()Ljava/lang/String;",
   );
+
+  static final _currentName = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public java.lang.String currentName()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1589,13 +2534,26 @@ class JsonParser extends jni.JObject {
   ///   JsonParseException for decoding problems
   ///@since 2.10
   jni.JString currentName() {
-    return _id_currentName(this, const jni.JStringType(), []);
+    return _currentName(reference.pointer, _id_currentName as jni.JMethodIDPtr)
+        .object(const jni.JStringType());
   }
 
   static final _id_getText = _class.instanceMethodId(
     r"getText",
     r"()Ljava/lang/String;",
   );
+
+  static final _getText = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract java.lang.String getText()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1609,13 +2567,25 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni.JString getText() {
-    return _id_getText(this, const jni.JStringType(), []);
+    return _getText(reference.pointer, _id_getText as jni.JMethodIDPtr)
+        .object(const jni.JStringType());
   }
 
   static final _id_getText1 = _class.instanceMethodId(
     r"getText",
     r"(Ljava/io/Writer;)I",
   );
+
+  static final _getText1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public int getText(java.io.Writer writer)
   ///
@@ -1637,13 +2607,27 @@ class JsonParser extends jni.JObject {
   int getText1(
     jni.JObject writer,
   ) {
-    return _id_getText1(this, const jni.jintType(), [writer.reference.pointer]);
+    return _getText1(reference.pointer, _id_getText1 as jni.JMethodIDPtr,
+            writer.reference.pointer)
+        .integer;
   }
 
   static final _id_getTextCharacters = _class.instanceMethodId(
     r"getTextCharacters",
     r"()[C",
   );
+
+  static final _getTextCharacters = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract char[] getTextCharacters()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1676,14 +2660,27 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni.JArray<jni.jchar> getTextCharacters() {
-    return _id_getTextCharacters(
-        this, const jni.JArrayType(jni.jcharType()), []);
+    return _getTextCharacters(
+            reference.pointer, _id_getTextCharacters as jni.JMethodIDPtr)
+        .object(const jni.JArrayType(jni.jcharType()));
   }
 
   static final _id_getTextLength = _class.instanceMethodId(
     r"getTextLength",
     r"()I",
   );
+
+  static final _getTextLength = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract int getTextLength()
   ///
@@ -1695,13 +2692,27 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   int getTextLength() {
-    return _id_getTextLength(this, const jni.jintType(), []);
+    return _getTextLength(
+            reference.pointer, _id_getTextLength as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_getTextOffset = _class.instanceMethodId(
     r"getTextOffset",
     r"()I",
   );
+
+  static final _getTextOffset = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract int getTextOffset()
   ///
@@ -1713,13 +2724,27 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   int getTextOffset() {
-    return _id_getTextOffset(this, const jni.jintType(), []);
+    return _getTextOffset(
+            reference.pointer, _id_getTextOffset as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_hasTextCharacters = _class.instanceMethodId(
     r"hasTextCharacters",
     r"()Z",
   );
+
+  static final _hasTextCharacters = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract boolean hasTextCharacters()
   ///
@@ -1738,13 +2763,27 @@ class JsonParser extends jni.JObject {
   ///   be efficiently returned via \#getTextCharacters; false
   ///   means that it may or may not exist
   bool hasTextCharacters() {
-    return _id_hasTextCharacters(this, const jni.jbooleanType(), []);
+    return _hasTextCharacters(
+            reference.pointer, _id_hasTextCharacters as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_getNumberValue = _class.instanceMethodId(
     r"getNumberValue",
     r"()Ljava/lang/Number;",
   );
+
+  static final _getNumberValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract java.lang.Number getNumberValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1760,13 +2799,27 @@ class JsonParser extends jni.JObject {
   ///    (invalid format for numbers); plain IOException if underlying
   ///    content read fails (possible if values are extracted lazily)
   jni.JNumber getNumberValue() {
-    return _id_getNumberValue(this, const jni.JNumberType(), []);
+    return _getNumberValue(
+            reference.pointer, _id_getNumberValue as jni.JMethodIDPtr)
+        .object(const jni.JNumberType());
   }
 
   static final _id_getNumberValueExact = _class.instanceMethodId(
     r"getNumberValueExact",
     r"()Ljava/lang/Number;",
   );
+
+  static final _getNumberValueExact = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public java.lang.Number getNumberValueExact()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1786,13 +2839,27 @@ class JsonParser extends jni.JObject {
   ///    content read fails (possible if values are extracted lazily)
   ///@since 2.12
   jni.JNumber getNumberValueExact() {
-    return _id_getNumberValueExact(this, const jni.JNumberType(), []);
+    return _getNumberValueExact(
+            reference.pointer, _id_getNumberValueExact as jni.JMethodIDPtr)
+        .object(const jni.JNumberType());
   }
 
   static final _id_getNumberType = _class.instanceMethodId(
     r"getNumberType",
     r"()Lcom/fasterxml/jackson/core/JsonParser$NumberType;",
   );
+
+  static final _getNumberType = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract com.fasterxml.jackson.core.JsonParser.NumberType getNumberType()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1805,13 +2872,27 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   JsonParser_NumberType getNumberType() {
-    return _id_getNumberType(this, const $JsonParser_NumberTypeType(), []);
+    return _getNumberType(
+            reference.pointer, _id_getNumberType as jni.JMethodIDPtr)
+        .object(const $JsonParser_NumberTypeType());
   }
 
   static final _id_getByteValue = _class.instanceMethodId(
     r"getByteValue",
     r"()B",
   );
+
+  static final _getByteValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallByteMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public byte getByteValue()
   ///
@@ -1837,13 +2918,27 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   int getByteValue() {
-    return _id_getByteValue(this, const jni.jbyteType(), []);
+    return _getByteValue(
+            reference.pointer, _id_getByteValue as jni.JMethodIDPtr)
+        .byte;
   }
 
   static final _id_getShortValue = _class.instanceMethodId(
     r"getShortValue",
     r"()S",
   );
+
+  static final _getShortValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallShortMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public short getShortValue()
   ///
@@ -1863,13 +2958,27 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   int getShortValue() {
-    return _id_getShortValue(this, const jni.jshortType(), []);
+    return _getShortValue(
+            reference.pointer, _id_getShortValue as jni.JMethodIDPtr)
+        .short;
   }
 
   static final _id_getIntValue = _class.instanceMethodId(
     r"getIntValue",
     r"()I",
   );
+
+  static final _getIntValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract int getIntValue()
   ///
@@ -1889,13 +2998,26 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   int getIntValue() {
-    return _id_getIntValue(this, const jni.jintType(), []);
+    return _getIntValue(reference.pointer, _id_getIntValue as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_getLongValue = _class.instanceMethodId(
     r"getLongValue",
     r"()J",
   );
+
+  static final _getLongValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallLongMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract long getLongValue()
   ///
@@ -1915,13 +3037,27 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   int getLongValue() {
-    return _id_getLongValue(this, const jni.jlongType(), []);
+    return _getLongValue(
+            reference.pointer, _id_getLongValue as jni.JMethodIDPtr)
+        .long;
   }
 
   static final _id_getBigIntegerValue = _class.instanceMethodId(
     r"getBigIntegerValue",
     r"()Ljava/math/BigInteger;",
   );
+
+  static final _getBigIntegerValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract java.math.BigInteger getBigIntegerValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1938,13 +3074,27 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni.JObject getBigIntegerValue() {
-    return _id_getBigIntegerValue(this, const jni.JObjectType(), []);
+    return _getBigIntegerValue(
+            reference.pointer, _id_getBigIntegerValue as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_getFloatValue = _class.instanceMethodId(
     r"getFloatValue",
     r"()F",
   );
+
+  static final _getFloatValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallFloatMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract float getFloatValue()
   ///
@@ -1964,13 +3114,27 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   double getFloatValue() {
-    return _id_getFloatValue(this, const jni.jfloatType(), []);
+    return _getFloatValue(
+            reference.pointer, _id_getFloatValue as jni.JMethodIDPtr)
+        .float;
   }
 
   static final _id_getDoubleValue = _class.instanceMethodId(
     r"getDoubleValue",
     r"()D",
   );
+
+  static final _getDoubleValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallDoubleMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract double getDoubleValue()
   ///
@@ -1990,13 +3154,27 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   double getDoubleValue() {
-    return _id_getDoubleValue(this, const jni.jdoubleType(), []);
+    return _getDoubleValue(
+            reference.pointer, _id_getDoubleValue as jni.JMethodIDPtr)
+        .doubleFloat;
   }
 
   static final _id_getDecimalValue = _class.instanceMethodId(
     r"getDecimalValue",
     r"()Ljava/math/BigDecimal;",
   );
+
+  static final _getDecimalValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public abstract java.math.BigDecimal getDecimalValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2010,13 +3188,27 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni.JObject getDecimalValue() {
-    return _id_getDecimalValue(this, const jni.JObjectType(), []);
+    return _getDecimalValue(
+            reference.pointer, _id_getDecimalValue as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_getBooleanValue = _class.instanceMethodId(
     r"getBooleanValue",
     r"()Z",
   );
+
+  static final _getBooleanValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public boolean getBooleanValue()
   ///
@@ -2032,13 +3224,27 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   bool getBooleanValue() {
-    return _id_getBooleanValue(this, const jni.jbooleanType(), []);
+    return _getBooleanValue(
+            reference.pointer, _id_getBooleanValue as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_getEmbeddedObject = _class.instanceMethodId(
     r"getEmbeddedObject",
     r"()Ljava/lang/Object;",
   );
+
+  static final _getEmbeddedObject = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public java.lang.Object getEmbeddedObject()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2058,13 +3264,26 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni.JObject getEmbeddedObject() {
-    return _id_getEmbeddedObject(this, const jni.JObjectType(), []);
+    return _getEmbeddedObject(
+            reference.pointer, _id_getEmbeddedObject as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_getBinaryValue = _class.instanceMethodId(
     r"getBinaryValue",
     r"(Lcom/fasterxml/jackson/core/Base64Variant;)[B",
   );
+
+  static final _getBinaryValue = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public abstract byte[] getBinaryValue(com.fasterxml.jackson.core.Base64Variant bv)
   /// The returned object must be released after use, by calling the [release] method.
@@ -2092,14 +3311,27 @@ class JsonParser extends jni.JObject {
   jni.JArray<jni.jbyte> getBinaryValue(
     jni.JObject bv,
   ) {
-    return _id_getBinaryValue(
-        this, const jni.JArrayType(jni.jbyteType()), [bv.reference.pointer]);
+    return _getBinaryValue(reference.pointer,
+            _id_getBinaryValue as jni.JMethodIDPtr, bv.reference.pointer)
+        .object(const jni.JArrayType(jni.jbyteType()));
   }
 
   static final _id_getBinaryValue1 = _class.instanceMethodId(
     r"getBinaryValue",
     r"()[B",
   );
+
+  static final _getBinaryValue1 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public byte[] getBinaryValue()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2111,13 +3343,26 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni.JArray<jni.jbyte> getBinaryValue1() {
-    return _id_getBinaryValue1(this, const jni.JArrayType(jni.jbyteType()), []);
+    return _getBinaryValue1(
+            reference.pointer, _id_getBinaryValue1 as jni.JMethodIDPtr)
+        .object(const jni.JArrayType(jni.jbyteType()));
   }
 
   static final _id_readBinaryValue = _class.instanceMethodId(
     r"readBinaryValue",
     r"(Ljava/io/OutputStream;)I",
   );
+
+  static final _readBinaryValue = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public int readBinaryValue(java.io.OutputStream out)
   ///
@@ -2135,14 +3380,29 @@ class JsonParser extends jni.JObject {
   int readBinaryValue(
     jni.JObject out,
   ) {
-    return _id_readBinaryValue(
-        this, const jni.jintType(), [out.reference.pointer]);
+    return _readBinaryValue(reference.pointer,
+            _id_readBinaryValue as jni.JMethodIDPtr, out.reference.pointer)
+        .integer;
   }
 
   static final _id_readBinaryValue1 = _class.instanceMethodId(
     r"readBinaryValue",
     r"(Lcom/fasterxml/jackson/core/Base64Variant;Ljava/io/OutputStream;)I",
   );
+
+  static final _readBinaryValue1 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
 
   /// from: public int readBinaryValue(com.fasterxml.jackson.core.Base64Variant bv, java.io.OutputStream out)
   ///
@@ -2158,14 +3418,30 @@ class JsonParser extends jni.JObject {
     jni.JObject bv,
     jni.JObject out,
   ) {
-    return _id_readBinaryValue1(this, const jni.jintType(),
-        [bv.reference.pointer, out.reference.pointer]);
+    return _readBinaryValue1(
+            reference.pointer,
+            _id_readBinaryValue1 as jni.JMethodIDPtr,
+            bv.reference.pointer,
+            out.reference.pointer)
+        .integer;
   }
 
   static final _id_getValueAsInt = _class.instanceMethodId(
     r"getValueAsInt",
     r"()I",
   );
+
+  static final _getValueAsInt = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public int getValueAsInt()
   ///
@@ -2183,13 +3459,23 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   int getValueAsInt() {
-    return _id_getValueAsInt(this, const jni.jintType(), []);
+    return _getValueAsInt(
+            reference.pointer, _id_getValueAsInt as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_getValueAsInt1 = _class.instanceMethodId(
     r"getValueAsInt",
     r"(I)I",
   );
+
+  static final _getValueAsInt1 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
 
   /// from: public int getValueAsInt(int def)
   ///
@@ -2209,13 +3495,27 @@ class JsonParser extends jni.JObject {
   int getValueAsInt1(
     int def,
   ) {
-    return _id_getValueAsInt1(this, const jni.jintType(), [jni.JValueInt(def)]);
+    return _getValueAsInt1(
+            reference.pointer, _id_getValueAsInt1 as jni.JMethodIDPtr, def)
+        .integer;
   }
 
   static final _id_getValueAsLong = _class.instanceMethodId(
     r"getValueAsLong",
     r"()J",
   );
+
+  static final _getValueAsLong = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallLongMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public long getValueAsLong()
   ///
@@ -2233,13 +3533,23 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   int getValueAsLong() {
-    return _id_getValueAsLong(this, const jni.jlongType(), []);
+    return _getValueAsLong(
+            reference.pointer, _id_getValueAsLong as jni.JMethodIDPtr)
+        .long;
   }
 
   static final _id_getValueAsLong1 = _class.instanceMethodId(
     r"getValueAsLong",
     r"(J)J",
   );
+
+  static final _getValueAsLong1 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_CallLongMethod")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
 
   /// from: public long getValueAsLong(long def)
   ///
@@ -2259,13 +3569,27 @@ class JsonParser extends jni.JObject {
   int getValueAsLong1(
     int def,
   ) {
-    return _id_getValueAsLong1(this, const jni.jlongType(), [def]);
+    return _getValueAsLong1(
+            reference.pointer, _id_getValueAsLong1 as jni.JMethodIDPtr, def)
+        .long;
   }
 
   static final _id_getValueAsDouble = _class.instanceMethodId(
     r"getValueAsDouble",
     r"()D",
   );
+
+  static final _getValueAsDouble = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallDoubleMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public double getValueAsDouble()
   ///
@@ -2283,13 +3607,23 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   double getValueAsDouble() {
-    return _id_getValueAsDouble(this, const jni.jdoubleType(), []);
+    return _getValueAsDouble(
+            reference.pointer, _id_getValueAsDouble as jni.JMethodIDPtr)
+        .doubleFloat;
   }
 
   static final _id_getValueAsDouble1 = _class.instanceMethodId(
     r"getValueAsDouble",
     r"(D)D",
   );
+
+  static final _getValueAsDouble1 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Double,)>)>>("globalEnv_CallDoubleMethod")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, double)>();
 
   /// from: public double getValueAsDouble(double def)
   ///
@@ -2309,13 +3643,27 @@ class JsonParser extends jni.JObject {
   double getValueAsDouble1(
     double def,
   ) {
-    return _id_getValueAsDouble1(this, const jni.jdoubleType(), [def]);
+    return _getValueAsDouble1(
+            reference.pointer, _id_getValueAsDouble1 as jni.JMethodIDPtr, def)
+        .doubleFloat;
   }
 
   static final _id_getValueAsBoolean = _class.instanceMethodId(
     r"getValueAsBoolean",
     r"()Z",
   );
+
+  static final _getValueAsBoolean = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public boolean getValueAsBoolean()
   ///
@@ -2333,13 +3681,23 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   bool getValueAsBoolean() {
-    return _id_getValueAsBoolean(this, const jni.jbooleanType(), []);
+    return _getValueAsBoolean(
+            reference.pointer, _id_getValueAsBoolean as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_getValueAsBoolean1 = _class.instanceMethodId(
     r"getValueAsBoolean",
     r"(Z)Z",
   );
+
+  static final _getValueAsBoolean1 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
 
   /// from: public boolean getValueAsBoolean(boolean def)
   ///
@@ -2359,14 +3717,27 @@ class JsonParser extends jni.JObject {
   bool getValueAsBoolean1(
     bool def,
   ) {
-    return _id_getValueAsBoolean1(
-        this, const jni.jbooleanType(), [def ? 1 : 0]);
+    return _getValueAsBoolean1(reference.pointer,
+            _id_getValueAsBoolean1 as jni.JMethodIDPtr, def ? 1 : 0)
+        .boolean;
   }
 
   static final _id_getValueAsString = _class.instanceMethodId(
     r"getValueAsString",
     r"()Ljava/lang/String;",
   );
+
+  static final _getValueAsString = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public java.lang.String getValueAsString()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2383,13 +3754,26 @@ class JsonParser extends jni.JObject {
   ///   JsonParseException for decoding problems
   ///@since 2.1
   jni.JString getValueAsString() {
-    return _id_getValueAsString(this, const jni.JStringType(), []);
+    return _getValueAsString(
+            reference.pointer, _id_getValueAsString as jni.JMethodIDPtr)
+        .object(const jni.JStringType());
   }
 
   static final _id_getValueAsString1 = _class.instanceMethodId(
     r"getValueAsString",
     r"(Ljava/lang/String;)Ljava/lang/String;",
   );
+
+  static final _getValueAsString1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public abstract java.lang.String getValueAsString(java.lang.String def)
   /// The returned object must be released after use, by calling the [release] method.
@@ -2409,14 +3793,27 @@ class JsonParser extends jni.JObject {
   jni.JString getValueAsString1(
     jni.JString def,
   ) {
-    return _id_getValueAsString1(
-        this, const jni.JStringType(), [def.reference.pointer]);
+    return _getValueAsString1(reference.pointer,
+            _id_getValueAsString1 as jni.JMethodIDPtr, def.reference.pointer)
+        .object(const jni.JStringType());
   }
 
   static final _id_canReadObjectId = _class.instanceMethodId(
     r"canReadObjectId",
     r"()Z",
   );
+
+  static final _canReadObjectId = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public boolean canReadObjectId()
   ///
@@ -2432,13 +3829,27 @@ class JsonParser extends jni.JObject {
   ///    {@code false} if not
   ///@since 2.3
   bool canReadObjectId() {
-    return _id_canReadObjectId(this, const jni.jbooleanType(), []);
+    return _canReadObjectId(
+            reference.pointer, _id_canReadObjectId as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_canReadTypeId = _class.instanceMethodId(
     r"canReadTypeId",
     r"()Z",
   );
+
+  static final _canReadTypeId = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public boolean canReadTypeId()
   ///
@@ -2454,13 +3865,27 @@ class JsonParser extends jni.JObject {
   ///    {@code false} if not
   ///@since 2.3
   bool canReadTypeId() {
-    return _id_canReadTypeId(this, const jni.jbooleanType(), []);
+    return _canReadTypeId(
+            reference.pointer, _id_canReadTypeId as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_getObjectId = _class.instanceMethodId(
     r"getObjectId",
     r"()Ljava/lang/Object;",
   );
+
+  static final _getObjectId = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public java.lang.Object getObjectId()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2479,13 +3904,26 @@ class JsonParser extends jni.JObject {
   ///   JsonParseException for decoding problems
   ///@since 2.3
   jni.JObject getObjectId() {
-    return _id_getObjectId(this, const jni.JObjectType(), []);
+    return _getObjectId(reference.pointer, _id_getObjectId as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_getTypeId = _class.instanceMethodId(
     r"getTypeId",
     r"()Ljava/lang/Object;",
   );
+
+  static final _getTypeId = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public java.lang.Object getTypeId()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2504,13 +3942,25 @@ class JsonParser extends jni.JObject {
   ///   JsonParseException for decoding problems
   ///@since 2.3
   jni.JObject getTypeId() {
-    return _id_getTypeId(this, const jni.JObjectType(), []);
+    return _getTypeId(reference.pointer, _id_getTypeId as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_readValueAs = _class.instanceMethodId(
     r"readValueAs",
     r"(Ljava/lang/Class;)Ljava/lang/Object;",
   );
+
+  static final _readValueAs = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public T readValueAs(java.lang.Class<T> valueType)
   /// The returned object must be released after use, by calling the [release] method.
@@ -2544,13 +3994,26 @@ class JsonParser extends jni.JObject {
     jni.JObject valueType, {
     required jni.JObjType<$T> T,
   }) {
-    return _id_readValueAs(this, T, [valueType.reference.pointer]);
+    return _readValueAs(reference.pointer, _id_readValueAs as jni.JMethodIDPtr,
+            valueType.reference.pointer)
+        .object(T);
   }
 
   static final _id_readValueAs1 = _class.instanceMethodId(
     r"readValueAs",
     r"(Lcom/fasterxml/jackson/core/type/TypeReference;)Ljava/lang/Object;",
   );
+
+  static final _readValueAs1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public T readValueAs(com.fasterxml.jackson.core.type.TypeReference<?> valueTypeRef)
   /// The returned object must be released after use, by calling the [release] method.
@@ -2581,13 +4044,28 @@ class JsonParser extends jni.JObject {
     jni.JObject valueTypeRef, {
     required jni.JObjType<$T> T,
   }) {
-    return _id_readValueAs1(this, T, [valueTypeRef.reference.pointer]);
+    return _readValueAs1(
+            reference.pointer,
+            _id_readValueAs1 as jni.JMethodIDPtr,
+            valueTypeRef.reference.pointer)
+        .object(T);
   }
 
   static final _id_readValuesAs = _class.instanceMethodId(
     r"readValuesAs",
     r"(Ljava/lang/Class;)Ljava/util/Iterator;",
   );
+
+  static final _readValuesAs = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public java.util.Iterator<T> readValuesAs(java.lang.Class<T> valueType)
   /// The returned object must be released after use, by calling the [release] method.
@@ -2604,14 +4082,26 @@ class JsonParser extends jni.JObject {
     jni.JObject valueType, {
     required jni.JObjType<$T> T,
   }) {
-    return _id_readValuesAs(
-        this, jni.JIteratorType(T), [valueType.reference.pointer]);
+    return _readValuesAs(reference.pointer,
+            _id_readValuesAs as jni.JMethodIDPtr, valueType.reference.pointer)
+        .object(jni.JIteratorType(T));
   }
 
   static final _id_readValuesAs1 = _class.instanceMethodId(
     r"readValuesAs",
     r"(Lcom/fasterxml/jackson/core/type/TypeReference;)Ljava/util/Iterator;",
   );
+
+  static final _readValuesAs1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public java.util.Iterator<T> readValuesAs(com.fasterxml.jackson.core.type.TypeReference<T> valueTypeRef)
   /// The returned object must be released after use, by calling the [release] method.
@@ -2628,14 +4118,29 @@ class JsonParser extends jni.JObject {
     jni.JObject valueTypeRef, {
     required jni.JObjType<$T> T,
   }) {
-    return _id_readValuesAs1(
-        this, jni.JIteratorType(T), [valueTypeRef.reference.pointer]);
+    return _readValuesAs1(
+            reference.pointer,
+            _id_readValuesAs1 as jni.JMethodIDPtr,
+            valueTypeRef.reference.pointer)
+        .object(jni.JIteratorType(T));
   }
 
   static final _id_readValueAsTree = _class.instanceMethodId(
     r"readValueAsTree",
     r"()Lcom/fasterxml/jackson/core/TreeNode;",
   );
+
+  static final _readValueAsTree = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public T readValueAsTree()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2652,7 +4157,9 @@ class JsonParser extends jni.JObject {
   $T readValueAsTree<$T extends jni.JObject>({
     required jni.JObjType<$T> T,
   }) {
-    return _id_readValueAsTree(this, T, []);
+    return _readValueAsTree(
+            reference.pointer, _id_readValueAsTree as jni.JMethodIDPtr)
+        .object(T);
   }
 }
 

--- a/pkgs/jnigen/test/jackson_core_test/third_party/dart_only/dart_bindings/com/fasterxml/jackson/core/JsonToken.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/dart_only/dart_bindings/com/fasterxml/jackson/core/JsonToken.dart
@@ -62,10 +62,23 @@ class JsonToken extends jni.JObject {
     r"()[Lcom/fasterxml/jackson/core/JsonToken;",
   );
 
+  static final _values = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public com.fasterxml.jackson.core.JsonToken[] values()
   /// The returned object must be released after use, by calling the [release] method.
   static jni.JArray<JsonToken> values() {
-    return _id_values(_class, const jni.JArrayType($JsonTokenType()), []);
+    return _values(_class.reference.pointer, _id_values as jni.JMethodIDPtr)
+        .object(const jni.JArrayType($JsonTokenType()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -73,13 +86,25 @@ class JsonToken extends jni.JObject {
     r"(Ljava/lang/String;)Lcom/fasterxml/jackson/core/JsonToken;",
   );
 
+  static final _valueOf = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: static public com.fasterxml.jackson.core.JsonToken valueOf(java.lang.String name)
   /// The returned object must be released after use, by calling the [release] method.
   static JsonToken valueOf(
     jni.JString name,
   ) {
-    return _id_valueOf(
-        _class, const $JsonTokenType(), [name.reference.pointer]);
+    return _valueOf(_class.reference.pointer, _id_valueOf as jni.JMethodIDPtr,
+            name.reference.pointer)
+        .object(const $JsonTokenType());
   }
 
   static final _id_id = _class.instanceMethodId(
@@ -87,9 +112,21 @@ class JsonToken extends jni.JObject {
     r"()I",
   );
 
+  static final _id = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public final int id()
   int id() {
-    return _id_id(this, const jni.jintType(), []);
+    return _id(reference.pointer, _id_id as jni.JMethodIDPtr).integer;
   }
 
   static final _id_asString = _class.instanceMethodId(
@@ -97,10 +134,23 @@ class JsonToken extends jni.JObject {
     r"()Ljava/lang/String;",
   );
 
+  static final _asString = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public final java.lang.String asString()
   /// The returned object must be released after use, by calling the [release] method.
   jni.JString asString() {
-    return _id_asString(this, const jni.JStringType(), []);
+    return _asString(reference.pointer, _id_asString as jni.JMethodIDPtr)
+        .object(const jni.JStringType());
   }
 
   static final _id_asCharArray = _class.instanceMethodId(
@@ -108,10 +158,23 @@ class JsonToken extends jni.JObject {
     r"()[C",
   );
 
+  static final _asCharArray = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public final char[] asCharArray()
   /// The returned object must be released after use, by calling the [release] method.
   jni.JArray<jni.jchar> asCharArray() {
-    return _id_asCharArray(this, const jni.JArrayType(jni.jcharType()), []);
+    return _asCharArray(reference.pointer, _id_asCharArray as jni.JMethodIDPtr)
+        .object(const jni.JArrayType(jni.jcharType()));
   }
 
   static final _id_asByteArray = _class.instanceMethodId(
@@ -119,10 +182,23 @@ class JsonToken extends jni.JObject {
     r"()[B",
   );
 
+  static final _asByteArray = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public final byte[] asByteArray()
   /// The returned object must be released after use, by calling the [release] method.
   jni.JArray<jni.jbyte> asByteArray() {
-    return _id_asByteArray(this, const jni.JArrayType(jni.jbyteType()), []);
+    return _asByteArray(reference.pointer, _id_asByteArray as jni.JMethodIDPtr)
+        .object(const jni.JArrayType(jni.jbyteType()));
   }
 
   static final _id_isNumeric = _class.instanceMethodId(
@@ -130,18 +206,43 @@ class JsonToken extends jni.JObject {
     r"()Z",
   );
 
+  static final _isNumeric = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public final boolean isNumeric()
   ///
   /// @return {@code True} if this token is {@code VALUE_NUMBER_INT} or {@code VALUE_NUMBER_FLOAT},
   ///   {@code false} otherwise
   bool isNumeric() {
-    return _id_isNumeric(this, const jni.jbooleanType(), []);
+    return _isNumeric(reference.pointer, _id_isNumeric as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_isStructStart = _class.instanceMethodId(
     r"isStructStart",
     r"()Z",
   );
+
+  static final _isStructStart = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public final boolean isStructStart()
   ///
@@ -153,13 +254,27 @@ class JsonToken extends jni.JObject {
   ///   {@code false} otherwise
   ///@since 2.3
   bool isStructStart() {
-    return _id_isStructStart(this, const jni.jbooleanType(), []);
+    return _isStructStart(
+            reference.pointer, _id_isStructStart as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_isStructEnd = _class.instanceMethodId(
     r"isStructEnd",
     r"()Z",
   );
+
+  static final _isStructEnd = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public final boolean isStructEnd()
   ///
@@ -171,13 +286,26 @@ class JsonToken extends jni.JObject {
   ///   {@code false} otherwise
   ///@since 2.3
   bool isStructEnd() {
-    return _id_isStructEnd(this, const jni.jbooleanType(), []);
+    return _isStructEnd(reference.pointer, _id_isStructEnd as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_isScalarValue = _class.instanceMethodId(
     r"isScalarValue",
     r"()Z",
   );
+
+  static final _isScalarValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
   /// from: public final boolean isScalarValue()
   ///
@@ -188,7 +316,9 @@ class JsonToken extends jni.JObject {
   ///@return {@code True} if this token is a scalar value token (one of
   ///   {@code VALUE_xxx} tokens), {@code false} otherwise
   bool isScalarValue() {
-    return _id_isScalarValue(this, const jni.jbooleanType(), []);
+    return _isScalarValue(
+            reference.pointer, _id_isScalarValue as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_isBoolean = _class.instanceMethodId(
@@ -196,12 +326,25 @@ class JsonToken extends jni.JObject {
     r"()Z",
   );
 
+  static final _isBoolean = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public final boolean isBoolean()
   ///
   /// @return {@code True} if this token is {@code VALUE_TRUE} or {@code VALUE_FALSE},
   ///   {@code false} otherwise
   bool isBoolean() {
-    return _id_isBoolean(this, const jni.jbooleanType(), []);
+    return _isBoolean(reference.pointer, _id_isBoolean as jni.JMethodIDPtr)
+        .boolean;
   }
 }
 

--- a/pkgs/jnigen/test/kotlin_test/dart_only/dart_bindings/kotlin.dart
+++ b/pkgs/jnigen/test/kotlin_test/dart_only/dart_bindings/kotlin.dart
@@ -45,10 +45,24 @@ class SuspendFun extends jni.JObject {
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory SuspendFun() {
-    return SuspendFun.fromReference(_id_new0(_class, referenceType, []));
+    return SuspendFun.fromReference(
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 
   static final _id_sayHello = _class.instanceMethodId(
@@ -56,13 +70,26 @@ class SuspendFun extends jni.JObject {
     r"(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;",
   );
 
+  static final _sayHello = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public final java.lang.Object sayHello(kotlin.coroutines.Continuation continuation)
   /// The returned object must be released after use, by calling the [release] method.
   Future<jni.JString> sayHello() async {
     final $p = ReceivePort();
     final $c = jni.JObject.fromReference(
         ProtectedJniExtensions.newPortContinuation($p));
-    _id_sayHello(this, const jni.JObjectType(), [$c.reference.pointer]);
+    _sayHello(reference.pointer, _id_sayHello as jni.JMethodIDPtr,
+            $c.reference.pointer)
+        .object(const jni.JObjectType());
     final $o = jni.JGlobalReference(jni.JObjectPtr.fromAddress(await $p.first));
     final $k = const jni.JStringType().jClass.reference.pointer;
     if (!jni.Jni.env.IsInstanceOf($o.pointer, $k)) {
@@ -76,6 +103,20 @@ class SuspendFun extends jni.JObject {
     r"(Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;",
   );
 
+  static final _sayHello1 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+
   /// from: public final java.lang.Object sayHello(java.lang.String string, kotlin.coroutines.Continuation continuation)
   /// The returned object must be released after use, by calling the [release] method.
   Future<jni.JString> sayHello1(
@@ -84,8 +125,9 @@ class SuspendFun extends jni.JObject {
     final $p = ReceivePort();
     final $c = jni.JObject.fromReference(
         ProtectedJniExtensions.newPortContinuation($p));
-    _id_sayHello1(this, const jni.JObjectType(),
-        [string.reference.pointer, $c.reference.pointer]);
+    _sayHello1(reference.pointer, _id_sayHello1 as jni.JMethodIDPtr,
+            string.reference.pointer, $c.reference.pointer)
+        .object(const jni.JObjectType());
     final $o = jni.JGlobalReference(jni.JObjectPtr.fromAddress(await $p.first));
     final $k = const jni.JStringType().jClass.reference.pointer;
     if (!jni.Jni.env.IsInstanceOf($o.pointer, $k)) {

--- a/pkgs/jnigen/test/simple_package_test/c_based/dart_bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/c_based/dart_bindings/simple_package.dart
@@ -123,10 +123,14 @@ class Example_Nested extends jni.JObject {
   }
 
   static final _usesAnonymousInnerClass = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Example_Nested__usesAnonymousInnerClass")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Example_Nested__usesAnonymousInnerClass")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public void usesAnonymousInnerClass()
   void usesAnonymousInnerClass() {
@@ -134,10 +138,14 @@ class Example_Nested extends jni.JObject {
   }
 
   static final _getValue = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Example_Nested__getValue")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Example_Nested__getValue")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean getValue()
   bool getValue() {
@@ -459,10 +467,14 @@ class Example extends jni.JObject {
   }
 
   static final _getNumber = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Example__getNumber")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Example__getNumber")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int getNumber()
   int getNumber() {
@@ -483,10 +495,14 @@ class Example extends jni.JObject {
   }
 
   static final _getIsUp = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Example__getIsUp")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Example__getIsUp")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public boolean getIsUp()
   bool getIsUp() {
@@ -507,10 +523,14 @@ class Example extends jni.JObject {
   }
 
   static final _getCodename = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Example__getCodename")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Example__getCodename")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.String getCodename()
   /// The returned object must be released after use, by calling the [release] method.
@@ -534,10 +554,14 @@ class Example extends jni.JObject {
   }
 
   static final _getRandom = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Example__getRandom")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Example__getRandom")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.util.Random getRandom()
   /// The returned object must be released after use, by calling the [release] method.
@@ -561,10 +585,14 @@ class Example extends jni.JObject {
   }
 
   static final _getRandomLong = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Example__getRandomLong")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Example__getRandomLong")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public long getRandomLong()
   int getRandomLong() {
@@ -656,10 +684,14 @@ class Example extends jni.JObject {
   }
 
   static final _finalMethod = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Example__finalMethod")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Example__finalMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public final void finalMethod()
   void finalMethod() {
@@ -667,10 +699,14 @@ class Example extends jni.JObject {
   }
 
   static final _getList = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Example__getList")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Example__getList")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.util.List<java.lang.String> getList()
   /// The returned object must be released after use, by calling the [release] method.
@@ -824,10 +860,14 @@ class Example extends jni.JObject {
   }
 
   static final _whichExample = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Example__whichExample")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Example__whichExample")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int whichExample()
   int whichExample() {
@@ -870,10 +910,14 @@ class Example extends jni.JObject {
   }
 
   static final _getSelf = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Example__getSelf")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Example__getSelf")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.github.dart_lang.jnigen.simple_package.Example getSelf()
   /// The returned object must be released after use, by calling the [release] method.
@@ -892,10 +936,14 @@ class Example extends jni.JObject {
   }
 
   static final _overloaded = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Example__overloaded")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Example__overloaded")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public void overloaded()
   void overloaded() {
@@ -1076,10 +1124,14 @@ class Example1 extends jni.JObject {
   }
 
   static final _whichExample = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Example1__whichExample")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Example1__whichExample")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int whichExample()
   int whichExample() {
@@ -1762,10 +1814,14 @@ class GrandParent<$T extends jni.JObject> extends jni.JObject {
   }
 
   static final _stringParent = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "GrandParent__stringParent")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("GrandParent__stringParent")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.github.dart_lang.jnigen.generics.GrandParent<T>.Parent<java.lang.String> stringParent()
   /// The returned object must be released after use, by calling the [release] method.
@@ -1827,10 +1883,14 @@ class GrandParent<$T extends jni.JObject> extends jni.JObject {
   }
 
   static final _staticParentWithSameType = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "GrandParent__staticParentWithSameType")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("GrandParent__staticParentWithSameType")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.github.dart_lang.jnigen.generics.GrandParent.StaticParent<T> staticParentWithSameType()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2099,10 +2159,14 @@ class MyMap<$K extends jni.JObject, $V extends jni.JObject>
   }
 
   static final _entryStack = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "MyMap__entryStack")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("MyMap__entryStack")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public com.github.dart_lang.jnigen.generics.MyStack<com.github.dart_lang.jnigen.generics.MyMap<K,V>.MyEntry> entryStack()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2289,8 +2353,13 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
 
   static final _pop = jniLookup<
           ffi.NativeFunction<
-              jni.JniResult Function(ffi.Pointer<ffi.Void>)>>("MyStack__pop")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("MyStack__pop")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public T pop()
   /// The returned object must be released after use, by calling the [release] method.
@@ -2300,8 +2369,13 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
 
   static final _size = jniLookup<
           ffi.NativeFunction<
-              jni.JniResult Function(ffi.Pointer<ffi.Void>)>>("MyStack__size")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("MyStack__size")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int size()
   int size() {
@@ -2941,8 +3015,13 @@ class MyRunnable extends jni.JObject {
   static const type = $MyRunnableType();
   static final _run = jniLookup<
           ffi.NativeFunction<
-              jni.JniResult Function(ffi.Pointer<ffi.Void>)>>("MyRunnable__run")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("MyRunnable__run")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract void run()
   void run() {
@@ -3118,10 +3197,14 @@ class MyRunnableRunner extends jni.JObject {
   }
 
   static final _runOnSameThread = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "MyRunnableRunner__runOnSameThread")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("MyRunnableRunner__runOnSameThread")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public void runOnSameThread()
   void runOnSameThread() {
@@ -3129,10 +3212,14 @@ class MyRunnableRunner extends jni.JObject {
   }
 
   static final _runOnAnotherThread = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "MyRunnableRunner__runOnAnotherThread")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("MyRunnableRunner__runOnAnotherThread")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public void runOnAnotherThread()
   void runOnAnotherThread() {
@@ -3245,10 +3332,14 @@ class JsonSerializable extends jni.JObject {
   /// The type which includes information such as the signature of this class.
   static const type = $JsonSerializableType();
   static final _value = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "JsonSerializable__value")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("JsonSerializable__value")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public abstract com.github.dart_lang.jnigen.annotations.JsonSerializable$Case value()
   /// The returned object must be released after use, by calling the [release] method.
@@ -3582,10 +3673,14 @@ class Exceptions extends jni.JObject {
   }
 
   static final _objectMethod = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Exceptions__objectMethod")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Exceptions__objectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.Object objectMethod()
   /// The returned object must be released after use, by calling the [release] method.
@@ -3594,10 +3689,14 @@ class Exceptions extends jni.JObject {
   }
 
   static final _intMethod = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Exceptions__intMethod")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Exceptions__intMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int intMethod()
   int intMethod() {
@@ -3605,10 +3704,14 @@ class Exceptions extends jni.JObject {
   }
 
   static final _objectArrayMethod = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Exceptions__objectArrayMethod")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Exceptions__objectArrayMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.lang.Object[] objectArrayMethod()
   /// The returned object must be released after use, by calling the [release] method.
@@ -3618,10 +3721,14 @@ class Exceptions extends jni.JObject {
   }
 
   static final _intArrayMethod = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Exceptions__intArrayMethod")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Exceptions__intArrayMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int[] intArrayMethod()
   /// The returned object must be released after use, by calling the [release] method.
@@ -3631,10 +3738,14 @@ class Exceptions extends jni.JObject {
   }
 
   static final _throwNullPointerException = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Exceptions__throwNullPointerException")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Exceptions__throwNullPointerException")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int throwNullPointerException()
   int throwNullPointerException() {
@@ -3642,10 +3753,14 @@ class Exceptions extends jni.JObject {
   }
 
   static final _throwFileNotFoundException = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Exceptions__throwFileNotFoundException")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Exceptions__throwFileNotFoundException")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.io.InputStream throwFileNotFoundException()
   /// The returned object must be released after use, by calling the [release] method.
@@ -3655,10 +3770,14 @@ class Exceptions extends jni.JObject {
   }
 
   static final _throwClassCastException = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Exceptions__throwClassCastException")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Exceptions__throwClassCastException")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public java.io.FileInputStream throwClassCastException()
   /// The returned object must be released after use, by calling the [release] method.
@@ -3668,10 +3787,14 @@ class Exceptions extends jni.JObject {
   }
 
   static final _throwArrayIndexException = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Exceptions__throwArrayIndexException")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Exceptions__throwArrayIndexException")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int throwArrayIndexException()
   int throwArrayIndexException() {
@@ -3679,10 +3802,14 @@ class Exceptions extends jni.JObject {
   }
 
   static final _throwArithmeticException = jniLookup<
-              ffi
-              .NativeFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>>(
-          "Exceptions__throwArithmeticException")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+              )>>("Exceptions__throwArithmeticException")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+          )>();
 
   /// from: public int throwArithmeticException()
   int throwArithmeticException() {

--- a/pkgs/jnigen/test/simple_package_test/dart_only/dart_bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/dart_only/dart_bindings/simple_package.dart
@@ -57,11 +57,24 @@ class Example_Nested_NestedTwice extends jni.JObject {
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory Example_Nested_NestedTwice() {
     return Example_Nested_NestedTwice.fromReference(
-        _id_new0(_class, referenceType, []));
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 }
 
@@ -111,13 +124,22 @@ class Example_Nested extends jni.JObject {
     r"(Z)V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
+
   /// from: public void <init>(boolean value)
   /// The returned object must be released after use, by calling the [release] method.
   factory Example_Nested(
     bool value,
   ) {
-    return Example_Nested.fromReference(
-        _id_new0(_class, referenceType, [value ? 1 : 0]));
+    return Example_Nested.fromReference(_new0(_class.reference.pointer,
+            _id_new0 as jni.JMethodIDPtr, value ? 1 : 0)
+        .reference);
   }
 
   static final _id_usesAnonymousInnerClass = _class.instanceMethodId(
@@ -125,9 +147,23 @@ class Example_Nested extends jni.JObject {
     r"()V",
   );
 
+  static final _usesAnonymousInnerClass = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void usesAnonymousInnerClass()
   void usesAnonymousInnerClass() {
-    _id_usesAnonymousInnerClass(this, const jni.jvoidType(), []);
+    _usesAnonymousInnerClass(
+            reference.pointer, _id_usesAnonymousInnerClass as jni.JMethodIDPtr)
+        .check();
   }
 
   static final _id_getValue = _class.instanceMethodId(
@@ -135,9 +171,22 @@ class Example_Nested extends jni.JObject {
     r"()Z",
   );
 
+  static final _getValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public boolean getValue()
   bool getValue() {
-    return _id_getValue(this, const jni.jbooleanType(), []);
+    return _getValue(reference.pointer, _id_getValue as jni.JMethodIDPtr)
+        .boolean;
   }
 
   static final _id_setValue = _class.instanceMethodId(
@@ -145,11 +194,23 @@ class Example_Nested extends jni.JObject {
     r"(Z)V",
   );
 
+  static final _setValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
+
   /// from: public void setValue(boolean value)
   void setValue(
     bool value,
   ) {
-    _id_setValue(this, const jni.jvoidType(), [value ? 1 : 0]);
+    _setValue(
+            reference.pointer, _id_setValue as jni.JMethodIDPtr, value ? 1 : 0)
+        .check();
   }
 }
 
@@ -209,13 +270,25 @@ class Example_NonStaticNested extends jni.JObject {
     r"(Lcom/github/dart_lang/jnigen/simple_package/Example;)V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public void <init>(com.github.dart_lang.jnigen.simple_package.Example $parent)
   /// The returned object must be released after use, by calling the [release] method.
   factory Example_NonStaticNested(
     Example $parent,
   ) {
-    return Example_NonStaticNested.fromReference(
-        _id_new0(_class, referenceType, [$parent.reference.pointer]));
+    return Example_NonStaticNested.fromReference(_new0(_class.reference.pointer,
+            _id_new0 as jni.JMethodIDPtr, $parent.reference.pointer)
+        .reference);
   }
 }
 
@@ -313,9 +386,23 @@ class Example extends jni.JObject {
     r"()I",
   );
 
+  static final _getAmount = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public int getAmount()
   static int getAmount() {
-    return _id_getAmount(_class, const jni.jintType(), []);
+    return _getAmount(
+            _class.reference.pointer, _id_getAmount as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_getPi = _class.staticMethodId(
@@ -323,9 +410,22 @@ class Example extends jni.JObject {
     r"()D",
   );
 
+  static final _getPi = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticDoubleMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public double getPi()
   static double getPi() {
-    return _id_getPi(_class, const jni.jdoubleType(), []);
+    return _getPi(_class.reference.pointer, _id_getPi as jni.JMethodIDPtr)
+        .doubleFloat;
   }
 
   static final _id_getAsterisk = _class.staticMethodId(
@@ -333,9 +433,23 @@ class Example extends jni.JObject {
     r"()C",
   );
 
+  static final _getAsterisk = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticCharMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public char getAsterisk()
   static int getAsterisk() {
-    return _id_getAsterisk(_class, const jni.jcharType(), []);
+    return _getAsterisk(
+            _class.reference.pointer, _id_getAsterisk as jni.JMethodIDPtr)
+        .char;
   }
 
   static final _id_getName = _class.staticMethodId(
@@ -343,10 +457,23 @@ class Example extends jni.JObject {
     r"()Ljava/lang/String;",
   );
 
+  static final _getName = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public java.lang.String getName()
   /// The returned object must be released after use, by calling the [release] method.
   static jni.JString getName() {
-    return _id_getName(_class, const jni.JStringType(), []);
+    return _getName(_class.reference.pointer, _id_getName as jni.JMethodIDPtr)
+        .object(const jni.JStringType());
   }
 
   static final _id_getNestedInstance = _class.staticMethodId(
@@ -354,10 +481,24 @@ class Example extends jni.JObject {
     r"()Lcom/github/dart_lang/jnigen/simple_package/Example$Nested;",
   );
 
+  static final _getNestedInstance = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public com.github.dart_lang.jnigen.simple_package.Example.Nested getNestedInstance()
   /// The returned object must be released after use, by calling the [release] method.
   static Example_Nested getNestedInstance() {
-    return _id_getNestedInstance(_class, const $Example_NestedType(), []);
+    return _getNestedInstance(
+            _class.reference.pointer, _id_getNestedInstance as jni.JMethodIDPtr)
+        .object(const $Example_NestedType());
   }
 
   static final _id_setAmount = _class.staticMethodId(
@@ -365,11 +506,23 @@ class Example extends jni.JObject {
     r"(I)V",
   );
 
+  static final _setAmount = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_CallStaticVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
+
   /// from: static public void setAmount(int newAmount)
   static void setAmount(
     int newAmount,
   ) {
-    _id_setAmount(_class, const jni.jvoidType(), [jni.JValueInt(newAmount)]);
+    _setAmount(_class.reference.pointer, _id_setAmount as jni.JMethodIDPtr,
+            newAmount)
+        .check();
   }
 
   static final _id_setName = _class.staticMethodId(
@@ -377,11 +530,24 @@ class Example extends jni.JObject {
     r"(Ljava/lang/String;)V",
   );
 
+  static final _setName = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JThrowablePtr Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallStaticVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: static public void setName(java.lang.String newName)
   static void setName(
     jni.JString newName,
   ) {
-    _id_setName(_class, const jni.jvoidType(), [newName.reference.pointer]);
+    _setName(_class.reference.pointer, _id_setName as jni.JMethodIDPtr,
+            newName.reference.pointer)
+        .check();
   }
 
   static final _id_setNestedInstance = _class.staticMethodId(
@@ -389,18 +555,48 @@ class Example extends jni.JObject {
     r"(Lcom/github/dart_lang/jnigen/simple_package/Example$Nested;)V",
   );
 
+  static final _setNestedInstance = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JThrowablePtr Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallStaticVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: static public void setNestedInstance(com.github.dart_lang.jnigen.simple_package.Example.Nested newNested)
   static void setNestedInstance(
     Example_Nested newNested,
   ) {
-    _id_setNestedInstance(
-        _class, const jni.jvoidType(), [newNested.reference.pointer]);
+    _setNestedInstance(
+            _class.reference.pointer,
+            _id_setNestedInstance as jni.JMethodIDPtr,
+            newNested.reference.pointer)
+        .check();
   }
 
   static final _id_max4 = _class.staticMethodId(
     r"max4",
     r"(IIII)I",
   );
+
+  static final _max4 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64
+                      )>)>>("globalEnv_CallStaticIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int, int, int, int)>();
 
   /// from: static public int max4(int a, int b, int c, int d)
   static int max4(
@@ -409,18 +605,35 @@ class Example extends jni.JObject {
     int c,
     int d,
   ) {
-    return _id_max4(_class, const jni.jintType(), [
-      jni.JValueInt(a),
-      jni.JValueInt(b),
-      jni.JValueInt(c),
-      jni.JValueInt(d)
-    ]);
+    return _max4(
+            _class.reference.pointer, _id_max4 as jni.JMethodIDPtr, a, b, c, d)
+        .integer;
   }
 
   static final _id_max8 = _class.staticMethodId(
     r"max8",
     r"(IIIIIIII)I",
   );
+
+  static final _max8 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64
+                      )>)>>("globalEnv_CallStaticIntMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int,
+              int, int, int, int, int, int, int)>();
 
   /// from: static public int max8(int a, int b, int c, int d, int e, int f, int g, int h)
   static int max8(
@@ -433,16 +646,9 @@ class Example extends jni.JObject {
     int g,
     int h,
   ) {
-    return _id_max8(_class, const jni.jintType(), [
-      jni.JValueInt(a),
-      jni.JValueInt(b),
-      jni.JValueInt(c),
-      jni.JValueInt(d),
-      jni.JValueInt(e),
-      jni.JValueInt(f),
-      jni.JValueInt(g),
-      jni.JValueInt(h)
-    ]);
+    return _max8(_class.reference.pointer, _id_max8 as jni.JMethodIDPtr, a, b,
+            c, d, e, f, g, h)
+        .integer;
   }
 
   static final _id_getNumber = _class.instanceMethodId(
@@ -450,9 +656,22 @@ class Example extends jni.JObject {
     r"()I",
   );
 
+  static final _getNumber = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public int getNumber()
   int getNumber() {
-    return _id_getNumber(this, const jni.jintType(), []);
+    return _getNumber(reference.pointer, _id_getNumber as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_setNumber = _class.instanceMethodId(
@@ -460,11 +679,22 @@ class Example extends jni.JObject {
     r"(I)V",
   );
 
+  static final _setNumber = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
+
   /// from: public void setNumber(int number)
   void setNumber(
     int number,
   ) {
-    _id_setNumber(this, const jni.jvoidType(), [jni.JValueInt(number)]);
+    _setNumber(reference.pointer, _id_setNumber as jni.JMethodIDPtr, number)
+        .check();
   }
 
   static final _id_getIsUp = _class.instanceMethodId(
@@ -472,9 +702,21 @@ class Example extends jni.JObject {
     r"()Z",
   );
 
+  static final _getIsUp = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallBooleanMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public boolean getIsUp()
   bool getIsUp() {
-    return _id_getIsUp(this, const jni.jbooleanType(), []);
+    return _getIsUp(reference.pointer, _id_getIsUp as jni.JMethodIDPtr).boolean;
   }
 
   static final _id_setUp = _class.instanceMethodId(
@@ -482,11 +724,22 @@ class Example extends jni.JObject {
     r"(Z)V",
   );
 
+  static final _setUp = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
+
   /// from: public void setUp(boolean isUp)
   void setUp(
     bool isUp,
   ) {
-    _id_setUp(this, const jni.jvoidType(), [isUp ? 1 : 0]);
+    _setUp(reference.pointer, _id_setUp as jni.JMethodIDPtr, isUp ? 1 : 0)
+        .check();
   }
 
   static final _id_getCodename = _class.instanceMethodId(
@@ -494,10 +747,23 @@ class Example extends jni.JObject {
     r"()Ljava/lang/String;",
   );
 
+  static final _getCodename = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public java.lang.String getCodename()
   /// The returned object must be released after use, by calling the [release] method.
   jni.JString getCodename() {
-    return _id_getCodename(this, const jni.JStringType(), []);
+    return _getCodename(reference.pointer, _id_getCodename as jni.JMethodIDPtr)
+        .object(const jni.JStringType());
   }
 
   static final _id_setCodename = _class.instanceMethodId(
@@ -505,11 +771,24 @@ class Example extends jni.JObject {
     r"(Ljava/lang/String;)V",
   );
 
+  static final _setCodename = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JThrowablePtr Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public void setCodename(java.lang.String codename)
   void setCodename(
     jni.JString codename,
   ) {
-    _id_setCodename(this, const jni.jvoidType(), [codename.reference.pointer]);
+    _setCodename(reference.pointer, _id_setCodename as jni.JMethodIDPtr,
+            codename.reference.pointer)
+        .check();
   }
 
   static final _id_getRandom = _class.instanceMethodId(
@@ -517,10 +796,23 @@ class Example extends jni.JObject {
     r"()Ljava/util/Random;",
   );
 
+  static final _getRandom = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public java.util.Random getRandom()
   /// The returned object must be released after use, by calling the [release] method.
   jni.JObject getRandom() {
-    return _id_getRandom(this, const jni.JObjectType(), []);
+    return _getRandom(reference.pointer, _id_getRandom as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_setRandom = _class.instanceMethodId(
@@ -528,11 +820,24 @@ class Example extends jni.JObject {
     r"(Ljava/util/Random;)V",
   );
 
+  static final _setRandom = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JThrowablePtr Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public void setRandom(java.util.Random random)
   void setRandom(
     jni.JObject random,
   ) {
-    _id_setRandom(this, const jni.jvoidType(), [random.reference.pointer]);
+    _setRandom(reference.pointer, _id_setRandom as jni.JMethodIDPtr,
+            random.reference.pointer)
+        .check();
   }
 
   static final _id_getRandomLong = _class.instanceMethodId(
@@ -540,15 +845,45 @@ class Example extends jni.JObject {
     r"()J",
   );
 
+  static final _getRandomLong = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallLongMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public long getRandomLong()
   int getRandomLong() {
-    return _id_getRandomLong(this, const jni.jlongType(), []);
+    return _getRandomLong(
+            reference.pointer, _id_getRandomLong as jni.JMethodIDPtr)
+        .long;
   }
 
   static final _id_add4Longs = _class.instanceMethodId(
     r"add4Longs",
     r"(JJJJ)J",
   );
+
+  static final _add4Longs = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64
+                      )>)>>("globalEnv_CallLongMethod")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int, int, int, int)>();
 
   /// from: public long add4Longs(long a, long b, long c, long d)
   int add4Longs(
@@ -557,13 +892,35 @@ class Example extends jni.JObject {
     int c,
     int d,
   ) {
-    return _id_add4Longs(this, const jni.jlongType(), [a, b, c, d]);
+    return _add4Longs(
+            reference.pointer, _id_add4Longs as jni.JMethodIDPtr, a, b, c, d)
+        .long;
   }
 
   static final _id_add8Longs = _class.instanceMethodId(
     r"add8Longs",
     r"(JJJJJJJJ)J",
   );
+
+  static final _add8Longs = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64
+                      )>)>>("globalEnv_CallLongMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int,
+              int, int, int, int, int, int, int)>();
 
   /// from: public long add8Longs(long a, long b, long c, long d, long e, long f, long g, long h)
   int add8Longs(
@@ -576,7 +933,9 @@ class Example extends jni.JObject {
     int g,
     int h,
   ) {
-    return _id_add8Longs(this, const jni.jlongType(), [a, b, c, d, e, f, g, h]);
+    return _add8Longs(reference.pointer, _id_add8Longs as jni.JMethodIDPtr, a,
+            b, c, d, e, f, g, h)
+        .long;
   }
 
   static final _id_getRandomNumericString = _class.instanceMethodId(
@@ -584,13 +943,27 @@ class Example extends jni.JObject {
     r"(Ljava/util/Random;)Ljava/lang/String;",
   );
 
+  static final _getRandomNumericString = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public java.lang.String getRandomNumericString(java.util.Random random)
   /// The returned object must be released after use, by calling the [release] method.
   jni.JString getRandomNumericString(
     jni.JObject random,
   ) {
-    return _id_getRandomNumericString(
-        this, const jni.JStringType(), [random.reference.pointer]);
+    return _getRandomNumericString(
+            reference.pointer,
+            _id_getRandomNumericString as jni.JMethodIDPtr,
+            random.reference.pointer)
+        .object(const jni.JStringType());
   }
 
   static final _id_protectedMethod = _class.instanceMethodId(
@@ -598,13 +971,28 @@ class Example extends jni.JObject {
     r"(Ljava/lang/String;Ljava/lang/String;)V",
   );
 
+  static final _protectedMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+
   /// from: protected void protectedMethod(java.lang.String a, java.lang.String b)
   void protectedMethod(
     jni.JString a,
     jni.JString b,
   ) {
-    _id_protectedMethod(this, const jni.jvoidType(),
-        [a.reference.pointer, b.reference.pointer]);
+    _protectedMethod(reference.pointer, _id_protectedMethod as jni.JMethodIDPtr,
+            a.reference.pointer, b.reference.pointer)
+        .check();
   }
 
   static final _id_finalMethod = _class.instanceMethodId(
@@ -612,9 +1000,22 @@ class Example extends jni.JObject {
     r"()V",
   );
 
+  static final _finalMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public final void finalMethod()
   void finalMethod() {
-    _id_finalMethod(this, const jni.jvoidType(), []);
+    _finalMethod(reference.pointer, _id_finalMethod as jni.JMethodIDPtr)
+        .check();
   }
 
   static final _id_getList = _class.instanceMethodId(
@@ -622,16 +1023,43 @@ class Example extends jni.JObject {
     r"()Ljava/util/List;",
   );
 
+  static final _getList = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public java.util.List<java.lang.String> getList()
   /// The returned object must be released after use, by calling the [release] method.
   jni.JList<jni.JString> getList() {
-    return _id_getList(this, const jni.JListType(jni.JStringType()), []);
+    return _getList(reference.pointer, _id_getList as jni.JMethodIDPtr)
+        .object(const jni.JListType(jni.JStringType()));
   }
 
   static final _id_joinStrings = _class.instanceMethodId(
     r"joinStrings",
     r"(Ljava/util/List;Ljava/lang/String;)Ljava/lang/String;",
   );
+
+  static final _joinStrings = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
 
   /// from: public java.lang.String joinStrings(java.util.List<java.lang.String> values, java.lang.String delim)
   /// The returned object must be released after use, by calling the [release] method.
@@ -641,14 +1069,40 @@ class Example extends jni.JObject {
     jni.JList<jni.JString> values,
     jni.JString delim,
   ) {
-    return _id_joinStrings(this, const jni.JStringType(),
-        [values.reference.pointer, delim.reference.pointer]);
+    return _joinStrings(reference.pointer, _id_joinStrings as jni.JMethodIDPtr,
+            values.reference.pointer, delim.reference.pointer)
+        .object(const jni.JStringType());
   }
 
   static final _id_methodWithSeveralParams = _class.instanceMethodId(
     r"methodWithSeveralParams",
     r"(CLjava/lang/String;[ILjava/lang/CharSequence;Ljava/util/List;Ljava/util/Map;)V",
   );
+
+  static final _methodWithSeveralParams = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Int64,
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+              ffi.Pointer<ffi.Void>,
+              jni.JMethodIDPtr,
+              int,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public void methodWithSeveralParams(char ch, java.lang.String s, int[] a, T t, java.util.List<T> lt, java.util.Map<java.lang.String,? extends java.lang.CharSequence> wm)
   void methodWithSeveralParams<$T extends jni.JObject>(
@@ -664,29 +1118,53 @@ class Example extends jni.JObject {
       (lt.$type as jni.JListType).E,
       t.$type,
     ]) as jni.JObjType<$T>;
-    _id_methodWithSeveralParams(this, const jni.jvoidType(), [
-      jni.JValueChar(ch),
-      s.reference.pointer,
-      a.reference.pointer,
-      t.reference.pointer,
-      lt.reference.pointer,
-      wm.reference.pointer
-    ]);
+    _methodWithSeveralParams(
+            reference.pointer,
+            _id_methodWithSeveralParams as jni.JMethodIDPtr,
+            ch,
+            s.reference.pointer,
+            a.reference.pointer,
+            t.reference.pointer,
+            lt.reference.pointer,
+            wm.reference.pointer)
+        .check();
   }
 
   static final _id_new0 = _class.constructorId(
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory Example() {
-    return Example.fromReference(_id_new0(_class, referenceType, []));
+    return Example.fromReference(
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 
   static final _id_new1 = _class.constructorId(
     r"(I)V",
   );
+
+  static final _new1 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
 
   /// from: public void <init>(int number)
   /// The returned object must be released after use, by calling the [release] method.
@@ -694,12 +1172,21 @@ class Example extends jni.JObject {
     int number,
   ) {
     return Example.fromReference(
-        _id_new1(_class, referenceType, [jni.JValueInt(number)]));
+        _new1(_class.reference.pointer, _id_new1 as jni.JMethodIDPtr, number)
+            .reference);
   }
 
   static final _id_new2 = _class.constructorId(
     r"(IZ)V",
   );
+
+  static final _new2 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64, ffi.Int64)>)>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int, int)>();
 
   /// from: public void <init>(int number, boolean isUp)
   /// The returned object must be released after use, by calling the [release] method.
@@ -707,13 +1194,29 @@ class Example extends jni.JObject {
     int number,
     bool isUp,
   ) {
-    return Example.fromReference(
-        _id_new2(_class, referenceType, [jni.JValueInt(number), isUp ? 1 : 0]));
+    return Example.fromReference(_new2(_class.reference.pointer,
+            _id_new2 as jni.JMethodIDPtr, number, isUp ? 1 : 0)
+        .reference);
   }
 
   static final _id_new3 = _class.constructorId(
     r"(IZLjava/lang/String;)V",
   );
+
+  static final _new3 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int,
+              int, ffi.Pointer<ffi.Void>)>();
 
   /// from: public void <init>(int number, boolean isUp, java.lang.String codename)
   /// The returned object must be released after use, by calling the [release] method.
@@ -722,13 +1225,38 @@ class Example extends jni.JObject {
     bool isUp,
     jni.JString codename,
   ) {
-    return Example.fromReference(_id_new3(_class, referenceType,
-        [jni.JValueInt(number), isUp ? 1 : 0, codename.reference.pointer]));
+    return Example.fromReference(_new3(
+            _class.reference.pointer,
+            _id_new3 as jni.JMethodIDPtr,
+            number,
+            isUp ? 1 : 0,
+            codename.reference.pointer)
+        .reference);
   }
 
   static final _id_new4 = _class.constructorId(
     r"(IIIIIIII)V",
   );
+
+  static final _new4 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64
+                      )>)>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int,
+              int, int, int, int, int, int, int)>();
 
   /// from: public void <init>(int a, int b, int c, int d, int e, int f, int g, int h)
   /// The returned object must be released after use, by calling the [release] method.
@@ -742,16 +1270,9 @@ class Example extends jni.JObject {
     int g,
     int h,
   ) {
-    return Example.fromReference(_id_new4(_class, referenceType, [
-      jni.JValueInt(a),
-      jni.JValueInt(b),
-      jni.JValueInt(c),
-      jni.JValueInt(d),
-      jni.JValueInt(e),
-      jni.JValueInt(f),
-      jni.JValueInt(g),
-      jni.JValueInt(h)
-    ]));
+    return Example.fromReference(_new4(_class.reference.pointer,
+            _id_new4 as jni.JMethodIDPtr, a, b, c, d, e, f, g, h)
+        .reference);
   }
 
   static final _id_whichExample = _class.instanceMethodId(
@@ -759,9 +1280,23 @@ class Example extends jni.JObject {
     r"()I",
   );
 
+  static final _whichExample = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public int whichExample()
   int whichExample() {
-    return _id_whichExample(this, const jni.jintType(), []);
+    return _whichExample(
+            reference.pointer, _id_whichExample as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_addInts = _class.staticMethodId(
@@ -769,13 +1304,23 @@ class Example extends jni.JObject {
     r"(II)I",
   );
 
+  static final _addInts = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr, ffi.VarArgs<(ffi.Int64, ffi.Int64)>)>>(
+          "globalEnv_CallStaticIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int, int)>();
+
   /// from: static public int addInts(int a, int b)
   static int addInts(
     int a,
     int b,
   ) {
-    return _id_addInts(
-        _class, const jni.jintType(), [jni.JValueInt(a), jni.JValueInt(b)]);
+    return _addInts(
+            _class.reference.pointer, _id_addInts as jni.JMethodIDPtr, a, b)
+        .integer;
   }
 
   static final _id_getArr = _class.staticMethodId(
@@ -783,10 +1328,23 @@ class Example extends jni.JObject {
     r"()[I",
   );
 
+  static final _getArr = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public int[] getArr()
   /// The returned object must be released after use, by calling the [release] method.
   static jni.JArray<jni.jint> getArr() {
-    return _id_getArr(_class, const jni.JArrayType(jni.jintType()), []);
+    return _getArr(_class.reference.pointer, _id_getArr as jni.JMethodIDPtr)
+        .object(const jni.JArrayType(jni.jintType()));
   }
 
   static final _id_addAll = _class.staticMethodId(
@@ -794,11 +1352,24 @@ class Example extends jni.JObject {
     r"([I)I",
   );
 
+  static final _addAll = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallStaticIntMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: static public int addAll(int[] arr)
   static int addAll(
     jni.JArray<jni.jint> arr,
   ) {
-    return _id_addAll(_class, const jni.jintType(), [arr.reference.pointer]);
+    return _addAll(_class.reference.pointer, _id_addAll as jni.JMethodIDPtr,
+            arr.reference.pointer)
+        .integer;
   }
 
   static final _id_getSelf = _class.instanceMethodId(
@@ -806,10 +1377,23 @@ class Example extends jni.JObject {
     r"()Lcom/github/dart_lang/jnigen/simple_package/Example;",
   );
 
+  static final _getSelf = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public com.github.dart_lang.jnigen.simple_package.Example getSelf()
   /// The returned object must be released after use, by calling the [release] method.
   Example getSelf() {
-    return _id_getSelf(this, const $ExampleType(), []);
+    return _getSelf(reference.pointer, _id_getSelf as jni.JMethodIDPtr)
+        .object(const $ExampleType());
   }
 
   static final _id_throwException = _class.staticMethodId(
@@ -817,9 +1401,23 @@ class Example extends jni.JObject {
     r"()V",
   );
 
+  static final _throwException = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public void throwException()
   static void throwException() {
-    _id_throwException(_class, const jni.jvoidType(), []);
+    _throwException(
+            _class.reference.pointer, _id_throwException as jni.JMethodIDPtr)
+        .check();
   }
 
   static final _id_overloaded = _class.instanceMethodId(
@@ -827,9 +1425,21 @@ class Example extends jni.JObject {
     r"()V",
   );
 
+  static final _overloaded = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void overloaded()
   void overloaded() {
-    _id_overloaded(this, const jni.jvoidType(), []);
+    _overloaded(reference.pointer, _id_overloaded as jni.JMethodIDPtr).check();
   }
 
   static final _id_overloaded1 = _class.instanceMethodId(
@@ -837,13 +1447,25 @@ class Example extends jni.JObject {
     r"(ILjava/lang/String;)V",
   );
 
+  static final _overloaded1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JThrowablePtr Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Int64, ffi.Pointer<ffi.Void>)>)>>(
+          "globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              int, ffi.Pointer<ffi.Void>)>();
+
   /// from: public void overloaded(int a, java.lang.String b)
   void overloaded1(
     int a,
     jni.JString b,
   ) {
-    _id_overloaded1(
-        this, const jni.jvoidType(), [jni.JValueInt(a), b.reference.pointer]);
+    _overloaded1(reference.pointer, _id_overloaded1 as jni.JMethodIDPtr, a,
+            b.reference.pointer)
+        .check();
   }
 
   static final _id_overloaded2 = _class.instanceMethodId(
@@ -851,11 +1473,22 @@ class Example extends jni.JObject {
     r"(I)V",
   );
 
+  static final _overloaded2 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Int64,)>)>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
+
   /// from: public void overloaded(int a)
   void overloaded2(
     int a,
   ) {
-    _id_overloaded2(this, const jni.jvoidType(), [jni.JValueInt(a)]);
+    _overloaded2(reference.pointer, _id_overloaded2 as jni.JMethodIDPtr, a)
+        .check();
   }
 
   static final _id_overloaded3 = _class.instanceMethodId(
@@ -863,13 +1496,28 @@ class Example extends jni.JObject {
     r"(Ljava/util/List;Ljava/lang/String;)V",
   );
 
+  static final _overloaded3 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+
   /// from: public void overloaded(java.util.List<java.lang.Integer> a, java.lang.String b)
   void overloaded3(
     jni.JList<jni.JInteger> a,
     jni.JString b,
   ) {
-    _id_overloaded3(this, const jni.jvoidType(),
-        [a.reference.pointer, b.reference.pointer]);
+    _overloaded3(reference.pointer, _id_overloaded3 as jni.JMethodIDPtr,
+            a.reference.pointer, b.reference.pointer)
+        .check();
   }
 
   static final _id_overloaded4 = _class.instanceMethodId(
@@ -877,11 +1525,24 @@ class Example extends jni.JObject {
     r"(Ljava/util/List;)V",
   );
 
+  static final _overloaded4 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JThrowablePtr Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public void overloaded(java.util.List<java.lang.Integer> a)
   void overloaded4(
     jni.JList<jni.JInteger> a,
   ) {
-    _id_overloaded4(this, const jni.jvoidType(), [a.reference.pointer]);
+    _overloaded4(reference.pointer, _id_overloaded4 as jni.JMethodIDPtr,
+            a.reference.pointer)
+        .check();
   }
 }
 
@@ -941,10 +1602,24 @@ class C2 extends jni.JObject {
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory C2() {
-    return C2.fromReference(_id_new0(_class, referenceType, []));
+    return C2.fromReference(
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 }
 
@@ -990,10 +1665,24 @@ class Example1 extends jni.JObject {
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory Example1() {
-    return Example1.fromReference(_id_new0(_class, referenceType, []));
+    return Example1.fromReference(
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 
   static final _id_whichExample = _class.instanceMethodId(
@@ -1001,9 +1690,23 @@ class Example1 extends jni.JObject {
     r"()I",
   );
 
+  static final _whichExample = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public int whichExample()
   int whichExample() {
-    return _id_whichExample(this, const jni.jintType(), []);
+    return _whichExample(
+            reference.pointer, _id_whichExample as jni.JMethodIDPtr)
+        .integer;
   }
 }
 
@@ -1110,6 +1813,20 @@ class GrandParent_Parent_Child<$T extends jni.JObject, $S extends jni.JObject,
     r"(Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent;Ljava/lang/Object;)V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+
   /// from: public void <init>(com.github.dart_lang.jnigen.generics.GrandParent$Parent $parent, U newValue)
   /// The returned object must be released after use, by calling the [release] method.
   factory GrandParent_Parent_Child(
@@ -1132,8 +1849,9 @@ class GrandParent_Parent_Child<$T extends jni.JObject, $S extends jni.JObject,
         T,
         S,
         U,
-        _id_new0(_class, referenceType,
-            [$parent.reference.pointer, newValue.reference.pointer]));
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr,
+                $parent.reference.pointer, newValue.reference.pointer)
+            .reference);
   }
 }
 
@@ -1238,6 +1956,20 @@ class GrandParent_Parent<$T extends jni.JObject, $S extends jni.JObject>
     r"(Lcom/github/dart_lang/jnigen/generics/GrandParent;Ljava/lang/Object;)V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+
   /// from: public void <init>(com.github.dart_lang.jnigen.generics.GrandParent $parent, S newValue)
   /// The returned object must be released after use, by calling the [release] method.
   factory GrandParent_Parent(
@@ -1255,8 +1987,9 @@ class GrandParent_Parent<$T extends jni.JObject, $S extends jni.JObject>
     return GrandParent_Parent.fromReference(
         T,
         S,
-        _id_new0(_class, referenceType,
-            [$parent.reference.pointer, newValue.reference.pointer]));
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr,
+                $parent.reference.pointer, newValue.reference.pointer)
+            .reference);
   }
 }
 
@@ -1357,6 +2090,25 @@ class GrandParent_StaticParent_Child<$S extends jni.JObject,
     r"(Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent;Ljava/lang/Object;Ljava/lang/Object;)V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>,
+              jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public void <init>(com.github.dart_lang.jnigen.generics.GrandParent$StaticParent $parent, S parentValue, U value)
   /// The returned object must be released after use, by calling the [release] method.
   factory GrandParent_StaticParent_Child(
@@ -1376,11 +2128,13 @@ class GrandParent_StaticParent_Child<$S extends jni.JObject,
     return GrandParent_StaticParent_Child.fromReference(
         S,
         U,
-        _id_new0(_class, referenceType, [
-          $parent.reference.pointer,
-          parentValue.reference.pointer,
-          value.reference.pointer
-        ]));
+        _new0(
+                _class.reference.pointer,
+                _id_new0 as jni.JMethodIDPtr,
+                $parent.reference.pointer,
+                parentValue.reference.pointer,
+                value.reference.pointer)
+            .reference);
   }
 }
 
@@ -1463,6 +2217,17 @@ class GrandParent_StaticParent<$S extends jni.JObject> extends jni.JObject {
     r"(Ljava/lang/Object;)V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public void <init>(S value)
   /// The returned object must be released after use, by calling the [release] method.
   factory GrandParent_StaticParent(
@@ -1473,7 +2238,10 @@ class GrandParent_StaticParent<$S extends jni.JObject> extends jni.JObject {
       value.$type,
     ]) as jni.JObjType<$S>;
     return GrandParent_StaticParent.fromReference(
-        S, _id_new0(_class, referenceType, [value.reference.pointer]));
+        S,
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr,
+                value.reference.pointer)
+            .reference);
   }
 }
 
@@ -1551,6 +2319,17 @@ class GrandParent<$T extends jni.JObject> extends jni.JObject {
     r"(Ljava/lang/Object;)V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public void <init>(T value)
   /// The returned object must be released after use, by calling the [release] method.
   factory GrandParent(
@@ -1561,7 +2340,10 @@ class GrandParent<$T extends jni.JObject> extends jni.JObject {
       value.$type,
     ]) as jni.JObjType<$T>;
     return GrandParent.fromReference(
-        T, _id_new0(_class, referenceType, [value.reference.pointer]));
+        T,
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr,
+                value.reference.pointer)
+            .reference);
   }
 
   static final _id_stringParent = _class.instanceMethodId(
@@ -1569,19 +2351,42 @@ class GrandParent<$T extends jni.JObject> extends jni.JObject {
     r"()Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent;",
   );
 
+  static final _stringParent = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public com.github.dart_lang.jnigen.generics.GrandParent<T>.Parent<java.lang.String> stringParent()
   /// The returned object must be released after use, by calling the [release] method.
   GrandParent_Parent<jni.JObject, jni.JString> stringParent() {
-    return _id_stringParent(
-        this,
-        const $GrandParent_ParentType(jni.JObjectType(), jni.JStringType()),
-        []);
+    return _stringParent(
+            reference.pointer, _id_stringParent as jni.JMethodIDPtr)
+        .object(const $GrandParent_ParentType(
+            jni.JObjectType(), jni.JStringType()));
   }
 
   static final _id_varParent = _class.instanceMethodId(
     r"varParent",
     r"(Ljava/lang/Object;)Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent;",
   );
+
+  static final _varParent = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: public com.github.dart_lang.jnigen.generics.GrandParent<T>.Parent<S> varParent(S nestedValue)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1592,10 +2397,9 @@ class GrandParent<$T extends jni.JObject> extends jni.JObject {
     S ??= jni.lowestCommonSuperType([
       nestedValue.$type,
     ]) as jni.JObjType<$S>;
-    return _id_varParent(
-        this,
-        $GrandParent_ParentType(const jni.JObjectType(), S),
-        [nestedValue.reference.pointer]);
+    return _varParent(reference.pointer, _id_varParent as jni.JMethodIDPtr,
+            nestedValue.reference.pointer)
+        .object($GrandParent_ParentType(const jni.JObjectType(), S));
   }
 
   static final _id_stringStaticParent = _class.staticMethodId(
@@ -1603,17 +2407,41 @@ class GrandParent<$T extends jni.JObject> extends jni.JObject {
     r"()Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent;",
   );
 
+  static final _stringStaticParent = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public com.github.dart_lang.jnigen.generics.GrandParent.StaticParent<java.lang.String> stringStaticParent()
   /// The returned object must be released after use, by calling the [release] method.
   static GrandParent_StaticParent<jni.JString> stringStaticParent() {
-    return _id_stringStaticParent(
-        _class, const $GrandParent_StaticParentType(jni.JStringType()), []);
+    return _stringStaticParent(_class.reference.pointer,
+            _id_stringStaticParent as jni.JMethodIDPtr)
+        .object(const $GrandParent_StaticParentType(jni.JStringType()));
   }
 
   static final _id_varStaticParent = _class.staticMethodId(
     r"varStaticParent",
     r"(Ljava/lang/Object;)Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent;",
   );
+
+  static final _varStaticParent = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: static public com.github.dart_lang.jnigen.generics.GrandParent.StaticParent<S> varStaticParent(S value)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1624,8 +2452,9 @@ class GrandParent<$T extends jni.JObject> extends jni.JObject {
     S ??= jni.lowestCommonSuperType([
       value.$type,
     ]) as jni.JObjType<$S>;
-    return _id_varStaticParent(
-        _class, $GrandParent_StaticParentType(S), [value.reference.pointer]);
+    return _varStaticParent(_class.reference.pointer,
+            _id_varStaticParent as jni.JMethodIDPtr, value.reference.pointer)
+        .object($GrandParent_StaticParentType(S));
   }
 
   static final _id_staticParentWithSameType = _class.instanceMethodId(
@@ -1633,11 +2462,24 @@ class GrandParent<$T extends jni.JObject> extends jni.JObject {
     r"()Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent;",
   );
 
+  static final _staticParentWithSameType = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public com.github.dart_lang.jnigen.generics.GrandParent.StaticParent<T> staticParentWithSameType()
   /// The returned object must be released after use, by calling the [release] method.
   GrandParent_StaticParent<$T> staticParentWithSameType() {
-    return _id_staticParentWithSameType(
-        this, $GrandParent_StaticParentType(T), []);
+    return _staticParentWithSameType(
+            reference.pointer, _id_staticParentWithSameType as jni.JMethodIDPtr)
+        .object($GrandParent_StaticParentType(T));
   }
 }
 
@@ -1733,6 +2575,25 @@ class MyMap_MyEntry<$K extends jni.JObject, $V extends jni.JObject>
     r"(Lcom/github/dart_lang/jnigen/generics/MyMap;Ljava/lang/Object;Ljava/lang/Object;)V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>,
+              jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public void <init>(com.github.dart_lang.jnigen.generics.MyMap $parent, K key, V value)
   /// The returned object must be released after use, by calling the [release] method.
   factory MyMap_MyEntry(
@@ -1753,11 +2614,13 @@ class MyMap_MyEntry<$K extends jni.JObject, $V extends jni.JObject>
     return MyMap_MyEntry.fromReference(
         K,
         V,
-        _id_new0(_class, referenceType, [
-          $parent.reference.pointer,
-          key.reference.pointer,
-          value.reference.pointer
-        ]));
+        _new0(
+                _class.reference.pointer,
+                _id_new0 as jni.JMethodIDPtr,
+                $parent.reference.pointer,
+                key.reference.pointer,
+                value.reference.pointer)
+            .reference);
   }
 }
 
@@ -1831,13 +2694,29 @@ class MyMap<$K extends jni.JObject, $V extends jni.JObject>
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory MyMap({
     required jni.JObjType<$K> K,
     required jni.JObjType<$V> V,
   }) {
-    return MyMap.fromReference(K, V, _id_new0(_class, referenceType, []));
+    return MyMap.fromReference(
+        K,
+        V,
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 
   static final _id_get0 = _class.instanceMethodId(
@@ -1845,12 +2724,25 @@ class MyMap<$K extends jni.JObject, $V extends jni.JObject>
     r"(Ljava/lang/Object;)Ljava/lang/Object;",
   );
 
+  static final _get0 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public V get(K key)
   /// The returned object must be released after use, by calling the [release] method.
   $V get0(
     $K key,
   ) {
-    return _id_get0(this, V, [key.reference.pointer]);
+    return _get0(reference.pointer, _id_get0 as jni.JMethodIDPtr,
+            key.reference.pointer)
+        .object(V);
   }
 
   static final _id_put = _class.instanceMethodId(
@@ -1858,13 +2750,29 @@ class MyMap<$K extends jni.JObject, $V extends jni.JObject>
     r"(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
   );
 
+  static final _put = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+
   /// from: public V put(K key, V value)
   /// The returned object must be released after use, by calling the [release] method.
   $V put(
     $K key,
     $V value,
   ) {
-    return _id_put(this, V, [key.reference.pointer, value.reference.pointer]);
+    return _put(reference.pointer, _id_put as jni.JMethodIDPtr,
+            key.reference.pointer, value.reference.pointer)
+        .object(V);
   }
 
   static final _id_entryStack = _class.instanceMethodId(
@@ -1872,14 +2780,24 @@ class MyMap<$K extends jni.JObject, $V extends jni.JObject>
     r"()Lcom/github/dart_lang/jnigen/generics/MyStack;",
   );
 
+  static final _entryStack = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public com.github.dart_lang.jnigen.generics.MyStack<com.github.dart_lang.jnigen.generics.MyMap<K,V>.MyEntry> entryStack()
   /// The returned object must be released after use, by calling the [release] method.
   MyStack<MyMap_MyEntry<jni.JObject, jni.JObject>> entryStack() {
-    return _id_entryStack(
-        this,
-        const $MyStackType(
-            $MyMap_MyEntryType(jni.JObjectType(), jni.JObjectType())),
-        []);
+    return _entryStack(reference.pointer, _id_entryStack as jni.JMethodIDPtr)
+        .object(const $MyStackType(
+            $MyMap_MyEntryType(jni.JObjectType(), jni.JObjectType())));
   }
 }
 
@@ -1946,18 +2864,44 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory MyStack({
     required jni.JObjType<$T> T,
   }) {
-    return MyStack.fromReference(T, _id_new0(_class, referenceType, []));
+    return MyStack.fromReference(
+        T,
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 
   static final _id_fromArray = _class.staticMethodId(
     r"fromArray",
     r"([Ljava/lang/Object;)Lcom/github/dart_lang/jnigen/generics/MyStack;",
   );
+
+  static final _fromArray = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: static public com.github.dart_lang.jnigen.generics.MyStack<T> fromArray(T[] arr)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1968,13 +2912,26 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
     T ??= jni.lowestCommonSuperType([
       ((arr.$type as jni.JArrayType).elementType as jni.JObjType),
     ]) as jni.JObjType<$T>;
-    return _id_fromArray(_class, $MyStackType(T), [arr.reference.pointer]);
+    return _fromArray(_class.reference.pointer,
+            _id_fromArray as jni.JMethodIDPtr, arr.reference.pointer)
+        .object($MyStackType(T));
   }
 
   static final _id_fromArrayOfArrayOfGrandParents = _class.staticMethodId(
     r"fromArrayOfArrayOfGrandParents",
     r"([[Lcom/github/dart_lang/jnigen/generics/GrandParent;)Lcom/github/dart_lang/jnigen/generics/MyStack;",
   );
+
+  static final _fromArrayOfArrayOfGrandParents = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: static public com.github.dart_lang.jnigen.generics.MyStack<S> fromArrayOfArrayOfGrandParents(com.github.dart_lang.jnigen.generics.GrandParent<S>[][] arr)
   /// The returned object must be released after use, by calling the [release] method.
@@ -1988,8 +2945,11 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
               .elementType as jni.JObjType) as $GrandParentType)
           .T,
     ]) as jni.JObjType<$S>;
-    return _id_fromArrayOfArrayOfGrandParents(
-        _class, $MyStackType(S), [arr.reference.pointer]);
+    return _fromArrayOfArrayOfGrandParents(
+            _class.reference.pointer,
+            _id_fromArrayOfArrayOfGrandParents as jni.JMethodIDPtr,
+            arr.reference.pointer)
+        .object($MyStackType(S));
   }
 
   static final _id_of = _class.staticMethodId(
@@ -1997,18 +2957,42 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
     r"()Lcom/github/dart_lang/jnigen/generics/MyStack;",
   );
 
+  static final _of = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public com.github.dart_lang.jnigen.generics.MyStack<T> of()
   /// The returned object must be released after use, by calling the [release] method.
   static MyStack<$T> of<$T extends jni.JObject>({
     required jni.JObjType<$T> T,
   }) {
-    return _id_of(_class, $MyStackType(T), []);
+    return _of(_class.reference.pointer, _id_of as jni.JMethodIDPtr)
+        .object($MyStackType(T));
   }
 
   static final _id_of1 = _class.staticMethodId(
     r"of",
     r"(Ljava/lang/Object;)Lcom/github/dart_lang/jnigen/generics/MyStack;",
   );
+
+  static final _of1 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: static public com.github.dart_lang.jnigen.generics.MyStack<T> of(T obj)
   /// The returned object must be released after use, by calling the [release] method.
@@ -2019,13 +3003,29 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
     T ??= jni.lowestCommonSuperType([
       obj.$type,
     ]) as jni.JObjType<$T>;
-    return _id_of1(_class, $MyStackType(T), [obj.reference.pointer]);
+    return _of1(_class.reference.pointer, _id_of1 as jni.JMethodIDPtr,
+            obj.reference.pointer)
+        .object($MyStackType(T));
   }
 
   static final _id_of2 = _class.staticMethodId(
     r"of",
     r"(Ljava/lang/Object;Ljava/lang/Object;)Lcom/github/dart_lang/jnigen/generics/MyStack;",
   );
+
+  static final _of2 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
 
   /// from: static public com.github.dart_lang.jnigen.generics.MyStack<T> of(T obj, T obj2)
   /// The returned object must be released after use, by calling the [release] method.
@@ -2038,8 +3038,9 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
       obj2.$type,
       obj.$type,
     ]) as jni.JObjType<$T>;
-    return _id_of2(_class, $MyStackType(T),
-        [obj.reference.pointer, obj2.reference.pointer]);
+    return _of2(_class.reference.pointer, _id_of2 as jni.JMethodIDPtr,
+            obj.reference.pointer, obj2.reference.pointer)
+        .object($MyStackType(T));
   }
 
   static final _id_push = _class.instanceMethodId(
@@ -2047,11 +3048,24 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
     r"(Ljava/lang/Object;)V",
   );
 
+  static final _push = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JThrowablePtr Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public void push(T item)
   void push(
     $T item,
   ) {
-    _id_push(this, const jni.jvoidType(), [item.reference.pointer]);
+    _push(reference.pointer, _id_push as jni.JMethodIDPtr,
+            item.reference.pointer)
+        .check();
   }
 
   static final _id_pop = _class.instanceMethodId(
@@ -2059,10 +3073,22 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
     r"()Ljava/lang/Object;",
   );
 
+  static final _pop = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public T pop()
   /// The returned object must be released after use, by calling the [release] method.
   $T pop() {
-    return _id_pop(this, T, []);
+    return _pop(reference.pointer, _id_pop as jni.JMethodIDPtr).object(T);
   }
 
   static final _id_size = _class.instanceMethodId(
@@ -2070,9 +3096,21 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
     r"()I",
   );
 
+  static final _size = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public int size()
   int size() {
-    return _id_size(this, const jni.jintType(), []);
+    return _size(reference.pointer, _id_size as jni.JMethodIDPtr).integer;
   }
 }
 
@@ -2136,12 +3174,27 @@ class StringKeyedMap<$V extends jni.JObject> extends MyMap<jni.JString, $V> {
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory StringKeyedMap({
     required jni.JObjType<$V> V,
   }) {
-    return StringKeyedMap.fromReference(V, _id_new0(_class, referenceType, []));
+    return StringKeyedMap.fromReference(
+        V,
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 }
 
@@ -2196,10 +3249,24 @@ class StringStack extends MyStack<jni.JString> {
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory StringStack() {
-    return StringStack.fromReference(_id_new0(_class, referenceType, []));
+    return StringStack.fromReference(
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 }
 
@@ -2256,13 +3323,27 @@ class StringValuedMap<$K extends jni.JObject> extends MyMap<$K, jni.JString> {
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory StringValuedMap({
     required jni.JObjType<$K> K,
   }) {
     return StringValuedMap.fromReference(
-        K, _id_new0(_class, referenceType, []));
+        K,
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 }
 
@@ -2328,11 +3409,24 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
     r"(Ljava/lang/String;)V",
   );
 
+  static final _voidCallback = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JThrowablePtr Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public abstract void voidCallback(java.lang.String s)
   void voidCallback(
     jni.JString s,
   ) {
-    _id_voidCallback(this, const jni.jvoidType(), [s.reference.pointer]);
+    _voidCallback(reference.pointer, _id_voidCallback as jni.JMethodIDPtr,
+            s.reference.pointer)
+        .check();
   }
 
   static final _id_stringCallback = _class.instanceMethodId(
@@ -2340,13 +3434,25 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
     r"(Ljava/lang/String;)Ljava/lang/String;",
   );
 
+  static final _stringCallback = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public abstract java.lang.String stringCallback(java.lang.String s)
   /// The returned object must be released after use, by calling the [release] method.
   jni.JString stringCallback(
     jni.JString s,
   ) {
-    return _id_stringCallback(
-        this, const jni.JStringType(), [s.reference.pointer]);
+    return _stringCallback(reference.pointer,
+            _id_stringCallback as jni.JMethodIDPtr, s.reference.pointer)
+        .object(const jni.JStringType());
   }
 
   static final _id_varCallback = _class.instanceMethodId(
@@ -2354,18 +3460,47 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
     r"(Ljava/lang/Object;)Ljava/lang/Object;",
   );
 
+  static final _varCallback = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public abstract T varCallback(T t)
   /// The returned object must be released after use, by calling the [release] method.
   $T varCallback(
     $T t,
   ) {
-    return _id_varCallback(this, T, [t.reference.pointer]);
+    return _varCallback(reference.pointer, _id_varCallback as jni.JMethodIDPtr,
+            t.reference.pointer)
+        .object(T);
   }
 
   static final _id_manyPrimitives = _class.instanceMethodId(
     r"manyPrimitives",
     r"(IZCD)J",
   );
+
+  static final _manyPrimitives = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Double
+                      )>)>>("globalEnv_CallLongMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int,
+              int, int, double)>();
 
   /// from: public abstract long manyPrimitives(int a, boolean b, char c, double d)
   int manyPrimitives(
@@ -2374,8 +3509,9 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
     int c,
     double d,
   ) {
-    return _id_manyPrimitives(this, const jni.jlongType(),
-        [jni.JValueInt(a), b ? 1 : 0, jni.JValueChar(c), d]);
+    return _manyPrimitives(reference.pointer,
+            _id_manyPrimitives as jni.JMethodIDPtr, a, b ? 1 : 0, c, d)
+        .long;
   }
 
   /// Maps a specific port to the implemented interface.
@@ -2592,17 +3728,57 @@ class MyInterfaceConsumer extends jni.JObject {
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory MyInterfaceConsumer() {
     return MyInterfaceConsumer.fromReference(
-        _id_new0(_class, referenceType, []));
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 
   static final _id_consumeOnAnotherThread = _class.staticMethodId(
     r"consumeOnAnotherThread",
     r"(Lcom/github/dart_lang/jnigen/interfaces/MyInterface;Ljava/lang/String;IZCDLjava/lang/Object;)V",
   );
+
+  static final _consumeOnAnotherThread = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Double,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_CallStaticVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+              ffi.Pointer<ffi.Void>,
+              jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Void>,
+              int,
+              int,
+              int,
+              double,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: static public void consumeOnAnotherThread(com.github.dart_lang.jnigen.interfaces.MyInterface<T> myInterface, java.lang.String s, int a, boolean b, char c, double d, T t)
   static void consumeOnAnotherThread<$T extends jni.JObject>(
@@ -2619,21 +3795,50 @@ class MyInterfaceConsumer extends jni.JObject {
       t.$type,
       (myInterface.$type as $MyInterfaceType).T,
     ]) as jni.JObjType<$T>;
-    _id_consumeOnAnotherThread(_class, const jni.jvoidType(), [
-      myInterface.reference.pointer,
-      s.reference.pointer,
-      jni.JValueInt(a),
-      b ? 1 : 0,
-      jni.JValueChar(c),
-      d,
-      t.reference.pointer
-    ]);
+    _consumeOnAnotherThread(
+            _class.reference.pointer,
+            _id_consumeOnAnotherThread as jni.JMethodIDPtr,
+            myInterface.reference.pointer,
+            s.reference.pointer,
+            a,
+            b ? 1 : 0,
+            c,
+            d,
+            t.reference.pointer)
+        .check();
   }
 
   static final _id_consumeOnSameThread = _class.staticMethodId(
     r"consumeOnSameThread",
     r"(Lcom/github/dart_lang/jnigen/interfaces/MyInterface;Ljava/lang/String;IZCDLjava/lang/Object;)V",
   );
+
+  static final _consumeOnSameThread = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Double,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>("globalEnv_CallStaticVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+              ffi.Pointer<ffi.Void>,
+              jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Void>,
+              int,
+              int,
+              int,
+              double,
+              ffi.Pointer<ffi.Void>)>();
 
   /// from: static public void consumeOnSameThread(com.github.dart_lang.jnigen.interfaces.MyInterface<T> myInterface, java.lang.String s, int a, boolean b, char c, double d, T t)
   static void consumeOnSameThread<$T extends jni.JObject>(
@@ -2650,15 +3855,17 @@ class MyInterfaceConsumer extends jni.JObject {
       t.$type,
       (myInterface.$type as $MyInterfaceType).T,
     ]) as jni.JObjType<$T>;
-    _id_consumeOnSameThread(_class, const jni.jvoidType(), [
-      myInterface.reference.pointer,
-      s.reference.pointer,
-      jni.JValueInt(a),
-      b ? 1 : 0,
-      jni.JValueChar(c),
-      d,
-      t.reference.pointer
-    ]);
+    _consumeOnSameThread(
+            _class.reference.pointer,
+            _id_consumeOnSameThread as jni.JMethodIDPtr,
+            myInterface.reference.pointer,
+            s.reference.pointer,
+            a,
+            b ? 1 : 0,
+            c,
+            d,
+            t.reference.pointer)
+        .check();
   }
 }
 
@@ -2708,9 +3915,21 @@ class MyRunnable extends jni.JObject {
     r"()V",
   );
 
+  static final _run = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public abstract void run()
   void run() {
-    _id_run(this, const jni.jvoidType(), []);
+    _run(reference.pointer, _id_run as jni.JMethodIDPtr).check();
   }
 
   /// Maps a specific port to the implemented interface.
@@ -2860,13 +4079,25 @@ class MyRunnableRunner extends jni.JObject {
     r"(Lcom/github/dart_lang/jnigen/interfaces/MyRunnable;)V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: public void <init>(com.github.dart_lang.jnigen.interfaces.MyRunnable runnable)
   /// The returned object must be released after use, by calling the [release] method.
   factory MyRunnableRunner(
     MyRunnable runnable,
   ) {
-    return MyRunnableRunner.fromReference(
-        _id_new0(_class, referenceType, [runnable.reference.pointer]));
+    return MyRunnableRunner.fromReference(_new0(_class.reference.pointer,
+            _id_new0 as jni.JMethodIDPtr, runnable.reference.pointer)
+        .reference);
   }
 
   static final _id_runOnSameThread = _class.instanceMethodId(
@@ -2874,9 +4105,22 @@ class MyRunnableRunner extends jni.JObject {
     r"()V",
   );
 
+  static final _runOnSameThread = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void runOnSameThread()
   void runOnSameThread() {
-    _id_runOnSameThread(this, const jni.jvoidType(), []);
+    _runOnSameThread(reference.pointer, _id_runOnSameThread as jni.JMethodIDPtr)
+        .check();
   }
 
   static final _id_runOnAnotherThread = _class.instanceMethodId(
@@ -2884,9 +4128,23 @@ class MyRunnableRunner extends jni.JObject {
     r"()V",
   );
 
+  static final _runOnAnotherThread = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void runOnAnotherThread()
   void runOnAnotherThread() {
-    _id_runOnAnotherThread(this, const jni.jvoidType(), []);
+    _runOnAnotherThread(
+            reference.pointer, _id_runOnAnotherThread as jni.JMethodIDPtr)
+        .check();
   }
 }
 
@@ -2936,11 +4194,23 @@ class JsonSerializable_Case extends jni.JObject {
     r"()[Lcom/github/dart_lang/jnigen/annotations/JsonSerializable$Case;",
   );
 
+  static final _values = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public com.github.dart_lang.jnigen.annotations.JsonSerializable.Case[] values()
   /// The returned object must be released after use, by calling the [release] method.
   static jni.JArray<JsonSerializable_Case> values() {
-    return _id_values(
-        _class, const jni.JArrayType($JsonSerializable_CaseType()), []);
+    return _values(_class.reference.pointer, _id_values as jni.JMethodIDPtr)
+        .object(const jni.JArrayType($JsonSerializable_CaseType()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -2948,13 +4218,25 @@ class JsonSerializable_Case extends jni.JObject {
     r"(Ljava/lang/String;)Lcom/github/dart_lang/jnigen/annotations/JsonSerializable$Case;",
   );
 
+  static final _valueOf = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: static public com.github.dart_lang.jnigen.annotations.JsonSerializable.Case valueOf(java.lang.String name)
   /// The returned object must be released after use, by calling the [release] method.
   static JsonSerializable_Case valueOf(
     jni.JString name,
   ) {
-    return _id_valueOf(
-        _class, const $JsonSerializable_CaseType(), [name.reference.pointer]);
+    return _valueOf(_class.reference.pointer, _id_valueOf as jni.JMethodIDPtr,
+            name.reference.pointer)
+        .object(const $JsonSerializable_CaseType());
   }
 }
 
@@ -3005,10 +4287,23 @@ class JsonSerializable extends jni.JObject {
     r"()Lcom/github/dart_lang/jnigen/annotations/JsonSerializable$Case;",
   );
 
+  static final _value = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public abstract com.github.dart_lang.jnigen.annotations.JsonSerializable$Case value()
   /// The returned object must be released after use, by calling the [release] method.
   JsonSerializable_Case value() {
-    return _id_value(this, const $JsonSerializable_CaseType(), []);
+    return _value(reference.pointer, _id_value as jni.JMethodIDPtr)
+        .object(const $JsonSerializable_CaseType());
   }
 
   /// Maps a specific port to the implemented interface.
@@ -3149,10 +4444,24 @@ class MyDataClass extends jni.JObject {
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory MyDataClass() {
-    return MyDataClass.fromReference(_id_new0(_class, referenceType, []));
+    return MyDataClass.fromReference(
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 }
 
@@ -3201,10 +4510,23 @@ class Color extends jni.JObject {
     r"()[Lcom/github/dart_lang/jnigen/simple_package/Color;",
   );
 
+  static final _values = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public com.github.dart_lang.jnigen.simple_package.Color[] values()
   /// The returned object must be released after use, by calling the [release] method.
   static jni.JArray<Color> values() {
-    return _id_values(_class, const jni.JArrayType($ColorType()), []);
+    return _values(_class.reference.pointer, _id_values as jni.JMethodIDPtr)
+        .object(const jni.JArrayType($ColorType()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -3212,12 +4534,25 @@ class Color extends jni.JObject {
     r"(Ljava/lang/String;)Lcom/github/dart_lang/jnigen/simple_package/Color;",
   );
 
+  static final _valueOf = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          "globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
   /// from: static public com.github.dart_lang.jnigen.simple_package.Color valueOf(java.lang.String name)
   /// The returned object must be released after use, by calling the [release] method.
   static Color valueOf(
     jni.JString name,
   ) {
-    return _id_valueOf(_class, const $ColorType(), [name.reference.pointer]);
+    return _valueOf(_class.reference.pointer, _id_valueOf as jni.JMethodIDPtr,
+            name.reference.pointer)
+        .object(const $ColorType());
   }
 }
 
@@ -3264,15 +4599,37 @@ class Exceptions extends jni.JObject {
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory Exceptions() {
-    return Exceptions.fromReference(_id_new0(_class, referenceType, []));
+    return Exceptions.fromReference(
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 
   static final _id_new1 = _class.constructorId(
     r"(F)V",
   );
+
+  static final _new1 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Double,)>)>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, double)>();
 
   /// from: public void <init>(float x)
   /// The returned object must be released after use, by calling the [release] method.
@@ -3280,12 +4637,31 @@ class Exceptions extends jni.JObject {
     double x,
   ) {
     return Exceptions.fromReference(
-        _id_new1(_class, referenceType, [jni.JValueFloat(x)]));
+        _new1(_class.reference.pointer, _id_new1 as jni.JMethodIDPtr, x)
+            .reference);
   }
 
   static final _id_new2 = _class.constructorId(
     r"(IIIIII)V",
   );
+
+  static final _new2 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64,
+                        ffi.Int64
+                      )>)>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int,
+              int, int, int, int, int)>();
 
   /// from: public void <init>(int a, int b, int c, int d, int e, int f)
   /// The returned object must be released after use, by calling the [release] method.
@@ -3297,14 +4673,9 @@ class Exceptions extends jni.JObject {
     int e,
     int f,
   ) {
-    return Exceptions.fromReference(_id_new2(_class, referenceType, [
-      jni.JValueInt(a),
-      jni.JValueInt(b),
-      jni.JValueInt(c),
-      jni.JValueInt(d),
-      jni.JValueInt(e),
-      jni.JValueInt(f)
-    ]));
+    return Exceptions.fromReference(_new2(_class.reference.pointer,
+            _id_new2 as jni.JMethodIDPtr, a, b, c, d, e, f)
+        .reference);
   }
 
   static final _id_staticObjectMethod = _class.staticMethodId(
@@ -3312,10 +4683,24 @@ class Exceptions extends jni.JObject {
     r"()Ljava/lang/Object;",
   );
 
+  static final _staticObjectMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public java.lang.Object staticObjectMethod()
   /// The returned object must be released after use, by calling the [release] method.
   static jni.JObject staticObjectMethod() {
-    return _id_staticObjectMethod(_class, const jni.JObjectType(), []);
+    return _staticObjectMethod(_class.reference.pointer,
+            _id_staticObjectMethod as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_staticIntMethod = _class.staticMethodId(
@@ -3323,9 +4708,23 @@ class Exceptions extends jni.JObject {
     r"()I",
   );
 
+  static final _staticIntMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public int staticIntMethod()
   static int staticIntMethod() {
-    return _id_staticIntMethod(_class, const jni.jintType(), []);
+    return _staticIntMethod(
+            _class.reference.pointer, _id_staticIntMethod as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_staticObjectArrayMethod = _class.staticMethodId(
@@ -3333,11 +4732,24 @@ class Exceptions extends jni.JObject {
     r"()[Ljava/lang/Object;",
   );
 
+  static final _staticObjectArrayMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public java.lang.Object[] staticObjectArrayMethod()
   /// The returned object must be released after use, by calling the [release] method.
   static jni.JArray<jni.JObject> staticObjectArrayMethod() {
-    return _id_staticObjectArrayMethod(
-        _class, const jni.JArrayType(jni.JObjectType()), []);
+    return _staticObjectArrayMethod(_class.reference.pointer,
+            _id_staticObjectArrayMethod as jni.JMethodIDPtr)
+        .object(const jni.JArrayType(jni.JObjectType()));
   }
 
   static final _id_staticIntArrayMethod = _class.staticMethodId(
@@ -3345,11 +4757,24 @@ class Exceptions extends jni.JObject {
     r"()[I",
   );
 
+  static final _staticIntArrayMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public int[] staticIntArrayMethod()
   /// The returned object must be released after use, by calling the [release] method.
   static jni.JArray<jni.jint> staticIntArrayMethod() {
-    return _id_staticIntArrayMethod(
-        _class, const jni.JArrayType(jni.jintType()), []);
+    return _staticIntArrayMethod(_class.reference.pointer,
+            _id_staticIntArrayMethod as jni.JMethodIDPtr)
+        .object(const jni.JArrayType(jni.jintType()));
   }
 
   static final _id_objectMethod = _class.instanceMethodId(
@@ -3357,10 +4782,24 @@ class Exceptions extends jni.JObject {
     r"()Ljava/lang/Object;",
   );
 
+  static final _objectMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public java.lang.Object objectMethod()
   /// The returned object must be released after use, by calling the [release] method.
   jni.JObject objectMethod() {
-    return _id_objectMethod(this, const jni.JObjectType(), []);
+    return _objectMethod(
+            reference.pointer, _id_objectMethod as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_intMethod = _class.instanceMethodId(
@@ -3368,9 +4807,22 @@ class Exceptions extends jni.JObject {
     r"()I",
   );
 
+  static final _intMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public int intMethod()
   int intMethod() {
-    return _id_intMethod(this, const jni.jintType(), []);
+    return _intMethod(reference.pointer, _id_intMethod as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_objectArrayMethod = _class.instanceMethodId(
@@ -3378,11 +4830,24 @@ class Exceptions extends jni.JObject {
     r"()[Ljava/lang/Object;",
   );
 
+  static final _objectArrayMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public java.lang.Object[] objectArrayMethod()
   /// The returned object must be released after use, by calling the [release] method.
   jni.JArray<jni.JObject> objectArrayMethod() {
-    return _id_objectArrayMethod(
-        this, const jni.JArrayType(jni.JObjectType()), []);
+    return _objectArrayMethod(
+            reference.pointer, _id_objectArrayMethod as jni.JMethodIDPtr)
+        .object(const jni.JArrayType(jni.JObjectType()));
   }
 
   static final _id_intArrayMethod = _class.instanceMethodId(
@@ -3390,10 +4855,24 @@ class Exceptions extends jni.JObject {
     r"()[I",
   );
 
+  static final _intArrayMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public int[] intArrayMethod()
   /// The returned object must be released after use, by calling the [release] method.
   jni.JArray<jni.jint> intArrayMethod() {
-    return _id_intArrayMethod(this, const jni.JArrayType(jni.jintType()), []);
+    return _intArrayMethod(
+            reference.pointer, _id_intArrayMethod as jni.JMethodIDPtr)
+        .object(const jni.JArrayType(jni.jintType()));
   }
 
   static final _id_throwNullPointerException = _class.instanceMethodId(
@@ -3401,9 +4880,23 @@ class Exceptions extends jni.JObject {
     r"()I",
   );
 
+  static final _throwNullPointerException = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public int throwNullPointerException()
   int throwNullPointerException() {
-    return _id_throwNullPointerException(this, const jni.jintType(), []);
+    return _throwNullPointerException(reference.pointer,
+            _id_throwNullPointerException as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_throwFileNotFoundException = _class.instanceMethodId(
@@ -3411,10 +4904,24 @@ class Exceptions extends jni.JObject {
     r"()Ljava/io/InputStream;",
   );
 
+  static final _throwFileNotFoundException = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public java.io.InputStream throwFileNotFoundException()
   /// The returned object must be released after use, by calling the [release] method.
   jni.JObject throwFileNotFoundException() {
-    return _id_throwFileNotFoundException(this, const jni.JObjectType(), []);
+    return _throwFileNotFoundException(reference.pointer,
+            _id_throwFileNotFoundException as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_throwClassCastException = _class.instanceMethodId(
@@ -3422,10 +4929,24 @@ class Exceptions extends jni.JObject {
     r"()Ljava/io/FileInputStream;",
   );
 
+  static final _throwClassCastException = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallObjectMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public java.io.FileInputStream throwClassCastException()
   /// The returned object must be released after use, by calling the [release] method.
   jni.JObject throwClassCastException() {
-    return _id_throwClassCastException(this, const jni.JObjectType(), []);
+    return _throwClassCastException(
+            reference.pointer, _id_throwClassCastException as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
   }
 
   static final _id_throwArrayIndexException = _class.instanceMethodId(
@@ -3433,9 +4954,23 @@ class Exceptions extends jni.JObject {
     r"()I",
   );
 
+  static final _throwArrayIndexException = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public int throwArrayIndexException()
   int throwArrayIndexException() {
-    return _id_throwArrayIndexException(this, const jni.jintType(), []);
+    return _throwArrayIndexException(
+            reference.pointer, _id_throwArrayIndexException as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_throwArithmeticException = _class.instanceMethodId(
@@ -3443,9 +4978,23 @@ class Exceptions extends jni.JObject {
     r"()I",
   );
 
+  static final _throwArithmeticException = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallIntMethod")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public int throwArithmeticException()
   int throwArithmeticException() {
-    return _id_throwArithmeticException(this, const jni.jintType(), []);
+    return _throwArithmeticException(
+            reference.pointer, _id_throwArithmeticException as jni.JMethodIDPtr)
+        .integer;
   }
 
   static final _id_throwLoremIpsum = _class.staticMethodId(
@@ -3453,9 +5002,23 @@ class Exceptions extends jni.JObject {
     r"()V",
   );
 
+  static final _throwLoremIpsum = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_CallStaticVoidMethod")
+      .asFunction<
+          jni.JThrowablePtr Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: static public void throwLoremIpsum()
   static void throwLoremIpsum() {
-    _id_throwLoremIpsum(_class, const jni.jvoidType(), []);
+    _throwLoremIpsum(
+            _class.reference.pointer, _id_throwLoremIpsum as jni.JMethodIDPtr)
+        .check();
   }
 }
 
@@ -3633,10 +5196,24 @@ class Fields extends jni.JObject {
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory Fields() {
-    return Fields.fromReference(_id_new0(_class, referenceType, []));
+    return Fields.fromReference(
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 }
 
@@ -3710,10 +5287,24 @@ class Fields_Nested extends jni.JObject {
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory Fields_Nested() {
-    return Fields_Nested.fromReference(_id_new0(_class, referenceType, []));
+    return Fields_Nested.fromReference(
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 }
 
@@ -3778,6 +5369,18 @@ class GenericTypeParams<$S extends jni.JObject, $K extends jni.JObject>
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory GenericTypeParams({
@@ -3785,7 +5388,10 @@ class GenericTypeParams<$S extends jni.JObject, $K extends jni.JObject>
     required jni.JObjType<$K> K,
   }) {
     return GenericTypeParams.fromReference(
-        S, K, _id_new0(_class, referenceType, []));
+        S,
+        K,
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 }
 
@@ -3843,10 +5449,24 @@ class StringMap extends StringKeyedMap<jni.JString> {
     r"()V",
   );
 
+  static final _new0 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>("globalEnv_NewObject")
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
   /// from: public void <init>()
   /// The returned object must be released after use, by calling the [release] method.
   factory StringMap() {
-    return StringMap.fromReference(_id_new0(_class, referenceType, []));
+    return StringMap.fromReference(
+        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            .reference);
   }
 }
 


### PR DESCRIPTION
This is part one of #660. 

Ignore the numerous `if (!isCBased)`s, I didn't separate the concerns much, since I wanted to remove C based bindings anyways.

For now I'm using the larger types like `Int64` and `Double`, for this to work on my machine. Once the fix for https://github.com/dart-lang/sdk/issues/55471 lands in stable, we can change this. Not sure if this workaround works everywhere, will wait for CI run. – Seems to be working!

I will add to the changelog in the second PR when removing the C based bindings completely.

