### PR TITLE
[jnigen] Add `getRange` method to `JArray<JPrimitive>` and change the dart equivalent type for `JArray<jchar>` to `int`

### DIFF
--- a/.github/workflows/jnigen.yaml
+++ b/.github/workflows/jnigen.yaml
@@ -90,10 +90,7 @@ jobs:
       ## So this is required to format generated bindings identically
       - name: install clang tools
         run: |
-          sudo rm -rf /var/lib/apt/lists/*
-          sudo apt-get clean
           sudo apt-get update -y
-          sudo apt-get upgrade
           sudo apt-get install -y clang-format
       - name: Install dependencies
         run: dart pub get
@@ -145,10 +142,7 @@ jobs:
           args: '--set-exit-if-changed'
       - name: install clang tools & CMake
         run: |
-          sudo rm -rf /var/lib/apt/lists/*
-          sudo apt-get clean
           sudo apt-get update -y
-          sudo apt-get upgrade
           sudo apt-get install -y clang-format build-essential cmake
       - run: flutter pub get
       - name: Check formatting
@@ -181,10 +175,7 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - run: |
-          sudo rm -rf /var/lib/apt/lists/*
-          sudo apt-get clean
           sudo apt-get update -y
-          sudo apt-get upgrade
           sudo apt-get install -y ninja-build libgtk-3-dev libclang-dev
       - run: dart pub get
       - run: dart run jni:setup
@@ -334,10 +325,7 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - run: |
-          sudo rm -rf /var/lib/apt/lists/*
-          sudo apt-get clean
           sudo apt-get update -y
-          sudo apt-get upgrade
           sudo apt-get install -y ninja-build libgtk-3-dev
       - run: flutter config --enable-linux-desktop
       - run: flutter pub get
@@ -400,10 +388,7 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - run: |
-          sudo rm -rf /var/lib/apt/lists/*
-          sudo apt-get clean
           sudo apt-get update -y
-          sudo apt-get upgrade
           sudo apt-get install -y ninja-build libgtk-3-dev clang-format
       - run: flutter config --enable-linux-desktop
       - run: dart pub get

--- a/.github/workflows/jnigen.yaml
+++ b/.github/workflows/jnigen.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: install clang tools
         run: |
           sudo apt-get clean
-          rm -rf /var/lib/apt/lists/*
+          sudo rm -rf /var/lib/apt/lists/*
           sudo apt-get clean
           sudo apt-get update -y
           sudo apt-get upgrade
@@ -147,7 +147,7 @@ jobs:
       - name: install clang tools & CMake
         run: |
           sudo apt-get clean
-          rm -rf /var/lib/apt/lists/*
+          sudo rm -rf /var/lib/apt/lists/*
           sudo apt-get clean
           sudo apt-get update -y
           sudo apt-get upgrade
@@ -184,7 +184,7 @@ jobs:
           java-version: '11'
       - run: |
           sudo apt-get clean
-          rm -rf /var/lib/apt/lists/*
+          sudo rm -rf /var/lib/apt/lists/*
           sudo apt-get clean
           sudo apt-get update -y
           sudo apt-get upgrade
@@ -338,7 +338,7 @@ jobs:
           java-version: '11'
       - run: |
           sudo apt-get clean
-          rm -rf /var/lib/apt/lists/*
+          sudo rm -rf /var/lib/apt/lists/*
           sudo apt-get clean
           sudo apt-get update -y
           sudo apt-get upgrade
@@ -405,7 +405,7 @@ jobs:
           java-version: '11'
       - run: |
           sudo apt-get clean
-          rm -rf /var/lib/apt/lists/*
+          sudo rm -rf /var/lib/apt/lists/*
           sudo apt-get clean
           sudo apt-get update -y
           sudo apt-get upgrade

--- a/.github/workflows/jnigen.yaml
+++ b/.github/workflows/jnigen.yaml
@@ -90,7 +90,6 @@ jobs:
       ## So this is required to format generated bindings identically
       - name: install clang tools
         run: |
-          sudo apt-get clean
           sudo rm -rf /var/lib/apt/lists/*
           sudo apt-get clean
           sudo apt-get update -y
@@ -146,7 +145,6 @@ jobs:
           args: '--set-exit-if-changed'
       - name: install clang tools & CMake
         run: |
-          sudo apt-get clean
           sudo rm -rf /var/lib/apt/lists/*
           sudo apt-get clean
           sudo apt-get update -y
@@ -183,7 +181,6 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - run: |
-          sudo apt-get clean
           sudo rm -rf /var/lib/apt/lists/*
           sudo apt-get clean
           sudo apt-get update -y
@@ -337,7 +334,6 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - run: |
-          sudo apt-get clean
           sudo rm -rf /var/lib/apt/lists/*
           sudo apt-get clean
           sudo apt-get update -y
@@ -404,7 +400,6 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - run: |
-          sudo apt-get clean
           sudo rm -rf /var/lib/apt/lists/*
           sudo apt-get clean
           sudo apt-get update -y

--- a/.github/workflows/jnigen.yaml
+++ b/.github/workflows/jnigen.yaml
@@ -90,7 +90,11 @@ jobs:
       ## So this is required to format generated bindings identically
       - name: install clang tools
         run: |
+          sudo apt-get clean
+          rm -rf /var/lib/apt/lists/*
+          sudo apt-get clean
           sudo apt-get update -y
+          sudo apt-get upgrade
           sudo apt-get install -y clang-format
       - name: Install dependencies
         run: dart pub get
@@ -142,7 +146,11 @@ jobs:
           args: '--set-exit-if-changed'
       - name: install clang tools & CMake
         run: |
+          sudo apt-get clean
+          rm -rf /var/lib/apt/lists/*
+          sudo apt-get clean
           sudo apt-get update -y
+          sudo apt-get upgrade
           sudo apt-get install -y clang-format build-essential cmake
       - run: flutter pub get
       - name: Check formatting
@@ -175,7 +183,11 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - run: |
+          sudo apt-get clean
+          rm -rf /var/lib/apt/lists/*
+          sudo apt-get clean
           sudo apt-get update -y
+          sudo apt-get upgrade
           sudo apt-get install -y ninja-build libgtk-3-dev libclang-dev
       - run: dart pub get
       - run: dart run jni:setup
@@ -325,7 +337,11 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - run: |
+          sudo apt-get clean
+          rm -rf /var/lib/apt/lists/*
+          sudo apt-get clean
           sudo apt-get update -y
+          sudo apt-get upgrade
           sudo apt-get install -y ninja-build libgtk-3-dev
       - run: flutter config --enable-linux-desktop
       - run: flutter pub get
@@ -388,7 +404,11 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - run: |
+          sudo apt-get clean
+          rm -rf /var/lib/apt/lists/*
+          sudo apt-get clean
           sudo apt-get update -y
+          sudo apt-get upgrade
           sudo apt-get install -y ninja-build libgtk-3-dev clang-format
       - run: flutter config --enable-linux-desktop
       - run: dart pub get

--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -6,6 +6,7 @@
   change the argument type of `operator []=` to accept `int`.
 - Added `getRange` method to `JArray` of primitive types that returns a
   `TypedData` list depending on the kind of the array.
+- Improved the performance of `JArray`'s `setRange` and `operator []=`.
 
 ## 0.8.0
 

--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.9.0-wip
 
+- **Breaking Change**
+  ([#1004](https://github.com/dart-lang/native/issues/1004)): Changed the return
+  type `operator []` of `JArray<jchar>` to `int` instead of `String`. Similarly,
+  change the argument type of `operator []=` to accept `int`.
 - Added `getRange` method to `JArray` of primitive types that returns a
   `TypedData` list depending on the kind of the array.
 

--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.9.0-wip
 
-- No changes yet.
+- Added `getRange` method to `JArray` of primitive types that returns a
+  `TypedData` list depending on the kind of the array.
 
 ## 0.8.0
 

--- a/pkgs/jni/lib/src/jarray.dart
+++ b/pkgs/jni/lib/src/jarray.dart
@@ -132,11 +132,11 @@ class JArray<E> extends JObject {
 
 extension NativeArray<E extends JPrimitive> on JArray<E> {
   void _allocate<T extends NativeType>(
-    int rangeLength,
+    int byteCount,
     void Function(Pointer<T> ptr) use,
   ) {
     using((arena) {
-      final ptr = arena.allocate<T>(rangeLength);
+      final ptr = arena.allocate<T>(byteCount);
       use(ptr);
     }, malloc);
   }

--- a/pkgs/jni/lib/src/jarray.dart
+++ b/pkgs/jni/lib/src/jarray.dart
@@ -218,7 +218,7 @@ extension ByteArray on JArray<jbyte> {
   }
 }
 
-/// `JArray<jchar>` is a 16-bit integer array.
+/// `JArray<jchar>` is a 16-bit unsigned integer array.
 ///
 /// Due to variable length encoding, the  number of code units is not equal to
 /// the number of characters.

--- a/pkgs/jni/lib/src/jarray.dart
+++ b/pkgs/jni/lib/src/jarray.dart
@@ -218,6 +218,10 @@ extension ByteArray on JArray<jbyte> {
   }
 }
 
+/// `JArray<jchar>` is a 16-bit integer array.
+///
+/// Due to variable length encoding, the  number of code units is not equal to
+/// the number of characters.
 extension CharArray on JArray<jchar> {
   int operator [](int index) {
     return _elementAt(index, JniCallType.charType).char;

--- a/pkgs/jni/lib/src/jarray.dart
+++ b/pkgs/jni/lib/src/jarray.dart
@@ -202,22 +202,22 @@ extension CharArray on JArray<jchar> {
     );
   }
 
-  void operator []=(int index, String value) {
+  void operator []=(int index, int value) {
     RangeError.checkValidIndex(index, this);
     _allocate<JCharMarker>(sizeOf<JCharMarker>(), (ptr) {
-      ptr.value = value.codeUnits.first;
+      ptr.value = value;
       Jni.env.SetCharArrayRegion(reference.pointer, index, 1, ptr);
     });
   }
 
-  void setRange(int start, int end, Iterable<String> iterable,
+  void setRange(int start, int end, Iterable<int> iterable,
       [int skipCount = 0]) {
     RangeError.checkValidRange(start, end, length);
     final size = end - start;
     final it = iterable.skip(skipCount).take(size);
     _allocate<JCharMarker>(sizeOf<JCharMarker>() * size, (ptr) {
       it.forEachIndexed((index, element) {
-        ptr[index] = element.codeUnits.first;
+        ptr[index] = element;
       });
       Jni.env.SetCharArrayRegion(reference.pointer, start, size, ptr);
     });

--- a/pkgs/jni/lib/src/jarray.dart
+++ b/pkgs/jni/lib/src/jarray.dart
@@ -159,10 +159,8 @@ extension BoolArray on JArray<jboolean> {
 
   void operator []=(int index, bool value) {
     RangeError.checkValidIndex(index, this);
-    _allocate<JBooleanMarker>(sizeOf<JBooleanMarker>(), (ptr) {
-      ptr.value = value ? 1 : 0;
-      Jni.env.SetBooleanArrayRegion(reference.pointer, index, 1, ptr);
-    });
+    Jni.accessors
+        .setBooleanArrayElement(reference.pointer, index, value ? 1 : 0);
   }
 
   Uint8List getRange(int start, int end, {Allocator allocator = malloc}) {
@@ -196,10 +194,7 @@ extension ByteArray on JArray<jbyte> {
 
   void operator []=(int index, int value) {
     RangeError.checkValidIndex(index, this);
-    _allocate<JByteMarker>(sizeOf<JByteMarker>(), (ptr) {
-      ptr.value = value;
-      Jni.env.SetByteArrayRegion(reference.pointer, index, 1, ptr);
-    });
+    Jni.accessors.setByteArrayElement(reference.pointer, index, value).check();
   }
 
   Int8List getRange(int start, int end, {Allocator allocator = malloc}) {
@@ -230,10 +225,7 @@ extension CharArray on JArray<jchar> {
 
   void operator []=(int index, int value) {
     RangeError.checkValidIndex(index, this);
-    _allocate<JCharMarker>(sizeOf<JCharMarker>(), (ptr) {
-      ptr.value = value;
-      Jni.env.SetCharArrayRegion(reference.pointer, index, 1, ptr);
-    });
+    Jni.accessors.setCharArrayElement(reference.pointer, index, value).check();
   }
 
   Uint16List getRange(int start, int end, {Allocator allocator = malloc}) {
@@ -264,10 +256,7 @@ extension ShortArray on JArray<jshort> {
 
   void operator []=(int index, int value) {
     RangeError.checkValidIndex(index, this);
-    _allocate<JShortMarker>(sizeOf<JShortMarker>(), (ptr) {
-      ptr.value = value;
-      Jni.env.SetShortArrayRegion(reference.pointer, index, 1, ptr);
-    });
+    Jni.accessors.setShortArrayElement(reference.pointer, index, value).check();
   }
 
   Int16List getRange(int start, int end, {Allocator allocator = malloc}) {
@@ -298,10 +287,7 @@ extension IntArray on JArray<jint> {
 
   void operator []=(int index, int value) {
     RangeError.checkValidIndex(index, this);
-    _allocate<JIntMarker>(sizeOf<JIntMarker>(), (ptr) {
-      ptr.value = value;
-      Jni.env.SetIntArrayRegion(reference.pointer, index, 1, ptr);
-    });
+    Jni.accessors.setIntArrayElement(reference.pointer, index, value).check();
   }
 
   Int32List getRange(int start, int end, {Allocator allocator = malloc}) {
@@ -332,10 +318,7 @@ extension LongArray on JArray<jlong> {
 
   void operator []=(int index, int value) {
     RangeError.checkValidIndex(index, this);
-    _allocate<JLongMarker>(sizeOf<JLongMarker>(), (ptr) {
-      ptr.value = value;
-      Jni.env.SetLongArrayRegion(reference.pointer, index, 1, ptr);
-    });
+    Jni.accessors.setLongArrayElement(reference.pointer, index, value).check();
   }
 
   Int64List getRange(int start, int end, {Allocator allocator = malloc}) {
@@ -366,10 +349,7 @@ extension FloatArray on JArray<jfloat> {
 
   void operator []=(int index, double value) {
     RangeError.checkValidIndex(index, this);
-    _allocate<JFloatMarker>(sizeOf<JFloatMarker>(), (ptr) {
-      ptr.value = value;
-      Jni.env.SetFloatArrayRegion(reference.pointer, index, 1, ptr);
-    });
+    Jni.accessors.setFloatArrayElement(reference.pointer, index, value).check();
   }
 
   Float32List getRange(int start, int end, {Allocator allocator = malloc}) {
@@ -400,10 +380,9 @@ extension DoubleArray on JArray<jdouble> {
 
   void operator []=(int index, double value) {
     RangeError.checkValidIndex(index, this);
-    _allocate<JDoubleMarker>(sizeOf<JDoubleMarker>(), (ptr) {
-      ptr.value = value;
-      Jni.env.SetDoubleArrayRegion(reference.pointer, index, 1, ptr);
-    });
+    Jni.accessors
+        .setDoubleArrayElement(reference.pointer, index, value)
+        .check();
   }
 
   Float64List getRange(int start, int end, {Allocator allocator = malloc}) {

--- a/pkgs/jni/lib/src/jarray.dart
+++ b/pkgs/jni/lib/src/jarray.dart
@@ -132,11 +132,11 @@ class JArray<E> extends JObject {
 
 extension NativeArray<E extends JPrimitive> on JArray<E> {
   void _allocate<T extends NativeType>(
-    int size,
+    int rangeLength,
     void Function(Pointer<T> ptr) use,
   ) {
     using((arena) {
-      final ptr = arena.allocate<T>(size);
+      final ptr = arena.allocate<T>(rangeLength);
       use(ptr);
     }, malloc);
   }
@@ -178,13 +178,13 @@ extension BoolArray on JArray<jboolean> {
   void setRange(int start, int end, Iterable<bool> iterable,
       [int skipCount = 0]) {
     RangeError.checkValidRange(start, end, length);
-    final size = end - start;
-    final it = iterable.skip(skipCount).take(size);
-    _allocate<JBooleanMarker>(sizeOf<JBooleanMarker>() * size, (ptr) {
+    final rangeLength = end - start;
+    final it = iterable.skip(skipCount).take(rangeLength);
+    _allocate<JBooleanMarker>(sizeOf<JBooleanMarker>() * rangeLength, (ptr) {
       it.forEachIndexed((index, element) {
         ptr[index] = element ? 1 : 0;
       });
-      Jni.env.SetBooleanArrayRegion(reference.pointer, start, size, ptr);
+      Jni.env.SetBooleanArrayRegion(reference.pointer, start, rangeLength, ptr);
     });
   }
 }
@@ -213,13 +213,12 @@ extension ByteArray on JArray<jbyte> {
   void setRange(int start, int end, Iterable<int> iterable,
       [int skipCount = 0]) {
     RangeError.checkValidRange(start, end, length);
-    final size = end - start;
-    final it = iterable.skip(skipCount).take(size);
-    _allocate<JByteMarker>(sizeOf<JByteMarker>() * size, (ptr) {
-      it.forEachIndexed((index, element) {
-        ptr[index] = element;
-      });
-      Jni.env.SetByteArrayRegion(reference.pointer, start, size, ptr);
+    final rangeLength = end - start;
+    _allocate<JByteMarker>(sizeOf<JByteMarker>() * rangeLength, (ptr) {
+      ptr
+          .asTypedList(rangeLength)
+          .setRange(0, rangeLength, iterable, skipCount);
+      Jni.env.SetByteArrayRegion(reference.pointer, start, rangeLength, ptr);
     });
   }
 }
@@ -248,13 +247,12 @@ extension CharArray on JArray<jchar> {
   void setRange(int start, int end, Iterable<int> iterable,
       [int skipCount = 0]) {
     RangeError.checkValidRange(start, end, length);
-    final size = end - start;
-    final it = iterable.skip(skipCount).take(size);
-    _allocate<JCharMarker>(sizeOf<JCharMarker>() * size, (ptr) {
-      it.forEachIndexed((index, element) {
-        ptr[index] = element;
-      });
-      Jni.env.SetCharArrayRegion(reference.pointer, start, size, ptr);
+    final rangeLength = end - start;
+    _allocate<JCharMarker>(sizeOf<JCharMarker>() * rangeLength, (ptr) {
+      ptr
+          .asTypedList(rangeLength)
+          .setRange(0, rangeLength, iterable, skipCount);
+      Jni.env.SetCharArrayRegion(reference.pointer, start, rangeLength, ptr);
     });
   }
 }
@@ -283,13 +281,12 @@ extension ShortArray on JArray<jshort> {
   void setRange(int start, int end, Iterable<int> iterable,
       [int skipCount = 0]) {
     RangeError.checkValidRange(start, end, length);
-    final size = end - start;
-    final it = iterable.skip(skipCount).take(size);
-    _allocate<JShortMarker>(sizeOf<JShortMarker>() * size, (ptr) {
-      it.forEachIndexed((index, element) {
-        ptr[index] = element;
-      });
-      Jni.env.SetShortArrayRegion(reference.pointer, start, size, ptr);
+    final rangeLength = end - start;
+    _allocate<JShortMarker>(sizeOf<JShortMarker>() * rangeLength, (ptr) {
+      ptr
+          .asTypedList(rangeLength)
+          .setRange(0, rangeLength, iterable, skipCount);
+      Jni.env.SetShortArrayRegion(reference.pointer, start, rangeLength, ptr);
     });
   }
 }
@@ -318,13 +315,12 @@ extension IntArray on JArray<jint> {
   void setRange(int start, int end, Iterable<int> iterable,
       [int skipCount = 0]) {
     RangeError.checkValidRange(start, end, length);
-    final size = end - start;
-    final it = iterable.skip(skipCount).take(size);
-    _allocate<JIntMarker>(sizeOf<JIntMarker>() * size, (ptr) {
-      it.forEachIndexed((index, element) {
-        ptr[index] = element;
-      });
-      Jni.env.SetIntArrayRegion(reference.pointer, start, size, ptr);
+    final rangeLength = end - start;
+    _allocate<JIntMarker>(sizeOf<JIntMarker>() * rangeLength, (ptr) {
+      ptr
+          .asTypedList(rangeLength)
+          .setRange(0, rangeLength, iterable, skipCount);
+      Jni.env.SetIntArrayRegion(reference.pointer, start, rangeLength, ptr);
     });
   }
 }
@@ -353,13 +349,12 @@ extension LongArray on JArray<jlong> {
   void setRange(int start, int end, Iterable<int> iterable,
       [int skipCount = 0]) {
     RangeError.checkValidRange(start, end, length);
-    final size = end - start;
-    final it = iterable.skip(skipCount).take(size);
-    _allocate<JLongMarker>(sizeOf<JLongMarker>() * size, (ptr) {
-      it.forEachIndexed((index, element) {
-        ptr[index] = element;
-      });
-      Jni.env.SetLongArrayRegion(reference.pointer, start, size, ptr);
+    final rangeLength = end - start;
+    _allocate<JLongMarker>(sizeOf<JLongMarker>() * rangeLength, (ptr) {
+      ptr
+          .asTypedList(rangeLength)
+          .setRange(0, rangeLength, iterable, skipCount);
+      Jni.env.SetLongArrayRegion(reference.pointer, start, rangeLength, ptr);
     });
   }
 }
@@ -388,13 +383,12 @@ extension FloatArray on JArray<jfloat> {
   void setRange(int start, int end, Iterable<double> iterable,
       [int skipCount = 0]) {
     RangeError.checkValidRange(start, end, length);
-    final size = end - start;
-    final it = iterable.skip(skipCount).take(size);
-    _allocate<JFloatMarker>(sizeOf<JFloatMarker>() * size, (ptr) {
-      it.forEachIndexed((index, element) {
-        ptr[index] = element;
-      });
-      Jni.env.SetFloatArrayRegion(reference.pointer, start, size, ptr);
+    final rangeLength = end - start;
+    _allocate<JFloatMarker>(sizeOf<JFloatMarker>() * rangeLength, (ptr) {
+      ptr
+          .asTypedList(rangeLength)
+          .setRange(0, rangeLength, iterable, skipCount);
+      Jni.env.SetFloatArrayRegion(reference.pointer, start, rangeLength, ptr);
     });
   }
 }
@@ -423,13 +417,12 @@ extension DoubleArray on JArray<jdouble> {
   void setRange(int start, int end, Iterable<double> iterable,
       [int skipCount = 0]) {
     RangeError.checkValidRange(start, end, length);
-    final size = end - start;
-    final it = iterable.skip(skipCount).take(size);
-    _allocate<JDoubleMarker>(sizeOf<JDoubleMarker>() * size, (ptr) {
-      it.forEachIndexed((index, element) {
-        ptr[index] = element;
-      });
-      Jni.env.SetDoubleArrayRegion(reference.pointer, start, size, ptr);
+    final rangeLength = end - start;
+    _allocate<JDoubleMarker>(sizeOf<JDoubleMarker>() * rangeLength, (ptr) {
+      ptr
+          .asTypedList(rangeLength)
+          .setRange(0, rangeLength, iterable, skipCount);
+      Jni.env.SetDoubleArrayRegion(reference.pointer, start, rangeLength, ptr);
     });
   }
 }
@@ -448,8 +441,8 @@ extension ObjectArray<T extends JObject> on JArray<T> {
 
   void setRange(int start, int end, Iterable<T> iterable, [int skipCount = 0]) {
     RangeError.checkValidRange(start, end, length);
-    final size = end - start;
-    final it = iterable.skip(skipCount).take(size);
+    final rangeLength = end - start;
+    final it = iterable.skip(skipCount).take(rangeLength);
     it.forEachIndexed((index, element) {
       this[index] = element;
     });

--- a/pkgs/jni/lib/src/jarray.dart
+++ b/pkgs/jni/lib/src/jarray.dart
@@ -218,7 +218,7 @@ extension ByteArray on JArray<jbyte> {
   }
 }
 
-/// `JArray<jchar>` is a 16-bit unsigned integer array.
+/// `JArray<jchar>` is a 16-bit integer array.
 ///
 /// Due to variable length encoding, the  number of code units is not equal to
 /// the number of characters.

--- a/pkgs/jni/lib/src/jarray.dart
+++ b/pkgs/jni/lib/src/jarray.dart
@@ -205,8 +205,7 @@ extension ByteArray on JArray<jbyte> {
   Int8List getRange(int start, int end, {Allocator allocator = malloc}) {
     RangeError.checkValidRange(start, end, length);
     final rangeLength = end - start;
-    final buffer =
-        allocator.allocate<JByteMarker>(sizeOf<JByteMarker>() * rangeLength);
+    final buffer = allocator<JByteMarker>(rangeLength);
     Jni.env.GetByteArrayRegion(reference.pointer, start, rangeLength, buffer);
     return buffer.asTypedList(rangeLength, finalizer: allocator._nativeFree);
   }
@@ -241,8 +240,7 @@ extension CharArray on JArray<jchar> {
   Uint16List getRange(int start, int end, {Allocator allocator = malloc}) {
     RangeError.checkValidRange(start, end, length);
     final rangeLength = end - start;
-    final buffer =
-        allocator.allocate<JCharMarker>(sizeOf<JCharMarker>() * rangeLength);
+    final buffer = allocator<JCharMarker>(rangeLength);
     Jni.env.GetCharArrayRegion(reference.pointer, start, rangeLength, buffer);
     return buffer.asTypedList(rangeLength, finalizer: allocator._nativeFree);
   }
@@ -277,8 +275,7 @@ extension ShortArray on JArray<jshort> {
   Int16List getRange(int start, int end, {Allocator allocator = malloc}) {
     RangeError.checkValidRange(start, end, length);
     final rangeLength = end - start;
-    final buffer =
-        allocator.allocate<JShortMarker>(sizeOf<JShortMarker>() * rangeLength);
+    final buffer = allocator<JShortMarker>(rangeLength);
     Jni.env.GetShortArrayRegion(reference.pointer, start, rangeLength, buffer);
     return buffer.asTypedList(rangeLength, finalizer: allocator._nativeFree);
   }
@@ -313,8 +310,7 @@ extension IntArray on JArray<jint> {
   Int32List getRange(int start, int end, {Allocator allocator = malloc}) {
     RangeError.checkValidRange(start, end, length);
     final rangeLength = end - start;
-    final buffer =
-        allocator.allocate<JIntMarker>(sizeOf<JIntMarker>() * rangeLength);
+    final buffer = allocator<JIntMarker>(rangeLength);
     Jni.env.GetIntArrayRegion(reference.pointer, start, rangeLength, buffer);
     return buffer.asTypedList(rangeLength, finalizer: allocator._nativeFree);
   }
@@ -349,8 +345,7 @@ extension LongArray on JArray<jlong> {
   Int64List getRange(int start, int end, {Allocator allocator = malloc}) {
     RangeError.checkValidRange(start, end, length);
     final rangeLength = end - start;
-    final buffer =
-        allocator.allocate<JLongMarker>(sizeOf<JLongMarker>() * rangeLength);
+    final buffer = allocator<JLongMarker>(rangeLength);
     Jni.env.GetLongArrayRegion(reference.pointer, start, rangeLength, buffer);
     return buffer.asTypedList(rangeLength, finalizer: allocator._nativeFree);
   }
@@ -385,8 +380,7 @@ extension FloatArray on JArray<jfloat> {
   Float32List getRange(int start, int end, {Allocator allocator = malloc}) {
     RangeError.checkValidRange(start, end, length);
     final rangeLength = end - start;
-    final buffer =
-        allocator.allocate<JFloatMarker>(sizeOf<JFloatMarker>() * rangeLength);
+    final buffer = allocator<JFloatMarker>(rangeLength);
     Jni.env.GetFloatArrayRegion(reference.pointer, start, rangeLength, buffer);
     return buffer.asTypedList(rangeLength, finalizer: allocator._nativeFree);
   }
@@ -421,8 +415,7 @@ extension DoubleArray on JArray<jdouble> {
   Float64List getRange(int start, int end, {Allocator allocator = malloc}) {
     RangeError.checkValidRange(start, end, length);
     final rangeLength = end - start;
-    final buffer = allocator
-        .allocate<JDoubleMarker>(sizeOf<JDoubleMarker>() * rangeLength);
+    final buffer = allocator<JDoubleMarker>(rangeLength);
     Jni.env.GetDoubleArrayRegion(reference.pointer, start, rangeLength, buffer);
     return buffer.asTypedList(rangeLength, finalizer: allocator._nativeFree);
   }

--- a/pkgs/jni/lib/src/jarray.dart
+++ b/pkgs/jni/lib/src/jarray.dart
@@ -5,6 +5,7 @@
 // ignore_for_file: unnecessary_cast, overridden_fields
 
 import 'dart:ffi';
+import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
 import 'package:ffi/ffi.dart';
@@ -141,6 +142,16 @@ extension NativeArray<E extends JPrimitive> on JArray<E> {
   }
 }
 
+extension on Allocator {
+  Pointer<NativeFinalizerFunction>? get _nativeFree {
+    return switch (this) {
+      malloc => malloc.nativeFree,
+      calloc => calloc.nativeFree,
+      _ => null,
+    };
+  }
+}
+
 extension BoolArray on JArray<jboolean> {
   bool operator [](int index) {
     return _elementAt(index, JniCallType.booleanType).boolean;
@@ -152,6 +163,16 @@ extension BoolArray on JArray<jboolean> {
       ptr.value = value ? 1 : 0;
       Jni.env.SetBooleanArrayRegion(reference.pointer, index, 1, ptr);
     });
+  }
+
+  Uint8List getRange(int start, int end, {Allocator allocator = malloc}) {
+    RangeError.checkValidRange(start, end, length);
+    final rangeLength = end - start;
+    final buffer = allocator
+        .allocate<JBooleanMarker>(sizeOf<JBooleanMarker>() * rangeLength);
+    Jni.env
+        .GetBooleanArrayRegion(reference.pointer, start, rangeLength, buffer);
+    return buffer.asTypedList(rangeLength, finalizer: allocator._nativeFree);
   }
 
   void setRange(int start, int end, Iterable<bool> iterable,
@@ -181,6 +202,15 @@ extension ByteArray on JArray<jbyte> {
     });
   }
 
+  Int8List getRange(int start, int end, {Allocator allocator = malloc}) {
+    RangeError.checkValidRange(start, end, length);
+    final rangeLength = end - start;
+    final buffer =
+        allocator.allocate<JByteMarker>(sizeOf<JByteMarker>() * rangeLength);
+    Jni.env.GetByteArrayRegion(reference.pointer, start, rangeLength, buffer);
+    return buffer.asTypedList(rangeLength, finalizer: allocator._nativeFree);
+  }
+
   void setRange(int start, int end, Iterable<int> iterable,
       [int skipCount = 0]) {
     RangeError.checkValidRange(start, end, length);
@@ -196,10 +226,8 @@ extension ByteArray on JArray<jbyte> {
 }
 
 extension CharArray on JArray<jchar> {
-  String operator [](int index) {
-    return String.fromCharCode(
-      _elementAt(index, JniCallType.charType).char,
-    );
+  int operator [](int index) {
+    return _elementAt(index, JniCallType.charType).char;
   }
 
   void operator []=(int index, int value) {
@@ -208,6 +236,15 @@ extension CharArray on JArray<jchar> {
       ptr.value = value;
       Jni.env.SetCharArrayRegion(reference.pointer, index, 1, ptr);
     });
+  }
+
+  Uint16List getRange(int start, int end, {Allocator allocator = malloc}) {
+    RangeError.checkValidRange(start, end, length);
+    final rangeLength = end - start;
+    final buffer =
+        allocator.allocate<JCharMarker>(sizeOf<JCharMarker>() * rangeLength);
+    Jni.env.GetCharArrayRegion(reference.pointer, start, rangeLength, buffer);
+    return buffer.asTypedList(rangeLength, finalizer: allocator._nativeFree);
   }
 
   void setRange(int start, int end, Iterable<int> iterable,
@@ -237,6 +274,15 @@ extension ShortArray on JArray<jshort> {
     });
   }
 
+  Int16List getRange(int start, int end, {Allocator allocator = malloc}) {
+    RangeError.checkValidRange(start, end, length);
+    final rangeLength = end - start;
+    final buffer =
+        allocator.allocate<JShortMarker>(sizeOf<JShortMarker>() * rangeLength);
+    Jni.env.GetShortArrayRegion(reference.pointer, start, rangeLength, buffer);
+    return buffer.asTypedList(rangeLength, finalizer: allocator._nativeFree);
+  }
+
   void setRange(int start, int end, Iterable<int> iterable,
       [int skipCount = 0]) {
     RangeError.checkValidRange(start, end, length);
@@ -262,6 +308,15 @@ extension IntArray on JArray<jint> {
       ptr.value = value;
       Jni.env.SetIntArrayRegion(reference.pointer, index, 1, ptr);
     });
+  }
+
+  Int32List getRange(int start, int end, {Allocator allocator = malloc}) {
+    RangeError.checkValidRange(start, end, length);
+    final rangeLength = end - start;
+    final buffer =
+        allocator.allocate<JIntMarker>(sizeOf<JIntMarker>() * rangeLength);
+    Jni.env.GetIntArrayRegion(reference.pointer, start, rangeLength, buffer);
+    return buffer.asTypedList(rangeLength, finalizer: allocator._nativeFree);
   }
 
   void setRange(int start, int end, Iterable<int> iterable,
@@ -291,6 +346,15 @@ extension LongArray on JArray<jlong> {
     });
   }
 
+  Int64List getRange(int start, int end, {Allocator allocator = malloc}) {
+    RangeError.checkValidRange(start, end, length);
+    final rangeLength = end - start;
+    final buffer =
+        allocator.allocate<JLongMarker>(sizeOf<JLongMarker>() * rangeLength);
+    Jni.env.GetLongArrayRegion(reference.pointer, start, rangeLength, buffer);
+    return buffer.asTypedList(rangeLength, finalizer: allocator._nativeFree);
+  }
+
   void setRange(int start, int end, Iterable<int> iterable,
       [int skipCount = 0]) {
     RangeError.checkValidRange(start, end, length);
@@ -318,6 +382,15 @@ extension FloatArray on JArray<jfloat> {
     });
   }
 
+  Float32List getRange(int start, int end, {Allocator allocator = malloc}) {
+    RangeError.checkValidRange(start, end, length);
+    final rangeLength = end - start;
+    final buffer =
+        allocator.allocate<JFloatMarker>(sizeOf<JFloatMarker>() * rangeLength);
+    Jni.env.GetFloatArrayRegion(reference.pointer, start, rangeLength, buffer);
+    return buffer.asTypedList(rangeLength, finalizer: allocator._nativeFree);
+  }
+
   void setRange(int start, int end, Iterable<double> iterable,
       [int skipCount = 0]) {
     RangeError.checkValidRange(start, end, length);
@@ -343,6 +416,15 @@ extension DoubleArray on JArray<jdouble> {
       ptr.value = value;
       Jni.env.SetDoubleArrayRegion(reference.pointer, index, 1, ptr);
     });
+  }
+
+  Float64List getRange(int start, int end, {Allocator allocator = malloc}) {
+    RangeError.checkValidRange(start, end, length);
+    final rangeLength = end - start;
+    final buffer = allocator
+        .allocate<JDoubleMarker>(sizeOf<JDoubleMarker>() * rangeLength);
+    Jni.env.GetDoubleArrayRegion(reference.pointer, start, rangeLength, buffer);
+    return buffer.asTypedList(rangeLength, finalizer: allocator._nativeFree);
   }
 
   void setRange(int start, int end, Iterable<double> iterable,

--- a/pkgs/jni/lib/src/third_party/global_env_extensions.dart
+++ b/pkgs/jni/lib/src/third_party/global_env_extensions.dart
@@ -1491,6 +1491,49 @@ class JniAccessors {
   JniResult getArrayElement(JArrayPtr array, int index, int type) =>
       _getArrayElement(array, index, type);
 
+  late final _setBooleanArrayElement = ptr.ref.setBooleanArrayElement
+      .asFunction<
+          JThrowablePtr Function(JArrayPtr array, int index, int value)>();
+  JThrowablePtr setBooleanArrayElement(JArrayPtr array, int index, int value) =>
+      _setBooleanArrayElement(array, index, value);
+
+  late final _setByteArrayElement = ptr.ref.setByteArrayElement.asFunction<
+      JThrowablePtr Function(JArrayPtr array, int index, int value)>();
+  JThrowablePtr setByteArrayElement(JArrayPtr array, int index, int value) =>
+      _setByteArrayElement(array, index, value);
+
+  late final _setShortArrayElement = ptr.ref.setShortArrayElement.asFunction<
+      JThrowablePtr Function(JArrayPtr array, int index, int value)>();
+  JThrowablePtr setShortArrayElement(JArrayPtr array, int index, int value) =>
+      _setShortArrayElement(array, index, value);
+
+  late final _setCharArrayElement = ptr.ref.setCharArrayElement.asFunction<
+      JThrowablePtr Function(JArrayPtr array, int index, int value)>();
+  JThrowablePtr setCharArrayElement(JArrayPtr array, int index, int value) =>
+      _setCharArrayElement(array, index, value);
+
+  late final _setIntArrayElement = ptr.ref.setIntArrayElement.asFunction<
+      JThrowablePtr Function(JArrayPtr array, int index, int value)>();
+  JThrowablePtr setIntArrayElement(JArrayPtr array, int index, int value) =>
+      _setIntArrayElement(array, index, value);
+
+  late final _setLongArrayElement = ptr.ref.setLongArrayElement.asFunction<
+      JThrowablePtr Function(JArrayPtr array, int index, int value)>();
+  JThrowablePtr setLongArrayElement(JArrayPtr array, int index, int value) =>
+      _setLongArrayElement(array, index, value);
+
+  late final _setFloatArrayElement = ptr.ref.setFloatArrayElement.asFunction<
+      JThrowablePtr Function(JArrayPtr array, int index, double value)>();
+  JThrowablePtr setFloatArrayElement(
+          JArrayPtr array, int index, double value) =>
+      _setFloatArrayElement(array, index, value);
+
+  late final _setDoubleArrayElement = ptr.ref.setDoubleArrayElement.asFunction<
+      JThrowablePtr Function(JArrayPtr array, int index, double value)>();
+  JThrowablePtr setDoubleArrayElement(
+          JArrayPtr array, int index, double value) =>
+      _setDoubleArrayElement(array, index, value);
+
   late final _callMethod = ptr.ref.callMethod.asFunction<
       JniResult Function(JObjectPtr obj, JMethodIDPtr methodID, int callType,
           ffi.Pointer<JValue> args)>();

--- a/pkgs/jni/lib/src/third_party/jni_bindings_generated.dart
+++ b/pkgs/jni/lib/src/third_party/jni_bindings_generated.dart
@@ -443,6 +443,54 @@ final class JniAccessorsStruct extends ffi.Struct {
       getArrayElement;
 
   external ffi.Pointer<
+          ffi.NativeFunction<
+              JThrowablePtr Function(
+                  JArrayPtr array, ffi.Int index, JBooleanMarker value)>>
+      setBooleanArrayElement;
+
+  external ffi.Pointer<
+          ffi.NativeFunction<
+              JThrowablePtr Function(
+                  JArrayPtr array, ffi.Int index, JByteMarker value)>>
+      setByteArrayElement;
+
+  external ffi.Pointer<
+          ffi.NativeFunction<
+              JThrowablePtr Function(
+                  JArrayPtr array, ffi.Int index, JShortMarker value)>>
+      setShortArrayElement;
+
+  external ffi.Pointer<
+          ffi.NativeFunction<
+              JThrowablePtr Function(
+                  JArrayPtr array, ffi.Int index, JCharMarker value)>>
+      setCharArrayElement;
+
+  external ffi.Pointer<
+          ffi.NativeFunction<
+              JThrowablePtr Function(
+                  JArrayPtr array, ffi.Int index, JIntMarker value)>>
+      setIntArrayElement;
+
+  external ffi.Pointer<
+          ffi.NativeFunction<
+              JThrowablePtr Function(
+                  JArrayPtr array, ffi.Int index, JLongMarker value)>>
+      setLongArrayElement;
+
+  external ffi.Pointer<
+          ffi.NativeFunction<
+              JThrowablePtr Function(
+                  JArrayPtr array, ffi.Int index, JFloatMarker value)>>
+      setFloatArrayElement;
+
+  external ffi.Pointer<
+          ffi.NativeFunction<
+              JThrowablePtr Function(
+                  JArrayPtr array, ffi.Int index, JDoubleMarker value)>>
+      setDoubleArrayElement;
+
+  external ffi.Pointer<
       ffi.NativeFunction<
           JniResult Function(JObjectPtr obj, JMethodIDPtr methodID,
               ffi.Int callType, ffi.Pointer<JValue> args)>> callMethod;

--- a/pkgs/jni/src/dartjni.c
+++ b/pkgs/jni/src/dartjni.c
@@ -517,6 +517,62 @@ JniResult getArrayElement(jarray array, int index, int type) {
   return jniResult;
 }
 
+jthrowable setBooleanArrayElement(jarray array, int index, jboolean value) {
+  attach_thread();
+  (*jniEnv)->SetBooleanArrayRegion(jniEnv, array, index, 1, &value);
+  jthrowable exception = check_exception();
+  return exception;
+}
+
+jthrowable setByteArrayElement(jarray array, int index, jbyte value) {
+  attach_thread();
+  (*jniEnv)->SetByteArrayRegion(jniEnv, array, index, 1, &value);
+  jthrowable exception = check_exception();
+  return exception;
+}
+
+jthrowable setShortArrayElement(jarray array, int index, jshort value) {
+  attach_thread();
+  (*jniEnv)->SetShortArrayRegion(jniEnv, array, index, 1, &value);
+  jthrowable exception = check_exception();
+  return exception;
+}
+
+jthrowable setCharArrayElement(jarray array, int index, jchar value) {
+  attach_thread();
+  (*jniEnv)->SetCharArrayRegion(jniEnv, array, index, 1, &value);
+  jthrowable exception = check_exception();
+  return exception;
+}
+
+jthrowable setIntArrayElement(jarray array, int index, jint value) {
+  attach_thread();
+  (*jniEnv)->SetIntArrayRegion(jniEnv, array, index, 1, &value);
+  jthrowable exception = check_exception();
+  return exception;
+}
+
+jthrowable setLongArrayElement(jarray array, int index, jlong value) {
+  attach_thread();
+  (*jniEnv)->SetLongArrayRegion(jniEnv, array, index, 1, &value);
+  jthrowable exception = check_exception();
+  return exception;
+}
+
+jthrowable setFloatArrayElement(jarray array, int index, jfloat value) {
+  attach_thread();
+  (*jniEnv)->SetFloatArrayRegion(jniEnv, array, index, 1, &value);
+  jthrowable exception = check_exception();
+  return exception;
+}
+
+jthrowable setDoubleArrayElement(jarray array, int index, jdouble value) {
+  attach_thread();
+  (*jniEnv)->SetDoubleArrayRegion(jniEnv, array, index, 1, &value);
+  jthrowable exception = check_exception();
+  return exception;
+}
+
 JniExceptionDetails getExceptionDetails(jthrowable exception) {
   JniExceptionDetails details;
   details.message = (*jniEnv)->CallObjectMethod(
@@ -552,6 +608,14 @@ JniAccessorsStruct accessors = {
     .newPrimitiveArray = newPrimitiveArray,
     .newObjectArray = newObjectArray,
     .getArrayElement = getArrayElement,
+    .setBooleanArrayElement = setBooleanArrayElement,
+    .setByteArrayElement = setByteArrayElement,
+    .setShortArrayElement = setShortArrayElement,
+    .setCharArrayElement = setCharArrayElement,
+    .setIntArrayElement = setIntArrayElement,
+    .setLongArrayElement = setLongArrayElement,
+    .setFloatArrayElement = setFloatArrayElement,
+    .setDoubleArrayElement = setDoubleArrayElement,
     .callMethod = callMethod,
     .callStaticMethod = callStaticMethod,
     .getField = getField,

--- a/pkgs/jni/src/dartjni.h
+++ b/pkgs/jni/src/dartjni.h
@@ -228,6 +228,14 @@ typedef struct JniAccessorsStruct {
                               jclass elementClass,
                               jobject initialElement);
   JniResult (*getArrayElement)(jarray array, int index, int type);
+  jthrowable (*setBooleanArrayElement)(jarray array, int index, jboolean value);
+  jthrowable (*setByteArrayElement)(jarray array, int index, jbyte value);
+  jthrowable (*setShortArrayElement)(jarray array, int index, jshort value);
+  jthrowable (*setCharArrayElement)(jarray array, int index, jchar value);
+  jthrowable (*setIntArrayElement)(jarray array, int index, jint value);
+  jthrowable (*setLongArrayElement)(jarray array, int index, jlong value);
+  jthrowable (*setFloatArrayElement)(jarray array, int index, jfloat value);
+  jthrowable (*setDoubleArrayElement)(jarray array, int index, jdouble value);
   JniResult (*callMethod)(jobject obj,
                           jmethodID methodID,
                           int callType,

--- a/pkgs/jni/src/dartjni.h
+++ b/pkgs/jni/src/dartjni.h
@@ -343,29 +343,6 @@ static inline jobject to_global_ref(jobject ref) {
   return g;
 }
 
-// These functions are useful for C+Dart bindings, and not required for pure dart bindings.
-
-FFI_PLUGIN_EXPORT JniContext* GetJniContextPtr();
-
-/// For use by jni_gen's generated code
-/// don't use these.
-
-// these 2 fn ptr vars will be defined by generated code library
-extern JniContext* (*context_getter)(void);
-extern JNIEnv* (*env_getter)(void);
-
-// this function will be exported by generated code library
-// it will set above 2 variables.
-FFI_PLUGIN_EXPORT void setJniGetters(struct JniContext* (*cg)(void),
-                                     JNIEnv* (*eg)(void));
-
-static inline void load_env() {
-  if (jniEnv == NULL) {
-    jni = context_getter();
-    jniEnv = env_getter();
-  }
-}
-
 static inline jthrowable check_exception() {
   jthrowable exception = (*jniEnv)->ExceptionOccurred(jniEnv);
   if (exception != NULL) (*jniEnv)->ExceptionClear(jniEnv);

--- a/pkgs/jni/test/jarray_test.dart
+++ b/pkgs/jni/test/jarray_test.dart
@@ -60,16 +60,16 @@ void run({required TestRunnerCallback testRunner}) {
     using((arena) {
       final array = JArray(jchar.type, 3)..releasedBy(arena);
       expect(array.length, 3);
-      array[0] = '~'.codeUnitAt(0);
+      array[0] = 'ح'.codeUnitAt(0);
       array[1] = '2'.codeUnitAt(0);
       array[2] = '3'.codeUnitAt(0);
-      expect(array[0], '~'.codeUnitAt(0));
+      expect(array[0], 'ح'.codeUnitAt(0));
       expect(array[1], '2'.codeUnitAt(0));
       expect(array[2], '3'.codeUnitAt(0));
       final firstTwo = array.getRange(0, 2);
       expect(firstTwo.length, 2);
       expect(firstTwo.elementSizeInBytes, sizeOf<JCharMarker>());
-      expect(firstTwo[0], '~'.codeUnitAt(0));
+      expect(firstTwo[0], 'ح'.codeUnitAt(0));
       expect(firstTwo[1], '2'.codeUnitAt(0));
       expect(() {
         array.getRange(0, 4);

--- a/pkgs/jni/test/jarray_test.dart
+++ b/pkgs/jni/test/jarray_test.dart
@@ -60,44 +60,35 @@ void run({required TestRunnerCallback testRunner}) {
     using((arena) {
       final array = JArray(jchar.type, 3)..releasedBy(arena);
       expect(array.length, 3);
-      array[0] = 'ح'.codeUnitAt(0);
-      array[1] = '2'.codeUnitAt(0);
-      array[2] = '3'.codeUnitAt(0);
-      expect(array[0], 'ح'.codeUnitAt(0));
-      expect(array[1], '2'.codeUnitAt(0));
-      expect(array[2], '3'.codeUnitAt(0));
+      array[0] = 1;
+      array[1] = 2;
+      array[2] = 3 + 256 * 256 * 5; // Truncates the input.
+      expect(array[0], 1);
+      expect(array[1], 2);
+      expect(array[2], 3);
       final firstTwo = array.getRange(0, 2);
       expect(firstTwo.length, 2);
       expect(firstTwo.elementSizeInBytes, sizeOf<JCharMarker>());
-      expect(firstTwo[0], 'ح'.codeUnitAt(0));
-      expect(firstTwo[1], '2'.codeUnitAt(0));
+      expect(firstTwo[0], 1);
+      expect(firstTwo[1], 2);
       expect(() {
         array.getRange(0, 4);
       }, throwsRangeError);
       expect(() {
         array.setRange(0, 4, []);
       }, throwsRangeError);
-      array.setRange(
-          0,
-          3,
-          [
-            '4'.codeUnitAt(0),
-            '5'.codeUnitAt(0),
-            '6'.codeUnitAt(0),
-            '7'.codeUnitAt(0)
-          ],
-          1);
-      expect(array[0], '5'.codeUnitAt(0));
-      expect(array[1], '6'.codeUnitAt(0));
-      expect(array[2], '7'.codeUnitAt(0));
+      array.setRange(0, 3, [4, 5, 6, 7], 1);
+      expect(array[0], 5);
+      expect(array[1], 6);
+      expect(array[2], 7);
       expect(() {
         final _ = array[-1];
       }, throwsRangeError);
       expect(() {
-        array[-1] = '4'.codeUnitAt(0);
+        array[-1] = 4;
       }, throwsRangeError);
       expect(() {
-        array[3] = '4'.codeUnitAt(0);
+        array[3] = 4;
       }, throwsRangeError);
     });
   });
@@ -107,7 +98,7 @@ void run({required TestRunnerCallback testRunner}) {
       expect(array.length, 3);
       array[0] = 1;
       array[1] = 2;
-      array[2] = 3 + 256 * 5; // truncates the input;
+      array[2] = 3 + 256 * 5; // Truncates the input.;
       expect(array[0], 1);
       expect(array[1], 2);
       expect(array[2], 3);
@@ -143,7 +134,7 @@ void run({required TestRunnerCallback testRunner}) {
       expect(array.length, 3);
       array[0] = 1;
       array[1] = 2;
-      array[2] = 3 + 256 * 256 * 5; // truncates the input
+      array[2] = 3 + 256 * 256 * 5; // Truncates the input.
       expect(array[0], 1);
       expect(array[1], 2);
       expect(array[2], 3);
@@ -179,7 +170,7 @@ void run({required TestRunnerCallback testRunner}) {
       expect(array.length, 3);
       array[0] = 1;
       array[1] = 2;
-      array[2] = 3 + 256 * 256 * 256 * 256 * 5; // truncates the input
+      array[2] = 3 + 256 * 256 * 256 * 256 * 5; // Truncates the input.
       expect(array[0], 1);
       expect(array[1], 2);
       expect(array[2], 3);

--- a/pkgs/jni/test/jarray_test.dart
+++ b/pkgs/jni/test/jarray_test.dart
@@ -48,24 +48,33 @@ void run({required TestRunnerCallback testRunner}) {
     using((arena) {
       final array = JArray(jchar.type, 3)..releasedBy(arena);
       expect(array.length, 3);
-      array[0] = 'ح';
-      array[1] = '2';
-      array[2] = '3';
-      expect(array[0], 'ح');
-      expect(array[1], '2');
-      expect(array[2], '3');
-      array.setRange(0, 3, ['4', '5', '6', '7'], 1);
-      expect(array[0], '5');
-      expect(array[1], '6');
-      expect(array[2], '7');
+      array[0] = '~'.codeUnitAt(0);
+      array[1] = '2'.codeUnitAt(0);
+      array[2] = '3'.codeUnitAt(0);
+      expect(array[0], '~'.codeUnitAt(0));
+      expect(array[1], '2'.codeUnitAt(0));
+      expect(array[2], '3'.codeUnitAt(0));
+      array.setRange(
+          0,
+          3,
+          [
+            '4'.codeUnitAt(0),
+            '5'.codeUnitAt(0),
+            '6'.codeUnitAt(0),
+            '7'.codeUnitAt(0)
+          ],
+          1);
+      expect(array[0], '5'.codeUnitAt(0));
+      expect(array[1], '6'.codeUnitAt(0));
+      expect(array[2], '7'.codeUnitAt(0));
       expect(() {
         final _ = array[-1];
       }, throwsRangeError);
       expect(() {
-        array[-1] = '4';
+        array[-1] = '4'.codeUnitAt(0);
       }, throwsRangeError);
       expect(() {
-        array[3] = '4';
+        array[3] = '4'.codeUnitAt(0);
       }, throwsRangeError);
     });
   });

--- a/pkgs/jni/test/jarray_test.dart
+++ b/pkgs/jni/test/jarray_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:ffi';
 import 'dart:io';
 
 import 'package:jni/jni.dart';
@@ -29,6 +30,17 @@ void run({required TestRunnerCallback testRunner}) {
       expect(array[0], true);
       expect(array[1], false);
       expect(array[2], false);
+      final firstTwo = array.getRange(0, 2);
+      expect(firstTwo.length, 2);
+      expect(firstTwo.elementSizeInBytes, sizeOf<JBooleanMarker>());
+      expect(firstTwo[0], 1);
+      expect(firstTwo[1], 0);
+      expect(() {
+        array.getRange(0, 4);
+      }, throwsRangeError);
+      expect(() {
+        array.setRange(0, 4, []);
+      }, throwsRangeError);
       array.setRange(0, 3, [false, true, true, true], 1);
       expect(array[0], true);
       expect(array[1], true);
@@ -54,6 +66,17 @@ void run({required TestRunnerCallback testRunner}) {
       expect(array[0], '~'.codeUnitAt(0));
       expect(array[1], '2'.codeUnitAt(0));
       expect(array[2], '3'.codeUnitAt(0));
+      final firstTwo = array.getRange(0, 2);
+      expect(firstTwo.length, 2);
+      expect(firstTwo.elementSizeInBytes, sizeOf<JCharMarker>());
+      expect(firstTwo[0], '~'.codeUnitAt(0));
+      expect(firstTwo[1], '2'.codeUnitAt(0));
+      expect(() {
+        array.getRange(0, 4);
+      }, throwsRangeError);
+      expect(() {
+        array.setRange(0, 4, []);
+      }, throwsRangeError);
       array.setRange(
           0,
           3,
@@ -88,6 +111,17 @@ void run({required TestRunnerCallback testRunner}) {
       expect(array[0], 1);
       expect(array[1], 2);
       expect(array[2], 3);
+      final firstTwo = array.getRange(0, 2);
+      expect(firstTwo.length, 2);
+      expect(firstTwo.elementSizeInBytes, sizeOf<JByteMarker>());
+      expect(firstTwo[0], 1);
+      expect(firstTwo[1], 2);
+      expect(() {
+        array.getRange(0, 4);
+      }, throwsRangeError);
+      expect(() {
+        array.setRange(0, 4, []);
+      }, throwsRangeError);
       array.setRange(0, 3, [4, 5, 6, 7], 1);
       expect(array[0], 5);
       expect(array[1], 6);
@@ -113,6 +147,17 @@ void run({required TestRunnerCallback testRunner}) {
       expect(array[0], 1);
       expect(array[1], 2);
       expect(array[2], 3);
+      final firstTwo = array.getRange(0, 2);
+      expect(firstTwo.length, 2);
+      expect(firstTwo.elementSizeInBytes, sizeOf<JShortMarker>());
+      expect(firstTwo[0], 1);
+      expect(firstTwo[1], 2);
+      expect(() {
+        array.getRange(0, 4);
+      }, throwsRangeError);
+      expect(() {
+        array.setRange(0, 4, []);
+      }, throwsRangeError);
       array.setRange(0, 3, [4, 5, 6, 7], 1);
       expect(array[0], 5);
       expect(array[1], 6);
@@ -138,6 +183,17 @@ void run({required TestRunnerCallback testRunner}) {
       expect(array[0], 1);
       expect(array[1], 2);
       expect(array[2], 3);
+      final firstTwo = array.getRange(0, 2);
+      expect(firstTwo.length, 2);
+      expect(firstTwo.elementSizeInBytes, sizeOf<JIntMarker>());
+      expect(firstTwo[0], 1);
+      expect(firstTwo[1], 2);
+      expect(() {
+        array.getRange(0, 4);
+      }, throwsRangeError);
+      expect(() {
+        array.setRange(0, 4, []);
+      }, throwsRangeError);
       array.setRange(0, 3, [4, 5, 6, 7], 1);
       expect(array[0], 5);
       expect(array[1], 6);
@@ -163,6 +219,17 @@ void run({required TestRunnerCallback testRunner}) {
       expect(array[0], 1);
       expect(array[1], 2);
       expect(array[2], 3 + 256 * 256 * 256 * 256 * 5);
+      final firstTwo = array.getRange(0, 2);
+      expect(firstTwo.length, 2);
+      expect(firstTwo.elementSizeInBytes, sizeOf<JLongMarker>());
+      expect(firstTwo[0], 1);
+      expect(firstTwo[1], 2);
+      expect(() {
+        array.getRange(0, 4);
+      }, throwsRangeError);
+      expect(() {
+        array.setRange(0, 4, []);
+      }, throwsRangeError);
       array.setRange(0, 3, [4, 5, 6, 7], 1);
       expect(array[0], 5);
       expect(array[1], 6);
@@ -189,6 +256,17 @@ void run({required TestRunnerCallback testRunner}) {
       expect(array[0], closeTo(0.5, epsilon));
       expect(array[1], closeTo(2, epsilon));
       expect(array[2], closeTo(3, epsilon));
+      final firstTwo = array.getRange(0, 2);
+      expect(firstTwo.length, 2);
+      expect(firstTwo.elementSizeInBytes, sizeOf<JFloatMarker>());
+      expect(firstTwo[0], closeTo(0.5, epsilon));
+      expect(firstTwo[1], closeTo(2, epsilon));
+      expect(() {
+        array.getRange(0, 4);
+      }, throwsRangeError);
+      expect(() {
+        array.setRange(0, 4, []);
+      }, throwsRangeError);
       array.setRange(0, 3, [4, 5, 6, 7], 1);
       expect(array[0], closeTo(5, epsilon));
       expect(array[1], closeTo(6, epsilon));
@@ -214,6 +292,17 @@ void run({required TestRunnerCallback testRunner}) {
       expect(array[0], closeTo(0.5, epsilon));
       expect(array[1], closeTo(2, epsilon));
       expect(array[2], closeTo(3, epsilon));
+      final firstTwo = array.getRange(0, 2);
+      expect(firstTwo.length, 2);
+      expect(firstTwo.elementSizeInBytes, sizeOf<JDoubleMarker>());
+      expect(firstTwo[0], closeTo(0.5, epsilon));
+      expect(firstTwo[1], closeTo(2, epsilon));
+      expect(() {
+        array.getRange(0, 4);
+      }, throwsRangeError);
+      expect(() {
+        array.setRange(0, 4, []);
+      }, throwsRangeError);
       array.setRange(0, 3, [4, 5, 6, 7], 1);
       expect(array[0], closeTo(5, epsilon));
       expect(array[1], closeTo(6, epsilon));


### PR DESCRIPTION
* Close #990
* Convert the return type of `operator []` of `JArray<jchar>` to `int`, to be more consistent with the `getRange` return type. Similarly `operator []=` gets an `int` now
* Remove some unused functions in `dartjni.c`
* Use `.asTypedList(len).setRange` in `setRange` to be more efficient (~5x faster on my machine)
* Close #1097 – Improve the performance of`JArray`'s `operator []=` (~70% faster on my machine)