### PR TITLE
[jnigen] Fix summarizer and improve errors

### DIFF
--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 - **Breaking Change** ([#660](https://github.com/dart-lang/native/issues/660)):
   Removed C-based bindings. Now all bindings are Dart-only.
-- Expand constraint on `package:cli_config` to allow `^0.2.0`.
-- Ignore `use_super_parameters` lint in generated files.
+- Expanded constraint on `package:cli_config` to allow `^0.2.0`.
+- Ignored `use_super_parameters` lint in generated files.
+- Fixed a bug in summarizer and improved the display of errors.
 
 ## 0.8.0
 

--- a/pkgs/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/SummarizerOptions.java
+++ b/pkgs/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/SummarizerOptions.java
@@ -1,5 +1,6 @@
 package com.github.dart_lang.jnigen.apisummarizer;
 
+import java.io.PrintWriter;
 import java.util.Arrays;
 import org.apache.commons.cli.*;
 
@@ -63,15 +64,22 @@ public class SummarizerOptions {
     try {
       cmd = parser.parse(options, args);
       if (cmd.getArgs().length < 1) {
-        throw new ParseException("Need to specify paths to source files");
+        throw new ParseException("Need to specify the package or class names");
       }
     } catch (ParseException e) {
-      System.out.println(e.getMessage());
+      System.err.println(e.getMessage());
       help.printHelp(
+          new PrintWriter(System.err, true),
+          help.getWidth(),
           "java -jar <JAR> [-s <SOURCE_DIR=.>] "
               + "[-c <CLASSES_JAR>] <CLASS_OR_PACKAGE_NAMES>\n"
               + "Class or package names should be fully qualified.\n\n",
-          options);
+          null,
+          options,
+          help.getLeftPadding(),
+          help.getDescPadding(),
+          null,
+          false);
       System.exit(1);
       throw new RuntimeException("Unreachable code");
     }

--- a/pkgs/jnigen/lib/src/summary/summary.dart
+++ b/pkgs/jnigen/lib/src/summary/summary.dart
@@ -71,11 +71,7 @@ class SummarizerCommand {
       final joined = paths
           .map((uri) => uri.toFilePath())
           .join(Platform.isWindows ? ';' : ':');
-      if (option.endsWith("=")) {
-        args.add(option + joined);
-      } else {
-        args.addAll([option, joined]);
-      }
+      args.addAll([option, '"$joined"']);
     }
   }
 


### PR DESCRIPTION
Close #877

Character `;` in Windows with `ja-JP` locale was treated as the end of the command. This was not the case in `en-US` locale so we didn't catch that. Thanks to @glanium for reporting this.

The fix is to wrap the paths in double quotes.

Also printing the errors in `stderr` instead of `stdout` so users can actually see what is wrong.