### PR TITLE
[infra] Swap weekly bot to x64

### DIFF
--- a/.github/workflows/ffigen_weekly.yml
+++ b/.github/workflows/ffigen_weekly.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   # Keep in sync with ffigen.yaml:test-mac
   test-mac-arm64:
-    runs-on: 'macos-latest-xlarge' # Arm64.
+    runs-on: 'macos-14-large' # x64
     defaults:
       run:
         working-directory: pkgs/ffigen/


### PR DESCRIPTION
`macos-latest` is now arm64. So in order to also have x64 coverage, swap the weekly bot to be an `x64` bot.

* https://github.com/dart-lang/native/issues/1115#issuecomment-2088093374