### PR TITLE
[jnigen] Fix summarizer encoding

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.9.1-wip
+## 0.9.1
 
-- Fix compilation on macOS for consumers that don't use JNI on macOS (which is still not supported) ([#1122](https://github.com/dart-lang/native/pull/1122)). 
+- Fixed compilation on macOS for consumers that don't use JNI on macOS (which is
+  still not supported) ([#1122](https://github.com/dart-lang/native/pull/1122)).
 
 ## 0.9.0
 

--- a/pkgs/jni/pubspec.yaml
+++ b/pkgs/jni/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jni
 description: A library to access JNI from Dart and Flutter that acts as a support library for package:jnigen.
-version: 0.9.1-wip
+version: 0.9.1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jni
 
 topics:

--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.1
+
+- Fixed a bug in summarizer where standard output would use the default encoding
+  of the operating system and therefore breaking the UTF-8 decoding for some
+  locales.
+
 ## 0.9.0
 
 - **Breaking Change** ([#660](https://github.com/dart-lang/native/issues/660)):

--- a/pkgs/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/Main.java
+++ b/pkgs/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/Main.java
@@ -11,10 +11,8 @@ import com.github.dart_lang.jnigen.apisummarizer.util.ClassFinder;
 import com.github.dart_lang.jnigen.apisummarizer.util.InputStreamProvider;
 import com.github.dart_lang.jnigen.apisummarizer.util.JsonWriter;
 import com.github.dart_lang.jnigen.apisummarizer.util.StreamUtil;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.OutputStream;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import javax.tools.DocumentationTool;
 import javax.tools.JavaFileObject;
@@ -65,7 +63,7 @@ public class Main {
     OutputStream output;
 
     if (options.outputFile == null || options.outputFile.equals("-")) {
-      output = System.out;
+      output = new PrintStream(System.out, true, StandardCharsets.UTF_8);
     } else {
       output = new FileOutputStream(options.outputFile);
     }

--- a/pkgs/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/Main.java
+++ b/pkgs/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/Main.java
@@ -48,7 +48,7 @@ public class Main {
       cli.addAll(List.of(options.toolArgs.split(" ")));
     }
 
-    javaDoc.getTask(null, fileManager, System.err::println, docletClass, cli, fileObjects).call();
+    javaDoc.getTask(null, fileManager, stderr::println, docletClass, cli, fileObjects).call();
 
     return SummarizerDoclet.getClasses();
   }
@@ -57,6 +57,8 @@ public class Main {
       DocumentationTool javaDoc, List<JavaFileObject> javaFileObjects, SummarizerOptions options) {
     return runDocletWithClass(javaDoc, SummarizerDoclet.class, javaFileObjects, options);
   }
+
+  static final PrintStream stderr = new PrintStream(System.err, true, StandardCharsets.UTF_8);
 
   public static void main(String[] args) throws FileNotFoundException {
     options = SummarizerOptions.parseArgs(args);
@@ -105,7 +107,7 @@ public class Main {
     }
 
     if (!notFound.isEmpty()) {
-      System.err.println("Not found: " + notFound);
+      stderr.println("Not found: " + notFound);
       System.exit(1);
     }
 

--- a/pkgs/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/SummarizerOptions.java
+++ b/pkgs/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/SummarizerOptions.java
@@ -67,9 +67,9 @@ public class SummarizerOptions {
         throw new ParseException("Need to specify the package or class names");
       }
     } catch (ParseException e) {
-      System.err.println(e.getMessage());
+      Main.stderr.println(e.getMessage());
       help.printHelp(
-          new PrintWriter(System.err, true),
+          new PrintWriter(Main.stderr, true),
           help.getWidth(),
           "java -jar <JAR> [-s <SOURCE_DIR=.>] "
               + "[-c <CLASSES_JAR>] <CLASS_OR_PACKAGE_NAMES>\n"

--- a/pkgs/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/util/Log.java
+++ b/pkgs/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/util/Log.java
@@ -4,11 +4,24 @@
 
 package com.github.dart_lang.jnigen.apisummarizer.util;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.logging.Level;
+import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 public class Log {
   private static final Logger logger = Logger.getLogger("ApiSummarizer");
+
+  static {
+    try {
+      InputStream stream = Log.class.getResourceAsStream("/logging.properties");
+      LogManager.getLogManager().readConfiguration(stream);
+      LogManager.getLogManager().addLogger(logger);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   private static void log(Level level, String format, Object... args) {
     String formatted = String.format(format, args);

--- a/pkgs/jnigen/java/src/main/resources/logging.properties
+++ b/pkgs/jnigen/java/src/main/resources/logging.properties
@@ -1,0 +1,6 @@
+handlers = java.util.logging.ConsoleHandler
+
+java.util.logging.FileHandler.encoding = UTF-8
+
+.level = INFO
+

--- a/pkgs/jnigen/pubspec.yaml
+++ b/pkgs/jnigen/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jnigen
 description: A Dart bindings generator for Java and Kotlin that uses JNI under the hood to interop with Java virtual machine.
-version: 0.9.0
+version: 0.9.1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jnigen
 
 environment:


### PR DESCRIPTION
Closes #1118

@glanium Please check if this works for you.

Use this dev dependency to test:

```yaml
jnigen:
  git:
    url: https://github.com/dart-lang/native
    ref: fix-encoding
    path: pkgs/jnigen/
```