### PR TITLE
[jnigen] Use utf-8 for standard error and standard out encoding

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.9.1-wip
+## 0.9.1
 
-- Fix compilation on macOS for consumers that don't use JNI on macOS (which is still not supported) ([#1122](https://github.com/dart-lang/native/pull/1122)). 
+- Fixed compilation on macOS for consumers that don't use JNI on macOS (which is
+  still not supported) ([#1122](https://github.com/dart-lang/native/pull/1122)).
 
 ## 0.9.0
 

--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.1
+
+- Fixed a bug in summarizer where standard output would use the default encoding
+  of the operating system and therefore breaking the UTF-8 decoding for some
+  locales.
+
 ## 0.9.0
 
 - **Breaking Change** ([#660](https://github.com/dart-lang/native/issues/660)):

--- a/pkgs/jnigen/lib/src/summary/summary.dart
+++ b/pkgs/jnigen/lib/src/summary/summary.dart
@@ -88,8 +88,12 @@ class SummarizerCommand {
     args.addAll(extraArgs);
     args.addAll(classes);
     log.info('execute $exec ${args.join(' ')}');
-    final proc = await Process.start(exec, args,
-        workingDirectory: workingDirectory?.toFilePath() ?? '.');
+    final proc = await Process.start(
+      exec,
+      args,
+      workingDirectory: workingDirectory?.toFilePath() ?? '.',
+      environment: {'JAVA_TOOL_OPTIONS': '-Dfile.encoding=UTF8'},
+    );
     return proc;
   }
 }


### PR DESCRIPTION
Trying again, this time using an environment variable. This seems to be working on my machine.

Closes #1118

@glanium Please check if this works for you.

**The branch is now `fix-encoding-2`**

Use this dev dependency to test:

```yaml
jnigen:
  git:
    url: https://github.com/dart-lang/native
    ref: fix-encoding-2
    path: pkgs/jnigen/
```