### PR TITLE
[native_assets_builder] Add dry run for link.dart

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.7.0-wip
 
 - Add support for `hook/link.dart` including dry runs.
+  Link hooks that do not have assets for link sent to them, are not run.
+  Link hooks are not ordered.
 - Fix test.
 
 ## 0.6.0

--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.7.0-wip
 
+- Add support for `hook/link.dart` including dry runs.
 - Fix test.
-- Add support for `hook/link.dart`.
 
 ## 0.6.0
 

--- a/pkgs/native_assets_builder/lib/native_assets_builder.dart
+++ b/pkgs/native_assets_builder/lib/native_assets_builder.dart
@@ -4,7 +4,8 @@
 
 export 'package:native_assets_builder/src/build_runner/build_runner.dart';
 export 'package:native_assets_builder/src/model/build_result.dart';
-export 'package:native_assets_builder/src/model/dry_run_result.dart';
+export 'package:native_assets_builder/src/model/build_dry_run_result.dart';
 export 'package:native_assets_builder/src/model/kernel_assets.dart';
 export 'package:native_assets_builder/src/model/link_result.dart';
+export 'package:native_assets_builder/src/model/link_dry_run_result.dart';
 export 'package:native_assets_builder/src/package_layout/package_layout.dart';

--- a/pkgs/native_assets_builder/lib/native_assets_builder.dart
+++ b/pkgs/native_assets_builder/lib/native_assets_builder.dart
@@ -3,9 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 export 'package:native_assets_builder/src/build_runner/build_runner.dart';
-export 'package:native_assets_builder/src/model/build_result.dart';
 export 'package:native_assets_builder/src/model/build_dry_run_result.dart';
+export 'package:native_assets_builder/src/model/build_result.dart';
 export 'package:native_assets_builder/src/model/kernel_assets.dart';
-export 'package:native_assets_builder/src/model/link_result.dart';
 export 'package:native_assets_builder/src/model/link_dry_run_result.dart';
+export 'package:native_assets_builder/src/model/link_result.dart';
 export 'package:native_assets_builder/src/package_layout/package_layout.dart';

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -9,11 +9,11 @@ import 'package:logging/logging.dart';
 import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:package_config/package_config.dart';
 
-import '../model/build_result.dart';
 import '../model/build_dry_run_result.dart';
+import '../model/build_result.dart';
 import '../model/hook_result.dart';
-import '../model/link_result.dart';
 import '../model/link_dry_run_result.dart';
+import '../model/link_result.dart';
 import '../package_layout/package_layout.dart';
 import '../utils/run_process.dart';
 import 'build_planner.dart';

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -10,9 +10,10 @@ import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:package_config/package_config.dart';
 
 import '../model/build_result.dart';
-import '../model/dry_run_result.dart';
+import '../model/build_dry_run_result.dart';
 import '../model/hook_result.dart';
 import '../model/link_result.dart';
+import '../model/link_dry_run_result.dart';
 import '../package_layout/package_layout.dart';
 import '../utils/run_process.dart';
 import 'build_planner.dart';
@@ -75,6 +76,7 @@ class NativeAssetsBuildRunner {
   /// If provided, only assets of all transitive dependencies of
   /// [runPackageName] are linked.
   Future<LinkResult> link({
+    required LinkModePreferenceImpl linkModePreference,
     required Target target,
     required Uri workingDirectory,
     required BuildModeImpl buildMode,
@@ -90,7 +92,7 @@ class NativeAssetsBuildRunner {
   }) async =>
       _run(
         hook: Hook.link,
-        linkModePreference: LinkModePreferenceImpl.dynamic,
+        linkModePreference: linkModePreference,
         target: target,
         workingDirectory: workingDirectory,
         buildMode: buildMode,
@@ -125,24 +127,30 @@ class NativeAssetsBuildRunner {
     assert(hook == Hook.link || buildResult == null);
 
     packageLayout ??= await PackageLayout.fromRootPackageRoot(workingDirectory);
-    final packagesWithAssets = await packageLayout.packagesWithAssets(hook);
-    final (buildPlan, packageGraph, planSuccess) = await _plannedPackages(
-      packagesWithAssets,
-      packageLayout,
-      runPackageName,
+    final (buildPlan, packageGraph, planSuccess) = await _makePlan(
+      hook: hook,
+      packageLayout: packageLayout,
+      buildResult: buildResult,
+      runPackageName: runPackageName,
     );
-    final hookResult = HookResult.failure();
     if (!planSuccess) {
-      return hookResult;
+      return HookResult.failure();
     }
+
+    var hookResult = HookResult();
     final metadata = <String, Metadata>{};
-    var success = true;
     for (final package in buildPlan) {
-      final dependencyMetadata = _metadataForPackage(
-        packageGraph: packageGraph,
-        packageName: package.name,
-        targetMetadata: metadata,
-      );
+      final DependencyMetadata? dependencyMetadata;
+      switch (hook) {
+        case Hook.build:
+          dependencyMetadata = _metadataForPackage(
+            packageGraph: packageGraph!,
+            packageName: package.name,
+            targetMetadata: metadata,
+          );
+        case Hook.link:
+          dependencyMetadata = null;
+      }
       final config = await _cliConfig(
         package,
         packageLayout,
@@ -159,7 +167,7 @@ class NativeAssetsBuildRunner {
         buildResult,
       );
 
-      final (buildOutput, packageSuccess) = await _runHookForPackageCached(
+      final (hookOutput, packageSuccess) = await _runHookForPackageCached(
         hook,
         config,
         packageLayout.packageConfigUri,
@@ -167,16 +175,14 @@ class NativeAssetsBuildRunner {
         includeParentEnvironment,
         resourceIdentifiers,
       );
-      hookResult.add(buildOutput);
-      success &= packageSuccess;
-
-      metadata[config.packageName] = buildOutput.metadata;
+      hookResult = hookResult.copyAdd(hookOutput, packageSuccess);
+      metadata[config.packageName] = hookOutput.metadata;
     }
 
-    return hookResult.withSuccess(success);
+    return hookResult;
   }
 
-  Future<HookConfigImpl> _cliConfig(
+  static Future<HookConfigImpl> _cliConfig(
     Package package,
     PackageLayout packageLayout,
     Target target,
@@ -227,7 +233,7 @@ class NativeAssetsBuildRunner {
         resourceIdentifierUri: resourceIdentifiers,
         assets: buildResult!.assetsForLinking[package.name] ?? [],
         supportedAssetTypes: supportedAssetTypes,
-        linkModePreference: LinkModePreferenceImpl.preferStatic,
+        linkModePreference: linkModePreference,
       );
     } else {
       return BuildConfigImpl(
@@ -253,7 +259,7 @@ class NativeAssetsBuildRunner {
   ///
   /// If provided, only native assets of all transitive dependencies of
   /// [runPackageName] are built.
-  Future<DryRunResult> dryRun({
+  Future<BuildDryRunResult> buildDryRun({
     required LinkModePreferenceImpl linkModePreference,
     required OSImpl targetOS,
     required Uri workingDirectory,
@@ -261,20 +267,70 @@ class NativeAssetsBuildRunner {
     PackageLayout? packageLayout,
     String? runPackageName,
     Iterable<String>? supportedAssetTypes,
+  }) =>
+      _runDryRun(
+        hook: Hook.build,
+        linkModePreference: linkModePreference,
+        targetOS: targetOS,
+        workingDirectory: workingDirectory,
+        includeParentEnvironment: includeParentEnvironment,
+        packageLayout: packageLayout,
+        runPackageName: runPackageName,
+        supportedAssetTypes: supportedAssetTypes,
+      );
+
+  /// [workingDirectory] is expected to contain `.dart_tool`.
+  ///
+  /// This method is invoked by launchers such as dartdev (for `dart run`) and
+  /// flutter_tools (for `flutter run` and `flutter build`).
+  ///
+  /// If provided, only native assets of all transitive dependencies of
+  /// [runPackageName] are built.
+  Future<LinkDryRunResult> linkDryRun({
+    required LinkModePreferenceImpl linkModePreference,
+    required OSImpl targetOS,
+    required Uri workingDirectory,
+    required bool includeParentEnvironment,
+    PackageLayout? packageLayout,
+    String? runPackageName,
+    Iterable<String>? supportedAssetTypes,
+    required BuildDryRunResult buildDryRunResult,
+  }) =>
+      _runDryRun(
+        hook: Hook.link,
+        linkModePreference: linkModePreference,
+        targetOS: targetOS,
+        workingDirectory: workingDirectory,
+        includeParentEnvironment: includeParentEnvironment,
+        packageLayout: packageLayout,
+        runPackageName: runPackageName,
+        supportedAssetTypes: supportedAssetTypes,
+        buildDryRunResult: buildDryRunResult,
+      );
+
+  Future<HookResult> _runDryRun({
+    required LinkModePreferenceImpl linkModePreference,
+    required OSImpl targetOS,
+    required Uri workingDirectory,
+    required bool includeParentEnvironment,
+    PackageLayout? packageLayout,
+    String? runPackageName,
+    Iterable<String>? supportedAssetTypes,
+    required Hook hook,
+    BuildDryRunResult? buildDryRunResult,
   }) async {
     packageLayout ??= await PackageLayout.fromRootPackageRoot(workingDirectory);
-    final packagesWithBuild =
-        await packageLayout.packagesWithAssets(Hook.build);
-    final (buildPlan, _, planSuccess) = await _plannedPackages(
-      packagesWithBuild,
-      packageLayout,
-      runPackageName,
+    final (buildPlan, _, planSuccess) = await _makePlan(
+      hook: hook,
+      packageLayout: packageLayout,
+      buildDryRunResult: buildDryRunResult,
+      runPackageName: runPackageName,
     );
-    final hookResult = HookResult.failure();
     if (!planSuccess) {
-      return hookResult;
+      return HookResult.failure();
     }
-    var success = true;
+
+    var hookResult = HookResult();
     for (final package in buildPlan) {
       final config = await _cliConfigDryRun(
         packageName: package.name,
@@ -283,37 +339,44 @@ class NativeAssetsBuildRunner {
         linkMode: linkModePreference,
         buildParentDir: packageLayout.dartToolNativeAssetsBuilder,
         supportedAssetTypes: supportedAssetTypes,
+        hook: hook,
+        buildDryRunResult: buildDryRunResult,
       );
-      final (buildOutput, packageSuccess) = await _runHookForPackage(
-        Hook.build,
+      var (buildOutput, packageSuccess) = await _runHookForPackage(
+        hook,
         config,
         packageLayout.packageConfigUri,
         workingDirectory,
         includeParentEnvironment,
         null,
       );
-      for (final asset in buildOutput.assets) {
-        switch (asset) {
-          case NativeCodeAssetImpl _:
-            if (asset.architecture != null) {
-              // Backwards compatibility, if an architecture is provided use it.
-              hookResult.assets.add(asset);
-            } else {
-              // Dry run does not report architecture. Dart VM branches on OS
-              // and Target when looking up assets, so populate assets for all
-              // architectures.
-              for (final architecture in asset.os.architectures) {
-                hookResult.assets
-                    .add(asset.copyWith(architecture: architecture));
-              }
-            }
-          case DataAssetImpl _:
-            hookResult.assets.add(asset);
-        }
-      }
-      success &= packageSuccess;
+      buildOutput = _expandArchsNativeCodeAssets(buildOutput);
+      hookResult = hookResult.copyAdd(buildOutput, packageSuccess);
     }
-    return hookResult.withSuccess(success);
+    return hookResult;
+  }
+
+  HookOutputImpl _expandArchsNativeCodeAssets(HookOutputImpl buildOutput) {
+    final assets = <AssetImpl>[];
+    for (final asset in buildOutput.assets) {
+      switch (asset) {
+        case NativeCodeAssetImpl _:
+          if (asset.architecture != null) {
+            // Backwards compatibility, if an architecture is provided use it.
+            assets.add(asset);
+          } else {
+            // Dry run does not report architecture. Dart VM branches on OS
+            // and Target when looking up assets, so populate assets for all
+            // architectures.
+            for (final architecture in asset.os.architectures) {
+              assets.add(asset.copyWith(architecture: architecture));
+            }
+          }
+        case DataAssetImpl _:
+          assets.add(asset);
+      }
+    }
+    return buildOutput.copyWith(assets: assets);
   }
 
   Future<_PackageBuildRecord> _runHookForPackageCached(
@@ -362,7 +425,7 @@ class NativeAssetsBuildRunner {
     bool includeParentEnvironment,
     Uri? resources,
   ) async {
-    final configFile = config.configFile;
+    final configFile = config.outputDirectory.resolve('../config.json');
     final configFileContents = config.toJsonString();
     logger.info('config.json contents: $configFileContents');
     await File.fromUri(configFile).writeAsString(configFileContents);
@@ -416,7 +479,7 @@ ${result.stdout}
               ? null
               : HookOutputImpl.readFromFile(file: config.outputFileV1_1_0!)) ??
           HookOutputImpl();
-      //As a link.dart can pipe through assets from other packages.
+      // The link.dart can pipe through assets from other packages.
       if (hook == Hook.build) {
         success &= validateAssetsPackage(
           buildOutput.assets,
@@ -434,19 +497,6 @@ ${e.message}
         ''');
       success = false;
       return (HookOutputImpl(), false);
-      // TODO(https://github.com/dart-lang/native/issues/109): Stop throwing
-      // type errors in native_assets_cli, release a new version of that package
-      // and then remove this.
-      // ignore: avoid_catching_errors
-    } on TypeError {
-      logger.severe('''
-Building native assets for package:${config.packageName} failed.
-${config.outputName} contained a type error.
-
-Contents: ${File.fromUri(config.outputFile).readAsStringSync()}.
-        ''');
-      success = false;
-      return (HookOutputImpl(), false);
     } finally {
       if (!success) {
         if (await buildOutputFile.exists()) {
@@ -456,28 +506,43 @@ Contents: ${File.fromUri(config.outputFile).readAsStringSync()}.
     }
   }
 
-  static Future<BuildConfigImpl> _cliConfigDryRun({
+  static Future<HookConfigImpl> _cliConfigDryRun({
     required String packageName,
     required Uri packageRoot,
     required OSImpl targetOS,
     required LinkModePreferenceImpl linkMode,
     required Uri buildParentDir,
+    required Hook hook,
+    BuildDryRunResult? buildDryRunResult,
     Iterable<String>? supportedAssetTypes,
   }) async {
-    final buildDirName = 'dry_run_${targetOS}_$linkMode';
-    final outDirUri = buildParentDir.resolve('$buildDirName/out/');
+    final hookDirName = 'dry_run_${hook.name}_${targetOS}_$linkMode';
+    final outDirUri = buildParentDir.resolve('$hookDirName/out/');
     final outDir = Directory.fromUri(outDirUri);
     if (!await outDir.exists()) {
       await outDir.create(recursive: true);
     }
-    return BuildConfigImpl.dryRun(
-      outputDirectory: outDirUri,
-      packageName: packageName,
-      packageRoot: packageRoot,
-      targetOS: targetOS,
-      linkModePreference: linkMode,
-      supportedAssetTypes: supportedAssetTypes,
-    );
+    switch (hook) {
+      case Hook.build:
+        return BuildConfigImpl.dryRun(
+          outputDirectory: outDirUri,
+          packageName: packageName,
+          packageRoot: packageRoot,
+          targetOS: targetOS,
+          linkModePreference: linkMode,
+          supportedAssetTypes: supportedAssetTypes,
+        );
+      case Hook.link:
+        return LinkConfigImpl.dryRun(
+          outputDirectory: outDirUri,
+          packageName: packageName,
+          packageRoot: packageRoot,
+          targetOS: targetOS,
+          assets: buildDryRunResult!.assetsForLinking[packageName] ?? [],
+          supportedAssetTypes: supportedAssetTypes,
+          linkModePreference: linkMode,
+        );
+    }
   }
 
   DependencyMetadata? _metadataForPackage({
@@ -513,29 +578,61 @@ Contents: ${File.fromUri(config.outputFile).readAsStringSync()}.
     }
   }
 
-  Future<(List<Package> plan, PackageGraph dependencyGraph, bool success)>
-      _plannedPackages(
-    List<Package> packagesWithNativeAssets,
-    PackageLayout packageLayout,
+  Future<(List<Package> plan, PackageGraph? dependencyGraph, bool success)>
+      _makePlan({
+    required PackageLayout packageLayout,
     String? runPackageName,
-  ) async {
-    if (packagesWithNativeAssets.length <= 1 && runPackageName == null) {
-      final dependencyGraph = PackageGraph({
-        for (final p in packagesWithNativeAssets) p.name: [],
-      });
-      return (packagesWithNativeAssets, dependencyGraph, true);
-    } else {
-      final planner = await NativeAssetsBuildPlanner.fromRootPackageRoot(
-        rootPackageRoot: packageLayout.rootPackageRoot,
-        packagesWithNativeAssets: packagesWithNativeAssets,
-        dartExecutable: Uri.file(Platform.resolvedExecutable),
-        logger: logger,
-      );
-      final (plan, planSuccess) = planner.plan(
-        runPackageName: runPackageName,
-      );
-      return (plan, planner.packageGraph, planSuccess);
+    required Hook hook,
+    // TODO(dacoharkes): How to share these two? Make them extend each other?
+    BuildResult? buildResult,
+    BuildDryRunResult? buildDryRunResult,
+  }) async {
+    final packagesWithHook = await packageLayout.packagesWithAssets(hook);
+    final List<Package> buildPlan;
+    final PackageGraph? packageGraph;
+    switch (hook) {
+      case Hook.build:
+        // Build hooks are run in toplogical order.
+        if (packagesWithHook.length <= 1 && runPackageName == null) {
+          final dependencyGraph = PackageGraph({
+            for (final p in packagesWithHook) p.name: [],
+          });
+          return (packagesWithHook, dependencyGraph, true);
+        } else {
+          final planner = await NativeAssetsBuildPlanner.fromRootPackageRoot(
+            rootPackageRoot: packageLayout.rootPackageRoot,
+            packagesWithNativeAssets: packagesWithHook,
+            dartExecutable: Uri.file(Platform.resolvedExecutable),
+            logger: logger,
+          );
+          final (plan, planSuccess) = planner.plan(
+            runPackageName: runPackageName,
+          );
+          return (plan, planner.packageGraph, planSuccess);
+        }
+      case Hook.link:
+        // Link hooks are not run in any particular order.
+        // Link hooks are skipped if no assets for linking are provided.
+        buildPlan = [];
+        final skipped = <String>[];
+        final assetsForLinking = buildResult?.assetsForLinking ??
+            buildDryRunResult?.assetsForLinking;
+        for (final package in packagesWithHook) {
+          if (assetsForLinking![package.name]?.isNotEmpty ?? false) {
+            buildPlan.add(package);
+          } else {
+            skipped.add(package.name);
+          }
+        }
+        if (skipped.isNotEmpty) {
+          logger.info(
+            'Skipping link hooks from ${skipped.join(', ')}'
+            ' due to no assets provided to link for these link hooks.',
+          );
+        }
+        packageGraph = null;
     }
+    return (buildPlan, packageGraph, true);
   }
 }
 

--- a/pkgs/native_assets_builder/lib/src/model/build_dry_run_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/build_dry_run_result.dart
@@ -6,8 +6,8 @@ import 'package:native_assets_cli/native_assets_cli_internal.dart';
 
 import '../../native_assets_builder.dart';
 
-/// Similar to a [BuildResult], but for the case of a dry run, where not assets
-/// are actually produced.
+/// The result of executing the build hooks in dry run mode from all packages in
+/// the dependency tree of the entry point application.
 abstract interface class BuildDryRunResult {
   /// The native assets produced by the hooks, which should be bundled.
   List<AssetImpl> get assets;

--- a/pkgs/native_assets_builder/lib/src/model/build_dry_run_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/build_dry_run_result.dart
@@ -8,12 +8,15 @@ import '../../native_assets_builder.dart';
 
 /// Similar to a [BuildResult], but for the case of a dry run, where not assets
 /// are actually produced.
-abstract interface class DryRunResult {
-  /// The native assets for all [Target]s for the dry run.
+abstract interface class BuildDryRunResult {
+  /// The native assets produced by the hooks, which should be bundled.
   List<AssetImpl> get assets;
 
-  /// Whether all builds completed without errors.
+  /// Whether all hooks completed without errors.
   ///
   /// All error messages are streamed to [NativeAssetsBuildRunner.logger].
   bool get success;
+
+  /// The native assets produced by the hooks, which should be linked.
+  Map<String, List<AssetImpl>> get assetsForLinking;
 }

--- a/pkgs/native_assets_builder/lib/src/model/build_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/build_result.dart
@@ -7,11 +7,17 @@ import 'package:native_assets_cli/native_assets_cli_internal.dart';
 /// The result of a build, executing the build.dart hooks from all packages in
 /// the dependency tree of the entry point application.
 abstract class BuildResult {
+  /// The files used by the hooks.
   List<Uri> get dependencies;
 
+  /// Whether all hooks completed without errors.
+  ///
+  /// All error messages are streamed to [NativeAssetsBuildRunner.logger].
   bool get success;
 
+  /// The native assets produced by the hooks, which should be bundled.
   List<AssetImpl> get assets;
 
+  /// The native assets produced by the hooks, which should be linked.
   Map<String, List<AssetImpl>> get assetsForLinking;
 }

--- a/pkgs/native_assets_builder/lib/src/model/build_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/build_result.dart
@@ -6,8 +6,8 @@ import 'package:native_assets_cli/native_assets_cli_internal.dart';
 
 import '../build_runner/build_runner.dart';
 
-/// The result of a build, executing the build.dart hooks from all packages in
-/// the dependency tree of the entry point application.
+/// The result of executing build hooks from all packages in the dependency tree
+/// of the entry point application.
 abstract class BuildResult {
   /// The files used by the hooks.
   List<Uri> get dependencies;

--- a/pkgs/native_assets_builder/lib/src/model/build_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/build_result.dart
@@ -4,6 +4,8 @@
 
 import 'package:native_assets_cli/native_assets_cli_internal.dart';
 
+import '../build_runner/build_runner.dart';
+
 /// The result of a build, executing the build.dart hooks from all packages in
 /// the dependency tree of the entry point application.
 abstract class BuildResult {

--- a/pkgs/native_assets_builder/lib/src/model/link_dry_run_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/link_dry_run_result.dart
@@ -4,17 +4,13 @@
 
 import 'package:native_assets_cli/native_assets_cli_internal.dart';
 
-import 'build_result.dart';
-import '../build_runner/build_runner.dart';
+import '../../native_assets_builder.dart';
 
-/// Similar to a [BuildResult], but for `link.dart` hooks instead of
-/// `build.dart` hooks.
-abstract interface class LinkResult {
+/// Similar to a [LinkResult], but for the case of a dry run, where not assets
+/// are actually produced.
+abstract interface class LinkDryRunResult {
   /// The native assets produced by the hooks, which should be bundled.
   List<AssetImpl> get assets;
-
-  /// The files used by the hooks.
-  List<Uri> get dependencies;
 
   /// Whether all hooks completed without errors.
   ///

--- a/pkgs/native_assets_builder/lib/src/model/link_dry_run_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/link_dry_run_result.dart
@@ -6,8 +6,8 @@ import 'package:native_assets_cli/native_assets_cli_internal.dart';
 
 import '../../native_assets_builder.dart';
 
-/// Similar to a [LinkResult], but for the case of a dry run, where not assets
-/// are actually produced.
+/// The result of executing the link hooks in dry run mode from all packages in
+/// the dependency tree of the entry point application.
 abstract interface class LinkDryRunResult {
   /// The native assets produced by the hooks, which should be bundled.
   List<AssetImpl> get assets;

--- a/pkgs/native_assets_builder/lib/src/model/link_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/link_result.dart
@@ -7,8 +7,8 @@ import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import '../build_runner/build_runner.dart';
 import 'build_result.dart';
 
-/// Similar to a [BuildResult], but for `link.dart` hooks instead of
-/// `build.dart` hooks.
+/// The result of executing the link hooks in dry run mode from all packages in
+/// the dependency tree of the entry point application.
 abstract interface class LinkResult {
   /// The native assets produced by the hooks, which should be bundled.
   List<AssetImpl> get assets;

--- a/pkgs/native_assets_builder/lib/src/model/link_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/link_result.dart
@@ -5,7 +5,6 @@
 import 'package:native_assets_cli/native_assets_cli_internal.dart';
 
 import '../build_runner/build_runner.dart';
-import 'build_result.dart';
 
 /// The result of executing the link hooks in dry run mode from all packages in
 /// the dependency tree of the entry point application.

--- a/pkgs/native_assets_builder/lib/src/model/link_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/link_result.dart
@@ -4,8 +4,8 @@
 
 import 'package:native_assets_cli/native_assets_cli_internal.dart';
 
-import 'build_result.dart';
 import '../build_runner/build_runner.dart';
+import 'build_result.dart';
 
 /// Similar to a [BuildResult], but for `link.dart` hooks instead of
 /// `build.dart` hooks.

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_build_dry_run_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_build_dry_run_test.dart
@@ -24,7 +24,7 @@ void main() async {
         logger: logger,
       );
 
-      final dryRunResult = await dryRun(
+      final dryRunResult = await buildDryRun(
         packageUri,
         logger,
         dartExecutable,
@@ -54,10 +54,9 @@ void main() async {
       }
 
       final dryRunDir = packageUri.resolve(
-          '.dart_tool/native_assets_builder/dry_run_${Target.current.os}_dynamic/');
+          '.dart_tool/native_assets_builder/dry_run_build_${Target.current.os}_dynamic/');
       expect(File.fromUri(dryRunDir.resolve('config.json')), exists);
       expect(File.fromUri(dryRunDir.resolve('out/build_output.json')), exists);
-      //
     });
   });
 }

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_cycle_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_cycle_test.dart
@@ -22,7 +22,7 @@ void main() async {
       );
       {
         final logMessages = <String>[];
-        final result = await dryRun(
+        final result = await buildDryRun(
           packageUri,
           createCapturingLogger(logMessages, level: Level.SEVERE),
           dartExecutable,

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
@@ -28,13 +28,13 @@ void main() async {
         dartExecutable: dartExecutable,
       );
 
-      await buildRunner.dryRun(
+      await buildRunner.buildDryRun(
         targetOS: Target.current.os,
         linkModePreference: LinkModePreferenceImpl.dynamic,
         workingDirectory: packageUri,
         includeParentEnvironment: true,
       );
-      await buildRunner.dryRun(
+      await buildRunner.buildDryRun(
         targetOS: Target.current.os,
         linkModePreference: LinkModePreferenceImpl.dynamic,
         workingDirectory: packageUri,

--- a/pkgs/native_assets_builder/test/build_runner/helpers.dart
+++ b/pkgs/native_assets_builder/test/build_runner/helpers.dart
@@ -79,6 +79,7 @@ Future<LinkResult> link(
         logger: logger,
         dartExecutable: dartExecutable,
       ).link(
+        linkModePreference: linkModePreference,
         buildMode: BuildModeImpl.release,
         target: Target.current,
         workingDirectory: packageUri,
@@ -114,7 +115,7 @@ Future<T> runWithLog<T>(
   return result;
 }
 
-Future<DryRunResult> dryRun(
+Future<BuildDryRunResult> buildDryRun(
   Uri packageUri,
   Logger logger,
   Uri dartExecutable, {
@@ -128,12 +129,38 @@ Future<DryRunResult> dryRun(
       final result = await NativeAssetsBuildRunner(
         logger: logger,
         dartExecutable: dartExecutable,
-      ).dryRun(
+      ).buildDryRun(
         linkModePreference: linkModePreference,
         targetOS: Target.current.os,
         workingDirectory: packageUri,
         includeParentEnvironment: includeParentEnvironment,
         packageLayout: packageLayout,
+      );
+      return result;
+    });
+
+Future<LinkDryRunResult> linkDryRun(
+  Uri packageUri,
+  Logger logger,
+  Uri dartExecutable, {
+  LinkModePreferenceImpl linkModePreference = LinkModePreferenceImpl.dynamic,
+  CCompilerConfigImpl? cCompilerConfig,
+  bool includeParentEnvironment = true,
+  List<String>? capturedLogs,
+  PackageLayout? packageLayout,
+  required BuildDryRunResult buildDryRunResult,
+}) async =>
+    runWithLog(capturedLogs, () async {
+      final result = await NativeAssetsBuildRunner(
+        logger: logger,
+        dartExecutable: dartExecutable,
+      ).linkDryRun(
+        linkModePreference: linkModePreference,
+        targetOS: Target.current.os,
+        workingDirectory: packageUri,
+        includeParentEnvironment: includeParentEnvironment,
+        packageLayout: packageLayout,
+        buildDryRunResult: buildDryRunResult,
       );
       return result;
     });

--- a/pkgs/native_assets_builder/test/build_runner/link_dry_run_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/link_dry_run_test.dart
@@ -26,18 +26,18 @@ void main() async {
           logger: logger,
         );
 
-        final buildResult = await build(
+        final buildResult = await buildDryRun(
           packageUri,
           logger,
           dartExecutable,
         );
         expect(buildResult.assets.length, 0);
 
-        final linkResult = await link(
+        final linkResult = await linkDryRun(
           packageUri,
           logger,
           dartExecutable,
-          buildResult: buildResult,
+          buildDryRunResult: buildResult,
         );
         expect(linkResult.assets.length, 2);
       });
@@ -66,7 +66,7 @@ void main() async {
         // First, run `pub get`, we need pub to resolve our dependencies.
         await runPubGet(workingDirectory: packageUri, logger: logger);
 
-        final buildResult = await build(
+        final buildResult = await buildDryRun(
           packageUri,
           logger,
           dartExecutable,
@@ -78,11 +78,11 @@ void main() async {
           orderedEquals(assetsForLinking),
         );
 
-        final linkResult = await link(
+        final linkResult = await linkDryRun(
           packageUri,
           logger,
           dartExecutable,
-          buildResult: buildResult,
+          buildDryRunResult: buildResult,
         );
         expect(linkResult.success, true);
 
@@ -90,44 +90,6 @@ void main() async {
       });
     },
   );
-
-  test('no_asset_for_link', timeout: longTimeout, () async {
-    await inTempDir((tempUri) async {
-      await copyTestProjects(targetUri: tempUri);
-      final packageUri = tempUri.resolve('no_asset_for_link/');
-
-      // First, run `pub get`, we need pub to resolve our dependencies.
-      await runPubGet(
-        workingDirectory: packageUri,
-        logger: logger,
-      );
-
-      final buildResult = await build(
-        packageUri,
-        logger,
-        dartExecutable,
-      );
-      expect(buildResult.assets.length, 0);
-      expect(buildResult.assetsForLinking.length, 0);
-
-      final logMessages = <String>[];
-      final linkResult = await link(
-        packageUri,
-        logger,
-        dartExecutable,
-        buildResult: buildResult,
-        capturedLogs: logMessages,
-      );
-      expect(linkResult.assets.length, 0);
-      expect(
-        logMessages,
-        contains(
-          'Skipping link hooks from no_asset_for_link due to '
-          'no assets provided to link for these link hooks.',
-        ),
-      );
-    });
-  });
 }
 
 Iterable<String> _getNames(List<AssetImpl> assets) =>

--- a/pkgs/native_assets_builder/test_data/manifest.yaml
+++ b/pkgs/native_assets_builder/test_data/manifest.yaml
@@ -85,3 +85,5 @@
 - add_asset_link/src/native_add.h
 - add_asset_link/src/native_add.c
 - add_asset_link/hook/build.dart
+- no_asset_for_link/pubspec.yaml
+- no_asset_for_link/hook/link.dart

--- a/pkgs/native_assets_builder/test_data/no_asset_for_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/no_asset_for_link/hook/link.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:native_assets_cli/native_assets_cli.dart';
+
+void main(List<String> arguments) async {
+  await link(arguments, (config, output) async {
+    output.addAssets(
+      config.assets,
+    );
+    output.addDependency(
+      config.packageRoot.resolve('hook/link.dart'),
+    );
+  });
+}

--- a/pkgs/native_assets_builder/test_data/no_asset_for_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/no_asset_for_link/pubspec.yaml
@@ -1,0 +1,18 @@
+name: no_asset_for_link
+description: A link hook, but no assets for link.
+version: 1.0.0
+
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies:
+  logging: ^1.1.1
+  meta: ^1.12.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+
+dev_dependencies:
+  lints: ^3.0.0
+  test: ^1.24.0

--- a/pkgs/native_assets_cli/lib/src/model/hook.dart
+++ b/pkgs/native_assets_cli/lib/src/model/hook.dart
@@ -7,14 +7,12 @@
 /// The `build.dart` hook runs before, and the `link.dart` hook after
 /// compilation. This enum holds static information about these hooks.
 enum Hook {
-  link('link', 'link_config'),
-  build('build', 'config');
+  link('link'),
+  build('build');
 
   final String _scriptName;
-  final String _configName;
 
   String get scriptName => '$_scriptName.dart';
-  String get configName => '$_configName.json';
 
-  const Hook(this._scriptName, this._configName);
+  const Hook(this._scriptName);
 }

--- a/pkgs/native_assets_cli/lib/src/model/hook_config.dart
+++ b/pkgs/native_assets_cli/lib/src/model/hook_config.dart
@@ -120,8 +120,6 @@ abstract class HookConfigImpl implements HookConfig {
         _targetAndroidNdkApi = null,
         _targetIOSSdk = null;
 
-  Uri get configFile => outputDirectory.resolve('../${hook.configName}');
-
   Uri get outputFile => outputDirectory.resolve(outputName);
 
   Uri? get outputFileV1_1_0 => outputNameV1_1_0 == null

--- a/pkgs/native_assets_cli/lib/src/model/hook_output.dart
+++ b/pkgs/native_assets_cli/lib/src/model/hook_output.dart
@@ -225,4 +225,12 @@ final class HookOutputImpl implements BuildOutput, LinkOutput {
   List<AssetImpl> _getAssetList(String? linkInPackage) => linkInPackage == null
       ? _assets
       : (_assetsForLinking[linkInPackage] ??= []);
+
+  HookOutputImpl copyWith({Iterable<AssetImpl>? assets}) => HookOutputImpl(
+        timestamp: timestamp,
+        assets: assets?.toList() ?? _assets,
+        assetsForLinking: assetsForLinking,
+        dependencies: _dependencies,
+        metadata: metadata,
+      );
 }

--- a/pkgs/native_assets_cli/test/model/link_config_test.dart
+++ b/pkgs/native_assets_cli/test/model/link_config_test.dart
@@ -334,7 +334,7 @@ void main() async {
       linkModePreference: LinkModePreferenceImpl.preferStatic,
     );
     final configFileContents = buildConfig.toJsonString();
-    final configUri = tempUri.resolve('link_config.json');
+    final configUri = tempUri.resolve('config.json');
     final configFile = File.fromUri(configUri);
     await configFile.writeAsString(configFileContents);
     final buildConfig2 =


### PR DESCRIPTION
In order to support link hooks in Flutter (https://github.com/flutter/flutter/issues/146263), we need dry run support for link hooks.

`package:native_assets_builder`

* added `NativeAssetsBuildRunner.linkDryRun` https://github.com/dart-lang/native/issues/1134
  * `NativeAssetsBuildRunner.link` add missing `linkModePreference` param.
  * `NativeAssetsBuildRunner.dryRun` renamed to `buildDryRun`
* Link hooks that do not have any assets for them to be linked, are no longer run.
* Link hooks are no longer run in the same topological order as build hooks, they are unordered.

`package:native_assets_cli`

* Removed `HookConfig.configFile`. It's perfectly fine for the native_assets_builder to give an arbitrary file name. (It defaults to `config.json` both for link and build hooks. They are in separate directories, so no need to use a different config name.)