### PR TITLE
[jni] Fix android example

### DIFF
--- a/pkgs/jni/android/src/main/java/com/github/dart_lang/jni/JniPlugin.java
+++ b/pkgs/jni/android/src/main/java/com/github/dart_lang/jni/JniPlugin.java
@@ -10,7 +10,6 @@ import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 public class JniPlugin implements FlutterPlugin, ActivityAware {
 
@@ -20,7 +19,7 @@ public class JniPlugin implements FlutterPlugin, ActivityAware {
   }
 
   @SuppressWarnings({"unused", "deprecation"})
-  public static void registerWith(Registrar registrar) {
+  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
     JniPlugin plugin = new JniPlugin();
     plugin.setup(registrar.activeContext());
   }

--- a/pkgs/jni/example/lib/main.dart
+++ b/pkgs/jni/example/lib/main.dart
@@ -90,7 +90,7 @@ void showToast(String text) {
   final toaster = makeText.call(toasterClass, const JObjectType(), [
     Jni.getCurrentActivity(),
     Jni.getCachedApplicationContext(),
-    '😀',
+    '😀'.toJString(),
     0,
   ]);
   final show = toasterClass.instanceMethodId('show', '()V');
@@ -110,10 +110,13 @@ void main() {
       Example("Minutes of usage since reboot",
           () => (uptime() / (60 * 1000)).floor()),
       Example("Back and forth string conversion", () => backAndForth()),
-      Example(
-          "Device name",
-          () => JClass.forName("android/os/Build")
-              .staticFieldId("DEVICE", const JStringType().signature)),
+      Example("Device name", () {
+        final buildClass = JClass.forName("android/os/Build");
+        return buildClass
+            .staticFieldId("DEVICE", JString.type.signature)
+            .get(buildClass, JString.type)
+            .toDartString(releaseOriginal: true);
+      }),
       Example(
         "Package name",
         () => JObject.fromReference(Jni.getCurrentActivity()).use((activity) =>


### PR DESCRIPTION
Some functionalities were broken after the refactor. This fixes it.

We need to add emulator tests to catch this in the future, I see that flutter samples and `package:http` have this setup in their CI. Tracking this in #1155.