### PR TITLE
[native_assets_cli] Publish 0.6.0

### DIFF
--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.0-wip
+## 0.6.0
 
 - Add support for `hook/link.dart`.
 

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   native assets CLI.
 
 # Note: Bump BuildConfig.version and BuildOutput.version on breaking changes!
-version: 0.6.0-wip
+version: 0.6.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
 topics:


### PR DESCRIPTION
We need a publishing round of the `native_*` packages for Flutter.

* https://github.com/flutter/flutter/issues/146263