### PR TITLE
Refactor cursor visitors

### DIFF
--- a/pkgs/ffigen/lib/src/header_parser/parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/parser.dart
@@ -151,7 +151,7 @@ List<Binding> parseToBindings(Config c) {
   bindings.addAll(unnamedEnumConstants);
 
   // Parse all saved macros.
-  bindings.addAll(parseSavedMacros()!);
+  bindings.addAll(parseSavedMacros());
 
   clangCmdArgs.dispose(cmdLen);
   clang.clang_disposeIndex(index);

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/function_type_param_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/function_type_param_parser.dart
@@ -2,10 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:ffi';
-
 import '../clang_bindings/clang_bindings.dart';
-import '../data.dart';
 import '../utils.dart';
 
 /// This type holds the list of `ParmDecl` nodes of a function type declaration.
@@ -17,38 +14,26 @@ class FunctionTypeParams {
         params = {};
 }
 
-FunctionTypeParams? _params;
-
-int _functionPointerFieldVisitor(
-    CXCursor cursor, CXCursor parent, Pointer<Void> clientData) {
-  if (cursor.kind == CXCursorKind.CXCursor_ParmDecl) {
-    final spelling = cursor.spelling();
-    if (spelling.isNotEmpty) {
-      _params!.paramNames.add(spelling);
-      _params!.params[spelling] = cursor;
-      return CXChildVisitResult.CXChildVisit_Continue;
-    } else {
-      // A parameter's spelling is empty, do not continue further traversal.
-      _params!.paramNames.clear();
-      _params!.params.clear();
-      return CXChildVisitResult.CXChildVisit_Break;
-    }
-  }
-  // The cursor itself may be a pointer etc..
-  return CXChildVisitResult.CXChildVisit_Recurse;
-}
-
 /// Returns `ParmDecl` nodes of function pointer declaration
 /// directly or indirectly pointed to by [cursor].
 FunctionTypeParams parseFunctionPointerParamNames(CXCursor cursor) {
-  _params = FunctionTypeParams();
-  clang.clang_visitChildren(
-    cursor,
-    Pointer.fromFunction(
-        _functionPointerFieldVisitor, exceptional_visitor_return),
-    nullptr,
-  );
-  final result = _params;
-  _params = null;
-  return result!;
+  final params = FunctionTypeParams();
+  cursor.visitChildrenMayRecurse((child, parent) {
+    if (child.kind == CXCursorKind.CXCursor_ParmDecl) {
+      final spelling = child.spelling();
+      if (spelling.isNotEmpty) {
+        params.paramNames.add(spelling);
+        params.params[spelling] = child;
+        return CXChildVisitResult.CXChildVisit_Continue;
+      } else {
+        // A parameter's spelling is empty, do not continue further traversal.
+        params.paramNames.clear();
+        params.params.clear();
+        return CXChildVisitResult.CXChildVisit_Break;
+      }
+    }
+    // The cursor itself may be a pointer etc..
+    return CXChildVisitResult.CXChildVisit_Recurse;
+  });
+  return params;
 }

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
@@ -91,7 +91,7 @@ List<Func>? parseFunctionDeclaration(clang_types.CXCursor cursor) {
 
     // Look for any annotations on the function.
     final objCReturnsRetained = cursor
-        .hasCursorWithKind(clang_types.CXCursorKind.CXCursor_NSReturnsRetained);
+        .hasChildWithKind(clang_types.CXCursorKind.CXCursor_NSReturnsRetained);
 
     // Initialized with a single value with no prefix and empty var args.
     var varArgFunctions = [VarArgFunction('', [])];

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:ffi';
-
 import 'package:ffigen/src/code_generator.dart';
 import 'package:ffigen/src/config_provider/config_types.dart';
 import 'package:ffigen/src/header_parser/data.dart';
@@ -15,30 +13,49 @@ import '../utils.dart';
 
 final _logger = Logger('ffigen.header_parser.functiondecl_parser');
 
-/// Holds temporary information regarding [Func] while parsing.
-class _ParserFunc {
-  /// Multiple values are since there may be more than one instance of the
-  /// same base C function with different variadic arguments.
-  List<Func> funcs = [];
-  bool incompleteStructParameter = false;
-  bool unimplementedParameterType = false;
-  bool objCReturnsRetained = false;
-  _ParserFunc();
-}
-
-final _stack = Stack<_ParserFunc>();
-
 /// Parses a function declaration.
 List<Func>? parseFunctionDeclaration(clang_types.CXCursor cursor) {
-  _stack.push(_ParserFunc());
+  /// Multiple values are since there may be more than one instance of the
+  /// same base C function with different variadic arguments.
+  final funcs = <Func>[];
 
   final funcUsr = cursor.usr();
   final funcName = cursor.spelling();
   if (shouldIncludeFunc(funcUsr, funcName)) {
     _logger.fine('++++ Adding Function: ${cursor.completeStringRepr()}');
 
-    final rt = _getFunctionReturnType(cursor);
-    final parameters = _getParameters(cursor, funcName);
+    final returnType = cursor.returnType().toCodeGenType();
+
+    final parameters = <Parameter>[];
+    bool incompleteStructParameter = false;
+    bool unimplementedParameterType = false;
+    final totalArgs = clang.clang_Cursor_getNumArguments(cursor);
+    for (var i = 0; i < totalArgs; i++) {
+      final paramCursor = clang.clang_Cursor_getArgument(cursor, i);
+
+      _logger.finer('===== parameter: ${paramCursor.completeStringRepr()}');
+
+      final paramType = paramCursor.toCodeGenType();
+      if (paramType.isIncompleteCompound) {
+        incompleteStructParameter = true;
+      } else if (paramType.baseType is UnimplementedType) {
+        _logger.finer('Unimplemented type: ${paramType.baseType}');
+        unimplementedParameterType = true;
+      }
+
+      final paramName = paramCursor.spelling();
+
+      /// If [paramName] is null or empty, its set to `arg$i` by code_generator.
+      parameters.add(
+        Parameter(
+          originalName: paramName,
+          name:
+              config.functionDecl.renameMemberUsingConfig(funcName, paramName),
+          type: paramType,
+        ),
+      );
+    }
+
     if (clang.clang_Cursor_isFunctionInlined(cursor) != 0 &&
         clang.clang_Cursor_getStorageClass(cursor) !=
             clang_types.CX_StorageClass.CX_SC_Extern) {
@@ -47,10 +64,10 @@ List<Func>? parseFunctionDeclaration(clang_types.CXCursor cursor) {
       _logger.warning(
           "Skipped Function '$funcName', inline functions are not supported.");
       // Returning empty so that [addToBindings] function excludes this.
-      return _stack.pop().funcs;
+      return funcs;
     }
 
-    if (rt.isIncompleteCompound || _stack.top.incompleteStructParameter) {
+    if (returnType.isIncompleteCompound || incompleteStructParameter) {
       _logger.fine(
           '---- Removed Function, reason: Incomplete struct pass/return by '
           'value: ${cursor.completeStringRepr()}');
@@ -58,26 +75,23 @@ List<Func>? parseFunctionDeclaration(clang_types.CXCursor cursor) {
           "Skipped Function '$funcName', Incomplete struct pass/return by "
           'value not supported.');
       // Returning null so that [addToBindings] function excludes this.
-      return _stack.pop().funcs;
+      return funcs;
     }
 
-    if (rt.baseType is UnimplementedType ||
-        _stack.top.unimplementedParameterType) {
+    if (returnType.baseType is UnimplementedType ||
+        unimplementedParameterType) {
       _logger.fine('---- Removed Function, reason: unsupported return type or '
           'parameter type: ${cursor.completeStringRepr()}');
       _logger.warning(
           "Skipped Function '$funcName', function has unsupported return type "
           'or parameter type.');
       // Returning null so that [addToBindings] function excludes this.
-      return _stack.pop().funcs;
+      return funcs;
     }
 
     // Look for any annotations on the function.
-    clang.clang_visitChildren(
-        cursor,
-        _parseAnnotationVisitorPtr ??= Pointer.fromFunction(
-            _parseAnnotationVisitor, exceptional_visitor_return),
-        nullptr);
+    final objCReturnsRetained = cursor
+        .hasCursorWithKind(clang_types.CXCursorKind.CXCursor_NSReturnsRetained);
 
     // Initialized with a single value with no prefix and empty var args.
     var varArgFunctions = [VarArgFunction('', [])];
@@ -85,12 +99,12 @@ List<Func>? parseFunctionDeclaration(clang_types.CXCursor cursor) {
       if (clang.clang_isFunctionTypeVariadic(cursor.type()) == 1) {
         varArgFunctions = config.varArgFunctions[funcName]!;
       } else {
-        _logger.warning(
-            "Skipping variadic-argument config for function $funcName since its not variadic.");
+        _logger.warning('Skipping variadic-argument config for function '
+            "'$funcName' since its not variadic.");
       }
     }
     for (final vaFunc in varArgFunctions) {
-      _stack.top.funcs.add(Func(
+      funcs.add(Func(
         dartDoc: getCursorDocComment(
           cursor,
           nesting.length + commentPrefix.length,
@@ -98,7 +112,7 @@ List<Func>? parseFunctionDeclaration(clang_types.CXCursor cursor) {
         usr: funcUsr + vaFunc.postfix,
         name: config.functionDecl.renameUsingConfig(funcName) + vaFunc.postfix,
         originalName: funcName,
-        returnType: rt,
+        returnType: returnType,
         parameters: parameters,
         varArgParameters:
             vaFunc.types.map((ta) => Parameter(type: ta, name: 'va')).toList(),
@@ -107,70 +121,14 @@ List<Func>? parseFunctionDeclaration(clang_types.CXCursor cursor) {
         exposeFunctionTypedefs:
             config.exposeFunctionTypedefs.shouldInclude(funcName),
         isLeaf: config.leafFunctions.shouldInclude(funcName),
-        objCReturnsRetained: _stack.top.objCReturnsRetained,
+        objCReturnsRetained: objCReturnsRetained,
         ffiNativeConfig: config.ffiNativeConfig,
       ));
     }
-    bindingsIndex.addFuncToSeen(funcUsr, _stack.top.funcs.last);
+    bindingsIndex.addFuncToSeen(funcUsr, funcs.last);
   } else if (bindingsIndex.isSeenFunc(funcUsr)) {
-    _stack.top.funcs.add(bindingsIndex.getSeenFunc(funcUsr)!);
+    funcs.add(bindingsIndex.getSeenFunc(funcUsr)!);
   }
 
-  return _stack.pop().funcs;
-}
-
-Type _getFunctionReturnType(clang_types.CXCursor cursor) {
-  return cursor.returnType().toCodeGenType();
-}
-
-List<Parameter> _getParameters(clang_types.CXCursor cursor, String funcName) {
-  final parameters = <Parameter>[];
-
-  final totalArgs = clang.clang_Cursor_getNumArguments(cursor);
-  for (var i = 0; i < totalArgs; i++) {
-    final paramCursor = clang.clang_Cursor_getArgument(cursor, i);
-
-    _logger.finer('===== parameter: ${paramCursor.completeStringRepr()}');
-
-    final pt = _getParameterType(paramCursor);
-    if (pt.isIncompleteCompound) {
-      _stack.top.incompleteStructParameter = true;
-    } else if (pt.baseType is UnimplementedType) {
-      _logger.finer('Unimplemented type: ${pt.baseType}');
-      _stack.top.unimplementedParameterType = true;
-    }
-
-    final pn = paramCursor.spelling();
-
-    /// If [pn] is null or empty, its set to `arg$i` by code_generator.
-    parameters.add(
-      Parameter(
-        originalName: pn,
-        name: config.functionDecl.renameMemberUsingConfig(funcName, pn),
-        type: pt,
-      ),
-    );
-  }
-
-  return parameters;
-}
-
-Type _getParameterType(clang_types.CXCursor cursor) {
-  return cursor.toCodeGenType();
-}
-
-Pointer<
-        NativeFunction<
-            Int32 Function(
-                clang_types.CXCursor, clang_types.CXCursor, Pointer<Void>)>>?
-    _parseAnnotationVisitorPtr;
-int _parseAnnotationVisitor(clang_types.CXCursor cursor,
-    clang_types.CXCursor parent, Pointer<Void> clientData) {
-  switch (cursor.kind) {
-    case clang_types.CXCursorKind.CXCursor_NSReturnsRetained:
-      _stack.top.objCReturnsRetained = true;
-      break;
-    default:
-  }
-  return clang_types.CXChildVisitResult.CXChildVisit_Continue;
+  return funcs;
 }

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:ffi';
-
 import 'package:ffigen/src/code_generator.dart';
 import 'package:ffigen/src/header_parser/data.dart';
 import 'package:logging/logging.dart';
@@ -13,41 +11,6 @@ import '../includer.dart';
 import '../utils.dart';
 
 final _logger = Logger('ffigen.header_parser.objcinterfacedecl_parser');
-
-Pointer<
-        NativeFunction<
-            Int32 Function(
-                clang_types.CXCursor, clang_types.CXCursor, Pointer<Void>)>>?
-    _parseInterfaceVisitorPtr;
-Pointer<
-        NativeFunction<
-            Int32 Function(
-                clang_types.CXCursor, clang_types.CXCursor, Pointer<Void>)>>?
-    _isClassDeclarationVisitorPtr;
-Pointer<
-        NativeFunction<
-            Int32 Function(
-                clang_types.CXCursor, clang_types.CXCursor, Pointer<Void>)>>?
-    _parseMethodVisitorPtr;
-Pointer<
-        NativeFunction<
-            Int32 Function(
-                clang_types.CXCursor, clang_types.CXCursor, Pointer<Void>)>>?
-    _findCategoryInterfaceVisitorPtr;
-
-class _ParsedObjCInterface {
-  ObjCInterface interface;
-  _ParsedObjCInterface(this.interface);
-}
-
-class _ParsedObjCMethod {
-  ObjCMethod method;
-  bool hasError = false;
-  _ParsedObjCMethod(this.method);
-}
-
-final _interfaceStack = Stack<_ParsedObjCInterface>();
-final _methodStack = Stack<_ParsedObjCMethod>();
 
 Type? parseObjCInterfaceDeclaration(
   clang_types.CXCursor cursor, {
@@ -91,61 +54,46 @@ void fillObjCInterfaceMethodsIfNeeded(
   _logger.fine('++++ Filling ObjC interface: '
       'Name: ${itf.originalName}, ${cursor.completeStringRepr()}');
 
-  _interfaceStack.push(_ParsedObjCInterface(itf));
-  clang.clang_visitChildren(
-      cursor,
-      _parseInterfaceVisitorPtr ??= Pointer.fromFunction(
-          _parseInterfaceVisitor, exceptional_visitor_return),
-      nullptr);
-  _interfaceStack.pop();
+  _fillInterface(itf, cursor);
 
   _logger.fine('++++ Finished ObjC interface: '
       'Name: ${itf.originalName}, ${cursor.completeStringRepr()}');
 }
 
-bool _isClassDeclarationResult = false;
+void _fillInterface(ObjCInterface itf, clang_types.CXCursor cursor) {
+  cursor.visitChildren((child) {
+    switch (child.kind) {
+      case clang_types.CXCursorKind.CXCursor_ObjCSuperClassRef:
+        _parseSuperType(child, itf);
+        break;
+      case clang_types.CXCursorKind.CXCursor_ObjCPropertyDecl:
+        _parseProperty(child, itf);
+        break;
+      case clang_types.CXCursorKind.CXCursor_ObjCInstanceMethodDecl:
+      case clang_types.CXCursorKind.CXCursor_ObjCClassMethodDecl:
+        _parseInterfaceMethod(child, itf);
+        break;
+    }
+  });
+}
+
 bool _isClassDeclaration(clang_types.CXCursor cursor) {
   // It's a class declaration if it has no children other than ObjCClassRef.
-  _isClassDeclarationResult = true;
-  clang.clang_visitChildren(
-      cursor,
-      _isClassDeclarationVisitorPtr ??= Pointer.fromFunction(
-          _isClassDeclarationVisitor, exceptional_visitor_return),
-      nullptr);
-  return _isClassDeclarationResult;
+  bool result = true;
+  cursor.visitChildrenMayBreak((child) {
+    if (cursor.kind == clang_types.CXCursorKind.CXCursor_ObjCClassRef) {
+      return true;
+    }
+    result = false;
+    return false;
+  });
+  return result;
 }
 
-int _isClassDeclarationVisitor(clang_types.CXCursor cursor,
-    clang_types.CXCursor parent, Pointer<Void> clientData) {
-  if (cursor.kind == clang_types.CXCursorKind.CXCursor_ObjCClassRef) {
-    return clang_types.CXChildVisitResult.CXChildVisit_Continue;
-  }
-  _isClassDeclarationResult = false;
-  return clang_types.CXChildVisitResult.CXChildVisit_Break;
-}
-
-int _parseInterfaceVisitor(clang_types.CXCursor cursor,
-    clang_types.CXCursor parent, Pointer<Void> clientData) {
-  switch (cursor.kind) {
-    case clang_types.CXCursorKind.CXCursor_ObjCSuperClassRef:
-      _parseSuperType(cursor);
-      break;
-    case clang_types.CXCursorKind.CXCursor_ObjCPropertyDecl:
-      _parseProperty(cursor);
-      break;
-    case clang_types.CXCursorKind.CXCursor_ObjCInstanceMethodDecl:
-    case clang_types.CXCursorKind.CXCursor_ObjCClassMethodDecl:
-      _parseMethod(cursor);
-      break;
-  }
-  return clang_types.CXChildVisitResult.CXChildVisit_Continue;
-}
-
-void _parseSuperType(clang_types.CXCursor cursor) {
+void _parseSuperType(clang_types.CXCursor cursor, ObjCInterface itf) {
   final superType = cursor.type().toCodeGenType();
   _logger.fine('       > Super type: '
       '$superType ${cursor.completeStringRepr()}');
-  final itf = _interfaceStack.top.interface;
   if (superType is ObjCInterface) {
     itf.superType = superType;
   } else {
@@ -154,8 +102,7 @@ void _parseSuperType(clang_types.CXCursor cursor) {
   }
 }
 
-void _parseProperty(clang_types.CXCursor cursor) {
-  final itf = _interfaceStack.top.interface;
+void _parseProperty(clang_types.CXCursor cursor, ObjCInterface itf) {
   final fieldName = cursor.spelling();
   final fieldType = cursor.type().toCodeGenType();
 
@@ -209,16 +156,23 @@ void _parseProperty(clang_types.CXCursor cursor) {
   }
 }
 
-void _parseMethod(clang_types.CXCursor cursor) {
+void _parseInterfaceMethod(clang_types.CXCursor cursor, ObjCInterface itf) {
+  final method = _parseMethod(cursor, itf.originalName);
+  if (method != null) {
+    itf.addMethod(method);
+  }
+}
+
+ObjCMethod? _parseMethod(clang_types.CXCursor cursor, String itfName) {
   final methodName = cursor.spelling();
   final isClassMethod =
       cursor.kind == clang_types.CXCursorKind.CXCursor_ObjCClassMethodDecl;
   final returnType = clang.clang_getCursorResultType(cursor).toCodeGenType();
   if (returnType.isIncompleteCompound) {
     _logger.warning('Method "$methodName" in instance '
-        '"${_interfaceStack.top.interface.originalName}" has incomplete '
+        '"$itfName" has incomplete '
         'return type: $returnType.');
-    return;
+    return null;
   }
   final method = ObjCMethod(
     originalName: methodName,
@@ -227,76 +181,56 @@ void _parseMethod(clang_types.CXCursor cursor) {
     isClass: isClassMethod,
     returnType: returnType,
   );
-  final parsed = _ParsedObjCMethod(method);
   _logger.fine('       > ${isClassMethod ? 'Class' : 'Instance'} method: '
       '${method.originalName} ${cursor.completeStringRepr()}');
-  _methodStack.push(parsed);
-  clang.clang_visitChildren(
-      cursor,
-      _parseMethodVisitorPtr ??=
-          Pointer.fromFunction(_parseMethodVisitor, exceptional_visitor_return),
-      nullptr);
-  _methodStack.pop();
-  if (parsed.hasError) {
-    // Discard it.
-    return;
-  }
-  _interfaceStack.top.interface.addMethod(method);
+
+  bool hasError = false;
+  cursor.visitChildren((child) {
+    switch (child.kind) {
+      case clang_types.CXCursorKind.CXCursor_ParmDecl:
+        if (!_parseMethodParam(child, itfName, method)) {
+          hasError = true;
+        }
+        break;
+      case clang_types.CXCursorKind.CXCursor_NSReturnsRetained:
+        method.returnsRetained = true;
+        break;
+      default:
+    }
+  });
+  return hasError ? null : method;
 }
 
-int _parseMethodVisitor(clang_types.CXCursor cursor,
-    clang_types.CXCursor parent, Pointer<Void> clientData) {
-  switch (cursor.kind) {
-    case clang_types.CXCursorKind.CXCursor_ParmDecl:
-      _parseMethodParam(cursor);
-      break;
-    case clang_types.CXCursorKind.CXCursor_NSReturnsRetained:
-      _markMethodReturnsRetained(cursor);
-      break;
-    default:
-  }
-  return clang_types.CXChildVisitResult.CXChildVisit_Continue;
-}
-
-void _parseMethodParam(clang_types.CXCursor cursor) {
-  final parsed = _methodStack.top;
+bool _parseMethodParam(
+    clang_types.CXCursor cursor, String itfName, ObjCMethod method) {
   final name = cursor.spelling();
   final type = cursor.type().toCodeGenType();
   if (type.isIncompleteCompound) {
-    parsed.hasError = true;
-    _logger.warning('Method "${parsed.method.originalName}" in instance '
-        '"${_interfaceStack.top.interface.originalName}" has incomplete '
+    _logger.warning('Method "${method.originalName}" in instance '
+        '"$itfName" has incomplete '
         'parameter type: $type.');
-    return;
+    return false;
   }
   _logger.fine(
       '           >> Parameter: $type $name ${cursor.completeStringRepr()}');
-  parsed.method.params.add(ObjCMethodParam(type, name));
-}
-
-void _markMethodReturnsRetained(clang_types.CXCursor cursor) {
-  _methodStack.top.method.returnsRetained = true;
+  method.params.add(ObjCMethodParam(type, name));
+  return true;
 }
 
 BindingType? parseObjCCategoryDeclaration(clang_types.CXCursor cursor) {
   // Categories add methods to an existing interface, so first we run a visitor
-  // to find the interface, then we fully parse that interface, then we run the
-  // _parseInterfaceVisitor over the category to add its methods etc. Reusing
-  // the interface visitor relies on the fact that the structure of the category
-  // AST looks exactly the same as the interface AST, and that the category's
+  // to find the interface, then we fully parse that interface, then we run
+  // _fillInterface over the category to add its methods etc. Reusing the
+  // interface visitor relies on the fact that the structure of the category AST
+  // looks exactly the same as the interface AST, and that the category's
   // interface is a different kind of node to the interface's super type (so is
-  // ignored by _parseInterfaceVisitor).
+  // ignored by _fillInterface).
   final name = cursor.spelling();
   _logger.fine('++++ Adding ObjC category: '
       'Name: $name, ${cursor.completeStringRepr()}');
 
-  _findCategoryInterfaceVisitorResult = null;
-  clang.clang_visitChildren(
-      cursor,
-      _findCategoryInterfaceVisitorPtr ??= Pointer.fromFunction(
-          _findCategoryInterfaceVisitor, exceptional_visitor_return),
-      nullptr);
-  final itfCursor = _findCategoryInterfaceVisitorResult;
+  final itfCursor =
+      cursor.findChildWithKind(clang_types.CXCursorKind.CXCursor_ObjCClassRef);
   if (itfCursor == null) {
     _logger.severe('Category $name has no interface.');
     return null;
@@ -311,26 +245,10 @@ BindingType? parseObjCCategoryDeclaration(clang_types.CXCursor cursor) {
     return null;
   }
 
-  _interfaceStack.push(_ParsedObjCInterface(itf));
-  clang.clang_visitChildren(
-      cursor,
-      _parseInterfaceVisitorPtr ??= Pointer.fromFunction(
-          _parseInterfaceVisitor, exceptional_visitor_return),
-      nullptr);
-  _interfaceStack.pop();
+  _fillInterface(itf, cursor);
 
   _logger.fine('++++ Finished ObjC category: '
       'Name: $name, ${cursor.completeStringRepr()}');
 
   return itf;
-}
-
-clang_types.CXCursor? _findCategoryInterfaceVisitorResult;
-int _findCategoryInterfaceVisitor(clang_types.CXCursor cursor,
-    clang_types.CXCursor parent, Pointer<Void> clientData) {
-  if (cursor.kind == clang_types.CXCursorKind.CXCursor_ObjCClassRef) {
-    _findCategoryInterfaceVisitorResult = cursor;
-    return clang_types.CXChildVisitResult.CXChildVisit_Break;
-  }
-  return clang_types.CXChildVisitResult.CXChildVisit_Continue;
 }

--- a/pkgs/ffigen/lib/src/header_parser/translation_unit_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/translation_unit_parser.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:ffi';
-
 import 'package:ffigen/src/code_generator.dart';
 import 'package:ffigen/src/header_parser/sub_parsers/macro_parser.dart';
 import 'package:ffigen/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart';
@@ -19,88 +17,55 @@ import 'utils.dart';
 
 final _logger = Logger('ffigen.header_parser.translation_unit_parser');
 
-late Set<Binding> _bindings;
-
-Pointer<
-        NativeFunction<
-            Int32 Function(
-                clang_types.CXCursor, clang_types.CXCursor, Pointer<Void>)>>?
-    _rootCursorVisitorPtr;
-
-Pointer<
-        NativeFunction<
-            Int32 Function(
-                clang_types.CXCursor, clang_types.CXCursor, Pointer<Void>)>>?
-    _cursorDefinitionVisitorPtr;
-
 /// Parses the translation unit and returns the generated bindings.
 Set<Binding> parseTranslationUnit(clang_types.CXCursor translationUnitCursor) {
-  _bindings = {};
-  final resultCode = clang.clang_visitChildren(
-    translationUnitCursor,
-    _rootCursorVisitorPtr ??=
-        Pointer.fromFunction(_rootCursorVisitor, exceptional_visitor_return),
-    nullptr,
-  );
+  final bindings = <Binding>{};
 
-  visitChildrenResultChecker(resultCode);
-
-  return _bindings;
-}
-
-/// Child visitor invoked on translationUnitCursor [CXCursorKind.CXCursor_TranslationUnit].
-int _rootCursorVisitor(clang_types.CXCursor cursor, clang_types.CXCursor parent,
-    Pointer<Void> clientData) {
-  try {
-    if (shouldIncludeRootCursor(cursor.sourceFileName())) {
-      _logger.finest('rootCursorVisitor: ${cursor.completeStringRepr()}');
-      switch (clang.clang_getCursorKind(cursor)) {
-        case clang_types.CXCursorKind.CXCursor_FunctionDecl:
-          addAllToBindings(parseFunctionDeclaration(cursor) as List<Binding>);
-          break;
-        case clang_types.CXCursorKind.CXCursor_StructDecl:
-        case clang_types.CXCursorKind.CXCursor_UnionDecl:
-        case clang_types.CXCursorKind.CXCursor_EnumDecl:
-        case clang_types.CXCursorKind.CXCursor_ObjCInterfaceDecl:
-          addToBindings(_getCodeGenTypeFromCursor(cursor));
-          break;
-        case clang_types.CXCursorKind.CXCursor_ObjCCategoryDecl:
-          addToBindings(parseObjCCategoryDeclaration(cursor));
-          break;
-        case clang_types.CXCursorKind.CXCursor_MacroDefinition:
-          saveMacroDefinition(cursor);
-          break;
-        case clang_types.CXCursorKind.CXCursor_VarDecl:
-          addToBindings(parseVarDeclaration(cursor));
-          break;
-        default:
-          _logger.finer('rootCursorVisitor: CursorKind not implemented');
+  translationUnitCursor.visitChildren((cursor) {
+    try {
+      if (shouldIncludeRootCursor(cursor.sourceFileName())) {
+        _logger.finest('rootCursorVisitor: ${cursor.completeStringRepr()}');
+        switch (clang.clang_getCursorKind(cursor)) {
+          case clang_types.CXCursorKind.CXCursor_FunctionDecl:
+            bindings.addAll(parseFunctionDeclaration(cursor) as List<Binding>);
+            break;
+          case clang_types.CXCursorKind.CXCursor_StructDecl:
+          case clang_types.CXCursorKind.CXCursor_UnionDecl:
+          case clang_types.CXCursorKind.CXCursor_EnumDecl:
+          case clang_types.CXCursorKind.CXCursor_ObjCInterfaceDecl:
+            addToBindings(bindings, _getCodeGenTypeFromCursor(cursor));
+            break;
+          case clang_types.CXCursorKind.CXCursor_ObjCCategoryDecl:
+            addToBindings(bindings, parseObjCCategoryDeclaration(cursor));
+            break;
+          case clang_types.CXCursorKind.CXCursor_MacroDefinition:
+            saveMacroDefinition(cursor);
+            break;
+          case clang_types.CXCursorKind.CXCursor_VarDecl:
+            addToBindings(bindings, parseVarDeclaration(cursor));
+            break;
+          default:
+            _logger.finer('rootCursorVisitor: CursorKind not implemented');
+        }
+      } else {
+        _logger.finest(
+            'rootCursorVisitor:(not included) ${cursor.completeStringRepr()}');
       }
-    } else {
-      _logger.finest(
-          'rootCursorVisitor:(not included) ${cursor.completeStringRepr()}');
+    } catch (e, s) {
+      _logger.severe(e);
+      _logger.severe(s);
+      rethrow;
     }
-  } catch (e, s) {
-    _logger.severe(e);
-    _logger.severe(s);
-    rethrow;
-  }
-  return clang_types.CXChildVisitResult.CXChildVisit_Continue;
+  });
+
+  return bindings;
 }
 
 /// Adds to binding if unseen and not null.
-void addToBindings(Binding? b) {
+void addToBindings(Set<Binding> bindings, Binding? b) {
   if (b != null) {
     // This is a set, and hence will not have duplicates.
-    _bindings.add(b);
-  }
-}
-
-/// Adds all binding if not empty.
-void addAllToBindings(List<Binding> b) {
-  if (b.isNotEmpty) {
-    // This is a set, and hence will not have duplicates.
-    _bindings.addAll(b);
+    bindings.add(b);
   }
 }
 
@@ -111,26 +76,13 @@ BindingType? _getCodeGenTypeFromCursor(clang_types.CXCursor cursor) {
 
 /// Visits all cursors and builds a map of usr and [CXCursor].
 void buildUsrCursorDefinitionMap(clang_types.CXCursor translationUnitCursor) {
-  _bindings = {};
-  final resultCode = clang.clang_visitChildren(
-    translationUnitCursor,
-    _cursorDefinitionVisitorPtr ??= Pointer.fromFunction(
-        _definitionCursorVisitor, exceptional_visitor_return),
-    nullptr,
-  );
-
-  visitChildrenResultChecker(resultCode);
-}
-
-/// Child visitor invoked on translationUnitCursor [CXCursorKind.CXCursor_TranslationUnit].
-int _definitionCursorVisitor(clang_types.CXCursor cursor,
-    clang_types.CXCursor parent, Pointer<Void> clientData) {
-  try {
-    cursorIndex.saveDefinition(cursor);
-  } catch (e, s) {
-    _logger.severe(e);
-    _logger.severe(s);
-    rethrow;
-  }
-  return clang_types.CXChildVisitResult.CXChildVisit_Continue;
+  translationUnitCursor.visitChildren((cursor) {
+    try {
+      cursorIndex.saveDefinition(cursor);
+    } catch (e, s) {
+      _logger.severe(e);
+      _logger.severe(s);
+      rethrow;
+    }
+  });
 }

--- a/pkgs/ffigen/lib/src/header_parser/utils.dart
+++ b/pkgs/ffigen/lib/src/header_parser/utils.dart
@@ -210,7 +210,7 @@ extension CXCursorExt on clang_types.CXCursor {
   }
 
   /// Returns whether there is a child with the given CXCursorKind.
-  bool hasCursorWithKind(int kind) => findChildWithKind(kind) != null;
+  bool hasChildWithKind(int kind) => findChildWithKind(kind) != null;
 
   /// Recursively print the AST, for debugging.
   void printAst([int maxDepth = 3]) => _printAst(maxDepth, 0);

--- a/pkgs/ffigen/lib/src/header_parser/utils.dart
+++ b/pkgs/ffigen/lib/src/header_parser/utils.dart
@@ -18,15 +18,8 @@ final _logger = Logger('ffigen.header_parser.utils');
 const exceptional_visitor_return =
     clang_types.CXChildVisitResult.CXChildVisit_Break;
 
-/// Check [resultCode] of [clang.clang_visitChildren_wrap].
-///
-/// Throws exception if resultCode is not [exceptional_visitor_return].
-void visitChildrenResultChecker(int resultCode) {
-  if (resultCode != exceptional_visitor_return) {
-    throw Exception(
-        'Exception thrown in a dart function called via C, use --verbose to see more details');
-  }
-}
+typedef _CursorVisitorCallback = Int32 Function(
+    clang_types.CXCursor, clang_types.CXCursor, Pointer<Void>);
 
 /// Logs the warnings/errors returned by clang for a translation unit.
 void logTuDiagnostics(
@@ -149,32 +142,86 @@ extension CXCursorExt on clang_types.CXCursor {
     return clang.clang_Location_isInSystemHeader(location) != 0;
   }
 
-  /// Recursively print the AST, for debugging.
-  void printAst([int maxDepth = 3]) {
-    _printAstVisitorMaxDepth = maxDepth;
-    _printAstVisitor(this, this, Pointer<Void>.fromAddress(0));
+  /// Visits all the direct children of this cursor.
+  ///
+  /// [callback] is called with the child cursor. The iteration continues until
+  /// completion. The only way it can be interrupted is if the [callback]
+  /// throws, in which case this method also throws.
+  void visitChildren(void Function(clang_types.CXCursor child) callback) {
+    final completed = visitChildrenMayBreak((clang_types.CXCursor child) {
+      callback(child);
+      return true;
+    });
+    if (!completed) {
+      throw Exception('Exception thrown in a dart function called via C, '
+          'use --verbose to see more details');
+    }
   }
-}
 
-Pointer<
-        NativeFunction<
-            Int32 Function(
-                clang_types.CXCursor, clang_types.CXCursor, Pointer<Void>)>>?
-    _printAstVisitorPtr;
-int _printAstVisitorMaxDepth = 0;
-int _printAstVisitor(clang_types.CXCursor cursor, clang_types.CXCursor parent,
-    Pointer<Void> clientData) {
-  final depth = clientData.address;
-  if (depth > _printAstVisitorMaxDepth) {
-    return clang_types.CXChildVisitResult.CXChildVisit_Break;
+  /// Visits all the direct children of this cursor.
+  ///
+  /// [callback] is called with the child cursor. If [callback] returns true,
+  /// the iteration will continue. Otherwise, if [callback] returns false, the
+  /// iteration will stop.
+  ///
+  /// Returns whether the iteration completed.
+  bool visitChildrenMayBreak(
+          bool Function(clang_types.CXCursor child) callback) =>
+      visitChildrenMayRecurse(
+          (clang_types.CXCursor child, clang_types.CXCursor parent) =>
+              callback(child)
+                  ? clang_types.CXChildVisitResult.CXChildVisit_Continue
+                  : clang_types.CXChildVisitResult.CXChildVisit_Break);
+
+  /// Visits all the direct children of this cursor.
+  ///
+  /// [callback] is called with the child cursor and parent cursor. If
+  /// [callback] returns CXChildVisit_Continue, the iteration continues. If it
+  /// returns CXChildVisit_Break the iteration stops. If it returns
+  /// CXChildVisit_Recurse, the iteration recurses into the node.
+  ///
+  /// Returns whether the iteration completed.
+  bool visitChildrenMayRecurse(
+      int Function(clang_types.CXCursor child, clang_types.CXCursor parent)
+          callback) {
+    final protocolVisitor = NativeCallable<_CursorVisitorCallback>.isolateLocal(
+        (clang_types.CXCursor child, clang_types.CXCursor parent,
+                Pointer<Void> clientData) =>
+            callback(child, parent),
+        exceptionalReturn: exceptional_visitor_return);
+    final result = clang.clang_visitChildren(
+        this, protocolVisitor.nativeFunction, nullptr);
+    protocolVisitor.close();
+    return result == 0;
   }
-  print(('  ' * depth) + cursor.completeStringRepr());
-  clang.clang_visitChildren(
-      cursor,
-      _printAstVisitorPtr ??=
-          Pointer.fromFunction(_printAstVisitor, exceptional_visitor_return),
-      Pointer<Void>.fromAddress(depth + 1));
-  return clang_types.CXChildVisitResult.CXChildVisit_Continue;
+
+  /// Returns the first child with the given CXCursorKind, or null if there
+  /// isn't one.
+  clang_types.CXCursor? findChildWithKind(int kind) {
+    clang_types.CXCursor? result;
+    visitChildrenMayBreak((child) {
+      if (child.kind == kind) {
+        result = child;
+        return false;
+      }
+      return true;
+    });
+    return result;
+  }
+
+  /// Returns whether there is a child with the given CXCursorKind.
+  bool hasCursorWithKind(int kind) => findChildWithKind(kind) != null;
+
+  /// Recursively print the AST, for debugging.
+  void printAst([int maxDepth = 3]) => _printAst(maxDepth, 0);
+  bool _printAst(int maxDepth, int depth) {
+    if (depth > maxDepth) {
+      return false;
+    }
+    print(('  ' * depth) + completeStringRepr());
+    visitChildren((child) => child._printAst(maxDepth, depth + 1));
+    return true;
+  }
 }
 
 const commentPrefix = '/// ';


### PR DESCRIPTION
Now that `NativeCallable.isolateLocal` supports lambdas, we can greatly simplify all the cursor visitors.

- Added `CXCursor.visitChildren`, `visitChildrenMayBreak`, and `visitChildrenMayRecurse`. Which are thin wrappers around `clang_visitChildren`, accepting Dart functions rather than native function pointers.
- Also added `findChildWithKind` and `hasChildWithKind`, which are built on top of those.
- Replaced all existing `clang_visitChildren` calls with calls to these new visitors.
- Since the new visitors take arbitrary Dart functions, we can delete all the globals and stacks that were used to pass args and get results from the old static visitor functions.
- I was also able to delete some of the helper classes that only existed to pass around these args and returns.