### PR TITLE
[native_assets_cli] Add `Builder` and `Linker` interfaces and docs

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1-wip
+
+- Nothing yet.
+
 ## 0.7.0
 
 - Add support for `hook/link.dart` including dry runs.

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -1,10 +1,10 @@
 name: native_assets_builder
 description: >-
   This package is the backend that invokes build hooks.
-version: 0.7.0
+version: 0.7.1-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_builder
 
-# publish_to: none
+publish_to: none
 
 environment:
   sdk: '>=3.3.0 <4.0.0'
@@ -13,9 +13,9 @@ dependencies:
   collection: ^1.18.0
   graphs: ^2.3.1
   logging: ^1.2.0
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #  path: ../native_assets_cli/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../native_assets_cli/
   package_config: ^2.1.0
   yaml: ^3.1.2
   yaml_edit: ^2.1.0

--- a/pkgs/native_assets_builder/test_data/add_asset_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/add_asset_link/hook/build.dart
@@ -22,8 +22,8 @@ void main(List<String> arguments) async {
       dartBuildFiles: ['hook/build.dart'],
       linkModePreference: LinkModePreference.dynamic,
     ).run(
-      buildConfig: config,
-      buildOutput: output,
+      config: config,
+      output: output,
       logger: logger,
       linkInPackage: 'add_asset_link',
     );

--- a/pkgs/native_assets_builder/test_data/add_asset_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/add_asset_link/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
 dependencies:
   logging: ^1.1.1
   meta: ^1.12.0
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
-  native_toolchain_c: ^0.4.2
-  # native_toolchain_c:
-  #   path: ../../../native_toolchain_c/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+  # native_toolchain_c: ^0.4.2
+  native_toolchain_c:
+    path: ../../../native_toolchain_c/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_builder/test_data/complex_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/complex_link/pubspec.yaml
@@ -12,9 +12,9 @@ dependencies:
   complex_link_helper:
     path: ../complex_link_helper/
   logging: ^1.1.1
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_builder/test_data/complex_link_helper/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/complex_link_helper/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   cli_config: ^0.2.0
   logging: ^1.1.1
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_builder/test_data/cyclic_package_1/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/cyclic_package_1/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   cyclic_package_2:
     path: ../cyclic_package_2
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #  path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test_data/cyclic_package_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/cyclic_package_2/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   cyclic_package_1:
     path: ../cyclic_package_1
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #  path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test_data/drop_dylib_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/drop_dylib_link/hook/build.dart
@@ -24,8 +24,8 @@ void main(List<String> arguments) async {
       dartBuildFiles: ['hook/build.dart'],
       linkModePreference: LinkModePreference.dynamic,
     ).run(
-      buildConfig: config,
-      buildOutput: output,
+      config: config,
+      output: output,
       logger: logger,
       linkInPackage: packageName,
     );
@@ -39,8 +39,8 @@ void main(List<String> arguments) async {
       dartBuildFiles: ['hook/build.dart'],
       linkModePreference: LinkModePreference.dynamic,
     ).run(
-      buildConfig: config,
-      buildOutput: output,
+      config: config,
+      output: output,
       logger: logger,
       linkInPackage: packageName,
     );

--- a/pkgs/native_assets_builder/test_data/drop_dylib_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/drop_dylib_link/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
 dependencies:
   logging: ^1.1.1
   meta: ^1.12.0
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
-  native_toolchain_c: ^0.4.2
-  # native_toolchain_c:
-  #   path: ../../../native_toolchain_c/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+  # native_toolchain_c: ^0.4.2
+  native_toolchain_c:
+    path: ../../../native_toolchain_c/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_builder/test_data/native_add/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/native_add/hook/build.dart
@@ -19,8 +19,8 @@ void main(List<String> arguments) async {
       dartBuildFiles: ['hook/build.dart'],
     );
     await cbuilder.run(
-      buildConfig: config,
-      buildOutput: output,
+      config: config,
+      output: output,
       logger: Logger('')
         ..level = Level.ALL
         ..onRecord.listen((record) {

--- a/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #  path: ../../../native_assets_cli/
-  native_toolchain_c: ^0.4.2
-  # native_toolchain_c:
-  #   path: ../../../native_toolchain_c/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+  # native_toolchain_c: ^0.4.2
+  native_toolchain_c:
+    path: ../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/native_add_add_source/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/native_add_add_source/hook/build.dart
@@ -20,8 +20,8 @@ void main(List<String> arguments) async {
       dartBuildFiles: ['hook/build.dart'],
     );
     await cbuilder.run(
-      buildConfig: config,
-      buildOutput: output,
+      config: config,
+      output: output,
       logger: Logger('')
         ..level = Level.ALL
         ..onRecord.listen((record) {

--- a/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #  path: ../../../native_assets_cli/
-  native_toolchain_c: ^0.4.2
-  # native_toolchain_c:
-  #   path: ../../../native_toolchain_c/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+  # native_toolchain_c: ^0.4.2
+  native_toolchain_c:
+    path: ../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/native_subtract/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/native_subtract/hook/build.dart
@@ -19,8 +19,8 @@ void main(List<String> arguments) async {
       dartBuildFiles: ['hook/build.dart'],
     );
     await cbuilder.run(
-      buildConfig: config,
-      buildOutput: output,
+      config: config,
+      output: output,
       logger: Logger('')
         ..level = Level.ALL
         ..onRecord.listen((record) {

--- a/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #  path: ../../../native_assets_cli/
-  native_toolchain_c: ^0.4.2
-  # native_toolchain_c:
-  #   path: ../../../native_toolchain_c/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+  # native_toolchain_c: ^0.4.2
+  native_toolchain_c:
+    path: ../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/no_asset_for_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/no_asset_for_link/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   logging: ^1.1.1
   meta: ^1.12.0
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_builder/test_data/package_reading_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/package_reading_metadata/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #  path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   package_with_metadata:
     path: ../package_with_metadata/
   yaml: ^3.1.1

--- a/pkgs/native_assets_builder/test_data/package_with_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/package_with_metadata/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #  path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test_data/simple_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/simple_link/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   cli_config: ^0.2.0
   logging: ^1.1.1
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_builder/test_data/wrong_build_output/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #  path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test_data/wrong_build_output_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output_2/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #  path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test_data/wrong_build_output_3/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output_3/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #  path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test_data/wrong_namespace_asset/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_namespace_asset/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #  path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1-wip
+
+- Introduce `Builder` and `Linker` interface.
+
 ## 0.6.0
 
 - Add support for `hook/link.dart`.

--- a/pkgs/native_assets_cli/example/build/local_asset/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/local_asset/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #   path: ../../../../native_assets_cli/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../../native_assets_cli/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_cli/example/build/native_add_library/hook/build.dart
+++ b/pkgs/native_assets_cli/example/build/native_add_library/hook/build.dart
@@ -18,8 +18,8 @@ void main(List<String> args) async {
       dartBuildFiles: ['hook/build.dart'],
     );
     await cbuilder.run(
-      buildConfig: config,
-      buildOutput: output,
+      config: config,
+      output: output,
       logger: Logger('')
         ..level = Level.ALL
         ..onRecord.listen((record) => print(record.message)),

--- a/pkgs/native_assets_cli/example/build/native_add_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/native_add_library/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #   path: ../../../../native_assets_cli/
-  native_toolchain_c: ^0.4.2
-  # native_toolchain_c:
-  #   path: ../../../../native_toolchain_c/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../../native_assets_cli/
+  # native_toolchain_c: ^0.4.2
+  native_toolchain_c:
+    path: ../../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_cli/example/build/use_dart_api/hook/build.dart
+++ b/pkgs/native_assets_cli/example/build/use_dart_api/hook/build.dart
@@ -20,8 +20,8 @@ void main(List<String> arguments) async {
       dartBuildFiles: ['hook/build.dart'],
     );
     await cbuilder.run(
-      buildConfig: config,
-      buildOutput: output,
+      config: config,
+      output: output,
       logger: Logger('')
         ..level = Level.ALL
         ..onRecord.listen((record) {

--- a/pkgs/native_assets_cli/example/build/use_dart_api/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/use_dart_api/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #   path: ../../../../native_assets_cli/
-  native_toolchain_c: ^0.4.2
-  # native_toolchain_c:
-  #   path: ../../../../native_toolchain_c/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../../native_assets_cli/
+  # native_toolchain_c: ^0.4.2
+  native_toolchain_c:
+    path: ../../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^10.0.0

--- a/pkgs/native_assets_cli/example/link/package_with_assets/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/link/package_with_assets/pubspec.yaml
@@ -11,9 +11,9 @@ environment:
 dependencies:
   logging: ^1.1.1
   meta: ^1.12.0
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #   path: ../../../../native_assets_cli/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../../../../native_assets_cli/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_cli/lib/native_assets_cli.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli.dart
@@ -18,13 +18,15 @@ export 'src/api/asset.dart'
         LookupInProcess,
         NativeCodeAsset,
         StaticLinking;
-export 'src/api/build.dart';
+export 'src/api/build.dart' show build;
 export 'src/api/build_config.dart' show BuildConfig, CCompilerConfig;
 export 'src/api/build_mode.dart' show BuildMode;
 export 'src/api/build_output.dart' show BuildOutput, LinkOutput;
+export 'src/api/builder.dart' show Builder;
 export 'src/api/hook_config.dart' show HookConfig;
 export 'src/api/ios_sdk.dart' show IOSSdk;
-export 'src/api/link.dart';
+export 'src/api/link.dart' show link;
 export 'src/api/link_config.dart' show LinkConfig;
 export 'src/api/link_mode_preference.dart' show LinkModePreference;
+export 'src/api/linker.dart' show Linker;
 export 'src/api/os.dart' show OS;

--- a/pkgs/native_assets_cli/lib/src/api/build_output.dart
+++ b/pkgs/native_assets_cli/lib/src/api/build_output.dart
@@ -37,7 +37,8 @@ part 'link_output.dart';
 ///
 /// For more information see [build].
 ///
-/// Designed to be a sink. [Builder]s stream outputs to the link output.
+/// Designed to be a sink. The [BuildOutput] is not intended to be read from.
+/// [Builder]s stream outputs to the link output. For more info see [Builder].
 abstract final class BuildOutput {
   /// Start time for the build of this output.
   ///

--- a/pkgs/native_assets_cli/lib/src/api/build_output.dart
+++ b/pkgs/native_assets_cli/lib/src/api/build_output.dart
@@ -17,8 +17,12 @@ import '../utils/json.dart';
 import '../utils/map.dart';
 import 'architecture.dart';
 import 'asset.dart';
+import 'build.dart';
 import 'build_config.dart';
+import 'builder.dart';
 import 'hook_config.dart';
+import 'link.dart';
+import 'linker.dart';
 import 'os.dart';
 
 part '../model/hook_output.dart';
@@ -30,6 +34,10 @@ part 'link_output.dart';
 /// hook exists, it will be automatically run, by the Flutter and Dart SDK
 /// tools. The hook is expect to produce a specific output which [BuildOutput]
 /// can produce.
+///
+/// For more information see [build].
+///
+/// Designed to be a sink. [Builder]s stream outputs to the link output.
 abstract final class BuildOutput {
   /// Start time for the build of this output.
   ///

--- a/pkgs/native_assets_cli/lib/src/api/build_output.dart
+++ b/pkgs/native_assets_cli/lib/src/api/build_output.dart
@@ -38,7 +38,7 @@ part 'link_output.dart';
 /// For more information see [build].
 ///
 /// Designed to be a sink. The [BuildOutput] is not intended to be read from.
-/// [Builder]s stream outputs to the link output. For more info see [Builder].
+/// [Builder]s stream outputs to the build output. For more info see [Builder].
 abstract final class BuildOutput {
   /// Start time for the build of this output.
   ///

--- a/pkgs/native_assets_cli/lib/src/api/builder.dart
+++ b/pkgs/native_assets_cli/lib/src/api/builder.dart
@@ -1,0 +1,75 @@
+import 'package:logging/logging.dart';
+
+import 'build_config.dart';
+import 'build_output.dart';
+import 'linker.dart';
+
+/// A builder to be run during a build hook.
+///
+/// [Builder]s should be used to build native code, download assets, and
+/// transform assets. A build hook is only rerun when its declared
+/// [BuildOutput.dependencies] change. ([Linker]s have access to tree-shaking
+/// information in some build modes, and could potentially build or download
+/// less assets. However, due to the tree-shaking information being an input to
+/// link hooks, link hooks are re-run much more often.)
+///
+/// A package to be used in build hooks should implement this interface. The
+/// typical pattern of build hooks should be a declarative specification of one
+/// or more builders (constructor calls), followed by [run]ning these builders.
+///
+/// For example with a single builder from `package:native_toolchain_c`:
+///
+/// ```dart
+/// import 'package:logging/logging.dart';
+/// import 'package:native_assets_cli/native_assets_cli.dart';
+/// import 'package:native_toolchain_c/native_toolchain_c.dart';
+///
+/// void main(List<String> args) async {
+///   await build(args, (config, output) async {
+///     final packageName = config.packageName;
+///     final cbuilder = CBuilder.library(
+///       name: packageName,
+///       assetName: '$packageName.dart',
+///       sources: [
+///         'src/$packageName.c',
+///       ],
+///       dartBuildFiles: ['hook/build.dart'],
+///     );
+///     await cbuilder.run(
+///       buildConfig: config,
+///       buildOutput: output,
+///       logger: Logger('')
+///         ..level = Level.ALL
+///         ..onRecord.listen((record) => print(record.message)),
+///     );
+///   });
+/// }
+/// ```
+///
+/// The builder is designed to immediately operate on [BuildConfig]. If a
+/// builder should deviate behavior from the build config, this should be
+/// configurable through a constructor parameter. For example, if a native
+/// compiler should output a static library to be sent to a linker, but the
+/// [BuildConfig.linkModePreference] is set to dynamic linking, the builder
+/// should have its own `linkModePreference` parameter in the constructor.
+///
+/// The builder is designed to immediately operate on [BuildOutput]. If a
+/// builder should output something else than standard, it should be
+/// configurable through a constructor parameter. For example to send an asset
+/// for linking to the output ([BuildOutput.addAsset] with `linkInPackage` set),
+/// the builder should have a constructor parameter. (Instead of capturing the
+/// BuildOutput as a return value and manually manipulating it in the build
+/// hook.) This ensures that builder is in control of what combination of build
+/// outputs are valid.
+abstract interface class Builder {
+  /// Runs this build.
+  ///
+  /// Reads the config from [config], streams output to [output], and streams
+  /// logs to [logger].
+  // TODO(dacoharkes): Should this be `build` instead of `run`?
+  Future<void> run({
+    required BuildConfig config,
+    required BuildOutput output,
+    required Logger? logger,
+  });
+}

--- a/pkgs/native_assets_cli/lib/src/api/builder.dart
+++ b/pkgs/native_assets_cli/lib/src/api/builder.dart
@@ -66,7 +66,6 @@ abstract interface class Builder {
   ///
   /// Reads the config from [config], streams output to [output], and streams
   /// logs to [logger].
-  // TODO(dacoharkes): Should this be `build` instead of `run`?
   Future<void> run({
     required BuildConfig config,
     required BuildOutput output,

--- a/pkgs/native_assets_cli/lib/src/api/link_output.dart
+++ b/pkgs/native_assets_cli/lib/src/api/link_output.dart
@@ -4,6 +4,16 @@
 
 part of 'build_output.dart';
 
+/// The output of a link hook (`hook/link.dart`) invocation.
+///
+/// A package can optionally provide link hook (`hook/link.dart`). If such a
+/// hook exists, and any build hook outputs packages for linking with it, it
+/// will be automatically run, by the Flutter and Dart SDK tools. The hook is
+/// expect to produce a specific output which [LinkOutput] can produce.
+///
+/// For more information see [link].
+///
+/// Designed to be a sink. [Linker]s stream outputs to the link output.
 abstract final class LinkOutput {
   /// Start time for the link of this output.
   ///

--- a/pkgs/native_assets_cli/lib/src/api/link_output.dart
+++ b/pkgs/native_assets_cli/lib/src/api/link_output.dart
@@ -13,7 +13,8 @@ part of 'build_output.dart';
 ///
 /// For more information see [link].
 ///
-/// Designed to be a sink. [Linker]s stream outputs to the link output.
+/// Designed to be a sink. The [LinkOutput] is not designed to be read from.
+/// [Linker]s stream outputs to the link output. For more info see [Linker].
 abstract final class LinkOutput {
   /// Start time for the link of this output.
   ///

--- a/pkgs/native_assets_cli/lib/src/api/linker.dart
+++ b/pkgs/native_assets_cli/lib/src/api/linker.dart
@@ -1,0 +1,40 @@
+import 'package:logging/logging.dart';
+
+import 'build_output.dart';
+import 'builder.dart';
+import 'link_config.dart';
+
+/// A linker to be run during a link hook.
+///
+/// [Linker]s should be used to shrink or omit assets based on tree-shaking
+/// information. [Linker]s have access to tree-shaking information in some build
+/// modes. However, due to the tree-shaking information being an input to link
+/// hooks, link hooks are re-run more often than [Builder]s. A link hook is
+/// rerun when its declared [BuildOutput.dependencies] or its [LinkConfig] tree
+/// shaking information changes.
+///
+/// A package to be used in link hooks should implement this interface. The
+/// typical pattern of link hooks should be a declarative specification of one
+/// or more linkers (constructor calls), followed by [run]ning these linkers.
+///
+/// The linker is designed to immediately operate on [LinkConfig]. If a linker
+/// should deviate behavior from the build config, this should be configurable
+/// through a constructor parameter.
+///
+/// The linker is designed to immediately operate on [LinkOutput]. If a linker
+/// should output something else than standard, it should be configurable
+/// through a constructor parameter.
+// TODO(dacoharkes): Add a doc comment reference when tree shaking info is
+// available.
+abstract interface class Linker {
+  /// Runs this linker.
+  ///
+  /// Reads the config from [config], streams output to [output], and streams
+  /// logs to [logger].
+  // TODO(dacoharkes): Should this be `link` instead of `run`?
+  Future<void> run({
+    required LinkConfig config,
+    required LinkOutput output,
+    required Logger? logger,
+  });
+}

--- a/pkgs/native_assets_cli/lib/src/api/linker.dart
+++ b/pkgs/native_assets_cli/lib/src/api/linker.dart
@@ -31,7 +31,6 @@ abstract interface class Linker {
   ///
   /// Reads the config from [config], streams output to [output], and streams
   /// logs to [logger].
-  // TODO(dacoharkes): Should this be `link` instead of `run`?
   Future<void> run({
     required LinkConfig config,
     required LinkOutput output,

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   native assets CLI.
 
 # Note: Bump BuildConfig.version and BuildOutput.version on breaking changes!
-version: 0.6.0
+version: 0.6.1-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
 topics:

--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0-wip
+
+- Renamed parameters in `Builder.run`.
+
 ## 0.4.2
 
 - Bump `package:native_assets_cli` to 0.5.0.

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
 version: 0.4.2
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
-# publish_to: none
+publish_to: none
 
 topics:
   - compiler
@@ -20,9 +20,9 @@ dependencies:
   glob: ^2.1.1
   logging: ^1.1.1
   meta: ^1.9.1
-  native_assets_cli: ^0.6.0
-  # native_assets_cli:
-  #  path: ../native_assets_cli/
+  # native_assets_cli: ^0.6.0
+  native_assets_cli:
+    path: ../native_assets_cli/
   pub_semver: ^2.1.3
 
 dev_dependencies:

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
@@ -53,8 +53,8 @@ void main() {
     );
     expect(
       () => cbuilder.run(
-        buildConfig: buildConfig,
-        buildOutput: buildOutput,
+        config: buildConfig,
+        output: buildOutput,
         logger: logger,
       ),
       throwsException,

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -145,8 +145,8 @@ Future<Uri> buildLib(
     dartBuildFiles: ['hook/build.dart'],
   );
   await cbuilder.run(
-    buildConfig: buildConfig,
-    buildOutput: buildOutput,
+    config: buildConfig,
+    output: buildOutput,
     logger: logger,
   );
 

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -78,8 +78,8 @@ void main() {
               dartBuildFiles: ['hook/build.dart'],
             );
             await cbuilder.run(
-              buildConfig: buildConfig,
-              buildOutput: buildOutput,
+              config: buildConfig,
+              output: buildOutput,
               logger: logger,
             );
 

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -64,8 +64,8 @@ void main() {
           dartBuildFiles: ['hook/build.dart'],
         );
         await cbuilder.run(
-          buildConfig: buildConfig,
-          buildOutput: buildOutput,
+          config: buildConfig,
+          output: buildOutput,
           logger: logger,
         );
 

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -62,8 +62,8 @@ void main() {
           dartBuildFiles: ['hook/build.dart'],
         );
         await cbuilder.run(
-          buildConfig: buildConfig,
-          buildOutput: buildOutput,
+          config: buildConfig,
+          output: buildOutput,
           logger: logger,
         );
 

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -74,8 +74,8 @@ void main() {
           dartBuildFiles: ['hook/build.dart'],
         );
         await cbuilder.run(
-          buildConfig: buildConfig,
-          buildOutput: buildOutput,
+          config: buildConfig,
+          output: buildOutput,
           logger: logger,
         );
 

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -66,8 +66,8 @@ void main() {
           dartBuildFiles: ['hook/build.dart'],
         );
         await cbuilder.run(
-          buildConfig: buildConfig,
-          buildOutput: buildOutput,
+          config: buildConfig,
+          output: buildOutput,
           logger: logger,
         );
 
@@ -147,8 +147,8 @@ void main() {
           dartBuildFiles: ['hook/build.dart'],
         );
         await cbuilder.run(
-          buildConfig: buildConfig,
-          buildOutput: buildOutput,
+          config: buildConfig,
+          output: buildOutput,
           logger: logger,
         );
 
@@ -245,8 +245,8 @@ void main() {
       dartBuildFiles: ['hook/build.dart'],
     );
     await cbuilder.run(
-      buildConfig: buildConfig,
-      buildOutput: buildOutput,
+      config: buildConfig,
+      output: buildOutput,
       logger: logger,
     );
 
@@ -299,8 +299,8 @@ void main() {
       dartBuildFiles: ['hook/build.dart'],
     );
     await cbuilder.run(
-      buildConfig: buildConfig,
-      buildOutput: buildOutput,
+      config: buildConfig,
+      output: buildOutput,
       logger: logger,
     );
 
@@ -350,8 +350,8 @@ void main() {
       dartBuildFiles: ['hook/build.dart'],
     );
     await cbuilder.run(
-      buildConfig: buildConfig,
-      buildOutput: buildOutput,
+      config: buildConfig,
+      output: buildOutput,
       logger: logger,
     );
 
@@ -411,8 +411,8 @@ void main() {
       dartBuildFiles: ['hook/build.dart'],
     );
     await cbuilder.run(
-      buildConfig: buildConfig,
-      buildOutput: buildOutput,
+      config: buildConfig,
+      output: buildOutput,
       logger: logger,
     );
 
@@ -472,16 +472,16 @@ void main() {
     if (buildConfig.targetOS == OS.windows) {
       await expectLater(
         () => cbuilder.run(
-          buildConfig: buildConfig,
-          buildOutput: buildOutput,
+          config: buildConfig,
+          output: buildOutput,
           logger: logger,
         ),
         throwsArgumentError,
       );
     } else {
       await cbuilder.run(
-        buildConfig: buildConfig,
-        buildOutput: buildOutput,
+        config: buildConfig,
+        output: buildOutput,
         logger: logger,
       );
 
@@ -545,8 +545,8 @@ Future<void> testDefines({
     dartBuildFiles: ['hook/build.dart'],
   );
   await cbuilder.run(
-    buildConfig: buildConfig,
-    buildOutput: buildOutput,
+    config: buildConfig,
+    output: buildOutput,
     logger: logger,
   );
 


### PR DESCRIPTION
This PR adds an opinionated `Builder` and `Linker` interface with documentation on what builders and linkers should be used for.

Closes: https://github.com/dart-lang/native/issues/995

(Also, flips all versions back to WIP, now that the link hooks have landed in both Dart and Flutter.)