### PR TITLE
Fix #1007

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -3,6 +3,8 @@
 - __Breaking change__: Code-gen the ObjC `id` type to `ObjCObjectBase` rather
   than `NSObject`, since not all ObjC classes inherit from `NSObject`. Eg
   `NSProxy`.
+- Rename ObjC interface methods that clash with type names. Fixes
+  https://github.com/dart-lang/native/issues/1007.
 
 ## 12.0.0
 

--- a/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
@@ -79,7 +79,8 @@ class ObjCInterface extends BindingType {
       s.write(makeDartDoc(dartDoc!));
     }
 
-    final uniqueNamer = UniqueNamer({name, 'pointer'});
+    final uniqueNamer =
+        UniqueNamer({name, 'pointer'}, parent: w.topLevelUniqueNamer);
 
     final rawObjType = PointerType(objCObjectType).getCType(w);
     final wrapObjType = ObjCBuiltInFunctions.objectBase.gen(w);

--- a/pkgs/ffigen/lib/src/code_generator/utils.dart
+++ b/pkgs/ffigen/lib/src/code_generator/utils.dart
@@ -15,9 +15,15 @@ class UniqueNamer {
   final Set<String> _usedUpNames;
 
   /// Creates a UniqueNamer with given [usedUpNames] and Dart reserved keywords.
-  UniqueNamer(Set<String> usedUpNames)
+  ///
+  /// If [parent] is provided, also includes all the parent's names.
+  UniqueNamer(Set<String> usedUpNames, {UniqueNamer? parent})
       : assert(keywords.intersection(usedUpNames).isEmpty),
-        _usedUpNames = {...keywords, ...usedUpNames};
+        _usedUpNames = {
+          ...keywords,
+          ...usedUpNames,
+          ...(parent?._usedUpNames ?? {}),
+        };
 
   /// Creates a UniqueNamer with given [usedUpNames] only.
   UniqueNamer._raw(this._usedUpNames);

--- a/pkgs/ffigen/test/native_objc_test/method_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/method_test.dart
@@ -98,7 +98,7 @@ void main() {
         // Test for https://github.com/dart-lang/native/issues/1007
         final resultPtr = calloc<Vec4>();
         final result = resultPtr.ref;
-        testInstance.Vec41(resultPtr);  // A slightly unfortunate rename :P
+        testInstance.Vec41(resultPtr); // A slightly unfortunate rename :P
         expect(result.x, 1);
         expect(result.y, 2);
         expect(result.z, 3);

--- a/pkgs/ffigen/test/native_objc_test/method_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/method_test.dart
@@ -93,6 +93,18 @@ void main() {
       test('Doubles', () {
         expect(testInstance.addDoubles_Y_(1.23, 4.56), closeTo(5.79, 1e-6));
       });
+
+      test('Method with same name as a type', () {
+        // Test for https://github.com/dart-lang/native/issues/1007
+        final resultPtr = calloc<Vec4>();
+        final result = resultPtr.ref;
+        testInstance.Vec41(resultPtr);  // A slightly unfortunate rename :P
+        expect(result.x, 1);
+        expect(result.y, 2);
+        expect(result.z, 3);
+        expect(result.w, 4);
+        calloc.free(resultPtr);
+      });
     });
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/method_test.m
+++ b/pkgs/ffigen/test/native_objc_test/method_test.m
@@ -24,6 +24,7 @@ typedef struct {
 -(Vec4)twiddleVec4Components:(Vec4)v;
 -(float)addFloats:(float)x Y:(float) y;
 -(double)addDoubles:(double)x Y:(double) y;
+-(Vec4)Vec4;
 
 @end
 
@@ -76,6 +77,15 @@ typedef struct {
 
 -(double)addDoubles:(double)x Y:(double) y {
     return x + y;
+}
+
+-(Vec4)Vec4 {
+    Vec4 u;
+    u.x = 1;
+    u.y = 2;
+    u.z = 3;
+    u.w = 4;
+    return u;
 }
 
 @end


### PR DESCRIPTION
In ObjC, methods and properties are allowed to have the same name as types (eg [CGImage is a type](https://developer.apple.com/documentation/coreimage/ciimage/1687603-cgimage?language=objc)). But this isn't allowed in Dart, so we have to rename any method that collides like this.

All our renaming logic is handled by `UniqueNamer`, and the types are all in `Writer.topLevelUniqueNamer`, so we just have to add all the top level namer's names to the interface level namer that renames the methods.