### PR TITLE
Generate real enums instead of enum-like classes

### DIFF
--- a/pkgs/ffigen/analysis_options.yaml
+++ b/pkgs/ffigen/analysis_options.yaml
@@ -15,6 +15,7 @@ analyzer:
     - example/objective_c/**
     - example/swift/**
     - test_flutter/native_objc_test/**
+    - test/native_objc_test/**
   language:
     strict-casts: true
     strict-inference: true

--- a/pkgs/ffigen/lib/src/code_generator/binding_string.dart
+++ b/pkgs/ffigen/lib/src/code_generator/binding_string.dart
@@ -21,7 +21,7 @@ enum BindingStringType {
   union,
   constant,
   global,
-  enumClass,
+  enum_,
   typeDef,
   objcInterface,
   objcBlock,

--- a/pkgs/ffigen/lib/src/code_generator/enum_class.dart
+++ b/pkgs/ffigen/lib/src/code_generator/enum_class.dart
@@ -29,12 +29,12 @@ import 'writer.dart';
 /// enum Fruits {
 ///   apple(0),
 ///   banana(10);
-/// 
+///
 ///   static const yellow_fruit = banana;
-/// 
+///
 ///   final int value;
 ///   const Fruit(this.value);
-/// 
+///
 ///   @override
 ///   String toString() {
 ///     if (this == banana) return "Fruits.banana, Fruits.yellow_fruit";
@@ -77,7 +77,9 @@ class EnumClass extends BindingType {
     uniqueToDuplicates.clear();
     duplicateToOriginal.clear();
     for (final ec in enumConstants) {
-      final original = uniqueMembers.firstWhereOrNull((other) => other.value == ec.value);
+      final original = uniqueMembers.firstWhereOrNull(
+        (other) => other.value == ec.value,
+      );
       if (original == null) {
         // This is a unique entry
         uniqueMembers.add(ec);
@@ -96,12 +98,8 @@ class EnumClass extends BindingType {
     required super.name,
     super.dartDoc,
     List<EnumConstant>? enumConstants,
-  }) : 
-    enumConstants = enumConstants ?? [],
-    namer = UniqueNamer({name})
-  { 
-    scanForDuplicates();
-  }
+  })  : enumConstants = enumConstants ?? [],
+        namer = UniqueNamer({name});
 
   void writeUniqueMembers(StringBuffer s) {
     s.write("$depth// ===== Unique members =====\n");
@@ -136,14 +134,17 @@ class EnumClass extends BindingType {
     for (final entry in uniqueToDuplicates.entries) {
       // [!] All enum values were given a name when their declarations were generated
       final unique = entry.key;
-      final originalName = enumNames[unique]!;      
+      final originalName = enumNames[unique]!;
       final duplicates = entry.value;
       if (duplicates.isEmpty) continue;
       final allDuplicates = [
         for (final duplicate in [unique] + duplicates)
           "$name.${enumNames[duplicate]!}",
       ].join(", ");
-      s.write('${depth * 2}if (this == $originalName) return "$allDuplicates";\n');
+      s.write(
+        '$depth$depth'
+        'if (this == $originalName) return "$allDuplicates";\n',
+      );
     }
     s.write("${depth * 2}return super.toString();\n");
     s.write("$depth}\n");
@@ -170,15 +171,15 @@ class EnumClass extends BindingType {
       writeEmptyEnum(s);
     } else {
       s.write('enum $name {\n');
-        writeUniqueMembers(s);
-        writeDuplicateMembers(s);
-        writeConstructor(s);
-        writeToStringOverride(s);
+      writeUniqueMembers(s);
+      writeDuplicateMembers(s);
+      writeConstructor(s);
+      writeToStringOverride(s);
       s.write('}\n\n');
     }
 
     return BindingString(
-      type: BindingStringType.enum_, 
+      type: BindingStringType.enum_,
       string: s.toString(),
     );
   }
@@ -186,7 +187,6 @@ class EnumClass extends BindingType {
   @override
   void addDependencies(Set<Binding> dependencies) {
     if (dependencies.contains(this)) return;
-
     dependencies.add(this);
   }
 

--- a/pkgs/ffigen/lib/src/code_generator/enum_class.dart
+++ b/pkgs/ffigen/lib/src/code_generator/enum_class.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:collection/collection.dart';
+
 import 'binding.dart';
 import 'binding_string.dart';
 import 'native_type.dart';
@@ -9,18 +11,35 @@ import 'type.dart';
 import 'utils.dart';
 import 'writer.dart';
 
+// Only uniques
+// duplicate --> original
+// unique --> all duplicates
+// typedef UniqueAndDuplicates = ({EnumConstant unique, List<EnumConstant> duplicates});
+// typedef DuplicateAndOriginal = ({EnumConstant duplicate, })
+
 /// A binding for enums in C.
 ///
 /// For a C enum -
 /// ```c
-/// enum Fruits {apple, banana = 10};
+/// enum Fruits {apple, banana = 10, yellow_fruit = 10};
 /// ```
 /// The generated dart code is
 ///
 /// ```dart
-/// class Fruits {
-///   static const apple = 0;
-///   static const banana = 10;
+/// enum Fruits {
+///   apple(0),
+///   banana(10);
+/// 
+///   static const yellow_fruit = banana;
+/// 
+///   final int value;
+///   const Fruit(this.value);
+/// 
+///   @override
+///   String toString() {
+///     if (this == banana) return "Fruits.banana, Fruits.yellow_fruit";
+///     return super.toString();
+///   }
 /// }
 /// ```
 class EnumClass extends BindingType {
@@ -28,43 +47,140 @@ class EnumClass extends BindingType {
 
   final List<EnumConstant> enumConstants;
 
+  /// Avoids naming members with [name] because dart doesn't allow values to
+  /// have the same name as the class.
+  final UniqueNamer namer;
+
+  final Map<EnumConstant, String> enumNames = {};
+
+  static const depth = '  ';
+
+  final Map<EnumConstant, List<EnumConstant>> uniqueToDuplicates = {};
+  final Map<EnumConstant, EnumConstant> duplicateToOriginal = {};
+  final Set<EnumConstant> uniqueMembers = {};
+
+  String formatValue(EnumConstant ec) {
+    final buffer = StringBuffer();
+    final enumValueName = namer.makeUnique(ec.name);
+    enumNames[ec] = enumValueName;
+    if (ec.dartDoc != null) {
+      buffer.write('$depth/// ');
+      buffer.writeAll(ec.dartDoc!.split('\n'), '\n$depth/// ');
+      buffer.write('\n');
+    }
+    buffer.write('$depth$enumValueName(${ec.value})');
+    return buffer.toString();
+  }
+
+  void scanForDuplicates() {
+    uniqueMembers.clear();
+    uniqueToDuplicates.clear();
+    duplicateToOriginal.clear();
+    for (final ec in enumConstants) {
+      final original = uniqueMembers.firstWhereOrNull((other) => other.value == ec.value);
+      if (original == null) {
+        // This is a unique entry
+        uniqueMembers.add(ec);
+        uniqueToDuplicates[ec] = [];
+      } else {
+        // This is a duplicate of a previous entry
+        duplicateToOriginal[ec] = original;
+        uniqueToDuplicates[original]!.add(ec);
+      }
+    }
+  }
+
   EnumClass({
     super.usr,
     super.originalName,
     required super.name,
     super.dartDoc,
     List<EnumConstant>? enumConstants,
-  }) : enumConstants = enumConstants ?? [];
+  }) : 
+    enumConstants = enumConstants ?? [],
+    namer = UniqueNamer({name})
+  { 
+    scanForDuplicates();
+  }
+
+  void writeUniqueMembers(StringBuffer s) {
+    s.write("$depth// ===== Unique members =====\n");
+    s.writeAll(uniqueMembers.map(formatValue), ",\n");
+    if (uniqueMembers.isNotEmpty) s.write('$depth;\n\n');
+  }
+
+  void writeDuplicateMembers(StringBuffer s) {
+    s.write("$depth// ===== Aliases =====\n");
+    for (final entry in duplicateToOriginal.entries) {
+      final duplicate = entry.key;
+      final original = entry.value;
+      final duplicateName = namer.makeUnique(duplicate.name);
+      enumNames[duplicate] = duplicateName;
+      // [!] Each original enum value was given a name in [writeUniqueMembers].
+      final originalName = enumNames[original]!;
+      s.write("${depth}static const $duplicateName = $originalName;\n");
+    }
+    s.write("\n");
+  }
+
+  void writeConstructor(StringBuffer s) {
+    s.write("$depth// ===== Constructor =====\n");
+    s.write("${depth}final int value;\n");
+    s.write("${depth}const $name(this.value);\n\n");
+  }
+
+  void writeToStringOverride(StringBuffer s) {
+    s.write("$depth// ===== Override toString() for aliases =====\n");
+    s.write("$depth@override\n");
+    s.write("${depth}String toString() {\n");
+    for (final entry in uniqueToDuplicates.entries) {
+      // [!] All enum values were given a name when their declarations were generated
+      final unique = entry.key;
+      final originalName = enumNames[unique]!;      
+      final duplicates = entry.value;
+      if (duplicates.isEmpty) continue;
+      final allDuplicates = [
+        for (final duplicate in [unique] + duplicates)
+          "$name.${enumNames[duplicate]!}",
+      ].join(", ");
+      s.write('${depth * 2}if (this == $originalName) return "$allDuplicates";\n');
+    }
+    s.write("${depth * 2}return super.toString();\n");
+    s.write("$depth}\n");
+  }
+
+  void writeDartDoc(StringBuffer s) {
+    if (dartDoc != null) {
+      s.write(makeDartDoc(dartDoc!));
+    }
+  }
+
+  void writeEmptyEnum(StringBuffer s) {
+    s.write("sealed class $name { }\n");
+  }
 
   @override
   BindingString toBindingString(Writer w) {
     final s = StringBuffer();
-    final enclosingClassName = name;
+    scanForDuplicates();
 
-    if (dartDoc != null) {
-      s.write(makeDartDoc(dartDoc!));
+    // Print the dartdoc.
+    writeDartDoc(s);
+    if (enumConstants.isEmpty) {
+      writeEmptyEnum(s);
+    } else {
+      s.write('enum $name {\n');
+        writeUniqueMembers(s);
+        writeDuplicateMembers(s);
+        writeConstructor(s);
+        writeToStringOverride(s);
+      s.write('}\n\n');
     }
-
-    /// Adding [enclosingClassName] because dart doesn't allow class member
-    /// to have the same name as the class.
-    final localUniqueNamer = UniqueNamer({enclosingClassName});
-
-    // Print enclosing class.
-    s.write('abstract class $enclosingClassName {\n');
-    const depth = '  ';
-    for (final ec in enumConstants) {
-      final enumValueName = localUniqueNamer.makeUnique(ec.name);
-      if (ec.dartDoc != null) {
-        s.write('$depth/// ');
-        s.writeAll(ec.dartDoc!.split('\n'), '\n$depth/// ');
-        s.write('\n');
-      }
-      s.write('${depth}static const int $enumValueName = ${ec.value};\n');
-    }
-    s.write('}\n\n');
 
     return BindingString(
-        type: BindingStringType.enumClass, string: s.toString());
+      type: BindingStringType.enum_, 
+      string: s.toString(),
+    );
   }
 
   @override


### PR DESCRIPTION
Fixes #446. @dcharkes @eernstg @mannprerak2 @liamappelbe from that issue. 

For the given enum (with defined values and duplicates):
```c
// No 0 value to ensure we always set a status
typedef enum CanStatus {
  ok = 1,
  socketCreateError = 2,
  example = 1;
} CanStatus;
```
Here's the current behavior:
```dart
// generated FFI bindings: 
abstract class CanStatus {
  static const int ok = 1;
  static const int socketCreateError = 2;
  static const int example = 3;
}
```

And here's the new behavior: 

```dart
enum CanStatus {
  // ===== Unique members =====
  ok(1),
  socketCreateError(2);

  // ===== Aliases =====
  static const example = ok;

  // ===== Constructor =====
  final int value;
  const CanStatus(this.value);

  // ===== Override toString() for aliases =====
  @override
  String toString() {
    if (this == ok) return "CanStatus.ok, CanStatus.example";
    return super.toString();
  }
}
```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [ ] Bump the major version as this will be a breaking change (enum values are no longer ints)
- [ ] Add a section to the changelog
- [ ] Document new fields and methods
- [ ] Run tests

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
