### PR TITLE
Remove un-needed registerWith method from `jni`

### DIFF
--- a/pkgs/jni/android/src/main/java/com/github/dart_lang/jni/JniPlugin.java
+++ b/pkgs/jni/android/src/main/java/com/github/dart_lang/jni/JniPlugin.java
@@ -18,12 +18,6 @@ public class JniPlugin implements FlutterPlugin, ActivityAware {
     setup(binding.getApplicationContext());
   }
 
-  @SuppressWarnings({"unused", "deprecation"})
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    JniPlugin plugin = new JniPlugin();
-    plugin.setup(registrar.activeContext());
-  }
-
   private void setup(Context context) {
     initializeJni(context, getClass().getClassLoader());
   }


### PR DESCRIPTION
Fixes #1204.

Tested with `flutter run --debug` in the `jni` example app with the changes in https://github.com/flutter/engine/pull/52022 applied. 


---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
