### PR TITLE
[jnigen] Fix generated vararg types

### DIFF
--- a/pkgs/jni/lib/internal_helpers_for_jnigen.dart
+++ b/pkgs/jni/lib/internal_helpers_for_jnigen.dart
@@ -6,8 +6,42 @@
 /// not to be used directly.
 library internal_helpers_for_jnigen;
 
+import 'dart:ffi' as ffi;
+
 export 'src/accessors.dart';
 export 'src/jni.dart' show ProtectedJniExtensions;
 export 'src/types.dart' show referenceType;
 export 'src/jreference.dart';
 export 'src/method_invocation.dart';
+
+/// Temporary fix for the macOS arm64 varargs problem.
+///
+/// This integer type is Int32 on all architectures, other than macOS arm64.
+/// Where it is Int64.
+@ffi.AbiSpecificIntegerMapping({
+  ffi.Abi.androidArm: ffi.Int32(),
+  ffi.Abi.androidArm64: ffi.Int32(),
+  ffi.Abi.androidIA32: ffi.Int32(),
+  ffi.Abi.androidX64: ffi.Int32(),
+  ffi.Abi.androidRiscv64: ffi.Int32(),
+  ffi.Abi.fuchsiaArm64: ffi.Int32(),
+  ffi.Abi.fuchsiaX64: ffi.Int32(),
+  ffi.Abi.fuchsiaRiscv64: ffi.Int32(),
+  ffi.Abi.iosArm: ffi.Int32(),
+  ffi.Abi.iosArm64: ffi.Int32(),
+  ffi.Abi.iosX64: ffi.Int32(),
+  ffi.Abi.linuxArm: ffi.Int32(),
+  ffi.Abi.linuxArm64: ffi.Int32(),
+  ffi.Abi.linuxIA32: ffi.Int32(),
+  ffi.Abi.linuxX64: ffi.Int32(),
+  ffi.Abi.linuxRiscv32: ffi.Int32(),
+  ffi.Abi.linuxRiscv64: ffi.Int32(),
+  ffi.Abi.macosArm64: ffi.Int64(), // <-- Only this is different.
+  ffi.Abi.macosX64: ffi.Int32(),
+  ffi.Abi.windowsArm64: ffi.Int32(),
+  ffi.Abi.windowsIA32: ffi.Int32(),
+  ffi.Abi.windowsX64: ffi.Int32(),
+})
+final class $Int32 extends ffi.AbiSpecificInteger {
+  const $Int32();
+}

--- a/pkgs/jni/tool/wrapper_generators/generate_dart_extensions.dart
+++ b/pkgs/jni/tool/wrapper_generators/generate_dart_extensions.dart
@@ -4,7 +4,6 @@
 
 import 'dart:io';
 
-import 'package:collection/collection.dart';
 import 'package:ffigen/src/code_generator.dart';
 
 import 'ffigen_util.dart';
@@ -177,7 +176,7 @@ String getGlobalEnvExtension(
   }
   final extensionFunctions = env.members
       .map((m) => getGlobalEnvExtensionFunction(m, checkedReturnTypes[m.name]))
-      .whereNotNull()
+      .nonNulls
       .join('\n');
   return '''
 /// Wraps over Pointer<GlobalJniEnvStruct> and exposes function pointer fields
@@ -235,7 +234,7 @@ String getFunctionPointerExtension(
   final extensionFunctions = compound.members
       .map((f) => getFunctionPointerExtensionFunction(f,
           indirect: indirect, implicitThis: implicitThis))
-      .whereNotNull()
+      .nonNulls
       .join('\n');
   return '''
 /// Wraps over the function pointers in $type and exposes them as methods.

--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.3-wip
+
+- Fixed a bug where wrong argument types were generated for varargs.
+- Fixed the macOS arm64 varargs issue caused by the previous release.
+
+
 ## 0.9.2
 
 - Fixed a bug where wrong argument types were generated for 32-bit

--- a/pkgs/jnigen/example/in_app_java/lib/android_utils.dart
+++ b/pkgs/jnigen/example/in_app_java/lib/android_utils.dart
@@ -188,7 +188,7 @@ class EmojiCompat_Config extends jni.JObject {
   static final _setReplaceAll = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Uint8,)>)>>("globalEnv_CallObjectMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -217,7 +217,7 @@ class EmojiCompat_Config extends jni.JObject {
   static final _setUseEmojiAsDefaultStyle = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Uint8,)>)>>("globalEnv_CallObjectMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -257,7 +257,7 @@ class EmojiCompat_Config extends jni.JObject {
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
                       jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Uint8, ffi.Pointer<ffi.Void>)>)>>(
+                      ffi.VarArgs<($Int32, ffi.Pointer<ffi.Void>)>)>>(
           "globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int,
@@ -298,7 +298,7 @@ class EmojiCompat_Config extends jni.JObject {
   static final _setEmojiSpanIndicatorEnabled = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Uint8,)>)>>("globalEnv_CallObjectMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -329,7 +329,7 @@ class EmojiCompat_Config extends jni.JObject {
   static final _setEmojiSpanIndicatorColor = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_CallObjectMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -356,7 +356,7 @@ class EmojiCompat_Config extends jni.JObject {
   static final _setMetadataLoadStrategy = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_CallObjectMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -649,9 +649,9 @@ class EmojiCompat_GlyphChecker extends jni.JObject {
                   ffi.VarArgs<
                       (
                         ffi.Pointer<ffi.Void>,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32
+                        $Int32,
+                        $Int32,
+                        $Int32
                       )>)>>("globalEnv_CallBooleanMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
@@ -1688,7 +1688,7 @@ class EmojiCompat extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Uint8,)>)>>("globalEnv_CallStaticVoidMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallStaticVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -1932,7 +1932,7 @@ class EmojiCompat extends jni.JObject {
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
                       jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, ffi.Int32)>)>>(
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, $Int32)>)>>(
           "globalEnv_CallIntMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
@@ -1971,7 +1971,7 @@ class EmojiCompat extends jni.JObject {
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
                       jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, ffi.Int32)>)>>(
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, $Int32)>)>>(
           "globalEnv_CallIntMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
@@ -2002,7 +2002,7 @@ class EmojiCompat extends jni.JObject {
                   ffi.VarArgs<
                       (
                         ffi.Pointer<ffi.Void>,
-                        ffi.Int32,
+                        $Int32,
                         ffi.Pointer<ffi.Void>
                       )>)>>("globalEnv_CallStaticBooleanMethod")
       .asFunction<
@@ -2055,9 +2055,9 @@ class EmojiCompat extends jni.JObject {
                       (
                         ffi.Pointer<ffi.Void>,
                         ffi.Pointer<ffi.Void>,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Uint8
+                        $Int32,
+                        $Int32,
+                        $Int32
                       )>)>>("globalEnv_CallStaticBooleanMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
@@ -2139,7 +2139,7 @@ class EmojiCompat extends jni.JObject {
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
                       jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, ffi.Int32)>)>>(
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, $Int32)>)>>(
           "globalEnv_CallBooleanMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
@@ -2177,7 +2177,7 @@ class EmojiCompat extends jni.JObject {
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
                       jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, ffi.Int32)>)>>(
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, $Int32)>)>>(
           "globalEnv_CallIntMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
@@ -2247,16 +2247,12 @@ class EmojiCompat extends jni.JObject {
   );
 
   static final _process1 = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                  ffi.Pointer<ffi.Void>,
-                  jni.JMethodIDPtr,
-                  ffi.VarArgs<
-                      (
-                        ffi.Pointer<ffi.Void>,
-                        ffi.Int32,
-                        ffi.Int32
-                      )>)>>("globalEnv_CallObjectMethod")
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, $Int32, $Int32)>)>>(
+          "globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
               ffi.Pointer<ffi.Void>, int, int)>();
@@ -2310,9 +2306,9 @@ class EmojiCompat extends jni.JObject {
                   ffi.VarArgs<
                       (
                         ffi.Pointer<ffi.Void>,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32
+                        $Int32,
+                        $Int32,
+                        $Int32
                       )>)>>("globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
@@ -2371,10 +2367,10 @@ class EmojiCompat extends jni.JObject {
                   ffi.VarArgs<
                       (
                         ffi.Pointer<ffi.Void>,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32
                       )>)>>("globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
@@ -2738,7 +2734,7 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper
                       (
                         ffi.Pointer<ffi.Void>,
                         ffi.Pointer<ffi.Void>,
-                        ffi.Int32
+                        $Int32
                       )>)>>("globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
@@ -2888,7 +2884,7 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
                       (
                         ffi.Pointer<ffi.Void>,
                         ffi.Pointer<ffi.Void>,
-                        ffi.Int32
+                        $Int32
                       )>)>>("globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
@@ -4158,7 +4154,7 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
   static final _new0 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32, ffi.Float)>)>>("globalEnv_NewObject")
+                  ffi.VarArgs<($Int32, ffi.Double)>)>>("globalEnv_NewObject")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int, double)>();
@@ -4185,7 +4181,7 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
   static final _new1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_NewObject")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_NewObject")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -4999,7 +4995,7 @@ class AndroidUtils extends jni.JObject {
                       (
                         ffi.Pointer<ffi.Void>,
                         ffi.Pointer<ffi.Void>,
-                        ffi.Int32
+                        $Int32
                       )>)>>("globalEnv_CallStaticVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,

--- a/pkgs/jnigen/example/notification_plugin/lib/notifications.dart
+++ b/pkgs/jnigen/example/notification_plugin/lib/notifications.dart
@@ -78,7 +78,7 @@ class Notifications extends jni.JObject {
                   ffi.VarArgs<
                       (
                         ffi.Pointer<ffi.Void>,
-                        ffi.Int32,
+                        $Int32,
                         ffi.Pointer<ffi.Void>,
                         ffi.Pointer<ffi.Void>
                       )>)>>("globalEnv_CallStaticVoidMethod")

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
@@ -510,7 +510,7 @@ class PDDocument extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -1883,7 +1883,7 @@ class PDDocument extends jni.JObject {
   static final _getPage = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_CallObjectMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -2089,7 +2089,7 @@ class PDDocument extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Uint8,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -2200,7 +2200,7 @@ class PDDocument extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Float,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<(ffi.Double,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, double)>();

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/text/PDFTextStripper.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/text/PDFTextStripper.dart
@@ -400,7 +400,7 @@ class PDFTextStripper extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Uint8,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -744,7 +744,7 @@ class PDFTextStripper extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -799,7 +799,7 @@ class PDFTextStripper extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -1059,7 +1059,7 @@ class PDFTextStripper extends jni.JObject {
                   jni.JThrowablePtr Function(
                       ffi.Pointer<ffi.Void>,
                       jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Uint8,)>)>>("globalEnv_CallVoidMethod")
+                      ffi.VarArgs<($Int32,)>)>>("globalEnv_CallVoidMethod")
           .asFunction<
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -1117,7 +1117,7 @@ class PDFTextStripper extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Uint8,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -1287,7 +1287,7 @@ class PDFTextStripper extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Uint8,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -1343,7 +1343,7 @@ class PDFTextStripper extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Uint8,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -1406,7 +1406,7 @@ class PDFTextStripper extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Float,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<(ffi.Double,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, double)>();
@@ -1463,7 +1463,7 @@ class PDFTextStripper extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Float,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<(ffi.Double,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, double)>();
@@ -1522,7 +1522,7 @@ class PDFTextStripper extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Float,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<(ffi.Double,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, double)>();
@@ -1579,7 +1579,7 @@ class PDFTextStripper extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Float,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<(ffi.Double,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, double)>();

--- a/pkgs/jnigen/lib/src/bindings/dart_generator.dart
+++ b/pkgs/jnigen/lib/src/bindings/dart_generator.dart
@@ -845,17 +845,11 @@ class _JniResultGetter extends TypeVisitor<String> {
   }
 }
 
-/// Type signature for C-based bindings.
+/// Type signature for Dart and C's varargs.
 ///
-/// When `isFFi` is `true`, it generates the ffi type signature and when it's
-/// false, it generates the dart type signature.
+/// When [isFFi] is `true`, it generates the ffi type signature for vararg.
 ///
-/// For example `ffi.Int32` is an ffi type signature while `int` is a Dart one:
-/// ```dart
-/// jniLookup<ffi.NativeFunction<jni.JniResult Function(ffi.Int32, ffi.Int32)>>(
-///       "sum")
-///   .asFunction<jni.JniResult Function(int, int)>();
-/// ```
+/// For example `ffi.Int32` is an ffi type signature while `int` is a Dart one.
 class _TypeSig extends TypeVisitor<String> {
   final bool isFfi;
 
@@ -863,7 +857,7 @@ class _TypeSig extends TypeVisitor<String> {
 
   @override
   String visitPrimitiveType(PrimitiveType node) {
-    if (isFfi) return '$_ffi.${node.ffiType}';
+    if (isFfi) return node.ffiVarArgType;
     if (node.name == 'boolean') return 'int';
     return node.dartType;
   }

--- a/pkgs/jnigen/lib/src/elements/elements.dart
+++ b/pkgs/jnigen/lib/src/elements/elements.dart
@@ -267,7 +267,7 @@ class PrimitiveType extends ReferredType {
       dartType: 'int',
       boxedName: 'Byte',
       cType: 'int8_t',
-      ffiType: 'Int8',
+      ffiVarArgType: '\$Int32',
     ),
     'short': PrimitiveType._(
       name: 'short',
@@ -275,7 +275,7 @@ class PrimitiveType extends ReferredType {
       dartType: 'int',
       boxedName: 'Short',
       cType: 'int16_t',
-      ffiType: 'Int16',
+      ffiVarArgType: '\$Int32',
     ),
     'char': PrimitiveType._(
       name: 'char',
@@ -283,7 +283,7 @@ class PrimitiveType extends ReferredType {
       dartType: 'int',
       boxedName: 'Character',
       cType: 'uint16_t',
-      ffiType: 'Uint16',
+      ffiVarArgType: '\$Int32',
     ),
     'int': PrimitiveType._(
       name: 'int',
@@ -291,7 +291,7 @@ class PrimitiveType extends ReferredType {
       dartType: 'int',
       boxedName: 'Integer',
       cType: 'int32_t',
-      ffiType: 'Int32',
+      ffiVarArgType: '\$Int32',
     ),
     'long': PrimitiveType._(
       name: 'long',
@@ -299,7 +299,7 @@ class PrimitiveType extends ReferredType {
       dartType: 'int',
       boxedName: 'Long',
       cType: 'int64_t',
-      ffiType: 'Int64',
+      ffiVarArgType: 'ffi.Int64',
     ),
     'float': PrimitiveType._(
       name: 'float',
@@ -307,7 +307,7 @@ class PrimitiveType extends ReferredType {
       dartType: 'double',
       boxedName: 'Float',
       cType: 'float',
-      ffiType: 'Float',
+      ffiVarArgType: 'ffi.Double',
     ),
     'double': PrimitiveType._(
       name: 'double',
@@ -315,7 +315,7 @@ class PrimitiveType extends ReferredType {
       dartType: 'double',
       boxedName: 'Double',
       cType: 'double',
-      ffiType: 'Double',
+      ffiVarArgType: 'ffi.Double',
     ),
     'boolean': PrimitiveType._(
       name: 'boolean',
@@ -323,7 +323,7 @@ class PrimitiveType extends ReferredType {
       dartType: 'bool',
       boxedName: 'Boolean',
       cType: 'uint8_t',
-      ffiType: 'Uint8',
+      ffiVarArgType: '\$Int32',
     ),
     'void': PrimitiveType._(
       name: 'void',
@@ -331,7 +331,7 @@ class PrimitiveType extends ReferredType {
       dartType: 'void',
       boxedName: 'Void', // Not used.
       cType: 'void',
-      ffiType: 'Void',
+      ffiVarArgType: 'ffi.Void', // Not used.
     ),
   };
 
@@ -341,7 +341,7 @@ class PrimitiveType extends ReferredType {
     required this.dartType,
     required this.boxedName,
     required this.cType,
-    required this.ffiType,
+    required this.ffiVarArgType,
   });
 
   @override
@@ -351,7 +351,7 @@ class PrimitiveType extends ReferredType {
   final String dartType;
   final String boxedName;
   final String cType;
-  final String ffiType;
+  final String ffiVarArgType;
 
   factory PrimitiveType.fromJson(Map<String, dynamic> json) {
     return _primitives[json['name']]!;

--- a/pkgs/jnigen/pubspec.yaml
+++ b/pkgs/jnigen/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jnigen
 description: A Dart bindings generator for Java and Kotlin that uses JNI under the hood to interop with Java virtual machine.
-version: 0.9.2
+version: 0.9.3-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jnigen
 
 environment:

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
@@ -169,7 +169,7 @@ class JsonFactory_Feature extends jni.JObject {
   static final _enabledIn = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_CallBooleanMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallBooleanMethod")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -455,7 +455,7 @@ class JsonFactory extends jni.JObject {
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
                       jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, ffi.Uint8)>)>>(
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, $Int32)>)>>(
           "globalEnv_NewObject")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
@@ -988,7 +988,7 @@ class JsonFactory extends jni.JObject {
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
                       jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, ffi.Uint8)>)>>(
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, $Int32)>)>>(
           "globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
@@ -1211,7 +1211,7 @@ class JsonFactory extends jni.JObject {
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
                       jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, ffi.Uint8)>)>>(
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, $Int32)>)>>(
           "globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
@@ -1425,7 +1425,7 @@ class JsonFactory extends jni.JObject {
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
                       jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, ffi.Uint8)>)>>(
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, $Int32)>)>>(
           "globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
@@ -2010,16 +2010,12 @@ class JsonFactory extends jni.JObject {
   );
 
   static final _createParser5 = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                  ffi.Pointer<ffi.Void>,
-                  jni.JMethodIDPtr,
-                  ffi.VarArgs<
-                      (
-                        ffi.Pointer<ffi.Void>,
-                        ffi.Int32,
-                        ffi.Int32
-                      )>)>>("globalEnv_CallObjectMethod")
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, $Int32, $Int32)>)>>(
+          "globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
               ffi.Pointer<ffi.Void>, int, int)>();
@@ -2113,16 +2109,12 @@ class JsonFactory extends jni.JObject {
   );
 
   static final _createParser8 = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                  ffi.Pointer<ffi.Void>,
-                  jni.JMethodIDPtr,
-                  ffi.VarArgs<
-                      (
-                        ffi.Pointer<ffi.Void>,
-                        ffi.Int32,
-                        ffi.Int32
-                      )>)>>("globalEnv_CallObjectMethod")
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, $Int32, $Int32)>)>>(
+          "globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
               ffi.Pointer<ffi.Void>, int, int)>();
@@ -2671,16 +2663,12 @@ class JsonFactory extends jni.JObject {
   );
 
   static final _createJsonParser5 = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                  ffi.Pointer<ffi.Void>,
-                  jni.JMethodIDPtr,
-                  ffi.VarArgs<
-                      (
-                        ffi.Pointer<ffi.Void>,
-                        ffi.Int32,
-                        ffi.Int32
-                      )>)>>("globalEnv_CallObjectMethod")
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, $Int32, $Int32)>)>>(
+          "globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
               ffi.Pointer<ffi.Void>, int, int)>();

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonParser.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonParser.dart
@@ -168,7 +168,7 @@ class JsonParser_Feature extends jni.JObject {
   static final _enabledIn = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_CallBooleanMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallBooleanMethod")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -391,7 +391,7 @@ class JsonParser extends jni.JObject {
   static final _new1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_NewObject")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_NewObject")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -1369,7 +1369,7 @@ class JsonParser extends jni.JObject {
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
                       jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, ffi.Uint8)>)>>(
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>, $Int32)>)>>(
           "globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
@@ -1487,7 +1487,7 @@ class JsonParser extends jni.JObject {
   static final _setFeatureMask = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_CallObjectMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -1514,10 +1514,9 @@ class JsonParser extends jni.JObject {
   );
 
   static final _overrideStdFeatures = ProtectedJniExtensions.lookup<
-              ffi.NativeFunction<
-                  jni.JniResult Function(ffi.Pointer<ffi.Void>,
-                      jni.JMethodIDPtr, ffi.VarArgs<(ffi.Int32, ffi.Int32)>)>>(
-          "globalEnv_CallObjectMethod")
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<($Int32, $Int32)>)>>("globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int, int)>();
@@ -1581,10 +1580,9 @@ class JsonParser extends jni.JObject {
   );
 
   static final _overrideFormatFeatures = ProtectedJniExtensions.lookup<
-              ffi.NativeFunction<
-                  jni.JniResult Function(ffi.Pointer<ffi.Void>,
-                      jni.JMethodIDPtr, ffi.VarArgs<(ffi.Int32, ffi.Int32)>)>>(
-          "globalEnv_CallObjectMethod")
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<($Int32, $Int32)>)>>("globalEnv_CallObjectMethod")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int, int)>();
@@ -1807,7 +1805,7 @@ class JsonParser extends jni.JObject {
   static final _nextIntValue = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_CallIntMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallIntMethod")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -2167,7 +2165,7 @@ class JsonParser extends jni.JObject {
   static final _hasTokenId = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_CallBooleanMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallBooleanMethod")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -3472,7 +3470,7 @@ class JsonParser extends jni.JObject {
   static final _getValueAsInt1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_CallIntMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallIntMethod")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -3694,7 +3692,7 @@ class JsonParser extends jni.JObject {
   static final _getValueAsBoolean1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Uint8,)>)>>("globalEnv_CallBooleanMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallBooleanMethod")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();

--- a/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
@@ -127,7 +127,7 @@ class Example_Nested extends jni.JObject {
   static final _new0 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Uint8,)>)>>("globalEnv_NewObject")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_NewObject")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -199,7 +199,7 @@ class Example_Nested extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Uint8,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -511,7 +511,7 @@ class Example extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_CallStaticVoidMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallStaticVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -583,17 +583,12 @@ class Example extends jni.JObject {
   );
 
   static final _max4 = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                  ffi.Pointer<ffi.Void>,
-                  jni.JMethodIDPtr,
-                  ffi.VarArgs<
-                      (
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32
-                      )>)>>("globalEnv_CallStaticIntMethod")
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<($Int32, $Int32, $Int32, $Int32)>)>>(
+          "globalEnv_CallStaticIntMethod")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int, int, int, int)>();
@@ -622,14 +617,14 @@ class Example extends jni.JObject {
                   jni.JMethodIDPtr,
                   ffi.VarArgs<
                       (
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32
                       )>)>>("globalEnv_CallStaticIntMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int,
@@ -684,7 +679,7 @@ class Example extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -729,7 +724,7 @@ class Example extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Uint8,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -1086,7 +1081,7 @@ class Example extends jni.JObject {
                   jni.JMethodIDPtr,
                   ffi.VarArgs<
                       (
-                        ffi.Uint16,
+                        $Int32,
                         ffi.Pointer<ffi.Void>,
                         ffi.Pointer<ffi.Void>,
                         ffi.Pointer<ffi.Void>,
@@ -1161,7 +1156,7 @@ class Example extends jni.JObject {
   static final _new1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_NewObject")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_NewObject")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -1183,7 +1178,7 @@ class Example extends jni.JObject {
   static final _new2 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32, ffi.Uint8)>)>>("globalEnv_NewObject")
+                  ffi.VarArgs<($Int32, $Int32)>)>>("globalEnv_NewObject")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int, int)>();
@@ -1204,16 +1199,12 @@ class Example extends jni.JObject {
   );
 
   static final _new3 = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                  ffi.Pointer<ffi.Void>,
-                  jni.JMethodIDPtr,
-                  ffi.VarArgs<
-                      (
-                        ffi.Int32,
-                        ffi.Uint8,
-                        ffi.Pointer<ffi.Void>
-                      )>)>>("globalEnv_NewObject")
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<($Int32, $Int32, ffi.Pointer<ffi.Void>)>)>>(
+          "globalEnv_NewObject")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int,
               int, ffi.Pointer<ffi.Void>)>();
@@ -1245,14 +1236,14 @@ class Example extends jni.JObject {
                   jni.JMethodIDPtr,
                   ffi.VarArgs<
                       (
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32
                       )>)>>("globalEnv_NewObject")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int,
@@ -1307,7 +1298,7 @@ class Example extends jni.JObject {
   static final _addInts = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(ffi.Pointer<ffi.Void>,
-                      jni.JMethodIDPtr, ffi.VarArgs<(ffi.Int32, ffi.Int32)>)>>(
+                      jni.JMethodIDPtr, ffi.VarArgs<($Int32, $Int32)>)>>(
           "globalEnv_CallStaticIntMethod")
       .asFunction<
           jni.JniResult Function(
@@ -1452,7 +1443,7 @@ class Example extends jni.JObject {
                   jni.JThrowablePtr Function(
                       ffi.Pointer<ffi.Void>,
                       jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Int32, ffi.Pointer<ffi.Void>)>)>>(
+                      ffi.VarArgs<($Int32, ffi.Pointer<ffi.Void>)>)>>(
           "globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
@@ -1478,7 +1469,7 @@ class Example extends jni.JObject {
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
                   jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Int32,)>)>>("globalEnv_CallVoidMethod")
+                  ffi.VarArgs<($Int32,)>)>>("globalEnv_CallVoidMethod")
       .asFunction<
           jni.JThrowablePtr Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
@@ -3487,17 +3478,12 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
   );
 
   static final _manyPrimitives = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                  ffi.Pointer<ffi.Void>,
-                  jni.JMethodIDPtr,
-                  ffi.VarArgs<
-                      (
-                        ffi.Int32,
-                        ffi.Uint8,
-                        ffi.Uint16,
-                        ffi.Double
-                      )>)>>("globalEnv_CallLongMethod")
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<($Int32, $Int32, $Int32, ffi.Double)>)>>(
+          "globalEnv_CallLongMethod")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int,
               int, int, double)>();
@@ -3762,9 +3748,9 @@ class MyInterfaceConsumer extends jni.JObject {
                       (
                         ffi.Pointer<ffi.Void>,
                         ffi.Pointer<ffi.Void>,
-                        ffi.Int32,
-                        ffi.Uint8,
-                        ffi.Uint16,
+                        $Int32,
+                        $Int32,
+                        $Int32,
                         ffi.Double,
                         ffi.Pointer<ffi.Void>
                       )>)>>("globalEnv_CallStaticVoidMethod")
@@ -3822,9 +3808,9 @@ class MyInterfaceConsumer extends jni.JObject {
                       (
                         ffi.Pointer<ffi.Void>,
                         ffi.Pointer<ffi.Void>,
-                        ffi.Int32,
-                        ffi.Uint8,
-                        ffi.Uint16,
+                        $Int32,
+                        $Int32,
+                        $Int32,
                         ffi.Double,
                         ffi.Pointer<ffi.Void>
                       )>)>>("globalEnv_CallStaticVoidMethod")
@@ -4626,7 +4612,7 @@ class Exceptions extends jni.JObject {
   static final _new1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Float,)>)>>("globalEnv_NewObject")
+                  ffi.VarArgs<(ffi.Double,)>)>>("globalEnv_NewObject")
       .asFunction<
           jni.JniResult Function(
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, double)>();
@@ -4652,12 +4638,12 @@ class Exceptions extends jni.JObject {
                   jni.JMethodIDPtr,
                   ffi.VarArgs<
                       (
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32,
-                        ffi.Int32
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32
                       )>)>>("globalEnv_NewObject")
       .asFunction<
           jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int,


### PR DESCRIPTION
Closes #1191. The issue was that using types shorter than int32 in varargs is undefined behavior. Also float is not supported; defaulting to double.

Fixed the macOS arm64 problem in the mean time by introducing an `AbiSpecificInteger` in `package:jni`.