### PR TITLE
Fix #1218

### DIFF
--- a/pkgs/objective_c/ios/objective_c.podspec
+++ b/pkgs/objective_c/ios/objective_c.podspec
@@ -21,6 +21,7 @@ A library to access Objective C from Flutter that acts as a support library for 
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '12.0'
+  s.requires_arc = []
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/pkgs/objective_c/macos/objective_c.podspec
+++ b/pkgs/objective_c/macos/objective_c.podspec
@@ -20,6 +20,7 @@ A library to access Objective C from Flutter that acts as a support library for 
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
+  s.requires_arc = []
 
   s.platform = :osx, '10.11'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }


### PR DESCRIPTION
package:objective_c uses manual ref counting, so we have to disable ARC in the podspecs.