### PR TITLE
[native_toolchain_c] `CBuilder` Objective-C clang flags

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.5.0-wip
 
 - Renamed parameters in `Builder.run`.
+- Added `Language.objectiveC`.
 
 ## 0.4.2
 

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -20,10 +20,17 @@ class Language {
   const Language._(this.name);
 
   static const Language c = Language._('c');
+
   static const Language cpp = Language._('c++');
 
+  static const Language objectiveC = Language._('objective c');
+
   /// Known values for [Language].
-  static const List<Language> values = [c, cpp];
+  static const List<Language> values = [
+    c,
+    cpp,
+    objectiveC,
+  ];
 
   @override
   String toString() => name;

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -70,6 +70,20 @@ class CBuilder implements Builder {
   /// Used to output the [BuildOutput.dependencies].
   final List<String> includes;
 
+  /// Frameworks to link.
+  ///
+  /// Only effective if [language] is [Language.objectiveC].
+  ///
+  /// Defaults to `['Foundation']`.
+  ///
+  /// Not used to output the [BuildOutput.dependencies], frameworks can be
+  /// mentioned by name if they are available on the system, so the file path
+  /// is not known. If you're depending on your own frameworks add them to
+  /// [BuildOutput.dependencies] manually.
+  final List<String> frameworks;
+
+  static const List<String> _defaultFrameworks = ['Foundation'];
+
   /// The dart files involved in building this artifact.
   ///
   /// Resolved against [BuildConfig.packageRoot].
@@ -162,6 +176,7 @@ class CBuilder implements Builder {
     required this.assetName,
     this.sources = const [],
     this.includes = const [],
+    this.frameworks = _defaultFrameworks,
     required this.dartBuildFiles,
     @visibleForTesting this.installName,
     this.flags = const [],
@@ -179,6 +194,7 @@ class CBuilder implements Builder {
     required this.name,
     this.sources = const [],
     this.includes = const [],
+    this.frameworks = _defaultFrameworks,
     required this.dartBuildFiles,
     this.flags = const [],
     this.defines = const {},
@@ -228,6 +244,7 @@ class CBuilder implements Builder {
         logger: logger,
         sources: sources,
         includes: includes,
+        frameworks: frameworks,
         dynamicLibrary: _type == _CBuilderType.library &&
                 linkMode == DynamicLoadingBundled()
             ? libUri

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -190,10 +190,6 @@ class RunCBuilder {
     await runProcess(
       executable: compiler.uri,
       arguments: [
-        if (language == Language.objectiveC) ...[
-          '-x',
-          'objective-c',
-        ],
         if (buildConfig.targetOS == OS.android) ...[
           '--target='
               '${androidNdkClangTargetFlags[architecture]!}'

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -190,6 +190,10 @@ class RunCBuilder {
     await runProcess(
       executable: compiler.uri,
       arguments: [
+        if (language == Language.objectiveC) ...[
+          '-x',
+          'objective-c',
+        ],
         if (buildConfig.targetOS == OS.android) ...[
           '--target='
               '${androidNdkClangTargetFlags[architecture]!}'
@@ -246,6 +250,10 @@ class RunCBuilder {
           if (value == null) '-D$name' else '-D$name=$value',
         for (final include in includes) '-I${include.toFilePath()}',
         ...sourceFiles,
+        if (language == Language.objectiveC) ...[
+          '-framework',
+          'Foundation',
+        ],
         if (executable != null) ...[
           '-o',
           outDir.resolveUri(executable!).toFilePath(),

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -23,6 +23,7 @@ class RunCBuilder {
   final Logger? logger;
   final List<Uri> sources;
   final List<Uri> includes;
+  final List<String> frameworks;
   final Uri? executable;
   final Uri? dynamicLibrary;
   final Uri? staticLibrary;
@@ -47,6 +48,7 @@ class RunCBuilder {
     this.logger,
     this.sources = const [],
     this.includes = const [],
+    required this.frameworks,
     this.executable,
     this.dynamicLibrary,
     this.staticLibrary,
@@ -247,8 +249,10 @@ class RunCBuilder {
         for (final include in includes) '-I${include.toFilePath()}',
         ...sourceFiles,
         if (language == Language.objectiveC) ...[
-          '-framework',
-          'Foundation',
+          for (final framework in frameworks) ...[
+            '-framework',
+            framework,
+          ],
         ],
         if (executable != null) ...[
           '-o',

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -36,115 +36,126 @@ void main() {
 
   const name = 'add';
 
-  for (final linkMode in [DynamicLoadingBundled(), StaticLinking()]) {
-    for (final targetIOSSdk in IOSSdk.values) {
-      for (final target in targets) {
-        if (target == Architecture.x64 && targetIOSSdk == IOSSdk.iPhoneOS) {
-          continue;
-        }
+  for (final language in [Language.c, Language.objectiveC]) {
+    for (final linkMode in [DynamicLoadingBundled(), StaticLinking()]) {
+      for (final targetIOSSdk in IOSSdk.values) {
+        for (final target in targets) {
+          if (target == Architecture.x64 && targetIOSSdk == IOSSdk.iPhoneOS) {
+            continue;
+          }
 
-        final libName = OS.iOS.libraryFileName(name, linkMode);
-        for (final installName in [
-          null,
-          if (linkMode == DynamicLoadingBundled())
-            Uri.file('@executable_path/Frameworks/$libName'),
-        ]) {
-          test(
-              'CBuilder $linkMode library $targetIOSSdk $target'
-                      ' ${installName ?? ''}'
-                  .trim(), () async {
-            final tempUri = await tempDirForTest();
-            final addCUri =
-                packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
-            final buildConfig = BuildConfig.build(
-              outputDirectory: tempUri,
-              packageName: name,
-              packageRoot: tempUri,
-              targetArchitecture: target,
-              targetOS: OS.iOS,
-              buildMode: BuildMode.release,
-              linkModePreference: linkMode == DynamicLoadingBundled()
-                  ? LinkModePreference.dynamic
-                  : LinkModePreference.static,
-              targetIOSSdk: targetIOSSdk,
-            );
-            final buildOutput = BuildOutput();
+          final libName = OS.iOS.libraryFileName(name, linkMode);
+          for (final installName in [
+            null,
+            if (linkMode == DynamicLoadingBundled())
+              Uri.file('@executable_path/Frameworks/$libName'),
+          ]) {
+            test(
+                'CBuilder $linkMode $language library $targetIOSSdk $target'
+                        ' ${installName ?? ''}'
+                    .trim(), () async {
+              final tempUri = await tempDirForTest();
+              final sourceUri = switch (language) {
+                Language.c =>
+                  packageUri.resolve('test/cbuilder/testfiles/add/src/add.c'),
+                Language.objectiveC => packageUri.resolve(
+                    'test/cbuilder/testfiles/add_objective_c/src/add.m'),
+                Language() => throw UnimplementedError(),
+              };
+              final buildConfig = BuildConfig.build(
+                outputDirectory: tempUri,
+                packageName: name,
+                packageRoot: tempUri,
+                targetArchitecture: target,
+                targetOS: OS.iOS,
+                buildMode: BuildMode.release,
+                linkModePreference: linkMode == DynamicLoadingBundled()
+                    ? LinkModePreference.dynamic
+                    : LinkModePreference.static,
+                targetIOSSdk: targetIOSSdk,
+              );
+              final buildOutput = BuildOutput();
 
-            final cbuilder = CBuilder.library(
-              name: name,
-              assetName: name,
-              sources: [addCUri.toFilePath()],
-              installName: installName,
-              dartBuildFiles: ['hook/build.dart'],
-            );
-            await cbuilder.run(
-              config: buildConfig,
-              output: buildOutput,
-              logger: logger,
-            );
+              final cbuilder = CBuilder.library(
+                name: name,
+                assetName: name,
+                sources: [sourceUri.toFilePath()],
+                installName: installName,
+                dartBuildFiles: ['hook/build.dart'],
+                language: language,
+              );
+              await cbuilder.run(
+                config: buildConfig,
+                output: buildOutput,
+                logger: logger,
+              );
 
-            final libUri = tempUri.resolve(libName);
-            final objdumpResult = await runProcess(
-              executable: Uri.file('objdump'),
-              arguments: ['-t', libUri.path],
-              logger: logger,
-            );
-            expect(objdumpResult.exitCode, 0);
-            final machine = objdumpResult.stdout
-                .split('\n')
-                .firstWhere((e) => e.contains('file format'));
-            expect(machine, contains(objdumpFileFormat[target]));
-
-            final otoolResult = await runProcess(
-              executable: Uri.file('otool'),
-              arguments: ['-l', libUri.path],
-              logger: logger,
-            );
-            expect(otoolResult.exitCode, 0);
-            if (targetIOSSdk == IOSSdk.iPhoneOS || target == Architecture.x64) {
-              // The x64 simulator behaves as device, presumably because the
-              // devices are never x64.
-              expect(otoolResult.stdout, contains('LC_VERSION_MIN_IPHONEOS'));
-              expect(otoolResult.stdout, isNot(contains('LC_BUILD_VERSION')));
-            } else {
-              expect(otoolResult.stdout,
-                  isNot(contains('LC_VERSION_MIN_IPHONEOS')));
-              expect(otoolResult.stdout, contains('LC_BUILD_VERSION'));
-              final platform = otoolResult.stdout
+              final libUri = tempUri.resolve(libName);
+              final objdumpResult = await runProcess(
+                executable: Uri.file('objdump'),
+                arguments: ['-t', libUri.path],
+                logger: logger,
+              );
+              expect(objdumpResult.exitCode, 0);
+              final machine = objdumpResult.stdout
                   .split('\n')
-                  .firstWhere((e) => e.contains('platform'));
-              const platformIosSimulator = 7;
-              expect(platform, contains(platformIosSimulator.toString()));
-            }
+                  .firstWhere((e) => e.contains('file format'));
+              expect(machine, contains(objdumpFileFormat[target]));
 
-            if (linkMode == DynamicLoadingBundled()) {
-              final libInstallName = await runOtoolInstallName(libUri, libName);
-              if (installName == null) {
-                // If no install path is passed, we have an absolute path.
-                final tempName = tempUri.pathSegments.lastWhere((e) => e != '');
-                final pathEnding =
-                    Uri.directory(tempName).resolve(libName).toFilePath();
-                expect(Uri.file(libInstallName).isAbsolute, true);
-                expect(libInstallName, contains(pathEnding));
-                final targetInstallName =
-                    '@executable_path/Frameworks/$libName';
-                await runProcess(
-                  executable: Uri.file('install_name_tool'),
-                  arguments: [
-                    '-id',
-                    targetInstallName,
-                    libUri.toFilePath(),
-                  ],
-                  logger: logger,
-                );
-                final libInstallName2 =
-                    await runOtoolInstallName(libUri, libName);
-                expect(libInstallName2, targetInstallName);
+              final otoolResult = await runProcess(
+                executable: Uri.file('otool'),
+                arguments: ['-l', libUri.path],
+                logger: logger,
+              );
+              expect(otoolResult.exitCode, 0);
+              if (targetIOSSdk == IOSSdk.iPhoneOS ||
+                  target == Architecture.x64) {
+                // The x64 simulator behaves as device, presumably because the
+                // devices are never x64.
+                expect(otoolResult.stdout, contains('LC_VERSION_MIN_IPHONEOS'));
+                expect(otoolResult.stdout, isNot(contains('LC_BUILD_VERSION')));
               } else {
-                expect(libInstallName, installName.toFilePath());
+                expect(otoolResult.stdout,
+                    isNot(contains('LC_VERSION_MIN_IPHONEOS')));
+                expect(otoolResult.stdout, contains('LC_BUILD_VERSION'));
+                final platform = otoolResult.stdout
+                    .split('\n')
+                    .firstWhere((e) => e.contains('platform'));
+                const platformIosSimulator = 7;
+                expect(platform, contains(platformIosSimulator.toString()));
               }
-            }
-          });
+
+              if (linkMode == DynamicLoadingBundled()) {
+                final libInstallName =
+                    await runOtoolInstallName(libUri, libName);
+                if (installName == null) {
+                  // If no install path is passed, we have an absolute path.
+                  final tempName =
+                      tempUri.pathSegments.lastWhere((e) => e != '');
+                  final pathEnding =
+                      Uri.directory(tempName).resolve(libName).toFilePath();
+                  expect(Uri.file(libInstallName).isAbsolute, true);
+                  expect(libInstallName, contains(pathEnding));
+                  final targetInstallName =
+                      '@executable_path/Frameworks/$libName';
+                  await runProcess(
+                    executable: Uri.file('install_name_tool'),
+                    arguments: [
+                      '-id',
+                      targetInstallName,
+                      libUri.toFilePath(),
+                    ],
+                    logger: logger,
+                  );
+                  final libInstallName2 =
+                      await runOtoolInstallName(libUri, libName);
+                  expect(libInstallName2, targetInstallName);
+                } else {
+                  expect(libInstallName, installName.toFilePath());
+                }
+              }
+            });
+          }
         }
       }
     }

--- a/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@OnPlatform({
+  'mac-os': Timeout.factor(2),
+  'windows': Timeout.factor(10),
+})
+library;
+
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_toolchain_c/native_toolchain_c.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+
+void main() {
+  if (!Platform.isMacOS) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
+
+  test('CBuilder compile objective c', () async {
+    final tempUri = await tempDirForTest();
+    final addMUri =
+        packageUri.resolve('test/cbuilder/testfiles/add_objective_c/src/add.m');
+    if (!await File.fromUri(addMUri).exists()) {
+      throw Exception('Run the test from the root directory.');
+    }
+    const name = 'add_objective_c';
+
+    final logMessages = <String>[];
+    final logger = createCapturingLogger(logMessages);
+
+    final buildConfig = BuildConfig.build(
+      buildMode: BuildMode.release,
+      outputDirectory: tempUri,
+      packageName: name,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.current,
+      targetOS: OS.current,
+      linkModePreference: LinkModePreference.dynamic,
+      cCompiler: CCompilerConfig(
+        compiler: cc,
+        envScript: envScript,
+        envScriptArgs: envScriptArgs,
+      ),
+    );
+    final buildOutput = BuildOutput();
+
+    final cbuilder = CBuilder.library(
+      name: name,
+      assetName: name,
+      sources: [addMUri.toFilePath()],
+      language: Language.objectiveC,
+      dartBuildFiles: ['hook/build.dart'],
+    );
+    await cbuilder.run(
+      config: buildConfig,
+      output: buildOutput,
+      logger: logger,
+    );
+
+    final dylibUri = tempUri.resolve(OS.current.dylibFileName(name));
+    expect(await File.fromUri(dylibUri).exists(), true);
+    final dylib = openDynamicLibraryForTest(dylibUri.toFilePath());
+    final add = dylib.lookupFunction<Int32 Function(Int32, Int32),
+        int Function(int, int)>('add');
+    expect(add(1, 2), 3);
+  });
+}

--- a/pkgs/native_toolchain_c/test/cbuilder/testfiles/add_objective_c/src/add.m
+++ b/pkgs/native_toolchain_c/test/cbuilder/testfiles/add_objective_c/src/add.m
@@ -1,0 +1,16 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+
+#if DEBUG
+#import <stdio.h>
+#endif
+
+NSInteger add(NSInteger a, NSInteger b) {
+#ifdef DEBUG
+  printf("Adding %ld and %ld.\n", (long)a, (long)b);
+#endif
+  return a + b;
+}

--- a/pkgs/native_toolchain_c/test/cbuilder/testfiles/add_objective_c/src/add.m
+++ b/pkgs/native_toolchain_c/test/cbuilder/testfiles/add_objective_c/src/add.m
@@ -12,5 +12,6 @@ NSInteger add(NSInteger a, NSInteger b) {
 #ifdef DEBUG
   printf("Adding %ld and %ld.\n", (long)a, (long)b);
 #endif
-  return a + b;
+  // Use NSNumber from Foundation to test the frameworks flags.
+  return [[NSNumber numberWithInteger:(a + b)] longValue];
 }


### PR DESCRIPTION
Adds Apple clang flags for compiling Objective-C with the `CBuilder`.

Issue:

* https://github.com/dart-lang/native/issues/1227

Also pins the dev CI to the latest working version:

* https://github.com/dart-lang/sdk/issues/56080