### PR TITLE
Fix a bug in Json helper class.

### DIFF
--- a/pkgs/swiftgen/swift2objc/lib/src/parser/_core/json.dart
+++ b/pkgs/swiftgen/swift2objc/lib/src/parser/_core/json.dart
@@ -56,14 +56,6 @@ class Json extends IterableBase<Json> {
     throw 'Expected a $T at "$path", found ${_json.runtimeType}';
   }
 
-  T? tryGet<T>() {
-    if (_json is T) {
-      return _json;
-    } else {
-      return null;
-    }
-  }
-
   @override
   Iterator<Json> get iterator => _JsonIterator(this);
 

--- a/pkgs/swiftgen/swift2objc/lib/src/parser/_core/json.dart
+++ b/pkgs/swiftgen/swift2objc/lib/src/parser/_core/json.dart
@@ -32,9 +32,6 @@ class Json extends IterableBase<Json> {
       if (_json is! Map) {
         throw 'Expected a map at "$path", found a ${_json.runtimeType}';
       }
-      if (_json.containsKey(index)) {
-        throw 'Field "$index" not found at "$path"';
-      }
       return Json(_json[index], [..._pathSegments, index]);
     }
 


### PR DESCRIPTION
Removed an `if` statement from the json subscript implementation. It was checking if the received key is in the map and throws if it's not. While that looked good initially it was problematic when trying to access a nullable field (or rather a field that may or may not exist).

Moreover, the check itself isn't really needed for two reasons:

1. If the key doesn't exist, accessing it will result in a `Json` instance with `_json` value of `null`, any further access will result in an error cause the subscript implementation checks for the type of `_json` before any access and will tell us that a null was found when a map/array was expected.

2. the `get` method checks the type of `_json` value before returning it so if it was null and we were expecting a non-nullable value, it will throw.

So given that, the check is implicitly there and not really needed.

Also removed an unused method `tryGet` which was just returning null if the _json value isn't what we wanted instead of throwing an error. It's not used anywhere so I removed it. 