### PR TITLE
Improve ergonomics of protocol bindings

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -72,7 +72,7 @@ class ObjCProtocol extends NoLookUpBinding with ObjCMethods {
 
       String listenerBuilder = '';
       if (block.hasListener) {
-        listenerBuilder = '(Function func) => $blockType.listener($wrapper),';
+        listenerBuilder = '($funcType func) => $blockType.listener($wrapper),';
       }
 
       buildImplementations.write('''
@@ -87,7 +87,7 @@ class ObjCProtocol extends NoLookUpBinding with ObjCMethods {
           isRequired: ${method.isRequired},
           isInstanceMethod: ${method.isInstanceMethod},
       ),
-      (Function func) => $blockType.fromFunction($wrapper),
+      ($funcType func) => $blockType.fromFunction($wrapper),
       $listenerBuilder
     );
 ''');

--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -47,7 +47,7 @@ class ObjCProtocol extends NoLookUpBinding with ObjCMethods {
       final argName = methodName;
       final block = method.protocolBlock;
       final blockType = block.getDartType(w);
-      final methodCtor =
+      final methodClass =
           block.hasListener ? protocolListenableMethod : protocolMethod;
 
       // The function type omits the first arg of the block, which is unused.
@@ -76,10 +76,10 @@ class ObjCProtocol extends NoLookUpBinding with ObjCMethods {
       }
 
       buildImplementations.write('''
-    builder.implementMethod($name.$fieldName, $argName);''');
+    $name.$fieldName.implement(builder, $argName);''');
 
       methodFields.write(makeDartDoc(method.dartDoc ?? method.originalName));
-      methodFields.write('''static final $fieldName = $methodCtor(
+      methodFields.write('''static final $fieldName = $methodClass<$funcType>(
       ${method.selObject!.name},
       $getSignature(
           ${_protocolPointer.name},
@@ -87,7 +87,6 @@ class ObjCProtocol extends NoLookUpBinding with ObjCMethods {
           isRequired: ${method.isRequired},
           isInstanceMethod: ${method.isInstanceMethod},
       ),
-      (Function func) => func is $funcType,
       (Function func) => $blockType.fromFunction($wrapper),
       $listenerBuilder
     );

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -177,13 +177,15 @@ void main() {
 
         final listenerCompleter = Completer<int>();
         final protocolBuilder = ObjCProtocolBuilder();
-        MyProtocol.addToBuilderAsListener(protocolBuilder,
+        MyProtocol.addToBuilderAsListener(
+          protocolBuilder,
           instanceMethod_withDouble_: (NSString s, double x) {
             return 'ProtocolBuilder: $s: $x'.toNSString();
           },
           voidMethod_: (int x) {
             listenerCompleter.complete(x);
-          },);
+          },
+        );
         SecondaryProtocol.addToBuilder(protocolBuilder,
             otherMethod_b_c_d_: (int a, int b, int c, int d) {
           return a * b * c * d;

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -110,11 +110,11 @@ void main() {
         final consumer = ProtocolConsumer.new1();
 
         final protocolBuilder = ObjCProtocolBuilder();
-        protocolBuilder.implementMethod(MyProtocol.instanceMethod_withDouble_,
+        MyProtocol.instanceMethod_withDouble_.implement(protocolBuilder,
             (NSString s, double x) {
           return 'ProtocolBuilder: $s: $x'.toNSString();
         });
-        protocolBuilder.implementMethod(SecondaryProtocol.otherMethod_b_c_d_,
+        SecondaryProtocol.otherMethod_b_c_d_.implement(protocolBuilder,
             (int a, int b, int c, int d) {
           return a * b * c * d;
         });
@@ -213,8 +213,7 @@ void main() {
         int count = 0;
 
         final protocolBuilder = ObjCProtocolBuilder();
-        protocolBuilder.implementMethodAsListener(MyProtocol.voidMethod_,
-            (int x) {
+        MyProtocol.voidMethod_.implementAsListener(protocolBuilder, (int x) {
           expect(x, 123);
           ++count;
           if (count == 1000) completer.complete();

--- a/pkgs/objective_c/lib/src/internal.dart
+++ b/pkgs/objective_c/lib/src/internal.dart
@@ -285,25 +285,6 @@ Function getBlockClosure(Pointer<c.ObjCBlock> block) {
   return _blockClosureRegistry[id]!;
 }
 
-/// Only for use by ffigen bindings.
-class ObjCProtocolMethod {
-  final Pointer<c.ObjCSelector> sel;
-  final objc.NSMethodSignature signature;
-  final bool Function(Function) isCorrectFunctionType;
-  final ObjCBlockBase Function(Function) createBlock;
-
-  ObjCProtocolMethod(
-      this.sel, this.signature, this.isCorrectFunctionType, this.createBlock);
-}
-
-/// Only for use by ffigen bindings.
-class ObjCProtocolListenableMethod extends ObjCProtocolMethod {
-  final ObjCBlockBase Function(Function) createListenerBlock;
-
-  ObjCProtocolListenableMethod(super.sel, super.signature,
-      super.isCorrectFunctionType, super.createBlock, this.createListenerBlock);
-}
-
 // Not exported by ../objective_c.dart, because they're only for testing.
 bool blockHasRegisteredClosure(Pointer<c.ObjCBlock> block) =>
     _blockClosureRegistry.containsKey(block.ref.target.address);

--- a/pkgs/objective_c/lib/src/protocol_builder.dart
+++ b/pkgs/objective_c/lib/src/protocol_builder.dart
@@ -2,55 +2,82 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:ffi';
+
+import 'c_bindings_generated.dart' as c;
 import 'objective_c_bindings_generated.dart' as objc;
-import 'internal.dart'
-    show ObjCBlockBase, ObjCProtocolMethod, ObjCProtocolListenableMethod;
+import 'internal.dart' show ObjCBlockBase;
 
 /// Helper class for building Objective C objects that implement protocols.
 class ObjCProtocolBuilder {
   final _builder = objc.DartProxyBuilder.new1();
 
-  /// Implement an ObjC protocol [method] using a Dart [function].
+  /// Add a method implementation to the protocol.
   ///
-  /// The implemented method must be invoked by ObjC code running on the same
-  /// thread as the isolate that called [implementMethod]. Invoking the method
-  /// on the wrong thread will result in a crash.
-  ///
-  /// The recommended way of getting the [method] object is to use ffigen to
-  /// generate bindings for the protocol you want to implement. The generated
-  /// bindings will include a [ObjCProtocolMethod] for each method of the
-  /// protocol.
-  void implementMethod(ObjCProtocolMethod method, Function? function) =>
-      _implement(method, function, method.createBlock);
-
-  /// Implement an ObjC protocol [method] as a listener using a Dart [function].
-  ///
-  /// This is based on FFI's NativeCallable.listener, and has the same
-  /// capabilities and limitations. This method can be invoked by ObjC from any
-  /// thread, but only supports void functions, and is not run synchronously.
-  /// See NativeCallable.listener for more details.
-  ///
-  /// The recommended way of getting the [method] object is to use ffigen to
-  /// generate bindings for the protocol you want to implement. The generated
-  /// bindings will include a [ObjCProtocolMethod] for each method of the
-  /// protocol. If that method can be implemented as a listener, the [method]
-  /// object will be a [ObjCProtocolListenableMethod].
-  void implementMethodAsListener(
-          ObjCProtocolListenableMethod method, Function? function) =>
-      _implement(method, function, method.createListenerBlock);
+  /// It is not recommended to call this method directly. Instead, use the
+  /// implement methods on [ObjCProtocolMethod] and its subclasses.
+  void implementMethod(Pointer<c.ObjCSelector> sel,
+          objc.NSMethodSignature signature, ObjCBlockBase block) =>
+      _builder.implementMethod_withSignature_andBlock_(
+          sel, signature, block.pointer.cast());
 
   /// Builds the object.
   ///
   /// This can be called multiple times to construct multiple object instances
   /// that all implement the same protocol methods using the same functions.
   objc.DartProxy build() => objc.DartProxy.newFromBuilder_(_builder);
+}
 
-  void _implement(ObjCProtocolMethod method, Function? function,
-      ObjCBlockBase Function(Function) blockMaker) {
+/// A method in an ObjC protocol.
+///
+/// Do not try to construct this class directly. The recommended way of getting
+/// a method object is to use ffigen to generate bindings for the protocol you
+/// want to implement. The generated bindings will include a
+/// [ObjCProtocolMethod] for each method of the protocol.
+class ObjCProtocolMethod<T extends Function> {
+  final Pointer<c.ObjCSelector> _sel;
+  final objc.NSMethodSignature _signature;
+  final ObjCBlockBase Function(Function) _createBlock;
+
+  /// Only for use by ffigen bindings.
+  ObjCProtocolMethod(this._sel, this._signature, this._createBlock);
+
+  /// Implement this method on the protocol [builder] using a Dart [function].
+  ///
+  /// The implemented method must be invoked by ObjC code running on the same
+  /// thread as the isolate that called [implementMethod]. Invoking the method
+  /// on the wrong thread will result in a crash.
+  void implement(ObjCProtocolBuilder builder, T? function) {
     if (function != null) {
-      assert(method.isCorrectFunctionType(function));
-      _builder.implementMethod_withSignature_andBlock_(
-          method.sel, method.signature, blockMaker(function).pointer.cast());
+      builder.implementMethod(_sel, _signature, _createBlock(function));
+    }
+  }
+}
+
+/// A method in an ObjC protocol that can be implemented as a listener.
+///
+/// Do not try to construct this class directly. The recommended way of getting
+/// a method object is to use ffigen to generate bindings for the protocol you
+/// want to implement. The generated bindings will include a
+/// [ObjCProtocolMethod] for each method of the protocol.
+class ObjCProtocolListenableMethod<T extends Function>
+    extends ObjCProtocolMethod<T> {
+  final ObjCBlockBase Function(Function) _createListenerBlock;
+
+  /// Only for use by ffigen bindings.
+  ObjCProtocolListenableMethod(super._sel, super._signature, super._createBlock,
+      this._createListenerBlock);
+
+  /// Implement this method on the protocol [builder] as a listener using a Dart
+  /// [function].
+  ///
+  /// This is based on FFI's NativeCallable.listener, and has the same
+  /// capabilities and limitations. This method can be invoked by ObjC from any
+  /// thread, but only supports void functions, and is not run synchronously.
+  /// See NativeCallable.listener for more details.
+  void implementAsListener(ObjCProtocolBuilder builder, T? function) {
+    if (function != null) {
+      builder.implementMethod(_sel, _signature, _createListenerBlock(function));
     }
   }
 }

--- a/pkgs/objective_c/lib/src/protocol_builder.dart
+++ b/pkgs/objective_c/lib/src/protocol_builder.dart
@@ -37,7 +37,7 @@ class ObjCProtocolBuilder {
 class ObjCProtocolMethod<T extends Function> {
   final Pointer<c.ObjCSelector> _sel;
   final objc.NSMethodSignature _signature;
-  final ObjCBlockBase Function(Function) _createBlock;
+  final ObjCBlockBase Function(T) _createBlock;
 
   /// Only for use by ffigen bindings.
   ObjCProtocolMethod(this._sel, this._signature, this._createBlock);
@@ -62,7 +62,7 @@ class ObjCProtocolMethod<T extends Function> {
 /// [ObjCProtocolMethod] for each method of the protocol.
 class ObjCProtocolListenableMethod<T extends Function>
     extends ObjCProtocolMethod<T> {
-  final ObjCBlockBase Function(Function) _createListenerBlock;
+  final ObjCBlockBase Function(T) _createListenerBlock;
 
   /// Only for use by ffigen bindings.
   ObjCProtocolListenableMethod(super._sel, super._signature, super._createBlock,


### PR DESCRIPTION
Fixes #1231 by implementing 2 ergonomic improvements:

- Add an `implement`/`implementAsListener` method to `ObjCProtocolMethod`/`ObjCProtocolListenableMethod` that takes the correct function type. The function type is now a type param of the method class.
  - This means the function type is checked/inferred at compile time rather than just checked at runtime.
  - From the caller's perspective, they basically just have to swap the builder and method objects: `builder.implementMethod(MyProtocol.myMethod, function)` -> `MyProtocol.myMethod.implement(builder, function)`
  - Also moved the method classes to the same file as `ObjCProtocolBuilder`, since they're closely related.
- Implemented @brianquinlan's suggestion of adding a `implementAsListener`/`addToBuilderAsListener` method that implements any listenable methods as listeners.
  - These methods are generated if there is at least one listenable method.