### PR TITLE
[ffigen] support generate unused typedefs

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -27,6 +27,8 @@
   `objc-protocols` config option to generate bindings for a protocol.
 - Fix some bugs where ObjC interface/protocol methods could collide with Dart
   built-in methods, or with types declared elsewhere in the generated bindings.
+- Add `include-unused-typedefs` to allow generating typedefs that are not
+  referred to anywhere, the default option is `false`.
 
 ## 12.0.0
 

--- a/pkgs/ffigen/README.md
+++ b/pkgs/ffigen/README.md
@@ -279,7 +279,7 @@ globals:
     Options -<br>
     - Include/Exclude (referred typedefs only).<br>
     - Rename typedefs.<br><br>
-    Note: Typedefs that are not referred to anywhere will not be generated.
+    Note: By default, typedefs that are not referred to anywhere will not be generated.
     </td>
     <td>
 
@@ -291,6 +291,20 @@ typedefs:
   rename:
     # Removes '_' from beginning of a typedef.
     '_(.*)': '$1'
+```
+  </td>
+  </tr>
+  <tr>
+    <td>include-unused-typedefs</td>
+    <td>
+      Also generate typedefs that are not referred to anywhere.
+      <br>
+      <b>Default: false</b>
+    </td>
+    <td>
+
+```yaml
+include-unused-typedefs: true
 ```
   </td>
   </tr>

--- a/pkgs/ffigen/ffigen.schema.json
+++ b/pkgs/ffigen/ffigen.schema.json
@@ -391,6 +391,9 @@
     "exclude-all-by-default": {
       "type": "boolean"
     },
+    "include-unused-typedefs": {
+      "type": "boolean"
+    },
     "generate-for-package-objective-c": {
       "type": "boolean"
     },

--- a/pkgs/ffigen/lib/src/code_generator/typealias.dart
+++ b/pkgs/ffigen/lib/src/code_generator/typealias.dart
@@ -195,6 +195,19 @@ class Typealias extends BindingType {
 
   @override
   String? getDefaultValue(Writer w) => type.getDefaultValue(w);
+
+  // used to compare whether two Typealias are same symbols. Useful when trying to
+  // add the to a set.
+  @override
+  operator ==(Object other) {
+    if (other is! Typealias) return false;
+    if (identical(this, other)) return true;
+    return other.usr == usr;
+  }
+
+  // [usr] is unique for specific symbols.
+  @override
+  int get hashCode => usr.hashCode;
 }
 
 /// Objective C's instancetype.

--- a/pkgs/ffigen/lib/src/code_generator/typealias.dart
+++ b/pkgs/ffigen/lib/src/code_generator/typealias.dart
@@ -196,8 +196,8 @@ class Typealias extends BindingType {
   @override
   String? getDefaultValue(Writer w) => type.getDefaultValue(w);
 
-  // used to compare whether two Typealias are same symbols. Useful when trying to
-  // add the to a set.
+  // Used to compare whether two Typealias are same symbols and ensure that they
+  // are unique when adding to a [Set].
   @override
   operator ==(Object other) {
     if (other is! Typealias) return false;

--- a/pkgs/ffigen/lib/src/config_provider/config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config.dart
@@ -106,6 +106,10 @@ class Config {
   bool get excludeAllByDefault => _excludeAllByDefault;
   late bool _excludeAllByDefault;
 
+  /// If enabled, unused typedefs will also be generated.
+  bool get includeUnusedTypedefs => _includeUnusedTypedefs;
+  late bool _includeUnusedTypedefs;
+
   /// Undocumented option that changes code generation for package:objective_c.
   /// The main difference is whether NSObject etc are imported from
   /// package:objective_c (the default) or code genned like any other class.
@@ -648,6 +652,13 @@ class Config {
           valueConfigSpec: BoolConfigSpec(),
           defaultValue: (node) => false,
           resultOrDefault: (node) => _excludeAllByDefault = node.value as bool,
+        ),
+        HeterogeneousMapEntry(
+          key: strings.includeUnusedTypedefs,
+          valueConfigSpec: BoolConfigSpec(),
+          defaultValue: (node) => false,
+          resultOrDefault: (node) =>
+              _includeUnusedTypedefs = node.value as bool,
         ),
         HeterogeneousMapEntry(
           key: strings.generateForPackageObjectiveC,

--- a/pkgs/ffigen/lib/src/header_parser/translation_unit_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/translation_unit_parser.dart
@@ -6,6 +6,7 @@ import 'package:ffigen/src/code_generator.dart';
 import 'package:ffigen/src/header_parser/sub_parsers/macro_parser.dart';
 import 'package:ffigen/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart';
 import 'package:ffigen/src/header_parser/sub_parsers/objcprotocoldecl_parser.dart';
+import 'package:ffigen/src/header_parser/sub_parsers/typedefdecl_parser.dart';
 import 'package:ffigen/src/header_parser/sub_parsers/var_parser.dart';
 import 'package:logging/logging.dart';
 
@@ -47,6 +48,11 @@ Set<Binding> parseTranslationUnit(clang_types.CXCursor translationUnitCursor) {
             break;
           case clang_types.CXCursorKind.CXCursor_VarDecl:
             addToBindings(bindings, parseVarDeclaration(cursor));
+            break;
+          case clang_types.CXCursorKind.CXCursor_TypedefDecl:
+            if (config.includeUnusedTypedefs) {
+              addToBindings(bindings, parseTypedefDeclaration(cursor));
+            }
             break;
           default:
             _logger.finer('rootCursorVisitor: CursorKind not implemented');

--- a/pkgs/ffigen/lib/src/strings.dart
+++ b/pkgs/ffigen/lib/src/strings.dart
@@ -76,6 +76,7 @@ const objcInterfaces = 'objc-interfaces';
 const objcProtocols = 'objc-protocols';
 
 const excludeAllByDefault = 'exclude-all-by-default';
+const includeUnusedTypedefs = 'include-unused-typedefs';
 const generateForPackageObjectiveC = 'generate-for-package-objective-c';
 
 // Sub-fields of Declarations.

--- a/pkgs/ffigen/test/collision_tests/expected_bindings/_expected_decl_decl_collision_bindings.dart
+++ b/pkgs/ffigen/test/collision_tests/expected_bindings/_expected_decl_decl_collision_bindings.dart
@@ -65,8 +65,6 @@ const int Test_Macro1 = 0;
 
 typedef testAlias = ffi.Void;
 typedef DarttestAlias = void;
-typedef testAlias1 = ffi.Void;
-typedef DarttestAlias1 = void;
 
 final class testCrossDecl extends ffi.Opaque {}
 

--- a/pkgs/ffigen/test/header_parser_tests/expected_bindings/_expected_typedef_bindings.dart
+++ b/pkgs/ffigen/test/header_parser_tests/expected_bindings/_expected_typedef_bindings.dart
@@ -85,25 +85,30 @@ class Bindings {
       _func4Ptr.asFunction<bool Function(ffi.Pointer<ffi.Bool>)>();
 }
 
+typedef NamedFunctionProto
+    = ffi.Pointer<ffi.NativeFunction<NamedFunctionProtoFunction>>;
+typedef NamedFunctionProtoFunction = ffi.Void Function();
+typedef DartNamedFunctionProtoFunction = void Function();
+
 final class Struct1 extends ffi.Struct {
   external NamedFunctionProto named;
 
   external ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> unnamed;
 }
 
-typedef NamedFunctionProto
-    = ffi.Pointer<ffi.NativeFunction<NamedFunctionProtoFunction>>;
-typedef NamedFunctionProtoFunction = ffi.Void Function();
-typedef DartNamedFunctionProtoFunction = void Function();
-
 final class AnonymousStructInTypedef extends ffi.Opaque {}
+
+typedef Typeref1 = AnonymousStructInTypedef;
+typedef Typeref2 = AnonymousStructInTypedef;
 
 final class _NamedStructInTypedef extends ffi.Opaque {}
 
-typedef NTyperef1 = ExcludedStruct;
+typedef NamedStructInTypedef = _NamedStructInTypedef;
 typedef ExcludedStruct = _ExcludedStruct;
 
 final class _ExcludedStruct extends ffi.Opaque {}
+
+typedef NTyperef1 = ExcludedStruct;
 
 enum AnonymousEnumInTypedef {
   a(0);
@@ -131,12 +136,18 @@ enum _NamedEnumInTypedef {
       };
 }
 
+typedef SpecifiedTypeAsIntPtr = ffi.Char;
+typedef DartSpecifiedTypeAsIntPtr = int;
 typedef NestingASpecifiedType = ffi.IntPtr;
 typedef DartNestingASpecifiedType = int;
 
 final class Struct2 extends ffi.Opaque {}
 
+typedef Struct3 = Struct2;
+
 final class WithBoolAlias extends ffi.Struct {
   @ffi.Bool()
   external bool b;
 }
+
+typedef IncludedTypedef = ffi.Pointer<ffi.Void>;

--- a/pkgs/ffigen/test/header_parser_tests/typedef.h
+++ b/pkgs/ffigen/test/header_parser_tests/typedef.h
@@ -69,3 +69,5 @@ BoolAlias func4(BoolAlias *a);
 struct WithBoolAlias{
     BoolAlias b;
 };
+
+typedef void* IncludedTypedef;

--- a/pkgs/ffigen/test/header_parser_tests/typedef_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/typedef_test.dart
@@ -31,6 +31,10 @@ ${strings.structs}:
   ${strings.exclude}:
     - ExcludedStruct
     - _ExcludedStruct
+${strings.includeUnusedTypedefs}: true
+${strings.typedefs}:
+  ${strings.exclude}:
+    - pStruct.*
 ${strings.typeMap}:
   ${strings.typeMapTypedefs}:
     'SpecifiedTypeAsIntPtr':


### PR DESCRIPTION
- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>

This PR fixes #320, aims to allow generating unused `typedefs`.

A new config option `include-unused-typedefs` is added to enable this feature and by default it is disabled, so this won't affect many users. However, the `operator ==` of `TypeAlias` was changed to filter out duplicate items in `Library.bindings`, which may affect some users just like `pkgs/ffigen/test/collision_tests/expected_bindings/_expected_decl_decl_collision_bindings.dart` shows.