### PR TITLE
[native_assets_cli] Publish 0.7.0

### DIFF
--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.0-wip
+## 0.7.0
 
 - `BuildConfig` constructors now have a required `linkingEnabled` parameter.
 

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   native assets CLI.
 
 # Note: Bump BuildConfig.version and BuildOutput.version on breaking changes!
-version: 0.7.0-wip
+version: 0.7.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
 topics:


### PR DESCRIPTION
Another round of rolling so we can update flutter_tools to address:

* https://github.com/dart-lang/native/issues/1252