### PR TITLE
[native_assets_builder] Publish 0.8.0

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.8.0-wip
+## 0.8.0
 
 - `BuildRunner.build` and `BuildRunner.buildDryRun` now have a required
   `linkingEnabled` parameter.

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -1,10 +1,10 @@
 name: native_assets_builder
 description: >-
   This package is the backend that invokes build hooks.
-version: 0.8.0-wip
+version: 0.8.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_builder
 
-publish_to: none
+# publish_to: none
 
 environment:
   sdk: '>=3.3.0 <4.0.0'

--- a/pkgs/native_assets_builder/test_data/add_asset_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/add_asset_link/pubspec.yaml
@@ -13,9 +13,9 @@ dependencies:
   native_assets_cli: ^0.7.0
   # native_assets_cli:
   #   path: ../../../native_assets_cli/
-  # native_toolchain_c: ^0.5.0
-  native_toolchain_c:
-    path: ../../../native_toolchain_c/
+  native_toolchain_c: ^0.5.1
+  # native_toolchain_c:
+  #   path: ../../../native_toolchain_c/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_builder/test_data/drop_dylib_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/drop_dylib_link/pubspec.yaml
@@ -13,9 +13,9 @@ dependencies:
   native_assets_cli: ^0.7.0
   # native_assets_cli:
   #   path: ../../../native_assets_cli/
-  # native_toolchain_c: ^0.5.0
-  native_toolchain_c:
-    path: ../../../native_toolchain_c/
+  native_toolchain_c: ^0.5.1
+  # native_toolchain_c:
+  #   path: ../../../native_toolchain_c/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
@@ -12,9 +12,9 @@ dependencies:
   native_assets_cli: ^0.7.0
   # native_assets_cli:
   #   path: ../../../native_assets_cli/
-  # native_toolchain_c: ^0.5.0
-  native_toolchain_c:
-    path: ../../../native_toolchain_c/
+  native_toolchain_c: ^0.5.1
+  # native_toolchain_c:
+  #   path: ../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
@@ -12,9 +12,9 @@ dependencies:
   native_assets_cli: ^0.7.0
   # native_assets_cli:
   #   path: ../../../native_assets_cli/
-  # native_toolchain_c: ^0.5.0
-  native_toolchain_c:
-    path: ../../../native_toolchain_c/
+  native_toolchain_c: ^0.5.1
+  # native_toolchain_c:
+  #   path: ../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
@@ -12,9 +12,9 @@ dependencies:
   native_assets_cli: ^0.7.0
   # native_assets_cli:
   #   path: ../../../native_assets_cli/
-  # native_toolchain_c: ^0.5.0
-  native_toolchain_c:
-    path: ../../../native_toolchain_c/
+  native_toolchain_c: ^0.5.1
+  # native_toolchain_c:
+  #   path: ../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_cli/example/build/native_add_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/native_add_library/pubspec.yaml
@@ -13,9 +13,9 @@ dependencies:
   native_assets_cli: ^0.7.0
   # native_assets_cli:
   #   path: ../../../../native_assets_cli/
-  # native_toolchain_c: ^0.5.0
-  native_toolchain_c:
-    path: ../../../../native_toolchain_c/
+  native_toolchain_c: ^0.5.1
+  # native_toolchain_c:
+  #   path: ../../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_cli/example/build/use_dart_api/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/use_dart_api/pubspec.yaml
@@ -12,9 +12,9 @@ dependencies:
   native_assets_cli: ^0.7.0
   # native_assets_cli:
   #   path: ../../../../native_assets_cli/
-  # native_toolchain_c: ^0.5.0
-  native_toolchain_c:
-    path: ../../../../native_toolchain_c/
+  native_toolchain_c: ^0.5.1
+  # native_toolchain_c:
+  #   path: ../../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^10.0.0


### PR DESCRIPTION
Another round of rolling so we can update flutter_tools to address:

* https://github.com/dart-lang/native/issues/1252