### PR TITLE
13 - tidy up analysis_options, remove lints that already exist

### DIFF
--- a/pkgs/jnigen/analysis_options.yaml
+++ b/pkgs/jnigen/analysis_options.yaml
@@ -9,6 +9,7 @@ analyzer:
     todo: ignore
   exclude: [build/**, example/**]
   language:
+    strict-casts: true
     strict-inference: true
     strict-raw-types: true
 
@@ -17,6 +18,3 @@ linter:
     dangling_library_doc_comments: true
     prefer_final_locals: true
     prefer_const_declarations: true
-    unawaited_futures: true
-    prefer_const_constructors: true
-    prefer_relative_imports: true


### PR DESCRIPTION
**Stack**:
- #1303 ⬅
- #1302
- #1301
- #1300
- #1299
- #1298
- #1297
- #1296
- #1295
- #1294
- #1293
- #1292
- #1291
- #1290


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*