### PR TITLE
[ffigen] Enable strict types

### DIFF
--- a/pkgs/ffi/analysis_options.yaml
+++ b/pkgs/ffi/analysis_options.yaml
@@ -1,9 +1,12 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
+  errors:
+    todo: ignore
   language:
     strict-casts: true
     strict-inference: true
+    strict-raw-types: true
 
 linter:
   rules:

--- a/pkgs/ffigen/analysis_options.yaml
+++ b/pkgs/ffigen/analysis_options.yaml
@@ -19,6 +19,7 @@ analyzer:
   language:
     strict-casts: true
     strict-inference: true
+    strict-raw-types: true
 
 linter:
   rules:

--- a/pkgs/ffigen/lib/src/config_provider/config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config.dart
@@ -748,7 +748,7 @@ class Config {
     );
   }
 
-  bool _libraryImportsPredefinedValidation(ConfigValue node) {
+  bool _libraryImportsPredefinedValidation(ConfigValue<Object?> node) {
     if (node.value is YamlMap) {
       return (node.value as YamlMap).keys.where((key) {
         if (strings.predefinedLibraryImports.containsKey(key)) {

--- a/pkgs/ffigen/lib/src/config_provider/config_spec.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config_spec.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:logging/logging.dart';
 import 'package:yaml/yaml.dart';
 

--- a/pkgs/ffigen/lib/src/config_provider/config_spec.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config_spec.dart
@@ -28,7 +28,7 @@ abstract class ConfigSpec<TE extends Object?, RE extends Object?> {
   String? schemaDescription;
 
   /// Custom validation hook, called post validation if successful.
-  bool Function(ConfigValue node)? customValidation;
+  bool Function(ConfigValue<Object?> node)? customValidation;
 
   /// Used to transform the payload to another type before passing to parent
   /// nodes and [result].
@@ -44,9 +44,9 @@ abstract class ConfigSpec<TE extends Object?, RE extends Object?> {
     required this.result,
   });
 
-  bool _validateNode(ConfigValue o, {bool log = true});
+  bool _validateNode(ConfigValue<Object?> o, {bool log = true});
 
-  ConfigValue<RE> _extractNode(ConfigValue o);
+  ConfigValue<RE> _extractNode(ConfigValue<Object?> o);
 
   /// ConfigSpec objects should call [_getJsonRefOrSchemaNode] instead to get
   /// the child json schema.
@@ -82,7 +82,7 @@ abstract class ConfigSpec<TE extends Object?, RE extends Object?> {
   /// all underlying ConfigSpecs if valid.
   /// Should ideally only be called if [validate] returns True. Throws
   /// [ConfigSpecExtractionError] if any validation fails.
-  ConfigValue extract(dynamic value) {
+  ConfigValue<Object?> extract(dynamic value) {
     return _extractNode(ConfigValue(path: [], value: value));
   }
 }
@@ -159,7 +159,7 @@ class ConfigValue<TE> {
 }
 
 class ConfigSpecExtractionError extends Error {
-  final ConfigValue? item;
+  final ConfigValue<Object?>? item;
   final String message;
   ConfigSpecExtractionError(this.item, [this.message = 'Invalid ConfigSpec']);
 
@@ -216,8 +216,8 @@ class HeterogeneousMapConfigSpec<CE extends Object?, RE extends Object?>
         allKeys = {for (final kv in entries) kv.key};
 
   @override
-  bool _validateNode(ConfigValue o, {bool log = true}) {
-    if (!o.checkType<Map>(log: log)) {
+  bool _validateNode(ConfigValue<Object?> o, {bool log = true}) {
+    if (!o.checkType<Map<dynamic, dynamic>>(log: log)) {
       return false;
     }
 
@@ -266,7 +266,7 @@ class HeterogeneousMapConfigSpec<CE extends Object?, RE extends Object?>
     return result;
   }
 
-  dynamic _getAllDefaults(ConfigValue o) {
+  dynamic _getAllDefaults(ConfigValue<Object?> o) {
     final result = <dynamic, CE>{};
     for (final entry in entries) {
       final path = [...o.path, entry.key];
@@ -298,8 +298,8 @@ class HeterogeneousMapConfigSpec<CE extends Object?, RE extends Object?>
   }
 
   @override
-  ConfigValue<RE> _extractNode(ConfigValue o) {
-    if (!o.checkType<Map>(log: false)) {
+  ConfigValue<RE> _extractNode(ConfigValue<Object?> o) {
+    if (!o.checkType<Map<dynamic, dynamic>>(log: false)) {
       throw ConfigSpecExtractionError(o);
     }
 
@@ -405,8 +405,8 @@ class MapConfigSpec<CE extends Object?, RE extends Object?>
   });
 
   @override
-  bool _validateNode(ConfigValue o, {bool log = true}) {
-    if (!o.checkType<Map>(log: log)) {
+  bool _validateNode(ConfigValue<Object?> o, {bool log = true}) {
+    if (!o.checkType<Map<dynamic, dynamic>>(log: log)) {
       return false;
     }
 
@@ -457,8 +457,8 @@ class MapConfigSpec<CE extends Object?, RE extends Object?>
   }
 
   @override
-  ConfigValue<RE> _extractNode(ConfigValue o) {
-    if (!o.checkType<Map>(log: false)) {
+  ConfigValue<RE> _extractNode(ConfigValue<Object?> o) {
+    if (!o.checkType<Map<dynamic, dynamic>>(log: false)) {
       throw ConfigSpecExtractionError(o);
     }
 
@@ -522,7 +522,7 @@ class ListConfigSpec<CE extends Object?, RE extends Object?>
   });
 
   @override
-  bool _validateNode(ConfigValue o, {bool log = true}) {
+  bool _validateNode(ConfigValue<Object?> o, {bool log = true}) {
     if (!o.checkType<YamlList>(log: log)) {
       return false;
     }
@@ -544,7 +544,7 @@ class ListConfigSpec<CE extends Object?, RE extends Object?>
   }
 
   @override
-  ConfigValue<RE> _extractNode(ConfigValue o) {
+  ConfigValue<RE> _extractNode(ConfigValue<Object?> o) {
     if (!o.checkType<YamlList>(log: false)) {
       throw ConfigSpecExtractionError(o);
     }
@@ -591,7 +591,7 @@ class StringConfigSpec<RE extends Object?> extends ConfigSpec<String, RE> {
   }) : _regexp = pattern == null ? null : RegExp(pattern, dotAll: true);
 
   @override
-  bool _validateNode(ConfigValue o, {bool log = true}) {
+  bool _validateNode(ConfigValue<Object?> o, {bool log = true}) {
     if (!o.checkType<String>(log: log)) {
       return false;
     }
@@ -610,7 +610,7 @@ class StringConfigSpec<RE extends Object?> extends ConfigSpec<String, RE> {
   }
 
   @override
-  ConfigValue<RE> _extractNode(ConfigValue o) {
+  ConfigValue<RE> _extractNode(ConfigValue<Object?> o) {
     if (!o.checkType<String>(log: false)) {
       throw ConfigSpecExtractionError(o);
     }
@@ -642,7 +642,7 @@ class IntConfigSpec<RE extends Object?> extends ConfigSpec<int, RE> {
   });
 
   @override
-  bool _validateNode(ConfigValue o, {bool log = true}) {
+  bool _validateNode(ConfigValue<Object?> o, {bool log = true}) {
     if (!o.checkType<int>(log: log)) {
       return false;
     }
@@ -653,7 +653,7 @@ class IntConfigSpec<RE extends Object?> extends ConfigSpec<int, RE> {
   }
 
   @override
-  ConfigValue<RE> _extractNode(ConfigValue o) {
+  ConfigValue<RE> _extractNode(ConfigValue<Object?> o) {
     if (!o.checkType<int>(log: false)) {
       throw ConfigSpecExtractionError(o);
     }
@@ -688,7 +688,7 @@ class EnumConfigSpec<CE extends Object?, RE extends Object?>
   });
 
   @override
-  bool _validateNode(ConfigValue o, {bool log = true}) {
+  bool _validateNode(ConfigValue<Object?> o, {bool log = true}) {
     if (!allowedValues.contains(o.value)) {
       if (log) {
         _logger.severe(
@@ -704,7 +704,7 @@ class EnumConfigSpec<CE extends Object?, RE extends Object?>
   }
 
   @override
-  ConfigValue<RE> _extractNode(ConfigValue o) {
+  ConfigValue<RE> _extractNode(ConfigValue<Object?> o) {
     if (!allowedValues.contains(o.value)) {
       throw ConfigSpecExtractionError(o);
     }
@@ -735,7 +735,7 @@ class BoolConfigSpec<RE> extends ConfigSpec<bool, RE> {
   });
 
   @override
-  bool _validateNode(ConfigValue o, {bool log = true}) {
+  bool _validateNode(ConfigValue<Object?> o, {bool log = true}) {
     if (!o.checkType<bool>(log: log)) {
       return false;
     }
@@ -746,7 +746,7 @@ class BoolConfigSpec<RE> extends ConfigSpec<bool, RE> {
   }
 
   @override
-  ConfigValue<RE> _extractNode(ConfigValue o) {
+  ConfigValue<RE> _extractNode(ConfigValue<Object?> o) {
     if (!o.checkType<bool>(log: false)) {
       throw ConfigSpecExtractionError(o);
     }
@@ -784,7 +784,7 @@ class OneOfConfigSpec<TE extends Object?, RE extends Object?>
   });
 
   @override
-  bool _validateNode(ConfigValue o, {bool log = true}) {
+  bool _validateNode(ConfigValue<Object?> o, {bool log = true}) {
     // Running first time with no logs.
     for (final spec in childConfigSpecs) {
       if (spec._validateNode(o, log: false)) {
@@ -806,7 +806,7 @@ class OneOfConfigSpec<TE extends Object?, RE extends Object?>
   }
 
   @override
-  ConfigValue<RE> _extractNode(ConfigValue o) {
+  ConfigValue<RE> _extractNode(ConfigValue<Object?> o) {
     for (final spec in childConfigSpecs) {
       if (spec._validateNode(o, log: false)) {
         return o

--- a/pkgs/objective_c/example/pubspec.lock
+++ b/pkgs/objective_c/example/pubspec.lock
@@ -203,10 +203,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   vector_math:
     dependency: transitive
     description:
@@ -219,10 +219,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "360c4271613beb44db559547d02f8b0dc044741d0eeb9aa6ccdb47e8ec54c63a"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.3"
+    version: "14.2.4"
   yaml:
     dependency: transitive
     description:
@@ -232,5 +232,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
Stop inferring dynamic type arguments.

This PR makes `ConfigValue` default to `Object?` as it already was doing in various places. And `Map` to `Map<dynamic, dynamic>` as it already was in various places.