### PR TITLE
[native_assets_cli] Publish 0.7.1

### DIFF
--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.1-wip
+## 0.7.1
 
 - `BuildConfig.dependencies` and `LinkConfig.dependencies` no longer have to
   specify Dart sources.

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   native assets CLI.
 
 # Note: Bump BuildConfig.version and BuildOutput.version on breaking changes!
-version: 0.7.1-wip
+version: 0.7.1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
 topics:


### PR DESCRIPTION
So we can roll to Flutter:

* https://github.com/dart-lang/native/issues/1256