### PR TITLE
[native_*] Hooks with `DataAsset`s read from disk

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.8.2-wip
 
-- Nothing yet.
+- Fix some more cases of: `BuildConfig.dependencies` and
+  `LinkConfig.dependencies` no longer have to specify Dart sources.
+- `DataAsset` test projects report all assets from `assets/` dir.
 
 ## 0.8.1
 

--- a/pkgs/native_assets_builder/test/build_runner/link_dry_run_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/link_dry_run_test.dart
@@ -74,10 +74,11 @@ void main() async {
           linkingEnabled: true,
         );
         expect(buildResult.success, true);
-        expect(_getNames(buildResult.assets), orderedEquals(builtHelperAssets));
+        expect(
+            _getNames(buildResult.assets), unorderedEquals(builtHelperAssets));
         expect(
           _getNames(buildResult.assetsForLinking['complex_link']!),
-          orderedEquals(assetsForLinking),
+          unorderedEquals(assetsForLinking),
         );
 
         final linkResult = await linkDryRun(
@@ -88,7 +89,7 @@ void main() async {
         );
         expect(linkResult.success, true);
 
-        expect(_getNames(linkResult.assets), orderedEquals(linkedAssets));
+        expect(_getNames(linkResult.assets), unorderedEquals(linkedAssets));
       });
     },
   );

--- a/pkgs/native_assets_builder/test/build_runner/link_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/link_test.dart
@@ -82,10 +82,11 @@ void main() async {
           linkingEnabled: true,
         );
         expect(buildResult.success, true);
-        expect(_getNames(buildResult.assets), orderedEquals(builtHelperAssets));
+        expect(
+            _getNames(buildResult.assets), unorderedEquals(builtHelperAssets));
         expect(
           _getNames(buildResult.assetsForLinking['complex_link']!),
-          orderedEquals(assetsForLinking),
+          unorderedEquals(assetsForLinking),
         );
 
         final linkResult = await link(
@@ -96,7 +97,7 @@ void main() async {
         );
         expect(linkResult.success, true);
 
-        expect(_getNames(linkResult.assets), orderedEquals(linkedAssets));
+        expect(_getNames(linkResult.assets), unorderedEquals(linkedAssets));
       });
     },
   );

--- a/pkgs/native_assets_builder/test_data/complex_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/complex_link/hook/build.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> args) async {
-  build(args, (config, output) async {
+  await build(args, (config, output) async {
     final packageName = config.packageName;
     final assetDirectory =
         Directory.fromUri(config.packageRoot.resolve('assets/'));

--- a/pkgs/native_assets_builder/test_data/complex_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/complex_link/hook/build.dart
@@ -2,21 +2,35 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:native_assets_cli/native_assets_cli.dart';
 
-const packageName = 'complex_link';
+void main(List<String> args) async {
+  build(args, (config, output) async {
+    final packageName = config.packageName;
+    final assetDirectory =
+        Directory.fromUri(config.packageRoot.resolve('assets/'));
+    // If assets are added, rerun hook.
+    output.addDependency(assetDirectory.uri);
 
-void main(List<String> args) async => build(args, (config, output) async {
-      output.addAssets(
-        List.generate(
-          2,
-          (index) => DataAsset(
-            name: 'data_$index',
-            // TODO(mosuem): Simplify specifying files/file paths
-            file: config.packageRoot.resolve('assets/data_$index.json'),
-            package: packageName,
-          ),
+    await for (final dataAsset in assetDirectory.list()) {
+      if (dataAsset is! File) {
+        continue;
+      }
+      final fileName = dataAsset.uri.pathSegments.last;
+      final name = fileName.split('.').first;
+      output.addAsset(
+        DataAsset(
+          package: packageName,
+          name: name,
+          file: dataAsset.uri,
         ),
-        linkInPackage: config.linkingEnabled ? 'complex_link' : null,
+        linkInPackage: config.linkingEnabled ? packageName : null,
       );
-    });
+      // TODO(https://github.com/dart-lang/native/issues/1208): Report
+      // dependency on asset.
+      output.addDependency(dataAsset.uri);
+    }
+  });
+}

--- a/pkgs/native_assets_builder/test_data/complex_link_helper/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/complex_link_helper/hook/build.dart
@@ -2,33 +2,37 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:native_assets_cli/native_assets_cli.dart';
 
-const packageName = 'complex_link_helper';
+void main(List<String> args) async {
+  build(args, (config, output) async {
+    final packageName = config.packageName;
+    final assetDirectory =
+        Directory.fromUri(config.packageRoot.resolve('assets/'));
+    // If assets are added, rerun hook.
+    output.addDependency(assetDirectory.uri);
 
-void main(List<String> args) async => build(args, (config, output) async {
-      output.addAssets(
-        List.generate(
-          2,
-          (index) => DataAsset(
-            name: 'data_helper_$index',
-            // TODO(mosuem): Simplify specifying files/file paths
-            file: config.packageRoot.resolve('assets/data_helper_$index.json'),
-            package: packageName,
-          ),
+    await for (final dataAsset in assetDirectory.list()) {
+      if (dataAsset is! File) {
+        continue;
+      }
+      final fileName = dataAsset.uri.pathSegments.last;
+      final name = fileName.split('.').first;
+      final forLinking = name.contains('2') || name.contains('3');
+      output.addAsset(
+        DataAsset(
+          package: packageName,
+          name: name,
+          file: dataAsset.uri,
         ),
+        linkInPackage:
+            forLinking && config.linkingEnabled ? 'complex_link' : null,
       );
-      output.addAssets(
-        List.generate(
-          2,
-          (index) => DataAsset(
-            name: 'data_helper_${index + 2}',
-            // TODO(mosuem): Simplify specifying files/file paths
-            file: config.packageRoot
-                .resolve('assets/data_helper_${index + 2}.json'),
-            package: packageName,
-          ),
-        ),
-        linkInPackage: config.linkingEnabled ? 'complex_link' : null,
-      );
-    });
+      // TODO(https://github.com/dart-lang/native/issues/1208): Report
+      // dependency on asset.
+      output.addDependency(dataAsset.uri);
+    }
+  });
+}

--- a/pkgs/native_assets_builder/test_data/complex_link_helper/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/complex_link_helper/hook/build.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> args) async {
-  build(args, (config, output) async {
+  await build(args, (config, output) async {
     final packageName = config.packageName;
     final assetDirectory =
         Directory.fromUri(config.packageRoot.resolve('assets/'));

--- a/pkgs/native_assets_builder/test_data/drop_dylib_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/drop_dylib_link/hook/build.dart
@@ -6,8 +6,6 @@ import 'package:logging/logging.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
-const packageName = 'drop_dylib_link';
-
 void main(List<String> arguments) async {
   await build(arguments, (config, output) async {
     final logger = Logger('')
@@ -15,7 +13,7 @@ void main(List<String> arguments) async {
       ..onRecord.listen((record) {
         print('${record.level.name}: ${record.time}: ${record.message}');
       });
-    final linkInPackage = config.linkingEnabled ? packageName : null;
+    final linkInPackage = config.linkingEnabled ? config.packageName : null;
     await CBuilder.library(
       name: 'add',
       assetName: 'dylib_add',

--- a/pkgs/native_assets_builder/test_data/native_add/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/native_add/hook/build.dart
@@ -6,10 +6,9 @@ import 'package:logging/logging.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
-const packageName = 'native_add';
-
 void main(List<String> arguments) async {
   await build(arguments, (config, output) async {
+    final packageName = config.packageName;
     final cbuilder = CBuilder.library(
       name: packageName,
       assetName: 'src/${packageName}_bindings_generated.dart',

--- a/pkgs/native_assets_builder/test_data/native_add_add_source/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/native_add_add_source/hook/build.dart
@@ -6,10 +6,9 @@ import 'package:logging/logging.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
-const packageName = 'native_add';
-
 void main(List<String> arguments) async {
   await build(arguments, (config, output) async {
+    final packageName = config.packageName;
     final cbuilder = CBuilder.library(
       name: packageName,
       assetName: '${packageName}_bindings_generated.dart',

--- a/pkgs/native_assets_builder/test_data/native_subtract/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/native_subtract/hook/build.dart
@@ -6,10 +6,9 @@ import 'package:logging/logging.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
-const packageName = 'native_subtract';
-
 void main(List<String> arguments) async {
   await build(arguments, (config, output) async {
+    final packageName = config.packageName;
     final cbuilder = CBuilder.library(
       name: packageName,
       assetName: 'src/${packageName}_bindings_generated.dart',

--- a/pkgs/native_assets_builder/test_data/simple_data_asset/bin/deep_modify_data_asset.dart.debug
+++ b/pkgs/native_assets_builder/test_data/simple_data_asset/bin/deep_modify_data_asset.dart.debug
@@ -10,7 +10,7 @@ Future<void> main(List<String> args) async {
 
 // Expect this to throw
 Future<String> getWorld() async {
-  const asset = ByteAsset('package:simple_data_asset/assetId');
+  const asset = ByteAsset('package:simple_data_asset/test_asset.txt');
   final byteBuffer = await asset.load();
   byteBuffer.buffer.asFloat32List()[0] = 1.0;
   return String.fromCharCodes(byteBuffer);

--- a/pkgs/native_assets_builder/test_data/simple_data_asset/bin/modify_data_asset.dart.debug
+++ b/pkgs/native_assets_builder/test_data/simple_data_asset/bin/modify_data_asset.dart.debug
@@ -10,7 +10,7 @@ Future<void> main(List<String> args) async {
 
 // Expect this to throw
 Future<String> getWorld() async {
-  const asset = ByteAsset('package:simple_data_asset/assetId');
+  const asset = ByteAsset('package:simple_data_asset/test_asset.txt');
   final byteBuffer = await asset.load();
   byteBuffer[0] = 42;
   return String.fromCharCodes(byteBuffer);

--- a/pkgs/native_assets_builder/test_data/simple_data_asset/bin/simple_data_asset.dart.debug
+++ b/pkgs/native_assets_builder/test_data/simple_data_asset/bin/simple_data_asset.dart.debug
@@ -8,7 +8,7 @@ Future<void> main(List<String> args) async {
 }
 
 Future<String> getWorld() async {
-  const asset = ByteAsset('package:simple_data_asset/assetId');
+  const asset = ByteAsset('package:simple_data_asset/test_asset.txt');
   final byteBuffer = await asset.load();
   return String.fromCharCodes(byteBuffer);
 }

--- a/pkgs/native_assets_builder/test_data/simple_data_asset/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/simple_data_asset/hook/build.dart
@@ -1,18 +1,35 @@
 // Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+import 'dart:io';
+
 import 'package:native_assets_cli/native_assets_cli.dart';
 
-void main(List<String> args) => build(
-      args,
-      (config, output) async {
+void main(List<String> args) async {
+  await build(
+    args,
+    (config, output) async {
+      final assetDirectory =
+          Directory.fromUri(config.packageRoot.resolve('assets/'));
+      // If assets are added, rerun hook.
+      output.addDependency(assetDirectory.uri);
+
+      await for (final dataAsset in assetDirectory.list()) {
+        if (dataAsset is! File) {
+          continue;
+        }
+        final name = dataAsset.uri.pathSegments.last;
         output.addAsset(
           DataAsset(
             package: config.packageName,
-            name: 'assetId',
-            file: config.packageRoot.resolve('asset/test_asset.txt'),
+            name: name,
+            file: dataAsset.uri,
           ),
         );
-        output.addDependency(config.packageRoot.resolve('hook/build.dart'));
-      },
-    );
+        // TODO(https://github.com/dart-lang/native/issues/1208): Report
+        // dependency on asset.
+        output.addDependency(dataAsset.uri);
+      }
+    },
+  );
+}

--- a/pkgs/native_assets_builder/test_data/simple_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/simple_link/hook/build.dart
@@ -2,21 +2,35 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:native_assets_cli/native_assets_cli.dart';
 
-const packageName = 'simple_link';
+void main(List<String> args) async {
+  await build(args, (config, output) async {
+    final packageName = config.packageName;
+    final assetDirectory =
+        Directory.fromUri(config.packageRoot.resolve('assets/'));
+    // If assets are added, rerun hook.
+    output.addDependency(assetDirectory.uri);
 
-void main(List<String> args) async => build(args, (config, output) async {
-      output.addAssets(
-        List.generate(
-          4,
-          (index) => DataAsset(
-            name: 'data_$index',
-            // TODO(mosuem): Simplify specifying files/file paths
-            file: config.packageRoot.resolve('assets/data_$index.json'),
-            package: packageName,
-          ),
+    await for (final dataAsset in assetDirectory.list()) {
+      if (dataAsset is! File) {
+        continue;
+      }
+      final fileName = dataAsset.uri.pathSegments.last;
+      final name = fileName.split('.').first;
+      output.addAsset(
+        DataAsset(
+          package: packageName,
+          name: name,
+          file: dataAsset.uri,
         ),
-        linkInPackage: config.linkingEnabled ? 'simple_link' : null,
+        linkInPackage: config.linkingEnabled ? packageName : null,
       );
-    });
+      // TODO(https://github.com/dart-lang/native/issues/1208): Report
+      // dependency on asset.
+      output.addDependency(dataAsset.uri);
+    }
+  });
+}

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.3-wip
+
+- Fix some more cases of: `BuildConfig.dependencies` and
+  `LinkConfig.dependencies` no longer have to specify Dart sources.
+- `DataAsset` examples report all assets from `assets/` dir.
+
 ## 0.7.2
 
 - Deprecate metadata concept.

--- a/pkgs/native_assets_cli/example/build/local_asset/hook/build.dart
+++ b/pkgs/native_assets_cli/example/build/local_asset/hook/build.dart
@@ -27,7 +27,6 @@ void main(List<String> args) async {
 
       output.addDependencies([
         assetSourcePath,
-        config.packageRoot.resolve('hook/build.dart'),
       ]);
     }
 

--- a/pkgs/native_assets_cli/example/build/use_dart_api/hook/build.dart
+++ b/pkgs/native_assets_cli/example/build/use_dart_api/hook/build.dart
@@ -6,10 +6,9 @@ import 'package:logging/logging.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
-const packageName = 'use_dart_api';
-
 void main(List<String> arguments) async {
   await build(arguments, (config, output) async {
+    final packageName = config.packageName;
     final cbuilder = CBuilder.library(
       name: packageName,
       assetName: 'src/${packageName}_bindings_generated.dart',

--- a/pkgs/native_assets_cli/lib/src/api/build.dart
+++ b/pkgs/native_assets_cli/lib/src/api/build.dart
@@ -26,7 +26,6 @@ import 'build_output.dart';
 ///       sources: [
 ///         'src/$packageName.c',
 ///       ],
-///       dartBuildFiles: ['hook/build.dart'],
 ///     );
 ///     await cbuilder.run(
 ///       buildConfig: config,
@@ -67,7 +66,6 @@ import 'build_output.dart';
 ///
 ///       output.addDependencies([
 ///         assetSourcePath,
-///         config.packageRoot.resolve('hook/build.dart'),
 ///       ]);
 ///     }
 ///

--- a/pkgs/native_assets_cli/lib/src/api/builder.dart
+++ b/pkgs/native_assets_cli/lib/src/api/builder.dart
@@ -37,7 +37,6 @@ import 'linker.dart';
 ///       sources: [
 ///         'src/$packageName.c',
 ///       ],
-///       dartBuildFiles: ['hook/build.dart'],
 ///     );
 ///     await cbuilder.run(
 ///       buildConfig: config,

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   native assets CLI.
 
 # Note: Bump BuildConfig.version and BuildOutput.version on breaking changes!
-version: 0.7.2
+version: 0.7.3-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
 topics:

--- a/pkgs/native_assets_cli/test/example/local_asset_test.dart
+++ b/pkgs/native_assets_cli/test/example/local_asset_test.dart
@@ -83,7 +83,6 @@ void main() async {
           dependencies,
           [
             testPackageUri.resolve('data/asset.txt'),
-            testPackageUri.resolve('hook/build.dart'),
           ],
         );
       }


### PR DESCRIPTION
While working on https://github.com/dart-lang/native/issues/1208, I released that most likely you'd want to report all files from the `assets/` directory as `DataAsset`s in a hook. (This also means that there's implicitly a `dependency` on the directory itself.)

This PR also cleans up the remaining dart files listed in `dependencies`.