### PR TITLE
Prepare to publish ffigen 13.0.0 and objective_c 1.1.0

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 13.0.0-wip
+## 13.0.0
 
 - __Breaking change__: Code-gen the ObjC `id` type to `ObjCObjectBase` rather
   than `NSObject`, since not all ObjC classes inherit from `NSObject`. Eg

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 13.0.0-wip
+version: 13.0.0
 description: >
   Generator for FFI bindings, using LibClang to parse C, Objective-C, and Swift
   files.

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0-wip
+## 1.1.0
 
 - Add `DartProxy`, which is an implementation of `NSProxy` that enables
   implementing ObjC protocols from Dart. Also adds `DartProxyBuilder` for

--- a/pkgs/objective_c/pubspec.yaml
+++ b/pkgs/objective_c/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: objective_c
 description: 'A library to access Objective C from Flutter that acts as a support library for package:ffigen.'
-version: 1.1.0-wip
+version: 1.1.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/objective_c
 
 topics:


### PR DESCRIPTION
These need to be published at about the same time as ffigen 13.0.0 generates ObjC bindings that depend on new features in objective_c 1.1.0.