### PR TITLE
[native_assets_builder] Lock the build directory

### DIFF
--- a/pkgs/native_assets_builder/test/build_runner/concurrency_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_test.dart
@@ -1,0 +1,136 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:native_assets_builder/src/utils/run_process.dart'
+    show RunProcessResult;
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+import 'helpers.dart';
+
+const Timeout longTimeout = Timeout(Duration(minutes: 5));
+
+void main() async {
+  test('Concurrent invocations', timeout: longTimeout, () async {
+    await inTempDir((tempUri) async {
+      await copyTestProjects(targetUri: tempUri);
+      final packageUri = tempUri.resolve('native_add/');
+
+      await runPubGet(
+        workingDirectory: packageUri,
+        logger: logger,
+      );
+
+      Future<RunProcessResult> runBuildInProcess() async {
+        final result = await runProcess(
+          executable: dartExecutable,
+          arguments: [
+            pkgNativeAssetsBuilderUri
+                .resolve('test/build_runner/concurrency_test_helper.dart')
+                .toFilePath(),
+            packageUri.toFilePath(),
+          ],
+          workingDirectory: packageUri,
+          logger: logger,
+        );
+        expect(result.exitCode, 0);
+        return result;
+      }
+
+      // Simulate running `dart run` concurrently in 3 different terminals.
+      await Future.wait([
+        runBuildInProcess(),
+        runBuildInProcess(),
+        runBuildInProcess(),
+      ]);
+    });
+  });
+
+  test('Terminations unlock', timeout: longTimeout, () async {
+    await inTempDir((tempUri) async {
+      await copyTestProjects(targetUri: tempUri);
+      final packageUri = tempUri.resolve('native_add/');
+
+      await runPubGet(
+        workingDirectory: packageUri,
+        logger: logger,
+      );
+
+      Future<int> runBuildInProcess({Duration? killAfter}) async {
+        final process = await Process.start(
+          dartExecutable.toFilePath(),
+          [
+            pkgNativeAssetsBuilderUri
+                .resolve('test/build_runner/concurrency_test_helper.dart')
+                .toFilePath(),
+            packageUri.toFilePath(),
+          ],
+          workingDirectory: packageUri.toFilePath(),
+        );
+        final stdoutSub = process.stdout
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())
+            .listen(logger.fine);
+        final stderrSub = process.stderr
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())
+            .listen(logger.severe);
+
+        Timer? timer;
+        if (killAfter != null) {
+          timer = Timer(killAfter, process.kill);
+        }
+        final (exitCode, _, _) = await (
+          process.exitCode,
+          stdoutSub.asFuture<void>(),
+          stderrSub.asFuture<void>()
+        ).wait;
+        if (timer != null) {
+          timer.cancel();
+        }
+
+        return exitCode;
+      }
+
+      File? findLockFile() {
+        final dir = Directory.fromUri(
+            packageUri.resolve('.dart_tool/native_assets_builder/'));
+        if (!dir.existsSync()) {
+          // Too quick, dir doesn't exist yet.
+          return null;
+        }
+        for (final entity in dir.listSync().whereType<Directory>()) {
+          final lockFile = File.fromUri(entity.uri.resolve('.lock'));
+          if (lockFile.existsSync()) {
+            final lockFileContents = lockFile.readAsStringSync();
+            expect(
+                lockFileContents, stringContainsInOrder(['Last acquired by']));
+            return lockFile;
+          }
+        }
+        return null;
+      }
+
+      // Simulate hitting ctrl+c on `dart` and `flutter` commands at different
+      // time intervals.
+      var milliseconds = 200;
+      while (findLockFile() == null) {
+        final result = await runBuildInProcess(
+          killAfter: Duration(milliseconds: milliseconds),
+        );
+        expect(result, isNot(0));
+        milliseconds = max((milliseconds * 1.2).round(), milliseconds + 200);
+      }
+      expect(findLockFile(), isNotNull);
+
+      final result2 = await runBuildInProcess();
+      expect(result2, 0);
+    });
+  });
+}

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:logging/logging.dart';
+import 'package:native_assets_builder/native_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
+
+import '../helpers.dart';
+
+// Is invoked concurrently multiple times in separate processes.
+void main(List<String> args) async {
+  final packageUri = Uri.directory(args[0]);
+
+  final result = await NativeAssetsBuildRunner(
+    logger: Logger(''),
+    dartExecutable: dartExecutable,
+  ).build(
+    buildMode: BuildModeImpl.release,
+    linkModePreference: LinkModePreferenceImpl.dynamic,
+    target: Target.current,
+    workingDirectory: packageUri,
+    includeParentEnvironment: true,
+    linkingEnabled: false,
+  );
+  if (!result.success) {
+    throw Error();
+  }
+  print('done');
+}


### PR DESCRIPTION
Partially addresses:

* https://github.com/dart-lang/native/issues/1319

Progress:

 * [ ] multiple invocations in the same Dart process   -> not entirely sure how to achieve this.
 * [x] multiple invocations in different Dart processes -> covered by tests
 * [x] it should keep working if any of these processes is abruptly terminated -> covered by tests

I'd also like to use the implementation of `Directory.exclusive` inside build hooks to address

* https://github.com/dart-lang/native/issues/1379

So we need to find a place to let that function live. `package:native_assets_cli` doesn't seem the right place. Maybe a new package in `dart-lang/tools`?

