### PR TITLE
Fix internal bug in `LinkerOptions`

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.3-wip
 
-- Nothing yet.
+- Fix internal bug in `LinkerOptions`.
 
 ## 0.5.2
 

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/linker_options.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/linker_options.dart
@@ -49,11 +49,11 @@ class LinkerOptions {
   LinkerOptions.treeshake({
     Iterable<String>? flags,
     required Iterable<String>? symbols,
-  })  : _linkerFlags = <String>{
+  })  : _linkerFlags = <String>[
           ...flags ?? [],
           '--strip-debug',
           if (symbols != null) ...symbols.expand((e) => ['-u', e]),
-        }.toList(),
+        ].toList(),
         gcSections = true,
         _wholeArchiveSandwich = symbols == null,
         linkerScript = _createLinkerScript(symbols);


### PR DESCRIPTION
Having a set swallowed all the necessary `-u`s for each symbol.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
