### PR TITLE
[ffi] Use `@Native`s for process lookup

### DIFF
--- a/pkgs/ffi/CHANGELOG.md
+++ b/pkgs/ffi/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 2.1.3-wip
+## 2.1.3
 
 - Use `package:dart_flutter_team_lints`.
+- Migrate from `DynamicLibrary.process()` to `@Native external` functions.
+  https://github.com/dart-lang/native/issues/1401
 
 ## 2.1.2
 

--- a/pkgs/ffi/lib/src/allocation.dart
+++ b/pkgs/ffi/lib/src/allocation.dart
@@ -8,12 +8,12 @@ import 'dart:io';
 typedef PosixMallocNative = Pointer Function(IntPtr);
 
 @Native<PosixMallocNative>(symbol: 'malloc')
-external Pointer<Void> posixMalloc(int size);
+external Pointer posixMalloc(int size);
 
 typedef PosixCallocNative = Pointer Function(IntPtr num, IntPtr size);
 
 @Native<PosixCallocNative>(symbol: 'malloc')
-external Pointer<Void> posixCalloc(int num, int size);
+external Pointer posixCalloc(int num, int size);
 
 typedef PosixFreeNative = Void Function(Pointer);
 

--- a/pkgs/ffi/lib/src/allocation.dart
+++ b/pkgs/ffi/lib/src/allocation.dart
@@ -12,7 +12,7 @@ external Pointer posixMalloc(int size);
 
 typedef PosixCallocNative = Pointer Function(IntPtr num, IntPtr size);
 
-@Native<PosixCallocNative>(symbol: 'malloc')
+@Native<PosixCallocNative>(symbol: 'calloc')
 external Pointer posixCalloc(int num, int size);
 
 typedef PosixFreeNative = Void Function(Pointer);

--- a/pkgs/ffi/lib/src/allocation.dart
+++ b/pkgs/ffi/lib/src/allocation.dart
@@ -5,37 +5,37 @@
 import 'dart:ffi';
 import 'dart:io';
 
-// Note that ole32.dll is the correct name in both 32-bit and 64-bit.
-final DynamicLibrary stdlib = Platform.isWindows
-    ? DynamicLibrary.open('ole32.dll')
-    : DynamicLibrary.process();
-
 typedef PosixMallocNative = Pointer Function(IntPtr);
-typedef PosixMalloc = Pointer Function(int);
-final PosixMalloc posixMalloc =
-    stdlib.lookupFunction<PosixMallocNative, PosixMalloc>('malloc');
+
+@Native<PosixMallocNative>(symbol: 'malloc')
+external Pointer<Void> posixMalloc(int size);
 
 typedef PosixCallocNative = Pointer Function(IntPtr num, IntPtr size);
-typedef PosixCalloc = Pointer Function(int num, int size);
-final PosixCalloc posixCalloc =
-    stdlib.lookupFunction<PosixCallocNative, PosixCalloc>('calloc');
+
+@Native<PosixCallocNative>(symbol: 'malloc')
+external Pointer<Void> posixCalloc(int num, int size);
 
 typedef PosixFreeNative = Void Function(Pointer);
-typedef PosixFree = void Function(Pointer);
+
+@Native<Void Function(Pointer)>(symbol: 'free')
+external void posixFree(Pointer ptr);
+
 final Pointer<NativeFunction<PosixFreeNative>> posixFreePointer =
-    stdlib.lookup('free');
-final PosixFree posixFree = posixFreePointer.asFunction();
+    Native.addressOf(posixFree);
+
+// Note that ole32.dll is the correct name in both 32-bit and 64-bit.
+final DynamicLibrary ole32lib = DynamicLibrary.open('ole32.dll');
 
 typedef WinCoTaskMemAllocNative = Pointer Function(Size);
 typedef WinCoTaskMemAlloc = Pointer Function(int);
 final WinCoTaskMemAlloc winCoTaskMemAlloc =
-    stdlib.lookupFunction<WinCoTaskMemAllocNative, WinCoTaskMemAlloc>(
+    ole32lib.lookupFunction<WinCoTaskMemAllocNative, WinCoTaskMemAlloc>(
         'CoTaskMemAlloc');
 
 typedef WinCoTaskMemFreeNative = Void Function(Pointer);
 typedef WinCoTaskMemFree = void Function(Pointer);
 final Pointer<NativeFunction<WinCoTaskMemFreeNative>> winCoTaskMemFreePointer =
-    stdlib.lookup('CoTaskMemFree');
+    ole32lib.lookup('CoTaskMemFree');
 final WinCoTaskMemFree winCoTaskMemFree = winCoTaskMemFreePointer.asFunction();
 
 /// Manages memory on the native heap.

--- a/pkgs/ffi/pubspec.yaml
+++ b/pkgs/ffi/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ffi
-version: 2.1.3-wip
+version: 2.1.3
 description: Utilities for working with Foreign Function Interface (FFI) code.
 repository: https://github.com/dart-lang/native/tree/main/pkgs/ffi
 
@@ -9,7 +9,7 @@ topics:
   - codegen
 
 environment:
-  sdk: '>=3.3.0-279.1.beta <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
 
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/1401

I don't think we want to fix the API leak, rather we'd like the public API be `Allocator` which has a `nativeFree`:

* https://github.com/dart-lang/sdk/issues/55571