### PR TITLE
[ffigen] use listSync instead of running ls

### DIFF
--- a/pkgs/ffigen/lib/src/config_provider/path_finder.dart
+++ b/pkgs/ffigen/lib/src/config_provider/path_finder.dart
@@ -32,17 +32,14 @@ List<String> getCStandardLibraryHeadersForMac() {
   for (final searchPath in searchPaths) {
     if (!Directory(searchPath).existsSync()) continue;
 
-    final result = Process.runSync('ls', [searchPath]);
-    final stdout = result.stdout as String;
-    if (stdout != '') {
-      final versions = stdout.split('\n').where((s) => s != '');
-      for (final version in versions) {
-        final path = p.join(searchPath, version, 'include');
-        if (Directory(path).existsSync()) {
-          _logger.fine('Added stdlib path: $path to compiler-opts.');
-          includePaths.add('-I$path');
-          return includePaths;
-        }
+    final versions = Directory(searchPath).listSync();
+    if (versions.isEmpty) continue;
+    for (final version in versions) {
+      final path = p.join(version.path, 'include');
+      if (Directory(path).existsSync()) {
+        _logger.fine('Added stdlib path: $path to compiler-opts.');
+        includePaths.add('-I$path');
+        return includePaths;
       }
     }
   }

--- a/pkgs/ffigen/lib/src/config_provider/path_finder.dart
+++ b/pkgs/ffigen/lib/src/config_provider/path_finder.dart
@@ -33,7 +33,6 @@ List<String> getCStandardLibraryHeadersForMac() {
     if (!Directory(searchPath).existsSync()) continue;
 
     final versions = Directory(searchPath).listSync();
-    if (versions.isEmpty) continue;
     for (final version in versions) {
       final path = p.join(version.path, 'include');
       if (Directory(path).existsSync()) {


### PR DESCRIPTION
Use dart:io operations to list contents of a directory instead of using Process.run('ls').

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
