### PR TITLE
[ffigen] Fix block inheritance issue

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -10,18 +10,9 @@
   correct Dart wrapper types, instead of the raw C-style pointers.
 - Rename `assetId` under *ffi-native* to `asset-id` to follow dash-case.
 - __Breaking change__: ObjC blocks are now passed through all ObjC APIs as
-  `ObjCBlockBase<Ret Function(Args...)>`, instead of the codegenned
-  `ObjCBlock_...` wrapper. This fixes a bug where subtyping rules
-  were being broken in methods that receive or return blocks, but it is a
-  breaking change for methods that return a block. To adapt to this change:
-  1. Change the type of any variables that store the blocks to
-     `ObjCBlockBase<...>`. This is the recommended approach if you are just
-     plumbing blocks from one ObjC API to another.
-  2. Wrap the result: `foo.getBlock()` -> `ObjCBlock_Bar(foo.getBlock())`.
-     The only reason you would ever need the wrapper object rather than the
-     raw `ObjCBlockBase<...>` is to use the code genned call operator, which
-     enables you to invoke the block from Dart. If you don't need to invoke
-     the block from Dart, there's no need to construct the wrapper.
+  `ObjCBlock<Ret Function(Args...)>`, instead of the codegenned
+  `ObjCBlock_...` wrapper. The wrapper is now a non-constructible set of util
+  methods for constructing `ObjCBlock`.
 
 
 ## 13.0.0

--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -8,29 +8,18 @@
   before this version.
 - Rename `assetId` under *ffi-native* to `asset-id` to follow dash-case.
 - __Breaking change__: ObjC blocks are now passed through all ObjC APIs as
-  `ObjCBlockBase<Ret Function(Args...)>`. This fixes a bug where subtyping rules
-  were being broken in methods that receive or return blocks, but leads to a
-  couple of minor breaking changes.
-  - The main breaking change is that any method returning a block now returns a
-    `ObjCBlockBase<...>` instead of the code genned wrapper type. There are two
-    ways to fix this:
-    1. Change the type of any variables that store the blocks to
-       `ObjCBlockBase<...>`. This is the recommended approach if you are just
-       plumbing blocks from one ObjC API to another.
-    2. Wrap the result: `foo.getBlock()` => `ObjCBlock_Bar(foo.getBlock())`.
-       The only reason you would ever need the wrapper object rather than the
-       raw `ObjCBlockBase<...>` is to use the code genned call operator, which
-       enables you to invoke the block from Dart. If you don't need to invoke
-       the block from Dart, there's no need to construct the wrapper.
-  - The other breaking change is that the way ffigen generates typedefs for
-    blocks has changed. Before, a typedef of `FooBlock` would have code genned
-    a `DartFooBlock` typedef that refers to the block's wrapper. Now
-    `DartFooBlock` refers to the `ObjCBlockBase<...>`, and a new
-    `WrapperFooBlock` typedef has been added to refer to the wrapper object.
-    If you were using the typedef to construct blocks, eg
-    `DartFooBlock.fromFunction(...)`, you'll need to change this to
-    `WrapperFooBlock.fromFunction(...)`. This only applies to typedefs generated
-    by ffigen. Typedefs you define yourself in Dart have not changed.
+  `ObjCBlockBase<Ret Function(Args...)>`, instead of the codegenned
+  `ObjCBlock_...` wrapper. This fixes a bug where subtyping rules
+  were being broken in methods that receive or return blocks, but it is a
+  breaking change for methods that return a block. To adapt to this change:
+  1. Change the type of any variables that store the blocks to
+     `ObjCBlockBase<...>`. This is the recommended approach if you are just
+     plumbing blocks from one ObjC API to another.
+  2. Wrap the result: `foo.getBlock()` -> `ObjCBlock_Bar(foo.getBlock())`.
+     The only reason you would ever need the wrapper object rather than the
+     raw `ObjCBlockBase<...>` is to use the code genned call operator, which
+     enables you to invoke the block from Dart. If you don't need to invoke
+     the block from Dart, there's no need to construct the wrapper.
 
 
 ## 13.0.0

--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -7,6 +7,31 @@
   version will omit APIs from the generated bindings if they were deprecated
   before this version.
 - Rename `assetId` under *ffi-native* to `asset-id` to follow dash-case.
+- __Breaking change__: ObjC blocks are now passed through all ObjC APIs as
+  `ObjCBlockBase<Ret Function(Args...)>`. This fixes a bug where subtyping rules
+  were being broken in methods that receive or return blocks, but leads to a
+  couple of minor breaking changes.
+  - The main breaking change is that any method returning a block now returns a
+    `ObjCBlockBase<...>` instead of the code genned wrapper type. There are two
+    ways to fix this:
+    1. Change the type of any variables that store the blocks to
+       `ObjCBlockBase<...>`. This is the recommended approach if you are just
+       plumbing blocks from one ObjC API to another.
+    2. Wrap the result: `foo.getBlock()` => `ObjCBlock_Bar(foo.getBlock())`.
+       The only reason you would ever need the wrapper object rather than the
+       raw `ObjCBlockBase<...>` is to use the code genned call operator, which
+       enables you to invoke the block from Dart. If you don't need to invoke
+       the block from Dart, there's no need to construct the wrapper.
+  - The other breaking change is that the way ffigen generates typedefs for
+    blocks has changed. Before, a typedef of `FooBlock` would have code genned
+    a `DartFooBlock` typedef that refers to the block's wrapper. Now
+    `DartFooBlock` refers to the `ObjCBlockBase<...>`, and a new
+    `WrapperFooBlock` typedef has been added to refer to the wrapper object.
+    If you were using the typedef to construct blocks, eg
+    `DartFooBlock.fromFunction(...)`, you'll need to change this to
+    `WrapperFooBlock.fromFunction(...)`. This only applies to typedefs generated
+    by ffigen. Typedefs you define yourself in Dart have not changed.
+
 
 ## 13.0.0
 

--- a/pkgs/ffigen/lib/src/code_generator/imports.dart
+++ b/pkgs/ffigen/lib/src/code_generator/imports.dart
@@ -129,4 +129,4 @@ final objCObjectType =
 final objCSelType =
     ImportedType(objcPkgImport, 'ObjCSelector', 'ObjCSelector', 'void');
 final objCBlockType =
-    ImportedType(objcPkgImport, 'ObjCBlock', 'ObjCBlock', 'id');
+    ImportedType(objcPkgImport, 'ObjCBlockImpl', 'ObjCBlockImpl', 'id');

--- a/pkgs/ffigen/lib/src/code_generator/objc_block.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_block.dart
@@ -67,8 +67,8 @@ class ObjCBlock extends BindingType {
   bool get hasListener => returnType == voidType;
 
   String _blockType(Writer w) {
-    final args = argTypes.map((t) => t.getCType(w)).join(', ');
-    final func = '${returnType.getCType(w)} Function($args)';
+    final args = argTypes.map((t) => t.getObjCBlockSignatureType(w)).join(', ');
+    final func = '${returnType.getObjCBlockSignatureType(w)} Function($args)';
     return '${ObjCBuiltInFunctions.blockType.gen(w)}<$func>';
   }
 
@@ -302,7 +302,7 @@ $blockTypedef $fnName($blockTypedef block) {
   String getDartType(Writer w) => _blockType(w);
 
   @override
-  String getDartWrapperType(Writer w) => name;
+  String getObjCBlockSignatureType(Writer w) => getDartType(w);
 
   @override
   String getNativeType({String varName = ''}) {
@@ -318,9 +318,6 @@ $blockTypedef $fnName($blockTypedef block) {
 
   @override
   bool get sameDartAndFfiDartType => false;
-
-  @override
-  bool get sameDartAndDartWrapperType => false;
 
   @override
   String convertDartTypeToFfiDartType(

--- a/pkgs/ffigen/lib/src/code_generator/objc_block.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_block.dart
@@ -163,7 +163,7 @@ abstract final class $name {
           _cFuncTrampoline ??= ${w.ffiLibraryPrefix}.Pointer.fromFunction<
               $trampFuncCType>($funcPtrTrampoline
                   $exceptionalReturn).cast(), ptr.cast()),
-          retain: true, release: true);
+          retain: false, release: true);
   static $voidPtr? _cFuncTrampoline;
 
   /// Creates a block from a Dart function.
@@ -175,7 +175,7 @@ abstract final class $name {
       $blockType($newClosureBlock(
           _dartFuncTrampoline ??= ${w.ffiLibraryPrefix}.Pointer.fromFunction<
               $trampFuncCType>($closureTrampoline $exceptionalReturn).cast(),
-          $convFn), retain: true, release: true);
+          $convFn), retain: false, release: true);
   static $voidPtr? _dartFuncTrampoline;
 ''');
 
@@ -210,7 +210,7 @@ abstract final class $name {
           (_dartFuncListenerTrampoline ??= $nativeCallableType.listener(
               $closureTrampoline $exceptionalReturn)..keepIsolateAlive =
                   false).nativeFunction.cast(), $listenerConvFn)),
-          retain: true, release: true);
+          retain: false, release: true);
   static $nativeCallableType? _dartFuncListenerTrampoline;
 ''');
     }

--- a/pkgs/ffigen/lib/src/code_generator/objc_block.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_block.dart
@@ -67,8 +67,8 @@ class ObjCBlock extends BindingType {
   bool get hasListener => returnType == voidType;
 
   String _blockBaseType(Writer w) {
-    final args = argTypes.map((t) => t.getDartType(w)).join(', ');
-    final func = '${returnType.getDartType(w)} Function($args)';
+    final args = argTypes.map((t) => t.getCType(w)).join(', ');
+    final func = '${returnType.getCType(w)} Function($args)';
     return '${ObjCBuiltInFunctions.blockBase.gen(w)}<$func>';
   }
 

--- a/pkgs/ffigen/lib/src/code_generator/objc_built_in_functions.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_built_in_functions.dart
@@ -26,7 +26,7 @@ class ObjCBuiltInFunctions {
       ObjCImport('getProtocolMethodSignature');
   static const getProtocol = ObjCImport('getProtocol');
   static const objectBase = ObjCImport('ObjCObjectBase');
-  static const blockBase = ObjCImport('ObjCBlockBase');
+  static const blockType = ObjCImport('ObjCBlock');
   static const protocolMethod = ObjCImport('ObjCProtocolMethod');
   static const protocolListenableMethod =
       ObjCImport('ObjCProtocolListenableMethod');

--- a/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
@@ -300,6 +300,9 @@ class ObjCInterface extends BindingType with ObjCMethods {
   String getNativeType({String varName = ''}) => '$originalName* $varName';
 
   @override
+  String getObjCBlockSignatureType(Writer w) => getDartType(w);
+
+  @override
   bool get sameFfiDartAndCType => true;
 
   @override

--- a/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
@@ -74,6 +74,7 @@ class ObjCInterface extends BindingType with ObjCMethods {
     }
 
     final s = StringBuffer();
+    s.write('\n');
     s.write(makeDartDoc(dartDoc ?? originalName));
 
     final methodNamer = createMethodRenamer(w);
@@ -108,7 +109,6 @@ class ObjCInterface extends BindingType with ObjCMethods {
       [_classObject.name],
     )};
   }
-
 ''');
 
     // Methods.
@@ -125,6 +125,7 @@ class ObjCInterface extends BindingType with ObjCMethods {
       }
 
       // The method declaration.
+      s.write('\n  ');
       s.write(makeDartDoc(m.dartDoc ?? m.originalName));
       s.write('  ');
       if (isStatic) {
@@ -203,7 +204,7 @@ class ObjCInterface extends BindingType with ObjCMethods {
         s.write('    return $result;');
       }
 
-      s.write('  }\n\n');
+      s.write('\n  }\n');
     }
 
     s.write('}\n\n');

--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -48,7 +48,7 @@ class ObjCProtocol extends NoLookUpBinding with ObjCMethods {
       final fieldName = methodName;
       final argName = methodName;
       final block = method.protocolBlock;
-      final blockType = block.getDartWrapperType(w);
+      final blockType = block.getDartType(w);
       final methodClass =
           block.hasListener ? protocolListenableMethod : protocolMethod;
 

--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -48,7 +48,7 @@ class ObjCProtocol extends NoLookUpBinding with ObjCMethods {
       final fieldName = methodName;
       final argName = methodName;
       final block = method.protocolBlock;
-      final blockType = block.getDartType(w);
+      final blockUtils = block.name;
       final methodClass =
           block.hasListener ? protocolListenableMethod : protocolMethod;
 
@@ -75,7 +75,7 @@ class ObjCProtocol extends NoLookUpBinding with ObjCMethods {
       var listenerBuilder = '';
       var maybeImplementAsListener = 'implement';
       if (block.hasListener) {
-        listenerBuilder = '($funcType func) => $blockType.listener($wrapper),';
+        listenerBuilder = '($funcType func) => $blockUtils.listener($wrapper),';
         maybeImplementAsListener = 'implementAsListener';
         anyListeners = true;
       }
@@ -94,7 +94,7 @@ class ObjCProtocol extends NoLookUpBinding with ObjCMethods {
           isRequired: ${method.isRequired},
           isInstanceMethod: ${method.isInstanceMethod},
       ),
-      ($funcType func) => $blockType.fromFunction($wrapper),
+      ($funcType func) => $blockUtils.fromFunction($wrapper),
       $listenerBuilder
     );
 ''');

--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -48,7 +48,7 @@ class ObjCProtocol extends NoLookUpBinding with ObjCMethods {
       final fieldName = methodName;
       final argName = methodName;
       final block = method.protocolBlock;
-      final blockType = block.getDartType(w);
+      final blockType = block.getDartWrapperType(w);
       final methodClass =
           block.hasListener ? protocolListenableMethod : protocolMethod;
 

--- a/pkgs/ffigen/lib/src/code_generator/type.dart
+++ b/pkgs/ffigen/lib/src/code_generator/type.dart
@@ -45,17 +45,15 @@ abstract class Type {
   String getFfiDartType(Writer w) => getCType(w);
 
   /// Returns the user type of the Type. This is the type that is presented to
-  /// users by the ffigened API. For C bindings this is always the same
-  /// as [getFfiDartType]. For ObjC bindings this refers to a wrapper object,
-  /// whether an internal wrapper object from package:objective_c, or the
-  /// outermost layer of wrapping (as returned by [getDartWrapperType]).
+  /// users by the ffigened API to users. For C bindings this is always the same
+  /// as getFfiDartType. For ObjC bindings this refers to the wrapper object.
   String getDartType(Writer w) => getFfiDartType(w);
 
-  /// Returns the outermost layer of wrapping type. This is usually the same as
-  /// [getDartType]. The only exception is ObjC blocks, where [getDartType]
-  /// returns `ObjCBlockBase`, and [getDartWrapperType] returns the codegenned
-  /// implementation of that interface.
-  String getDartWrapperType(Writer w) => getDartType(w);
+  /// Returns the type to be used if this type appears in an ObjC block
+  /// signature. By default it's the same as [getCType]. But for some types
+  /// that's not enough to distinguish them (eg all ObjC objects have a C type
+  /// of `Pointer<objc.ObjCObject>`), so we use [getDartType] instead.
+  String getObjCBlockSignatureType(Writer w) => getCType(w);
 
   /// Returns the C/ObjC type of the Type. This is the type as it appears in
   /// C/ObjC source code. It should not be used in Dart source code.
@@ -74,9 +72,6 @@ abstract class Type {
 
   /// Returns whether the dart type and FFI dart type string are same.
   bool get sameDartAndFfiDartType => true;
-
-  /// Returns whether the dart type and dart wrapper type string are same.
-  bool get sameDartAndDartWrapperType => true;
 
   /// Returns generated Dart code that converts the given value from its
   /// DartType to its FfiDartType.
@@ -162,7 +157,7 @@ abstract class BindingType extends NoLookUpBinding implements Type {
   String getDartType(Writer w) => getFfiDartType(w);
 
   @override
-  String getDartWrapperType(Writer w) => getDartType(w);
+  String getObjCBlockSignatureType(Writer w) => getCType(w);
 
   @override
   String getNativeType({String varName = ''}) =>
@@ -173,9 +168,6 @@ abstract class BindingType extends NoLookUpBinding implements Type {
 
   @override
   bool get sameDartAndFfiDartType => true;
-
-  @override
-  bool get sameDartAndDartWrapperType => true;
 
   @override
   String convertDartTypeToFfiDartType(

--- a/pkgs/ffigen/lib/src/code_generator/type.dart
+++ b/pkgs/ffigen/lib/src/code_generator/type.dart
@@ -45,9 +45,17 @@ abstract class Type {
   String getFfiDartType(Writer w) => getCType(w);
 
   /// Returns the user type of the Type. This is the type that is presented to
-  /// users by the ffigened API to users. For C bindings this is always the same
-  /// as getFfiDartType. For ObjC bindings this refers to the wrapper object.
+  /// users by the ffigened API. For C bindings this is always the same
+  /// as [getFfiDartType]. For ObjC bindings this refers to a wrapper object,
+  /// whether an internal wrapper object from package:objective_c, or the
+  /// outermost layer of wrapping (as returned by [getDartWrapperType]).
   String getDartType(Writer w) => getFfiDartType(w);
+
+  /// Returns the outermost layer of wrapping type. This is usually the same as
+  /// [getDartType]. The only exception is ObjC blocks, where [getDartType]
+  /// returns `ObjCBlockBase`, and [getDartWrapperType] returns the codegenned
+  /// implementation of that interface.
+  String getDartWrapperType(Writer w) => getDartType(w);
 
   /// Returns the C/ObjC type of the Type. This is the type as it appears in
   /// C/ObjC source code. It should not be used in Dart source code.
@@ -66,6 +74,9 @@ abstract class Type {
 
   /// Returns whether the dart type and FFI dart type string are same.
   bool get sameDartAndFfiDartType => true;
+
+  /// Returns whether the dart type and dart wrapper type string are same.
+  bool get sameDartAndDartWrapperType => true;
 
   /// Returns generated Dart code that converts the given value from its
   /// DartType to its FfiDartType.
@@ -151,6 +162,9 @@ abstract class BindingType extends NoLookUpBinding implements Type {
   String getDartType(Writer w) => getFfiDartType(w);
 
   @override
+  String getDartWrapperType(Writer w) => getDartType(w);
+
+  @override
   String getNativeType({String varName = ''}) =>
       throw UnsupportedError('No native mapping for type: $this');
 
@@ -159,6 +173,9 @@ abstract class BindingType extends NoLookUpBinding implements Type {
 
   @override
   bool get sameDartAndFfiDartType => true;
+
+  @override
+  bool get sameDartAndDartWrapperType => true;
 
   @override
   String convertDartTypeToFfiDartType(

--- a/pkgs/ffigen/lib/src/code_generator/typealias.dart
+++ b/pkgs/ffigen/lib/src/code_generator/typealias.dart
@@ -19,7 +19,6 @@ class Typealias extends BindingType {
   final Type type;
   String? _ffiDartAliasName;
   String? _dartAliasName;
-  String? _wrapperAliasName;
 
   /// Creates a Typealias.
   ///
@@ -79,11 +78,6 @@ class Typealias extends BindingType {
             (!genFfiDartType && type is! Typealias && !type.sameDartAndCType)
                 ? 'Dart$name'
                 : null,
-        _wrapperAliasName = (!genFfiDartType &&
-                type is! Typealias &&
-                !type.sameDartAndDartWrapperType)
-            ? 'Wrapper$name'
-            : null,
         super(
           name: genFfiDartType ? 'Native$name' : name,
         );
@@ -121,10 +115,7 @@ class Typealias extends BindingType {
       sb.write('typedef $_ffiDartAliasName = ${type.getFfiDartType(w)};\n');
     }
     if (_dartAliasName != null) {
-      sb.write('typedef $_dartAliasName = ${type.getDartType(w)};\n');
-    }
-    if (_wrapperAliasName != null) {
-      sb.write('typedef $_wrapperAliasName = ${type.getDartWrapperType(w)};\n');
+      sb.write('typedef $_dartAliasName = ${type.getDartWrapperType(w)};\n');
     }
     return BindingString(
         type: BindingStringType.typeDef, string: sb.toString());
@@ -156,7 +147,7 @@ class Typealias extends BindingType {
 
   @override
   String getDartType(Writer w) {
-    if (_dartAliasName != null) {
+    if (_dartAliasName != null && type.sameDartAndDartWrapperType) {
       return _dartAliasName!;
     } else if (type.sameDartAndCType) {
       return getFfiDartType(w);

--- a/pkgs/ffigen/lib/src/code_generator/typealias.dart
+++ b/pkgs/ffigen/lib/src/code_generator/typealias.dart
@@ -19,6 +19,7 @@ class Typealias extends BindingType {
   final Type type;
   String? _ffiDartAliasName;
   String? _dartAliasName;
+  String? _wrapperAliasName;
 
   /// Creates a Typealias.
   ///
@@ -78,6 +79,11 @@ class Typealias extends BindingType {
             (!genFfiDartType && type is! Typealias && !type.sameDartAndCType)
                 ? 'Dart$name'
                 : null,
+        _wrapperAliasName = (!genFfiDartType &&
+                type is! Typealias &&
+                !type.sameDartAndDartWrapperType)
+            ? 'Wrapper$name'
+            : null,
         super(
           name: genFfiDartType ? 'Native$name' : name,
         );
@@ -116,6 +122,9 @@ class Typealias extends BindingType {
     }
     if (_dartAliasName != null) {
       sb.write('typedef $_dartAliasName = ${type.getDartType(w)};\n');
+    }
+    if (_wrapperAliasName != null) {
+      sb.write('typedef $_wrapperAliasName = ${type.getDartWrapperType(w)};\n');
     }
     return BindingString(
         type: BindingStringType.typeDef, string: sb.toString());

--- a/pkgs/ffigen/lib/src/code_generator/typealias.dart
+++ b/pkgs/ffigen/lib/src/code_generator/typealias.dart
@@ -115,7 +115,7 @@ class Typealias extends BindingType {
       sb.write('typedef $_ffiDartAliasName = ${type.getFfiDartType(w)};\n');
     }
     if (_dartAliasName != null) {
-      sb.write('typedef $_dartAliasName = ${type.getDartWrapperType(w)};\n');
+      sb.write('typedef $_dartAliasName = ${type.getDartType(w)};\n');
     }
     return BindingString(
         type: BindingStringType.typeDef, string: sb.toString());
@@ -147,7 +147,7 @@ class Typealias extends BindingType {
 
   @override
   String getDartType(Writer w) {
-    if (_dartAliasName != null && type.sameDartAndDartWrapperType) {
+    if (_dartAliasName != null) {
       return _dartAliasName!;
     } else if (type.sameDartAndCType) {
       return getFfiDartType(w);

--- a/pkgs/ffigen/lib/src/code_generator/writer.dart
+++ b/pkgs/ffigen/lib/src/code_generator/writer.dart
@@ -405,7 +405,7 @@ class Writer {
     }
 
     // If it's a framework header, use a <> style import.
-    return '#import <$frameworkHeader>';
+    return '#import <$frameworkHeader>\n';
   }
 
   /// Writes the Objective C code needed for the bindings, if any. Returns null

--- a/pkgs/ffigen/test/native_objc_test/block_inherit_config.yaml
+++ b/pkgs/ffigen/test/native_objc_test/block_inherit_config.yaml
@@ -1,0 +1,24 @@
+name: BlockInheritTestObjCLibrary
+description: 'Tests inheritance rules for blocks.'
+language: objc
+output:
+  bindings: 'block_inherit_bindings.dart'
+  objc-bindings: 'block_inherit_bindings.m'
+exclude-all-by-default: true
+objc-interfaces:
+  include:
+    - Mammal
+    - Platypus
+    - BlockInheritTestBase
+    - BlockInheritTestChild
+typedefs:
+  include:
+    - ReturnMammal
+    - ReturnPlatypus
+    - AcceptMammal
+    - AcceptPlatypus
+headers:
+  entry-points:
+    - 'block_inherit_test.m'
+preamble: |
+  // ignore_for_file: camel_case_types, non_constant_identifier_names, unnecessary_non_null_assertion, unused_element, unused_field

--- a/pkgs/ffigen/test/native_objc_test/block_inherit_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_inherit_test.dart
@@ -1,0 +1,104 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// ignore_for_file: unused_local_variable
+
+// Objective C support is only available on mac.
+@TestOn('mac-os')
+
+import 'dart:async';
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:ffi/ffi.dart';
+import 'package:objective_c/objective_c.dart';
+import 'package:test/test.dart';
+
+import '../test_utils.dart';
+import 'block_inherit_bindings.dart';
+import 'util.dart';
+
+void main() {
+  group('Block inheritance', () {
+    setUpAll(() {
+      // TODO(https://github.com/dart-lang/native/issues/1068): Remove this.
+      DynamicLibrary.open('../objective_c/test/objective_c.dylib');
+      final dylib = File('test/native_objc_test/block_inherit_test.dylib');
+      verifySetupFile(dylib);
+      DynamicLibrary.open(dylib.absolute.path);
+
+      generateBindingsForCoverage('block_inherit');
+    });
+
+    test('BlockInheritTestBase', () {
+      BlockInheritTestBase baseObj = BlockInheritTestBase.new1();
+      expect(baseObj.getAnimal().laysEggs(), false);
+      expect(baseObj.acceptAnimal_(Platypus.new1()), true);
+
+      WrapperReturnMammal returner = WrapperReturnMammal(baseObj.getReturner());
+      Mammal returnerResult = returner();
+      expect(returnerResult.laysEggs(), false);
+
+      WrapperAcceptPlatypus accepter =
+          WrapperAcceptPlatypus(baseObj.getAccepter());
+      expect(accepter(Platypus.new1()), true);
+
+      final platypus = Platypus.new1();
+      WrapperReturnPlatypus platypusReturner =
+          WrapperReturnPlatypus.fromFunction(() => platypus);
+      expect(baseObj.invokeReturner_(platypusReturner).laysEggs(), true);
+
+      WrapperAcceptMammal mammalAccepter = WrapperAcceptMammal.fromFunction(
+          (Mammal mammal) => mammal.laysEggs());
+      expect(baseObj.invokeAccepter_(mammalAccepter), false);
+    });
+
+    test('BlockInheritTestChild', () {
+      BlockInheritTestChild childObj = BlockInheritTestChild.new1();
+      BlockInheritTestBase baseObj = childObj;
+      expect(baseObj.getAnimal().laysEggs(), true);
+      expect(baseObj.acceptAnimal_(Platypus.new1()), true);
+      expect(childObj.acceptAnimal_(Mammal.new1()), false);
+
+      WrapperReturnMammal baseReturner =
+          WrapperReturnMammal(baseObj.getReturner());
+      Mammal baseReturnerResult = baseReturner();
+      expect(baseReturnerResult.laysEggs(), true);
+
+      WrapperReturnPlatypus childReturner =
+          WrapperReturnPlatypus(childObj.getReturner());
+      Platypus childReturnerResult = childReturner();
+      expect(childReturnerResult.laysEggs(), true);
+
+      WrapperAcceptPlatypus baseAccepter =
+          WrapperAcceptPlatypus(baseObj.getAccepter());
+      expect(baseAccepter(Platypus.new1()), true);
+
+      WrapperAcceptMammal childAccepter =
+          WrapperAcceptMammal(childObj.getAccepter());
+      expect(childAccepter(Mammal.new1()), false);
+
+      final platypus = Platypus.new1();
+      WrapperReturnPlatypus platypusReturner =
+          WrapperReturnPlatypus.fromFunction(() => platypus);
+      expect(baseObj.invokeReturner_(platypusReturner).laysEggs(), true);
+
+      final mammal = Mammal.new1();
+      WrapperReturnMammal mammalReturner =
+          WrapperReturnMammal.fromFunction(() => mammal);
+      expect(childObj.invokeReturner_(mammalReturner).laysEggs(), false);
+      expect(childObj.invokeReturner_(platypusReturner).laysEggs(), true);
+
+      WrapperAcceptMammal mammalAccepter = WrapperAcceptMammal.fromFunction(
+          (Mammal mammal) => mammal.laysEggs());
+      expect(baseObj.invokeAccepter_(mammalAccepter), true);
+
+      WrapperAcceptPlatypus platypusAccepter =
+          WrapperAcceptPlatypus.fromFunction(
+              (Platypus platypus) => platypus.laysEggs());
+      expect(childObj.invokeAccepter_(platypusAccepter), true);
+      expect(childObj.invokeAccepter_(mammalAccepter), true);
+    });
+  });
+}

--- a/pkgs/ffigen/test/native_objc_test/block_inherit_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_inherit_test.dart
@@ -36,20 +36,21 @@ void main() {
       expect(baseObj.getAnimal().laysEggs(), false);
       expect(baseObj.acceptAnimal_(Platypus.new1()), true);
 
-      ObjCBlock<Pointer<ObjCObject> Function()> returner = baseObj.getReturner();
+      ObjCBlock<Mammal Function()> returner = baseObj.getReturner();
       Mammal returnerResult = returner();
       expect(returnerResult.laysEggs(), false);
 
-      ObjCBlock<Bool Function(Pointer<ObjCObject>)> accepter = baseObj.getAccepter();
+      ObjCBlock<Bool Function(Platypus)> accepter = baseObj.getAccepter();
       expect(accepter(Platypus.new1()), true);
 
       final platypus = Platypus.new1();
-      ObjCBlock<Pointer<ObjCObject> Function()> platypusReturner =
-          DartReturnPlatypus.fromFunction(() => platypus);
+      ObjCBlock<Platypus Function()> platypusReturner =
+          ObjCBlock_Platypus.fromFunction(() => platypus);
       expect(baseObj.invokeReturner_(platypusReturner).laysEggs(), true);
 
-      ObjCBlock<Bool Function(Pointer<ObjCObject>)> mammalAccepter =
-          DartAcceptMammal.fromFunction((Mammal mammal) => mammal.laysEggs());
+      ObjCBlock<Bool Function(Mammal)> mammalAccepter =
+          ObjCBlock_bool_Mammal.fromFunction(
+              (Mammal mammal) => mammal.laysEggs());
       expect(baseObj.invokeAccepter_(mammalAccepter), false);
     });
 
@@ -60,39 +61,40 @@ void main() {
       expect(baseObj.acceptAnimal_(Platypus.new1()), true);
       expect(childObj.acceptAnimal_(Mammal.new1()), false);
 
-      ObjCBlock<Pointer<ObjCObject> Function()> baseReturner = baseObj.getReturner();
+      ObjCBlock<Mammal Function()> baseReturner = baseObj.getReturner();
       Mammal baseReturnerResult = baseReturner();
       expect(baseReturnerResult.laysEggs(), true);
 
-      ObjCBlock<Pointer<ObjCObject> Function()> childReturner =
-          childObj.getReturner();
+      ObjCBlock<Platypus Function()> childReturner = childObj.getReturner();
       Platypus childReturnerResult = childReturner();
       expect(childReturnerResult.laysEggs(), true);
 
-      ObjCBlock<Bool Function(Pointer<ObjCObject>)> baseAccepter =
-          baseObj.getAccepter();
+      ObjCBlock<Bool Function(Platypus)> baseAccepter = baseObj.getAccepter();
       expect(baseAccepter(Platypus.new1()), true);
 
-      ObjCBlock<Bool Function(Pointer<ObjCObject>)> childAccepter = childObj.getAccepter();
+      ObjCBlock<Bool Function(Mammal)> childAccepter = childObj.getAccepter();
       expect(childAccepter(Mammal.new1()), false);
+      expect(childAccepter(Platypus.new1()), true);
 
       final platypus = Platypus.new1();
-      ObjCBlock<Pointer<ObjCObject> Function()> platypusReturner =
-          DartReturnPlatypus.fromFunction(() => platypus);
+      ObjCBlock<Platypus Function()> platypusReturner =
+          ObjCBlock_Platypus.fromFunction(() => platypus);
       expect(baseObj.invokeReturner_(platypusReturner).laysEggs(), true);
 
       final mammal = Mammal.new1();
-      ObjCBlock<Pointer<ObjCObject> Function()> mammalReturner =
-          DartReturnMammal.fromFunction(() => mammal);
+      ObjCBlock<Mammal Function()> mammalReturner =
+          ObjCBlock_Mammal.fromFunction(() => mammal);
       expect(childObj.invokeReturner_(mammalReturner).laysEggs(), false);
       expect(childObj.invokeReturner_(platypusReturner).laysEggs(), true);
 
-      ObjCBlock<Bool Function(Pointer<ObjCObject>)> mammalAccepter =
-          DartAcceptMammal.fromFunction((Mammal mammal) => mammal.laysEggs());
+      ObjCBlock<Bool Function(Mammal)> mammalAccepter =
+          ObjCBlock_bool_Mammal.fromFunction(
+              (Mammal mammal) => mammal.laysEggs());
       expect(baseObj.invokeAccepter_(mammalAccepter), true);
 
-      ObjCBlock<Bool Function(Pointer<ObjCObject>)> platypusAccepter = DartAcceptPlatypus.fromFunction(
-          (Platypus platypus) => platypus.laysEggs());
+      ObjCBlock<Bool Function(Platypus)> platypusAccepter =
+          ObjCBlock_bool_Platypus.fromFunction(
+              (Platypus platypus) => platypus.laysEggs());
       expect(childObj.invokeAccepter_(platypusAccepter), true);
       expect(childObj.invokeAccepter_(mammalAccepter), true);
     });

--- a/pkgs/ffigen/test/native_objc_test/block_inherit_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_inherit_test.dart
@@ -2,16 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: unused_local_variable
+// We're testing inheritance rules, so explicit types are handy for clarity.
+// ignore_for_file: omit_local_variable_types
 
 // Objective C support is only available on mac.
 @TestOn('mac-os')
 
-import 'dart:async';
 import 'dart:ffi';
 import 'dart:io';
 
-import 'package:ffi/ffi.dart';
 import 'package:objective_c/objective_c.dart';
 import 'package:test/test.dart';
 
@@ -32,67 +31,70 @@ void main() {
     });
 
     test('BlockInheritTestBase', () {
-      BlockInheritTestBase baseObj = BlockInheritTestBase.new1();
+      final BlockInheritTestBase baseObj = BlockInheritTestBase.new1();
       expect(baseObj.getAnimal().laysEggs(), false);
       expect(baseObj.acceptAnimal_(Platypus.new1()), true);
 
-      ObjCBlock<Mammal Function()> returner = baseObj.getReturner();
-      Mammal returnerResult = returner();
+      final ObjCBlock<Mammal Function()> returner = baseObj.getReturner();
+      final Mammal returnerResult = returner();
       expect(returnerResult.laysEggs(), false);
 
-      ObjCBlock<Bool Function(Platypus)> accepter = baseObj.getAccepter();
+      final ObjCBlock<Bool Function(Platypus)> accepter = baseObj.getAccepter();
       expect(accepter(Platypus.new1()), true);
 
       final platypus = Platypus.new1();
-      ObjCBlock<Platypus Function()> platypusReturner =
+      final ObjCBlock<Platypus Function()> platypusReturner =
           ObjCBlock_Platypus.fromFunction(() => platypus);
       expect(baseObj.invokeReturner_(platypusReturner).laysEggs(), true);
 
-      ObjCBlock<Bool Function(Mammal)> mammalAccepter =
+      final ObjCBlock<Bool Function(Mammal)> mammalAccepter =
           ObjCBlock_bool_Mammal.fromFunction(
               (Mammal mammal) => mammal.laysEggs());
       expect(baseObj.invokeAccepter_(mammalAccepter), false);
     });
 
     test('BlockInheritTestChild', () {
-      BlockInheritTestChild childObj = BlockInheritTestChild.new1();
-      BlockInheritTestBase baseObj = childObj;
+      final BlockInheritTestChild childObj = BlockInheritTestChild.new1();
+      final BlockInheritTestBase baseObj = childObj;
       expect(baseObj.getAnimal().laysEggs(), true);
       expect(baseObj.acceptAnimal_(Platypus.new1()), true);
       expect(childObj.acceptAnimal_(Mammal.new1()), false);
 
-      ObjCBlock<Mammal Function()> baseReturner = baseObj.getReturner();
-      Mammal baseReturnerResult = baseReturner();
+      final ObjCBlock<Mammal Function()> baseReturner = baseObj.getReturner();
+      final Mammal baseReturnerResult = baseReturner();
       expect(baseReturnerResult.laysEggs(), true);
 
-      ObjCBlock<Platypus Function()> childReturner = childObj.getReturner();
-      Platypus childReturnerResult = childReturner();
+      final ObjCBlock<Platypus Function()> childReturner =
+          childObj.getReturner();
+      final Platypus childReturnerResult = childReturner();
       expect(childReturnerResult.laysEggs(), true);
 
-      ObjCBlock<Bool Function(Platypus)> baseAccepter = baseObj.getAccepter();
+      final ObjCBlock<Bool Function(Platypus)> baseAccepter =
+          baseObj.getAccepter();
       expect(baseAccepter(Platypus.new1()), true);
 
-      ObjCBlock<Bool Function(Mammal)> childAccepter = childObj.getAccepter();
+      final ObjCBlock<Bool Function(Mammal)> childAccepter =
+          childObj.getAccepter();
       expect(childAccepter(Mammal.new1()), false);
       expect(childAccepter(Platypus.new1()), true);
 
       final platypus = Platypus.new1();
-      ObjCBlock<Platypus Function()> platypusReturner =
+      final ObjCBlock<Platypus Function()> platypusReturner =
           ObjCBlock_Platypus.fromFunction(() => platypus);
       expect(baseObj.invokeReturner_(platypusReturner).laysEggs(), true);
 
       final mammal = Mammal.new1();
-      ObjCBlock<Mammal Function()> mammalReturner =
+      final ObjCBlock<Mammal Function()> mammalReturner =
           ObjCBlock_Mammal.fromFunction(() => mammal);
       expect(childObj.invokeReturner_(mammalReturner).laysEggs(), false);
       expect(childObj.invokeReturner_(platypusReturner).laysEggs(), true);
 
-      ObjCBlock<Bool Function(Mammal)> mammalAccepter =
+      final ObjCBlock<Bool Function(Mammal)> mammalAccepter =
           ObjCBlock_bool_Mammal.fromFunction(
               (Mammal mammal) => mammal.laysEggs());
       expect(baseObj.invokeAccepter_(mammalAccepter), true);
 
-      ObjCBlock<Bool Function(Platypus)> platypusAccepter =
+      final ObjCBlock<Bool Function(Platypus)> platypusAccepter =
           ObjCBlock_bool_Platypus.fromFunction(
               (Platypus platypus) => platypus.laysEggs());
       expect(childObj.invokeAccepter_(platypusAccepter), true);

--- a/pkgs/ffigen/test/native_objc_test/block_inherit_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_inherit_test.dart
@@ -36,19 +36,19 @@ void main() {
       expect(baseObj.getAnimal().laysEggs(), false);
       expect(baseObj.acceptAnimal_(Platypus.new1()), true);
 
-      DartReturnMammal returner = DartReturnMammal(baseObj.getReturner());
+      ObjCBlock<Pointer<ObjCObject> Function()> returner = baseObj.getReturner();
       Mammal returnerResult = returner();
       expect(returnerResult.laysEggs(), false);
 
-      DartAcceptPlatypus accepter = DartAcceptPlatypus(baseObj.getAccepter());
+      ObjCBlock<Bool Function(Pointer<ObjCObject>)> accepter = baseObj.getAccepter();
       expect(accepter(Platypus.new1()), true);
 
       final platypus = Platypus.new1();
-      DartReturnPlatypus platypusReturner =
+      ObjCBlock<Pointer<ObjCObject> Function()> platypusReturner =
           DartReturnPlatypus.fromFunction(() => platypus);
       expect(baseObj.invokeReturner_(platypusReturner).laysEggs(), true);
 
-      DartAcceptMammal mammalAccepter =
+      ObjCBlock<Bool Function(Pointer<ObjCObject>)> mammalAccepter =
           DartAcceptMammal.fromFunction((Mammal mammal) => mammal.laysEggs());
       expect(baseObj.invokeAccepter_(mammalAccepter), false);
     });
@@ -60,38 +60,38 @@ void main() {
       expect(baseObj.acceptAnimal_(Platypus.new1()), true);
       expect(childObj.acceptAnimal_(Mammal.new1()), false);
 
-      DartReturnMammal baseReturner = DartReturnMammal(baseObj.getReturner());
+      ObjCBlock<Pointer<ObjCObject> Function()> baseReturner = baseObj.getReturner();
       Mammal baseReturnerResult = baseReturner();
       expect(baseReturnerResult.laysEggs(), true);
 
-      DartReturnPlatypus childReturner =
-          DartReturnPlatypus(childObj.getReturner());
+      ObjCBlock<Pointer<ObjCObject> Function()> childReturner =
+          childObj.getReturner();
       Platypus childReturnerResult = childReturner();
       expect(childReturnerResult.laysEggs(), true);
 
-      DartAcceptPlatypus baseAccepter =
-          DartAcceptPlatypus(baseObj.getAccepter());
+      ObjCBlock<Bool Function(Pointer<ObjCObject>)> baseAccepter =
+          baseObj.getAccepter();
       expect(baseAccepter(Platypus.new1()), true);
 
-      DartAcceptMammal childAccepter = DartAcceptMammal(childObj.getAccepter());
+      ObjCBlock<Bool Function(Pointer<ObjCObject>)> childAccepter = childObj.getAccepter();
       expect(childAccepter(Mammal.new1()), false);
 
       final platypus = Platypus.new1();
-      DartReturnPlatypus platypusReturner =
+      ObjCBlock<Pointer<ObjCObject> Function()> platypusReturner =
           DartReturnPlatypus.fromFunction(() => platypus);
       expect(baseObj.invokeReturner_(platypusReturner).laysEggs(), true);
 
       final mammal = Mammal.new1();
-      DartReturnMammal mammalReturner =
+      ObjCBlock<Pointer<ObjCObject> Function()> mammalReturner =
           DartReturnMammal.fromFunction(() => mammal);
       expect(childObj.invokeReturner_(mammalReturner).laysEggs(), false);
       expect(childObj.invokeReturner_(platypusReturner).laysEggs(), true);
 
-      DartAcceptMammal mammalAccepter =
+      ObjCBlock<Bool Function(Pointer<ObjCObject>)> mammalAccepter =
           DartAcceptMammal.fromFunction((Mammal mammal) => mammal.laysEggs());
       expect(baseObj.invokeAccepter_(mammalAccepter), true);
 
-      DartAcceptPlatypus platypusAccepter = DartAcceptPlatypus.fromFunction(
+      ObjCBlock<Bool Function(Pointer<ObjCObject>)> platypusAccepter = DartAcceptPlatypus.fromFunction(
           (Platypus platypus) => platypus.laysEggs());
       expect(childObj.invokeAccepter_(platypusAccepter), true);
       expect(childObj.invokeAccepter_(mammalAccepter), true);

--- a/pkgs/ffigen/test/native_objc_test/block_inherit_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_inherit_test.dart
@@ -36,21 +36,20 @@ void main() {
       expect(baseObj.getAnimal().laysEggs(), false);
       expect(baseObj.acceptAnimal_(Platypus.new1()), true);
 
-      WrapperReturnMammal returner = WrapperReturnMammal(baseObj.getReturner());
+      DartReturnMammal returner = DartReturnMammal(baseObj.getReturner());
       Mammal returnerResult = returner();
       expect(returnerResult.laysEggs(), false);
 
-      WrapperAcceptPlatypus accepter =
-          WrapperAcceptPlatypus(baseObj.getAccepter());
+      DartAcceptPlatypus accepter = DartAcceptPlatypus(baseObj.getAccepter());
       expect(accepter(Platypus.new1()), true);
 
       final platypus = Platypus.new1();
-      WrapperReturnPlatypus platypusReturner =
-          WrapperReturnPlatypus.fromFunction(() => platypus);
+      DartReturnPlatypus platypusReturner =
+          DartReturnPlatypus.fromFunction(() => platypus);
       expect(baseObj.invokeReturner_(platypusReturner).laysEggs(), true);
 
-      WrapperAcceptMammal mammalAccepter = WrapperAcceptMammal.fromFunction(
-          (Mammal mammal) => mammal.laysEggs());
+      DartAcceptMammal mammalAccepter =
+          DartAcceptMammal.fromFunction((Mammal mammal) => mammal.laysEggs());
       expect(baseObj.invokeAccepter_(mammalAccepter), false);
     });
 
@@ -61,42 +60,39 @@ void main() {
       expect(baseObj.acceptAnimal_(Platypus.new1()), true);
       expect(childObj.acceptAnimal_(Mammal.new1()), false);
 
-      WrapperReturnMammal baseReturner =
-          WrapperReturnMammal(baseObj.getReturner());
+      DartReturnMammal baseReturner = DartReturnMammal(baseObj.getReturner());
       Mammal baseReturnerResult = baseReturner();
       expect(baseReturnerResult.laysEggs(), true);
 
-      WrapperReturnPlatypus childReturner =
-          WrapperReturnPlatypus(childObj.getReturner());
+      DartReturnPlatypus childReturner =
+          DartReturnPlatypus(childObj.getReturner());
       Platypus childReturnerResult = childReturner();
       expect(childReturnerResult.laysEggs(), true);
 
-      WrapperAcceptPlatypus baseAccepter =
-          WrapperAcceptPlatypus(baseObj.getAccepter());
+      DartAcceptPlatypus baseAccepter =
+          DartAcceptPlatypus(baseObj.getAccepter());
       expect(baseAccepter(Platypus.new1()), true);
 
-      WrapperAcceptMammal childAccepter =
-          WrapperAcceptMammal(childObj.getAccepter());
+      DartAcceptMammal childAccepter = DartAcceptMammal(childObj.getAccepter());
       expect(childAccepter(Mammal.new1()), false);
 
       final platypus = Platypus.new1();
-      WrapperReturnPlatypus platypusReturner =
-          WrapperReturnPlatypus.fromFunction(() => platypus);
+      DartReturnPlatypus platypusReturner =
+          DartReturnPlatypus.fromFunction(() => platypus);
       expect(baseObj.invokeReturner_(platypusReturner).laysEggs(), true);
 
       final mammal = Mammal.new1();
-      WrapperReturnMammal mammalReturner =
-          WrapperReturnMammal.fromFunction(() => mammal);
+      DartReturnMammal mammalReturner =
+          DartReturnMammal.fromFunction(() => mammal);
       expect(childObj.invokeReturner_(mammalReturner).laysEggs(), false);
       expect(childObj.invokeReturner_(platypusReturner).laysEggs(), true);
 
-      WrapperAcceptMammal mammalAccepter = WrapperAcceptMammal.fromFunction(
-          (Mammal mammal) => mammal.laysEggs());
+      DartAcceptMammal mammalAccepter =
+          DartAcceptMammal.fromFunction((Mammal mammal) => mammal.laysEggs());
       expect(baseObj.invokeAccepter_(mammalAccepter), true);
 
-      WrapperAcceptPlatypus platypusAccepter =
-          WrapperAcceptPlatypus.fromFunction(
-              (Platypus platypus) => platypus.laysEggs());
+      DartAcceptPlatypus platypusAccepter = DartAcceptPlatypus.fromFunction(
+          (Platypus platypus) => platypus.laysEggs());
       expect(childObj.invokeAccepter_(platypusAccepter), true);
       expect(childObj.invokeAccepter_(mammalAccepter), true);
     });

--- a/pkgs/ffigen/test/native_objc_test/block_inherit_test.m
+++ b/pkgs/ffigen/test/native_objc_test/block_inherit_test.m
@@ -1,0 +1,94 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#import <Foundation/NSObject.h>
+
+@interface Mammal : NSObject {}
+- (BOOL)laysEggs;
+@end
+@implementation Mammal
+- (BOOL)laysEggs { return NO; }
+@end
+
+@interface Platypus : Mammal {}
+@end
+@implementation Platypus
+- (BOOL)laysEggs { return YES; }
+@end
+
+typedef Mammal* (^ReturnMammal)();
+typedef Platypus* (^ReturnPlatypus)();
+typedef BOOL (^AcceptMammal)(Mammal*);
+typedef BOOL (^AcceptPlatypus)(Platypus*);
+
+// Note: Returns are covariant, args are contravariant.
+// Platypus <: Mammal
+// ReturnPlatypus <: ReturnMammal  (covariant)
+// AcceptMammal <: AcceptPlatypus  (contravariant)
+
+@interface BlockInheritTestBase : NSObject {}
+// Returns are covariant, args are contravariant.
+- (Mammal*) getAnimal NS_RETURNS_RETAINED;
+- (BOOL) acceptAnimal: (Platypus*)platypus;
+- (ReturnMammal) getReturner NS_RETURNS_RETAINED;
+- (AcceptPlatypus) getAccepter NS_RETURNS_RETAINED;
+- (Mammal*) invokeReturner: (ReturnPlatypus)returner NS_RETURNS_RETAINED;
+- (BOOL) invokeAccepter: (AcceptMammal)accepter;
+@end
+@implementation BlockInheritTestBase
+- (Mammal*) getAnimal NS_RETURNS_RETAINED { return [Mammal new]; }
+- (BOOL) acceptAnimal: (Platypus*)platypus { return [platypus laysEggs]; }
+
+- (ReturnMammal) getReturner NS_RETURNS_RETAINED {
+  return [^Mammal*() { return [Mammal new]; } copy];
+}
+
+- (AcceptPlatypus) getAccepter NS_RETURNS_RETAINED {
+  return [^BOOL (Platypus* platypus) { return [platypus laysEggs]; } copy];
+}
+
+- (Mammal*) invokeReturner: (ReturnPlatypus)returner NS_RETURNS_RETAINED {
+  return returner();
+}
+
+- (BOOL) invokeAccepter: (AcceptMammal)accepter {
+  Mammal* mammal = [Mammal new];
+  BOOL result = accepter(mammal);
+  [mammal release];
+  return result;
+}
+@end
+
+@interface BlockInheritTestChild : BlockInheritTestBase {}
+// Returns are covariant, args are contravariant.
+- (Platypus*) getAnimal NS_RETURNS_RETAINED;
+- (BOOL) acceptAnimal: (Mammal*)mammal;
+- (ReturnPlatypus) getReturner NS_RETURNS_RETAINED;
+- (AcceptMammal) getAccepter NS_RETURNS_RETAINED;
+- (Mammal*) invokeReturner: (ReturnMammal)returner NS_RETURNS_RETAINED;
+- (BOOL) invokeAccepter: (AcceptPlatypus)accepter;
+@end
+@implementation BlockInheritTestChild
+- (Platypus*) getAnimal NS_RETURNS_RETAINED { return [Platypus new]; }
+- (BOOL) acceptAnimal: (Mammal*)mammal { return [mammal laysEggs]; }
+
+- (ReturnPlatypus) getReturner NS_RETURNS_RETAINED {
+  return [^Platypus*() { return [Platypus new]; } copy];
+}
+
+- (AcceptMammal) getAccepter NS_RETURNS_RETAINED {
+  return [^BOOL (Mammal* mammal) { return [mammal laysEggs]; } copy];
+}
+
+- (Mammal*) invokeReturner: (ReturnMammal)returner NS_RETURNS_RETAINED {
+  return returner();
+}
+
+- (BOOL) invokeAccepter: (AcceptPlatypus)accepter {
+  Platypus* platypus = [Platypus new];
+  BOOL result = accepter(platypus);
+  [platypus release];
+  return result;
+}
+@end

--- a/pkgs/ffigen/test/native_objc_test/block_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test.dart
@@ -45,8 +45,8 @@ void main() {
     });
 
     test('Block from function pointer', () {
-      final block = WrapperIntBlock.fromFunctionPointer(
-          Pointer.fromFunction(_add100, 999));
+      final block =
+          DartIntBlock.fromFunctionPointer(Pointer.fromFunction(_add100, 999));
       final blockTester = BlockTester.makeFromBlock_(block);
       blockTester.pokeBlock();
       expect(blockTester.call_(123), 223);
@@ -58,7 +58,7 @@ void main() {
     }
 
     test('Block from function', () {
-      final block = WrapperIntBlock.fromFunction(makeAdder(4000));
+      final block = DartIntBlock.fromFunction(makeAdder(4000));
       final blockTester = BlockTester.makeFromBlock_(block);
       blockTester.pokeBlock();
       expect(blockTester.call_(123), 4123);
@@ -68,7 +68,7 @@ void main() {
     test('Listener block same thread', () async {
       final hasRun = Completer<void>();
       int value = 0;
-      final block = WrapperVoidBlock.listener(() {
+      final block = DartVoidBlock.listener(() {
         value = 123;
         hasRun.complete();
       });
@@ -82,7 +82,7 @@ void main() {
     test('Listener block new thread', () async {
       final hasRun = Completer<void>();
       int value = 0;
-      final block = WrapperVoidBlock.listener(() {
+      final block = DartVoidBlock.listener(() {
         value = 123;
         hasRun.complete();
       });
@@ -95,7 +95,7 @@ void main() {
     });
 
     test('Float block', () {
-      final block = WrapperFloatBlock.fromFunction((double x) {
+      final block = DartFloatBlock.fromFunction((double x) {
         return x + 4.56;
       });
       expect(block(1.23), closeTo(5.79, 1e-6));
@@ -103,7 +103,7 @@ void main() {
     });
 
     test('Double block', () {
-      final block = WrapperDoubleBlock.fromFunction((double x) {
+      final block = DartDoubleBlock.fromFunction((double x) {
         return x + 4.56;
       });
       expect(block(1.23), closeTo(5.79, 1e-6));
@@ -121,7 +121,7 @@ void main() {
 
         final tempPtr = arena<Vec4>();
         final temp = tempPtr.ref;
-        final block = WrapperVec4Block.fromFunction((Vec4 v) {
+        final block = DartVec4Block.fromFunction((Vec4 v) {
           // Twiddle the Vec4 components.
           temp.x = v.y;
           temp.y = v.z;
@@ -148,7 +148,7 @@ void main() {
 
     test('Object block', () {
       bool isCalled = false;
-      final block = WrapperObjectBlock.fromFunction((DummyObject x) {
+      final block = DartObjectBlock.fromFunction((DummyObject x) {
         isCalled = true;
         return x;
       });
@@ -167,7 +167,7 @@ void main() {
 
     test('Nullable object block', () {
       bool isCalled = false;
-      final block = WrapperNullableObjectBlock.fromFunction((DummyObject? x) {
+      final block = DartNullableObjectBlock.fromFunction((DummyObject? x) {
         isCalled = true;
         return x;
       });
@@ -190,7 +190,7 @@ void main() {
 
     test('Object listener block', () async {
       final hasRun = Completer<void>();
-      final block = WrapperObjectListenerBlock.listener((DummyObject x) {
+      final block = DartObjectListenerBlock.listener((DummyObject x) {
         expect(x, isNotNull);
         hasRun.complete();
       });
@@ -201,7 +201,7 @@ void main() {
 
     test('Nullable listener block', () async {
       final hasRun = Completer<void>();
-      final block = WrapperNullableListenerBlock.listener((DummyObject? x) {
+      final block = DartNullableListenerBlock.listener((DummyObject? x) {
         expect(x, isNull);
         hasRun.complete();
       });
@@ -212,7 +212,7 @@ void main() {
 
     test('Struct listener block', () async {
       final hasRun = Completer<void>();
-      final block = WrapperStructListenerBlock.listener(
+      final block = DartStructListenerBlock.listener(
           (Vec2 vec2, Vec4 vec4, NSObject dummy) {
         expect(vec2.x, 100);
         expect(vec2.y, 200);
@@ -233,7 +233,7 @@ void main() {
 
     test('NSString listener block', () async {
       final hasRun = Completer<void>();
-      final block = WrapperNSStringListenerBlock.listener((NSString s) {
+      final block = DartNSStringListenerBlock.listener((NSString s) {
         expect(s.toString(), "Foo 123");
         hasRun.complete();
       });
@@ -244,7 +244,7 @@ void main() {
 
     test('No trampoline listener block', () async {
       final hasRun = Completer<void>();
-      final block = WrapperNoTrampolineListenerBlock.listener(
+      final block = DartNoTrampolineListenerBlock.listener(
           (int x, Vec4 vec4, Pointer<Char> charPtr) {
         expect(x, 123);
 
@@ -263,39 +263,39 @@ void main() {
     });
 
     test('Block block', () {
-      final blockBlock =
-          WrapperBlockBlock.fromFunction((DartIntBlock intBlock) {
-        return WrapperIntBlock.fromFunction((int x) {
-          return 3 * WrapperIntBlock(intBlock)(x);
+      final blockBlock = DartBlockBlock.fromFunction(
+          (ObjCBlockBase<int Function(int)> intBlock) {
+        return DartIntBlock.fromFunction((int x) {
+          return 3 * DartIntBlock(intBlock)(x);
         });
       });
 
-      final intBlock = WrapperIntBlock.fromFunction((int x) {
+      final intBlock = DartIntBlock.fromFunction((int x) {
         return 5 * x;
       });
       final result1 = blockBlock(intBlock);
-      expect(WrapperIntBlock(result1)(1), 15);
+      expect(DartIntBlock(result1)(1), 15);
 
       final result2 = BlockTester.newBlock_withMult_(blockBlock, 2);
-      expect(WrapperIntBlock(result2)(1), 6);
+      expect(DartIntBlock(result2)(1), 6);
     });
 
     test('Native block block', () {
       final blockBlock = BlockTester.newBlockBlock_(7);
 
-      final intBlock = WrapperIntBlock.fromFunction((int x) {
+      final intBlock = DartIntBlock.fromFunction((int x) {
         return 5 * x;
       });
-      final result1 = WrapperBlockBlock(blockBlock)(intBlock);
-      expect(WrapperIntBlock(result1)(1), 35);
+      final result1 = DartBlockBlock(blockBlock)(intBlock);
+      expect(DartIntBlock(result1)(1), 35);
 
       final result2 = BlockTester.newBlock_withMult_(blockBlock, 2);
-      expect(WrapperIntBlock(result2)(1), 14);
+      expect(DartIntBlock(result2)(1), 14);
     });
 
     Pointer<ObjCBlock> funcPointerBlockRefCountTest() {
-      final block = WrapperIntBlock.fromFunctionPointer(
-          Pointer.fromFunction(_add100, 999));
+      final block =
+          DartIntBlock.fromFunctionPointer(Pointer.fromFunction(_add100, 999));
       expect(
           internal_for_testing.blockHasRegisteredClosure(block.pointer), false);
       expect(blockRetainCount(block.pointer), 1);
@@ -309,7 +309,7 @@ void main() {
     });
 
     Pointer<ObjCBlock> funcBlockRefCountTest() {
-      final block = WrapperIntBlock.fromFunction(makeAdder(4000));
+      final block = DartIntBlock.fromFunction(makeAdder(4000));
       expect(
           internal_for_testing.blockHasRegisteredClosure(block.pointer), true);
       expect(blockRetainCount(block.pointer), 1);
@@ -326,7 +326,7 @@ void main() {
     });
 
     Pointer<ObjCBlock> blockManualRetainRefCountTest() {
-      final block = WrapperIntBlock.fromFunction(makeAdder(4000));
+      final block = DartIntBlock.fromFunction(makeAdder(4000));
       expect(
           internal_for_testing.blockHasRegisteredClosure(block.pointer), true);
       expect(blockRetainCount(block.pointer), 1);
@@ -336,7 +336,7 @@ void main() {
     }
 
     int blockManualRetainRefCountTest2(Pointer<ObjCBlock> rawBlock) {
-      final block = WrapperIntBlock.castFromPointer(rawBlock.cast(),
+      final block = DartIntBlock.castFromPointer(rawBlock.cast(),
           retain: false, release: true);
       return blockRetainCount(block.pointer);
     }
@@ -355,17 +355,17 @@ void main() {
 
     (Pointer<ObjCBlock>, Pointer<ObjCBlock>, Pointer<ObjCBlock>)
         blockBlockDartCallRefCountTest() {
-      final inputBlock = WrapperIntBlock.fromFunction((int x) {
+      final inputBlock = DartIntBlock.fromFunction((int x) {
         return 5 * x;
       });
-      final blockBlock =
-          WrapperBlockBlock.fromFunction((DartIntBlock intBlock) {
-        return WrapperIntBlock.fromFunction((int x) {
-          return 3 * WrapperIntBlock(intBlock)(x);
+      final blockBlock = DartBlockBlock.fromFunction(
+          (ObjCBlockBase<int Function(int)> intBlock) {
+        return DartIntBlock.fromFunction((int x) {
+          return 3 * DartIntBlock(intBlock)(x);
         });
       });
       final outputBlock = blockBlock(inputBlock);
-      expect(WrapperIntBlock(outputBlock)(1), 15);
+      expect(DartIntBlock(outputBlock)(1), 15);
       doGC();
 
       // One reference held by inputBlock object, another bound to the
@@ -411,15 +411,15 @@ void main() {
     (Pointer<ObjCBlock>, Pointer<ObjCBlock>, Pointer<ObjCBlock>)
         blockBlockObjCCallRefCountTest() {
       late Pointer<ObjCBlock> inputBlock;
-      final blockBlock =
-          WrapperBlockBlock.fromFunction((DartIntBlock intBlock) {
+      final blockBlock = DartBlockBlock.fromFunction(
+          (ObjCBlockBase<int Function(int)> intBlock) {
         inputBlock = intBlock.pointer;
-        return WrapperIntBlock.fromFunction((int x) {
-          return 3 * WrapperIntBlock(intBlock)(x);
+        return DartIntBlock.fromFunction((int x) {
+          return 3 * DartIntBlock(intBlock)(x);
         });
       });
       final outputBlock = BlockTester.newBlock_withMult_(blockBlock, 2);
-      expect(WrapperIntBlock(outputBlock)(1), 6);
+      expect(DartIntBlock(outputBlock)(1), 6);
       doGC();
 
       expect(blockRetainCount(inputBlock), 1);
@@ -459,12 +459,12 @@ void main() {
 
     (Pointer<ObjCBlock>, Pointer<ObjCBlock>, Pointer<ObjCBlock>)
         nativeBlockBlockDartCallRefCountTest() {
-      final inputBlock = WrapperIntBlock.fromFunction((int x) {
+      final inputBlock = DartIntBlock.fromFunction((int x) {
         return 5 * x;
       });
       final blockBlock = BlockTester.newBlockBlock_(7);
-      final outputBlock = WrapperBlockBlock(blockBlock)(inputBlock);
-      expect(WrapperIntBlock(outputBlock)(1), 35);
+      final outputBlock = DartBlockBlock(blockBlock)(inputBlock);
+      expect(DartIntBlock(outputBlock)(1), 35);
       doGC();
 
       // One reference held by inputBlock object, another held internally by the
@@ -489,7 +489,7 @@ void main() {
         nativeBlockBlockObjCCallRefCountTest() {
       final blockBlock = BlockTester.newBlockBlock_(7);
       final outputBlock = BlockTester.newBlock_withMult_(blockBlock, 2);
-      expect(WrapperIntBlock(outputBlock)(1), 14);
+      expect(DartIntBlock(outputBlock)(1), 14);
       doGC();
 
       expect(blockRetainCount(blockBlock.pointer), 1);
@@ -510,7 +510,7 @@ void main() {
       inputCounter.value = 0;
       outputCounter.value = 0;
 
-      final block = WrapperObjectBlock.fromFunction((DummyObject x) {
+      final block = DartObjectBlock.fromFunction((DummyObject x) {
         return DummyObject.newWithCounter_(outputCounter);
       });
 
@@ -538,7 +538,7 @@ void main() {
       inputCounter.value = 0;
       outputCounter.value = 0;
 
-      final block = WrapperObjectBlock.fromFunction((DummyObject x) {
+      final block = DartObjectBlock.fromFunction((DummyObject x) {
         x.setCounter_(inputCounter);
         return DummyObject.newWithCounter_(outputCounter);
       });
@@ -568,8 +568,9 @@ void main() {
     Future<(Pointer<ObjCBlock>, Pointer<ObjCBlock>)>
         listenerBlockArgumentRetentionTest() async {
       final hasRun = Completer<void>();
-      late DartIntBlock inputBlock;
-      final blockBlock = WrapperListenerBlock.listener((DartIntBlock intBlock) {
+      late ObjCBlockBase<int Function(int)> inputBlock;
+      final blockBlock = DartListenerBlock.listener(
+          (ObjCBlockBase<int Function(int)> intBlock) {
         expect(blockRetainCount(intBlock.pointer), 1);
         inputBlock = intBlock;
         hasRun.complete();
@@ -579,7 +580,7 @@ void main() {
       thread.start();
 
       await hasRun.future;
-      expect(WrapperIntBlock(inputBlock)(123), 12300);
+      expect(DartIntBlock(inputBlock)(123), 12300);
       doGC();
 
       expect(blockRetainCount(inputBlock.pointer), 1);
@@ -600,7 +601,7 @@ void main() {
     });
 
     test('Block fields have sensible values', () {
-      final block = WrapperIntBlock.fromFunction(makeAdder(4000));
+      final block = DartIntBlock.fromFunction(makeAdder(4000));
       final blockPtr = block.pointer;
       expect(blockPtr.ref.isa, isNot(0));
       expect(blockPtr.ref.flags, isNot(0)); // Set by Block_copy.

--- a/pkgs/ffigen/test/native_objc_test/block_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test.dart
@@ -264,7 +264,7 @@ void main() {
 
     test('Block block', () {
       final blockBlock = DartBlockBlock.fromFunction(
-          (ObjCBlockBase<int Function(int)> intBlock) {
+          (ObjCBlockBase<Int32 Function(Int32)> intBlock) {
         return DartIntBlock.fromFunction((int x) {
           return 3 * DartIntBlock(intBlock)(x);
         });
@@ -359,7 +359,7 @@ void main() {
         return 5 * x;
       });
       final blockBlock = DartBlockBlock.fromFunction(
-          (ObjCBlockBase<int Function(int)> intBlock) {
+          (ObjCBlockBase<Int32 Function(Int32)> intBlock) {
         return DartIntBlock.fromFunction((int x) {
           return 3 * DartIntBlock(intBlock)(x);
         });
@@ -412,7 +412,7 @@ void main() {
         blockBlockObjCCallRefCountTest() {
       late Pointer<ObjCBlock> inputBlock;
       final blockBlock = DartBlockBlock.fromFunction(
-          (ObjCBlockBase<int Function(int)> intBlock) {
+          (ObjCBlockBase<Int32 Function(Int32)> intBlock) {
         inputBlock = intBlock.pointer;
         return DartIntBlock.fromFunction((int x) {
           return 3 * DartIntBlock(intBlock)(x);
@@ -568,9 +568,9 @@ void main() {
     Future<(Pointer<ObjCBlock>, Pointer<ObjCBlock>)>
         listenerBlockArgumentRetentionTest() async {
       final hasRun = Completer<void>();
-      late ObjCBlockBase<int Function(int)> inputBlock;
+      late ObjCBlockBase<Int32 Function(Int32)> inputBlock;
       final blockBlock = DartListenerBlock.listener(
-          (ObjCBlockBase<int Function(int)> intBlock) {
+          (ObjCBlockBase<Int32 Function(Int32)> intBlock) {
         expect(blockRetainCount(intBlock.pointer), 1);
         inputBlock = intBlock;
         hasRun.complete();

--- a/pkgs/ffigen/test/native_objc_test/block_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test.dart
@@ -21,6 +21,21 @@ import '../test_utils.dart';
 import 'block_bindings.dart';
 import 'util.dart';
 
+typedef IntBlock = ObjCBlock_Int32_Int32;
+typedef VoidBlock = ObjCBlock_ffiVoid;
+typedef ListenerBlock = ObjCBlock_ffiVoid_IntBlock;
+typedef FloatBlock = ObjCBlock_ffiFloat_ffiFloat;
+typedef DoubleBlock = ObjCBlock_ffiDouble_ffiDouble;
+typedef Vec4Block = ObjCBlock_Vec4_Vec4;
+typedef ObjectBlock = ObjCBlock_DummyObject_DummyObject;
+typedef NullableObjectBlock = ObjCBlock_DummyObject_DummyObject1;
+typedef ObjectListenerBlock = ObjCBlock_ffiVoid_DummyObject;
+typedef NullableListenerBlock = ObjCBlock_ffiVoid_DummyObject1;
+typedef StructListenerBlock = ObjCBlock_ffiVoid_Vec2_Vec4_NSObject;
+typedef NSStringListenerBlock = ObjCBlock_ffiVoid_NSString;
+typedef NoTrampolineListenerBlock = ObjCBlock_ffiVoid_Int32_Vec4_ffiChar;
+typedef BlockBlock = ObjCBlock_IntBlock_IntBlock;
+
 void main() {
   group('Blocks', () {
     setUpAll(() {
@@ -33,7 +48,7 @@ void main() {
       generateBindingsForCoverage('block');
     });
 
-    test('BlockTester is working', () {
+    /*test('BlockTester is working', () {
       // This doesn't test any Block functionality, just that the BlockTester
       // itself is working correctly.
       final blockTester = BlockTester.makeFromMultiplier_(10);
@@ -46,7 +61,7 @@ void main() {
 
     test('Block from function pointer', () {
       final block =
-          DartIntBlock.fromFunctionPointer(Pointer.fromFunction(_add100, 999));
+          IntBlock.fromFunctionPointer(Pointer.fromFunction(_add100, 999));
       final blockTester = BlockTester.makeFromBlock_(block);
       blockTester.pokeBlock();
       expect(blockTester.call_(123), 223);
@@ -58,7 +73,7 @@ void main() {
     }
 
     test('Block from function', () {
-      final block = DartIntBlock.fromFunction(makeAdder(4000));
+      final block = IntBlock.fromFunction(makeAdder(4000));
       final blockTester = BlockTester.makeFromBlock_(block);
       blockTester.pokeBlock();
       expect(blockTester.call_(123), 4123);
@@ -68,7 +83,7 @@ void main() {
     test('Listener block same thread', () async {
       final hasRun = Completer<void>();
       int value = 0;
-      final block = DartVoidBlock.listener(() {
+      final block = VoidBlock.listener(() {
         value = 123;
         hasRun.complete();
       });
@@ -82,7 +97,7 @@ void main() {
     test('Listener block new thread', () async {
       final hasRun = Completer<void>();
       int value = 0;
-      final block = DartVoidBlock.listener(() {
+      final block = VoidBlock.listener(() {
         value = 123;
         hasRun.complete();
       });
@@ -95,7 +110,7 @@ void main() {
     });
 
     test('Float block', () {
-      final block = DartFloatBlock.fromFunction((double x) {
+      final block = FloatBlock.fromFunction((double x) {
         return x + 4.56;
       });
       expect(block(1.23), closeTo(5.79, 1e-6));
@@ -103,7 +118,7 @@ void main() {
     });
 
     test('Double block', () {
-      final block = DartDoubleBlock.fromFunction((double x) {
+      final block = DoubleBlock.fromFunction((double x) {
         return x + 4.56;
       });
       expect(block(1.23), closeTo(5.79, 1e-6));
@@ -121,7 +136,7 @@ void main() {
 
         final tempPtr = arena<Vec4>();
         final temp = tempPtr.ref;
-        final block = DartVec4Block.fromFunction((Vec4 v) {
+        final block = Vec4Block.fromFunction((Vec4 v) {
           // Twiddle the Vec4 components.
           temp.x = v.y;
           temp.y = v.z;
@@ -148,7 +163,7 @@ void main() {
 
     test('Object block', () {
       bool isCalled = false;
-      final block = DartObjectBlock.fromFunction((DummyObject x) {
+      final block = ObjectBlock.fromFunction((DummyObject x) {
         isCalled = true;
         return x;
       });
@@ -167,7 +182,7 @@ void main() {
 
     test('Nullable object block', () {
       bool isCalled = false;
-      final block = DartNullableObjectBlock.fromFunction((DummyObject? x) {
+      final block = NullableObjectBlock.fromFunction((DummyObject? x) {
         isCalled = true;
         return x;
       });
@@ -190,7 +205,7 @@ void main() {
 
     test('Object listener block', () async {
       final hasRun = Completer<void>();
-      final block = DartObjectListenerBlock.listener((DummyObject x) {
+      final block = ObjectListenerBlock.listener((DummyObject x) {
         expect(x, isNotNull);
         hasRun.complete();
       });
@@ -201,7 +216,7 @@ void main() {
 
     test('Nullable listener block', () async {
       final hasRun = Completer<void>();
-      final block = DartNullableListenerBlock.listener((DummyObject? x) {
+      final block = NullableListenerBlock.listener((DummyObject? x) {
         expect(x, isNull);
         hasRun.complete();
       });
@@ -212,7 +227,7 @@ void main() {
 
     test('Struct listener block', () async {
       final hasRun = Completer<void>();
-      final block = DartStructListenerBlock.listener(
+      final block = StructListenerBlock.listener(
           (Vec2 vec2, Vec4 vec4, NSObject dummy) {
         expect(vec2.x, 100);
         expect(vec2.y, 200);
@@ -233,7 +248,7 @@ void main() {
 
     test('NSString listener block', () async {
       final hasRun = Completer<void>();
-      final block = DartNSStringListenerBlock.listener((NSString s) {
+      final block = NSStringListenerBlock.listener((NSString s) {
         expect(s.toString(), "Foo 123");
         hasRun.complete();
       });
@@ -244,7 +259,7 @@ void main() {
 
     test('No trampoline listener block', () async {
       final hasRun = Completer<void>();
-      final block = DartNoTrampolineListenerBlock.listener(
+      final block = NoTrampolineListenerBlock.listener(
           (int x, Vec4 vec4, Pointer<Char> charPtr) {
         expect(x, 123);
 
@@ -263,39 +278,39 @@ void main() {
     });
 
     test('Block block', () {
-      final blockBlock = DartBlockBlock.fromFunction(
-          (ObjCBlockBase<Int32 Function(Int32)> intBlock) {
-        return DartIntBlock.fromFunction((int x) {
-          return 3 * DartIntBlock(intBlock)(x);
+      final blockBlock = BlockBlock.fromFunction(
+          (ObjCBlock<Int32 Function(Int32)> intBlock) {
+        return IntBlock.fromFunction((int x) {
+          return 3 * intBlock(x);
         });
       });
 
-      final intBlock = DartIntBlock.fromFunction((int x) {
+      final intBlock = IntBlock.fromFunction((int x) {
         return 5 * x;
       });
       final result1 = blockBlock(intBlock);
-      expect(DartIntBlock(result1)(1), 15);
+      expect(result1(1), 15);
 
       final result2 = BlockTester.newBlock_withMult_(blockBlock, 2);
-      expect(DartIntBlock(result2)(1), 6);
+      expect(result2(1), 6);
     });
 
     test('Native block block', () {
       final blockBlock = BlockTester.newBlockBlock_(7);
 
-      final intBlock = DartIntBlock.fromFunction((int x) {
+      final intBlock = IntBlock.fromFunction((int x) {
         return 5 * x;
       });
-      final result1 = DartBlockBlock(blockBlock)(intBlock);
-      expect(DartIntBlock(result1)(1), 35);
+      final result1 = blockBlock(intBlock);
+      expect(result1(1), 35);
 
       final result2 = BlockTester.newBlock_withMult_(blockBlock, 2);
-      expect(DartIntBlock(result2)(1), 14);
-    });
+      expect(result2(1), 14);
+    });*/
 
-    Pointer<ObjCBlock> funcPointerBlockRefCountTest() {
+    Pointer<ObjCBlockImpl> funcPointerBlockRefCountTest() {
       final block =
-          DartIntBlock.fromFunctionPointer(Pointer.fromFunction(_add100, 999));
+          IntBlock.fromFunctionPointer(Pointer.fromFunction(_add100, 999));
       expect(
           internal_for_testing.blockHasRegisteredClosure(block.pointer), false);
       expect(blockRetainCount(block.pointer), 1);
@@ -308,8 +323,8 @@ void main() {
       expect(blockRetainCount(rawBlock), 0);
     });
 
-    Pointer<ObjCBlock> funcBlockRefCountTest() {
-      final block = DartIntBlock.fromFunction(makeAdder(4000));
+    /*Pointer<ObjCBlockImpl> funcBlockRefCountTest() {
+      final block = IntBlock.fromFunction(makeAdder(4000));
       expect(
           internal_for_testing.blockHasRegisteredClosure(block.pointer), true);
       expect(blockRetainCount(block.pointer), 1);
@@ -325,8 +340,8 @@ void main() {
           false);
     });
 
-    Pointer<ObjCBlock> blockManualRetainRefCountTest() {
-      final block = DartIntBlock.fromFunction(makeAdder(4000));
+    Pointer<ObjCBlockImpl> blockManualRetainRefCountTest() {
+      final block = IntBlock.fromFunction(makeAdder(4000));
       expect(
           internal_for_testing.blockHasRegisteredClosure(block.pointer), true);
       expect(blockRetainCount(block.pointer), 1);
@@ -335,8 +350,8 @@ void main() {
       return rawBlock;
     }
 
-    int blockManualRetainRefCountTest2(Pointer<ObjCBlock> rawBlock) {
-      final block = DartIntBlock.castFromPointer(rawBlock.cast(),
+    int blockManualRetainRefCountTest2(Pointer<ObjCBlockImpl> rawBlock) {
+      final block = IntBlock.castFromPointer(rawBlock.cast(),
           retain: false, release: true);
       return blockRetainCount(block.pointer);
     }
@@ -353,19 +368,19 @@ void main() {
           false);
     });
 
-    (Pointer<ObjCBlock>, Pointer<ObjCBlock>, Pointer<ObjCBlock>)
+    (Pointer<ObjCBlockImpl>, Pointer<ObjCBlockImpl>, Pointer<ObjCBlockImpl>)
         blockBlockDartCallRefCountTest() {
-      final inputBlock = DartIntBlock.fromFunction((int x) {
+      final inputBlock = IntBlock.fromFunction((int x) {
         return 5 * x;
       });
-      final blockBlock = DartBlockBlock.fromFunction(
-          (ObjCBlockBase<Int32 Function(Int32)> intBlock) {
-        return DartIntBlock.fromFunction((int x) {
-          return 3 * DartIntBlock(intBlock)(x);
+      final blockBlock = BlockBlock.fromFunction(
+          (ObjCBlock<Int32 Function(Int32)> intBlock) {
+        return IntBlock.fromFunction((int x) {
+          return 3 * intBlock(x);
         });
       });
       final outputBlock = blockBlock(inputBlock);
-      expect(DartIntBlock(outputBlock)(1), 15);
+      expect(outputBlock(1), 15);
       doGC();
 
       // One reference held by inputBlock object, another bound to the
@@ -408,18 +423,18 @@ void main() {
           false);
     });
 
-    (Pointer<ObjCBlock>, Pointer<ObjCBlock>, Pointer<ObjCBlock>)
+    (Pointer<ObjCBlockImpl>, Pointer<ObjCBlockImpl>, Pointer<ObjCBlockImpl>)
         blockBlockObjCCallRefCountTest() {
-      late Pointer<ObjCBlock> inputBlock;
-      final blockBlock = DartBlockBlock.fromFunction(
-          (ObjCBlockBase<Int32 Function(Int32)> intBlock) {
+      late Pointer<ObjCBlockImpl> inputBlock;
+      final blockBlock = BlockBlock.fromFunction(
+          (ObjCBlock<Int32 Function(Int32)> intBlock) {
         inputBlock = intBlock.pointer;
-        return DartIntBlock.fromFunction((int x) {
-          return 3 * DartIntBlock(intBlock)(x);
+        return IntBlock.fromFunction((int x) {
+          return 3 * intBlock(x);
         });
       });
       final outputBlock = BlockTester.newBlock_withMult_(blockBlock, 2);
-      expect(DartIntBlock(outputBlock)(1), 6);
+      expect(outputBlock(1), 6);
       doGC();
 
       expect(blockRetainCount(inputBlock), 1);
@@ -457,14 +472,14 @@ void main() {
           false);
     });
 
-    (Pointer<ObjCBlock>, Pointer<ObjCBlock>, Pointer<ObjCBlock>)
+    (Pointer<ObjCBlockImpl>, Pointer<ObjCBlockImpl>, Pointer<ObjCBlockImpl>)
         nativeBlockBlockDartCallRefCountTest() {
-      final inputBlock = DartIntBlock.fromFunction((int x) {
+      final inputBlock = IntBlock.fromFunction((int x) {
         return 5 * x;
       });
       final blockBlock = BlockTester.newBlockBlock_(7);
-      final outputBlock = DartBlockBlock(blockBlock)(inputBlock);
-      expect(DartIntBlock(outputBlock)(1), 35);
+      final outputBlock = blockBlock(inputBlock);
+      expect(outputBlock(1), 35);
       doGC();
 
       // One reference held by inputBlock object, another held internally by the
@@ -485,11 +500,11 @@ void main() {
       expect(blockRetainCount(outputBlock), 0);
     });
 
-    (Pointer<ObjCBlock>, Pointer<ObjCBlock>)
+    (Pointer<ObjCBlockImpl>, Pointer<ObjCBlockImpl>)
         nativeBlockBlockObjCCallRefCountTest() {
       final blockBlock = BlockTester.newBlockBlock_(7);
       final outputBlock = BlockTester.newBlock_withMult_(blockBlock, 2);
-      expect(DartIntBlock(outputBlock)(1), 14);
+      expect(outputBlock(1), 14);
       doGC();
 
       expect(blockRetainCount(blockBlock.pointer), 1);
@@ -510,7 +525,7 @@ void main() {
       inputCounter.value = 0;
       outputCounter.value = 0;
 
-      final block = DartObjectBlock.fromFunction((DummyObject x) {
+      final block = ObjectBlock.fromFunction((DummyObject x) {
         return DummyObject.newWithCounter_(outputCounter);
       });
 
@@ -538,7 +553,7 @@ void main() {
       inputCounter.value = 0;
       outputCounter.value = 0;
 
-      final block = DartObjectBlock.fromFunction((DummyObject x) {
+      final block = ObjectBlock.fromFunction((DummyObject x) {
         x.setCounter_(inputCounter);
         return DummyObject.newWithCounter_(outputCounter);
       });
@@ -565,12 +580,12 @@ void main() {
       });
     });
 
-    Future<(Pointer<ObjCBlock>, Pointer<ObjCBlock>)>
+    Future<(Pointer<ObjCBlockImpl>, Pointer<ObjCBlockImpl>)>
         listenerBlockArgumentRetentionTest() async {
       final hasRun = Completer<void>();
-      late ObjCBlockBase<Int32 Function(Int32)> inputBlock;
-      final blockBlock = DartListenerBlock.listener(
-          (ObjCBlockBase<Int32 Function(Int32)> intBlock) {
+      late ObjCBlock<Int32 Function(Int32)> inputBlock;
+      final blockBlock = ListenerBlock.listener(
+          (ObjCBlock<Int32 Function(Int32)> intBlock) {
         expect(blockRetainCount(intBlock.pointer), 1);
         inputBlock = intBlock;
         hasRun.complete();
@@ -580,7 +595,7 @@ void main() {
       thread.start();
 
       await hasRun.future;
-      expect(DartIntBlock(inputBlock)(123), 12300);
+      expect(inputBlock(123), 12300);
       doGC();
 
       expect(blockRetainCount(inputBlock.pointer), 1);
@@ -601,7 +616,7 @@ void main() {
     });
 
     test('Block fields have sensible values', () {
-      final block = DartIntBlock.fromFunction(makeAdder(4000));
+      final block = IntBlock.fromFunction(makeAdder(4000));
       final blockPtr = block.pointer;
       expect(blockPtr.ref.isa, isNot(0));
       expect(blockPtr.ref.flags, isNot(0)); // Set by Block_copy.
@@ -614,7 +629,7 @@ void main() {
       expect(descPtr.ref.copy_helper, nullptr);
       expect(descPtr.ref.dispose_helper, isNot(nullptr));
       expect(descPtr.ref.signature, nullptr);
-    });
+    });*/
   });
 }
 

--- a/pkgs/ffigen/test/native_objc_test/block_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test.dart
@@ -48,7 +48,7 @@ void main() {
       generateBindingsForCoverage('block');
     });
 
-    /*test('BlockTester is working', () {
+    test('BlockTester is working', () {
       // This doesn't test any Block functionality, just that the BlockTester
       // itself is working correctly.
       final blockTester = BlockTester.makeFromMultiplier_(10);
@@ -227,8 +227,8 @@ void main() {
 
     test('Struct listener block', () async {
       final hasRun = Completer<void>();
-      final block = StructListenerBlock.listener(
-          (Vec2 vec2, Vec4 vec4, NSObject dummy) {
+      final block =
+          StructListenerBlock.listener((Vec2 vec2, Vec4 vec4, NSObject dummy) {
         expect(vec2.x, 100);
         expect(vec2.y, 200);
 
@@ -278,8 +278,8 @@ void main() {
     });
 
     test('Block block', () {
-      final blockBlock = BlockBlock.fromFunction(
-          (ObjCBlock<Int32 Function(Int32)> intBlock) {
+      final blockBlock =
+          BlockBlock.fromFunction((ObjCBlock<Int32 Function(Int32)> intBlock) {
         return IntBlock.fromFunction((int x) {
           return 3 * intBlock(x);
         });
@@ -306,7 +306,7 @@ void main() {
 
       final result2 = BlockTester.newBlock_withMult_(blockBlock, 2);
       expect(result2(1), 14);
-    });*/
+    });
 
     Pointer<ObjCBlockImpl> funcPointerBlockRefCountTest() {
       final block =
@@ -323,7 +323,7 @@ void main() {
       expect(blockRetainCount(rawBlock), 0);
     });
 
-    /*Pointer<ObjCBlockImpl> funcBlockRefCountTest() {
+    Pointer<ObjCBlockImpl> funcBlockRefCountTest() {
       final block = IntBlock.fromFunction(makeAdder(4000));
       expect(
           internal_for_testing.blockHasRegisteredClosure(block.pointer), true);
@@ -373,8 +373,8 @@ void main() {
       final inputBlock = IntBlock.fromFunction((int x) {
         return 5 * x;
       });
-      final blockBlock = BlockBlock.fromFunction(
-          (ObjCBlock<Int32 Function(Int32)> intBlock) {
+      final blockBlock =
+          BlockBlock.fromFunction((ObjCBlock<Int32 Function(Int32)> intBlock) {
         return IntBlock.fromFunction((int x) {
           return 3 * intBlock(x);
         });
@@ -426,8 +426,8 @@ void main() {
     (Pointer<ObjCBlockImpl>, Pointer<ObjCBlockImpl>, Pointer<ObjCBlockImpl>)
         blockBlockObjCCallRefCountTest() {
       late Pointer<ObjCBlockImpl> inputBlock;
-      final blockBlock = BlockBlock.fromFunction(
-          (ObjCBlock<Int32 Function(Int32)> intBlock) {
+      final blockBlock =
+          BlockBlock.fromFunction((ObjCBlock<Int32 Function(Int32)> intBlock) {
         inputBlock = intBlock.pointer;
         return IntBlock.fromFunction((int x) {
           return 3 * intBlock(x);
@@ -584,8 +584,8 @@ void main() {
         listenerBlockArgumentRetentionTest() async {
       final hasRun = Completer<void>();
       late ObjCBlock<Int32 Function(Int32)> inputBlock;
-      final blockBlock = ListenerBlock.listener(
-          (ObjCBlock<Int32 Function(Int32)> intBlock) {
+      final blockBlock =
+          ListenerBlock.listener((ObjCBlock<Int32 Function(Int32)> intBlock) {
         expect(blockRetainCount(intBlock.pointer), 1);
         inputBlock = intBlock;
         hasRun.complete();
@@ -629,7 +629,7 @@ void main() {
       expect(descPtr.ref.copy_helper, nullptr);
       expect(descPtr.ref.dispose_helper, isNot(nullptr));
       expect(descPtr.ref.signature, nullptr);
-    });*/
+    });
   });
 }
 

--- a/pkgs/ffigen/test/native_objc_test/block_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test.dart
@@ -45,8 +45,8 @@ void main() {
     });
 
     test('Block from function pointer', () {
-      final block =
-          WrapperIntBlock.fromFunctionPointer(Pointer.fromFunction(_add100, 999));
+      final block = WrapperIntBlock.fromFunctionPointer(
+          Pointer.fromFunction(_add100, 999));
       final blockTester = BlockTester.makeFromBlock_(block);
       blockTester.pokeBlock();
       expect(blockTester.call_(123), 223);
@@ -263,7 +263,8 @@ void main() {
     });
 
     test('Block block', () {
-      final blockBlock = WrapperBlockBlock.fromFunction((DartIntBlock intBlock) {
+      final blockBlock =
+          WrapperBlockBlock.fromFunction((DartIntBlock intBlock) {
         return WrapperIntBlock.fromFunction((int x) {
           return 3 * WrapperIntBlock(intBlock)(x);
         });
@@ -293,8 +294,8 @@ void main() {
     });
 
     Pointer<ObjCBlock> funcPointerBlockRefCountTest() {
-      final block =
-          WrapperIntBlock.fromFunctionPointer(Pointer.fromFunction(_add100, 999));
+      final block = WrapperIntBlock.fromFunctionPointer(
+          Pointer.fromFunction(_add100, 999));
       expect(
           internal_for_testing.blockHasRegisteredClosure(block.pointer), false);
       expect(blockRetainCount(block.pointer), 1);
@@ -357,7 +358,8 @@ void main() {
       final inputBlock = WrapperIntBlock.fromFunction((int x) {
         return 5 * x;
       });
-      final blockBlock = WrapperBlockBlock.fromFunction((DartIntBlock intBlock) {
+      final blockBlock =
+          WrapperBlockBlock.fromFunction((DartIntBlock intBlock) {
         return WrapperIntBlock.fromFunction((int x) {
           return 3 * WrapperIntBlock(intBlock)(x);
         });
@@ -409,7 +411,8 @@ void main() {
     (Pointer<ObjCBlock>, Pointer<ObjCBlock>, Pointer<ObjCBlock>)
         blockBlockObjCCallRefCountTest() {
       late Pointer<ObjCBlock> inputBlock;
-      final blockBlock = WrapperBlockBlock.fromFunction((DartIntBlock intBlock) {
+      final blockBlock =
+          WrapperBlockBlock.fromFunction((DartIntBlock intBlock) {
         inputBlock = intBlock.pointer;
         return WrapperIntBlock.fromFunction((int x) {
           return 3 * WrapperIntBlock(intBlock)(x);

--- a/pkgs/ffigen/test/native_objc_test/block_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test.dart
@@ -46,7 +46,7 @@ void main() {
 
     test('Block from function pointer', () {
       final block =
-          DartIntBlock.fromFunctionPointer(Pointer.fromFunction(_add100, 999));
+          WrapperIntBlock.fromFunctionPointer(Pointer.fromFunction(_add100, 999));
       final blockTester = BlockTester.makeFromBlock_(block);
       blockTester.pokeBlock();
       expect(blockTester.call_(123), 223);
@@ -58,7 +58,7 @@ void main() {
     }
 
     test('Block from function', () {
-      final block = DartIntBlock.fromFunction(makeAdder(4000));
+      final block = WrapperIntBlock.fromFunction(makeAdder(4000));
       final blockTester = BlockTester.makeFromBlock_(block);
       blockTester.pokeBlock();
       expect(blockTester.call_(123), 4123);
@@ -68,7 +68,7 @@ void main() {
     test('Listener block same thread', () async {
       final hasRun = Completer<void>();
       int value = 0;
-      final block = DartVoidBlock.listener(() {
+      final block = WrapperVoidBlock.listener(() {
         value = 123;
         hasRun.complete();
       });
@@ -82,7 +82,7 @@ void main() {
     test('Listener block new thread', () async {
       final hasRun = Completer<void>();
       int value = 0;
-      final block = DartVoidBlock.listener(() {
+      final block = WrapperVoidBlock.listener(() {
         value = 123;
         hasRun.complete();
       });
@@ -95,7 +95,7 @@ void main() {
     });
 
     test('Float block', () {
-      final block = DartFloatBlock.fromFunction((double x) {
+      final block = WrapperFloatBlock.fromFunction((double x) {
         return x + 4.56;
       });
       expect(block(1.23), closeTo(5.79, 1e-6));
@@ -103,7 +103,7 @@ void main() {
     });
 
     test('Double block', () {
-      final block = DartDoubleBlock.fromFunction((double x) {
+      final block = WrapperDoubleBlock.fromFunction((double x) {
         return x + 4.56;
       });
       expect(block(1.23), closeTo(5.79, 1e-6));
@@ -121,7 +121,7 @@ void main() {
 
         final tempPtr = arena<Vec4>();
         final temp = tempPtr.ref;
-        final block = DartVec4Block.fromFunction((Vec4 v) {
+        final block = WrapperVec4Block.fromFunction((Vec4 v) {
           // Twiddle the Vec4 components.
           temp.x = v.y;
           temp.y = v.z;
@@ -148,7 +148,7 @@ void main() {
 
     test('Object block', () {
       bool isCalled = false;
-      final block = DartObjectBlock.fromFunction((DummyObject x) {
+      final block = WrapperObjectBlock.fromFunction((DummyObject x) {
         isCalled = true;
         return x;
       });
@@ -167,7 +167,7 @@ void main() {
 
     test('Nullable object block', () {
       bool isCalled = false;
-      final block = DartNullableObjectBlock.fromFunction((DummyObject? x) {
+      final block = WrapperNullableObjectBlock.fromFunction((DummyObject? x) {
         isCalled = true;
         return x;
       });
@@ -190,7 +190,7 @@ void main() {
 
     test('Object listener block', () async {
       final hasRun = Completer<void>();
-      final block = DartObjectListenerBlock.listener((DummyObject x) {
+      final block = WrapperObjectListenerBlock.listener((DummyObject x) {
         expect(x, isNotNull);
         hasRun.complete();
       });
@@ -201,7 +201,7 @@ void main() {
 
     test('Nullable listener block', () async {
       final hasRun = Completer<void>();
-      final block = DartNullableListenerBlock.listener((DummyObject? x) {
+      final block = WrapperNullableListenerBlock.listener((DummyObject? x) {
         expect(x, isNull);
         hasRun.complete();
       });
@@ -212,7 +212,7 @@ void main() {
 
     test('Struct listener block', () async {
       final hasRun = Completer<void>();
-      final block = DartStructListenerBlock.listener(
+      final block = WrapperStructListenerBlock.listener(
           (Vec2 vec2, Vec4 vec4, NSObject dummy) {
         expect(vec2.x, 100);
         expect(vec2.y, 200);
@@ -233,7 +233,7 @@ void main() {
 
     test('NSString listener block', () async {
       final hasRun = Completer<void>();
-      final block = DartNSStringListenerBlock.listener((NSString s) {
+      final block = WrapperNSStringListenerBlock.listener((NSString s) {
         expect(s.toString(), "Foo 123");
         hasRun.complete();
       });
@@ -244,7 +244,7 @@ void main() {
 
     test('No trampoline listener block', () async {
       final hasRun = Completer<void>();
-      final block = DartNoTrampolineListenerBlock.listener(
+      final block = WrapperNoTrampolineListenerBlock.listener(
           (int x, Vec4 vec4, Pointer<Char> charPtr) {
         expect(x, 123);
 
@@ -263,38 +263,38 @@ void main() {
     });
 
     test('Block block', () {
-      final blockBlock = DartBlockBlock.fromFunction((DartIntBlock intBlock) {
-        return DartIntBlock.fromFunction((int x) {
-          return 3 * intBlock(x);
+      final blockBlock = WrapperBlockBlock.fromFunction((DartIntBlock intBlock) {
+        return WrapperIntBlock.fromFunction((int x) {
+          return 3 * WrapperIntBlock(intBlock)(x);
         });
       });
 
-      final intBlock = DartIntBlock.fromFunction((int x) {
+      final intBlock = WrapperIntBlock.fromFunction((int x) {
         return 5 * x;
       });
       final result1 = blockBlock(intBlock);
-      expect(result1(1), 15);
+      expect(WrapperIntBlock(result1)(1), 15);
 
       final result2 = BlockTester.newBlock_withMult_(blockBlock, 2);
-      expect(result2(1), 6);
+      expect(WrapperIntBlock(result2)(1), 6);
     });
 
     test('Native block block', () {
       final blockBlock = BlockTester.newBlockBlock_(7);
 
-      final intBlock = DartIntBlock.fromFunction((int x) {
+      final intBlock = WrapperIntBlock.fromFunction((int x) {
         return 5 * x;
       });
-      final result1 = blockBlock(intBlock);
-      expect(result1(1), 35);
+      final result1 = WrapperBlockBlock(blockBlock)(intBlock);
+      expect(WrapperIntBlock(result1)(1), 35);
 
       final result2 = BlockTester.newBlock_withMult_(blockBlock, 2);
-      expect(result2(1), 14);
+      expect(WrapperIntBlock(result2)(1), 14);
     });
 
     Pointer<ObjCBlock> funcPointerBlockRefCountTest() {
       final block =
-          DartIntBlock.fromFunctionPointer(Pointer.fromFunction(_add100, 999));
+          WrapperIntBlock.fromFunctionPointer(Pointer.fromFunction(_add100, 999));
       expect(
           internal_for_testing.blockHasRegisteredClosure(block.pointer), false);
       expect(blockRetainCount(block.pointer), 1);
@@ -308,7 +308,7 @@ void main() {
     });
 
     Pointer<ObjCBlock> funcBlockRefCountTest() {
-      final block = DartIntBlock.fromFunction(makeAdder(4000));
+      final block = WrapperIntBlock.fromFunction(makeAdder(4000));
       expect(
           internal_for_testing.blockHasRegisteredClosure(block.pointer), true);
       expect(blockRetainCount(block.pointer), 1);
@@ -325,7 +325,7 @@ void main() {
     });
 
     Pointer<ObjCBlock> blockManualRetainRefCountTest() {
-      final block = DartIntBlock.fromFunction(makeAdder(4000));
+      final block = WrapperIntBlock.fromFunction(makeAdder(4000));
       expect(
           internal_for_testing.blockHasRegisteredClosure(block.pointer), true);
       expect(blockRetainCount(block.pointer), 1);
@@ -335,7 +335,7 @@ void main() {
     }
 
     int blockManualRetainRefCountTest2(Pointer<ObjCBlock> rawBlock) {
-      final block = DartIntBlock.castFromPointer(rawBlock.cast(),
+      final block = WrapperIntBlock.castFromPointer(rawBlock.cast(),
           retain: false, release: true);
       return blockRetainCount(block.pointer);
     }
@@ -354,16 +354,16 @@ void main() {
 
     (Pointer<ObjCBlock>, Pointer<ObjCBlock>, Pointer<ObjCBlock>)
         blockBlockDartCallRefCountTest() {
-      final inputBlock = DartIntBlock.fromFunction((int x) {
+      final inputBlock = WrapperIntBlock.fromFunction((int x) {
         return 5 * x;
       });
-      final blockBlock = DartBlockBlock.fromFunction((DartIntBlock intBlock) {
-        return DartIntBlock.fromFunction((int x) {
-          return 3 * intBlock(x);
+      final blockBlock = WrapperBlockBlock.fromFunction((DartIntBlock intBlock) {
+        return WrapperIntBlock.fromFunction((int x) {
+          return 3 * WrapperIntBlock(intBlock)(x);
         });
       });
       final outputBlock = blockBlock(inputBlock);
-      expect(outputBlock(1), 15);
+      expect(WrapperIntBlock(outputBlock)(1), 15);
       doGC();
 
       // One reference held by inputBlock object, another bound to the
@@ -409,14 +409,14 @@ void main() {
     (Pointer<ObjCBlock>, Pointer<ObjCBlock>, Pointer<ObjCBlock>)
         blockBlockObjCCallRefCountTest() {
       late Pointer<ObjCBlock> inputBlock;
-      final blockBlock = DartBlockBlock.fromFunction((DartIntBlock intBlock) {
+      final blockBlock = WrapperBlockBlock.fromFunction((DartIntBlock intBlock) {
         inputBlock = intBlock.pointer;
-        return DartIntBlock.fromFunction((int x) {
-          return 3 * intBlock(x);
+        return WrapperIntBlock.fromFunction((int x) {
+          return 3 * WrapperIntBlock(intBlock)(x);
         });
       });
       final outputBlock = BlockTester.newBlock_withMult_(blockBlock, 2);
-      expect(outputBlock(1), 6);
+      expect(WrapperIntBlock(outputBlock)(1), 6);
       doGC();
 
       expect(blockRetainCount(inputBlock), 1);
@@ -456,12 +456,12 @@ void main() {
 
     (Pointer<ObjCBlock>, Pointer<ObjCBlock>, Pointer<ObjCBlock>)
         nativeBlockBlockDartCallRefCountTest() {
-      final inputBlock = DartIntBlock.fromFunction((int x) {
+      final inputBlock = WrapperIntBlock.fromFunction((int x) {
         return 5 * x;
       });
       final blockBlock = BlockTester.newBlockBlock_(7);
-      final outputBlock = blockBlock(inputBlock);
-      expect(outputBlock(1), 35);
+      final outputBlock = WrapperBlockBlock(blockBlock)(inputBlock);
+      expect(WrapperIntBlock(outputBlock)(1), 35);
       doGC();
 
       // One reference held by inputBlock object, another held internally by the
@@ -486,7 +486,7 @@ void main() {
         nativeBlockBlockObjCCallRefCountTest() {
       final blockBlock = BlockTester.newBlockBlock_(7);
       final outputBlock = BlockTester.newBlock_withMult_(blockBlock, 2);
-      expect(outputBlock(1), 14);
+      expect(WrapperIntBlock(outputBlock)(1), 14);
       doGC();
 
       expect(blockRetainCount(blockBlock.pointer), 1);
@@ -507,7 +507,7 @@ void main() {
       inputCounter.value = 0;
       outputCounter.value = 0;
 
-      final block = DartObjectBlock.fromFunction((DummyObject x) {
+      final block = WrapperObjectBlock.fromFunction((DummyObject x) {
         return DummyObject.newWithCounter_(outputCounter);
       });
 
@@ -535,7 +535,7 @@ void main() {
       inputCounter.value = 0;
       outputCounter.value = 0;
 
-      final block = DartObjectBlock.fromFunction((DummyObject x) {
+      final block = WrapperObjectBlock.fromFunction((DummyObject x) {
         x.setCounter_(inputCounter);
         return DummyObject.newWithCounter_(outputCounter);
       });
@@ -566,7 +566,7 @@ void main() {
         listenerBlockArgumentRetentionTest() async {
       final hasRun = Completer<void>();
       late DartIntBlock inputBlock;
-      final blockBlock = DartListenerBlock.listener((DartIntBlock intBlock) {
+      final blockBlock = WrapperListenerBlock.listener((DartIntBlock intBlock) {
         expect(blockRetainCount(intBlock.pointer), 1);
         inputBlock = intBlock;
         hasRun.complete();
@@ -576,7 +576,7 @@ void main() {
       thread.start();
 
       await hasRun.future;
-      expect(inputBlock(123), 12300);
+      expect(WrapperIntBlock(inputBlock)(123), 12300);
       doGC();
 
       expect(blockRetainCount(inputBlock.pointer), 1);
@@ -597,7 +597,7 @@ void main() {
     });
 
     test('Block fields have sensible values', () {
-      final block = DartIntBlock.fromFunction(makeAdder(4000));
+      final block = WrapperIntBlock.fromFunction(makeAdder(4000));
       final blockPtr = block.pointer;
       expect(blockPtr.ref.isa, isNot(0));
       expect(blockPtr.ref.flags, isNot(0)); // Set by Block_copy.

--- a/pkgs/ffigen/test/native_objc_test/global_native_config.yaml
+++ b/pkgs/ffigen/test/native_objc_test/global_native_config.yaml
@@ -6,11 +6,11 @@ exclude-all-by-default: true
 ffi-native:
 globals:
   include:
-    - globalString
-    - globalObject
-    - globalBlock
+    - globalNativeString
+    - globalNativeObject
+    - globalNativeBlock
 headers:
   entry-points:
-    - 'global_test.h'
+    - 'global_native_test.h'
 preamble: |
   // ignore_for_file: camel_case_types, non_constant_identifier_names, unnecessary_non_null_assertion, unused_element, unused_field

--- a/pkgs/ffigen/test/native_objc_test/global_native_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_native_test.dart
@@ -62,7 +62,8 @@ void main() {
     test('Global block', () {
       globalNativeBlock = ObjCBlock_Int32_Int32.fromFunction((int x) => x * 10);
       expect(globalNativeBlock!(123), 1230);
-      globalNativeBlock = ObjCBlock_Int32_Int32.fromFunction((int x) => x + 1000);
+      globalNativeBlock =
+          ObjCBlock_Int32_Int32.fromFunction((int x) => x + 1000);
       expect(globalNativeBlock!(456), 1456);
     });
 

--- a/pkgs/ffigen/test/native_objc_test/global_native_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_native_test.dart
@@ -61,12 +61,13 @@ void main() {
 
     test('Global block', () {
       globalBlock = ObjCBlock_Int32_Int32.fromFunction((int x) => x * 10);
-      expect(ObjCBlock_Int32_Int32(globalBlock!)(123), 1230);
+      expect(globalBlock!(123), 1230);
       globalBlock = ObjCBlock_Int32_Int32.fromFunction((int x) => x + 1000);
-      expect(ObjCBlock_Int32_Int32(globalBlock!)(456), 1456);
+      expect(globalBlock!(456), 1456);
     });
 
-    (Pointer<ObjCBlock>, Pointer<ObjCBlock>) globalBlockRefCountingInner() {
+    (Pointer<ObjCBlockImpl>, Pointer<ObjCBlockImpl>)
+        globalBlockRefCountingInner() {
       final blk1 = ObjCBlock_Int32_Int32.fromFunction((int x) => x * 10);
       globalBlock = blk1;
       final blk1raw = blk1.pointer;

--- a/pkgs/ffigen/test/native_objc_test/global_native_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_native_test.dart
@@ -27,19 +27,19 @@ void main() {
     });
 
     test('Global string', () {
-      expect(globalString.toString(), 'Hello World');
-      globalString = 'Something else'.toNSString();
-      expect(globalString.toString(), 'Something else');
+      expect(globalNativeString.toString(), 'Hello World');
+      globalNativeString = 'Something else'.toNSString();
+      expect(globalNativeString.toString(), 'Something else');
     });
 
     (Pointer<ObjCObject>, Pointer<ObjCObject>) globalObjectRefCountingInner() {
       final obj1 = NSObject.new1();
-      globalObject = obj1;
+      globalNativeObject = obj1;
       final obj1raw = obj1.pointer;
       expect(objectRetainCount(obj1raw), 2); // obj1, and the global variable.
 
       final obj2 = NSObject.new1();
-      globalObject = obj2;
+      globalNativeObject = obj2;
       final obj2raw = obj2.pointer;
       expect(objectRetainCount(obj2raw), 2); // obj2, and the global variable.
       expect(objectRetainCount(obj1raw), 1); // Just obj1.
@@ -54,27 +54,27 @@ void main() {
       expect(objectRetainCount(obj2raw), 1); // Just the global variable.
       expect(objectRetainCount(obj1raw), 0);
 
-      globalObject = null;
+      globalNativeObject = null;
       expect(objectRetainCount(obj2raw), 0);
       expect(objectRetainCount(obj1raw), 0);
     });
 
     test('Global block', () {
-      globalBlock = ObjCBlock_Int32_Int32.fromFunction((int x) => x * 10);
-      expect(globalBlock!(123), 1230);
-      globalBlock = ObjCBlock_Int32_Int32.fromFunction((int x) => x + 1000);
-      expect(globalBlock!(456), 1456);
+      globalNativeBlock = ObjCBlock_Int32_Int32.fromFunction((int x) => x * 10);
+      expect(globalNativeBlock!(123), 1230);
+      globalNativeBlock = ObjCBlock_Int32_Int32.fromFunction((int x) => x + 1000);
+      expect(globalNativeBlock!(456), 1456);
     });
 
     (Pointer<ObjCBlockImpl>, Pointer<ObjCBlockImpl>)
         globalBlockRefCountingInner() {
       final blk1 = ObjCBlock_Int32_Int32.fromFunction((int x) => x * 10);
-      globalBlock = blk1;
+      globalNativeBlock = blk1;
       final blk1raw = blk1.pointer;
       expect(blockRetainCount(blk1raw), 2); // blk1, and the global variable.
 
       final blk2 = ObjCBlock_Int32_Int32.fromFunction((int x) => x + 1000);
-      globalBlock = blk2;
+      globalNativeBlock = blk2;
       final blk2raw = blk2.pointer;
       expect(blockRetainCount(blk2raw), 2); // blk2, and the global variable.
       expect(blockRetainCount(blk1raw), 1); // Just blk1.
@@ -89,7 +89,7 @@ void main() {
       expect(blockRetainCount(blk2raw), 1); // Just the global variable.
       expect(blockRetainCount(blk1raw), 0);
 
-      globalBlock = null;
+      globalNativeBlock = null;
       expect(blockRetainCount(blk2raw), 0);
       expect(blockRetainCount(blk1raw), 0);
     });

--- a/pkgs/ffigen/test/native_objc_test/global_native_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_native_test.dart
@@ -61,9 +61,9 @@ void main() {
 
     test('Global block', () {
       globalBlock = ObjCBlock_Int32_Int32.fromFunction((int x) => x * 10);
-      expect(globalBlock!(123), 1230);
+      expect(ObjCBlock_Int32_Int32(globalBlock!)(123), 1230);
       globalBlock = ObjCBlock_Int32_Int32.fromFunction((int x) => x + 1000);
-      expect(globalBlock!(456), 1456);
+      expect(ObjCBlock_Int32_Int32(globalBlock!)(456), 1456);
     });
 
     (Pointer<ObjCBlock>, Pointer<ObjCBlock>) globalBlockRefCountingInner() {

--- a/pkgs/ffigen/test/native_objc_test/global_native_test.h
+++ b/pkgs/ffigen/test/native_objc_test/global_native_test.h
@@ -3,10 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 #import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
 
-#include "global_test.h"
-#include "util.h"
-
-NSString* globalNativeString = @"Hello World";
-NSObject* _Nullable globalNativeObject = nil;
-int32_t (^_Nullable globalNativeBlock)(int32_t) = nil;
+NSString* globalNativeString;
+NSObject* _Nullable globalNativeObject;
+int32_t (^_Nullable globalNativeBlock)(int32_t);

--- a/pkgs/ffigen/test/native_objc_test/global_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_test.dart
@@ -63,9 +63,9 @@ void main() {
 
     test('Global block', () {
       lib.globalBlock = ObjCBlock_Int32_Int32.fromFunction((int x) => x * 10);
-      expect(lib.globalBlock!(123), 1230);
+      expect(ObjCBlock_Int32_Int32(lib.globalBlock!)(123), 1230);
       lib.globalBlock = ObjCBlock_Int32_Int32.fromFunction((int x) => x + 1000);
-      expect(lib.globalBlock!(456), 1456);
+      expect(ObjCBlock_Int32_Int32(lib.globalBlock!)(456), 1456);
     });
 
     (Pointer<ObjCBlock>, Pointer<ObjCBlock>) globalBlockRefCountingInner() {

--- a/pkgs/ffigen/test/native_objc_test/global_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_test.dart
@@ -63,12 +63,13 @@ void main() {
 
     test('Global block', () {
       lib.globalBlock = ObjCBlock_Int32_Int32.fromFunction((int x) => x * 10);
-      expect(ObjCBlock_Int32_Int32(lib.globalBlock!)(123), 1230);
+      expect(lib.globalBlock!(123), 1230);
       lib.globalBlock = ObjCBlock_Int32_Int32.fromFunction((int x) => x + 1000);
-      expect(ObjCBlock_Int32_Int32(lib.globalBlock!)(456), 1456);
+      expect(lib.globalBlock!(456), 1456);
     });
 
-    (Pointer<ObjCBlock>, Pointer<ObjCBlock>) globalBlockRefCountingInner() {
+    (Pointer<ObjCBlockImpl>, Pointer<ObjCBlockImpl>)
+        globalBlockRefCountingInner() {
       final blk1 = ObjCBlock_Int32_Int32.fromFunction((int x) => x * 10);
       lib.globalBlock = blk1;
       final blk1raw = blk1.pointer;

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -289,7 +289,7 @@ void main() {
         expect(count, 1000);
       });
 
-      (DartProxy, Pointer<ObjCBlock>) blockRefCountTestInner() {
+      (DartProxy, Pointer<ObjCBlockImpl>) blockRefCountTestInner() {
         final proxyBuilder = DartProxyBuilder.new1();
         final protocol = getProtocol('MyProtocol');
 
@@ -316,7 +316,7 @@ void main() {
         return (proxy, blockPtr);
       }
 
-      (Pointer<ObjCObject>, Pointer<ObjCBlock>) blockRefCountTest() {
+      (Pointer<ObjCObject>, Pointer<ObjCBlockImpl>) blockRefCountTest() {
         final (proxy, blockPtr) = blockRefCountTestInner();
         final proxyPtr = proxy.pointer;
 

--- a/pkgs/ffigen/test/native_objc_test/static_func_native_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_native_test.dart
@@ -82,7 +82,7 @@ void main() {
       });
     });
 
-    Pointer<ObjCBlock> staticFuncOfBlockRefCountTest() {
+    Pointer<ObjCBlockImpl> staticFuncOfBlockRefCountTest() {
       final block = IntBlock.fromFunction((int x) => 2 * x);
       expect(blockRetainCount(block.pointer.cast()), 1);
 

--- a/pkgs/ffigen/test/native_objc_test/static_func_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_test.dart
@@ -84,7 +84,7 @@ void main() {
       });
     });
 
-    Pointer<ObjCBlock> staticFuncOfBlockRefCountTest() {
+    Pointer<ObjCBlockImpl> staticFuncOfBlockRefCountTest() {
       final block = IntBlock.fromFunction((int x) => 2 * x);
       expect(blockRetainCount(block.pointer.cast()), 1);
 

--- a/pkgs/ffigen/test/native_objc_test/util.dart
+++ b/pkgs/ffigen/test/native_objc_test/util.dart
@@ -42,7 +42,7 @@ external bool _isReadableMemory(Pointer<Void> ptr);
     isLeaf: true, symbol: 'getBlockRetainCount')
 external int _getBlockRetainCount(Pointer<Void> block);
 
-int blockRetainCount(Pointer<ObjCBlock> block) {
+int blockRetainCount(Pointer<ObjCBlockImpl> block) {
   if (!_isReadableMemory(block.cast())) return 0;
   if (!internal_for_testing.isValidBlock(block)) return 0;
   return _getBlockRetainCount(block.cast());

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Drop API methods that are deprecated in the oldest versions of iOS and macOS
   that flutter supports.
+- `ObjCBlockBase` now takes the block's signature as a type parameter.
 
 ## 1.1.0
 

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Drop API methods that are deprecated in the oldest versions of iOS and macOS
   that flutter supports.
-- `ObjCBlockBase` now takes the block's signature as a type parameter.
+- Added `ObjCBlock`, which is the new user-facing representation of ObjC blocks.
 
 ## 1.1.0
 

--- a/pkgs/objective_c/lib/objective_c.dart
+++ b/pkgs/objective_c/lib/objective_c.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+export 'src/block.dart';
 export 'src/c_bindings_generated.dart'
     show
         ObjCBlockImpl,
@@ -11,7 +12,14 @@ export 'src/c_bindings_generated.dart'
         blockRelease,
         objectRelease,
         objectRetain;
-export 'src/internal.dart' hide blockHasRegisteredClosure;
+export 'src/internal.dart'
+    hide
+        blockHasRegisteredClosure,
+        isValidBlock,
+        isValidClass,
+        isValidObject,
+        ObjCFinalizable,
+        ObjCBlockBase;
 export 'src/ns_data.dart';
 export 'src/ns_mutable_data.dart';
 export 'src/ns_string.dart';

--- a/pkgs/objective_c/lib/objective_c.dart
+++ b/pkgs/objective_c/lib/objective_c.dart
@@ -14,12 +14,11 @@ export 'src/c_bindings_generated.dart'
         objectRetain;
 export 'src/internal.dart'
     hide
+        ObjCBlockBase,
         blockHasRegisteredClosure,
         isValidBlock,
         isValidClass,
-        isValidObject,
-        ObjCFinalizable,
-        ObjCBlockBase;
+        isValidObject;
 export 'src/ns_data.dart';
 export 'src/ns_mutable_data.dart';
 export 'src/ns_string.dart';

--- a/pkgs/objective_c/lib/objective_c.dart
+++ b/pkgs/objective_c/lib/objective_c.dart
@@ -4,7 +4,7 @@
 
 export 'src/c_bindings_generated.dart'
     show
-        ObjCBlock,
+        ObjCBlockImpl,
         ObjCObject,
         ObjCSelector,
         blockCopy,

--- a/pkgs/objective_c/lib/src/block.dart
+++ b/pkgs/objective_c/lib/src/block.dart
@@ -2,11 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:ffi';
-
-import 'package:ffi/ffi.dart';
-
-import 'c_bindings_generated.dart' as c;
 import 'internal.dart';
 
 /// An Objective-C block. Blocks are ObjC's equivalent of lambda functions.

--- a/pkgs/objective_c/lib/src/block.dart
+++ b/pkgs/objective_c/lib/src/block.dart
@@ -4,19 +4,25 @@
 
 import 'internal.dart';
 
-/// An Objective-C block. Blocks are ObjC's equivalent of lambda functions.
+/// An Objective-C block.
+///
+/// Blocks are ObjC's equivalent of lambda functions.
 ///
 /// Ffigen generates utility classes for each block signature referenced in the
 /// API it is generating. These utils enable construction of an `ObjCBlock` from
 /// a Dart `Function`, and invoking an `ObjCBlock` from Dart.
 ///
-/// T is the signature of the block, as a Dart `Function`. The arguments and
+/// [T] is the signature of the block, as a Dart `Function`. The arguments and
 /// returns of the `Function` should be specified as follows:
 ///  - For ObjC objects, use the ffigen generated wrapper object.
 ///  - For ObjC blocks, use `ObjCBlock<...>`.
 ///  - For all other types, use the FFI type (eg `Int32` instead of `int`).
 /// For example, the block type `int32_t (^)(NSString*)` would be represented in
-/// Dart as `ObjCBlock<ffi.Int32 Function(NSString)>`. The best way to figure
+/// Dart as `ObjCBlock<ffi.Int32 Function(NSString)>`. This is necessary to
+/// fully distinguish all the block signatures. For instance, ObjC's `int32_t`
+/// and `int64_t` both map to Dart's `int`, so we need to use the FFI types
+/// `Int32`/`Int64`, but all ObjC objects have FFI type `Pointer<ObjCObject>` so
+/// we use Dart wrapper objects like `NSString` instead. The best way to figure
 /// out the block's type is to simply copy it from the ffigen generated API.
 class ObjCBlock<T extends Function> extends ObjCBlockBase {
   /// This constructor is only for use by ffigen bindings.

--- a/pkgs/objective_c/lib/src/block.dart
+++ b/pkgs/objective_c/lib/src/block.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+
+import 'c_bindings_generated.dart' as c;
+import 'internal.dart';
+
+/// An Objective-C block. Blocks are ObjC's equivalent of lambda functions.
+///
+/// Ffigen generates utility classes for each block signature referenced in the
+/// API it is generating. These utils enable construction of an `ObjCBlock` from
+/// a Dart `Function`, and invoking an `ObjCBlock` from Dart.
+///
+/// T is the signature of the block, as a Dart `Function`. The arguments and
+/// returns of the `Function` should be specified as follows:
+///  - For ObjC objects, use the ffigen generated wrapper object.
+///  - For ObjC blocks, use `ObjCBlock<...>`.
+///  - For all other types, use the FFI type (eg `Int32` instead of `int`).
+/// For example, the block type `int32_t (^)(NSString*)` would be represented in
+/// Dart as `ObjCBlock<ffi.Int32 Function(NSString)>`. The best way to figure
+/// out the block's type is to simply copy it from the ffigen generated API.
+class ObjCBlock<T extends Function> extends ObjCBlockBase {
+  /// This constructor is only for use by ffigen bindings.
+  ObjCBlock(super.ptr, {required super.retain, required super.release});
+}

--- a/pkgs/objective_c/lib/src/c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/c_bindings_generated.dart
@@ -135,14 +135,14 @@ external ObjCMethodDesc getMethodDescription(
   bool isInstanceMethod,
 );
 
-@ffi.Native<ffi.Void Function(ffi.Pointer<ObjCBlock>)>(isLeaf: true)
+@ffi.Native<ffi.Void Function(ffi.Pointer<ObjCBlockImpl>)>(isLeaf: true)
 external void disposeObjCBlockWithClosure(
-  ffi.Pointer<ObjCBlock> block,
+  ffi.Pointer<ObjCBlockImpl> block,
 );
 
-@ffi.Native<ffi.Bool Function(ffi.Pointer<ObjCBlock>)>(isLeaf: true)
+@ffi.Native<ffi.Bool Function(ffi.Pointer<ObjCBlockImpl>)>(isLeaf: true)
 external bool isValidBlock(
-  ffi.Pointer<ObjCBlock> block,
+  ffi.Pointer<ObjCBlockImpl> block,
 );
 
 typedef ObjCSelector = _ObjCSelector;
@@ -165,9 +165,9 @@ final class _ObjCMethodDesc extends ffi.Struct {
   external ffi.Pointer<ffi.Char> types;
 }
 
-typedef ObjCBlock = _ObjCBlock;
+typedef ObjCBlockImpl = _ObjCBlockImpl;
 
-final class _ObjCBlock extends ffi.Struct {
+final class _ObjCBlockImpl extends ffi.Struct {
   external ffi.Pointer<ffi.Void> isa;
 
   @ffi.Int()

--- a/pkgs/objective_c/lib/src/internal.dart
+++ b/pkgs/objective_c/lib/src/internal.dart
@@ -184,9 +184,20 @@ bool _isValidClass(Pointer<c.ObjCObject> clazz) {
   return _allClasses.contains(clazz);
 }
 
-/// Only for use by ffigen bindings.
-class ObjCBlockBase<T extends Function> extends _ObjCFinalizable<c.ObjCBlock> {
-  ObjCBlockBase(super.ptr, {required super.retain, required super.release});
+/// An Objective-C block. Blocks are ObjC's equivalent of lambda functions.
+///
+/// T is the signature of the block, as a Dart `Function`. The arguments and
+/// returns of the `Function` should use FFI types like `Int32`, instead of Dart
+/// types like `int`. For example, the block type `int32_t (^)(NSString*)`
+/// would be represented in Dart as
+/// `ObjCBlock<ffi.Int32 Function(Pointer<objc.ObjCObject>)>`.
+///
+/// Ffigen generates utility classes for each block signature referenced in the
+/// API it is generating. These utils enable construction of an `ObjCBlock` from
+/// a Dart `Function`, and invoking an `ObjCBlock` from Dart.
+class ObjCBlock<T extends Function> extends _ObjCFinalizable<c.ObjCBlockImpl> {
+  /// This constructor is only for use by ffigen bindings.
+  ObjCBlock(super.ptr, {required super.retain, required super.release});
 
   static final _blockFinalizer = NativeFinalizer(
       Native.addressOf<NativeFunction<Void Function(Pointer<Void>)>>(
@@ -196,24 +207,24 @@ class ObjCBlockBase<T extends Function> extends _ObjCFinalizable<c.ObjCBlock> {
   NativeFinalizer get _finalizer => _blockFinalizer;
 
   @override
-  void _retain(Pointer<c.ObjCBlock> ptr) {
+  void _retain(Pointer<c.ObjCBlockImpl> ptr) {
     assert(c.isValidBlock(ptr));
     c.blockCopy(ptr.cast());
   }
 
   @override
-  void _release(Pointer<c.ObjCBlock> ptr) {
+  void _release(Pointer<c.ObjCBlockImpl> ptr) {
     assert(c.isValidBlock(ptr));
     c.blockRelease(ptr.cast());
   }
 }
 
 Pointer<c.ObjCBlockDesc> _newBlockDesc(
-    Pointer<NativeFunction<Void Function(Pointer<c.ObjCBlock>)>>
+    Pointer<NativeFunction<Void Function(Pointer<c.ObjCBlockImpl>)>>
         disposeHelper) {
   final desc = calloc.allocate<c.ObjCBlockDesc>(sizeOf<c.ObjCBlockDesc>());
   desc.ref.reserved = 0;
-  desc.ref.size = sizeOf<c.ObjCBlock>();
+  desc.ref.size = sizeOf<c.ObjCBlockImpl>();
   desc.ref.copy_helper = nullptr;
   desc.ref.dispose_helper = disposeHelper.cast();
   desc.ref.signature = nullptr;
@@ -222,12 +233,12 @@ Pointer<c.ObjCBlockDesc> _newBlockDesc(
 
 final _pointerBlockDesc = _newBlockDesc(nullptr);
 final _closureBlockDesc = _newBlockDesc(
-    Native.addressOf<NativeFunction<Void Function(Pointer<c.ObjCBlock>)>>(
+    Native.addressOf<NativeFunction<Void Function(Pointer<c.ObjCBlockImpl>)>>(
         c.disposeObjCBlockWithClosure));
 
-Pointer<c.ObjCBlock> _newBlock(Pointer<Void> invoke, Pointer<Void> target,
+Pointer<c.ObjCBlockImpl> _newBlock(Pointer<Void> invoke, Pointer<Void> target,
     Pointer<c.ObjCBlockDesc> descriptor, int disposePort, int flags) {
-  final b = calloc.allocate<c.ObjCBlock>(sizeOf<c.ObjCBlock>());
+  final b = calloc.allocate<c.ObjCBlockImpl>(sizeOf<c.ObjCBlockImpl>());
   b.ref.isa =
       Native.addressOf<Array<Pointer<Void>>>(c.NSConcreteGlobalBlock).cast();
   b.ref.flags = flags;
@@ -237,7 +248,7 @@ Pointer<c.ObjCBlock> _newBlock(Pointer<Void> invoke, Pointer<Void> target,
   b.ref.dispose_port = disposePort;
   b.ref.descriptor = descriptor;
   assert(c.isValidBlock(b));
-  final copy = c.blockCopy(b.cast()).cast<c.ObjCBlock>();
+  final copy = c.blockCopy(b.cast()).cast<c.ObjCBlockImpl>();
   calloc.free(b);
   assert(copy.ref.isa ==
       Native.addressOf<Array<Pointer<Void>>>(c.NSConcreteMallocBlock).cast());
@@ -248,12 +259,12 @@ Pointer<c.ObjCBlock> _newBlock(Pointer<Void> invoke, Pointer<Void> target,
 const int _blockHasCopyDispose = 1 << 25;
 
 /// Only for use by ffigen bindings.
-Pointer<c.ObjCBlock> newClosureBlock(Pointer<Void> invoke, Function fn) =>
+Pointer<c.ObjCBlockImpl> newClosureBlock(Pointer<Void> invoke, Function fn) =>
     _newBlock(invoke, _registerBlockClosure(fn), _closureBlockDesc,
         _blockClosureDisposer.sendPort.nativePort, _blockHasCopyDispose);
 
 /// Only for use by ffigen bindings.
-Pointer<c.ObjCBlock> newPointerBlock(
+Pointer<c.ObjCBlockImpl> newPointerBlock(
         Pointer<Void> invoke, Pointer<Void> target) =>
     _newBlock(invoke, target, _pointerBlockDesc, 0, 0);
 
@@ -279,15 +290,15 @@ Pointer<Void> _registerBlockClosure(Function closure) {
 }
 
 /// Only for use by ffigen bindings.
-Function getBlockClosure(Pointer<c.ObjCBlock> block) {
+Function getBlockClosure(Pointer<c.ObjCBlockImpl> block) {
   var id = block.ref.target.address;
   assert(_blockClosureRegistry.containsKey(id));
   return _blockClosureRegistry[id]!;
 }
 
 // Not exported by ../objective_c.dart, because they're only for testing.
-bool blockHasRegisteredClosure(Pointer<c.ObjCBlock> block) =>
+bool blockHasRegisteredClosure(Pointer<c.ObjCBlockImpl> block) =>
     _blockClosureRegistry.containsKey(block.ref.target.address);
-bool isValidBlock(Pointer<c.ObjCBlock> block) => c.isValidBlock(block);
+bool isValidBlock(Pointer<c.ObjCBlockImpl> block) => c.isValidBlock(block);
 bool isValidClass(Pointer<c.ObjCObject> clazz) => _isValidClass(clazz);
 bool isValidObject(Pointer<c.ObjCObject> object) => _isValidObject(object);

--- a/pkgs/objective_c/lib/src/internal.dart
+++ b/pkgs/objective_c/lib/src/internal.dart
@@ -76,11 +76,12 @@ final msgSendStretPointer =
 final useMsgSendVariants =
     Abi.current() == Abi.iosX64 || Abi.current() == Abi.macosX64;
 
-class _ObjCFinalizable<T extends NativeType> implements Finalizable {
+/// Only for use by ffigen bindings.
+class ObjCFinalizable<T extends NativeType> implements Finalizable {
   final Pointer<T> _ptr;
   bool _pendingRelease;
 
-  _ObjCFinalizable(this._ptr, {required bool retain, required bool release})
+  ObjCFinalizable(this._ptr, {required bool retain, required bool release})
       : _pendingRelease = release {
     if (retain) {
       _retain(_ptr.cast());
@@ -105,7 +106,7 @@ class _ObjCFinalizable<T extends NativeType> implements Finalizable {
 
   @override
   bool operator ==(Object other) {
-    return other is _ObjCFinalizable && _ptr == other._ptr;
+    return other is ObjCFinalizable && _ptr == other._ptr;
   }
 
   @override
@@ -129,7 +130,7 @@ class _ObjCFinalizable<T extends NativeType> implements Finalizable {
 }
 
 /// Only for use by ffigen bindings.
-class ObjCObjectBase extends _ObjCFinalizable<c.ObjCObject> {
+class ObjCObjectBase extends ObjCFinalizable<c.ObjCObject> {
   ObjCObjectBase(super.ptr, {required super.retain, required super.release});
 
   static final _objectFinalizer = NativeFinalizer(
@@ -184,20 +185,9 @@ bool _isValidClass(Pointer<c.ObjCObject> clazz) {
   return _allClasses.contains(clazz);
 }
 
-/// An Objective-C block. Blocks are ObjC's equivalent of lambda functions.
-///
-/// T is the signature of the block, as a Dart `Function`. The arguments and
-/// returns of the `Function` should use FFI types like `Int32`, instead of Dart
-/// types like `int`. For example, the block type `int32_t (^)(NSString*)`
-/// would be represented in Dart as
-/// `ObjCBlock<ffi.Int32 Function(Pointer<objc.ObjCObject>)>`.
-///
-/// Ffigen generates utility classes for each block signature referenced in the
-/// API it is generating. These utils enable construction of an `ObjCBlock` from
-/// a Dart `Function`, and invoking an `ObjCBlock` from Dart.
-class ObjCBlock<T extends Function> extends _ObjCFinalizable<c.ObjCBlockImpl> {
-  /// This constructor is only for use by ffigen bindings.
-  ObjCBlock(super.ptr, {required super.retain, required super.release});
+/// Only for use by ffigen bindings.
+class ObjCBlockBase extends ObjCFinalizable<c.ObjCBlockImpl> {
+  ObjCBlockBase(super.ptr, {required super.retain, required super.release});
 
   static final _blockFinalizer = NativeFinalizer(
       Native.addressOf<NativeFunction<Void Function(Pointer<Void>)>>(

--- a/pkgs/objective_c/lib/src/internal.dart
+++ b/pkgs/objective_c/lib/src/internal.dart
@@ -77,11 +77,11 @@ final useMsgSendVariants =
     Abi.current() == Abi.iosX64 || Abi.current() == Abi.macosX64;
 
 /// Only for use by ffigen bindings.
-class ObjCFinalizable<T extends NativeType> implements Finalizable {
+class _ObjCFinalizable<T extends NativeType> implements Finalizable {
   final Pointer<T> _ptr;
   bool _pendingRelease;
 
-  ObjCFinalizable(this._ptr, {required bool retain, required bool release})
+  _ObjCFinalizable(this._ptr, {required bool retain, required bool release})
       : _pendingRelease = release {
     if (retain) {
       _retain(_ptr.cast());
@@ -106,7 +106,7 @@ class ObjCFinalizable<T extends NativeType> implements Finalizable {
 
   @override
   bool operator ==(Object other) {
-    return other is ObjCFinalizable && _ptr == other._ptr;
+    return other is _ObjCFinalizable && _ptr == other._ptr;
   }
 
   @override
@@ -130,7 +130,7 @@ class ObjCFinalizable<T extends NativeType> implements Finalizable {
 }
 
 /// Only for use by ffigen bindings.
-class ObjCObjectBase extends ObjCFinalizable<c.ObjCObject> {
+class ObjCObjectBase extends _ObjCFinalizable<c.ObjCObject> {
   ObjCObjectBase(super.ptr, {required super.retain, required super.release});
 
   static final _objectFinalizer = NativeFinalizer(
@@ -186,7 +186,7 @@ bool _isValidClass(Pointer<c.ObjCObject> clazz) {
 }
 
 /// Only for use by ffigen bindings.
-class ObjCBlockBase extends ObjCFinalizable<c.ObjCBlockImpl> {
+class ObjCBlockBase extends _ObjCFinalizable<c.ObjCBlockImpl> {
   ObjCBlockBase(super.ptr, {required super.retain, required super.release});
 
   static final _blockFinalizer = NativeFinalizer(

--- a/pkgs/objective_c/lib/src/internal.dart
+++ b/pkgs/objective_c/lib/src/internal.dart
@@ -185,7 +185,7 @@ bool _isValidClass(Pointer<c.ObjCObject> clazz) {
 }
 
 /// Only for use by ffigen bindings.
-class ObjCBlockBase extends _ObjCFinalizable<c.ObjCBlock> {
+class ObjCBlockBase<T extends Function> extends _ObjCFinalizable<c.ObjCBlock> {
   ObjCBlockBase(super.ptr, {required super.retain, required super.release});
 
   static final _blockFinalizer = NativeFinalizer(

--- a/pkgs/objective_c/lib/src/protocol_builder.dart
+++ b/pkgs/objective_c/lib/src/protocol_builder.dart
@@ -5,7 +5,7 @@
 import 'dart:ffi';
 
 import 'c_bindings_generated.dart' as c;
-import 'internal.dart' show ObjCBlockBase;
+import 'internal.dart' show ObjCBlock;
 import 'objective_c_bindings_generated.dart' as objc;
 
 /// Helper class for building Objective C objects that implement protocols.
@@ -17,7 +17,7 @@ class ObjCProtocolBuilder {
   /// It is not recommended to call this method directly. Instead, use the
   /// implement methods on [ObjCProtocolMethod] and its subclasses.
   void implementMethod(Pointer<c.ObjCSelector> sel,
-          objc.NSMethodSignature signature, ObjCBlockBase block) =>
+          objc.NSMethodSignature signature, ObjCBlock block) =>
       _builder.implementMethod_withSignature_andBlock_(
           sel, signature, block.pointer.cast());
 
@@ -37,7 +37,7 @@ class ObjCProtocolBuilder {
 class ObjCProtocolMethod<T extends Function> {
   final Pointer<c.ObjCSelector> _sel;
   final objc.NSMethodSignature _signature;
-  final ObjCBlockBase Function(T) _createBlock;
+  final ObjCBlock Function(T) _createBlock;
 
   /// Only for use by ffigen bindings.
   ObjCProtocolMethod(this._sel, this._signature, this._createBlock);
@@ -62,7 +62,7 @@ class ObjCProtocolMethod<T extends Function> {
 /// [ObjCProtocolMethod] for each method of the protocol.
 class ObjCProtocolListenableMethod<T extends Function>
     extends ObjCProtocolMethod<T> {
-  final ObjCBlockBase Function(T) _createListenerBlock;
+  final ObjCBlock Function(T) _createListenerBlock;
 
   /// Only for use by ffigen bindings.
   ObjCProtocolListenableMethod(super._sel, super._signature, super._createBlock,

--- a/pkgs/objective_c/lib/src/protocol_builder.dart
+++ b/pkgs/objective_c/lib/src/protocol_builder.dart
@@ -5,7 +5,7 @@
 import 'dart:ffi';
 
 import 'c_bindings_generated.dart' as c;
-import 'internal.dart' show ObjCBlock;
+import 'internal.dart' show ObjCBlockBase;
 import 'objective_c_bindings_generated.dart' as objc;
 
 /// Helper class for building Objective C objects that implement protocols.
@@ -17,7 +17,7 @@ class ObjCProtocolBuilder {
   /// It is not recommended to call this method directly. Instead, use the
   /// implement methods on [ObjCProtocolMethod] and its subclasses.
   void implementMethod(Pointer<c.ObjCSelector> sel,
-          objc.NSMethodSignature signature, ObjCBlock block) =>
+          objc.NSMethodSignature signature, ObjCBlockBase block) =>
       _builder.implementMethod_withSignature_andBlock_(
           sel, signature, block.pointer.cast());
 
@@ -37,7 +37,7 @@ class ObjCProtocolBuilder {
 class ObjCProtocolMethod<T extends Function> {
   final Pointer<c.ObjCSelector> _sel;
   final objc.NSMethodSignature _signature;
-  final ObjCBlock Function(T) _createBlock;
+  final ObjCBlockBase Function(T) _createBlock;
 
   /// Only for use by ffigen bindings.
   ObjCProtocolMethod(this._sel, this._signature, this._createBlock);
@@ -62,7 +62,7 @@ class ObjCProtocolMethod<T extends Function> {
 /// [ObjCProtocolMethod] for each method of the protocol.
 class ObjCProtocolListenableMethod<T extends Function>
     extends ObjCProtocolMethod<T> {
-  final ObjCBlock Function(T) _createListenerBlock;
+  final ObjCBlockBase Function(T) _createListenerBlock;
 
   /// Only for use by ffigen bindings.
   ObjCProtocolListenableMethod(super._sel, super._signature, super._createBlock,

--- a/pkgs/objective_c/src/objective_c.c
+++ b/pkgs/objective_c/src/objective_c.c
@@ -11,11 +11,11 @@
 
 // Dispose helper for ObjC blocks that wrap a Dart closure. For these blocks,
 // the target is an int ID, and the dispose_port is listening for these IDs.
-void disposeObjCBlockWithClosure(ObjCBlock* block) {
+void disposeObjCBlockWithClosure(ObjCBlockImpl* block) {
   Dart_PostInteger_DL(block->dispose_port, (int64_t)block->target);
 }
 
-bool isValidBlock(ObjCBlock* block) {
+bool isValidBlock(ObjCBlockImpl* block) {
   if (block == NULL) return false;
   void* isa = block->isa;
   return isa == &_NSConcreteStackBlock || isa == &_NSConcreteMallocBlock ||

--- a/pkgs/objective_c/src/objective_c.h
+++ b/pkgs/objective_c/src/objective_c.h
@@ -8,10 +8,10 @@
 #include "objective_c_runtime.h"
 
 // Dispose helper for ObjC blocks that wrap a Dart closure.
-void disposeObjCBlockWithClosure(ObjCBlock* block);
+void disposeObjCBlockWithClosure(ObjCBlockImpl* block);
 
 // Returns whether the block is valid and live. The pointer must point to
 // readable memory, or be null. May (rarely) return false positives.
-bool isValidBlock(ObjCBlock* block);
+bool isValidBlock(ObjCBlockImpl* block);
 
 #endif  // OBJECTIVE_C_SRC_OBJECTIVE_C_H_

--- a/pkgs/objective_c/src/objective_c_runtime.h
+++ b/pkgs/objective_c/src/objective_c_runtime.h
@@ -4,7 +4,7 @@
 
 // This file exposes a subset of the Objective C runtime. Ideally we'd just run
 // ffigen directly on the runtime headers that come with XCode, but those
-// headers don't have everything we need (e.g. the ObjCBlock struct).
+// headers don't have everything we need (e.g. the ObjCBlockImpl struct).
 
 #ifndef OBJECTIVE_C_SRC_OBJECTIVE_C_RUNTIME_H_
 #define OBJECTIVE_C_SRC_OBJECTIVE_C_RUNTIME_H_
@@ -31,23 +31,23 @@ void objc_msgSend_stret();
 // See https://clang.llvm.org/docs/Block-ABI-Apple.html
 typedef struct _ObjCBlockDesc {
   unsigned long int reserved;
-  unsigned long int size;  // sizeof(_ObjCBlock)
+  unsigned long int size;  // sizeof(ObjCBlockImpl)
   void (*copy_helper)(void *dst, void *src);
   void (*dispose_helper)(void *src);
   const char *signature;
 } ObjCBlockDesc;
 
-typedef struct _ObjCBlock {
+typedef struct _ObjCBlockImpl {
   void *isa;  // _NSConcreteGlobalBlock
   int flags;
   int reserved;
-  void *invoke;  // RET (*invoke)(ObjCBlock *, ARGS...);
+  void *invoke;  // RET (*invoke)(ObjCBlockImpl *, ARGS...);
   ObjCBlockDesc *descriptor;
 
   // Captured variables follow. These are specific to our use case.
   void *target;
   Dart_Port dispose_port;
-} ObjCBlock;
+} ObjCBlockImpl;
 
 // https://opensource.apple.com/source/libclosure/libclosure-38/Block_private.h
 extern void *_NSConcreteStackBlock[32];


### PR DESCRIPTION
If an ObjC class `Child` inherits from `Base`, and overrides a method that accepts or returns a block, it may use a different type of block than `Base`'s method, according to certain subtyping rules. The issue is that when ffigen codegens those methods, it uses the Dart wrapper objects to represent the blocks in the method signatures, but those wrappers are essentially unrelated, so this breaks Dart's method overriding rules.

The basic idea of the fix is to add a new class to package:objective_c, `ObjCBlock`, which extends `ObjCBlockBase` and includes the block's signature as a type param. Then anywhere we were previously passing a generated block wrapper through an API, we instead pass a `ObjCBlock<signature>`. That way the subtyping rules are enforced by Dart's ordinary subtyping rules. [Simplfied example](https://dartpad.dev/?id=f987590bbdc4e04fbd24b850a70086ba). The generated block wrapper is now just a set of utility methods for constructing `ObjCBlock`s, and the call operator is implemented as an extension method.

The rest of the PR is dealing with the consequences of this change:
- The C struct underlying the block implementation has been renamed from `ObjCBlock` to `ObjCBlockImpl`.
- I had to add another `get*Type` method to ffigen's `Type` class, `getObjCBlockSignatureType`, which is used in `ObjCBlock<signature>`.
  - The Dart signatures need to form a 1:1 mapping with the native block signature, otherwise the extension methods will clash. But the type param isn't actually used for anything other than distinguishing the types, so we can use whatever type works.
  - For most types we can use the FFI type (so `Int32` instead of `int`), but this doesn't work for ObjC objects (which all have FFI type `Pointer<ObjCObject>`) and blocks.
  - So ObjC objects and blocks need to use their Dart type (ie the codegenned wrapper type, like `NSString`), and blocks use the `ObjCBlock<signature>` type.

Fixes https://github.com/dart-lang/native/issues/1416