### PR TITLE
[native_*] Use skips that don't rely on `package:test`

### DIFF
--- a/pkgs/native_assets_builder/test/build_runner/link_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/link_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:native_assets_cli/native_assets_cli.dart' as cli;
 import 'package:native_assets_cli/src/api/asset.dart';
 import 'package:test/test.dart';
@@ -150,6 +152,11 @@ void main() async {
     });
   });
 
+  if (Platform.isMacOS || Platform.isWindows) {
+    // https://github.com/dart-lang/native/issues/1376.
+    return;
+  }
+
   test(
     'treeshaking assets using CLinker',
     timeout: longTimeout,
@@ -184,10 +191,6 @@ void main() async {
         expect(linkResult.assets.length, 1);
         expect(linkResult.assets.first, isA<NativeCodeAsset>());
       });
-    },
-    onPlatform: {
-      'mac-os': const Skip('https://github.com/dart-lang/native/issues/1376.'),
-      'windows': const Skip('https://github.com/dart-lang/native/issues/1376.'),
     },
   );
 }

--- a/pkgs/native_toolchain_c/test/clinker/throws_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/throws_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:test/test.dart';
@@ -10,6 +12,11 @@ import '../helpers.dart';
 
 Future<void> main() async {
   for (final os in OS.values) {
+    if (Platform.isLinux) {
+      // Is implemented.
+      continue;
+    }
+
     test(
       'throws on some platforms',
       () async {
@@ -36,9 +43,6 @@ Future<void> main() async {
           ),
           throwsUnsupportedError,
         );
-      },
-      onPlatform: {
-        'linux': const Skip('Is implemented'),
       },
     );
   }


### PR DESCRIPTION
While trying to roll recent changes into the Dart SDK, the tests are not skipped with the Dart SDK test runner (which is not `package:test`).

See failures on https://dart-ci.firebaseapp.com/cl/382001/1