### PR TITLE
[native_toolchain_c] Fix test to not assume working dir

### DIFF
--- a/pkgs/native_toolchain_c/test/clinker/treeshake_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_test.dart
@@ -29,7 +29,8 @@ Future<void> main() async {
         linkerOptions: LinkerOptions.manual(
           flags: ['--strip-debug', '-u', 'my_other_func'],
           gcSections: true,
-          linkerScript: Uri.file('test/clinker/testfiles/linker/symbols.lds'),
+          linkerScript:
+              packageUri.resolve('test/clinker/testfiles/linker/symbols.lds'),
         ),
       );
   CLinker linkerAuto(List<String> sources) => CLinker.library(


### PR DESCRIPTION
We cannot assume that tests are run from the root of the package. This leads to:

```
SEVERE: 2024-08-23 06:22:38.618901: /usr/bin/arm-linux-gnueabihf-ld: cannot open linker script file test/clinker/testfiles/linker/symbols.lds: No such file or directory
```

From [log](https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8738809276935778721/+/u/test_results/new_test_failures__logs_).