### PR TITLE
[native_toolchain_c] Pass in archiver from environment in test

### DIFF
--- a/pkgs/native_toolchain_c/test/clinker/objects_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/objects_test.dart
@@ -33,14 +33,22 @@ Future<void> main() async {
     final uri = await buildTestArchive(tempUri, os, architecture);
 
     final linkConfig = LinkConfig.build(
-        outputDirectory: tempUri,
-        packageName: 'testpackage',
-        packageRoot: tempUri,
-        targetArchitecture: architecture,
-        targetOS: os,
-        buildMode: BuildMode.debug,
-        linkModePreference: LinkModePreference.dynamic,
-        assets: []);
+      outputDirectory: tempUri,
+      packageName: 'testpackage',
+      packageRoot: tempUri,
+      targetArchitecture: architecture,
+      targetOS: os,
+      buildMode: BuildMode.debug,
+      linkModePreference: LinkModePreference.dynamic,
+      assets: [],
+      cCompiler: CCompilerConfig(
+        compiler: cc,
+        archiver: ar,
+        linker: ld,
+        envScript: envScript,
+        envScriptArgs: envScriptArgs,
+      ),
+    );
     await CLinker.library(
       name: name,
       assetName: '',


### PR DESCRIPTION
On the Dart CI, the toolchains are not in the default location, so they need to be consumed from the environment.

This is automatic when we invoke build hooks via a process invocation because the environment vars override the JSON config. However, in unit tests where we construct `BuildConfig` and `LinkConfig` manually, we need to pass in the archiver/linker/compiler manually.

Closes: https://github.com/dart-lang/native/issues/1447

