### PR TITLE
[doc] Document testing constraints for Dart SDK

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,9 @@ We pledge to maintain an open and welcoming environment. For details, see our
 ## Tests
 
 Packages `native_assets_cli`, `native_assets_builder`, and `native_toolchain_c`
-roll into the Dart SDK and flutter_tools. The tests of these packages are run
-on the Dart SDK in a different way than on the GitHub actions on this repo.
+roll into the Dart SDK. The tests of these packages are run on the Dart SDK in
+[a different way](https://github.com/dart-lang/sdk/issues/56574) than on the
+GitHub actions on this repo.
 
 1. The `tools/test.py` runs `(.*)test.dart`, so no `package:test` annotations
    are respected. So, things such as skips should be done with early returns.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,3 +49,19 @@ This project follows
 
 We pledge to maintain an open and welcoming environment. For details, see our
 [code of conduct](https://dart.dev/code-of-conduct).
+
+## Tests
+
+Packages `native_assets_cli`, `native_assets_builder`, and `native_toolchain_c`
+roll into the Dart SDK and flutter_tools. The tests of these packages are run
+on the Dart SDK in a different way than on the GitHub actions on this repo.
+
+1. The `tools/test.py` runs `(.*)test.dart`, so no `package:test` annotations
+   are respected. So, things such as skips should be done with early returns.
+2. The `tools/test.py` does not run test in the root directory of the package,
+   So, any test accessing test data must do so via `findPackageRoot`.
+3. Native toolchains for cross compilation are not available. So tests doing
+   cross compilation must be in a separate test file, and will be skipped on
+   the Dart CI.
+4. Native toolchains are not installed in default locations. So, any test
+   manually instantiating `HookConfig`s must pass in the environment.


### PR DESCRIPTION
When this repo rolls into the Dart SDK, the tests are run on the Dart CI which has a bunch of extra constraints.

Unfortunately, we can't run on the Dart CI from a GitHub action, so we can't see violating those constraints on the CI here.

The next best thing is to document the constraints.