### PR TITLE
[native_*] Make locking tests less timing sensitive

### DIFF
--- a/pkgs/native_assets_builder/test/build_runner/concurrency_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_test.dart
@@ -187,22 +187,12 @@ void main() async {
       await runBuildInProcess();
       s.stop();
       final cachedInvocationDuration = s.elapsed;
-      // Give a hook longer to run than it needs. So we're sure it's being
-      // held up by the lock not being released.
-      final singleHookTimeout = Duration(
-        milliseconds: min(
-          cachedInvocationDuration.inMilliseconds * 2,
-          cachedInvocationDuration.inMilliseconds + 2000,
-        ),
-      );
+      // Some arbitrary time that the inner process will wait to try to grab the
+      // lock. At least a multiple of the magic constant of 50 milliseconds.
+      const singleHookTimeout = Duration(milliseconds: 200);
       // And give the timer to end this test and release the lock even more
-      // time.
-      final helperTimeout = Duration(
-        milliseconds: min(
-          singleHookTimeout.inMilliseconds * 2,
-          singleHookTimeout.inMilliseconds + 4000,
-        ),
-      );
+      // time. In a normal test run, the timer should always be cancelled.
+      final helperTimeout = cachedInvocationDuration * 10;
       printOnFailure([
         'cachedInvocationDuration',
         cachedInvocationDuration,

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_test.dart
@@ -187,12 +187,12 @@ void main() async {
       await runBuildInProcess();
       s.stop();
       final cachedInvocationDuration = s.elapsed;
-      // Some arbitrary time that the inner process will wait to try to grab the
-      // lock. At least a multiple of the magic constant of 50 milliseconds.
-      const singleHookTimeout = Duration(milliseconds: 200);
+      // Give a hook longer to run than it needs. So we're sure it's being
+      // held up by the lock not being released.
+      final singleHookTimeout = cachedInvocationDuration * 2;
       // And give the timer to end this test and release the lock even more
       // time. In a normal test run, the timer should always be cancelled.
-      final helperTimeout = cachedInvocationDuration * 10;
+      final helperTimeout = singleHookTimeout * 10;
       printOnFailure([
         'cachedInvocationDuration',
         cachedInvocationDuration,

--- a/pkgs/native_assets_cli/test/locking/locking_test.dart
+++ b/pkgs/native_assets_cli/test/locking/locking_test.dart
@@ -166,19 +166,13 @@ void main() async {
       s.stop();
       final oneTimeRun = s.elapsed;
       printOnFailure('oneTimeRun: $oneTimeRun');
-      final helperProcessTimeout = Duration(
-        milliseconds: min(
-          oneTimeRun.inMilliseconds * 2,
-          oneTimeRun.inMilliseconds + 1000,
-        ),
-      );
+      // Some arbitrary time that the inner process will wait to try to grab the
+      // lock. At least a multiple of the magic constant of 50 milliseconds.
+      const helperProcessTimeout = Duration(milliseconds: 200);
       printOnFailure('helperProcessTimeout: $helperProcessTimeout');
-      final timerTimeout = Duration(
-        milliseconds: min(
-          helperProcessTimeout.inMilliseconds * 2,
-          helperProcessTimeout.inMilliseconds + 1000,
-        ),
-      );
+      // In a normal test run, the timer should always be cancelled. But pass
+      // some reasonable upper bound.
+      final timerTimeout = oneTimeRun * 10;
       printOnFailure('timerTimeout: $timerTimeout');
 
       final randomAccessFile = await lockFile.open(mode: FileMode.write);


### PR DESCRIPTION
Make locking tests way less sensitive to timing:

* Reduce the timeout time _inside_ helper processes for the locking test.
* Give the test a 10x to timeout. (We don't technically need the timeout, as normal test flow should cancel the timer. But it's nice that tests fail at some point instead of hanging.)

This should fix the flakiness on the Dart SDK CI when attempting to roll these tests in.

Additionally, add more debug prints for if the tests fail.

Flaky failures: https://dart-ci.firebaseapp.com/cl/381984/7

Success run with this PR: https://dart-ci.firebaseapp.com/cl/382180/3