### PR TITLE
[native_toolchain_c] Pass in archiver from environment in test - take 2

### DIFF
--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
@@ -37,11 +37,7 @@ void main() {
       targetOS: OS.current,
       linkModePreference: LinkModePreference.dynamic,
       buildMode: BuildMode.release,
-      cCompiler: CCompilerConfig(
-        compiler: cc,
-        envScript: envScript,
-        envScriptArgs: envScriptArgs,
-      ),
+      cCompiler: cCompiler,
       linkingEnabled: false,
     );
     final buildOutput = BuildOutput();

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -52,11 +52,7 @@ void main() {
           buildMode: buildMode,
           // Ignored by executables.
           linkModePreference: LinkModePreference.dynamic,
-          cCompiler: CCompilerConfig(
-            compiler: cc,
-            envScript: envScript,
-            envScriptArgs: envScriptArgs,
-          ),
+          cCompiler: cCompiler,
           linkingEnabled: false,
         );
         final buildOutput = BuildOutput();
@@ -132,11 +128,7 @@ void main() {
                 targetOS: OS.current,
                 buildMode: BuildMode.release,
                 linkModePreference: LinkModePreference.dynamic,
-                cCompiler: CCompilerConfig(
-                  compiler: cc,
-                  envScript: envScript,
-                  envScriptArgs: envScriptArgs,
-                ),
+                cCompiler: cCompiler,
                 linkingEnabled: false,
               );
         final buildOutput = BuildOutput();
@@ -226,11 +218,7 @@ void main() {
       buildMode: BuildMode.release,
       // Ignored by executables.
       linkModePreference: LinkModePreference.dynamic,
-      cCompiler: CCompilerConfig(
-        compiler: cc,
-        envScript: envScript,
-        envScriptArgs: envScriptArgs,
-      ),
+      cCompiler: cCompiler,
       linkingEnabled: false,
     );
     final buildOutput = BuildOutput();
@@ -284,11 +272,7 @@ void main() {
       targetOS: OS.current,
       buildMode: BuildMode.release,
       linkModePreference: LinkModePreference.dynamic,
-      cCompiler: CCompilerConfig(
-        compiler: cc,
-        envScript: envScript,
-        envScriptArgs: envScriptArgs,
-      ),
+      cCompiler: cCompiler,
       linkingEnabled: false,
     );
     final buildOutput = BuildOutput();
@@ -330,11 +314,7 @@ void main() {
       targetOS: OS.current,
       buildMode: BuildMode.release,
       linkModePreference: LinkModePreference.dynamic,
-      cCompiler: CCompilerConfig(
-        compiler: cc,
-        envScript: envScript,
-        envScriptArgs: envScriptArgs,
-      ),
+      cCompiler: cCompiler,
       linkingEnabled: false,
     );
     final buildOutput = BuildOutput();
@@ -390,11 +370,7 @@ void main() {
       targetOS: OS.current,
       // Ignored by executables.
       linkModePreference: LinkModePreference.dynamic,
-      cCompiler: CCompilerConfig(
-        compiler: cc,
-        envScript: envScript,
-        envScriptArgs: envScriptArgs,
-      ),
+      cCompiler: cCompiler,
       linkingEnabled: false,
     );
     final buildOutput = BuildOutput();
@@ -455,11 +431,7 @@ void main() {
       targetOS: OS.current,
       // Ignored by executables.
       linkModePreference: LinkModePreference.dynamic,
-      cCompiler: CCompilerConfig(
-        compiler: cc,
-        envScript: envScript,
-        envScriptArgs: envScriptArgs,
-      ),
+      cCompiler: cCompiler,
       linkingEnabled: false,
     );
     final buildOutput = BuildOutput();
@@ -527,11 +499,7 @@ Future<void> testDefines({
     buildMode: buildMode,
     // Ignored by executables.
     linkModePreference: LinkModePreference.dynamic,
-    cCompiler: CCompilerConfig(
-      compiler: cc,
-      envScript: envScript,
-      envScriptArgs: envScriptArgs,
-    ),
+    cCompiler: cCompiler,
     linkingEnabled: false,
   );
   final buildOutput = BuildOutput();

--- a/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
@@ -43,11 +43,7 @@ void main() {
       targetArchitecture: Architecture.current,
       targetOS: OS.current,
       linkModePreference: LinkModePreference.dynamic,
-      cCompiler: CCompilerConfig(
-        compiler: cc,
-        envScript: envScript,
-        envScriptArgs: envScriptArgs,
-      ),
+      cCompiler: cCompiler,
       linkingEnabled: false,
     );
     final buildOutput = BuildOutput();

--- a/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
+++ b/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
@@ -33,11 +33,7 @@ Future<Uri> buildTestArchive(
     targetOS: os,
     buildMode: BuildMode.release,
     linkModePreference: LinkModePreference.dynamic,
-    cCompiler: CCompilerConfig(
-      compiler: cc,
-      envScript: envScript,
-      envScriptArgs: envScriptArgs,
-    ),
+    cCompiler: cCompiler,
     linkingEnabled: false,
   );
   final buildOutput = BuildOutput();

--- a/pkgs/native_toolchain_c/test/clinker/objects_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/objects_test.dart
@@ -31,7 +31,6 @@ Future<void> main() async {
     final tempUri = await tempDirForTest();
 
     final uri = await buildTestArchive(tempUri, os, architecture);
-
     final linkConfig = LinkConfig.build(
       outputDirectory: tempUri,
       packageName: 'testpackage',
@@ -41,15 +40,10 @@ Future<void> main() async {
       buildMode: BuildMode.debug,
       linkModePreference: LinkModePreference.dynamic,
       assets: [],
-      cCompiler: CCompilerConfig(
-        compiler: cc,
-        archiver: ar,
-        linker: ld,
-        envScript: envScript,
-        envScriptArgs: envScriptArgs,
-      ),
+      cCompiler: cCompiler,
     );
     printOnFailure(linkConfig.cCompiler.toString());
+    printOnFailure(Platform.environment.keys.toList().toString());
     await CLinker.library(
       name: name,
       assetName: '',

--- a/pkgs/native_toolchain_c/test/clinker/objects_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/objects_test.dart
@@ -49,6 +49,7 @@ Future<void> main() async {
         envScriptArgs: envScriptArgs,
       ),
     );
+    printOnFailure(linkConfig.cCompiler.toString());
     await CLinker.library(
       name: name,
       assetName: '',

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
@@ -67,15 +67,10 @@ Future<void> runTests(List<Architecture> architectures) async {
           buildMode: BuildMode.release,
           linkModePreference: LinkModePreference.dynamic,
           assets: [],
-          cCompiler: CCompilerConfig(
-            compiler: cc,
-            archiver: ar,
-            linker: ld,
-            envScript: envScript,
-            envScriptArgs: envScriptArgs,
-          ),
+          cCompiler: cCompiler,
         );
         printOnFailure(config.cCompiler.toString());
+        printOnFailure(Platform.environment.keys.toList().toString());
         await clinker.linker([testArchive.toFilePath()]).run(
           config: config,
           output: linkOutput,

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
@@ -67,7 +67,15 @@ Future<void> runTests(List<Architecture> architectures) async {
           buildMode: BuildMode.release,
           linkModePreference: LinkModePreference.dynamic,
           assets: [],
+          cCompiler: CCompilerConfig(
+            compiler: cc,
+            archiver: ar,
+            linker: ld,
+            envScript: envScript,
+            envScriptArgs: envScriptArgs,
+          ),
         );
+        printOnFailure(config.cCompiler.toString());
         await clinker.linker([testArchive.toFilePath()]).run(
           config: config,
           output: linkOutput,

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -123,30 +123,41 @@ String unparseKey(String key) => key.replaceAll('.', '__').toUpperCase();
 /// Archiver provided by the environment.
 ///
 /// Provided on Dart CI.
-final Uri? ar = Platform.environment[unparseKey('c_compiler.ar')]?.asFileUri();
+final Uri? _ar = Platform.environment[unparseKey('c_compiler.ar')]?.asFileUri();
 
 /// Compiler provided by the environment.
 ///
 /// Provided on Dart CI.
-final Uri? cc = Platform.environment[unparseKey('c_compiler.cc')]?.asFileUri();
+final Uri? _cc = Platform.environment[unparseKey('c_compiler.cc')]?.asFileUri();
 
 /// Linker provided by the environment.
 ///
 /// Provided on Dart CI.
-final Uri? ld = Platform.environment[unparseKey('c_compiler.ld')]?.asFileUri();
+final Uri? _ld = Platform.environment[unparseKey('c_compiler.ld')]?.asFileUri();
 
-/// Path to script that sets environment variables for [cc], [ld], and [ar].
+/// Path to script that sets environment variables for [_cc], [_ld], and [_ar].
 ///
 /// Provided on Dart CI.
-final Uri? envScript =
+final Uri? _envScript =
     Platform.environment[unparseKey('c_compiler.env_script')]?.asFileUri();
 
-/// Arguments for [envScript] provided by environment.
+/// Arguments for [_envScript] provided by environment.
 ///
 /// Provided on Dart CI.
-final List<String>? envScriptArgs = Platform
+final List<String>? _envScriptArgs = Platform
     .environment[unparseKey('c_compiler.env_script_arguments')]
     ?.split(' ');
+
+/// Configuration for the native toolchain.
+///
+/// Provided on Dart CI.
+final cCompiler = CCompilerConfig(
+  compiler: _cc,
+  archiver: _ar,
+  linker: _ld,
+  envScript: _envScript,
+  envScriptArgs: _envScriptArgs,
+);
 
 extension on String {
   Uri asFileUri() => Uri.file(this);


### PR DESCRIPTION
After this the linker is found on the Dart SDK CI. (Unfortunately, the test then fails with https://github.com/dart-lang/native/issues/1460)

Dart SDK Run _with_ this PR:

* https://dart-ci.firebaseapp.com/cl/382181/1