### PR TITLE
Revert "[infra] Use Dart 3.3.0 as stable on Windows (#1160)"

### DIFF
--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -31,25 +31,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        # TODO(https://github.com/dart-lang/native/issues/1154): Use 'stable' instead of 3.3.0.
-        sdk: [stable, 3.3.0, dev]
+        sdk: [stable, dev]
         package: [native_assets_builder, native_assets_cli, native_toolchain_c]
         # Breaking changes temporarily break the example run on the Dart SDK until native_assets_builder is rolled into the Dart SDK dev build.
         breaking-change: [false]
-        exclude:
-          # TODO(https://github.com/dart-lang/native/issues/1154): Use 'stable' instead of 3.3.0.
-          - os: macos
-            sdk: 3.3.0
-          - os: ubuntu
-            sdk: 3.3.0
-          - os: windows
-            sdk: stable
-          # native_assets_builder uses `dart compile kernel --depfile` which is only available in 3.5.0.
-          # We don't care too much about native_assets_builder on stable. It will be pulled into Dart and Flutter on last master/main.
-          - sdk: stable
-            package: native_assets_builder
-          - sdk: 3.3.0
-            package: native_assets_builder
+
 
     runs-on: ${{ matrix.os }}-latest
 


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/1154