### PR TITLE
[native_toolchain_c] Support `ld.ldd` as linker on Linux

### DIFF
--- a/pkgs/native_toolchain_c/lib/src/cbuilder/linker_options.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/linker_options.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import '../native_toolchain/apple_clang.dart';
 import '../native_toolchain/clang.dart';
 import '../native_toolchain/gcc.dart';
 import '../tool/tool.dart';
@@ -61,12 +62,15 @@ class LinkerOptions {
   Iterable<String> _toLinkerSyntax(Tool linker, List<String> flagList) {
     if (linker == clang) {
       return flagList.map((e) => '-Wl,$e');
-    } else if (linker == gnuLinker) {
+    } else if (isClangLikeLinker(linker)) {
       return flagList;
     } else {
       throw UnsupportedError('Linker flags for $linker are not supported');
     }
   }
+
+  static bool isClangLikeLinker(Tool tool) =>
+      tool == appleLd || tool == gnuLinker || tool == lld;
 
   static Uri? _createLinkerScript(Iterable<String>? symbols) {
     if (symbols == null) return null;

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -253,7 +253,8 @@ class RunCBuilder {
               if (executable != null) ...[
                 // Generate position-independent code for executables.
                 '-fPIE',
-                // Tell the linker to generate a position-independent executable.
+                // Tell the linker to generate a position-independent
+                // executable.
                 '-pie',
               ],
             ] else ...[

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -114,7 +114,7 @@ class RunCBuilder {
     final toolInstance_ =
         linkerOptions != null ? await linker() : await compiler();
     final tool = toolInstance_.tool;
-    if (isClangLikeCompiler(tool) || isClangLikeLinker(tool)) {
+    if (isClangLikeCompiler(tool) || LinkerOptions.isClangLikeLinker(tool)) {
       await runClangLike(tool: toolInstance_);
       return;
     } else if (tool == cl) {
@@ -126,9 +126,6 @@ class RunCBuilder {
 
   static bool isClangLikeCompiler(Tool tool) =>
       tool == appleClang || tool == clang || tool == gcc;
-
-  static bool isClangLikeLinker(Tool tool) =>
-      tool == appleLd || tool == gnuLinker || tool == lld;
 
   Future<void> runClangLike({required ToolInstance tool}) async {
     final isStaticLib = staticLibrary != null;

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -12,6 +12,7 @@ import '../native_toolchain/clang.dart';
 import '../native_toolchain/gcc.dart';
 import '../native_toolchain/msvc.dart';
 import '../native_toolchain/xcode.dart';
+import '../tool/tool.dart';
 import '../tool/tool_instance.dart';
 import '../utils/env_from_bat.dart';
 import '../utils/run_process.dart';
@@ -113,10 +114,7 @@ class RunCBuilder {
     final toolInstance_ =
         linkerOptions != null ? await linker() : await compiler();
     final tool = toolInstance_.tool;
-    if (tool == appleClang ||
-        tool == clang ||
-        tool == gcc ||
-        tool == gnuLinker) {
+    if (isClangLikeCompiler(tool) || isClangLikeLinker(tool)) {
       await runClangLike(tool: toolInstance_);
       return;
     } else if (tool == cl) {
@@ -125,6 +123,12 @@ class RunCBuilder {
       throw UnimplementedError('This package does not know how to run $tool.');
     }
   }
+
+  static bool isClangLikeCompiler(Tool tool) =>
+      tool == appleClang || tool == clang || tool == gcc;
+
+  static bool isClangLikeLinker(Tool tool) =>
+      tool == appleLd || tool == gnuLinker || tool == lld;
 
   Future<void> runClangLike({required ToolInstance tool}) async {
     final isStaticLib = staticLibrary != null;

--- a/pkgs/native_toolchain_c/lib/src/native_toolchain/gcc.dart
+++ b/pkgs/native_toolchain_c/lib/src/native_toolchain/gcc.dart
@@ -10,7 +10,15 @@ import '../tool/tool_resolver.dart';
 /// The GNU Compiler Collection for [Architecture.current].
 ///
 /// https://gcc.gnu.org/
-final gcc = Tool(name: 'GCC');
+final gcc = Tool(
+  name: 'GCC',
+  defaultResolver: CliVersionResolver(
+    wrappedResolver: PathToolResolver(
+      toolName: 'GCC',
+      executableName: 'gcc',
+    ),
+  ),
+);
 
 /// The GNU GCC archiver for [Architecture.current].
 final gnuArchiver = Tool(name: 'GNU archiver');


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/1460

* Allows any kind of gnu-like linker. (We use Clangs' `ld.lld` instead of the GCC linker on the Dart SDK CI)
* Passes the PIC/PIE flags as expected to the linker
  * `-f` means forward to linker, but if we invoke linker directly, we don't need that.
  * only PIE makes sense, PIC only has an effect on the compilation as far as I understand (not on linking).

Testing:

* We don't have `ld.ldd` on the GitHub CI, so we can't run a unit test here.
  * If we'd do mocking of process and file system, we could have an invocation expectation: https://github.com/dart-lang/native/issues/90
  * We run the test on the Dart CI [failing invocation](https://dart-ci.firebaseapp.com/cl/382384/3) -> [succeeding linking, failing on a `readelf`](https://dart-ci.firebaseapp.com/cl/382384/4)
  * Tested locally with `ld.lld` by patching pkgs/native_toolchain_c/lib/src/cbuilder/compiler_resolver.dart to prefer `lld` over `x86_64LinuxGnuLd`.