### PR TITLE
[native_toolchain_c] Only use `nm` to inspect symbols

### DIFF
--- a/pkgs/native_toolchain_c/test/clinker/objects_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/objects_test.dart
@@ -58,12 +58,12 @@ Future<void> main() async {
     expect(linkOutput.assets, hasLength(1));
     final asset = linkOutput.assets.first;
     expect(asset, isA<NativeCodeAsset>());
-    final file = (asset as NativeCodeAsset).file;
-    expect(file, isNotNull, reason: 'Asset $asset has a file');
-    final filePath = file!.toFilePath();
-    expect(filePath, endsWith(os.dylibFileName(name)));
-    final readelf = await readelfSymbols(filePath);
-    expect(readelf, contains('my_other_func'));
-    expect(readelf, contains('my_func'));
+    await expectSymbols(
+      asset: asset as NativeCodeAsset,
+      symbols: [
+        'my_func',
+        'my_other_func',
+      ],
+    );
   });
 }

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
@@ -76,14 +76,16 @@ Future<void> runTests(List<Architecture> architectures) async {
           output: linkOutput,
           logger: logger,
         );
-        final filePath = linkOutput.assets.first.file!.toFilePath();
+
+        final asset = linkOutput.assets.first as NativeCodeAsset;
+        final filePath = asset.file!.toFilePath();
 
         final machine = await readelfMachine(filePath);
         expect(machine, contains(readElfMachine[architecture]));
 
-        final symbols = await readelfSymbols(filePath);
+        final symbols = await nmReadSymbols(asset);
         if (clinker.linker != linkerAutoEmpty) {
-          expect(symbols, matches(r'[0-9]+\smy_other_func'));
+          expect(symbols, contains('my_other_func'));
           expect(symbols, isNot(contains('my_func')));
         } else {
           expect(symbols, contains('my_other_func'));


### PR DESCRIPTION
We were using both `nm` and `readelf` to inspect symbols of dylibs. Apparently the `readelf` on the Dart SDK CI is pretty old and doesn't have `-C`.

```
SEVERE: 2024-08-27 06:21:38.923027: readelf: invalid option -- 'C'
```

[log](https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8738447274147496209/+/u/test_results/new_test_failures__logs_)

Green run on Dart CI with this PR: https://dart-ci.firebaseapp.com/cl/382384/5