### PR TITLE
Remove Kotlin and Gradle dependencies from jnigen / publish 0.11.0

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.11.0-wip
+## 0.11.0
 
 - **Breaking Change** Removed `Jni.accessors`.
 - Made most `Jni.env` methods into leaf functions to speed up their execution.
+- Removed the dependency on `kotlin_gradle_plugin`.
 
 ## 0.10.1
 

--- a/pkgs/jni/android/build.gradle
+++ b/pkgs/jni/android/build.gradle
@@ -8,11 +8,6 @@ buildscript {
         google()
         mavenCentral()
     }
-
-    dependencies {
-        // The Android Gradle Plugin knows how to build native code with the NDK.
-        classpath 'com.android.tools.build:gradle:7.1.2'
-    }
 }
 
 rootProject.allprojects {

--- a/pkgs/jni/android/build.gradle
+++ b/pkgs/jni/android/build.gradle
@@ -4,7 +4,6 @@ group 'com.github.dart_lang.jni'
 version '1.0'
 
 buildscript {
-    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()
@@ -13,7 +12,6 @@ buildscript {
     dependencies {
         // The Android Gradle Plugin knows how to build native code with the NDK.
         classpath 'com.android.tools.build:gradle:7.1.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 

--- a/pkgs/jni/pubspec.yaml
+++ b/pkgs/jni/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jni
 description: A library to access JNI from Dart and Flutter that acts as a support library for package:jnigen.
-version: 0.11.0-wip
+version: 0.11.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jni
 
 topics:

--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.11.0
+
+- No changes. Keep major version in sync with `package:jni`.
+
 ## 0.10.1
 
-- Add backticks to code references in doc comments.
+- Added backticks to code references in doc comments.
 
 ## 0.10.0
 

--- a/pkgs/jnigen/pubspec.yaml
+++ b/pkgs/jnigen/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jnigen
 description: A Dart bindings generator for Java and Kotlin that uses JNI under the hood to interop with Java virtual machine.
-version: 0.10.1
+version: 0.11.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jnigen
 
 environment:


### PR DESCRIPTION
Closes #1135.

Everything seems to still work without these dependencies and we don't have to keep updating them every time flutter updates them.