### PR TITLE
[objective_c] Force `.pointer` to go through `.ref`

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/global.dart
+++ b/pkgs/ffigen/lib/src/code_generator/global.dart
@@ -59,7 +59,7 @@ class Global extends LookUpBinding {
         final newValue =
             type.convertDartTypeToFfiDartType(w, 'value', objCRetain: true);
         s.write('''set $globalVarName($dartType value) {
-  $releaseOldValue.release();
+  $releaseOldValue.ref.release();
   $pointerValue = $newValue;
 }''');
       }

--- a/pkgs/ffigen/lib/src/code_generator/objc_block.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_block.dart
@@ -240,8 +240,8 @@ extension $callExtension on $blockType {
             p.type.convertDartTypeToFfiDartType(w, p.name, objCRetain: false))
         .join(', ');
     final callMethodInvocation = '''
-pointer.ref.invoke.cast<$natTrampFnType>().asFunction<$trampFuncFfiDartType>()(
-    pointer, $callMethodArgs)''';
+ref.pointer.ref.invoke.cast<$natTrampFnType>().asFunction<$trampFuncFfiDartType>()(
+    ref.pointer, $callMethodArgs)''';
     s.write(returnType.convertFfiDartTypeToDartType(w, callMethodInvocation,
         objCRetain: false));
     s.write(';\n');

--- a/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
@@ -92,7 +92,7 @@ class ObjCInterface extends BindingType with ObjCMethods {
 
   /// Constructs a [$name] that points to the same underlying object as [other].
   $name.castFrom($wrapObjType other) :
-      this._(other.pointer, retain: true, release: true);
+      this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [$name] that wraps the given raw object pointer.
   $name.castFromPointer($rawObjType other,
@@ -103,7 +103,7 @@ class ObjCInterface extends BindingType with ObjCMethods {
   static bool isInstance($wrapObjType obj) {
     return ${_isKindOfClassMsgSend.invoke(
       w,
-      'obj.pointer',
+      'obj.ref.pointer',
       _isKindOfClass.name,
       [_classObject.name],
     )};
@@ -326,7 +326,7 @@ class ObjCInterface extends BindingType with ObjCMethods {
       ObjCInterface.generateGetId(value, objCRetain);
 
   static String generateGetId(String value, bool objCRetain) =>
-      objCRetain ? '$value.retainAndReturnPointer()' : '$value.pointer';
+      objCRetain ? '$value.ref.retainAndReturnPointer()' : '$value.ref.pointer';
 
   @override
   String convertFfiDartTypeToDartType(

--- a/pkgs/ffigen/test/native_objc_test/arc_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/arc_test.dart
@@ -44,19 +44,19 @@ void main() {
       final obj2 = ArcTestObject.newWithCounter_(counter);
       expect(counter.value, 2);
 
-      final obj1raw = obj1.pointer;
-      final obj2raw = obj2.pointer;
+      final obj1raw = obj1.ref.pointer;
+      final obj2raw = obj2.ref.pointer;
 
       expect(objectRetainCount(obj1raw), 1);
       expect(objectRetainCount(obj2raw), 1);
 
       final obj2b =
           ArcTestObject.castFromPointer(obj2raw, retain: true, release: true);
-      expect(objectRetainCount(obj2b.pointer), 2);
+      expect(objectRetainCount(obj2b.ref.pointer), 2);
 
       final obj2c =
           ArcTestObject.castFromPointer(obj2raw, retain: true, release: true);
-      expect(objectRetainCount(obj2c.pointer), 3);
+      expect(objectRetainCount(obj2c.ref.pointer), 3);
 
       return (obj1raw, obj2raw);
     }
@@ -84,9 +84,9 @@ void main() {
       final obj3 = ArcTestObject.allocTheThing().initWithCounter_(counter);
       expect(counter.value, 3);
 
-      final obj1raw = obj1.pointer;
-      final obj2raw = obj2.pointer;
-      final obj3raw = obj3.pointer;
+      final obj1raw = obj1.ref.pointer;
+      final obj2raw = obj2.ref.pointer;
+      final obj3raw = obj3.ref.pointer;
 
       expect(objectRetainCount(obj1raw), 2);
       expect(objectRetainCount(obj2raw), 3);
@@ -142,15 +142,15 @@ void main() {
       final obj9 = obj1.copyMeConsumeSelf();
       expect(counter.value, 9);
 
-      final obj1raw = obj1.pointer;
-      final obj2raw = obj2.pointer;
-      final obj3raw = obj3.pointer;
-      final obj4raw = obj4.pointer;
-      final obj5raw = obj5.pointer;
-      final obj6raw = obj6.pointer;
-      final obj7raw = obj7.pointer;
-      final obj8raw = obj8.pointer;
-      final obj9raw = obj9.pointer;
+      final obj1raw = obj1.ref.pointer;
+      final obj2raw = obj2.ref.pointer;
+      final obj3raw = obj3.ref.pointer;
+      final obj4raw = obj4.ref.pointer;
+      final obj5raw = obj5.ref.pointer;
+      final obj6raw = obj6.ref.pointer;
+      final obj7raw = obj7.ref.pointer;
+      final obj8raw = obj8.ref.pointer;
+      final obj9raw = obj9.ref.pointer;
 
       expect(objectRetainCount(obj1raw), 1);
       expect(objectRetainCount(obj2raw), 1);
@@ -218,7 +218,7 @@ void main() {
       final obj1 = ArcTestObject.makeAndAutorelease_(counter);
       expect(counter.value, 1);
 
-      final obj1raw = obj1.pointer;
+      final obj1raw = obj1.ref.pointer;
       expect(objectRetainCount(obj1raw), 2);
       return obj1raw;
     }
@@ -239,7 +239,7 @@ void main() {
 
       final pool2 = lib.objc_autoreleasePoolPush();
       final obj2 = ArcTestObject.makeAndAutorelease_(counter);
-      final obj2raw = obj2.pointer;
+      final obj2raw = obj2.ref.pointer;
       expect(counter.value, 1);
       expect(objectRetainCount(obj2raw), 2);
       doGC();
@@ -249,7 +249,7 @@ void main() {
       // The obj2 variable still holds a reference to the object.
       expect(counter.value, 1);
       expect(objectRetainCount(obj2raw), 1);
-      obj2.release();
+      obj2.ref.release();
       expect(counter.value, 0);
       expect(objectRetainCount(obj2raw), 0);
 
@@ -260,7 +260,7 @@ void main() {
         Pointer<Int32> counter, ArcTestObject outerObj) {
       final assignObj = ArcTestObject.newWithCounter_(counter);
       expect(counter.value, 2);
-      final assignObjRaw = assignObj.pointer;
+      final assignObjRaw = assignObj.ref.pointer;
       expect(objectRetainCount(assignObjRaw), 1);
       outerObj.assignedProperty = assignObj;
       expect(counter.value, 2);
@@ -277,7 +277,7 @@ void main() {
         Pointer<Int32> counter) {
       final outerObj = ArcTestObject.newWithCounter_(counter);
       expect(counter.value, 1);
-      final outerObjRaw = outerObj.pointer;
+      final outerObjRaw = outerObj.ref.pointer;
       expect(objectRetainCount(outerObjRaw), 1);
       final assignObjRaw = assignPropertiesInnerInner(counter, outerObj);
       doGC();
@@ -304,7 +304,7 @@ void main() {
         Pointer<Int32> counter, ArcTestObject outerObj) {
       final retainObj = ArcTestObject.newWithCounter_(counter);
       expect(counter.value, 2);
-      final retainObjRaw = retainObj.pointer;
+      final retainObjRaw = retainObj.ref.pointer;
       expect(objectRetainCount(retainObjRaw), 1);
       outerObj.retainedProperty = retainObj;
       expect(counter.value, 2);
@@ -317,7 +317,7 @@ void main() {
         Pointer<Int32> counter) {
       final outerObj = ArcTestObject.newWithCounter_(counter);
       expect(counter.value, 1);
-      final outerObjRaw = outerObj.pointer;
+      final outerObjRaw = outerObj.ref.pointer;
       expect(objectRetainCount(outerObjRaw), 1);
       final retainObjRaw = retainPropertiesInnerInner(counter, outerObj);
       doGC();
@@ -364,9 +364,9 @@ void main() {
       expect(counter.value, 3);
       expect(anotherCopy, outerObj.copiedProperty);
 
-      final outerObjRaw = outerObj.pointer;
-      final copyObjRaw = copyObj.pointer;
-      final anotherCopyRaw = anotherCopy.pointer;
+      final outerObjRaw = outerObj.ref.pointer;
+      final copyObjRaw = copyObj.ref.pointer;
+      final anotherCopyRaw = anotherCopy.ref.pointer;
 
       expect(objectRetainCount(outerObjRaw), 1);
       expect(objectRetainCount(copyObjRaw), 1);
@@ -405,22 +405,22 @@ void main() {
       final obj3 = ArcTestObject.newWithCounter_(counter);
       expect(counter.value, 3);
 
-      final obj1raw = obj1.pointer;
-      final obj2raw = obj2.pointer;
-      final obj3raw = obj3.pointer;
+      final obj1raw = obj1.ref.pointer;
+      final obj2raw = obj2.ref.pointer;
+      final obj3raw = obj3.ref.pointer;
 
       expect(objectRetainCount(obj1raw), 1);
       expect(objectRetainCount(obj2raw), 1);
       expect(objectRetainCount(obj3raw), 1);
 
-      obj1.release();
+      obj1.ref.release();
       expect(counter.value, 2);
-      obj2.release();
+      obj2.ref.release();
       expect(counter.value, 1);
-      obj3.release();
+      obj3.ref.release();
       expect(counter.value, 0);
 
-      expect(() => obj1.release(), throwsStateError);
+      expect(() => obj1.ref.release(), throwsStateError);
       calloc.free(counter);
 
       expect(objectRetainCount(obj1raw), 0);
@@ -434,8 +434,8 @@ void main() {
       final objRefs = <ArcTestObject>[];
       for (int i = 1; i < 1000; ++i) {
         final expectedCount = i < 128 ? i : 128;
-        expect(objectRetainCount(obj.pointer), expectedCount);
-        objRefs.add(ArcTestObject.castFromPointer(obj.pointer,
+        expect(objectRetainCount(obj.ref.pointer), expectedCount);
+        objRefs.add(ArcTestObject.castFromPointer(obj.ref.pointer,
             retain: true, release: true));
       }
       expect(counter.value, 1);
@@ -444,7 +444,7 @@ void main() {
     test('Consumed arguments', () {
       final counter = calloc<Int32>();
       ArcTestObject? obj1 = ArcTestObject.newWithCounter_(counter);
-      final obj1raw = obj1.pointer;
+      final obj1raw = obj1.ref.pointer;
 
       expect(objectRetainCount(obj1raw), 1);
       expect(counter.value, 1);

--- a/pkgs/ffigen/test/native_objc_test/block_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test.dart
@@ -176,7 +176,7 @@ void main() {
       isCalled = false;
       final result2 = BlockTester.callObjectBlock_(block);
       expect(result2, isNot(obj));
-      expect(result2.pointer, isNot(nullptr));
+      expect(result2.ref.pointer, isNot(nullptr));
       expect(isCalled, isTrue);
     });
 
@@ -311,10 +311,10 @@ void main() {
     Pointer<ObjCBlockImpl> funcPointerBlockRefCountTest() {
       final block =
           IntBlock.fromFunctionPointer(Pointer.fromFunction(_add100, 999));
-      expect(
-          internal_for_testing.blockHasRegisteredClosure(block.pointer), false);
-      expect(blockRetainCount(block.pointer), 1);
-      return block.pointer;
+      expect(internal_for_testing.blockHasRegisteredClosure(block.ref.pointer),
+          false);
+      expect(blockRetainCount(block.ref.pointer), 1);
+      return block.ref.pointer;
     }
 
     test('Function pointer block ref counting', () {
@@ -325,10 +325,10 @@ void main() {
 
     Pointer<ObjCBlockImpl> funcBlockRefCountTest() {
       final block = IntBlock.fromFunction(makeAdder(4000));
-      expect(
-          internal_for_testing.blockHasRegisteredClosure(block.pointer), true);
-      expect(blockRetainCount(block.pointer), 1);
-      return block.pointer;
+      expect(internal_for_testing.blockHasRegisteredClosure(block.ref.pointer),
+          true);
+      expect(blockRetainCount(block.ref.pointer), 1);
+      return block.ref.pointer;
     }
 
     test('Function block ref counting', () async {
@@ -342,10 +342,10 @@ void main() {
 
     Pointer<ObjCBlockImpl> blockManualRetainRefCountTest() {
       final block = IntBlock.fromFunction(makeAdder(4000));
-      expect(
-          internal_for_testing.blockHasRegisteredClosure(block.pointer), true);
-      expect(blockRetainCount(block.pointer), 1);
-      final rawBlock = block.retainAndReturnPointer();
+      expect(internal_for_testing.blockHasRegisteredClosure(block.ref.pointer),
+          true);
+      expect(blockRetainCount(block.ref.pointer), 1);
+      final rawBlock = block.ref.retainAndReturnPointer();
       expect(blockRetainCount(rawBlock), 2);
       return rawBlock;
     }
@@ -353,7 +353,7 @@ void main() {
     int blockManualRetainRefCountTest2(Pointer<ObjCBlockImpl> rawBlock) {
       final block = IntBlock.castFromPointer(rawBlock.cast(),
           retain: false, release: true);
-      return blockRetainCount(block.pointer);
+      return blockRetainCount(block.ref.pointer);
     }
 
     test('Block ref counting with manual retain and release', () async {
@@ -385,23 +385,27 @@ void main() {
 
       // One reference held by inputBlock object, another bound to the
       // outputBlock lambda.
-      expect(blockRetainCount(inputBlock.pointer), 2);
+      expect(blockRetainCount(inputBlock.ref.pointer), 2);
       expect(
           internal_for_testing
-              .blockHasRegisteredClosure(inputBlock.pointer.cast()),
+              .blockHasRegisteredClosure(inputBlock.ref.pointer.cast()),
           true);
 
-      expect(blockRetainCount(blockBlock.pointer), 1);
+      expect(blockRetainCount(blockBlock.ref.pointer), 1);
       expect(
           internal_for_testing
-              .blockHasRegisteredClosure(blockBlock.pointer.cast()),
+              .blockHasRegisteredClosure(blockBlock.ref.pointer.cast()),
           true);
-      expect(blockRetainCount(outputBlock.pointer), 1);
+      expect(blockRetainCount(outputBlock.ref.pointer), 1);
       expect(
           internal_for_testing
-              .blockHasRegisteredClosure(outputBlock.pointer.cast()),
+              .blockHasRegisteredClosure(outputBlock.ref.pointer.cast()),
           true);
-      return (inputBlock.pointer, blockBlock.pointer, outputBlock.pointer);
+      return (
+        inputBlock.ref.pointer,
+        blockBlock.ref.pointer,
+        outputBlock.ref.pointer
+      );
     }
 
     test('Calling a block block from Dart has correct ref counting', () async {
@@ -428,7 +432,7 @@ void main() {
       late Pointer<ObjCBlockImpl> inputBlock;
       final blockBlock =
           BlockBlock.fromFunction((ObjCBlock<Int32 Function(Int32)> intBlock) {
-        inputBlock = intBlock.pointer;
+        inputBlock = intBlock.ref.pointer;
         return IntBlock.fromFunction((int x) {
           return 3 * intBlock(x);
         });
@@ -440,17 +444,17 @@ void main() {
       expect(blockRetainCount(inputBlock), 1);
       expect(internal_for_testing.blockHasRegisteredClosure(inputBlock.cast()),
           false);
-      expect(blockRetainCount(blockBlock.pointer), 1);
+      expect(blockRetainCount(blockBlock.ref.pointer), 1);
       expect(
           internal_for_testing
-              .blockHasRegisteredClosure(blockBlock.pointer.cast()),
+              .blockHasRegisteredClosure(blockBlock.ref.pointer.cast()),
           true);
-      expect(blockRetainCount(outputBlock.pointer), 1);
+      expect(blockRetainCount(outputBlock.ref.pointer), 1);
       expect(
           internal_for_testing
-              .blockHasRegisteredClosure(outputBlock.pointer.cast()),
+              .blockHasRegisteredClosure(outputBlock.ref.pointer.cast()),
           true);
-      return (inputBlock, blockBlock.pointer, outputBlock.pointer);
+      return (inputBlock, blockBlock.ref.pointer, outputBlock.ref.pointer);
     }
 
     test('Calling a block block from ObjC has correct ref counting', () async {
@@ -484,11 +488,15 @@ void main() {
 
       // One reference held by inputBlock object, another held internally by the
       // ObjC implementation of the blockBlock.
-      expect(blockRetainCount(inputBlock.pointer), 2);
+      expect(blockRetainCount(inputBlock.ref.pointer), 2);
 
-      expect(blockRetainCount(blockBlock.pointer), 1);
-      expect(blockRetainCount(outputBlock.pointer), 1);
-      return (inputBlock.pointer, blockBlock.pointer, outputBlock.pointer);
+      expect(blockRetainCount(blockBlock.ref.pointer), 1);
+      expect(blockRetainCount(outputBlock.ref.pointer), 1);
+      return (
+        inputBlock.ref.pointer,
+        blockBlock.ref.pointer,
+        outputBlock.ref.pointer
+      );
     }
 
     test('Calling a native block block from Dart has correct ref counting', () {
@@ -507,9 +515,9 @@ void main() {
       expect(outputBlock(1), 14);
       doGC();
 
-      expect(blockRetainCount(blockBlock.pointer), 1);
-      expect(blockRetainCount(outputBlock.pointer), 1);
-      return (blockBlock.pointer, outputBlock.pointer);
+      expect(blockRetainCount(blockBlock.ref.pointer), 1);
+      expect(blockRetainCount(outputBlock.ref.pointer), 1);
+      return (blockBlock.ref.pointer, outputBlock.ref.pointer);
     }
 
     test('Calling a native block block from ObjC has correct ref counting', () {
@@ -586,7 +594,7 @@ void main() {
       late ObjCBlock<Int32 Function(Int32)> inputBlock;
       final blockBlock =
           ListenerBlock.listener((ObjCBlock<Int32 Function(Int32)> intBlock) {
-        expect(blockRetainCount(intBlock.pointer), 1);
+        expect(blockRetainCount(intBlock.ref.pointer), 1);
         inputBlock = intBlock;
         hasRun.complete();
       });
@@ -596,12 +604,12 @@ void main() {
 
       await hasRun.future;
       expect(inputBlock(123), 12300);
-      thread.release();
+      thread.ref.release();
       doGC();
 
-      expect(blockRetainCount(inputBlock.pointer), 1);
-      expect(blockRetainCount(blockBlock.pointer), 1);
-      return (inputBlock.pointer, blockBlock.pointer);
+      expect(blockRetainCount(inputBlock.ref.pointer), 1);
+      expect(blockRetainCount(blockBlock.ref.pointer), 1);
+      return (inputBlock.ref.pointer, blockBlock.ref.pointer);
     }
 
     test('Listener block arguments are not prematurely destroyed', () async {
@@ -618,7 +626,7 @@ void main() {
 
     test('Block fields have sensible values', () {
       final block = IntBlock.fromFunction(makeAdder(4000));
-      final blockPtr = block.pointer;
+      final blockPtr = block.ref.pointer;
       expect(blockPtr.ref.isa, isNot(0));
       expect(blockPtr.ref.flags, isNot(0)); // Set by Block_copy.
       expect(blockPtr.ref.reserved, 0);

--- a/pkgs/ffigen/test/native_objc_test/cast_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/cast_test.dart
@@ -43,7 +43,7 @@ void main() {
 
     test('pointers are equal', () {
       final meAsInt = testInstance!.meAsInt();
-      expect(testInstance!.pointer.address, meAsInt);
+      expect(testInstance!.ref.pointer.address, meAsInt);
     });
 
     test('equality equals', () {

--- a/pkgs/ffigen/test/native_objc_test/global_native_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_native_test.dart
@@ -35,12 +35,12 @@ void main() {
     (Pointer<ObjCObject>, Pointer<ObjCObject>) globalObjectRefCountingInner() {
       final obj1 = NSObject.new1();
       globalNativeObject = obj1;
-      final obj1raw = obj1.pointer;
+      final obj1raw = obj1.ref.pointer;
       expect(objectRetainCount(obj1raw), 2); // obj1, and the global variable.
 
       final obj2 = NSObject.new1();
       globalNativeObject = obj2;
-      final obj2raw = obj2.pointer;
+      final obj2raw = obj2.ref.pointer;
       expect(objectRetainCount(obj2raw), 2); // obj2, and the global variable.
       expect(objectRetainCount(obj1raw), 1); // Just obj1.
       expect(obj1, isNotNull); // Force obj1 to stay in scope.
@@ -73,12 +73,12 @@ void main() {
         globalBlockRefCountingInner() {
       final blk1 = ObjCBlock_Int32_Int32.fromFunction((int x) => x * 10);
       globalNativeBlock = blk1;
-      final blk1raw = blk1.pointer;
+      final blk1raw = blk1.ref.pointer;
       expect(blockRetainCount(blk1raw), 2); // blk1, and the global variable.
 
       final blk2 = ObjCBlock_Int32_Int32.fromFunction((int x) => x + 1000);
       globalNativeBlock = blk2;
-      final blk2raw = blk2.pointer;
+      final blk2raw = blk2.ref.pointer;
       expect(blockRetainCount(blk2raw), 2); // blk2, and the global variable.
       expect(blockRetainCount(blk1raw), 1); // Just blk1.
       expect(blk1, isNotNull); // Force blk1 to stay in scope.

--- a/pkgs/ffigen/test/native_objc_test/global_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_test.dart
@@ -37,12 +37,12 @@ void main() {
     (Pointer<ObjCObject>, Pointer<ObjCObject>) globalObjectRefCountingInner() {
       final obj1 = NSObject.new1();
       lib.globalObject = obj1;
-      final obj1raw = obj1.pointer;
+      final obj1raw = obj1.ref.pointer;
       expect(objectRetainCount(obj1raw), 2); // obj1, and the global variable.
 
       final obj2 = NSObject.new1();
       lib.globalObject = obj2;
-      final obj2raw = obj2.pointer;
+      final obj2raw = obj2.ref.pointer;
       expect(objectRetainCount(obj2raw), 2); // obj2, and the global variable.
       expect(objectRetainCount(obj1raw), 1); // Just obj1.
       expect(obj1, isNotNull); // Force obj1 to stay in scope.
@@ -74,12 +74,12 @@ void main() {
         globalBlockRefCountingInner() {
       final blk1 = ObjCBlock_Int32_Int32.fromFunction((int x) => x * 10);
       lib.globalBlock = blk1;
-      final blk1raw = blk1.pointer;
+      final blk1raw = blk1.ref.pointer;
       expect(blockRetainCount(blk1raw), 2); // blk1, and the global variable.
 
       final blk2 = ObjCBlock_Int32_Int32.fromFunction((int x) => x + 1000);
       lib.globalBlock = blk2;
-      final blk2raw = blk2.pointer;
+      final blk2raw = blk2.ref.pointer;
       expect(blockRetainCount(blk2raw), 2); // blk2, and the global variable.
       expect(blockRetainCount(blk1raw), 1); // Just blk1.
       expect(blk1, isNotNull); // Force blk1 to stay in scope.

--- a/pkgs/ffigen/test/native_objc_test/isolate_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/isolate_test.dart
@@ -82,7 +82,7 @@ void main() {
       expect(oldValue, 123);
       expect(sendable.value, 456);
 
-      final pointer = sendable.pointer;
+      final pointer = sendable.ref.pointer;
       expect(objectRetainCount(pointer), 1);
 
       expect(await queue.next, null); // onExit
@@ -107,7 +107,7 @@ void main() {
       expect(oldValue, 123);
       expect(sendable.value, 456);
 
-      final pointer = sendable.pointer;
+      final pointer = sendable.ref.pointer;
       expect(objectRetainCount(pointer), 1);
 
       sendable = null;
@@ -148,7 +148,7 @@ void main() {
       final value = await completer.future;
       expect(value, 123);
 
-      final pointer = block.pointer;
+      final pointer = block.ref.pointer;
       expect(blockRetainCount(pointer), 1);
 
       expect(await queue.next, null); // onExit
@@ -178,7 +178,7 @@ void main() {
       final value = await completer.future;
       expect(value, 123);
 
-      final pointer = block.pointer;
+      final pointer = block.ref.pointer;
       expect(blockRetainCount(pointer), 1);
 
       block = null;
@@ -188,38 +188,38 @@ void main() {
 
     test('Manual release across isolates', () async {
       final sendable = Sendable.new1();
-      final pointer = sendable.pointer;
+      final pointer = sendable.ref.pointer;
 
       expect(objectRetainCount(pointer), 1);
-      expect(sendable.isReleased, isFalse);
+      expect(sendable.ref.isReleased, isFalse);
 
       final (oldIsReleased, newIsReleased) = await isolateRun(() {
-        final oldIsReleased = sendable.isReleased;
-        sendable!.release();
-        return (oldIsReleased, sendable.isReleased);
+        final oldIsReleased = sendable.ref.isReleased;
+        sendable!.ref.release();
+        return (oldIsReleased, sendable.ref.isReleased);
       });
 
       expect(oldIsReleased, isFalse);
       expect(newIsReleased, isTrue);
 
-      expect(sendable.isReleased, isTrue);
+      expect(sendable.ref.isReleased, isTrue);
       expect(objectRetainCount(pointer), 0);
     });
 
     test('Use after release and double release', () async {
       final sendable = Sendable.new1();
       sendable.value = 123;
-      final pointer = sendable.pointer;
+      final pointer = sendable.ref.pointer;
 
-      expect(sendable.isReleased, isFalse);
+      expect(sendable.ref.isReleased, isFalse);
 
       await isolateRun(() {
-        sendable!.release();
+        sendable!.ref.release();
       });
 
-      expect(sendable.isReleased, isTrue);
+      expect(sendable.ref.isReleased, isTrue);
       expect(() => sendable.value, throwsA(isA<UseAfterReleaseError>()));
-      expect(() => sendable.release(), throwsA(isA<DoubleReleaseError>()));
+      expect(() => sendable.ref.release(), throwsA(isA<DoubleReleaseError>()));
     });
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -220,7 +220,7 @@ void main() {
           return 'DartProxy: $s: $x'.toNSString();
         });
         proxyBuilder.implementMethod_withSignature_andBlock_(
-            sel, signature, block.pointer.cast());
+            sel, signature, block.ref.pointer.cast());
 
         final optSel = registerName('optionalMethod:');
         final optSignature = getProtocolMethodSignature(protocol, optSel,
@@ -230,7 +230,7 @@ void main() {
           return s.y - s.x;
         });
         proxyBuilder.implementMethod_withSignature_andBlock_(
-            optSel, optSignature, optBlock.pointer.cast());
+            optSel, optSignature, optBlock.ref.pointer.cast());
 
         final otherSel = registerName('otherMethod:b:c:d:');
         final otherSignature = getProtocolMethodSignature(
@@ -241,7 +241,7 @@ void main() {
           return a * b * c * d;
         });
         proxyBuilder.implementMethod_withSignature_andBlock_(
-            otherSel, otherSignature, otherBlock.pointer.cast());
+            otherSel, otherSignature, otherBlock.ref.pointer.cast());
 
         final proxy = DartProxy.newFromBuilder_(proxyBuilder);
 
@@ -299,12 +299,12 @@ void main() {
         final block = InstanceMethodBlock.fromFunction(
             (Pointer<Void> p, NSString s, double x) => 'Hello'.toNSString());
         proxyBuilder.implementMethod_withSignature_andBlock_(
-            sel, signature, block.pointer.cast());
+            sel, signature, block.ref.pointer.cast());
 
         final proxy = DartProxy.newFromBuilder_(proxyBuilder);
 
-        final proxyPtr = proxy.pointer;
-        final blockPtr = block.pointer;
+        final proxyPtr = proxy.ref.pointer;
+        final blockPtr = block.ref.pointer;
 
         // There are 2 references to the block. One owned by the Dart wrapper
         // object, and the other owned by the proxy. The method signature is
@@ -318,7 +318,7 @@ void main() {
 
       (Pointer<ObjCObject>, Pointer<ObjCBlockImpl>) blockRefCountTest() {
         final (proxy, blockPtr) = blockRefCountTestInner();
-        final proxyPtr = proxy.pointer;
+        final proxyPtr = proxy.ref.pointer;
 
         // The Dart side block pointer has gone out of scope, but the proxy
         // still owns a reference to it. Same for the signature.

--- a/pkgs/ffigen/test/native_objc_test/ref_count_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/ref_count_test.dart
@@ -44,19 +44,19 @@ void main() {
       final obj2 = RefCountTestObject.newWithCounter_(counter);
       expect(counter.value, 2);
 
-      final obj1raw = obj1.pointer;
-      final obj2raw = obj2.pointer;
+      final obj1raw = obj1.ref.pointer;
+      final obj2raw = obj2.ref.pointer;
 
       expect(objectRetainCount(obj1raw), 1);
       expect(objectRetainCount(obj2raw), 1);
 
       final obj2b = RefCountTestObject.castFromPointer(obj2raw,
           retain: true, release: true);
-      expect(objectRetainCount(obj2b.pointer), 2);
+      expect(objectRetainCount(obj2b.ref.pointer), 2);
 
       final obj2c = RefCountTestObject.castFromPointer(obj2raw,
           retain: true, release: true);
-      expect(objectRetainCount(obj2c.pointer), 3);
+      expect(objectRetainCount(obj2c.ref.pointer), 3);
 
       return (obj1raw, obj2raw);
     }
@@ -85,9 +85,9 @@ void main() {
       final obj3 = RefCountTestObject.allocTheThing().initWithCounter_(counter);
       expect(counter.value, 3);
 
-      final obj1raw = obj1.pointer;
-      final obj2raw = obj2.pointer;
-      final obj3raw = obj3.pointer;
+      final obj1raw = obj1.ref.pointer;
+      final obj2raw = obj2.ref.pointer;
+      final obj3raw = obj3.ref.pointer;
 
       expect(objectRetainCount(obj1raw), 2);
       expect(objectRetainCount(obj2raw), 3);
@@ -143,15 +143,15 @@ void main() {
       final obj9 = obj1.copyMeConsumeSelf();
       expect(counter.value, 9);
 
-      final obj1raw = obj1.pointer;
-      final obj2raw = obj2.pointer;
-      final obj3raw = obj3.pointer;
-      final obj4raw = obj4.pointer;
-      final obj5raw = obj5.pointer;
-      final obj6raw = obj6.pointer;
-      final obj7raw = obj7.pointer;
-      final obj8raw = obj8.pointer;
-      final obj9raw = obj9.pointer;
+      final obj1raw = obj1.ref.pointer;
+      final obj2raw = obj2.ref.pointer;
+      final obj3raw = obj3.ref.pointer;
+      final obj4raw = obj4.ref.pointer;
+      final obj5raw = obj5.ref.pointer;
+      final obj6raw = obj6.ref.pointer;
+      final obj7raw = obj7.ref.pointer;
+      final obj8raw = obj8.ref.pointer;
+      final obj9raw = obj9.ref.pointer;
 
       expect(objectRetainCount(obj1raw), 1);
       expect(objectRetainCount(obj2raw), 1);
@@ -219,7 +219,7 @@ void main() {
       final obj1 = RefCountTestObject.makeAndAutorelease_(counter);
       expect(counter.value, 1);
 
-      final obj1raw = obj1.pointer;
+      final obj1raw = obj1.ref.pointer;
       expect(objectRetainCount(obj1raw), 2);
       return obj1raw;
     }
@@ -240,7 +240,7 @@ void main() {
 
       final pool2 = lib.objc_autoreleasePoolPush();
       final obj2 = RefCountTestObject.makeAndAutorelease_(counter);
-      final obj2raw = obj2.pointer;
+      final obj2raw = obj2.ref.pointer;
       expect(counter.value, 1);
       expect(objectRetainCount(obj2raw), 2);
       doGC();
@@ -250,7 +250,7 @@ void main() {
       // The obj2 variable still holds a reference to the object.
       expect(counter.value, 1);
       expect(objectRetainCount(obj2raw), 1);
-      obj2.release();
+      obj2.ref.release();
       expect(counter.value, 0);
       expect(objectRetainCount(obj2raw), 0);
 
@@ -261,7 +261,7 @@ void main() {
         Pointer<Int32> counter, RefCountTestObject outerObj) {
       final assignObj = RefCountTestObject.newWithCounter_(counter);
       expect(counter.value, 2);
-      final assignObjRaw = assignObj.pointer;
+      final assignObjRaw = assignObj.ref.pointer;
       expect(objectRetainCount(assignObjRaw), 1);
       outerObj.assignedProperty = assignObj;
       expect(counter.value, 2);
@@ -278,7 +278,7 @@ void main() {
         Pointer<Int32> counter) {
       final outerObj = RefCountTestObject.newWithCounter_(counter);
       expect(counter.value, 1);
-      final outerObjRaw = outerObj.pointer;
+      final outerObjRaw = outerObj.ref.pointer;
       expect(objectRetainCount(outerObjRaw), 1);
       final assignObjRaw = assignPropertiesInnerInner(counter, outerObj);
       doGC();
@@ -305,7 +305,7 @@ void main() {
         Pointer<Int32> counter, RefCountTestObject outerObj) {
       final retainObj = RefCountTestObject.newWithCounter_(counter);
       expect(counter.value, 2);
-      final retainObjRaw = retainObj.pointer;
+      final retainObjRaw = retainObj.ref.pointer;
       expect(objectRetainCount(retainObjRaw), 1);
       outerObj.retainedProperty = retainObj;
       expect(counter.value, 2);
@@ -318,7 +318,7 @@ void main() {
         Pointer<Int32> counter) {
       final outerObj = RefCountTestObject.newWithCounter_(counter);
       expect(counter.value, 1);
-      final outerObjRaw = outerObj.pointer;
+      final outerObjRaw = outerObj.ref.pointer;
       expect(objectRetainCount(outerObjRaw), 1);
       final retainObjRaw = retainPropertiesInnerInner(counter, outerObj);
       doGC();
@@ -365,9 +365,9 @@ void main() {
       expect(counter.value, 3);
       expect(anotherCopy, outerObj.copiedProperty);
 
-      final outerObjRaw = outerObj.pointer;
-      final copyObjRaw = copyObj.pointer;
-      final anotherCopyRaw = anotherCopy.pointer;
+      final outerObjRaw = outerObj.ref.pointer;
+      final copyObjRaw = copyObj.ref.pointer;
+      final anotherCopyRaw = anotherCopy.ref.pointer;
 
       expect(objectRetainCount(outerObjRaw), 1);
       expect(objectRetainCount(copyObjRaw), 1);
@@ -440,22 +440,22 @@ void main() {
       final obj3 = RefCountTestObject.newWithCounter_(counter);
       expect(counter.value, 3);
 
-      final obj1raw = obj1.pointer;
-      final obj2raw = obj2.pointer;
-      final obj3raw = obj3.pointer;
+      final obj1raw = obj1.ref.pointer;
+      final obj2raw = obj2.ref.pointer;
+      final obj3raw = obj3.ref.pointer;
 
       expect(objectRetainCount(obj1raw), 1);
       expect(objectRetainCount(obj2raw), 1);
       expect(objectRetainCount(obj3raw), 1);
 
-      obj1.release();
+      obj1.ref.release();
       expect(counter.value, 2);
-      obj2.release();
+      obj2.ref.release();
       expect(counter.value, 1);
-      obj3.release();
+      obj3.ref.release();
       expect(counter.value, 0);
 
-      expect(() => obj1.release(), throwsStateError);
+      expect(() => obj1.ref.release(), throwsStateError);
       calloc.free(counter);
 
       expect(objectRetainCount(obj1raw), 0);
@@ -466,7 +466,7 @@ void main() {
     Pointer<ObjCObject> manualRetainInner(Pointer<Int32> counter) {
       final obj = RefCountTestObject.newWithCounter_(counter);
       expect(counter.value, 1);
-      final objRaw = obj.retainAndReturnPointer();
+      final objRaw = obj.ref.retainAndReturnPointer();
       expect(objectRetainCount(objRaw), 2);
       return objRaw;
     }
@@ -497,10 +497,10 @@ void main() {
       final obj1 = RefCountTestObject.new1();
       obj1.setCounter_(counter);
       expect(counter.value, 1);
-      expect(objectRetainCount(obj1.pointer), 1);
+      expect(objectRetainCount(obj1.ref.pointer), 1);
       final obj1b = obj1.unownedReference();
       expect(counter.value, 1);
-      expect(objectRetainCount(obj1b.pointer), 2);
+      expect(objectRetainCount(obj1b.ref.pointer), 2);
 
       // Make a second object so that the counter check in unownedReferenceInner
       // sees some sort of change. Otherwise this test could pass just by the GC
@@ -508,7 +508,7 @@ void main() {
       final obj2 = RefCountTestObject.new1();
       obj2.setCounter_(counter);
       expect(counter.value, 2);
-      expect(objectRetainCount(obj2.pointer), 1);
+      expect(objectRetainCount(obj2.ref.pointer), 1);
 
       return obj1b;
     }
@@ -519,8 +519,8 @@ void main() {
       // The underlying object obj1 and obj1b points to still exists, because
       // obj1b took a reference to it. So we still have 1 object.
       expect(counter.value, 1);
-      expect(objectRetainCount(obj1b.pointer), 1);
-      return obj1b.pointer;
+      expect(objectRetainCount(obj1b.ref.pointer), 1);
+      return obj1b.ref.pointer;
     }
 
     test("Method that returns a reference we don't own", () {
@@ -543,8 +543,8 @@ void main() {
       final objRefs = <RefCountTestObject>[];
       for (int i = 1; i < 1000; ++i) {
         final expectedCount = i < 128 ? i : 128;
-        expect(objectRetainCount(obj.pointer), expectedCount);
-        objRefs.add(RefCountTestObject.castFromPointer(obj.pointer,
+        expect(objectRetainCount(obj.ref.pointer), expectedCount);
+        objRefs.add(RefCountTestObject.castFromPointer(obj.ref.pointer,
             retain: true, release: true));
       }
       expect(counter.value, 1);
@@ -553,7 +553,7 @@ void main() {
     test('Consumed arguments', () {
       final counter = calloc<Int32>();
       RefCountTestObject? obj1 = RefCountTestObject.newWithCounter_(counter);
-      final obj1raw = obj1.pointer;
+      final obj1raw = obj1.ref.pointer;
 
       expect(objectRetainCount(obj1raw), 1);
       expect(counter.value, 1);

--- a/pkgs/ffigen/test/native_objc_test/static_func_native_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_native_test.dart
@@ -88,15 +88,15 @@ void main() {
 
     Pointer<ObjCBlockImpl> staticFuncOfBlockRefCountTest() {
       final block = IntBlock.fromFunction((int x) => 2 * x);
-      expect(blockRetainCount(block.pointer.cast()), 1);
+      expect(blockRetainCount(block.ref.pointer.cast()), 1);
 
       final pool = objc_autoreleasePoolPush();
       final outputBlock = staticFuncOfBlock(block);
       objc_autoreleasePoolPop(pool);
       expect(block, outputBlock);
-      expect(blockRetainCount(block.pointer.cast()), 2);
+      expect(blockRetainCount(block.ref.pointer.cast()), 2);
 
-      return block.pointer;
+      return block.ref.pointer;
     }
 
     test('Blocks passed through static functions have correct ref counts', () {
@@ -155,7 +155,7 @@ void main() {
         'have correct ref counts', () {
       final counter = calloc<Int32>();
       StaticFuncTestObj? obj1 = StaticFuncTestObj.newWithCounter_(counter);
-      final obj1raw = obj1.pointer;
+      final obj1raw = obj1.ref.pointer;
 
       expect(objectRetainCount(obj1raw), 1);
       expect(counter.value, 1);

--- a/pkgs/ffigen/test/native_objc_test/static_func_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_test.dart
@@ -90,15 +90,15 @@ void main() {
 
     Pointer<ObjCBlockImpl> staticFuncOfBlockRefCountTest() {
       final block = IntBlock.fromFunction((int x) => 2 * x);
-      expect(blockRetainCount(block.pointer.cast()), 1);
+      expect(blockRetainCount(block.ref.pointer.cast()), 1);
 
       final pool = lib.objc_autoreleasePoolPush();
       final outputBlock = lib.staticFuncOfBlock(block);
       lib.objc_autoreleasePoolPop(pool);
       expect(block, outputBlock);
-      expect(blockRetainCount(block.pointer.cast()), 2);
+      expect(blockRetainCount(block.ref.pointer.cast()), 2);
 
-      return block.pointer;
+      return block.ref.pointer;
     }
 
     test('Blocks passed through static functions have correct ref counts', () {
@@ -157,7 +157,7 @@ void main() {
         'have correct ref counts', () {
       final counter = calloc<Int32>();
       StaticFuncTestObj? obj1 = StaticFuncTestObj.newWithCounter_(counter);
-      final obj1raw = obj1.pointer;
+      final obj1raw = obj1.ref.pointer;
 
       expect(objectRetainCount(obj1raw), 1);
       expect(counter.value, 1);

--- a/pkgs/ffigen/test/native_objc_test/typedef_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/typedef_test.dart
@@ -28,7 +28,7 @@ void main() {
       // https://github.com/dart-lang/ffigen/issues/386
       // Make sure that the typedef DartSomeClassPtr is for SomeClass.
       final DartSomeClassPtr instance = SomeClass.new1();
-      expect(instance.pointer, isNot(nullptr));
+      expect(instance.ref.pointer, isNot(nullptr));
     });
   });
 }

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -1,10 +1,14 @@
-## 1.2.0-wip
+## 2.0.0-wip
 
 - Drop API methods that are deprecated in the oldest versions of iOS and macOS
   that flutter supports.
 - Added `ObjCBlock`, which is the new user-facing representation of ObjC blocks.
 - Migrate to ARC (Automatic Reference Counting).
 - Enable ObjC objects and blocks to be sent between isolates.
+- __Breaking change__: Remove some convenience methods from `_ObjCRefHolder`:
+  `isReleased`, `release`, `pointer`, and `retainAndReturnPointer`. Uses of
+  these methods now need to go through `.ref`. Eg `obj.pointer` becomes
+  `obj.ref.pointer`.
 
 ## 1.1.0
 

--- a/pkgs/objective_c/lib/src/internal.dart
+++ b/pkgs/objective_c/lib/src/internal.dart
@@ -169,31 +169,15 @@ abstract final class _ObjCReference<T extends NativeType>
 // deeply-immutable classes must be final, but the ffigen bindings need to
 // extend ObjCObjectBase/ObjCBlockBase.
 class _ObjCRefHolder<T extends NativeType, Ref extends _ObjCReference<T>> {
-  final Ref _ref;
+  final Ref ref;
 
-  _ObjCRefHolder(this._ref);
-
-  bool get isReleased => _ref.isReleased;
-
-  /// Releases the reference to the underlying ObjC object held by this wrapper.
-  /// Throws a StateError if this wrapper doesn't currently hold a reference.
-  void release() => _ref.release();
-
-  /// Return a pointer to this object.
-  Pointer<T> get pointer => _ref.pointer;
-
-  /// Retain a reference to this object and then return the pointer. This
-  /// reference must be released when you are done with it. If you wrap this
-  /// reference in another object, make sure to release it but not retain it:
-  /// `castFromPointer(lib, pointer, retain: false, release: true)`
-  Pointer<T> retainAndReturnPointer() => _ref.retainAndReturnPointer();
+  _ObjCRefHolder(this.ref);
 
   @override
-  bool operator ==(Object other) =>
-      other is _ObjCRefHolder && _ref == other._ref;
+  bool operator ==(Object other) => other is _ObjCRefHolder && ref == other.ref;
 
   @override
-  int get hashCode => _ref.hashCode;
+  int get hashCode => ref.hashCode;
 }
 
 @pragma('vm:deeply-immutable')

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -27,7 +27,7 @@ class NSObject extends objc.ObjCObjectBase {
 
   /// Constructs a [NSObject] that points to the same underlying object as [other].
   NSObject.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSObject] that wraps the given raw object pointer.
   NSObject.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -36,7 +36,8 @@ class NSObject extends objc.ObjCObjectBase {
 
   /// Returns whether [obj] is an instance of [NSObject].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_0(obj.pointer, _sel_isKindOfClass_, _class_NSObject);
+    return _objc_msgSend_0(
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSObject);
   }
 
   /// load
@@ -51,8 +52,8 @@ class NSObject extends objc.ObjCObjectBase {
 
   /// init
   NSObject init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSObject.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSObject.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// new
@@ -75,18 +76,18 @@ class NSObject extends objc.ObjCObjectBase {
 
   /// dealloc
   void dealloc() {
-    _objc_msgSend_1(this.pointer, _sel_dealloc);
+    _objc_msgSend_1(this.ref.pointer, _sel_dealloc);
   }
 
   /// copy
   objc.ObjCObjectBase copy() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_copy);
+    final _ret = _objc_msgSend_2(this.ref.pointer, _sel_copy);
     return objc.ObjCObjectBase(_ret, retain: false, release: true);
   }
 
   /// mutableCopy
   objc.ObjCObjectBase mutableCopy() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_mutableCopy);
+    final _ret = _objc_msgSend_2(this.ref.pointer, _sel_mutableCopy);
     return objc.ObjCObjectBase(_ret, retain: false, release: true);
   }
 
@@ -113,13 +114,14 @@ class NSObject extends objc.ObjCObjectBase {
   /// conformsToProtocol:
   static bool conformsToProtocol_(Protocol protocol) {
     return _objc_msgSend_5(
-        _class_NSObject, _sel_conformsToProtocol_, protocol.pointer);
+        _class_NSObject, _sel_conformsToProtocol_, protocol.ref.pointer);
   }
 
   /// methodForSelector:
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> methodForSelector_(
       ffi.Pointer<objc.ObjCSelector> aSelector) {
-    return _objc_msgSend_6(this.pointer, _sel_methodForSelector_, aSelector);
+    return _objc_msgSend_6(
+        this.ref.pointer, _sel_methodForSelector_, aSelector);
   }
 
   /// instanceMethodForSelector:
@@ -131,28 +133,29 @@ class NSObject extends objc.ObjCObjectBase {
 
   /// doesNotRecognizeSelector:
   void doesNotRecognizeSelector_(ffi.Pointer<objc.ObjCSelector> aSelector) {
-    _objc_msgSend_7(this.pointer, _sel_doesNotRecognizeSelector_, aSelector);
+    _objc_msgSend_7(
+        this.ref.pointer, _sel_doesNotRecognizeSelector_, aSelector);
   }
 
   /// forwardingTargetForSelector:
   objc.ObjCObjectBase forwardingTargetForSelector_(
       ffi.Pointer<objc.ObjCSelector> aSelector) {
     final _ret = _objc_msgSend_8(
-        this.pointer, _sel_forwardingTargetForSelector_, aSelector);
+        this.ref.pointer, _sel_forwardingTargetForSelector_, aSelector);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
   /// forwardInvocation:
   void forwardInvocation_(NSInvocation anInvocation) {
     _objc_msgSend_9(
-        this.pointer, _sel_forwardInvocation_, anInvocation.pointer);
+        this.ref.pointer, _sel_forwardInvocation_, anInvocation.ref.pointer);
   }
 
   /// methodSignatureForSelector:
   NSMethodSignature methodSignatureForSelector_(
       ffi.Pointer<objc.ObjCSelector> aSelector) {
     final _ret = _objc_msgSend_240(
-        this.pointer, _sel_methodSignatureForSelector_, aSelector);
+        this.ref.pointer, _sel_methodSignatureForSelector_, aSelector);
     return NSMethodSignature.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -167,7 +170,7 @@ class NSObject extends objc.ObjCObjectBase {
   /// isSubclassOfClass:
   static bool isSubclassOfClass_(objc.ObjCObjectBase aClass) {
     return _objc_msgSend_0(
-        _class_NSObject, _sel_isSubclassOfClass_, aClass.pointer);
+        _class_NSObject, _sel_isSubclassOfClass_, aClass.ref.pointer);
   }
 
   /// resolveClassMethod:
@@ -221,14 +224,14 @@ class NSObject extends objc.ObjCObjectBase {
 
   /// classForCoder
   objc.ObjCObjectBase get classForCoder {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_classForCoder);
+    final _ret = _objc_msgSend_2(this.ref.pointer, _sel_classForCoder);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
   /// replacementObjectForCoder:
   objc.ObjCObjectBase? replacementObjectForCoder_(NSCoder coder) {
     final _ret = _objc_msgSend_18(
-        this.pointer, _sel_replacementObjectForCoder_, coder.pointer);
+        this.ref.pointer, _sel_replacementObjectForCoder_, coder.ref.pointer);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -236,8 +239,8 @@ class NSObject extends objc.ObjCObjectBase {
 
   /// awakeAfterUsingCoder:
   objc.ObjCObjectBase? awakeAfterUsingCoder_(NSCoder coder) {
-    final _ret = _objc_msgSend_18(
-        this.pointer, _sel_awakeAfterUsingCoder_, coder.pointer);
+    final _ret = _objc_msgSend_18(this.ref.retainAndReturnPointer(),
+        _sel_awakeAfterUsingCoder_, coder.ref.pointer);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: false, release: true);
@@ -245,7 +248,8 @@ class NSObject extends objc.ObjCObjectBase {
 
   /// autoContentAccessingProxy
   objc.ObjCObjectBase get autoContentAccessingProxy {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_autoContentAccessingProxy);
+    final _ret =
+        _objc_msgSend_2(this.ref.pointer, _sel_autoContentAccessingProxy);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
@@ -258,11 +262,11 @@ class NSObject extends objc.ObjCObjectBase {
           ffi.Pointer<objc.ObjCSelector> didRecoverSelector,
           ffi.Pointer<ffi.Void> contextInfo) {
     _objc_msgSend_242(
-        this.pointer,
+        this.ref.pointer,
         _sel_attemptRecoveryFromError_optionIndex_delegate_didRecoverSelector_contextInfo_,
-        error.pointer,
+        error.ref.pointer,
         recoveryOptionIndex,
-        delegate?.pointer ?? ffi.nullptr,
+        delegate?.ref.pointer ?? ffi.nullptr,
         didRecoverSelector,
         contextInfo);
   }
@@ -271,9 +275,9 @@ class NSObject extends objc.ObjCObjectBase {
   bool attemptRecoveryFromError_optionIndex_(
       NSError error, int recoveryOptionIndex) {
     return _objc_msgSend_243(
-        this.pointer,
+        this.ref.pointer,
         _sel_attemptRecoveryFromError_optionIndex_,
-        error.pointer,
+        error.ref.pointer,
         recoveryOptionIndex);
   }
 
@@ -284,11 +288,11 @@ class NSObject extends objc.ObjCObjectBase {
       NSDictionary? change,
       ffi.Pointer<ffi.Void> context) {
     _objc_msgSend_244(
-        this.pointer,
+        this.ref.pointer,
         _sel_observeValueForKeyPath_ofObject_change_context_,
-        keyPath?.pointer ?? ffi.nullptr,
-        object?.pointer ?? ffi.nullptr,
-        change?.pointer ?? ffi.nullptr,
+        keyPath?.ref.pointer ?? ffi.nullptr,
+        object?.ref.pointer ?? ffi.nullptr,
+        change?.ref.pointer ?? ffi.nullptr,
         context);
   }
 
@@ -299,10 +303,10 @@ class NSObject extends objc.ObjCObjectBase {
       NSKeyValueObservingOptions options,
       ffi.Pointer<ffi.Void> context) {
     _objc_msgSend_138(
-        this.pointer,
+        this.ref.pointer,
         _sel_addObserver_forKeyPath_options_context_,
-        observer.pointer,
-        keyPath.pointer,
+        observer.ref.pointer,
+        keyPath.ref.pointer,
         options.value,
         context);
   }
@@ -310,83 +314,85 @@ class NSObject extends objc.ObjCObjectBase {
   /// removeObserver:forKeyPath:context:
   void removeObserver_forKeyPath_context_(
       NSObject observer, NSString keyPath, ffi.Pointer<ffi.Void> context) {
-    _objc_msgSend_139(this.pointer, _sel_removeObserver_forKeyPath_context_,
-        observer.pointer, keyPath.pointer, context);
+    _objc_msgSend_139(this.ref.pointer, _sel_removeObserver_forKeyPath_context_,
+        observer.ref.pointer, keyPath.ref.pointer, context);
   }
 
   /// removeObserver:forKeyPath:
   void removeObserver_forKeyPath_(NSObject observer, NSString keyPath) {
-    _objc_msgSend_140(this.pointer, _sel_removeObserver_forKeyPath_,
-        observer.pointer, keyPath.pointer);
+    _objc_msgSend_140(this.ref.pointer, _sel_removeObserver_forKeyPath_,
+        observer.ref.pointer, keyPath.ref.pointer);
   }
 
   /// willChangeValueForKey:
   void willChangeValueForKey_(NSString key) {
-    _objc_msgSend_148(this.pointer, _sel_willChangeValueForKey_, key.pointer);
+    _objc_msgSend_148(
+        this.ref.pointer, _sel_willChangeValueForKey_, key.ref.pointer);
   }
 
   /// didChangeValueForKey:
   void didChangeValueForKey_(NSString key) {
-    _objc_msgSend_148(this.pointer, _sel_didChangeValueForKey_, key.pointer);
+    _objc_msgSend_148(
+        this.ref.pointer, _sel_didChangeValueForKey_, key.ref.pointer);
   }
 
   /// willChange:valuesAtIndexes:forKey:
   void willChange_valuesAtIndexes_forKey_(
       NSKeyValueChange changeKind, NSIndexSet indexes, NSString key) {
-    _objc_msgSend_245(this.pointer, _sel_willChange_valuesAtIndexes_forKey_,
-        changeKind.value, indexes.pointer, key.pointer);
+    _objc_msgSend_245(this.ref.pointer, _sel_willChange_valuesAtIndexes_forKey_,
+        changeKind.value, indexes.ref.pointer, key.ref.pointer);
   }
 
   /// didChange:valuesAtIndexes:forKey:
   void didChange_valuesAtIndexes_forKey_(
       NSKeyValueChange changeKind, NSIndexSet indexes, NSString key) {
-    _objc_msgSend_245(this.pointer, _sel_didChange_valuesAtIndexes_forKey_,
-        changeKind.value, indexes.pointer, key.pointer);
+    _objc_msgSend_245(this.ref.pointer, _sel_didChange_valuesAtIndexes_forKey_,
+        changeKind.value, indexes.ref.pointer, key.ref.pointer);
   }
 
   /// willChangeValueForKey:withSetMutation:usingObjects:
   void willChangeValueForKey_withSetMutation_usingObjects_(
       NSString key, NSKeyValueSetMutationKind mutationKind, NSSet objects) {
     _objc_msgSend_246(
-        this.pointer,
+        this.ref.pointer,
         _sel_willChangeValueForKey_withSetMutation_usingObjects_,
-        key.pointer,
+        key.ref.pointer,
         mutationKind.value,
-        objects.pointer);
+        objects.ref.pointer);
   }
 
   /// didChangeValueForKey:withSetMutation:usingObjects:
   void didChangeValueForKey_withSetMutation_usingObjects_(
       NSString key, NSKeyValueSetMutationKind mutationKind, NSSet objects) {
     _objc_msgSend_246(
-        this.pointer,
+        this.ref.pointer,
         _sel_didChangeValueForKey_withSetMutation_usingObjects_,
-        key.pointer,
+        key.ref.pointer,
         mutationKind.value,
-        objects.pointer);
+        objects.ref.pointer);
   }
 
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSObject,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSObject,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 
   /// observationInfo
   ffi.Pointer<ffi.Void> get observationInfo {
-    return _objc_msgSend_35(this.pointer, _sel_observationInfo);
+    return _objc_msgSend_35(this.ref.pointer, _sel_observationInfo);
   }
 
   /// setObservationInfo:
   set observationInfo(ffi.Pointer<ffi.Void> value) {
-    return _objc_msgSend_247(this.pointer, _sel_setObservationInfo_, value);
+    return _objc_msgSend_247(this.ref.pointer, _sel_setObservationInfo_, value);
   }
 }
 
@@ -453,7 +459,7 @@ class Protocol extends objc.ObjCObjectBase {
 
   /// Constructs a [Protocol] that points to the same underlying object as [other].
   Protocol.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [Protocol] that wraps the given raw object pointer.
   Protocol.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -462,7 +468,8 @@ class Protocol extends objc.ObjCObjectBase {
 
   /// Returns whether [obj] is an instance of [Protocol].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_0(obj.pointer, _sel_isKindOfClass_, _class_Protocol);
+    return _objc_msgSend_0(
+        obj.ref.pointer, _sel_isKindOfClass_, _class_Protocol);
   }
 }
 
@@ -537,7 +544,7 @@ class NSInvocation extends objc.ObjCObjectBase {
 
   /// Constructs a [NSInvocation] that points to the same underlying object as [other].
   NSInvocation.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSInvocation] that wraps the given raw object pointer.
   NSInvocation.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -547,7 +554,7 @@ class NSInvocation extends objc.ObjCObjectBase {
   /// Returns whether [obj] is an instance of [NSInvocation].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_NSInvocation);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSInvocation);
   }
 }
 
@@ -572,7 +579,7 @@ class NSMethodSignature extends NSObject {
 
   /// Constructs a [NSMethodSignature] that points to the same underlying object as [other].
   NSMethodSignature.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSMethodSignature] that wraps the given raw object pointer.
   NSMethodSignature.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -582,7 +589,7 @@ class NSMethodSignature extends NSObject {
   /// Returns whether [obj] is an instance of [NSMethodSignature].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_NSMethodSignature);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSMethodSignature);
   }
 
   /// signatureWithObjCTypes:
@@ -597,38 +604,40 @@ class NSMethodSignature extends NSObject {
 
   /// numberOfArguments
   int get numberOfArguments {
-    return _objc_msgSend_11(this.pointer, _sel_numberOfArguments);
+    return _objc_msgSend_11(this.ref.pointer, _sel_numberOfArguments);
   }
 
   /// getArgumentTypeAtIndex:
   ffi.Pointer<ffi.Char> getArgumentTypeAtIndex_(int idx) {
-    return _objc_msgSend_12(this.pointer, _sel_getArgumentTypeAtIndex_, idx);
+    return _objc_msgSend_12(
+        this.ref.pointer, _sel_getArgumentTypeAtIndex_, idx);
   }
 
   /// frameLength
   int get frameLength {
-    return _objc_msgSend_11(this.pointer, _sel_frameLength);
+    return _objc_msgSend_11(this.ref.pointer, _sel_frameLength);
   }
 
   /// isOneway
   bool isOneway() {
-    return _objc_msgSend_13(this.pointer, _sel_isOneway);
+    return _objc_msgSend_13(this.ref.pointer, _sel_isOneway);
   }
 
   /// methodReturnType
   ffi.Pointer<ffi.Char> get methodReturnType {
-    return _objc_msgSend_14(this.pointer, _sel_methodReturnType);
+    return _objc_msgSend_14(this.ref.pointer, _sel_methodReturnType);
   }
 
   /// methodReturnLength
   int get methodReturnLength {
-    return _objc_msgSend_11(this.pointer, _sel_methodReturnLength);
+    return _objc_msgSend_11(this.ref.pointer, _sel_methodReturnLength);
   }
 
   /// init
   NSMethodSignature init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSMethodSignature.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSMethodSignature.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// new
@@ -656,14 +665,14 @@ class NSMethodSignature extends NSObject {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSMethodSignature,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSMethodSignature,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -726,7 +735,7 @@ class NSSet extends NSObject {
 
   /// Constructs a [NSSet] that points to the same underlying object as [other].
   NSSet.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSSet] that wraps the given raw object pointer.
   NSSet.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -735,17 +744,18 @@ class NSSet extends NSObject {
 
   /// Returns whether [obj] is an instance of [NSSet].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_0(obj.pointer, _sel_isKindOfClass_, _class_NSSet);
+    return _objc_msgSend_0(obj.ref.pointer, _sel_isKindOfClass_, _class_NSSet);
   }
 
   /// count
   int get count {
-    return _objc_msgSend_11(this.pointer, _sel_count);
+    return _objc_msgSend_11(this.ref.pointer, _sel_count);
   }
 
   /// member:
   objc.ObjCObjectBase? member_(objc.ObjCObjectBase object) {
-    final _ret = _objc_msgSend_15(this.pointer, _sel_member_, object.pointer);
+    final _ret =
+        _objc_msgSend_15(this.ref.pointer, _sel_member_, object.ref.pointer);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -753,42 +763,42 @@ class NSSet extends NSObject {
 
   /// objectEnumerator
   NSEnumerator objectEnumerator() {
-    final _ret = _objc_msgSend_110(this.pointer, _sel_objectEnumerator);
+    final _ret = _objc_msgSend_110(this.ref.pointer, _sel_objectEnumerator);
     return NSEnumerator.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// init
   NSSet init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithObjects:count:
   NSSet initWithObjects_count_(
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
-    final _ret = _objc_msgSend_100(
-        this.pointer, _sel_initWithObjects_count_, objects, cnt);
-    return NSSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_100(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_count_, objects, cnt);
+    return NSSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
   NSSet? initWithCoder_(NSCoder coder) {
-    final _ret =
-        _objc_msgSend_18(this.pointer, _sel_initWithCoder_, coder.pointer);
+    final _ret = _objc_msgSend_18(this.ref.retainAndReturnPointer(),
+        _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSSet.castFromPointer(_ret, retain: true, release: true);
+        : NSSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// allObjects
   NSArray get allObjects {
-    final _ret = _objc_msgSend_142(this.pointer, _sel_allObjects);
+    final _ret = _objc_msgSend_142(this.ref.pointer, _sel_allObjects);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// anyObject
   objc.ObjCObjectBase? anyObject() {
-    final _ret = _objc_msgSend_16(this.pointer, _sel_anyObject);
+    final _ret = _objc_msgSend_16(this.ref.pointer, _sel_anyObject);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -797,70 +807,74 @@ class NSSet extends NSObject {
   /// containsObject:
   bool containsObject_(objc.ObjCObjectBase anObject) {
     return _objc_msgSend_0(
-        this.pointer, _sel_containsObject_, anObject.pointer);
+        this.ref.pointer, _sel_containsObject_, anObject.ref.pointer);
   }
 
   /// description
   NSString get description {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_description);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_description);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// descriptionWithLocale:
   NSString descriptionWithLocale_(objc.ObjCObjectBase? locale) {
-    final _ret = _objc_msgSend_86(this.pointer, _sel_descriptionWithLocale_,
-        locale?.pointer ?? ffi.nullptr);
+    final _ret = _objc_msgSend_86(this.ref.pointer, _sel_descriptionWithLocale_,
+        locale?.ref.pointer ?? ffi.nullptr);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// intersectsSet:
   bool intersectsSet_(NSSet otherSet) {
     return _objc_msgSend_234(
-        this.pointer, _sel_intersectsSet_, otherSet.pointer);
+        this.ref.pointer, _sel_intersectsSet_, otherSet.ref.pointer);
   }
 
   /// isEqualToSet:
   bool isEqualToSet_(NSSet otherSet) {
     return _objc_msgSend_234(
-        this.pointer, _sel_isEqualToSet_, otherSet.pointer);
+        this.ref.pointer, _sel_isEqualToSet_, otherSet.ref.pointer);
   }
 
   /// isSubsetOfSet:
   bool isSubsetOfSet_(NSSet otherSet) {
     return _objc_msgSend_234(
-        this.pointer, _sel_isSubsetOfSet_, otherSet.pointer);
+        this.ref.pointer, _sel_isSubsetOfSet_, otherSet.ref.pointer);
   }
 
   /// makeObjectsPerformSelector:
   void makeObjectsPerformSelector_(ffi.Pointer<objc.ObjCSelector> aSelector) {
-    _objc_msgSend_7(this.pointer, _sel_makeObjectsPerformSelector_, aSelector);
+    _objc_msgSend_7(
+        this.ref.pointer, _sel_makeObjectsPerformSelector_, aSelector);
   }
 
   /// makeObjectsPerformSelector:withObject:
   void makeObjectsPerformSelector_withObject_(
       ffi.Pointer<objc.ObjCSelector> aSelector, objc.ObjCObjectBase? argument) {
-    _objc_msgSend_116(this.pointer, _sel_makeObjectsPerformSelector_withObject_,
-        aSelector, argument?.pointer ?? ffi.nullptr);
+    _objc_msgSend_116(
+        this.ref.pointer,
+        _sel_makeObjectsPerformSelector_withObject_,
+        aSelector,
+        argument?.ref.pointer ?? ffi.nullptr);
   }
 
   /// setByAddingObject:
   NSSet setByAddingObject_(objc.ObjCObjectBase anObject) {
     final _ret = _objc_msgSend_235(
-        this.pointer, _sel_setByAddingObject_, anObject.pointer);
+        this.ref.pointer, _sel_setByAddingObject_, anObject.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// setByAddingObjectsFromSet:
   NSSet setByAddingObjectsFromSet_(NSSet other) {
     final _ret = _objc_msgSend_236(
-        this.pointer, _sel_setByAddingObjectsFromSet_, other.pointer);
+        this.ref.pointer, _sel_setByAddingObjectsFromSet_, other.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// setByAddingObjectsFromArray:
   NSSet setByAddingObjectsFromArray_(NSArray other) {
     final _ret = _objc_msgSend_237(
-        this.pointer, _sel_setByAddingObjectsFromArray_, other.pointer);
+        this.ref.pointer, _sel_setByAddingObjectsFromArray_, other.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -872,8 +886,8 @@ class NSSet extends NSObject {
 
   /// setWithObject:
   static NSSet setWithObject_(objc.ObjCObjectBase object) {
-    final _ret =
-        _objc_msgSend_126(_class_NSSet, _sel_setWithObject_, object.pointer);
+    final _ret = _objc_msgSend_126(
+        _class_NSSet, _sel_setWithObject_, object.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -887,50 +901,51 @@ class NSSet extends NSObject {
 
   /// setWithObjects:
   static NSSet setWithObjects_(objc.ObjCObjectBase firstObj) {
-    final _ret =
-        _objc_msgSend_126(_class_NSSet, _sel_setWithObjects_, firstObj.pointer);
+    final _ret = _objc_msgSend_126(
+        _class_NSSet, _sel_setWithObjects_, firstObj.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// setWithSet:
   static NSSet setWithSet_(NSSet set) {
-    final _ret = _objc_msgSend_238(_class_NSSet, _sel_setWithSet_, set.pointer);
+    final _ret =
+        _objc_msgSend_238(_class_NSSet, _sel_setWithSet_, set.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// setWithArray:
   static NSSet setWithArray_(NSArray array) {
     final _ret =
-        _objc_msgSend_127(_class_NSSet, _sel_setWithArray_, array.pointer);
+        _objc_msgSend_127(_class_NSSet, _sel_setWithArray_, array.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// initWithObjects:
   NSSet initWithObjects_(objc.ObjCObjectBase firstObj) {
-    final _ret = _objc_msgSend_126(
-        this.pointer, _sel_initWithObjects_, firstObj.pointer);
-    return NSSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_126(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_, firstObj.ref.pointer);
+    return NSSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithSet:
   NSSet initWithSet_(NSSet set) {
-    final _ret =
-        _objc_msgSend_238(this.pointer, _sel_initWithSet_, set.pointer);
-    return NSSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_238(
+        this.ref.retainAndReturnPointer(), _sel_initWithSet_, set.ref.pointer);
+    return NSSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithSet:copyItems:
   NSSet initWithSet_copyItems_(NSSet set, bool flag) {
-    final _ret = _objc_msgSend_239(
-        this.pointer, _sel_initWithSet_copyItems_, set.pointer, flag);
+    final _ret = _objc_msgSend_239(this.ref.retainAndReturnPointer(),
+        _sel_initWithSet_copyItems_, set.ref.pointer, flag);
     return NSSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithArray:
   NSSet initWithArray_(NSArray array) {
-    final _ret =
-        _objc_msgSend_127(this.pointer, _sel_initWithArray_, array.pointer);
-    return NSSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_127(this.ref.retainAndReturnPointer(),
+        _sel_initWithArray_, array.ref.pointer);
+    return NSSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// addObserver:forKeyPath:options:context:
@@ -940,10 +955,10 @@ class NSSet extends NSObject {
       NSKeyValueObservingOptions options,
       ffi.Pointer<ffi.Void> context) {
     _objc_msgSend_138(
-        this.pointer,
+        this.ref.pointer,
         _sel_addObserver_forKeyPath_options_context_,
-        observer.pointer,
-        keyPath.pointer,
+        observer.ref.pointer,
+        keyPath.ref.pointer,
         options.value,
         context);
   }
@@ -951,14 +966,14 @@ class NSSet extends NSObject {
   /// removeObserver:forKeyPath:context:
   void removeObserver_forKeyPath_context_(
       NSObject observer, NSString keyPath, ffi.Pointer<ffi.Void> context) {
-    _objc_msgSend_139(this.pointer, _sel_removeObserver_forKeyPath_context_,
-        observer.pointer, keyPath.pointer, context);
+    _objc_msgSend_139(this.ref.pointer, _sel_removeObserver_forKeyPath_context_,
+        observer.ref.pointer, keyPath.ref.pointer, context);
   }
 
   /// removeObserver:forKeyPath:
   void removeObserver_forKeyPath_(NSObject observer, NSString keyPath) {
-    _objc_msgSend_140(this.pointer, _sel_removeObserver_forKeyPath_,
-        observer.pointer, keyPath.pointer);
+    _objc_msgSend_140(this.ref.pointer, _sel_removeObserver_forKeyPath_,
+        observer.ref.pointer, keyPath.ref.pointer);
   }
 
   /// new
@@ -981,15 +996,15 @@ class NSSet extends NSObject {
 
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
-    final _ret = _objc_msgSend_95(
-        _class_NSSet, _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+    final _ret = _objc_msgSend_95(_class_NSSet,
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
-    return _objc_msgSend_26(
-        _class_NSSet, _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+    return _objc_msgSend_26(_class_NSSet,
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -1015,7 +1030,7 @@ class NSEnumerator extends NSObject {
 
   /// Constructs a [NSEnumerator] that points to the same underlying object as [other].
   NSEnumerator.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSEnumerator] that wraps the given raw object pointer.
   NSEnumerator.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -1025,12 +1040,12 @@ class NSEnumerator extends NSObject {
   /// Returns whether [obj] is an instance of [NSEnumerator].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_NSEnumerator);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSEnumerator);
   }
 
   /// nextObject
   objc.ObjCObjectBase? nextObject() {
-    final _ret = _objc_msgSend_16(this.pointer, _sel_nextObject);
+    final _ret = _objc_msgSend_16(this.ref.pointer, _sel_nextObject);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -1038,14 +1053,14 @@ class NSEnumerator extends NSObject {
 
   /// allObjects
   objc.ObjCObjectBase get allObjects {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_allObjects);
+    final _ret = _objc_msgSend_2(this.ref.pointer, _sel_allObjects);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
   /// init
   NSEnumerator init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSEnumerator.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSEnumerator.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// new
@@ -1070,14 +1085,14 @@ class NSEnumerator extends NSObject {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSEnumerator,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSEnumerator,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -1115,7 +1130,7 @@ class NSString extends NSObject {
 
   /// Constructs a [NSString] that points to the same underlying object as [other].
   NSString.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSString] that wraps the given raw object pointer.
   NSString.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -1124,78 +1139,82 @@ class NSString extends NSObject {
 
   /// Returns whether [obj] is an instance of [NSString].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_0(obj.pointer, _sel_isKindOfClass_, _class_NSString);
+    return _objc_msgSend_0(
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSString);
   }
 
   /// length
   int get length {
-    return _objc_msgSend_11(this.pointer, _sel_length);
+    return _objc_msgSend_11(this.ref.pointer, _sel_length);
   }
 
   /// characterAtIndex:
   int characterAtIndex_(int index) {
-    return _objc_msgSend_17(this.pointer, _sel_characterAtIndex_, index);
+    return _objc_msgSend_17(this.ref.pointer, _sel_characterAtIndex_, index);
   }
 
   /// init
   NSString init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSString.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
   NSString? initWithCoder_(NSCoder coder) {
-    final _ret =
-        _objc_msgSend_18(this.pointer, _sel_initWithCoder_, coder.pointer);
+    final _ret = _objc_msgSend_18(this.ref.retainAndReturnPointer(),
+        _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSString.castFromPointer(_ret, retain: true, release: true);
+        : NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// substringFromIndex:
   NSString substringFromIndex_(int from) {
-    final _ret = _objc_msgSend_19(this.pointer, _sel_substringFromIndex_, from);
+    final _ret =
+        _objc_msgSend_19(this.ref.pointer, _sel_substringFromIndex_, from);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// substringToIndex:
   NSString substringToIndex_(int to) {
-    final _ret = _objc_msgSend_19(this.pointer, _sel_substringToIndex_, to);
+    final _ret = _objc_msgSend_19(this.ref.pointer, _sel_substringToIndex_, to);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// substringWithRange:
   NSString substringWithRange_(NSRange range) {
     final _ret =
-        _objc_msgSend_20(this.pointer, _sel_substringWithRange_, range);
+        _objc_msgSend_20(this.ref.pointer, _sel_substringWithRange_, range);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// getCharacters:range:
   void getCharacters_range_(
       ffi.Pointer<ffi.UnsignedShort> buffer, NSRange range) {
-    _objc_msgSend_21(this.pointer, _sel_getCharacters_range_, buffer, range);
+    _objc_msgSend_21(
+        this.ref.pointer, _sel_getCharacters_range_, buffer, range);
   }
 
   /// compare:
   NSComparisonResult compare_(NSString string) {
-    final _ret = _objc_msgSend_22(this.pointer, _sel_compare_, string.pointer);
+    final _ret =
+        _objc_msgSend_22(this.ref.pointer, _sel_compare_, string.ref.pointer);
     return NSComparisonResult.fromValue(_ret);
   }
 
   /// compare:options:
   NSComparisonResult compare_options_(
       NSString string, NSStringCompareOptions mask) {
-    final _ret = _objc_msgSend_23(
-        this.pointer, _sel_compare_options_, string.pointer, mask.value);
+    final _ret = _objc_msgSend_23(this.ref.pointer, _sel_compare_options_,
+        string.ref.pointer, mask.value);
     return NSComparisonResult.fromValue(_ret);
   }
 
   /// compare:options:range:
   NSComparisonResult compare_options_range_(NSString string,
       NSStringCompareOptions mask, NSRange rangeOfReceiverToCompare) {
-    final _ret = _objc_msgSend_24(this.pointer, _sel_compare_options_range_,
-        string.pointer, mask.value, rangeOfReceiverToCompare);
+    final _ret = _objc_msgSend_24(this.ref.pointer, _sel_compare_options_range_,
+        string.ref.pointer, mask.value, rangeOfReceiverToCompare);
     return NSComparisonResult.fromValue(_ret);
   }
 
@@ -1206,111 +1225,112 @@ class NSString extends NSObject {
       NSRange rangeOfReceiverToCompare,
       objc.ObjCObjectBase? locale) {
     final _ret = _objc_msgSend_25(
-        this.pointer,
+        this.ref.pointer,
         _sel_compare_options_range_locale_,
-        string.pointer,
+        string.ref.pointer,
         mask.value,
         rangeOfReceiverToCompare,
-        locale?.pointer ?? ffi.nullptr);
+        locale?.ref.pointer ?? ffi.nullptr);
     return NSComparisonResult.fromValue(_ret);
   }
 
   /// caseInsensitiveCompare:
   NSComparisonResult caseInsensitiveCompare_(NSString string) {
     final _ret = _objc_msgSend_22(
-        this.pointer, _sel_caseInsensitiveCompare_, string.pointer);
+        this.ref.pointer, _sel_caseInsensitiveCompare_, string.ref.pointer);
     return NSComparisonResult.fromValue(_ret);
   }
 
   /// localizedCompare:
   NSComparisonResult localizedCompare_(NSString string) {
-    final _ret =
-        _objc_msgSend_22(this.pointer, _sel_localizedCompare_, string.pointer);
+    final _ret = _objc_msgSend_22(
+        this.ref.pointer, _sel_localizedCompare_, string.ref.pointer);
     return NSComparisonResult.fromValue(_ret);
   }
 
   /// localizedCaseInsensitiveCompare:
   NSComparisonResult localizedCaseInsensitiveCompare_(NSString string) {
-    final _ret = _objc_msgSend_22(
-        this.pointer, _sel_localizedCaseInsensitiveCompare_, string.pointer);
+    final _ret = _objc_msgSend_22(this.ref.pointer,
+        _sel_localizedCaseInsensitiveCompare_, string.ref.pointer);
     return NSComparisonResult.fromValue(_ret);
   }
 
   /// localizedStandardCompare:
   NSComparisonResult localizedStandardCompare_(NSString string) {
     final _ret = _objc_msgSend_22(
-        this.pointer, _sel_localizedStandardCompare_, string.pointer);
+        this.ref.pointer, _sel_localizedStandardCompare_, string.ref.pointer);
     return NSComparisonResult.fromValue(_ret);
   }
 
   /// isEqualToString:
   bool isEqualToString_(NSString aString) {
     return _objc_msgSend_26(
-        this.pointer, _sel_isEqualToString_, aString.pointer);
+        this.ref.pointer, _sel_isEqualToString_, aString.ref.pointer);
   }
 
   /// hasPrefix:
   bool hasPrefix_(NSString str) {
-    return _objc_msgSend_26(this.pointer, _sel_hasPrefix_, str.pointer);
+    return _objc_msgSend_26(this.ref.pointer, _sel_hasPrefix_, str.ref.pointer);
   }
 
   /// hasSuffix:
   bool hasSuffix_(NSString str) {
-    return _objc_msgSend_26(this.pointer, _sel_hasSuffix_, str.pointer);
+    return _objc_msgSend_26(this.ref.pointer, _sel_hasSuffix_, str.ref.pointer);
   }
 
   /// commonPrefixWithString:options:
   NSString commonPrefixWithString_options_(
       NSString str, NSStringCompareOptions mask) {
-    final _ret = _objc_msgSend_27(this.pointer,
-        _sel_commonPrefixWithString_options_, str.pointer, mask.value);
+    final _ret = _objc_msgSend_27(this.ref.pointer,
+        _sel_commonPrefixWithString_options_, str.ref.pointer, mask.value);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// containsString:
   bool containsString_(NSString str) {
-    return _objc_msgSend_26(this.pointer, _sel_containsString_, str.pointer);
+    return _objc_msgSend_26(
+        this.ref.pointer, _sel_containsString_, str.ref.pointer);
   }
 
   /// localizedCaseInsensitiveContainsString:
   bool localizedCaseInsensitiveContainsString_(NSString str) {
-    return _objc_msgSend_26(this.pointer,
-        _sel_localizedCaseInsensitiveContainsString_, str.pointer);
+    return _objc_msgSend_26(this.ref.pointer,
+        _sel_localizedCaseInsensitiveContainsString_, str.ref.pointer);
   }
 
   /// localizedStandardContainsString:
   bool localizedStandardContainsString_(NSString str) {
-    return _objc_msgSend_26(
-        this.pointer, _sel_localizedStandardContainsString_, str.pointer);
+    return _objc_msgSend_26(this.ref.pointer,
+        _sel_localizedStandardContainsString_, str.ref.pointer);
   }
 
   /// localizedStandardRangeOfString:
   void localizedStandardRangeOfString_(
       ffi.Pointer<NSRange> stret, NSString str) {
     objc.useMsgSendVariants
-        ? _objc_msgSend_28Stret(stret, this.pointer,
-            _sel_localizedStandardRangeOfString_, str.pointer)
-        : stret.ref = _objc_msgSend_28(
-            this.pointer, _sel_localizedStandardRangeOfString_, str.pointer);
+        ? _objc_msgSend_28Stret(stret, this.ref.pointer,
+            _sel_localizedStandardRangeOfString_, str.ref.pointer)
+        : stret.ref = _objc_msgSend_28(this.ref.pointer,
+            _sel_localizedStandardRangeOfString_, str.ref.pointer);
   }
 
   /// rangeOfString:
   void rangeOfString_(ffi.Pointer<NSRange> stret, NSString searchString) {
     objc.useMsgSendVariants
-        ? _objc_msgSend_28Stret(
-            stret, this.pointer, _sel_rangeOfString_, searchString.pointer)
+        ? _objc_msgSend_28Stret(stret, this.ref.pointer, _sel_rangeOfString_,
+            searchString.ref.pointer)
         : stret.ref = _objc_msgSend_28(
-            this.pointer, _sel_rangeOfString_, searchString.pointer);
+            this.ref.pointer, _sel_rangeOfString_, searchString.ref.pointer);
   }
 
   /// rangeOfString:options:
   void rangeOfString_options_(ffi.Pointer<NSRange> stret, NSString searchString,
       NSStringCompareOptions mask) {
     objc.useMsgSendVariants
-        ? _objc_msgSend_29Stret(stret, this.pointer,
-            _sel_rangeOfString_options_, searchString.pointer, mask.value)
-        : stret.ref = _objc_msgSend_29(this.pointer,
-            _sel_rangeOfString_options_, searchString.pointer, mask.value);
+        ? _objc_msgSend_29Stret(stret, this.ref.pointer,
+            _sel_rangeOfString_options_, searchString.ref.pointer, mask.value)
+        : stret.ref = _objc_msgSend_29(this.ref.pointer,
+            _sel_rangeOfString_options_, searchString.ref.pointer, mask.value);
   }
 
   /// rangeOfString:options:range:
@@ -1322,15 +1342,15 @@ class NSString extends NSObject {
     objc.useMsgSendVariants
         ? _objc_msgSend_30Stret(
             stret,
-            this.pointer,
+            this.ref.pointer,
             _sel_rangeOfString_options_range_,
-            searchString.pointer,
+            searchString.ref.pointer,
             mask.value,
             rangeOfReceiverToSearch)
         : stret.ref = _objc_msgSend_30(
-            this.pointer,
+            this.ref.pointer,
             _sel_rangeOfString_options_range_,
-            searchString.pointer,
+            searchString.ref.pointer,
             mask.value,
             rangeOfReceiverToSearch);
   }
@@ -1345,29 +1365,29 @@ class NSString extends NSObject {
     objc.useMsgSendVariants
         ? _objc_msgSend_31Stret(
             stret,
-            this.pointer,
+            this.ref.pointer,
             _sel_rangeOfString_options_range_locale_,
-            searchString.pointer,
+            searchString.ref.pointer,
             mask.value,
             rangeOfReceiverToSearch,
-            locale?.pointer ?? ffi.nullptr)
+            locale?.ref.pointer ?? ffi.nullptr)
         : stret.ref = _objc_msgSend_31(
-            this.pointer,
+            this.ref.pointer,
             _sel_rangeOfString_options_range_locale_,
-            searchString.pointer,
+            searchString.ref.pointer,
             mask.value,
             rangeOfReceiverToSearch,
-            locale?.pointer ?? ffi.nullptr);
+            locale?.ref.pointer ?? ffi.nullptr);
   }
 
   /// rangeOfCharacterFromSet:
   void rangeOfCharacterFromSet_(
       ffi.Pointer<NSRange> stret, NSCharacterSet searchSet) {
     objc.useMsgSendVariants
-        ? _objc_msgSend_193Stret(stret, this.pointer,
-            _sel_rangeOfCharacterFromSet_, searchSet.pointer)
-        : stret.ref = _objc_msgSend_193(
-            this.pointer, _sel_rangeOfCharacterFromSet_, searchSet.pointer);
+        ? _objc_msgSend_193Stret(stret, this.ref.pointer,
+            _sel_rangeOfCharacterFromSet_, searchSet.ref.pointer)
+        : stret.ref = _objc_msgSend_193(this.ref.pointer,
+            _sel_rangeOfCharacterFromSet_, searchSet.ref.pointer);
   }
 
   /// rangeOfCharacterFromSet:options:
@@ -1376,14 +1396,14 @@ class NSString extends NSObject {
     objc.useMsgSendVariants
         ? _objc_msgSend_194Stret(
             stret,
-            this.pointer,
+            this.ref.pointer,
             _sel_rangeOfCharacterFromSet_options_,
-            searchSet.pointer,
+            searchSet.ref.pointer,
             mask.value)
         : stret.ref = _objc_msgSend_194(
-            this.pointer,
+            this.ref.pointer,
             _sel_rangeOfCharacterFromSet_options_,
-            searchSet.pointer,
+            searchSet.ref.pointer,
             mask.value);
   }
 
@@ -1396,15 +1416,15 @@ class NSString extends NSObject {
     objc.useMsgSendVariants
         ? _objc_msgSend_195Stret(
             stret,
-            this.pointer,
+            this.ref.pointer,
             _sel_rangeOfCharacterFromSet_options_range_,
-            searchSet.pointer,
+            searchSet.ref.pointer,
             mask.value,
             rangeOfReceiverToSearch)
         : stret.ref = _objc_msgSend_195(
-            this.pointer,
+            this.ref.pointer,
             _sel_rangeOfCharacterFromSet_options_range_,
-            searchSet.pointer,
+            searchSet.ref.pointer,
             mask.value,
             rangeOfReceiverToSearch);
   }
@@ -1413,125 +1433,127 @@ class NSString extends NSObject {
   void rangeOfComposedCharacterSequenceAtIndex_(
       ffi.Pointer<NSRange> stret, int index) {
     objc.useMsgSendVariants
-        ? _objc_msgSend_196Stret(stret, this.pointer,
+        ? _objc_msgSend_196Stret(stret, this.ref.pointer,
             _sel_rangeOfComposedCharacterSequenceAtIndex_, index)
-        : stret.ref = _objc_msgSend_196(
-            this.pointer, _sel_rangeOfComposedCharacterSequenceAtIndex_, index);
+        : stret.ref = _objc_msgSend_196(this.ref.pointer,
+            _sel_rangeOfComposedCharacterSequenceAtIndex_, index);
   }
 
   /// rangeOfComposedCharacterSequencesForRange:
   void rangeOfComposedCharacterSequencesForRange_(
       ffi.Pointer<NSRange> stret, NSRange range) {
     objc.useMsgSendVariants
-        ? _objc_msgSend_197Stret(stret, this.pointer,
+        ? _objc_msgSend_197Stret(stret, this.ref.pointer,
             _sel_rangeOfComposedCharacterSequencesForRange_, range)
-        : stret.ref = _objc_msgSend_197(this.pointer,
+        : stret.ref = _objc_msgSend_197(this.ref.pointer,
             _sel_rangeOfComposedCharacterSequencesForRange_, range);
   }
 
   /// stringByAppendingString:
   NSString stringByAppendingString_(NSString aString) {
     final _ret = _objc_msgSend_103(
-        this.pointer, _sel_stringByAppendingString_, aString.pointer);
+        this.ref.pointer, _sel_stringByAppendingString_, aString.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringByAppendingFormat:
   NSString stringByAppendingFormat_(NSString format) {
     final _ret = _objc_msgSend_103(
-        this.pointer, _sel_stringByAppendingFormat_, format.pointer);
+        this.ref.pointer, _sel_stringByAppendingFormat_, format.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// doubleValue
   double get doubleValue {
     return objc.useMsgSendVariants
-        ? _objc_msgSend_83Fpret(this.pointer, _sel_doubleValue)
-        : _objc_msgSend_83(this.pointer, _sel_doubleValue);
+        ? _objc_msgSend_83Fpret(this.ref.pointer, _sel_doubleValue)
+        : _objc_msgSend_83(this.ref.pointer, _sel_doubleValue);
   }
 
   /// floatValue
   double get floatValue {
     return objc.useMsgSendVariants
-        ? _objc_msgSend_82Fpret(this.pointer, _sel_floatValue)
-        : _objc_msgSend_82(this.pointer, _sel_floatValue);
+        ? _objc_msgSend_82Fpret(this.ref.pointer, _sel_floatValue)
+        : _objc_msgSend_82(this.ref.pointer, _sel_floatValue);
   }
 
   /// intValue
   int get intValue {
-    return _objc_msgSend_77(this.pointer, _sel_intValue);
+    return _objc_msgSend_77(this.ref.pointer, _sel_intValue);
   }
 
   /// integerValue
   int get integerValue {
-    return _objc_msgSend_79(this.pointer, _sel_integerValue);
+    return _objc_msgSend_79(this.ref.pointer, _sel_integerValue);
   }
 
   /// longLongValue
   int get longLongValue {
-    return _objc_msgSend_80(this.pointer, _sel_longLongValue);
+    return _objc_msgSend_80(this.ref.pointer, _sel_longLongValue);
   }
 
   /// boolValue
   bool get boolValue {
-    return _objc_msgSend_13(this.pointer, _sel_boolValue);
+    return _objc_msgSend_13(this.ref.pointer, _sel_boolValue);
   }
 
   /// uppercaseString
   NSString get uppercaseString {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_uppercaseString);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_uppercaseString);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// lowercaseString
   NSString get lowercaseString {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_lowercaseString);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_lowercaseString);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// capitalizedString
   NSString get capitalizedString {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_capitalizedString);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_capitalizedString);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// localizedUppercaseString
   NSString get localizedUppercaseString {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_localizedUppercaseString);
+    final _ret =
+        _objc_msgSend_36(this.ref.pointer, _sel_localizedUppercaseString);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// localizedLowercaseString
   NSString get localizedLowercaseString {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_localizedLowercaseString);
+    final _ret =
+        _objc_msgSend_36(this.ref.pointer, _sel_localizedLowercaseString);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// localizedCapitalizedString
   NSString get localizedCapitalizedString {
     final _ret =
-        _objc_msgSend_36(this.pointer, _sel_localizedCapitalizedString);
+        _objc_msgSend_36(this.ref.pointer, _sel_localizedCapitalizedString);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// uppercaseStringWithLocale:
   NSString uppercaseStringWithLocale_(NSLocale? locale) {
-    final _ret = _objc_msgSend_198(this.pointer,
-        _sel_uppercaseStringWithLocale_, locale?.pointer ?? ffi.nullptr);
+    final _ret = _objc_msgSend_198(this.ref.pointer,
+        _sel_uppercaseStringWithLocale_, locale?.ref.pointer ?? ffi.nullptr);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// lowercaseStringWithLocale:
   NSString lowercaseStringWithLocale_(NSLocale? locale) {
-    final _ret = _objc_msgSend_198(this.pointer,
-        _sel_lowercaseStringWithLocale_, locale?.pointer ?? ffi.nullptr);
+    final _ret = _objc_msgSend_198(this.ref.pointer,
+        _sel_lowercaseStringWithLocale_, locale?.ref.pointer ?? ffi.nullptr);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// capitalizedStringWithLocale:
   NSString capitalizedStringWithLocale_(NSLocale? locale) {
-    final _ret = _objc_msgSend_198(this.pointer,
-        _sel_capitalizedStringWithLocale_, locale?.pointer ?? ffi.nullptr);
+    final _ret = _objc_msgSend_198(this.ref.pointer,
+        _sel_capitalizedStringWithLocale_, locale?.ref.pointer ?? ffi.nullptr);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -1541,17 +1563,22 @@ class NSString extends NSObject {
       ffi.Pointer<ffi.UnsignedLong> lineEndPtr,
       ffi.Pointer<ffi.UnsignedLong> contentsEndPtr,
       NSRange range) {
-    _objc_msgSend_199(this.pointer, _sel_getLineStart_end_contentsEnd_forRange_,
-        startPtr, lineEndPtr, contentsEndPtr, range);
+    _objc_msgSend_199(
+        this.ref.pointer,
+        _sel_getLineStart_end_contentsEnd_forRange_,
+        startPtr,
+        lineEndPtr,
+        contentsEndPtr,
+        range);
   }
 
   /// lineRangeForRange:
   void lineRangeForRange_(ffi.Pointer<NSRange> stret, NSRange range) {
     objc.useMsgSendVariants
         ? _objc_msgSend_197Stret(
-            stret, this.pointer, _sel_lineRangeForRange_, range)
+            stret, this.ref.pointer, _sel_lineRangeForRange_, range)
         : stret.ref =
-            _objc_msgSend_197(this.pointer, _sel_lineRangeForRange_, range);
+            _objc_msgSend_197(this.ref.pointer, _sel_lineRangeForRange_, range);
   }
 
   /// getParagraphStart:end:contentsEnd:forRange:
@@ -1561,7 +1588,7 @@ class NSString extends NSObject {
       ffi.Pointer<ffi.UnsignedLong> contentsEndPtr,
       NSRange range) {
     _objc_msgSend_199(
-        this.pointer,
+        this.ref.pointer,
         _sel_getParagraphStart_end_contentsEnd_forRange_,
         startPtr,
         parEndPtr,
@@ -1573,29 +1600,29 @@ class NSString extends NSObject {
   void paragraphRangeForRange_(ffi.Pointer<NSRange> stret, NSRange range) {
     objc.useMsgSendVariants
         ? _objc_msgSend_197Stret(
-            stret, this.pointer, _sel_paragraphRangeForRange_, range)
+            stret, this.ref.pointer, _sel_paragraphRangeForRange_, range)
         : stret.ref = _objc_msgSend_197(
-            this.pointer, _sel_paragraphRangeForRange_, range);
+            this.ref.pointer, _sel_paragraphRangeForRange_, range);
   }
 
   /// UTF8String
   ffi.Pointer<ffi.Char> get UTF8String {
-    return _objc_msgSend_14(this.pointer, _sel_UTF8String);
+    return _objc_msgSend_14(this.ref.pointer, _sel_UTF8String);
   }
 
   /// fastestEncoding
   int get fastestEncoding {
-    return _objc_msgSend_11(this.pointer, _sel_fastestEncoding);
+    return _objc_msgSend_11(this.ref.pointer, _sel_fastestEncoding);
   }
 
   /// smallestEncoding
   int get smallestEncoding {
-    return _objc_msgSend_11(this.pointer, _sel_smallestEncoding);
+    return _objc_msgSend_11(this.ref.pointer, _sel_smallestEncoding);
   }
 
   /// dataUsingEncoding:allowLossyConversion:
   NSData? dataUsingEncoding_allowLossyConversion_(int encoding, bool lossy) {
-    final _ret = _objc_msgSend_200(this.pointer,
+    final _ret = _objc_msgSend_200(this.ref.pointer,
         _sel_dataUsingEncoding_allowLossyConversion_, encoding, lossy);
     return _ret.address == 0
         ? null
@@ -1605,7 +1632,7 @@ class NSString extends NSObject {
   /// dataUsingEncoding:
   NSData? dataUsingEncoding_(int encoding) {
     final _ret =
-        _objc_msgSend_201(this.pointer, _sel_dataUsingEncoding_, encoding);
+        _objc_msgSend_201(this.ref.pointer, _sel_dataUsingEncoding_, encoding);
     return _ret.address == 0
         ? null
         : NSData.castFromPointer(_ret, retain: true, release: true);
@@ -1614,19 +1641,20 @@ class NSString extends NSObject {
   /// canBeConvertedToEncoding:
   bool canBeConvertedToEncoding_(int encoding) {
     return _objc_msgSend_123(
-        this.pointer, _sel_canBeConvertedToEncoding_, encoding);
+        this.ref.pointer, _sel_canBeConvertedToEncoding_, encoding);
   }
 
   /// cStringUsingEncoding:
   ffi.Pointer<ffi.Char> cStringUsingEncoding_(int encoding) {
-    return _objc_msgSend_12(this.pointer, _sel_cStringUsingEncoding_, encoding);
+    return _objc_msgSend_12(
+        this.ref.pointer, _sel_cStringUsingEncoding_, encoding);
   }
 
   /// getCString:maxLength:encoding:
   bool getCString_maxLength_encoding_(
       ffi.Pointer<ffi.Char> buffer, int maxBufferCount, int encoding) {
-    return _objc_msgSend_202(this.pointer, _sel_getCString_maxLength_encoding_,
-        buffer, maxBufferCount, encoding);
+    return _objc_msgSend_202(this.ref.pointer,
+        _sel_getCString_maxLength_encoding_, buffer, maxBufferCount, encoding);
   }
 
   /// getBytes:maxLength:usedLength:encoding:options:range:remainingRange:
@@ -1639,7 +1667,7 @@ class NSString extends NSObject {
       NSRange range,
       ffi.Pointer<NSRange> leftover) {
     return _objc_msgSend_203(
-        this.pointer,
+        this.ref.pointer,
         _sel_getBytes_maxLength_usedLength_encoding_options_range_remainingRange_,
         buffer,
         maxBufferCount,
@@ -1653,13 +1681,13 @@ class NSString extends NSObject {
   /// maximumLengthOfBytesUsingEncoding:
   int maximumLengthOfBytesUsingEncoding_(int enc) {
     return _objc_msgSend_120(
-        this.pointer, _sel_maximumLengthOfBytesUsingEncoding_, enc);
+        this.ref.pointer, _sel_maximumLengthOfBytesUsingEncoding_, enc);
   }
 
   /// lengthOfBytesUsingEncoding:
   int lengthOfBytesUsingEncoding_(int enc) {
     return _objc_msgSend_120(
-        this.pointer, _sel_lengthOfBytesUsingEncoding_, enc);
+        this.ref.pointer, _sel_lengthOfBytesUsingEncoding_, enc);
   }
 
   /// availableStringEncodings
@@ -1682,49 +1710,49 @@ class NSString extends NSObject {
   /// decomposedStringWithCanonicalMapping
   NSString get decomposedStringWithCanonicalMapping {
     final _ret = _objc_msgSend_36(
-        this.pointer, _sel_decomposedStringWithCanonicalMapping);
+        this.ref.pointer, _sel_decomposedStringWithCanonicalMapping);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// precomposedStringWithCanonicalMapping
   NSString get precomposedStringWithCanonicalMapping {
     final _ret = _objc_msgSend_36(
-        this.pointer, _sel_precomposedStringWithCanonicalMapping);
+        this.ref.pointer, _sel_precomposedStringWithCanonicalMapping);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// decomposedStringWithCompatibilityMapping
   NSString get decomposedStringWithCompatibilityMapping {
     final _ret = _objc_msgSend_36(
-        this.pointer, _sel_decomposedStringWithCompatibilityMapping);
+        this.ref.pointer, _sel_decomposedStringWithCompatibilityMapping);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// precomposedStringWithCompatibilityMapping
   NSString get precomposedStringWithCompatibilityMapping {
     final _ret = _objc_msgSend_36(
-        this.pointer, _sel_precomposedStringWithCompatibilityMapping);
+        this.ref.pointer, _sel_precomposedStringWithCompatibilityMapping);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// componentsSeparatedByString:
   NSArray componentsSeparatedByString_(NSString separator) {
-    final _ret = _objc_msgSend_205(
-        this.pointer, _sel_componentsSeparatedByString_, separator.pointer);
+    final _ret = _objc_msgSend_205(this.ref.pointer,
+        _sel_componentsSeparatedByString_, separator.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// componentsSeparatedByCharactersInSet:
   NSArray componentsSeparatedByCharactersInSet_(NSCharacterSet separator) {
-    final _ret = _objc_msgSend_206(this.pointer,
-        _sel_componentsSeparatedByCharactersInSet_, separator.pointer);
+    final _ret = _objc_msgSend_206(this.ref.pointer,
+        _sel_componentsSeparatedByCharactersInSet_, separator.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringByTrimmingCharactersInSet:
   NSString stringByTrimmingCharactersInSet_(NSCharacterSet set) {
-    final _ret = _objc_msgSend_207(
-        this.pointer, _sel_stringByTrimmingCharactersInSet_, set.pointer);
+    final _ret = _objc_msgSend_207(this.ref.pointer,
+        _sel_stringByTrimmingCharactersInSet_, set.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -1732,10 +1760,10 @@ class NSString extends NSObject {
   NSString stringByPaddingToLength_withString_startingAtIndex_(
       int newLength, NSString padString, int padIndex) {
     final _ret = _objc_msgSend_208(
-        this.pointer,
+        this.ref.pointer,
         _sel_stringByPaddingToLength_withString_startingAtIndex_,
         newLength,
-        padString.pointer,
+        padString.ref.pointer,
         padIndex);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
@@ -1744,10 +1772,10 @@ class NSString extends NSObject {
   NSString stringByFoldingWithOptions_locale_(
       NSStringCompareOptions options, NSLocale? locale) {
     final _ret = _objc_msgSend_209(
-        this.pointer,
+        this.ref.pointer,
         _sel_stringByFoldingWithOptions_locale_,
         options.value,
-        locale?.pointer ?? ffi.nullptr);
+        locale?.ref.pointer ?? ffi.nullptr);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -1758,10 +1786,10 @@ class NSString extends NSObject {
       NSStringCompareOptions options,
       NSRange searchRange) {
     final _ret = _objc_msgSend_210(
-        this.pointer,
+        this.ref.pointer,
         _sel_stringByReplacingOccurrencesOfString_withString_options_range_,
-        target.pointer,
-        replacement.pointer,
+        target.ref.pointer,
+        replacement.ref.pointer,
         options.value,
         searchRange);
     return NSString.castFromPointer(_ret, retain: true, release: true);
@@ -1771,10 +1799,10 @@ class NSString extends NSObject {
   NSString stringByReplacingOccurrencesOfString_withString_(
       NSString target, NSString replacement) {
     final _ret = _objc_msgSend_211(
-        this.pointer,
+        this.ref.pointer,
         _sel_stringByReplacingOccurrencesOfString_withString_,
-        target.pointer,
-        replacement.pointer);
+        target.ref.pointer,
+        replacement.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -1782,18 +1810,21 @@ class NSString extends NSObject {
   NSString stringByReplacingCharactersInRange_withString_(
       NSRange range, NSString replacement) {
     final _ret = _objc_msgSend_212(
-        this.pointer,
+        this.ref.pointer,
         _sel_stringByReplacingCharactersInRange_withString_,
         range,
-        replacement.pointer);
+        replacement.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringByApplyingTransform:reverse:
   NSString? stringByApplyingTransform_reverse_(
       NSString transform, bool reverse) {
-    final _ret = _objc_msgSend_213(this.pointer,
-        _sel_stringByApplyingTransform_reverse_, transform.pointer, reverse);
+    final _ret = _objc_msgSend_213(
+        this.ref.pointer,
+        _sel_stringByApplyingTransform_reverse_,
+        transform.ref.pointer,
+        reverse);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -1803,9 +1834,9 @@ class NSString extends NSObject {
   bool writeToURL_atomically_encoding_error_(NSURL url, bool useAuxiliaryFile,
       int enc, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     return _objc_msgSend_214(
-        this.pointer,
+        this.ref.pointer,
         _sel_writeToURL_atomically_encoding_error_,
-        url.pointer,
+        url.ref.pointer,
         useAuxiliaryFile,
         enc,
         error);
@@ -1818,9 +1849,9 @@ class NSString extends NSObject {
       int enc,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     return _objc_msgSend_215(
-        this.pointer,
+        this.ref.pointer,
         _sel_writeToFile_atomically_encoding_error_,
-        path.pointer,
+        path.ref.pointer,
         useAuxiliaryFile,
         enc,
         error);
@@ -1828,20 +1859,20 @@ class NSString extends NSObject {
 
   /// description
   NSString get description {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_description);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_description);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// hash
   int get hash {
-    return _objc_msgSend_11(this.pointer, _sel_hash);
+    return _objc_msgSend_11(this.ref.pointer, _sel_hash);
   }
 
   /// initWithCharactersNoCopy:length:freeWhenDone:
   NSString initWithCharactersNoCopy_length_freeWhenDone_(
       ffi.Pointer<ffi.UnsignedShort> characters, int length, bool freeBuffer) {
     final _ret = _objc_msgSend_216(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithCharactersNoCopy_length_freeWhenDone_,
         characters,
         length,
@@ -1852,40 +1883,43 @@ class NSString extends NSObject {
   /// initWithCharacters:length:
   NSString initWithCharacters_length_(
       ffi.Pointer<ffi.UnsignedShort> characters, int length) {
-    final _ret = _objc_msgSend_217(
-        this.pointer, _sel_initWithCharacters_length_, characters, length);
-    return NSString.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_217(this.ref.retainAndReturnPointer(),
+        _sel_initWithCharacters_length_, characters, length);
+    return NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithUTF8String:
   NSString? initWithUTF8String_(ffi.Pointer<ffi.Char> nullTerminatedCString) {
-    final _ret = _objc_msgSend_218(
-        this.pointer, _sel_initWithUTF8String_, nullTerminatedCString);
+    final _ret = _objc_msgSend_218(this.ref.retainAndReturnPointer(),
+        _sel_initWithUTF8String_, nullTerminatedCString);
     return _ret.address == 0
         ? null
-        : NSString.castFromPointer(_ret, retain: true, release: true);
+        : NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithString:
   NSString initWithString_(NSString aString) {
-    final _ret =
-        _objc_msgSend_45(this.pointer, _sel_initWithString_, aString.pointer);
-    return NSString.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_45(this.ref.retainAndReturnPointer(),
+        _sel_initWithString_, aString.ref.pointer);
+    return NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithFormat:
   NSString initWithFormat_(NSString format) {
-    final _ret =
-        _objc_msgSend_45(this.pointer, _sel_initWithFormat_, format.pointer);
-    return NSString.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_45(this.ref.retainAndReturnPointer(),
+        _sel_initWithFormat_, format.ref.pointer);
+    return NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithFormat:locale:
   NSString initWithFormat_locale_(
       NSString format, objc.ObjCObjectBase? locale) {
-    final _ret = _objc_msgSend_219(this.pointer, _sel_initWithFormat_locale_,
-        format.pointer, locale?.pointer ?? ffi.nullptr);
-    return NSString.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_219(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithFormat_locale_,
+        format.ref.pointer,
+        locale?.ref.pointer ?? ffi.nullptr);
+    return NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithValidatedFormat:validFormatSpecifiers:error:
@@ -1894,14 +1928,14 @@ class NSString extends NSObject {
       NSString validFormatSpecifiers,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     final _ret = _objc_msgSend_220(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithValidatedFormat_validFormatSpecifiers_error_,
-        format.pointer,
-        validFormatSpecifiers.pointer,
+        format.ref.pointer,
+        validFormatSpecifiers.ref.pointer,
         error);
     return _ret.address == 0
         ? null
-        : NSString.castFromPointer(_ret, retain: true, release: true);
+        : NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithValidatedFormat:validFormatSpecifiers:locale:error:
@@ -1911,41 +1945,41 @@ class NSString extends NSObject {
       objc.ObjCObjectBase? locale,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     final _ret = _objc_msgSend_221(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithValidatedFormat_validFormatSpecifiers_locale_error_,
-        format.pointer,
-        validFormatSpecifiers.pointer,
-        locale?.pointer ?? ffi.nullptr,
+        format.ref.pointer,
+        validFormatSpecifiers.ref.pointer,
+        locale?.ref.pointer ?? ffi.nullptr,
         error);
     return _ret.address == 0
         ? null
-        : NSString.castFromPointer(_ret, retain: true, release: true);
+        : NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithData:encoding:
   NSString? initWithData_encoding_(NSData data, int encoding) {
-    final _ret = _objc_msgSend_222(
-        this.pointer, _sel_initWithData_encoding_, data.pointer, encoding);
+    final _ret = _objc_msgSend_222(this.ref.retainAndReturnPointer(),
+        _sel_initWithData_encoding_, data.ref.pointer, encoding);
     return _ret.address == 0
         ? null
-        : NSString.castFromPointer(_ret, retain: true, release: true);
+        : NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBytes:length:encoding:
   NSString? initWithBytes_length_encoding_(
       ffi.Pointer<ffi.Void> bytes, int len, int encoding) {
-    final _ret = _objc_msgSend_223(this.pointer,
+    final _ret = _objc_msgSend_223(this.ref.retainAndReturnPointer(),
         _sel_initWithBytes_length_encoding_, bytes, len, encoding);
     return _ret.address == 0
         ? null
-        : NSString.castFromPointer(_ret, retain: true, release: true);
+        : NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBytesNoCopy:length:encoding:freeWhenDone:
   NSString? initWithBytesNoCopy_length_encoding_freeWhenDone_(
       ffi.Pointer<ffi.Void> bytes, int len, int encoding, bool freeBuffer) {
     final _ret = _objc_msgSend_224(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithBytesNoCopy_length_encoding_freeWhenDone_,
         bytes,
         len,
@@ -1965,7 +1999,7 @@ class NSString extends NSObject {
   /// stringWithString:
   static NSString stringWithString_(NSString string) {
     final _ret = _objc_msgSend_45(
-        _class_NSString, _sel_stringWithString_, string.pointer);
+        _class_NSString, _sel_stringWithString_, string.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -1990,14 +2024,14 @@ class NSString extends NSObject {
   /// stringWithFormat:
   static NSString stringWithFormat_(NSString format) {
     final _ret = _objc_msgSend_45(
-        _class_NSString, _sel_stringWithFormat_, format.pointer);
+        _class_NSString, _sel_stringWithFormat_, format.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// localizedStringWithFormat:
   static NSString localizedStringWithFormat_(NSString format) {
     final _ret = _objc_msgSend_45(
-        _class_NSString, _sel_localizedStringWithFormat_, format.pointer);
+        _class_NSString, _sel_localizedStringWithFormat_, format.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -2009,8 +2043,8 @@ class NSString extends NSObject {
     final _ret = _objc_msgSend_220(
         _class_NSString,
         _sel_stringWithValidatedFormat_validFormatSpecifiers_error_,
-        format.pointer,
-        validFormatSpecifiers.pointer,
+        format.ref.pointer,
+        validFormatSpecifiers.ref.pointer,
         error);
     return _ret.address == 0
         ? null
@@ -2026,8 +2060,8 @@ class NSString extends NSObject {
     final _ret = _objc_msgSend_220(
         _class_NSString,
         _sel_localizedStringWithValidatedFormat_validFormatSpecifiers_error_,
-        format.pointer,
-        validFormatSpecifiers.pointer,
+        format.ref.pointer,
+        validFormatSpecifiers.ref.pointer,
         error);
     return _ret.address == 0
         ? null
@@ -2037,11 +2071,11 @@ class NSString extends NSObject {
   /// initWithCString:encoding:
   NSString? initWithCString_encoding_(
       ffi.Pointer<ffi.Char> nullTerminatedCString, int encoding) {
-    final _ret = _objc_msgSend_225(this.pointer, _sel_initWithCString_encoding_,
-        nullTerminatedCString, encoding);
+    final _ret = _objc_msgSend_225(this.ref.retainAndReturnPointer(),
+        _sel_initWithCString_encoding_, nullTerminatedCString, encoding);
     return _ret.address == 0
         ? null
-        : NSString.castFromPointer(_ret, retain: true, release: true);
+        : NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// stringWithCString:encoding:
@@ -2057,28 +2091,40 @@ class NSString extends NSObject {
   /// initWithContentsOfURL:encoding:error:
   NSString? initWithContentsOfURL_encoding_error_(
       NSURL url, int enc, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    final _ret = _objc_msgSend_226(this.pointer,
-        _sel_initWithContentsOfURL_encoding_error_, url.pointer, enc, error);
+    final _ret = _objc_msgSend_226(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfURL_encoding_error_,
+        url.ref.pointer,
+        enc,
+        error);
     return _ret.address == 0
         ? null
-        : NSString.castFromPointer(_ret, retain: true, release: true);
+        : NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfFile:encoding:error:
   NSString? initWithContentsOfFile_encoding_error_(
       NSString path, int enc, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    final _ret = _objc_msgSend_227(this.pointer,
-        _sel_initWithContentsOfFile_encoding_error_, path.pointer, enc, error);
+    final _ret = _objc_msgSend_227(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfFile_encoding_error_,
+        path.ref.pointer,
+        enc,
+        error);
     return _ret.address == 0
         ? null
-        : NSString.castFromPointer(_ret, retain: true, release: true);
+        : NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// stringWithContentsOfURL:encoding:error:
   static NSString? stringWithContentsOfURL_encoding_error_(
       NSURL url, int enc, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    final _ret = _objc_msgSend_226(_class_NSString,
-        _sel_stringWithContentsOfURL_encoding_error_, url.pointer, enc, error);
+    final _ret = _objc_msgSend_226(
+        _class_NSString,
+        _sel_stringWithContentsOfURL_encoding_error_,
+        url.ref.pointer,
+        enc,
+        error);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -2090,7 +2136,7 @@ class NSString extends NSObject {
     final _ret = _objc_msgSend_227(
         _class_NSString,
         _sel_stringWithContentsOfFile_encoding_error_,
-        path.pointer,
+        path.ref.pointer,
         enc,
         error);
     return _ret.address == 0
@@ -2104,14 +2150,14 @@ class NSString extends NSObject {
       ffi.Pointer<ffi.UnsignedLong> enc,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     final _ret = _objc_msgSend_228(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_usedEncoding_error_,
-        url.pointer,
+        url.ref.pointer,
         enc,
         error);
     return _ret.address == 0
         ? null
-        : NSString.castFromPointer(_ret, retain: true, release: true);
+        : NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfFile:usedEncoding:error:
@@ -2120,14 +2166,14 @@ class NSString extends NSObject {
       ffi.Pointer<ffi.UnsignedLong> enc,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     final _ret = _objc_msgSend_229(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfFile_usedEncoding_error_,
-        path.pointer,
+        path.ref.pointer,
         enc,
         error);
     return _ret.address == 0
         ? null
-        : NSString.castFromPointer(_ret, retain: true, release: true);
+        : NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// stringWithContentsOfURL:usedEncoding:error:
@@ -2138,7 +2184,7 @@ class NSString extends NSObject {
     final _ret = _objc_msgSend_228(
         _class_NSString,
         _sel_stringWithContentsOfURL_usedEncoding_error_,
-        url.pointer,
+        url.ref.pointer,
         enc,
         error);
     return _ret.address == 0
@@ -2154,7 +2200,7 @@ class NSString extends NSObject {
     final _ret = _objc_msgSend_229(
         _class_NSString,
         _sel_stringWithContentsOfFile_usedEncoding_error_,
-        path.pointer,
+        path.ref.pointer,
         enc,
         error);
     return _ret.address == 0
@@ -2172,22 +2218,22 @@ class NSString extends NSObject {
     return _objc_msgSend_230(
         _class_NSString,
         _sel_stringEncodingForData_encodingOptions_convertedString_usedLossyConversion_,
-        data.pointer,
-        opts?.pointer ?? ffi.nullptr,
+        data.ref.pointer,
+        opts?.ref.pointer ?? ffi.nullptr,
         string,
         usedLossyConversion);
   }
 
   /// propertyList
   objc.ObjCObjectBase propertyList() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_propertyList);
+    final _ret = _objc_msgSend_2(this.ref.pointer, _sel_propertyList);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
   /// propertyListFromStringsFileFormat
   NSDictionary? propertyListFromStringsFileFormat() {
-    final _ret =
-        _objc_msgSend_231(this.pointer, _sel_propertyListFromStringsFileFormat);
+    final _ret = _objc_msgSend_231(
+        this.ref.pointer, _sel_propertyListFromStringsFileFormat);
     return _ret.address == 0
         ? null
         : NSDictionary.castFromPointer(_ret, retain: true, release: true);
@@ -2195,16 +2241,16 @@ class NSString extends NSObject {
 
   /// getCharacters:
   void getCharacters_(ffi.Pointer<ffi.UnsignedShort> buffer) {
-    _objc_msgSend_232(this.pointer, _sel_getCharacters_, buffer);
+    _objc_msgSend_232(this.ref.pointer, _sel_getCharacters_, buffer);
   }
 
   /// stringByAddingPercentEncodingWithAllowedCharacters:
   NSString? stringByAddingPercentEncodingWithAllowedCharacters_(
       NSCharacterSet allowedCharacters) {
     final _ret = _objc_msgSend_233(
-        this.pointer,
+        this.ref.pointer,
         _sel_stringByAddingPercentEncodingWithAllowedCharacters_,
-        allowedCharacters.pointer);
+        allowedCharacters.ref.pointer);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -2212,8 +2258,8 @@ class NSString extends NSObject {
 
   /// stringByRemovingPercentEncoding
   NSString? get stringByRemovingPercentEncoding {
-    final _ret =
-        _objc_msgSend_58(this.pointer, _sel_stringByRemovingPercentEncoding);
+    final _ret = _objc_msgSend_58(
+        this.ref.pointer, _sel_stringByRemovingPercentEncoding);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -2240,14 +2286,14 @@ class NSString extends NSObject {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSString,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSString,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -2271,7 +2317,7 @@ class NSCoder extends objc.ObjCObjectBase {
 
   /// Constructs a [NSCoder] that points to the same underlying object as [other].
   NSCoder.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSCoder] that wraps the given raw object pointer.
   NSCoder.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -2280,7 +2326,8 @@ class NSCoder extends objc.ObjCObjectBase {
 
   /// Returns whether [obj] is an instance of [NSCoder].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_0(obj.pointer, _sel_isKindOfClass_, _class_NSCoder);
+    return _objc_msgSend_0(
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSCoder);
   }
 }
 
@@ -2594,7 +2641,7 @@ class NSLocale extends objc.ObjCObjectBase {
 
   /// Constructs a [NSLocale] that points to the same underlying object as [other].
   NSLocale.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSLocale] that wraps the given raw object pointer.
   NSLocale.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -2603,7 +2650,8 @@ class NSLocale extends objc.ObjCObjectBase {
 
   /// Returns whether [obj] is an instance of [NSLocale].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_0(obj.pointer, _sel_isKindOfClass_, _class_NSLocale);
+    return _objc_msgSend_0(
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSLocale);
   }
 }
 
@@ -2657,7 +2705,7 @@ class NSCharacterSet extends NSObject {
 
   /// Constructs a [NSCharacterSet] that points to the same underlying object as [other].
   NSCharacterSet.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSCharacterSet] that wraps the given raw object pointer.
   NSCharacterSet.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -2667,7 +2715,7 @@ class NSCharacterSet extends NSObject {
   /// Returns whether [obj] is an instance of [NSCharacterSet].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_NSCharacterSet);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSCharacterSet);
   }
 
   /// controlCharacterSet
@@ -2772,7 +2820,7 @@ class NSCharacterSet extends NSObject {
   static NSCharacterSet getNewlineCharacterSet() {
     final _ret =
         _objc_msgSend_32(_class_NSCharacterSet, _sel_newlineCharacterSet);
-    return NSCharacterSet.castFromPointer(_ret, retain: false, release: true);
+    return NSCharacterSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// characterSetWithRange:
@@ -2785,21 +2833,21 @@ class NSCharacterSet extends NSObject {
   /// characterSetWithCharactersInString:
   static NSCharacterSet characterSetWithCharactersInString_(NSString aString) {
     final _ret = _objc_msgSend_34(_class_NSCharacterSet,
-        _sel_characterSetWithCharactersInString_, aString.pointer);
+        _sel_characterSetWithCharactersInString_, aString.ref.pointer);
     return NSCharacterSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// characterSetWithBitmapRepresentation:
   static NSCharacterSet characterSetWithBitmapRepresentation_(NSData data) {
     final _ret = _objc_msgSend_186(_class_NSCharacterSet,
-        _sel_characterSetWithBitmapRepresentation_, data.pointer);
+        _sel_characterSetWithBitmapRepresentation_, data.ref.pointer);
     return NSCharacterSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// characterSetWithContentsOfFile:
   static NSCharacterSet? characterSetWithContentsOfFile_(NSString fName) {
     final _ret = _objc_msgSend_187(_class_NSCharacterSet,
-        _sel_characterSetWithContentsOfFile_, fName.pointer);
+        _sel_characterSetWithContentsOfFile_, fName.ref.pointer);
     return _ret.address == 0
         ? null
         : NSCharacterSet.castFromPointer(_ret, retain: true, release: true);
@@ -2807,43 +2855,45 @@ class NSCharacterSet extends NSObject {
 
   /// initWithCoder:
   NSCharacterSet initWithCoder_(NSCoder coder) {
-    final _ret =
-        _objc_msgSend_188(this.pointer, _sel_initWithCoder_, coder.pointer);
-    return NSCharacterSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_188(this.ref.retainAndReturnPointer(),
+        _sel_initWithCoder_, coder.ref.pointer);
+    return NSCharacterSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// characterIsMember:
   bool characterIsMember_(int aCharacter) {
-    return _objc_msgSend_189(this.pointer, _sel_characterIsMember_, aCharacter);
+    return _objc_msgSend_189(
+        this.ref.pointer, _sel_characterIsMember_, aCharacter);
   }
 
   /// bitmapRepresentation
   NSData get bitmapRepresentation {
-    final _ret = _objc_msgSend_57(this.pointer, _sel_bitmapRepresentation);
+    final _ret = _objc_msgSend_57(this.ref.pointer, _sel_bitmapRepresentation);
     return NSData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// invertedSet
   NSCharacterSet get invertedSet {
-    final _ret = _objc_msgSend_32(this.pointer, _sel_invertedSet);
+    final _ret = _objc_msgSend_32(this.ref.pointer, _sel_invertedSet);
     return NSCharacterSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// longCharacterIsMember:
   bool longCharacterIsMember_(int theLongChar) {
     return _objc_msgSend_190(
-        this.pointer, _sel_longCharacterIsMember_, theLongChar);
+        this.ref.pointer, _sel_longCharacterIsMember_, theLongChar);
   }
 
   /// isSupersetOfSet:
   bool isSupersetOfSet_(NSCharacterSet theOtherSet) {
     return _objc_msgSend_191(
-        this.pointer, _sel_isSupersetOfSet_, theOtherSet.pointer);
+        this.ref.pointer, _sel_isSupersetOfSet_, theOtherSet.ref.pointer);
   }
 
   /// hasMemberInPlane:
   bool hasMemberInPlane_(int thePlane) {
-    return _objc_msgSend_192(this.pointer, _sel_hasMemberInPlane_, thePlane);
+    return _objc_msgSend_192(
+        this.ref.pointer, _sel_hasMemberInPlane_, thePlane);
   }
 
   /// URLUserAllowedCharacterSet
@@ -2890,8 +2940,8 @@ class NSCharacterSet extends NSObject {
 
   /// init
   NSCharacterSet init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSCharacterSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSCharacterSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// new
@@ -2916,14 +2966,14 @@ class NSCharacterSet extends NSObject {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSCharacterSet,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSCharacterSet,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -2991,7 +3041,7 @@ class NSData extends NSObject {
 
   /// Constructs a [NSData] that points to the same underlying object as [other].
   NSData.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSData] that wraps the given raw object pointer.
   NSData.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -3000,56 +3050,58 @@ class NSData extends NSObject {
 
   /// Returns whether [obj] is an instance of [NSData].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_0(obj.pointer, _sel_isKindOfClass_, _class_NSData);
+    return _objc_msgSend_0(obj.ref.pointer, _sel_isKindOfClass_, _class_NSData);
   }
 
   /// length
   int get length {
-    return _objc_msgSend_11(this.pointer, _sel_length);
+    return _objc_msgSend_11(this.ref.pointer, _sel_length);
   }
 
   /// bytes
   ffi.Pointer<ffi.Void> get bytes {
-    return _objc_msgSend_35(this.pointer, _sel_bytes);
+    return _objc_msgSend_35(this.ref.pointer, _sel_bytes);
   }
 
   /// description
   NSString get description {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_description);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_description);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// getBytes:length:
   void getBytes_length_(ffi.Pointer<ffi.Void> buffer, int length) {
-    _objc_msgSend_37(this.pointer, _sel_getBytes_length_, buffer, length);
+    _objc_msgSend_37(this.ref.pointer, _sel_getBytes_length_, buffer, length);
   }
 
   /// getBytes:range:
   void getBytes_range_(ffi.Pointer<ffi.Void> buffer, NSRange range) {
-    _objc_msgSend_38(this.pointer, _sel_getBytes_range_, buffer, range);
+    _objc_msgSend_38(this.ref.pointer, _sel_getBytes_range_, buffer, range);
   }
 
   /// isEqualToData:
   bool isEqualToData_(NSData other) {
-    return _objc_msgSend_39(this.pointer, _sel_isEqualToData_, other.pointer);
+    return _objc_msgSend_39(
+        this.ref.pointer, _sel_isEqualToData_, other.ref.pointer);
   }
 
   /// subdataWithRange:
   NSData subdataWithRange_(NSRange range) {
-    final _ret = _objc_msgSend_40(this.pointer, _sel_subdataWithRange_, range);
+    final _ret =
+        _objc_msgSend_40(this.ref.pointer, _sel_subdataWithRange_, range);
     return NSData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// writeToFile:atomically:
   bool writeToFile_atomically_(NSString path, bool useAuxiliaryFile) {
-    return _objc_msgSend_41(this.pointer, _sel_writeToFile_atomically_,
-        path.pointer, useAuxiliaryFile);
+    return _objc_msgSend_41(this.ref.pointer, _sel_writeToFile_atomically_,
+        path.ref.pointer, useAuxiliaryFile);
   }
 
   /// writeToURL:atomically:
   bool writeToURL_atomically_(NSURL url, bool atomically) {
-    return _objc_msgSend_134(
-        this.pointer, _sel_writeToURL_atomically_, url.pointer, atomically);
+    return _objc_msgSend_134(this.ref.pointer, _sel_writeToURL_atomically_,
+        url.ref.pointer, atomically);
   }
 
   /// writeToFile:options:error:
@@ -3057,8 +3109,8 @@ class NSData extends NSObject {
       NSString path,
       NSDataWritingOptions writeOptionsMask,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> errorPtr) {
-    return _objc_msgSend_172(this.pointer, _sel_writeToFile_options_error_,
-        path.pointer, writeOptionsMask.value, errorPtr);
+    return _objc_msgSend_172(this.ref.pointer, _sel_writeToFile_options_error_,
+        path.ref.pointer, writeOptionsMask.value, errorPtr);
   }
 
   /// writeToURL:options:error:
@@ -3066,8 +3118,8 @@ class NSData extends NSObject {
       NSURL url,
       NSDataWritingOptions writeOptionsMask,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> errorPtr) {
-    return _objc_msgSend_173(this.pointer, _sel_writeToURL_options_error_,
-        url.pointer, writeOptionsMask.value, errorPtr);
+    return _objc_msgSend_173(this.ref.pointer, _sel_writeToURL_options_error_,
+        url.ref.pointer, writeOptionsMask.value, errorPtr);
   }
 
   /// rangeOfData:options:range:
@@ -3076,15 +3128,15 @@ class NSData extends NSObject {
     objc.useMsgSendVariants
         ? _objc_msgSend_174Stret(
             stret,
-            this.pointer,
+            this.ref.pointer,
             _sel_rangeOfData_options_range_,
-            dataToFind.pointer,
+            dataToFind.ref.pointer,
             mask.value,
             searchRange)
         : stret.ref = _objc_msgSend_174(
-            this.pointer,
+            this.ref.pointer,
             _sel_rangeOfData_options_range_,
-            dataToFind.pointer,
+            dataToFind.ref.pointer,
             mask.value,
             searchRange);
   }
@@ -3107,7 +3159,7 @@ class NSData extends NSObject {
       ffi.Pointer<ffi.Void> bytes, int length) {
     final _ret = _objc_msgSend_175(
         _class_NSData, _sel_dataWithBytesNoCopy_length_, bytes, length);
-    return NSData.castFromPointer(_ret, retain: false, release: true);
+    return NSData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dataWithBytesNoCopy:length:freeWhenDone:
@@ -3115,7 +3167,7 @@ class NSData extends NSObject {
       ffi.Pointer<ffi.Void> bytes, int length, bool b) {
     final _ret = _objc_msgSend_176(_class_NSData,
         _sel_dataWithBytesNoCopy_length_freeWhenDone_, bytes, length, b);
-    return NSData.castFromPointer(_ret, retain: false, release: true);
+    return NSData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dataWithContentsOfFile:options:error:
@@ -3126,7 +3178,7 @@ class NSData extends NSObject {
     final _ret = _objc_msgSend_177(
         _class_NSData,
         _sel_dataWithContentsOfFile_options_error_,
-        path.pointer,
+        path.ref.pointer,
         readOptionsMask.value,
         errorPtr);
     return _ret.address == 0
@@ -3142,7 +3194,7 @@ class NSData extends NSObject {
     final _ret = _objc_msgSend_178(
         _class_NSData,
         _sel_dataWithContentsOfURL_options_error_,
-        url.pointer,
+        url.ref.pointer,
         readOptionsMask.value,
         errorPtr);
     return _ret.address == 0
@@ -3153,7 +3205,7 @@ class NSData extends NSObject {
   /// dataWithContentsOfFile:
   static NSData? dataWithContentsOfFile_(NSString path) {
     final _ret = _objc_msgSend_52(
-        _class_NSData, _sel_dataWithContentsOfFile_, path.pointer);
+        _class_NSData, _sel_dataWithContentsOfFile_, path.ref.pointer);
     return _ret.address == 0
         ? null
         : NSData.castFromPointer(_ret, retain: true, release: true);
@@ -3162,7 +3214,7 @@ class NSData extends NSObject {
   /// dataWithContentsOfURL:
   static NSData? dataWithContentsOfURL_(NSURL url) {
     final _ret = _objc_msgSend_179(
-        _class_NSData, _sel_dataWithContentsOfURL_, url.pointer);
+        _class_NSData, _sel_dataWithContentsOfURL_, url.ref.pointer);
     return _ret.address == 0
         ? null
         : NSData.castFromPointer(_ret, retain: true, release: true);
@@ -3170,22 +3222,22 @@ class NSData extends NSObject {
 
   /// initWithBytes:length:
   NSData initWithBytes_length_(ffi.Pointer<ffi.Void> bytes, int length) {
-    final _ret = _objc_msgSend_175(
-        this.pointer, _sel_initWithBytes_length_, bytes, length);
-    return NSData.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_175(this.ref.retainAndReturnPointer(),
+        _sel_initWithBytes_length_, bytes, length);
+    return NSData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBytesNoCopy:length:
   NSData initWithBytesNoCopy_length_(ffi.Pointer<ffi.Void> bytes, int length) {
-    final _ret = _objc_msgSend_175(
-        this.pointer, _sel_initWithBytesNoCopy_length_, bytes, length);
+    final _ret = _objc_msgSend_175(this.ref.retainAndReturnPointer(),
+        _sel_initWithBytesNoCopy_length_, bytes, length);
     return NSData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBytesNoCopy:length:freeWhenDone:
   NSData initWithBytesNoCopy_length_freeWhenDone_(
       ffi.Pointer<ffi.Void> bytes, int length, bool b) {
-    final _ret = _objc_msgSend_176(this.pointer,
+    final _ret = _objc_msgSend_176(this.ref.retainAndReturnPointer(),
         _sel_initWithBytesNoCopy_length_freeWhenDone_, bytes, length, b);
     return NSData.castFromPointer(_ret, retain: false, release: true);
   }
@@ -3196,14 +3248,14 @@ class NSData extends NSObject {
       NSDataReadingOptions readOptionsMask,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> errorPtr) {
     final _ret = _objc_msgSend_177(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfFile_options_error_,
-        path.pointer,
+        path.ref.pointer,
         readOptionsMask.value,
         errorPtr);
     return _ret.address == 0
         ? null
-        : NSData.castFromPointer(_ret, retain: true, release: true);
+        : NSData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfURL:options:error:
@@ -3212,45 +3264,45 @@ class NSData extends NSObject {
       NSDataReadingOptions readOptionsMask,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> errorPtr) {
     final _ret = _objc_msgSend_178(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_options_error_,
-        url.pointer,
+        url.ref.pointer,
         readOptionsMask.value,
         errorPtr);
     return _ret.address == 0
         ? null
-        : NSData.castFromPointer(_ret, retain: true, release: true);
+        : NSData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfFile:
   NSData? initWithContentsOfFile_(NSString path) {
-    final _ret = _objc_msgSend_52(
-        this.pointer, _sel_initWithContentsOfFile_, path.pointer);
+    final _ret = _objc_msgSend_52(this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfFile_, path.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSData.castFromPointer(_ret, retain: true, release: true);
+        : NSData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfURL:
   NSData? initWithContentsOfURL_(NSURL url) {
-    final _ret = _objc_msgSend_179(
-        this.pointer, _sel_initWithContentsOfURL_, url.pointer);
+    final _ret = _objc_msgSend_179(this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfURL_, url.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSData.castFromPointer(_ret, retain: true, release: true);
+        : NSData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithData:
   NSData initWithData_(NSData data) {
-    final _ret =
-        _objc_msgSend_180(this.pointer, _sel_initWithData_, data.pointer);
-    return NSData.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_180(this.ref.retainAndReturnPointer(),
+        _sel_initWithData_, data.ref.pointer);
+    return NSData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// dataWithData:
   static NSData dataWithData_(NSData data) {
     final _ret =
-        _objc_msgSend_180(_class_NSData, _sel_dataWithData_, data.pointer);
+        _objc_msgSend_180(_class_NSData, _sel_dataWithData_, data.ref.pointer);
     return NSData.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -3258,20 +3310,20 @@ class NSData extends NSObject {
   NSData? initWithBase64EncodedString_options_(
       NSString base64String, NSDataBase64DecodingOptions options) {
     final _ret = _objc_msgSend_181(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithBase64EncodedString_options_,
-        base64String.pointer,
+        base64String.ref.pointer,
         options.value);
     return _ret.address == 0
         ? null
-        : NSData.castFromPointer(_ret, retain: true, release: true);
+        : NSData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// base64EncodedStringWithOptions:
   NSString base64EncodedStringWithOptions_(
       NSDataBase64EncodingOptions options) {
     final _ret = _objc_msgSend_182(
-        this.pointer, _sel_base64EncodedStringWithOptions_, options.value);
+        this.ref.pointer, _sel_base64EncodedStringWithOptions_, options.value);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -3279,19 +3331,19 @@ class NSData extends NSObject {
   NSData? initWithBase64EncodedData_options_(
       NSData base64Data, NSDataBase64DecodingOptions options) {
     final _ret = _objc_msgSend_183(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithBase64EncodedData_options_,
-        base64Data.pointer,
+        base64Data.ref.pointer,
         options.value);
     return _ret.address == 0
         ? null
-        : NSData.castFromPointer(_ret, retain: true, release: true);
+        : NSData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// base64EncodedDataWithOptions:
   NSData base64EncodedDataWithOptions_(NSDataBase64EncodingOptions options) {
     final _ret = _objc_msgSend_184(
-        this.pointer, _sel_base64EncodedDataWithOptions_, options.value);
+        this.ref.pointer, _sel_base64EncodedDataWithOptions_, options.value);
     return NSData.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -3299,7 +3351,7 @@ class NSData extends NSObject {
   NSData? decompressedDataUsingAlgorithm_error_(
       NSDataCompressionAlgorithm algorithm,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    final _ret = _objc_msgSend_185(this.pointer,
+    final _ret = _objc_msgSend_185(this.ref.pointer,
         _sel_decompressedDataUsingAlgorithm_error_, algorithm.value, error);
     return _ret.address == 0
         ? null
@@ -3310,7 +3362,7 @@ class NSData extends NSObject {
   NSData? compressedDataUsingAlgorithm_error_(
       NSDataCompressionAlgorithm algorithm,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    final _ret = _objc_msgSend_185(this.pointer,
+    final _ret = _objc_msgSend_185(this.ref.pointer,
         _sel_compressedDataUsingAlgorithm_error_, algorithm.value, error);
     return _ret.address == 0
         ? null
@@ -3319,8 +3371,8 @@ class NSData extends NSObject {
 
   /// init
   NSData init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSData.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// new
@@ -3344,14 +3396,14 @@ class NSData extends NSObject {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSData,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
-    return _objc_msgSend_26(
-        _class_NSData, _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+    return _objc_msgSend_26(_class_NSData,
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -3443,7 +3495,7 @@ class NSURL extends NSObject {
 
   /// Constructs a [NSURL] that points to the same underlying object as [other].
   NSURL.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSURL] that wraps the given raw object pointer.
   NSURL.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -3452,43 +3504,43 @@ class NSURL extends NSObject {
 
   /// Returns whether [obj] is an instance of [NSURL].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_0(obj.pointer, _sel_isKindOfClass_, _class_NSURL);
+    return _objc_msgSend_0(obj.ref.pointer, _sel_isKindOfClass_, _class_NSURL);
   }
 
   /// initFileURLWithPath:isDirectory:relativeToURL:
   NSURL initFileURLWithPath_isDirectory_relativeToURL_(
       NSString path, bool isDir, NSURL? baseURL) {
     final _ret = _objc_msgSend_42(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initFileURLWithPath_isDirectory_relativeToURL_,
-        path.pointer,
+        path.ref.pointer,
         isDir,
-        baseURL?.pointer ?? ffi.nullptr);
-    return NSURL.castFromPointer(_ret, retain: true, release: true);
+        baseURL?.ref.pointer ?? ffi.nullptr);
+    return NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initFileURLWithPath:relativeToURL:
   NSURL initFileURLWithPath_relativeToURL_(NSString path, NSURL? baseURL) {
     final _ret = _objc_msgSend_43(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initFileURLWithPath_relativeToURL_,
-        path.pointer,
-        baseURL?.pointer ?? ffi.nullptr);
-    return NSURL.castFromPointer(_ret, retain: true, release: true);
+        path.ref.pointer,
+        baseURL?.ref.pointer ?? ffi.nullptr);
+    return NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initFileURLWithPath:isDirectory:
   NSURL initFileURLWithPath_isDirectory_(NSString path, bool isDir) {
-    final _ret = _objc_msgSend_44(this.pointer,
-        _sel_initFileURLWithPath_isDirectory_, path.pointer, isDir);
-    return NSURL.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_44(this.ref.retainAndReturnPointer(),
+        _sel_initFileURLWithPath_isDirectory_, path.ref.pointer, isDir);
+    return NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initFileURLWithPath:
   NSURL initFileURLWithPath_(NSString path) {
-    final _ret =
-        _objc_msgSend_45(this.pointer, _sel_initFileURLWithPath_, path.pointer);
-    return NSURL.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_45(this.ref.retainAndReturnPointer(),
+        _sel_initFileURLWithPath_, path.ref.pointer);
+    return NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// fileURLWithPath:isDirectory:relativeToURL:
@@ -3497,9 +3549,9 @@ class NSURL extends NSObject {
     final _ret = _objc_msgSend_46(
         _class_NSURL,
         _sel_fileURLWithPath_isDirectory_relativeToURL_,
-        path.pointer,
+        path.ref.pointer,
         isDir,
-        baseURL?.pointer ?? ffi.nullptr);
+        baseURL?.ref.pointer ?? ffi.nullptr);
     return NSURL.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -3508,22 +3560,22 @@ class NSURL extends NSObject {
     final _ret = _objc_msgSend_47(
         _class_NSURL,
         _sel_fileURLWithPath_relativeToURL_,
-        path.pointer,
-        baseURL?.pointer ?? ffi.nullptr);
+        path.ref.pointer,
+        baseURL?.ref.pointer ?? ffi.nullptr);
     return NSURL.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// fileURLWithPath:isDirectory:
   static NSURL fileURLWithPath_isDirectory_(NSString path, bool isDir) {
-    final _ret = _objc_msgSend_48(
-        _class_NSURL, _sel_fileURLWithPath_isDirectory_, path.pointer, isDir);
+    final _ret = _objc_msgSend_48(_class_NSURL,
+        _sel_fileURLWithPath_isDirectory_, path.ref.pointer, isDir);
     return NSURL.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// fileURLWithPath:
   static NSURL fileURLWithPath_(NSString path) {
     final _ret =
-        _objc_msgSend_49(_class_NSURL, _sel_fileURLWithPath_, path.pointer);
+        _objc_msgSend_49(_class_NSURL, _sel_fileURLWithPath_, path.ref.pointer);
     return NSURL.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -3531,12 +3583,12 @@ class NSURL extends NSObject {
   NSURL initFileURLWithFileSystemRepresentation_isDirectory_relativeToURL_(
       ffi.Pointer<ffi.Char> path, bool isDir, NSURL? baseURL) {
     final _ret = _objc_msgSend_50(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initFileURLWithFileSystemRepresentation_isDirectory_relativeToURL_,
         path,
         isDir,
-        baseURL?.pointer ?? ffi.nullptr);
-    return NSURL.castFromPointer(_ret, retain: true, release: true);
+        baseURL?.ref.pointer ?? ffi.nullptr);
+    return NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// fileURLWithFileSystemRepresentation:isDirectory:relativeToURL:
@@ -3547,35 +3599,35 @@ class NSURL extends NSObject {
         _sel_fileURLWithFileSystemRepresentation_isDirectory_relativeToURL_,
         path,
         isDir,
-        baseURL?.pointer ?? ffi.nullptr);
+        baseURL?.ref.pointer ?? ffi.nullptr);
     return NSURL.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// initWithString:
   NSURL? initWithString_(NSString URLString) {
-    final _ret =
-        _objc_msgSend_52(this.pointer, _sel_initWithString_, URLString.pointer);
+    final _ret = _objc_msgSend_52(this.ref.retainAndReturnPointer(),
+        _sel_initWithString_, URLString.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSURL.castFromPointer(_ret, retain: true, release: true);
+        : NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithString:relativeToURL:
   NSURL? initWithString_relativeToURL_(NSString URLString, NSURL? baseURL) {
     final _ret = _objc_msgSend_53(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithString_relativeToURL_,
-        URLString.pointer,
-        baseURL?.pointer ?? ffi.nullptr);
+        URLString.ref.pointer,
+        baseURL?.ref.pointer ?? ffi.nullptr);
     return _ret.address == 0
         ? null
-        : NSURL.castFromPointer(_ret, retain: true, release: true);
+        : NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// URLWithString:
   static NSURL? URLWithString_(NSString URLString) {
-    final _ret =
-        _objc_msgSend_52(_class_NSURL, _sel_URLWithString_, URLString.pointer);
+    final _ret = _objc_msgSend_52(
+        _class_NSURL, _sel_URLWithString_, URLString.ref.pointer);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: true, release: true);
@@ -3587,8 +3639,8 @@ class NSURL extends NSObject {
     final _ret = _objc_msgSend_53(
         _class_NSURL,
         _sel_URLWithString_relativeToURL_,
-        URLString.pointer,
-        baseURL?.pointer ?? ffi.nullptr);
+        URLString.ref.pointer,
+        baseURL?.ref.pointer ?? ffi.nullptr);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: true, release: true);
@@ -3598,13 +3650,13 @@ class NSURL extends NSObject {
   NSURL? initWithString_encodingInvalidCharacters_(
       NSString URLString, bool encodingInvalidCharacters) {
     final _ret = _objc_msgSend_54(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithString_encodingInvalidCharacters_,
-        URLString.pointer,
+        URLString.ref.pointer,
         encodingInvalidCharacters);
     return _ret.address == 0
         ? null
-        : NSURL.castFromPointer(_ret, retain: true, release: true);
+        : NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// URLWithString:encodingInvalidCharacters:
@@ -3613,7 +3665,7 @@ class NSURL extends NSObject {
     final _ret = _objc_msgSend_54(
         _class_NSURL,
         _sel_URLWithString_encodingInvalidCharacters_,
-        URLString.pointer,
+        URLString.ref.pointer,
         encodingInvalidCharacters);
     return _ret.address == 0
         ? null
@@ -3623,11 +3675,11 @@ class NSURL extends NSObject {
   /// initWithDataRepresentation:relativeToURL:
   NSURL initWithDataRepresentation_relativeToURL_(NSData data, NSURL? baseURL) {
     final _ret = _objc_msgSend_55(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithDataRepresentation_relativeToURL_,
-        data.pointer,
-        baseURL?.pointer ?? ffi.nullptr);
-    return NSURL.castFromPointer(_ret, retain: true, release: true);
+        data.ref.pointer,
+        baseURL?.ref.pointer ?? ffi.nullptr);
+    return NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// URLWithDataRepresentation:relativeToURL:
@@ -3636,8 +3688,8 @@ class NSURL extends NSObject {
     final _ret = _objc_msgSend_56(
         _class_NSURL,
         _sel_URLWithDataRepresentation_relativeToURL_,
-        data.pointer,
-        baseURL?.pointer ?? ffi.nullptr);
+        data.ref.pointer,
+        baseURL?.ref.pointer ?? ffi.nullptr);
     return NSURL.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -3645,11 +3697,11 @@ class NSURL extends NSObject {
   NSURL initAbsoluteURLWithDataRepresentation_relativeToURL_(
       NSData data, NSURL? baseURL) {
     final _ret = _objc_msgSend_55(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initAbsoluteURLWithDataRepresentation_relativeToURL_,
-        data.pointer,
-        baseURL?.pointer ?? ffi.nullptr);
-    return NSURL.castFromPointer(_ret, retain: true, release: true);
+        data.ref.pointer,
+        baseURL?.ref.pointer ?? ffi.nullptr);
+    return NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// absoluteURLWithDataRepresentation:relativeToURL:
@@ -3658,20 +3710,20 @@ class NSURL extends NSObject {
     final _ret = _objc_msgSend_56(
         _class_NSURL,
         _sel_absoluteURLWithDataRepresentation_relativeToURL_,
-        data.pointer,
-        baseURL?.pointer ?? ffi.nullptr);
+        data.ref.pointer,
+        baseURL?.ref.pointer ?? ffi.nullptr);
     return NSURL.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dataRepresentation
   NSData get dataRepresentation {
-    final _ret = _objc_msgSend_57(this.pointer, _sel_dataRepresentation);
+    final _ret = _objc_msgSend_57(this.ref.pointer, _sel_dataRepresentation);
     return NSData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// absoluteString
   NSString? get absoluteString {
-    final _ret = _objc_msgSend_58(this.pointer, _sel_absoluteString);
+    final _ret = _objc_msgSend_58(this.ref.pointer, _sel_absoluteString);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -3679,13 +3731,13 @@ class NSURL extends NSObject {
 
   /// relativeString
   NSString get relativeString {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_relativeString);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_relativeString);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// baseURL
   NSURL? get baseURL {
-    final _ret = _objc_msgSend_59(this.pointer, _sel_baseURL);
+    final _ret = _objc_msgSend_59(this.ref.pointer, _sel_baseURL);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: true, release: true);
@@ -3693,7 +3745,7 @@ class NSURL extends NSObject {
 
   /// absoluteURL
   NSURL? get absoluteURL {
-    final _ret = _objc_msgSend_59(this.pointer, _sel_absoluteURL);
+    final _ret = _objc_msgSend_59(this.ref.pointer, _sel_absoluteURL);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: true, release: true);
@@ -3701,7 +3753,7 @@ class NSURL extends NSObject {
 
   /// scheme
   NSString? get scheme {
-    final _ret = _objc_msgSend_58(this.pointer, _sel_scheme);
+    final _ret = _objc_msgSend_58(this.ref.pointer, _sel_scheme);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -3709,7 +3761,7 @@ class NSURL extends NSObject {
 
   /// resourceSpecifier
   NSString? get resourceSpecifier {
-    final _ret = _objc_msgSend_58(this.pointer, _sel_resourceSpecifier);
+    final _ret = _objc_msgSend_58(this.ref.pointer, _sel_resourceSpecifier);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -3717,7 +3769,7 @@ class NSURL extends NSObject {
 
   /// host
   NSString? get host {
-    final _ret = _objc_msgSend_58(this.pointer, _sel_host);
+    final _ret = _objc_msgSend_58(this.ref.pointer, _sel_host);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -3725,7 +3777,7 @@ class NSURL extends NSObject {
 
   /// port
   NSNumber? get port {
-    final _ret = _objc_msgSend_96(this.pointer, _sel_port);
+    final _ret = _objc_msgSend_96(this.ref.pointer, _sel_port);
     return _ret.address == 0
         ? null
         : NSNumber.castFromPointer(_ret, retain: true, release: true);
@@ -3733,7 +3785,7 @@ class NSURL extends NSObject {
 
   /// user
   NSString? get user {
-    final _ret = _objc_msgSend_58(this.pointer, _sel_user);
+    final _ret = _objc_msgSend_58(this.ref.pointer, _sel_user);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -3741,7 +3793,7 @@ class NSURL extends NSObject {
 
   /// password
   NSString? get password {
-    final _ret = _objc_msgSend_58(this.pointer, _sel_password);
+    final _ret = _objc_msgSend_58(this.ref.pointer, _sel_password);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -3749,7 +3801,7 @@ class NSURL extends NSObject {
 
   /// path
   NSString? get path {
-    final _ret = _objc_msgSend_58(this.pointer, _sel_path);
+    final _ret = _objc_msgSend_58(this.ref.pointer, _sel_path);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -3757,7 +3809,7 @@ class NSURL extends NSObject {
 
   /// fragment
   NSString? get fragment {
-    final _ret = _objc_msgSend_58(this.pointer, _sel_fragment);
+    final _ret = _objc_msgSend_58(this.ref.pointer, _sel_fragment);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -3765,7 +3817,7 @@ class NSURL extends NSObject {
 
   /// parameterString
   NSString? get parameterString {
-    final _ret = _objc_msgSend_58(this.pointer, _sel_parameterString);
+    final _ret = _objc_msgSend_58(this.ref.pointer, _sel_parameterString);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -3773,7 +3825,7 @@ class NSURL extends NSObject {
 
   /// query
   NSString? get query {
-    final _ret = _objc_msgSend_58(this.pointer, _sel_query);
+    final _ret = _objc_msgSend_58(this.ref.pointer, _sel_query);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -3781,7 +3833,7 @@ class NSURL extends NSObject {
 
   /// relativePath
   NSString? get relativePath {
-    final _ret = _objc_msgSend_58(this.pointer, _sel_relativePath);
+    final _ret = _objc_msgSend_58(this.ref.pointer, _sel_relativePath);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -3789,29 +3841,29 @@ class NSURL extends NSObject {
 
   /// hasDirectoryPath
   bool get hasDirectoryPath {
-    return _objc_msgSend_13(this.pointer, _sel_hasDirectoryPath);
+    return _objc_msgSend_13(this.ref.pointer, _sel_hasDirectoryPath);
   }
 
   /// getFileSystemRepresentation:maxLength:
   bool getFileSystemRepresentation_maxLength_(
       ffi.Pointer<ffi.Char> buffer, int maxBufferLength) {
-    return _objc_msgSend_97(this.pointer,
+    return _objc_msgSend_97(this.ref.pointer,
         _sel_getFileSystemRepresentation_maxLength_, buffer, maxBufferLength);
   }
 
   /// fileSystemRepresentation
   ffi.Pointer<ffi.Char> get fileSystemRepresentation {
-    return _objc_msgSend_14(this.pointer, _sel_fileSystemRepresentation);
+    return _objc_msgSend_14(this.ref.pointer, _sel_fileSystemRepresentation);
   }
 
   /// isFileURL
   bool get fileURL {
-    return _objc_msgSend_13(this.pointer, _sel_isFileURL);
+    return _objc_msgSend_13(this.ref.pointer, _sel_isFileURL);
   }
 
   /// standardizedURL
   NSURL? get standardizedURL {
-    final _ret = _objc_msgSend_59(this.pointer, _sel_standardizedURL);
+    final _ret = _objc_msgSend_59(this.ref.pointer, _sel_standardizedURL);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: true, release: true);
@@ -3821,17 +3873,17 @@ class NSURL extends NSObject {
   bool checkResourceIsReachableAndReturnError_(
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     return _objc_msgSend_143(
-        this.pointer, _sel_checkResourceIsReachableAndReturnError_, error);
+        this.ref.pointer, _sel_checkResourceIsReachableAndReturnError_, error);
   }
 
   /// isFileReferenceURL
   bool isFileReferenceURL() {
-    return _objc_msgSend_13(this.pointer, _sel_isFileReferenceURL);
+    return _objc_msgSend_13(this.ref.pointer, _sel_isFileReferenceURL);
   }
 
   /// fileReferenceURL
   NSURL? fileReferenceURL() {
-    final _ret = _objc_msgSend_59(this.pointer, _sel_fileReferenceURL);
+    final _ret = _objc_msgSend_59(this.ref.pointer, _sel_fileReferenceURL);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: true, release: true);
@@ -3839,7 +3891,7 @@ class NSURL extends NSObject {
 
   /// filePathURL
   NSURL? get filePathURL {
-    final _ret = _objc_msgSend_59(this.pointer, _sel_filePathURL);
+    final _ret = _objc_msgSend_59(this.ref.pointer, _sel_filePathURL);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: true, release: true);
@@ -3850,15 +3902,15 @@ class NSURL extends NSObject {
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> value,
       NSString key,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    return _objc_msgSend_144(this.pointer, _sel_getResourceValue_forKey_error_,
-        value, key.pointer, error);
+    return _objc_msgSend_144(this.ref.pointer,
+        _sel_getResourceValue_forKey_error_, value, key.ref.pointer, error);
   }
 
   /// resourceValuesForKeys:error:
   objc.ObjCObjectBase? resourceValuesForKeys_error_(
       NSArray keys, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    final _ret = _objc_msgSend_145(
-        this.pointer, _sel_resourceValuesForKeys_error_, keys.pointer, error);
+    final _ret = _objc_msgSend_145(this.ref.pointer,
+        _sel_resourceValuesForKeys_error_, keys.ref.pointer, error);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -3867,33 +3919,37 @@ class NSURL extends NSObject {
   /// setResourceValue:forKey:error:
   bool setResourceValue_forKey_error_(objc.ObjCObjectBase? value, NSString key,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    return _objc_msgSend_146(this.pointer, _sel_setResourceValue_forKey_error_,
-        value?.pointer ?? ffi.nullptr, key.pointer, error);
+    return _objc_msgSend_146(
+        this.ref.pointer,
+        _sel_setResourceValue_forKey_error_,
+        value?.ref.pointer ?? ffi.nullptr,
+        key.ref.pointer,
+        error);
   }
 
   /// setResourceValues:error:
   bool setResourceValues_error_(objc.ObjCObjectBase keyedValues,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    return _objc_msgSend_147(this.pointer, _sel_setResourceValues_error_,
-        keyedValues.pointer, error);
+    return _objc_msgSend_147(this.ref.pointer, _sel_setResourceValues_error_,
+        keyedValues.ref.pointer, error);
   }
 
   /// removeCachedResourceValueForKey:
   void removeCachedResourceValueForKey_(NSString key) {
-    _objc_msgSend_148(
-        this.pointer, _sel_removeCachedResourceValueForKey_, key.pointer);
+    _objc_msgSend_148(this.ref.pointer, _sel_removeCachedResourceValueForKey_,
+        key.ref.pointer);
   }
 
   /// removeAllCachedResourceValues
   void removeAllCachedResourceValues() {
-    _objc_msgSend_1(this.pointer, _sel_removeAllCachedResourceValues);
+    _objc_msgSend_1(this.ref.pointer, _sel_removeAllCachedResourceValues);
   }
 
   /// setTemporaryResourceValue:forKey:
   void setTemporaryResourceValue_forKey_(
       objc.ObjCObjectBase? value, NSString key) {
-    _objc_msgSend_149(this.pointer, _sel_setTemporaryResourceValue_forKey_,
-        value?.pointer ?? ffi.nullptr, key.pointer);
+    _objc_msgSend_149(this.ref.pointer, _sel_setTemporaryResourceValue_forKey_,
+        value?.ref.pointer ?? ffi.nullptr, key.ref.pointer);
   }
 
   /// bookmarkDataWithOptions:includingResourceValuesForKeys:relativeToURL:error:
@@ -3904,11 +3960,11 @@ class NSURL extends NSObject {
           NSURL? relativeURL,
           ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     final _ret = _objc_msgSend_150(
-        this.pointer,
+        this.ref.pointer,
         _sel_bookmarkDataWithOptions_includingResourceValuesForKeys_relativeToURL_error_,
         options.value,
-        keys?.pointer ?? ffi.nullptr,
-        relativeURL?.pointer ?? ffi.nullptr,
+        keys?.ref.pointer ?? ffi.nullptr,
+        relativeURL?.ref.pointer ?? ffi.nullptr,
         error);
     return _ret.address == 0
         ? null
@@ -3924,16 +3980,16 @@ class NSURL extends NSObject {
           ffi.Pointer<ffi.Bool> isStale,
           ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     final _ret = _objc_msgSend_151(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initByResolvingBookmarkData_options_relativeToURL_bookmarkDataIsStale_error_,
-        bookmarkData.pointer,
+        bookmarkData.ref.pointer,
         options.value,
-        relativeURL?.pointer ?? ffi.nullptr,
+        relativeURL?.ref.pointer ?? ffi.nullptr,
         isStale,
         error);
     return _ret.address == 0
         ? null
-        : NSURL.castFromPointer(_ret, retain: true, release: true);
+        : NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// URLByResolvingBookmarkData:options:relativeToURL:bookmarkDataIsStale:error:
@@ -3947,9 +4003,9 @@ class NSURL extends NSObject {
     final _ret = _objc_msgSend_151(
         _class_NSURL,
         _sel_URLByResolvingBookmarkData_options_relativeToURL_bookmarkDataIsStale_error_,
-        bookmarkData.pointer,
+        bookmarkData.ref.pointer,
         options.value,
-        relativeURL?.pointer ?? ffi.nullptr,
+        relativeURL?.ref.pointer ?? ffi.nullptr,
         isStale,
         error);
     return _ret.address == 0
@@ -3963,8 +4019,8 @@ class NSURL extends NSObject {
     final _ret = _objc_msgSend_152(
         _class_NSURL,
         _sel_resourceValuesForKeys_fromBookmarkData_,
-        keys.pointer,
-        bookmarkData.pointer);
+        keys.ref.pointer,
+        bookmarkData.ref.pointer);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -3979,8 +4035,8 @@ class NSURL extends NSObject {
     return _objc_msgSend_153(
         _class_NSURL,
         _sel_writeBookmarkData_toURL_options_error_,
-        bookmarkData.pointer,
-        bookmarkFileURL.pointer,
+        bookmarkData.ref.pointer,
+        bookmarkFileURL.ref.pointer,
         options,
         error);
   }
@@ -3991,7 +4047,7 @@ class NSURL extends NSObject {
     final _ret = _objc_msgSend_154(
         _class_NSURL,
         _sel_bookmarkDataWithContentsOfURL_error_,
-        bookmarkFileURL.pointer,
+        bookmarkFileURL.ref.pointer,
         error);
     return _ret.address == 0
         ? null
@@ -4006,7 +4062,7 @@ class NSURL extends NSObject {
     final _ret = _objc_msgSend_155(
         _class_NSURL,
         _sel_URLByResolvingAliasFileAtURL_options_error_,
-        url.pointer,
+        url.ref.pointer,
         options.value,
         error);
     return _ret.address == 0
@@ -4017,12 +4073,12 @@ class NSURL extends NSObject {
   /// startAccessingSecurityScopedResource
   bool startAccessingSecurityScopedResource() {
     return _objc_msgSend_13(
-        this.pointer, _sel_startAccessingSecurityScopedResource);
+        this.ref.pointer, _sel_startAccessingSecurityScopedResource);
   }
 
   /// stopAccessingSecurityScopedResource
   void stopAccessingSecurityScopedResource() {
-    _objc_msgSend_1(this.pointer, _sel_stopAccessingSecurityScopedResource);
+    _objc_msgSend_1(this.ref.pointer, _sel_stopAccessingSecurityScopedResource);
   }
 
   /// getPromisedItemResourceValue:forKey:error:
@@ -4031,18 +4087,18 @@ class NSURL extends NSObject {
       NSString key,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     return _objc_msgSend_144(
-        this.pointer,
+        this.ref.pointer,
         _sel_getPromisedItemResourceValue_forKey_error_,
         value,
-        key.pointer,
+        key.ref.pointer,
         error);
   }
 
   /// promisedItemResourceValuesForKeys:error:
   NSDictionary? promisedItemResourceValuesForKeys_error_(
       NSArray keys, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    final _ret = _objc_msgSend_168(this.pointer,
-        _sel_promisedItemResourceValuesForKeys_error_, keys.pointer, error);
+    final _ret = _objc_msgSend_168(this.ref.pointer,
+        _sel_promisedItemResourceValuesForKeys_error_, keys.ref.pointer, error);
     return _ret.address == 0
         ? null
         : NSDictionary.castFromPointer(_ret, retain: true, release: true);
@@ -4051,14 +4107,14 @@ class NSURL extends NSObject {
   /// checkPromisedItemIsReachableAndReturnError:
   bool checkPromisedItemIsReachableAndReturnError_(
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    return _objc_msgSend_143(
-        this.pointer, _sel_checkPromisedItemIsReachableAndReturnError_, error);
+    return _objc_msgSend_143(this.ref.pointer,
+        _sel_checkPromisedItemIsReachableAndReturnError_, error);
   }
 
   /// fileURLWithPathComponents:
   static NSURL? fileURLWithPathComponents_(NSArray components) {
     final _ret = _objc_msgSend_169(
-        _class_NSURL, _sel_fileURLWithPathComponents_, components.pointer);
+        _class_NSURL, _sel_fileURLWithPathComponents_, components.ref.pointer);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: true, release: true);
@@ -4066,7 +4122,7 @@ class NSURL extends NSObject {
 
   /// pathComponents
   NSArray? get pathComponents {
-    final _ret = _objc_msgSend_141(this.pointer, _sel_pathComponents);
+    final _ret = _objc_msgSend_141(this.ref.pointer, _sel_pathComponents);
     return _ret.address == 0
         ? null
         : NSArray.castFromPointer(_ret, retain: true, release: true);
@@ -4074,7 +4130,7 @@ class NSURL extends NSObject {
 
   /// lastPathComponent
   NSString? get lastPathComponent {
-    final _ret = _objc_msgSend_58(this.pointer, _sel_lastPathComponent);
+    final _ret = _objc_msgSend_58(this.ref.pointer, _sel_lastPathComponent);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -4082,7 +4138,7 @@ class NSURL extends NSObject {
 
   /// pathExtension
   NSString? get pathExtension {
-    final _ret = _objc_msgSend_58(this.pointer, _sel_pathExtension);
+    final _ret = _objc_msgSend_58(this.ref.pointer, _sel_pathExtension);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -4090,8 +4146,8 @@ class NSURL extends NSObject {
 
   /// URLByAppendingPathComponent:
   NSURL? URLByAppendingPathComponent_(NSString pathComponent) {
-    final _ret = _objc_msgSend_170(
-        this.pointer, _sel_URLByAppendingPathComponent_, pathComponent.pointer);
+    final _ret = _objc_msgSend_170(this.ref.pointer,
+        _sel_URLByAppendingPathComponent_, pathComponent.ref.pointer);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: true, release: true);
@@ -4101,9 +4157,9 @@ class NSURL extends NSObject {
   NSURL? URLByAppendingPathComponent_isDirectory_(
       NSString pathComponent, bool isDirectory) {
     final _ret = _objc_msgSend_171(
-        this.pointer,
+        this.ref.pointer,
         _sel_URLByAppendingPathComponent_isDirectory_,
-        pathComponent.pointer,
+        pathComponent.ref.pointer,
         isDirectory);
     return _ret.address == 0
         ? null
@@ -4113,7 +4169,7 @@ class NSURL extends NSObject {
   /// URLByDeletingLastPathComponent
   NSURL? get URLByDeletingLastPathComponent {
     final _ret =
-        _objc_msgSend_59(this.pointer, _sel_URLByDeletingLastPathComponent);
+        _objc_msgSend_59(this.ref.pointer, _sel_URLByDeletingLastPathComponent);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: true, release: true);
@@ -4121,8 +4177,8 @@ class NSURL extends NSObject {
 
   /// URLByAppendingPathExtension:
   NSURL? URLByAppendingPathExtension_(NSString pathExtension) {
-    final _ret = _objc_msgSend_170(
-        this.pointer, _sel_URLByAppendingPathExtension_, pathExtension.pointer);
+    final _ret = _objc_msgSend_170(this.ref.pointer,
+        _sel_URLByAppendingPathExtension_, pathExtension.ref.pointer);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: true, release: true);
@@ -4131,7 +4187,7 @@ class NSURL extends NSObject {
   /// URLByDeletingPathExtension
   NSURL? get URLByDeletingPathExtension {
     final _ret =
-        _objc_msgSend_59(this.pointer, _sel_URLByDeletingPathExtension);
+        _objc_msgSend_59(this.ref.pointer, _sel_URLByDeletingPathExtension);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: true, release: true);
@@ -4139,7 +4195,8 @@ class NSURL extends NSObject {
 
   /// URLByStandardizingPath
   NSURL? get URLByStandardizingPath {
-    final _ret = _objc_msgSend_59(this.pointer, _sel_URLByStandardizingPath);
+    final _ret =
+        _objc_msgSend_59(this.ref.pointer, _sel_URLByStandardizingPath);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: true, release: true);
@@ -4148,7 +4205,7 @@ class NSURL extends NSObject {
   /// URLByResolvingSymlinksInPath
   NSURL? get URLByResolvingSymlinksInPath {
     final _ret =
-        _objc_msgSend_59(this.pointer, _sel_URLByResolvingSymlinksInPath);
+        _objc_msgSend_59(this.ref.pointer, _sel_URLByResolvingSymlinksInPath);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: true, release: true);
@@ -4156,8 +4213,8 @@ class NSURL extends NSObject {
 
   /// init
   NSURL init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSURL.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// new
@@ -4180,15 +4237,15 @@ class NSURL extends NSObject {
 
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
-    final _ret = _objc_msgSend_95(
-        _class_NSURL, _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+    final _ret = _objc_msgSend_95(_class_NSURL,
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
-    return _objc_msgSend_26(
-        _class_NSURL, _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+    return _objc_msgSend_26(_class_NSURL,
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -4479,7 +4536,7 @@ class NSNumber extends NSValue {
 
   /// Constructs a [NSNumber] that points to the same underlying object as [other].
   NSNumber.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSNumber] that wraps the given raw object pointer.
   NSNumber.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -4488,216 +4545,226 @@ class NSNumber extends NSValue {
 
   /// Returns whether [obj] is an instance of [NSNumber].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_0(obj.pointer, _sel_isKindOfClass_, _class_NSNumber);
+    return _objc_msgSend_0(
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSNumber);
   }
 
   /// initWithCoder:
   NSNumber? initWithCoder_(NSCoder coder) {
-    final _ret =
-        _objc_msgSend_18(this.pointer, _sel_initWithCoder_, coder.pointer);
+    final _ret = _objc_msgSend_18(this.ref.retainAndReturnPointer(),
+        _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSNumber.castFromPointer(_ret, retain: true, release: true);
+        : NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithChar:
   NSNumber initWithChar_(int value) {
-    final _ret = _objc_msgSend_60(this.pointer, _sel_initWithChar_, value);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_60(
+        this.ref.retainAndReturnPointer(), _sel_initWithChar_, value);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithUnsignedChar:
   NSNumber initWithUnsignedChar_(int value) {
-    final _ret =
-        _objc_msgSend_61(this.pointer, _sel_initWithUnsignedChar_, value);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_61(
+        this.ref.retainAndReturnPointer(), _sel_initWithUnsignedChar_, value);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithShort:
   NSNumber initWithShort_(int value) {
-    final _ret = _objc_msgSend_62(this.pointer, _sel_initWithShort_, value);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_62(
+        this.ref.retainAndReturnPointer(), _sel_initWithShort_, value);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithUnsignedShort:
   NSNumber initWithUnsignedShort_(int value) {
-    final _ret =
-        _objc_msgSend_63(this.pointer, _sel_initWithUnsignedShort_, value);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_63(
+        this.ref.retainAndReturnPointer(), _sel_initWithUnsignedShort_, value);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithInt:
   NSNumber initWithInt_(int value) {
-    final _ret = _objc_msgSend_64(this.pointer, _sel_initWithInt_, value);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_64(
+        this.ref.retainAndReturnPointer(), _sel_initWithInt_, value);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithUnsignedInt:
   NSNumber initWithUnsignedInt_(int value) {
-    final _ret =
-        _objc_msgSend_65(this.pointer, _sel_initWithUnsignedInt_, value);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_65(
+        this.ref.retainAndReturnPointer(), _sel_initWithUnsignedInt_, value);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithLong:
   NSNumber initWithLong_(int value) {
-    final _ret = _objc_msgSend_66(this.pointer, _sel_initWithLong_, value);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_66(
+        this.ref.retainAndReturnPointer(), _sel_initWithLong_, value);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithUnsignedLong:
   NSNumber initWithUnsignedLong_(int value) {
-    final _ret =
-        _objc_msgSend_67(this.pointer, _sel_initWithUnsignedLong_, value);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_67(
+        this.ref.retainAndReturnPointer(), _sel_initWithUnsignedLong_, value);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithLongLong:
   NSNumber initWithLongLong_(int value) {
-    final _ret = _objc_msgSend_68(this.pointer, _sel_initWithLongLong_, value);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_68(
+        this.ref.retainAndReturnPointer(), _sel_initWithLongLong_, value);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithUnsignedLongLong:
   NSNumber initWithUnsignedLongLong_(int value) {
-    final _ret =
-        _objc_msgSend_69(this.pointer, _sel_initWithUnsignedLongLong_, value);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_69(this.ref.retainAndReturnPointer(),
+        _sel_initWithUnsignedLongLong_, value);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithFloat:
   NSNumber initWithFloat_(double value) {
-    final _ret = _objc_msgSend_70(this.pointer, _sel_initWithFloat_, value);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_70(
+        this.ref.retainAndReturnPointer(), _sel_initWithFloat_, value);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithDouble:
   NSNumber initWithDouble_(double value) {
-    final _ret = _objc_msgSend_71(this.pointer, _sel_initWithDouble_, value);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_71(
+        this.ref.retainAndReturnPointer(), _sel_initWithDouble_, value);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBool:
   NSNumber initWithBool_(bool value) {
-    final _ret = _objc_msgSend_72(this.pointer, _sel_initWithBool_, value);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_72(
+        this.ref.retainAndReturnPointer(), _sel_initWithBool_, value);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithInteger:
   NSNumber initWithInteger_(int value) {
-    final _ret = _objc_msgSend_66(this.pointer, _sel_initWithInteger_, value);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_66(
+        this.ref.retainAndReturnPointer(), _sel_initWithInteger_, value);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithUnsignedInteger:
   NSNumber initWithUnsignedInteger_(int value) {
-    final _ret =
-        _objc_msgSend_67(this.pointer, _sel_initWithUnsignedInteger_, value);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_67(this.ref.retainAndReturnPointer(),
+        _sel_initWithUnsignedInteger_, value);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// charValue
   int get charValue {
-    return _objc_msgSend_73(this.pointer, _sel_charValue);
+    return _objc_msgSend_73(this.ref.pointer, _sel_charValue);
   }
 
   /// unsignedCharValue
   int get unsignedCharValue {
-    return _objc_msgSend_74(this.pointer, _sel_unsignedCharValue);
+    return _objc_msgSend_74(this.ref.pointer, _sel_unsignedCharValue);
   }
 
   /// shortValue
   int get shortValue {
-    return _objc_msgSend_75(this.pointer, _sel_shortValue);
+    return _objc_msgSend_75(this.ref.pointer, _sel_shortValue);
   }
 
   /// unsignedShortValue
   int get unsignedShortValue {
-    return _objc_msgSend_76(this.pointer, _sel_unsignedShortValue);
+    return _objc_msgSend_76(this.ref.pointer, _sel_unsignedShortValue);
   }
 
   /// intValue
   int get intValue {
-    return _objc_msgSend_77(this.pointer, _sel_intValue);
+    return _objc_msgSend_77(this.ref.pointer, _sel_intValue);
   }
 
   /// unsignedIntValue
   int get unsignedIntValue {
-    return _objc_msgSend_78(this.pointer, _sel_unsignedIntValue);
+    return _objc_msgSend_78(this.ref.pointer, _sel_unsignedIntValue);
   }
 
   /// longValue
   int get longValue {
-    return _objc_msgSend_79(this.pointer, _sel_longValue);
+    return _objc_msgSend_79(this.ref.pointer, _sel_longValue);
   }
 
   /// unsignedLongValue
   int get unsignedLongValue {
-    return _objc_msgSend_11(this.pointer, _sel_unsignedLongValue);
+    return _objc_msgSend_11(this.ref.pointer, _sel_unsignedLongValue);
   }
 
   /// longLongValue
   int get longLongValue {
-    return _objc_msgSend_80(this.pointer, _sel_longLongValue);
+    return _objc_msgSend_80(this.ref.pointer, _sel_longLongValue);
   }
 
   /// unsignedLongLongValue
   int get unsignedLongLongValue {
-    return _objc_msgSend_81(this.pointer, _sel_unsignedLongLongValue);
+    return _objc_msgSend_81(this.ref.pointer, _sel_unsignedLongLongValue);
   }
 
   /// floatValue
   double get floatValue {
     return objc.useMsgSendVariants
-        ? _objc_msgSend_82Fpret(this.pointer, _sel_floatValue)
-        : _objc_msgSend_82(this.pointer, _sel_floatValue);
+        ? _objc_msgSend_82Fpret(this.ref.pointer, _sel_floatValue)
+        : _objc_msgSend_82(this.ref.pointer, _sel_floatValue);
   }
 
   /// doubleValue
   double get doubleValue {
     return objc.useMsgSendVariants
-        ? _objc_msgSend_83Fpret(this.pointer, _sel_doubleValue)
-        : _objc_msgSend_83(this.pointer, _sel_doubleValue);
+        ? _objc_msgSend_83Fpret(this.ref.pointer, _sel_doubleValue)
+        : _objc_msgSend_83(this.ref.pointer, _sel_doubleValue);
   }
 
   /// boolValue
   bool get boolValue {
-    return _objc_msgSend_13(this.pointer, _sel_boolValue);
+    return _objc_msgSend_13(this.ref.pointer, _sel_boolValue);
   }
 
   /// integerValue
   int get integerValue {
-    return _objc_msgSend_79(this.pointer, _sel_integerValue);
+    return _objc_msgSend_79(this.ref.pointer, _sel_integerValue);
   }
 
   /// unsignedIntegerValue
   int get unsignedIntegerValue {
-    return _objc_msgSend_11(this.pointer, _sel_unsignedIntegerValue);
+    return _objc_msgSend_11(this.ref.pointer, _sel_unsignedIntegerValue);
   }
 
   /// stringValue
   NSString get stringValue {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_stringValue);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_stringValue);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// compare:
   NSComparisonResult compare_(NSNumber otherNumber) {
-    final _ret =
-        _objc_msgSend_84(this.pointer, _sel_compare_, otherNumber.pointer);
+    final _ret = _objc_msgSend_84(
+        this.ref.pointer, _sel_compare_, otherNumber.ref.pointer);
     return NSComparisonResult.fromValue(_ret);
   }
 
   /// isEqualToNumber:
   bool isEqualToNumber_(NSNumber number) {
     return _objc_msgSend_85(
-        this.pointer, _sel_isEqualToNumber_, number.pointer);
+        this.ref.pointer, _sel_isEqualToNumber_, number.ref.pointer);
   }
 
   /// descriptionWithLocale:
   NSString descriptionWithLocale_(objc.ObjCObjectBase? locale) {
-    final _ret = _objc_msgSend_86(this.pointer, _sel_descriptionWithLocale_,
-        locale?.pointer ?? ffi.nullptr);
+    final _ret = _objc_msgSend_86(this.ref.pointer, _sel_descriptionWithLocale_,
+        locale?.ref.pointer ?? ffi.nullptr);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -4805,9 +4872,9 @@ class NSNumber extends NSValue {
   /// initWithBytes:objCType:
   NSNumber initWithBytes_objCType_(
       ffi.Pointer<ffi.Void> value, ffi.Pointer<ffi.Char> type) {
-    final _ret = _objc_msgSend_87(
-        this.pointer, _sel_initWithBytes_objCType_, value, type);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_87(this.ref.retainAndReturnPointer(),
+        _sel_initWithBytes_objCType_, value, type);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// valueWithBytes:objCType:
@@ -4829,7 +4896,7 @@ class NSNumber extends NSValue {
   /// valueWithNonretainedObject:
   static NSValue valueWithNonretainedObject_(objc.ObjCObjectBase? anObject) {
     final _ret = _objc_msgSend_89(_class_NSNumber,
-        _sel_valueWithNonretainedObject_, anObject?.pointer ?? ffi.nullptr);
+        _sel_valueWithNonretainedObject_, anObject?.ref.pointer ?? ffi.nullptr);
     return NSValue.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -4848,8 +4915,8 @@ class NSNumber extends NSValue {
 
   /// init
   NSNumber init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSNumber.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// new
@@ -4873,14 +4940,14 @@ class NSNumber extends NSValue {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSNumber,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSNumber,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -5195,7 +5262,7 @@ class NSValue extends NSObject {
 
   /// Constructs a [NSValue] that points to the same underlying object as [other].
   NSValue.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSValue] that wraps the given raw object pointer.
   NSValue.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -5204,34 +5271,35 @@ class NSValue extends NSObject {
 
   /// Returns whether [obj] is an instance of [NSValue].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_0(obj.pointer, _sel_isKindOfClass_, _class_NSValue);
+    return _objc_msgSend_0(
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSValue);
   }
 
   /// getValue:size:
   void getValue_size_(ffi.Pointer<ffi.Void> value, int size) {
-    _objc_msgSend_37(this.pointer, _sel_getValue_size_, value, size);
+    _objc_msgSend_37(this.ref.pointer, _sel_getValue_size_, value, size);
   }
 
   /// objCType
   ffi.Pointer<ffi.Char> get objCType {
-    return _objc_msgSend_14(this.pointer, _sel_objCType);
+    return _objc_msgSend_14(this.ref.pointer, _sel_objCType);
   }
 
   /// initWithBytes:objCType:
   NSValue initWithBytes_objCType_(
       ffi.Pointer<ffi.Void> value, ffi.Pointer<ffi.Char> type) {
-    final _ret = _objc_msgSend_87(
-        this.pointer, _sel_initWithBytes_objCType_, value, type);
-    return NSValue.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_87(this.ref.retainAndReturnPointer(),
+        _sel_initWithBytes_objCType_, value, type);
+    return NSValue.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
   NSValue? initWithCoder_(NSCoder coder) {
-    final _ret =
-        _objc_msgSend_18(this.pointer, _sel_initWithCoder_, coder.pointer);
+    final _ret = _objc_msgSend_18(this.ref.retainAndReturnPointer(),
+        _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSValue.castFromPointer(_ret, retain: true, release: true);
+        : NSValue.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// valueWithBytes:objCType:
@@ -5253,13 +5321,14 @@ class NSValue extends NSObject {
   /// valueWithNonretainedObject:
   static NSValue valueWithNonretainedObject_(objc.ObjCObjectBase? anObject) {
     final _ret = _objc_msgSend_89(_class_NSValue,
-        _sel_valueWithNonretainedObject_, anObject?.pointer ?? ffi.nullptr);
+        _sel_valueWithNonretainedObject_, anObject?.ref.pointer ?? ffi.nullptr);
     return NSValue.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// nonretainedObjectValue
   objc.ObjCObjectBase? get nonretainedObjectValue {
-    final _ret = _objc_msgSend_16(this.pointer, _sel_nonretainedObjectValue);
+    final _ret =
+        _objc_msgSend_16(this.ref.pointer, _sel_nonretainedObjectValue);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -5274,17 +5343,18 @@ class NSValue extends NSObject {
 
   /// pointerValue
   ffi.Pointer<ffi.Void> get pointerValue {
-    return _objc_msgSend_35(this.pointer, _sel_pointerValue);
+    return _objc_msgSend_35(this.ref.pointer, _sel_pointerValue);
   }
 
   /// isEqualToValue:
   bool isEqualToValue_(NSValue value) {
-    return _objc_msgSend_91(this.pointer, _sel_isEqualToValue_, value.pointer);
+    return _objc_msgSend_91(
+        this.ref.pointer, _sel_isEqualToValue_, value.ref.pointer);
   }
 
   /// getValue:
   void getValue_(ffi.Pointer<ffi.Void> value) {
-    _objc_msgSend_92(this.pointer, _sel_getValue_, value);
+    _objc_msgSend_92(this.ref.pointer, _sel_getValue_, value);
   }
 
   /// valueWithRange:
@@ -5296,14 +5366,14 @@ class NSValue extends NSObject {
   /// rangeValue
   void getRangeValue(ffi.Pointer<NSRange> stret) {
     objc.useMsgSendVariants
-        ? _objc_msgSend_94Stret(stret, this.pointer, _sel_rangeValue)
-        : stret.ref = _objc_msgSend_94(this.pointer, _sel_rangeValue);
+        ? _objc_msgSend_94Stret(stret, this.ref.pointer, _sel_rangeValue)
+        : stret.ref = _objc_msgSend_94(this.ref.pointer, _sel_rangeValue);
   }
 
   /// init
   NSValue init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSValue.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSValue.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// new
@@ -5327,14 +5397,14 @@ class NSValue extends NSObject {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSValue,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSValue,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -5503,7 +5573,7 @@ class NSError extends NSObject {
 
   /// Constructs a [NSError] that points to the same underlying object as [other].
   NSError.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSError] that wraps the given raw object pointer.
   NSError.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -5512,19 +5582,20 @@ class NSError extends NSObject {
 
   /// Returns whether [obj] is an instance of [NSError].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_0(obj.pointer, _sel_isKindOfClass_, _class_NSError);
+    return _objc_msgSend_0(
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSError);
   }
 
   /// initWithDomain:code:userInfo:
   NSError initWithDomain_code_userInfo_(
       NSString domain, int code, objc.ObjCObjectBase? dict) {
     final _ret = _objc_msgSend_98(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithDomain_code_userInfo_,
-        domain.pointer,
+        domain.ref.pointer,
         code,
-        dict?.pointer ?? ffi.nullptr);
-    return NSError.castFromPointer(_ret, retain: true, release: true);
+        dict?.ref.pointer ?? ffi.nullptr);
+    return NSError.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// errorWithDomain:code:userInfo:
@@ -5533,38 +5604,39 @@ class NSError extends NSObject {
     final _ret = _objc_msgSend_98(
         _class_NSError,
         _sel_errorWithDomain_code_userInfo_,
-        domain.pointer,
+        domain.ref.pointer,
         code,
-        dict?.pointer ?? ffi.nullptr);
+        dict?.ref.pointer ?? ffi.nullptr);
     return NSError.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// domain
   NSString get domain {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_domain);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_domain);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// code
   int get code {
-    return _objc_msgSend_79(this.pointer, _sel_code);
+    return _objc_msgSend_79(this.ref.pointer, _sel_code);
   }
 
   /// userInfo
   objc.ObjCObjectBase get userInfo {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_userInfo);
+    final _ret = _objc_msgSend_2(this.ref.pointer, _sel_userInfo);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
   /// localizedDescription
   NSString get localizedDescription {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_localizedDescription);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_localizedDescription);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// localizedFailureReason
   NSString? get localizedFailureReason {
-    final _ret = _objc_msgSend_58(this.pointer, _sel_localizedFailureReason);
+    final _ret =
+        _objc_msgSend_58(this.ref.pointer, _sel_localizedFailureReason);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -5573,7 +5645,7 @@ class NSError extends NSObject {
   /// localizedRecoverySuggestion
   NSString? get localizedRecoverySuggestion {
     final _ret =
-        _objc_msgSend_58(this.pointer, _sel_localizedRecoverySuggestion);
+        _objc_msgSend_58(this.ref.pointer, _sel_localizedRecoverySuggestion);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -5581,7 +5653,8 @@ class NSError extends NSObject {
 
   /// localizedRecoveryOptions
   NSArray? get localizedRecoveryOptions {
-    final _ret = _objc_msgSend_141(this.pointer, _sel_localizedRecoveryOptions);
+    final _ret =
+        _objc_msgSend_141(this.ref.pointer, _sel_localizedRecoveryOptions);
     return _ret.address == 0
         ? null
         : NSArray.castFromPointer(_ret, retain: true, release: true);
@@ -5589,7 +5662,7 @@ class NSError extends NSObject {
 
   /// recoveryAttempter
   objc.ObjCObjectBase? get recoveryAttempter {
-    final _ret = _objc_msgSend_16(this.pointer, _sel_recoveryAttempter);
+    final _ret = _objc_msgSend_16(this.ref.pointer, _sel_recoveryAttempter);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -5597,7 +5670,7 @@ class NSError extends NSObject {
 
   /// helpAnchor
   NSString? get helpAnchor {
-    final _ret = _objc_msgSend_58(this.pointer, _sel_helpAnchor);
+    final _ret = _objc_msgSend_58(this.ref.pointer, _sel_helpAnchor);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -5605,14 +5678,14 @@ class NSError extends NSObject {
 
   /// underlyingErrors
   NSArray get underlyingErrors {
-    final _ret = _objc_msgSend_142(this.pointer, _sel_underlyingErrors);
+    final _ret = _objc_msgSend_142(this.ref.pointer, _sel_underlyingErrors);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// init
   NSError init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSError.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSError.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// new
@@ -5636,14 +5709,14 @@ class NSError extends NSObject {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSError,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSError,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -5686,7 +5759,7 @@ class NSArray extends NSObject {
 
   /// Constructs a [NSArray] that points to the same underlying object as [other].
   NSArray.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSArray] that wraps the given raw object pointer.
   NSArray.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -5695,80 +5768,81 @@ class NSArray extends NSObject {
 
   /// Returns whether [obj] is an instance of [NSArray].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_0(obj.pointer, _sel_isKindOfClass_, _class_NSArray);
+    return _objc_msgSend_0(
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSArray);
   }
 
   /// count
   int get count {
-    return _objc_msgSend_11(this.pointer, _sel_count);
+    return _objc_msgSend_11(this.ref.pointer, _sel_count);
   }
 
   /// objectAtIndex:
   objc.ObjCObjectBase objectAtIndex_(int index) {
-    final _ret = _objc_msgSend_99(this.pointer, _sel_objectAtIndex_, index);
+    final _ret = _objc_msgSend_99(this.ref.pointer, _sel_objectAtIndex_, index);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
   /// init
   NSArray init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSArray.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithObjects:count:
   NSArray initWithObjects_count_(
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
-    final _ret = _objc_msgSend_100(
-        this.pointer, _sel_initWithObjects_count_, objects, cnt);
-    return NSArray.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_100(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_count_, objects, cnt);
+    return NSArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
   NSArray? initWithCoder_(NSCoder coder) {
-    final _ret =
-        _objc_msgSend_18(this.pointer, _sel_initWithCoder_, coder.pointer);
+    final _ret = _objc_msgSend_18(this.ref.retainAndReturnPointer(),
+        _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSArray.castFromPointer(_ret, retain: true, release: true);
+        : NSArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// arrayByAddingObject:
   NSArray arrayByAddingObject_(objc.ObjCObjectBase anObject) {
     final _ret = _objc_msgSend_101(
-        this.pointer, _sel_arrayByAddingObject_, anObject.pointer);
+        this.ref.pointer, _sel_arrayByAddingObject_, anObject.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// arrayByAddingObjectsFromArray:
   NSArray arrayByAddingObjectsFromArray_(NSArray otherArray) {
-    final _ret = _objc_msgSend_102(
-        this.pointer, _sel_arrayByAddingObjectsFromArray_, otherArray.pointer);
+    final _ret = _objc_msgSend_102(this.ref.pointer,
+        _sel_arrayByAddingObjectsFromArray_, otherArray.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// componentsJoinedByString:
   NSString componentsJoinedByString_(NSString separator) {
-    final _ret = _objc_msgSend_103(
-        this.pointer, _sel_componentsJoinedByString_, separator.pointer);
+    final _ret = _objc_msgSend_103(this.ref.pointer,
+        _sel_componentsJoinedByString_, separator.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// containsObject:
   bool containsObject_(objc.ObjCObjectBase anObject) {
     return _objc_msgSend_0(
-        this.pointer, _sel_containsObject_, anObject.pointer);
+        this.ref.pointer, _sel_containsObject_, anObject.ref.pointer);
   }
 
   /// description
   NSString get description {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_description);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_description);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// descriptionWithLocale:
   NSString descriptionWithLocale_(objc.ObjCObjectBase? locale) {
-    final _ret = _objc_msgSend_86(this.pointer, _sel_descriptionWithLocale_,
-        locale?.pointer ?? ffi.nullptr);
+    final _ret = _objc_msgSend_86(this.ref.pointer, _sel_descriptionWithLocale_,
+        locale?.ref.pointer ?? ffi.nullptr);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -5776,17 +5850,17 @@ class NSArray extends NSObject {
   NSString descriptionWithLocale_indent_(
       objc.ObjCObjectBase? locale, int level) {
     final _ret = _objc_msgSend_104(
-        this.pointer,
+        this.ref.pointer,
         _sel_descriptionWithLocale_indent_,
-        locale?.pointer ?? ffi.nullptr,
+        locale?.ref.pointer ?? ffi.nullptr,
         level);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// firstObjectCommonWithArray:
   objc.ObjCObjectBase? firstObjectCommonWithArray_(NSArray otherArray) {
-    final _ret = _objc_msgSend_105(
-        this.pointer, _sel_firstObjectCommonWithArray_, otherArray.pointer);
+    final _ret = _objc_msgSend_105(this.ref.pointer,
+        _sel_firstObjectCommonWithArray_, otherArray.ref.pointer);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -5795,43 +5869,43 @@ class NSArray extends NSObject {
   /// getObjects:range:
   void getObjects_range_(
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, NSRange range) {
-    _objc_msgSend_106(this.pointer, _sel_getObjects_range_, objects, range);
+    _objc_msgSend_106(this.ref.pointer, _sel_getObjects_range_, objects, range);
   }
 
   /// indexOfObject:
   int indexOfObject_(objc.ObjCObjectBase anObject) {
     return _objc_msgSend_107(
-        this.pointer, _sel_indexOfObject_, anObject.pointer);
+        this.ref.pointer, _sel_indexOfObject_, anObject.ref.pointer);
   }
 
   /// indexOfObject:inRange:
   int indexOfObject_inRange_(objc.ObjCObjectBase anObject, NSRange range) {
-    return _objc_msgSend_108(
-        this.pointer, _sel_indexOfObject_inRange_, anObject.pointer, range);
+    return _objc_msgSend_108(this.ref.pointer, _sel_indexOfObject_inRange_,
+        anObject.ref.pointer, range);
   }
 
   /// indexOfObjectIdenticalTo:
   int indexOfObjectIdenticalTo_(objc.ObjCObjectBase anObject) {
     return _objc_msgSend_107(
-        this.pointer, _sel_indexOfObjectIdenticalTo_, anObject.pointer);
+        this.ref.pointer, _sel_indexOfObjectIdenticalTo_, anObject.ref.pointer);
   }
 
   /// indexOfObjectIdenticalTo:inRange:
   int indexOfObjectIdenticalTo_inRange_(
       objc.ObjCObjectBase anObject, NSRange range) {
-    return _objc_msgSend_108(this.pointer,
-        _sel_indexOfObjectIdenticalTo_inRange_, anObject.pointer, range);
+    return _objc_msgSend_108(this.ref.pointer,
+        _sel_indexOfObjectIdenticalTo_inRange_, anObject.ref.pointer, range);
   }
 
   /// isEqualToArray:
   bool isEqualToArray_(NSArray otherArray) {
     return _objc_msgSend_109(
-        this.pointer, _sel_isEqualToArray_, otherArray.pointer);
+        this.ref.pointer, _sel_isEqualToArray_, otherArray.ref.pointer);
   }
 
   /// firstObject
   objc.ObjCObjectBase? get firstObject {
-    final _ret = _objc_msgSend_16(this.pointer, _sel_firstObject);
+    final _ret = _objc_msgSend_16(this.ref.pointer, _sel_firstObject);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -5839,7 +5913,7 @@ class NSArray extends NSObject {
 
   /// lastObject
   objc.ObjCObjectBase? get lastObject {
-    final _ret = _objc_msgSend_16(this.pointer, _sel_lastObject);
+    final _ret = _objc_msgSend_16(this.ref.pointer, _sel_lastObject);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -5847,19 +5921,20 @@ class NSArray extends NSObject {
 
   /// objectEnumerator
   NSEnumerator objectEnumerator() {
-    final _ret = _objc_msgSend_110(this.pointer, _sel_objectEnumerator);
+    final _ret = _objc_msgSend_110(this.ref.pointer, _sel_objectEnumerator);
     return NSEnumerator.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// reverseObjectEnumerator
   NSEnumerator reverseObjectEnumerator() {
-    final _ret = _objc_msgSend_110(this.pointer, _sel_reverseObjectEnumerator);
+    final _ret =
+        _objc_msgSend_110(this.ref.pointer, _sel_reverseObjectEnumerator);
     return NSEnumerator.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// sortedArrayHint
   NSData get sortedArrayHint {
-    final _ret = _objc_msgSend_57(this.pointer, _sel_sortedArrayHint);
+    final _ret = _objc_msgSend_57(this.ref.pointer, _sel_sortedArrayHint);
     return NSData.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -5871,7 +5946,7 @@ class NSArray extends NSObject {
                       ffi.Pointer<objc.ObjCObject>, ffi.Pointer<ffi.Void>)>>
           comparator,
       ffi.Pointer<ffi.Void> context) {
-    final _ret = _objc_msgSend_111(this.pointer,
+    final _ret = _objc_msgSend_111(this.ref.pointer,
         _sel_sortedArrayUsingFunction_context_, comparator, context);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
@@ -5886,25 +5961,25 @@ class NSArray extends NSObject {
       ffi.Pointer<ffi.Void> context,
       NSData? hint) {
     final _ret = _objc_msgSend_112(
-        this.pointer,
+        this.ref.pointer,
         _sel_sortedArrayUsingFunction_context_hint_,
         comparator,
         context,
-        hint?.pointer ?? ffi.nullptr);
+        hint?.ref.pointer ?? ffi.nullptr);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// sortedArrayUsingSelector:
   NSArray sortedArrayUsingSelector_(ffi.Pointer<objc.ObjCSelector> comparator) {
     final _ret = _objc_msgSend_113(
-        this.pointer, _sel_sortedArrayUsingSelector_, comparator);
+        this.ref.pointer, _sel_sortedArrayUsingSelector_, comparator);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// subarrayWithRange:
   NSArray subarrayWithRange_(NSRange range) {
     final _ret =
-        _objc_msgSend_114(this.pointer, _sel_subarrayWithRange_, range);
+        _objc_msgSend_114(this.ref.pointer, _sel_subarrayWithRange_, range);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -5912,32 +5987,36 @@ class NSArray extends NSObject {
   bool writeToURL_error_(
       NSURL url, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     return _objc_msgSend_115(
-        this.pointer, _sel_writeToURL_error_, url.pointer, error);
+        this.ref.pointer, _sel_writeToURL_error_, url.ref.pointer, error);
   }
 
   /// makeObjectsPerformSelector:
   void makeObjectsPerformSelector_(ffi.Pointer<objc.ObjCSelector> aSelector) {
-    _objc_msgSend_7(this.pointer, _sel_makeObjectsPerformSelector_, aSelector);
+    _objc_msgSend_7(
+        this.ref.pointer, _sel_makeObjectsPerformSelector_, aSelector);
   }
 
   /// makeObjectsPerformSelector:withObject:
   void makeObjectsPerformSelector_withObject_(
       ffi.Pointer<objc.ObjCSelector> aSelector, objc.ObjCObjectBase? argument) {
-    _objc_msgSend_116(this.pointer, _sel_makeObjectsPerformSelector_withObject_,
-        aSelector, argument?.pointer ?? ffi.nullptr);
+    _objc_msgSend_116(
+        this.ref.pointer,
+        _sel_makeObjectsPerformSelector_withObject_,
+        aSelector,
+        argument?.ref.pointer ?? ffi.nullptr);
   }
 
   /// objectsAtIndexes:
   NSArray objectsAtIndexes_(NSIndexSet indexes) {
     final _ret = _objc_msgSend_125(
-        this.pointer, _sel_objectsAtIndexes_, indexes.pointer);
+        this.ref.pointer, _sel_objectsAtIndexes_, indexes.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// objectAtIndexedSubscript:
   objc.ObjCObjectBase objectAtIndexedSubscript_(int idx) {
     final _ret =
-        _objc_msgSend_99(this.pointer, _sel_objectAtIndexedSubscript_, idx);
+        _objc_msgSend_99(this.ref.pointer, _sel_objectAtIndexedSubscript_, idx);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
@@ -5950,7 +6029,7 @@ class NSArray extends NSObject {
   /// arrayWithObject:
   static NSArray arrayWithObject_(objc.ObjCObjectBase anObject) {
     final _ret = _objc_msgSend_126(
-        _class_NSArray, _sel_arrayWithObject_, anObject.pointer);
+        _class_NSArray, _sel_arrayWithObject_, anObject.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -5965,53 +6044,53 @@ class NSArray extends NSObject {
   /// arrayWithObjects:
   static NSArray arrayWithObjects_(objc.ObjCObjectBase firstObj) {
     final _ret = _objc_msgSend_126(
-        _class_NSArray, _sel_arrayWithObjects_, firstObj.pointer);
+        _class_NSArray, _sel_arrayWithObjects_, firstObj.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// arrayWithArray:
   static NSArray arrayWithArray_(NSArray array) {
-    final _ret =
-        _objc_msgSend_127(_class_NSArray, _sel_arrayWithArray_, array.pointer);
+    final _ret = _objc_msgSend_127(
+        _class_NSArray, _sel_arrayWithArray_, array.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// initWithObjects:
   NSArray initWithObjects_(objc.ObjCObjectBase firstObj) {
-    final _ret = _objc_msgSend_126(
-        this.pointer, _sel_initWithObjects_, firstObj.pointer);
-    return NSArray.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_126(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_, firstObj.ref.pointer);
+    return NSArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithArray:
   NSArray initWithArray_(NSArray array) {
-    final _ret =
-        _objc_msgSend_127(this.pointer, _sel_initWithArray_, array.pointer);
-    return NSArray.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_127(this.ref.retainAndReturnPointer(),
+        _sel_initWithArray_, array.ref.pointer);
+    return NSArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithArray:copyItems:
   NSArray initWithArray_copyItems_(NSArray array, bool flag) {
-    final _ret = _objc_msgSend_128(
-        this.pointer, _sel_initWithArray_copyItems_, array.pointer, flag);
+    final _ret = _objc_msgSend_128(this.ref.retainAndReturnPointer(),
+        _sel_initWithArray_copyItems_, array.ref.pointer, flag);
     return NSArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfURL:error:
   NSArray? initWithContentsOfURL_error_(
       NSURL url, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    final _ret = _objc_msgSend_129(
-        this.pointer, _sel_initWithContentsOfURL_error_, url.pointer, error);
+    final _ret = _objc_msgSend_129(this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfURL_error_, url.ref.pointer, error);
     return _ret.address == 0
         ? null
-        : NSArray.castFromPointer(_ret, retain: true, release: true);
+        : NSArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// arrayWithContentsOfURL:error:
   static NSArray? arrayWithContentsOfURL_error_(
       NSURL url, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    final _ret = _objc_msgSend_129(
-        _class_NSArray, _sel_arrayWithContentsOfURL_error_, url.pointer, error);
+    final _ret = _objc_msgSend_129(_class_NSArray,
+        _sel_arrayWithContentsOfURL_error_, url.ref.pointer, error);
     return _ret.address == 0
         ? null
         : NSArray.castFromPointer(_ret, retain: true, release: true);
@@ -6020,22 +6099,25 @@ class NSArray extends NSObject {
   /// differenceFromArray:withOptions:
   objc.ObjCObjectBase differenceFromArray_withOptions_(
       NSArray other, NSOrderedCollectionDifferenceCalculationOptions options) {
-    final _ret = _objc_msgSend_130(this.pointer,
-        _sel_differenceFromArray_withOptions_, other.pointer, options.value);
+    final _ret = _objc_msgSend_130(
+        this.ref.pointer,
+        _sel_differenceFromArray_withOptions_,
+        other.ref.pointer,
+        options.value);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
   /// differenceFromArray:
   objc.ObjCObjectBase differenceFromArray_(NSArray other) {
     final _ret = _objc_msgSend_127(
-        this.pointer, _sel_differenceFromArray_, other.pointer);
+        this.ref.pointer, _sel_differenceFromArray_, other.ref.pointer);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
   /// arrayByApplyingDifference:
   NSArray? arrayByApplyingDifference_(objc.ObjCObjectBase difference) {
-    final _ret = _objc_msgSend_131(
-        this.pointer, _sel_arrayByApplyingDifference_, difference.pointer);
+    final _ret = _objc_msgSend_131(this.ref.pointer,
+        _sel_arrayByApplyingDifference_, difference.ref.pointer);
     return _ret.address == 0
         ? null
         : NSArray.castFromPointer(_ret, retain: true, release: true);
@@ -6044,7 +6126,7 @@ class NSArray extends NSObject {
   /// arrayWithContentsOfFile:
   static NSArray? arrayWithContentsOfFile_(NSString path) {
     final _ret = _objc_msgSend_132(
-        _class_NSArray, _sel_arrayWithContentsOfFile_, path.pointer);
+        _class_NSArray, _sel_arrayWithContentsOfFile_, path.ref.pointer);
     return _ret.address == 0
         ? null
         : NSArray.castFromPointer(_ret, retain: true, release: true);
@@ -6053,7 +6135,7 @@ class NSArray extends NSObject {
   /// arrayWithContentsOfURL:
   static NSArray? arrayWithContentsOfURL_(NSURL url) {
     final _ret = _objc_msgSend_133(
-        _class_NSArray, _sel_arrayWithContentsOfURL_, url.pointer);
+        _class_NSArray, _sel_arrayWithContentsOfURL_, url.ref.pointer);
     return _ret.address == 0
         ? null
         : NSArray.castFromPointer(_ret, retain: true, release: true);
@@ -6061,32 +6143,32 @@ class NSArray extends NSObject {
 
   /// initWithContentsOfFile:
   NSArray? initWithContentsOfFile_(NSString path) {
-    final _ret = _objc_msgSend_132(
-        this.pointer, _sel_initWithContentsOfFile_, path.pointer);
+    final _ret = _objc_msgSend_132(this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfFile_, path.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSArray.castFromPointer(_ret, retain: true, release: true);
+        : NSArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfURL:
   NSArray? initWithContentsOfURL_(NSURL url) {
-    final _ret = _objc_msgSend_133(
-        this.pointer, _sel_initWithContentsOfURL_, url.pointer);
+    final _ret = _objc_msgSend_133(this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfURL_, url.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSArray.castFromPointer(_ret, retain: true, release: true);
+        : NSArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// writeToFile:atomically:
   bool writeToFile_atomically_(NSString path, bool useAuxiliaryFile) {
-    return _objc_msgSend_41(this.pointer, _sel_writeToFile_atomically_,
-        path.pointer, useAuxiliaryFile);
+    return _objc_msgSend_41(this.ref.pointer, _sel_writeToFile_atomically_,
+        path.ref.pointer, useAuxiliaryFile);
   }
 
   /// writeToURL:atomically:
   bool writeToURL_atomically_(NSURL url, bool atomically) {
-    return _objc_msgSend_134(
-        this.pointer, _sel_writeToURL_atomically_, url.pointer, atomically);
+    return _objc_msgSend_134(this.ref.pointer, _sel_writeToURL_atomically_,
+        url.ref.pointer, atomically);
   }
 
   /// addObserver:toObjectsAtIndexes:forKeyPath:options:context:
@@ -6097,11 +6179,11 @@ class NSArray extends NSObject {
       NSKeyValueObservingOptions options,
       ffi.Pointer<ffi.Void> context) {
     _objc_msgSend_135(
-        this.pointer,
+        this.ref.pointer,
         _sel_addObserver_toObjectsAtIndexes_forKeyPath_options_context_,
-        observer.pointer,
-        indexes.pointer,
-        keyPath.pointer,
+        observer.ref.pointer,
+        indexes.ref.pointer,
+        keyPath.ref.pointer,
         options.value,
         context);
   }
@@ -6113,11 +6195,11 @@ class NSArray extends NSObject {
       NSString keyPath,
       ffi.Pointer<ffi.Void> context) {
     _objc_msgSend_136(
-        this.pointer,
+        this.ref.pointer,
         _sel_removeObserver_fromObjectsAtIndexes_forKeyPath_context_,
-        observer.pointer,
-        indexes.pointer,
-        keyPath.pointer,
+        observer.ref.pointer,
+        indexes.ref.pointer,
+        keyPath.ref.pointer,
         context);
   }
 
@@ -6125,11 +6207,11 @@ class NSArray extends NSObject {
   void removeObserver_fromObjectsAtIndexes_forKeyPath_(
       NSObject observer, NSIndexSet indexes, NSString keyPath) {
     _objc_msgSend_137(
-        this.pointer,
+        this.ref.pointer,
         _sel_removeObserver_fromObjectsAtIndexes_forKeyPath_,
-        observer.pointer,
-        indexes.pointer,
-        keyPath.pointer);
+        observer.ref.pointer,
+        indexes.ref.pointer,
+        keyPath.ref.pointer);
   }
 
   /// addObserver:forKeyPath:options:context:
@@ -6139,10 +6221,10 @@ class NSArray extends NSObject {
       NSKeyValueObservingOptions options,
       ffi.Pointer<ffi.Void> context) {
     _objc_msgSend_138(
-        this.pointer,
+        this.ref.pointer,
         _sel_addObserver_forKeyPath_options_context_,
-        observer.pointer,
-        keyPath.pointer,
+        observer.ref.pointer,
+        keyPath.ref.pointer,
         options.value,
         context);
   }
@@ -6150,14 +6232,14 @@ class NSArray extends NSObject {
   /// removeObserver:forKeyPath:context:
   void removeObserver_forKeyPath_context_(
       NSObject observer, NSString keyPath, ffi.Pointer<ffi.Void> context) {
-    _objc_msgSend_139(this.pointer, _sel_removeObserver_forKeyPath_context_,
-        observer.pointer, keyPath.pointer, context);
+    _objc_msgSend_139(this.ref.pointer, _sel_removeObserver_forKeyPath_context_,
+        observer.ref.pointer, keyPath.ref.pointer, context);
   }
 
   /// removeObserver:forKeyPath:
   void removeObserver_forKeyPath_(NSObject observer, NSString keyPath) {
-    _objc_msgSend_140(this.pointer, _sel_removeObserver_forKeyPath_,
-        observer.pointer, keyPath.pointer);
+    _objc_msgSend_140(this.ref.pointer, _sel_removeObserver_forKeyPath_,
+        observer.ref.pointer, keyPath.ref.pointer);
   }
 
   /// new
@@ -6181,14 +6263,14 @@ class NSArray extends NSObject {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSArray,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSArray,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -6467,7 +6549,7 @@ class NSIndexSet extends NSObject {
 
   /// Constructs a [NSIndexSet] that points to the same underlying object as [other].
   NSIndexSet.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSIndexSet] that wraps the given raw object pointer.
   NSIndexSet.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -6476,7 +6558,8 @@ class NSIndexSet extends NSObject {
 
   /// Returns whether [obj] is an instance of [NSIndexSet].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_0(obj.pointer, _sel_isKindOfClass_, _class_NSIndexSet);
+    return _objc_msgSend_0(
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSIndexSet);
   }
 
   /// indexSet
@@ -6501,65 +6584,67 @@ class NSIndexSet extends NSObject {
 
   /// initWithIndexesInRange:
   NSIndexSet initWithIndexesInRange_(NSRange range) {
-    final _ret =
-        _objc_msgSend_117(this.pointer, _sel_initWithIndexesInRange_, range);
-    return NSIndexSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_117(
+        this.ref.retainAndReturnPointer(), _sel_initWithIndexesInRange_, range);
+    return NSIndexSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithIndexSet:
   NSIndexSet initWithIndexSet_(NSIndexSet indexSet) {
-    final _ret = _objc_msgSend_118(
-        this.pointer, _sel_initWithIndexSet_, indexSet.pointer);
-    return NSIndexSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_118(this.ref.retainAndReturnPointer(),
+        _sel_initWithIndexSet_, indexSet.ref.pointer);
+    return NSIndexSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithIndex:
   NSIndexSet initWithIndex_(int value) {
-    final _ret = _objc_msgSend_99(this.pointer, _sel_initWithIndex_, value);
-    return NSIndexSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_99(
+        this.ref.retainAndReturnPointer(), _sel_initWithIndex_, value);
+    return NSIndexSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// isEqualToIndexSet:
   bool isEqualToIndexSet_(NSIndexSet indexSet) {
     return _objc_msgSend_119(
-        this.pointer, _sel_isEqualToIndexSet_, indexSet.pointer);
+        this.ref.pointer, _sel_isEqualToIndexSet_, indexSet.ref.pointer);
   }
 
   /// count
   int get count {
-    return _objc_msgSend_11(this.pointer, _sel_count);
+    return _objc_msgSend_11(this.ref.pointer, _sel_count);
   }
 
   /// firstIndex
   int get firstIndex {
-    return _objc_msgSend_11(this.pointer, _sel_firstIndex);
+    return _objc_msgSend_11(this.ref.pointer, _sel_firstIndex);
   }
 
   /// lastIndex
   int get lastIndex {
-    return _objc_msgSend_11(this.pointer, _sel_lastIndex);
+    return _objc_msgSend_11(this.ref.pointer, _sel_lastIndex);
   }
 
   /// indexGreaterThanIndex:
   int indexGreaterThanIndex_(int value) {
-    return _objc_msgSend_120(this.pointer, _sel_indexGreaterThanIndex_, value);
+    return _objc_msgSend_120(
+        this.ref.pointer, _sel_indexGreaterThanIndex_, value);
   }
 
   /// indexLessThanIndex:
   int indexLessThanIndex_(int value) {
-    return _objc_msgSend_120(this.pointer, _sel_indexLessThanIndex_, value);
+    return _objc_msgSend_120(this.ref.pointer, _sel_indexLessThanIndex_, value);
   }
 
   /// indexGreaterThanOrEqualToIndex:
   int indexGreaterThanOrEqualToIndex_(int value) {
     return _objc_msgSend_120(
-        this.pointer, _sel_indexGreaterThanOrEqualToIndex_, value);
+        this.ref.pointer, _sel_indexGreaterThanOrEqualToIndex_, value);
   }
 
   /// indexLessThanOrEqualToIndex:
   int indexLessThanOrEqualToIndex_(int value) {
     return _objc_msgSend_120(
-        this.pointer, _sel_indexLessThanOrEqualToIndex_, value);
+        this.ref.pointer, _sel_indexLessThanOrEqualToIndex_, value);
   }
 
   /// getIndexes:maxCount:inIndexRange:
@@ -6567,41 +6652,43 @@ class NSIndexSet extends NSObject {
       ffi.Pointer<ffi.UnsignedLong> indexBuffer,
       int bufferSize,
       ffi.Pointer<NSRange> range) {
-    return _objc_msgSend_121(this.pointer,
+    return _objc_msgSend_121(this.ref.pointer,
         _sel_getIndexes_maxCount_inIndexRange_, indexBuffer, bufferSize, range);
   }
 
   /// countOfIndexesInRange:
   int countOfIndexesInRange_(NSRange range) {
-    return _objc_msgSend_122(this.pointer, _sel_countOfIndexesInRange_, range);
+    return _objc_msgSend_122(
+        this.ref.pointer, _sel_countOfIndexesInRange_, range);
   }
 
   /// containsIndex:
   bool containsIndex_(int value) {
-    return _objc_msgSend_123(this.pointer, _sel_containsIndex_, value);
+    return _objc_msgSend_123(this.ref.pointer, _sel_containsIndex_, value);
   }
 
   /// containsIndexesInRange:
   bool containsIndexesInRange_(NSRange range) {
-    return _objc_msgSend_124(this.pointer, _sel_containsIndexesInRange_, range);
+    return _objc_msgSend_124(
+        this.ref.pointer, _sel_containsIndexesInRange_, range);
   }
 
   /// containsIndexes:
   bool containsIndexes_(NSIndexSet indexSet) {
     return _objc_msgSend_119(
-        this.pointer, _sel_containsIndexes_, indexSet.pointer);
+        this.ref.pointer, _sel_containsIndexes_, indexSet.ref.pointer);
   }
 
   /// intersectsIndexesInRange:
   bool intersectsIndexesInRange_(NSRange range) {
     return _objc_msgSend_124(
-        this.pointer, _sel_intersectsIndexesInRange_, range);
+        this.ref.pointer, _sel_intersectsIndexesInRange_, range);
   }
 
   /// init
   NSIndexSet init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSIndexSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSIndexSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// new
@@ -6625,14 +6712,14 @@ class NSIndexSet extends NSObject {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSIndexSet,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSIndexSet,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -7356,7 +7443,7 @@ class NSDictionary extends NSObject {
 
   /// Constructs a [NSDictionary] that points to the same underlying object as [other].
   NSDictionary.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSDictionary] that wraps the given raw object pointer.
   NSDictionary.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -7366,18 +7453,18 @@ class NSDictionary extends NSObject {
   /// Returns whether [obj] is an instance of [NSDictionary].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_NSDictionary);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSDictionary);
   }
 
   /// count
   int get count {
-    return _objc_msgSend_11(this.pointer, _sel_count);
+    return _objc_msgSend_11(this.ref.pointer, _sel_count);
   }
 
   /// objectForKey:
   objc.ObjCObjectBase? objectForKey_(objc.ObjCObjectBase aKey) {
-    final _ret =
-        _objc_msgSend_15(this.pointer, _sel_objectForKey_, aKey.pointer);
+    final _ret = _objc_msgSend_15(
+        this.ref.pointer, _sel_objectForKey_, aKey.ref.pointer);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -7385,14 +7472,14 @@ class NSDictionary extends NSObject {
 
   /// keyEnumerator
   NSEnumerator keyEnumerator() {
-    final _ret = _objc_msgSend_110(this.pointer, _sel_keyEnumerator);
+    final _ret = _objc_msgSend_110(this.ref.pointer, _sel_keyEnumerator);
     return NSEnumerator.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// init
   NSDictionary init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSDictionary.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSDictionary.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithObjects:forKeys:count:
@@ -7400,56 +7487,56 @@ class NSDictionary extends NSObject {
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> keys,
       int cnt) {
-    final _ret = _objc_msgSend_156(
-        this.pointer, _sel_initWithObjects_forKeys_count_, objects, keys, cnt);
-    return NSDictionary.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_156(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_forKeys_count_, objects, keys, cnt);
+    return NSDictionary.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
   NSDictionary? initWithCoder_(NSCoder coder) {
-    final _ret =
-        _objc_msgSend_18(this.pointer, _sel_initWithCoder_, coder.pointer);
+    final _ret = _objc_msgSend_18(this.ref.retainAndReturnPointer(),
+        _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSDictionary.castFromPointer(_ret, retain: true, release: true);
+        : NSDictionary.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// allKeys
   NSArray get allKeys {
-    final _ret = _objc_msgSend_142(this.pointer, _sel_allKeys);
+    final _ret = _objc_msgSend_142(this.ref.pointer, _sel_allKeys);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// allKeysForObject:
   NSArray allKeysForObject_(objc.ObjCObjectBase anObject) {
     final _ret = _objc_msgSend_101(
-        this.pointer, _sel_allKeysForObject_, anObject.pointer);
+        this.ref.pointer, _sel_allKeysForObject_, anObject.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// allValues
   NSArray get allValues {
-    final _ret = _objc_msgSend_142(this.pointer, _sel_allValues);
+    final _ret = _objc_msgSend_142(this.ref.pointer, _sel_allValues);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// description
   NSString get description {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_description);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_description);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// descriptionInStringsFileFormat
   NSString get descriptionInStringsFileFormat {
     final _ret =
-        _objc_msgSend_36(this.pointer, _sel_descriptionInStringsFileFormat);
+        _objc_msgSend_36(this.ref.pointer, _sel_descriptionInStringsFileFormat);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// descriptionWithLocale:
   NSString descriptionWithLocale_(objc.ObjCObjectBase? locale) {
-    final _ret = _objc_msgSend_86(this.pointer, _sel_descriptionWithLocale_,
-        locale?.pointer ?? ffi.nullptr);
+    final _ret = _objc_msgSend_86(this.ref.pointer, _sel_descriptionWithLocale_,
+        locale?.ref.pointer ?? ffi.nullptr);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -7457,30 +7544,33 @@ class NSDictionary extends NSObject {
   NSString descriptionWithLocale_indent_(
       objc.ObjCObjectBase? locale, int level) {
     final _ret = _objc_msgSend_104(
-        this.pointer,
+        this.ref.pointer,
         _sel_descriptionWithLocale_indent_,
-        locale?.pointer ?? ffi.nullptr,
+        locale?.ref.pointer ?? ffi.nullptr,
         level);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// isEqualToDictionary:
   bool isEqualToDictionary_(NSDictionary otherDictionary) {
-    return _objc_msgSend_157(
-        this.pointer, _sel_isEqualToDictionary_, otherDictionary.pointer);
+    return _objc_msgSend_157(this.ref.pointer, _sel_isEqualToDictionary_,
+        otherDictionary.ref.pointer);
   }
 
   /// objectEnumerator
   NSEnumerator objectEnumerator() {
-    final _ret = _objc_msgSend_110(this.pointer, _sel_objectEnumerator);
+    final _ret = _objc_msgSend_110(this.ref.pointer, _sel_objectEnumerator);
     return NSEnumerator.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// objectsForKeys:notFoundMarker:
   NSArray objectsForKeys_notFoundMarker_(
       NSArray keys, objc.ObjCObjectBase marker) {
-    final _ret = _objc_msgSend_158(this.pointer,
-        _sel_objectsForKeys_notFoundMarker_, keys.pointer, marker.pointer);
+    final _ret = _objc_msgSend_158(
+        this.ref.pointer,
+        _sel_objectsForKeys_notFoundMarker_,
+        keys.ref.pointer,
+        marker.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -7488,14 +7578,14 @@ class NSDictionary extends NSObject {
   bool writeToURL_error_(
       NSURL url, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     return _objc_msgSend_115(
-        this.pointer, _sel_writeToURL_error_, url.pointer, error);
+        this.ref.pointer, _sel_writeToURL_error_, url.ref.pointer, error);
   }
 
   /// keysSortedByValueUsingSelector:
   NSArray keysSortedByValueUsingSelector_(
       ffi.Pointer<objc.ObjCSelector> comparator) {
     final _ret = _objc_msgSend_113(
-        this.pointer, _sel_keysSortedByValueUsingSelector_, comparator);
+        this.ref.pointer, _sel_keysSortedByValueUsingSelector_, comparator);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -7505,13 +7595,13 @@ class NSDictionary extends NSObject {
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> keys,
       int count) {
     _objc_msgSend_159(
-        this.pointer, _sel_getObjects_andKeys_count_, objects, keys, count);
+        this.ref.pointer, _sel_getObjects_andKeys_count_, objects, keys, count);
   }
 
   /// objectForKeyedSubscript:
   objc.ObjCObjectBase? objectForKeyedSubscript_(objc.ObjCObjectBase key) {
     final _ret = _objc_msgSend_15(
-        this.pointer, _sel_objectForKeyedSubscript_, key.pointer);
+        this.ref.pointer, _sel_objectForKeyedSubscript_, key.ref.pointer);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -7519,8 +7609,8 @@ class NSDictionary extends NSObject {
 
   /// dictionaryWithContentsOfFile:
   static NSDictionary? dictionaryWithContentsOfFile_(NSString path) {
-    final _ret = _objc_msgSend_160(
-        _class_NSDictionary, _sel_dictionaryWithContentsOfFile_, path.pointer);
+    final _ret = _objc_msgSend_160(_class_NSDictionary,
+        _sel_dictionaryWithContentsOfFile_, path.ref.pointer);
     return _ret.address == 0
         ? null
         : NSDictionary.castFromPointer(_ret, retain: true, release: true);
@@ -7528,8 +7618,8 @@ class NSDictionary extends NSObject {
 
   /// dictionaryWithContentsOfURL:
   static NSDictionary? dictionaryWithContentsOfURL_(NSURL url) {
-    final _ret = _objc_msgSend_161(
-        _class_NSDictionary, _sel_dictionaryWithContentsOfURL_, url.pointer);
+    final _ret = _objc_msgSend_161(_class_NSDictionary,
+        _sel_dictionaryWithContentsOfURL_, url.ref.pointer);
     return _ret.address == 0
         ? null
         : NSDictionary.castFromPointer(_ret, retain: true, release: true);
@@ -7537,32 +7627,32 @@ class NSDictionary extends NSObject {
 
   /// initWithContentsOfFile:
   NSDictionary? initWithContentsOfFile_(NSString path) {
-    final _ret = _objc_msgSend_160(
-        this.pointer, _sel_initWithContentsOfFile_, path.pointer);
+    final _ret = _objc_msgSend_160(this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfFile_, path.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSDictionary.castFromPointer(_ret, retain: true, release: true);
+        : NSDictionary.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfURL:
   NSDictionary? initWithContentsOfURL_(NSURL url) {
-    final _ret = _objc_msgSend_161(
-        this.pointer, _sel_initWithContentsOfURL_, url.pointer);
+    final _ret = _objc_msgSend_161(this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfURL_, url.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSDictionary.castFromPointer(_ret, retain: true, release: true);
+        : NSDictionary.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// writeToFile:atomically:
   bool writeToFile_atomically_(NSString path, bool useAuxiliaryFile) {
-    return _objc_msgSend_41(this.pointer, _sel_writeToFile_atomically_,
-        path.pointer, useAuxiliaryFile);
+    return _objc_msgSend_41(this.ref.pointer, _sel_writeToFile_atomically_,
+        path.ref.pointer, useAuxiliaryFile);
   }
 
   /// writeToURL:atomically:
   bool writeToURL_atomically_(NSURL url, bool atomically) {
-    return _objc_msgSend_134(
-        this.pointer, _sel_writeToURL_atomically_, url.pointer, atomically);
+    return _objc_msgSend_134(this.ref.pointer, _sel_writeToURL_atomically_,
+        url.ref.pointer, atomically);
   }
 
   /// dictionary
@@ -7575,7 +7665,7 @@ class NSDictionary extends NSObject {
   static NSDictionary dictionaryWithObject_forKey_(
       objc.ObjCObjectBase object, objc.ObjCObjectBase key) {
     final _ret = _objc_msgSend_162(_class_NSDictionary,
-        _sel_dictionaryWithObject_forKey_, object.pointer, key.pointer);
+        _sel_dictionaryWithObject_forKey_, object.ref.pointer, key.ref.pointer);
     return NSDictionary.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -7593,69 +7683,72 @@ class NSDictionary extends NSObject {
   static NSDictionary dictionaryWithObjectsAndKeys_(
       objc.ObjCObjectBase firstObject) {
     final _ret = _objc_msgSend_126(_class_NSDictionary,
-        _sel_dictionaryWithObjectsAndKeys_, firstObject.pointer);
+        _sel_dictionaryWithObjectsAndKeys_, firstObject.ref.pointer);
     return NSDictionary.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dictionaryWithDictionary:
   static NSDictionary dictionaryWithDictionary_(NSDictionary dict) {
     final _ret = _objc_msgSend_163(
-        _class_NSDictionary, _sel_dictionaryWithDictionary_, dict.pointer);
+        _class_NSDictionary, _sel_dictionaryWithDictionary_, dict.ref.pointer);
     return NSDictionary.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dictionaryWithObjects:forKeys:
   static NSDictionary dictionaryWithObjects_forKeys_(
       NSArray objects, NSArray keys) {
-    final _ret = _objc_msgSend_164(_class_NSDictionary,
-        _sel_dictionaryWithObjects_forKeys_, objects.pointer, keys.pointer);
+    final _ret = _objc_msgSend_164(
+        _class_NSDictionary,
+        _sel_dictionaryWithObjects_forKeys_,
+        objects.ref.pointer,
+        keys.ref.pointer);
     return NSDictionary.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// initWithObjectsAndKeys:
   NSDictionary initWithObjectsAndKeys_(objc.ObjCObjectBase firstObject) {
-    final _ret = _objc_msgSend_126(
-        this.pointer, _sel_initWithObjectsAndKeys_, firstObject.pointer);
-    return NSDictionary.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_126(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjectsAndKeys_, firstObject.ref.pointer);
+    return NSDictionary.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithDictionary:
   NSDictionary initWithDictionary_(NSDictionary otherDictionary) {
-    final _ret = _objc_msgSend_163(
-        this.pointer, _sel_initWithDictionary_, otherDictionary.pointer);
-    return NSDictionary.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_163(this.ref.retainAndReturnPointer(),
+        _sel_initWithDictionary_, otherDictionary.ref.pointer);
+    return NSDictionary.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithDictionary:copyItems:
   NSDictionary initWithDictionary_copyItems_(
       NSDictionary otherDictionary, bool flag) {
-    final _ret = _objc_msgSend_165(this.pointer,
-        _sel_initWithDictionary_copyItems_, otherDictionary.pointer, flag);
+    final _ret = _objc_msgSend_165(this.ref.retainAndReturnPointer(),
+        _sel_initWithDictionary_copyItems_, otherDictionary.ref.pointer, flag);
     return NSDictionary.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithObjects:forKeys:
   NSDictionary initWithObjects_forKeys_(NSArray objects, NSArray keys) {
-    final _ret = _objc_msgSend_164(this.pointer, _sel_initWithObjects_forKeys_,
-        objects.pointer, keys.pointer);
-    return NSDictionary.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_164(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_forKeys_, objects.ref.pointer, keys.ref.pointer);
+    return NSDictionary.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfURL:error:
   NSDictionary? initWithContentsOfURL_error_(
       NSURL url, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    final _ret = _objc_msgSend_166(
-        this.pointer, _sel_initWithContentsOfURL_error_, url.pointer, error);
+    final _ret = _objc_msgSend_166(this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfURL_error_, url.ref.pointer, error);
     return _ret.address == 0
         ? null
-        : NSDictionary.castFromPointer(_ret, retain: true, release: true);
+        : NSDictionary.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// dictionaryWithContentsOfURL:error:
   static NSDictionary? dictionaryWithContentsOfURL_error_(
       NSURL url, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     final _ret = _objc_msgSend_166(_class_NSDictionary,
-        _sel_dictionaryWithContentsOfURL_error_, url.pointer, error);
+        _sel_dictionaryWithContentsOfURL_error_, url.ref.pointer, error);
     return _ret.address == 0
         ? null
         : NSDictionary.castFromPointer(_ret, retain: true, release: true);
@@ -7664,7 +7757,7 @@ class NSDictionary extends NSObject {
   /// sharedKeySetForKeys:
   static objc.ObjCObjectBase sharedKeySetForKeys_(NSArray keys) {
     final _ret = _objc_msgSend_127(
-        _class_NSDictionary, _sel_sharedKeySetForKeys_, keys.pointer);
+        _class_NSDictionary, _sel_sharedKeySetForKeys_, keys.ref.pointer);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
@@ -7673,7 +7766,7 @@ class NSDictionary extends NSObject {
       ffi.Pointer<NSFastEnumerationState> state,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> buffer,
       int len) {
-    return _objc_msgSend_167(this.pointer,
+    return _objc_msgSend_167(this.ref.pointer,
         _sel_countByEnumeratingWithState_objects_count_, state, buffer, len);
   }
 
@@ -7699,14 +7792,14 @@ class NSDictionary extends NSObject {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSDictionary,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSDictionary,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -9578,7 +9671,7 @@ class NSMutableIndexSet extends NSIndexSet {
 
   /// Constructs a [NSMutableIndexSet] that points to the same underlying object as [other].
   NSMutableIndexSet.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSMutableIndexSet] that wraps the given raw object pointer.
   NSMutableIndexSet.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -9588,48 +9681,49 @@ class NSMutableIndexSet extends NSIndexSet {
   /// Returns whether [obj] is an instance of [NSMutableIndexSet].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_NSMutableIndexSet);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSMutableIndexSet);
   }
 
   /// addIndexes:
   void addIndexes_(NSIndexSet indexSet) {
-    _objc_msgSend_248(this.pointer, _sel_addIndexes_, indexSet.pointer);
+    _objc_msgSend_248(this.ref.pointer, _sel_addIndexes_, indexSet.ref.pointer);
   }
 
   /// removeIndexes:
   void removeIndexes_(NSIndexSet indexSet) {
-    _objc_msgSend_248(this.pointer, _sel_removeIndexes_, indexSet.pointer);
+    _objc_msgSend_248(
+        this.ref.pointer, _sel_removeIndexes_, indexSet.ref.pointer);
   }
 
   /// removeAllIndexes
   void removeAllIndexes() {
-    _objc_msgSend_1(this.pointer, _sel_removeAllIndexes);
+    _objc_msgSend_1(this.ref.pointer, _sel_removeAllIndexes);
   }
 
   /// addIndex:
   void addIndex_(int value) {
-    _objc_msgSend_249(this.pointer, _sel_addIndex_, value);
+    _objc_msgSend_249(this.ref.pointer, _sel_addIndex_, value);
   }
 
   /// removeIndex:
   void removeIndex_(int value) {
-    _objc_msgSend_249(this.pointer, _sel_removeIndex_, value);
+    _objc_msgSend_249(this.ref.pointer, _sel_removeIndex_, value);
   }
 
   /// addIndexesInRange:
   void addIndexesInRange_(NSRange range) {
-    _objc_msgSend_250(this.pointer, _sel_addIndexesInRange_, range);
+    _objc_msgSend_250(this.ref.pointer, _sel_addIndexesInRange_, range);
   }
 
   /// removeIndexesInRange:
   void removeIndexesInRange_(NSRange range) {
-    _objc_msgSend_250(this.pointer, _sel_removeIndexesInRange_, range);
+    _objc_msgSend_250(this.ref.pointer, _sel_removeIndexesInRange_, range);
   }
 
   /// shiftIndexesStartingAtIndex:by:
   void shiftIndexesStartingAtIndex_by_(int index, int delta) {
     _objc_msgSend_251(
-        this.pointer, _sel_shiftIndexesStartingAtIndex_by_, index, delta);
+        this.ref.pointer, _sel_shiftIndexesStartingAtIndex_by_, index, delta);
   }
 
   /// indexSet
@@ -9654,28 +9748,33 @@ class NSMutableIndexSet extends NSIndexSet {
 
   /// initWithIndexesInRange:
   NSMutableIndexSet initWithIndexesInRange_(NSRange range) {
-    final _ret =
-        _objc_msgSend_117(this.pointer, _sel_initWithIndexesInRange_, range);
-    return NSMutableIndexSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_117(
+        this.ref.retainAndReturnPointer(), _sel_initWithIndexesInRange_, range);
+    return NSMutableIndexSet.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// initWithIndexSet:
   NSMutableIndexSet initWithIndexSet_(NSIndexSet indexSet) {
-    final _ret = _objc_msgSend_118(
-        this.pointer, _sel_initWithIndexSet_, indexSet.pointer);
-    return NSMutableIndexSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_118(this.ref.retainAndReturnPointer(),
+        _sel_initWithIndexSet_, indexSet.ref.pointer);
+    return NSMutableIndexSet.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// initWithIndex:
   NSMutableIndexSet initWithIndex_(int value) {
-    final _ret = _objc_msgSend_99(this.pointer, _sel_initWithIndex_, value);
-    return NSMutableIndexSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_99(
+        this.ref.retainAndReturnPointer(), _sel_initWithIndex_, value);
+    return NSMutableIndexSet.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// init
   NSMutableIndexSet init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSMutableIndexSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSMutableIndexSet.castFromPointer(_ret,
+        retain: false, release: true);
   }
 
   /// new
@@ -9703,14 +9802,14 @@ class NSMutableIndexSet extends NSIndexSet {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSMutableIndexSet,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSMutableIndexSet,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -9785,7 +9884,7 @@ class NSMutableArray extends NSArray {
 
   /// Constructs a [NSMutableArray] that points to the same underlying object as [other].
   NSMutableArray.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSMutableArray] that wraps the given raw object pointer.
   NSMutableArray.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -9795,119 +9894,120 @@ class NSMutableArray extends NSArray {
   /// Returns whether [obj] is an instance of [NSMutableArray].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_NSMutableArray);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSMutableArray);
   }
 
   /// addObject:
   void addObject_(objc.ObjCObjectBase anObject) {
-    _objc_msgSend_252(this.pointer, _sel_addObject_, anObject.pointer);
+    _objc_msgSend_252(this.ref.pointer, _sel_addObject_, anObject.ref.pointer);
   }
 
   /// insertObject:atIndex:
   void insertObject_atIndex_(objc.ObjCObjectBase anObject, int index) {
-    _objc_msgSend_253(
-        this.pointer, _sel_insertObject_atIndex_, anObject.pointer, index);
+    _objc_msgSend_253(this.ref.pointer, _sel_insertObject_atIndex_,
+        anObject.ref.pointer, index);
   }
 
   /// removeLastObject
   void removeLastObject() {
-    _objc_msgSend_1(this.pointer, _sel_removeLastObject);
+    _objc_msgSend_1(this.ref.pointer, _sel_removeLastObject);
   }
 
   /// removeObjectAtIndex:
   void removeObjectAtIndex_(int index) {
-    _objc_msgSend_249(this.pointer, _sel_removeObjectAtIndex_, index);
+    _objc_msgSend_249(this.ref.pointer, _sel_removeObjectAtIndex_, index);
   }
 
   /// replaceObjectAtIndex:withObject:
   void replaceObjectAtIndex_withObject_(
       int index, objc.ObjCObjectBase anObject) {
-    _objc_msgSend_254(this.pointer, _sel_replaceObjectAtIndex_withObject_,
-        index, anObject.pointer);
+    _objc_msgSend_254(this.ref.pointer, _sel_replaceObjectAtIndex_withObject_,
+        index, anObject.ref.pointer);
   }
 
   /// init
   NSMutableArray init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSMutableArray.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSMutableArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCapacity:
   NSMutableArray initWithCapacity_(int numItems) {
-    final _ret =
-        _objc_msgSend_99(this.pointer, _sel_initWithCapacity_, numItems);
-    return NSMutableArray.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_99(
+        this.ref.retainAndReturnPointer(), _sel_initWithCapacity_, numItems);
+    return NSMutableArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
   NSMutableArray? initWithCoder_(NSCoder coder) {
-    final _ret =
-        _objc_msgSend_18(this.pointer, _sel_initWithCoder_, coder.pointer);
+    final _ret = _objc_msgSend_18(this.ref.retainAndReturnPointer(),
+        _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSMutableArray.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// addObjectsFromArray:
   void addObjectsFromArray_(NSArray otherArray) {
     _objc_msgSend_255(
-        this.pointer, _sel_addObjectsFromArray_, otherArray.pointer);
+        this.ref.pointer, _sel_addObjectsFromArray_, otherArray.ref.pointer);
   }
 
   /// exchangeObjectAtIndex:withObjectAtIndex:
   void exchangeObjectAtIndex_withObjectAtIndex_(int idx1, int idx2) {
-    _objc_msgSend_256(this.pointer,
+    _objc_msgSend_256(this.ref.pointer,
         _sel_exchangeObjectAtIndex_withObjectAtIndex_, idx1, idx2);
   }
 
   /// removeAllObjects
   void removeAllObjects() {
-    _objc_msgSend_1(this.pointer, _sel_removeAllObjects);
+    _objc_msgSend_1(this.ref.pointer, _sel_removeAllObjects);
   }
 
   /// removeObject:inRange:
   void removeObject_inRange_(objc.ObjCObjectBase anObject, NSRange range) {
-    _objc_msgSend_257(
-        this.pointer, _sel_removeObject_inRange_, anObject.pointer, range);
+    _objc_msgSend_257(this.ref.pointer, _sel_removeObject_inRange_,
+        anObject.ref.pointer, range);
   }
 
   /// removeObject:
   void removeObject_(objc.ObjCObjectBase anObject) {
-    _objc_msgSend_252(this.pointer, _sel_removeObject_, anObject.pointer);
+    _objc_msgSend_252(
+        this.ref.pointer, _sel_removeObject_, anObject.ref.pointer);
   }
 
   /// removeObjectIdenticalTo:inRange:
   void removeObjectIdenticalTo_inRange_(
       objc.ObjCObjectBase anObject, NSRange range) {
-    _objc_msgSend_257(this.pointer, _sel_removeObjectIdenticalTo_inRange_,
-        anObject.pointer, range);
+    _objc_msgSend_257(this.ref.pointer, _sel_removeObjectIdenticalTo_inRange_,
+        anObject.ref.pointer, range);
   }
 
   /// removeObjectIdenticalTo:
   void removeObjectIdenticalTo_(objc.ObjCObjectBase anObject) {
     _objc_msgSend_252(
-        this.pointer, _sel_removeObjectIdenticalTo_, anObject.pointer);
+        this.ref.pointer, _sel_removeObjectIdenticalTo_, anObject.ref.pointer);
   }
 
   /// removeObjectsInArray:
   void removeObjectsInArray_(NSArray otherArray) {
     _objc_msgSend_255(
-        this.pointer, _sel_removeObjectsInArray_, otherArray.pointer);
+        this.ref.pointer, _sel_removeObjectsInArray_, otherArray.ref.pointer);
   }
 
   /// removeObjectsInRange:
   void removeObjectsInRange_(NSRange range) {
-    _objc_msgSend_250(this.pointer, _sel_removeObjectsInRange_, range);
+    _objc_msgSend_250(this.ref.pointer, _sel_removeObjectsInRange_, range);
   }
 
   /// replaceObjectsInRange:withObjectsFromArray:range:
   void replaceObjectsInRange_withObjectsFromArray_range_(
       NSRange range, NSArray otherArray, NSRange otherRange) {
     _objc_msgSend_258(
-        this.pointer,
+        this.ref.pointer,
         _sel_replaceObjectsInRange_withObjectsFromArray_range_,
         range,
-        otherArray.pointer,
+        otherArray.ref.pointer,
         otherRange);
   }
 
@@ -9915,15 +10015,15 @@ class NSMutableArray extends NSArray {
   void replaceObjectsInRange_withObjectsFromArray_(
       NSRange range, NSArray otherArray) {
     _objc_msgSend_259(
-        this.pointer,
+        this.ref.pointer,
         _sel_replaceObjectsInRange_withObjectsFromArray_,
         range,
-        otherArray.pointer);
+        otherArray.ref.pointer);
   }
 
   /// setArray:
   void setArray_(NSArray otherArray) {
-    _objc_msgSend_255(this.pointer, _sel_setArray_, otherArray.pointer);
+    _objc_msgSend_255(this.ref.pointer, _sel_setArray_, otherArray.ref.pointer);
   }
 
   /// sortUsingFunction:context:
@@ -9935,37 +10035,40 @@ class NSMutableArray extends NSArray {
           compare,
       ffi.Pointer<ffi.Void> context) {
     _objc_msgSend_260(
-        this.pointer, _sel_sortUsingFunction_context_, compare, context);
+        this.ref.pointer, _sel_sortUsingFunction_context_, compare, context);
   }
 
   /// sortUsingSelector:
   void sortUsingSelector_(ffi.Pointer<objc.ObjCSelector> comparator) {
-    _objc_msgSend_7(this.pointer, _sel_sortUsingSelector_, comparator);
+    _objc_msgSend_7(this.ref.pointer, _sel_sortUsingSelector_, comparator);
   }
 
   /// insertObjects:atIndexes:
   void insertObjects_atIndexes_(NSArray objects, NSIndexSet indexes) {
-    _objc_msgSend_261(this.pointer, _sel_insertObjects_atIndexes_,
-        objects.pointer, indexes.pointer);
+    _objc_msgSend_261(this.ref.pointer, _sel_insertObjects_atIndexes_,
+        objects.ref.pointer, indexes.ref.pointer);
   }
 
   /// removeObjectsAtIndexes:
   void removeObjectsAtIndexes_(NSIndexSet indexes) {
     _objc_msgSend_248(
-        this.pointer, _sel_removeObjectsAtIndexes_, indexes.pointer);
+        this.ref.pointer, _sel_removeObjectsAtIndexes_, indexes.ref.pointer);
   }
 
   /// replaceObjectsAtIndexes:withObjects:
   void replaceObjectsAtIndexes_withObjects_(
       NSIndexSet indexes, NSArray objects) {
-    _objc_msgSend_262(this.pointer, _sel_replaceObjectsAtIndexes_withObjects_,
-        indexes.pointer, objects.pointer);
+    _objc_msgSend_262(
+        this.ref.pointer,
+        _sel_replaceObjectsAtIndexes_withObjects_,
+        indexes.ref.pointer,
+        objects.ref.pointer);
   }
 
   /// setObject:atIndexedSubscript:
   void setObject_atIndexedSubscript_(objc.ObjCObjectBase obj, int idx) {
-    _objc_msgSend_253(
-        this.pointer, _sel_setObject_atIndexedSubscript_, obj.pointer, idx);
+    _objc_msgSend_253(this.ref.pointer, _sel_setObject_atIndexedSubscript_,
+        obj.ref.pointer, idx);
   }
 
   /// arrayWithCapacity:
@@ -9978,7 +10081,7 @@ class NSMutableArray extends NSArray {
   /// arrayWithContentsOfFile:
   static NSArray? arrayWithContentsOfFile_(NSString path) {
     final _ret = _objc_msgSend_132(
-        _class_NSMutableArray, _sel_arrayWithContentsOfFile_, path.pointer);
+        _class_NSMutableArray, _sel_arrayWithContentsOfFile_, path.ref.pointer);
     return _ret.address == 0
         ? null
         : NSArray.castFromPointer(_ret, retain: true, release: true);
@@ -9987,7 +10090,7 @@ class NSMutableArray extends NSArray {
   /// arrayWithContentsOfURL:
   static NSArray? arrayWithContentsOfURL_(NSURL url) {
     final _ret = _objc_msgSend_133(
-        _class_NSMutableArray, _sel_arrayWithContentsOfURL_, url.pointer);
+        _class_NSMutableArray, _sel_arrayWithContentsOfURL_, url.ref.pointer);
     return _ret.address == 0
         ? null
         : NSArray.castFromPointer(_ret, retain: true, release: true);
@@ -9995,33 +10098,34 @@ class NSMutableArray extends NSArray {
 
   /// initWithContentsOfFile:
   NSMutableArray? initWithContentsOfFile_(NSString path) {
-    final _ret = _objc_msgSend_263(
-        this.pointer, _sel_initWithContentsOfFile_, path.pointer);
+    final _ret = _objc_msgSend_263(this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfFile_, path.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSMutableArray.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfURL:
   NSMutableArray? initWithContentsOfURL_(NSURL url) {
-    final _ret = _objc_msgSend_264(
-        this.pointer, _sel_initWithContentsOfURL_, url.pointer);
+    final _ret = _objc_msgSend_264(this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfURL_, url.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSMutableArray.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// applyDifference:
   void applyDifference_(objc.ObjCObjectBase difference) {
-    _objc_msgSend_252(this.pointer, _sel_applyDifference_, difference.pointer);
+    _objc_msgSend_252(
+        this.ref.pointer, _sel_applyDifference_, difference.ref.pointer);
   }
 
   /// initWithObjects:count:
   NSMutableArray initWithObjects_count_(
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
-    final _ret = _objc_msgSend_100(
-        this.pointer, _sel_initWithObjects_count_, objects, cnt);
-    return NSMutableArray.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_100(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_count_, objects, cnt);
+    return NSMutableArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// array
@@ -10033,7 +10137,7 @@ class NSMutableArray extends NSArray {
   /// arrayWithObject:
   static NSMutableArray arrayWithObject_(objc.ObjCObjectBase anObject) {
     final _ret = _objc_msgSend_126(
-        _class_NSMutableArray, _sel_arrayWithObject_, anObject.pointer);
+        _class_NSMutableArray, _sel_arrayWithObject_, anObject.ref.pointer);
     return NSMutableArray.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -10048,35 +10152,35 @@ class NSMutableArray extends NSArray {
   /// arrayWithObjects:
   static NSMutableArray arrayWithObjects_(objc.ObjCObjectBase firstObj) {
     final _ret = _objc_msgSend_126(
-        _class_NSMutableArray, _sel_arrayWithObjects_, firstObj.pointer);
+        _class_NSMutableArray, _sel_arrayWithObjects_, firstObj.ref.pointer);
     return NSMutableArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// arrayWithArray:
   static NSMutableArray arrayWithArray_(NSArray array) {
     final _ret = _objc_msgSend_127(
-        _class_NSMutableArray, _sel_arrayWithArray_, array.pointer);
+        _class_NSMutableArray, _sel_arrayWithArray_, array.ref.pointer);
     return NSMutableArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// initWithObjects:
   NSMutableArray initWithObjects_(objc.ObjCObjectBase firstObj) {
-    final _ret = _objc_msgSend_126(
-        this.pointer, _sel_initWithObjects_, firstObj.pointer);
-    return NSMutableArray.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_126(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_, firstObj.ref.pointer);
+    return NSMutableArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithArray:
   NSMutableArray initWithArray_(NSArray array) {
-    final _ret =
-        _objc_msgSend_127(this.pointer, _sel_initWithArray_, array.pointer);
-    return NSMutableArray.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_127(this.ref.retainAndReturnPointer(),
+        _sel_initWithArray_, array.ref.pointer);
+    return NSMutableArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithArray:copyItems:
   NSMutableArray initWithArray_copyItems_(NSArray array, bool flag) {
-    final _ret = _objc_msgSend_128(
-        this.pointer, _sel_initWithArray_copyItems_, array.pointer, flag);
+    final _ret = _objc_msgSend_128(this.ref.retainAndReturnPointer(),
+        _sel_initWithArray_copyItems_, array.ref.pointer, flag);
     return NSMutableArray.castFromPointer(_ret, retain: false, release: true);
   }
 
@@ -10084,7 +10188,7 @@ class NSMutableArray extends NSArray {
   static NSArray? arrayWithContentsOfURL_error_(
       NSURL url, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     final _ret = _objc_msgSend_129(_class_NSMutableArray,
-        _sel_arrayWithContentsOfURL_error_, url.pointer, error);
+        _sel_arrayWithContentsOfURL_error_, url.ref.pointer, error);
     return _ret.address == 0
         ? null
         : NSArray.castFromPointer(_ret, retain: true, release: true);
@@ -10112,14 +10216,14 @@ class NSMutableArray extends NSArray {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSMutableArray,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSMutableArray,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -10349,7 +10453,7 @@ class NSMutableData extends NSData {
 
   /// Constructs a [NSMutableData] that points to the same underlying object as [other].
   NSMutableData.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSMutableData] that wraps the given raw object pointer.
   NSMutableData.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -10359,61 +10463,65 @@ class NSMutableData extends NSData {
   /// Returns whether [obj] is an instance of [NSMutableData].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_NSMutableData);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSMutableData);
   }
 
   /// mutableBytes
   ffi.Pointer<ffi.Void> get mutableBytes {
-    return _objc_msgSend_35(this.pointer, _sel_mutableBytes);
+    return _objc_msgSend_35(this.ref.pointer, _sel_mutableBytes);
   }
 
   /// length
   int get length {
-    return _objc_msgSend_11(this.pointer, _sel_length);
+    return _objc_msgSend_11(this.ref.pointer, _sel_length);
   }
 
   /// setLength:
   set length(int value) {
-    return _objc_msgSend_265(this.pointer, _sel_setLength_, value);
+    return _objc_msgSend_265(this.ref.pointer, _sel_setLength_, value);
   }
 
   /// appendBytes:length:
   void appendBytes_length_(ffi.Pointer<ffi.Void> bytes, int length) {
-    _objc_msgSend_37(this.pointer, _sel_appendBytes_length_, bytes, length);
+    _objc_msgSend_37(this.ref.pointer, _sel_appendBytes_length_, bytes, length);
   }
 
   /// appendData:
   void appendData_(NSData other) {
-    _objc_msgSend_266(this.pointer, _sel_appendData_, other.pointer);
+    _objc_msgSend_266(this.ref.pointer, _sel_appendData_, other.ref.pointer);
   }
 
   /// increaseLengthBy:
   void increaseLengthBy_(int extraLength) {
-    _objc_msgSend_249(this.pointer, _sel_increaseLengthBy_, extraLength);
+    _objc_msgSend_249(this.ref.pointer, _sel_increaseLengthBy_, extraLength);
   }
 
   /// replaceBytesInRange:withBytes:
   void replaceBytesInRange_withBytes_(
       NSRange range, ffi.Pointer<ffi.Void> bytes) {
     _objc_msgSend_267(
-        this.pointer, _sel_replaceBytesInRange_withBytes_, range, bytes);
+        this.ref.pointer, _sel_replaceBytesInRange_withBytes_, range, bytes);
   }
 
   /// resetBytesInRange:
   void resetBytesInRange_(NSRange range) {
-    _objc_msgSend_250(this.pointer, _sel_resetBytesInRange_, range);
+    _objc_msgSend_250(this.ref.pointer, _sel_resetBytesInRange_, range);
   }
 
   /// setData:
   void setData_(NSData data) {
-    _objc_msgSend_266(this.pointer, _sel_setData_, data.pointer);
+    _objc_msgSend_266(this.ref.pointer, _sel_setData_, data.ref.pointer);
   }
 
   /// replaceBytesInRange:withBytes:length:
   void replaceBytesInRange_withBytes_length_(NSRange range,
       ffi.Pointer<ffi.Void> replacementBytes, int replacementLength) {
-    _objc_msgSend_268(this.pointer, _sel_replaceBytesInRange_withBytes_length_,
-        range, replacementBytes, replacementLength);
+    _objc_msgSend_268(
+        this.ref.pointer,
+        _sel_replaceBytesInRange_withBytes_length_,
+        range,
+        replacementBytes,
+        replacementLength);
   }
 
   /// dataWithCapacity:
@@ -10436,33 +10544,34 @@ class NSMutableData extends NSData {
 
   /// initWithCapacity:
   NSMutableData? initWithCapacity_(int capacity) {
-    final _ret =
-        _objc_msgSend_269(this.pointer, _sel_initWithCapacity_, capacity);
+    final _ret = _objc_msgSend_269(
+        this.ref.retainAndReturnPointer(), _sel_initWithCapacity_, capacity);
     return _ret.address == 0
         ? null
-        : NSMutableData.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithLength:
   NSMutableData? initWithLength_(int length) {
-    final _ret = _objc_msgSend_269(this.pointer, _sel_initWithLength_, length);
+    final _ret = _objc_msgSend_269(
+        this.ref.retainAndReturnPointer(), _sel_initWithLength_, length);
     return _ret.address == 0
         ? null
-        : NSMutableData.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// decompressUsingAlgorithm:error:
   bool decompressUsingAlgorithm_error_(NSDataCompressionAlgorithm algorithm,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    return _objc_msgSend_270(this.pointer, _sel_decompressUsingAlgorithm_error_,
-        algorithm.value, error);
+    return _objc_msgSend_270(this.ref.pointer,
+        _sel_decompressUsingAlgorithm_error_, algorithm.value, error);
   }
 
   /// compressUsingAlgorithm:error:
   bool compressUsingAlgorithm_error_(NSDataCompressionAlgorithm algorithm,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    return _objc_msgSend_270(this.pointer, _sel_compressUsingAlgorithm_error_,
-        algorithm.value, error);
+    return _objc_msgSend_270(this.ref.pointer,
+        _sel_compressUsingAlgorithm_error_, algorithm.value, error);
   }
 
   /// data
@@ -10484,7 +10593,7 @@ class NSMutableData extends NSData {
       ffi.Pointer<ffi.Void> bytes, int length) {
     final _ret = _objc_msgSend_175(
         _class_NSMutableData, _sel_dataWithBytesNoCopy_length_, bytes, length);
-    return NSMutableData.castFromPointer(_ret, retain: false, release: true);
+    return NSMutableData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dataWithBytesNoCopy:length:freeWhenDone:
@@ -10492,7 +10601,7 @@ class NSMutableData extends NSData {
       ffi.Pointer<ffi.Void> bytes, int length, bool b) {
     final _ret = _objc_msgSend_176(_class_NSMutableData,
         _sel_dataWithBytesNoCopy_length_freeWhenDone_, bytes, length, b);
-    return NSMutableData.castFromPointer(_ret, retain: false, release: true);
+    return NSMutableData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dataWithContentsOfFile:options:error:
@@ -10503,7 +10612,7 @@ class NSMutableData extends NSData {
     final _ret = _objc_msgSend_177(
         _class_NSMutableData,
         _sel_dataWithContentsOfFile_options_error_,
-        path.pointer,
+        path.ref.pointer,
         readOptionsMask.value,
         errorPtr);
     return _ret.address == 0
@@ -10519,7 +10628,7 @@ class NSMutableData extends NSData {
     final _ret = _objc_msgSend_178(
         _class_NSMutableData,
         _sel_dataWithContentsOfURL_options_error_,
-        url.pointer,
+        url.ref.pointer,
         readOptionsMask.value,
         errorPtr);
     return _ret.address == 0
@@ -10530,7 +10639,7 @@ class NSMutableData extends NSData {
   /// dataWithContentsOfFile:
   static NSMutableData? dataWithContentsOfFile_(NSString path) {
     final _ret = _objc_msgSend_52(
-        _class_NSMutableData, _sel_dataWithContentsOfFile_, path.pointer);
+        _class_NSMutableData, _sel_dataWithContentsOfFile_, path.ref.pointer);
     return _ret.address == 0
         ? null
         : NSMutableData.castFromPointer(_ret, retain: true, release: true);
@@ -10539,7 +10648,7 @@ class NSMutableData extends NSData {
   /// dataWithContentsOfURL:
   static NSMutableData? dataWithContentsOfURL_(NSURL url) {
     final _ret = _objc_msgSend_179(
-        _class_NSMutableData, _sel_dataWithContentsOfURL_, url.pointer);
+        _class_NSMutableData, _sel_dataWithContentsOfURL_, url.ref.pointer);
     return _ret.address == 0
         ? null
         : NSMutableData.castFromPointer(_ret, retain: true, release: true);
@@ -10547,23 +10656,23 @@ class NSMutableData extends NSData {
 
   /// initWithBytes:length:
   NSMutableData initWithBytes_length_(ffi.Pointer<ffi.Void> bytes, int length) {
-    final _ret = _objc_msgSend_175(
-        this.pointer, _sel_initWithBytes_length_, bytes, length);
-    return NSMutableData.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_175(this.ref.retainAndReturnPointer(),
+        _sel_initWithBytes_length_, bytes, length);
+    return NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBytesNoCopy:length:
   NSMutableData initWithBytesNoCopy_length_(
       ffi.Pointer<ffi.Void> bytes, int length) {
-    final _ret = _objc_msgSend_175(
-        this.pointer, _sel_initWithBytesNoCopy_length_, bytes, length);
+    final _ret = _objc_msgSend_175(this.ref.retainAndReturnPointer(),
+        _sel_initWithBytesNoCopy_length_, bytes, length);
     return NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBytesNoCopy:length:freeWhenDone:
   NSMutableData initWithBytesNoCopy_length_freeWhenDone_(
       ffi.Pointer<ffi.Void> bytes, int length, bool b) {
-    final _ret = _objc_msgSend_176(this.pointer,
+    final _ret = _objc_msgSend_176(this.ref.retainAndReturnPointer(),
         _sel_initWithBytesNoCopy_length_freeWhenDone_, bytes, length, b);
     return NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
@@ -10574,14 +10683,14 @@ class NSMutableData extends NSData {
       NSDataReadingOptions readOptionsMask,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> errorPtr) {
     final _ret = _objc_msgSend_177(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfFile_options_error_,
-        path.pointer,
+        path.ref.pointer,
         readOptionsMask.value,
         errorPtr);
     return _ret.address == 0
         ? null
-        : NSMutableData.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfURL:options:error:
@@ -10590,45 +10699,45 @@ class NSMutableData extends NSData {
       NSDataReadingOptions readOptionsMask,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> errorPtr) {
     final _ret = _objc_msgSend_178(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_options_error_,
-        url.pointer,
+        url.ref.pointer,
         readOptionsMask.value,
         errorPtr);
     return _ret.address == 0
         ? null
-        : NSMutableData.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfFile:
   NSMutableData? initWithContentsOfFile_(NSString path) {
-    final _ret = _objc_msgSend_52(
-        this.pointer, _sel_initWithContentsOfFile_, path.pointer);
+    final _ret = _objc_msgSend_52(this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfFile_, path.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSMutableData.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfURL:
   NSMutableData? initWithContentsOfURL_(NSURL url) {
-    final _ret = _objc_msgSend_179(
-        this.pointer, _sel_initWithContentsOfURL_, url.pointer);
+    final _ret = _objc_msgSend_179(this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfURL_, url.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSMutableData.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithData:
   NSMutableData initWithData_(NSData data) {
-    final _ret =
-        _objc_msgSend_180(this.pointer, _sel_initWithData_, data.pointer);
-    return NSMutableData.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_180(this.ref.retainAndReturnPointer(),
+        _sel_initWithData_, data.ref.pointer);
+    return NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// dataWithData:
   static NSMutableData dataWithData_(NSData data) {
     final _ret = _objc_msgSend_180(
-        _class_NSMutableData, _sel_dataWithData_, data.pointer);
+        _class_NSMutableData, _sel_dataWithData_, data.ref.pointer);
     return NSMutableData.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -10636,33 +10745,33 @@ class NSMutableData extends NSData {
   NSMutableData? initWithBase64EncodedString_options_(
       NSString base64String, NSDataBase64DecodingOptions options) {
     final _ret = _objc_msgSend_181(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithBase64EncodedString_options_,
-        base64String.pointer,
+        base64String.ref.pointer,
         options.value);
     return _ret.address == 0
         ? null
-        : NSMutableData.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBase64EncodedData:options:
   NSMutableData? initWithBase64EncodedData_options_(
       NSData base64Data, NSDataBase64DecodingOptions options) {
     final _ret = _objc_msgSend_183(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithBase64EncodedData_options_,
-        base64Data.pointer,
+        base64Data.ref.pointer,
         options.value);
     return _ret.address == 0
         ? null
-        : NSMutableData.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// decompressedDataUsingAlgorithm:error:
   NSMutableData? decompressedDataUsingAlgorithm_error_(
       NSDataCompressionAlgorithm algorithm,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    final _ret = _objc_msgSend_185(this.pointer,
+    final _ret = _objc_msgSend_185(this.ref.pointer,
         _sel_decompressedDataUsingAlgorithm_error_, algorithm.value, error);
     return _ret.address == 0
         ? null
@@ -10673,7 +10782,7 @@ class NSMutableData extends NSData {
   NSMutableData? compressedDataUsingAlgorithm_error_(
       NSDataCompressionAlgorithm algorithm,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    final _ret = _objc_msgSend_185(this.pointer,
+    final _ret = _objc_msgSend_185(this.ref.pointer,
         _sel_compressedDataUsingAlgorithm_error_, algorithm.value, error);
     return _ret.address == 0
         ? null
@@ -10682,8 +10791,8 @@ class NSMutableData extends NSData {
 
   /// init
   NSMutableData init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSMutableData.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// new
@@ -10708,14 +10817,14 @@ class NSMutableData extends NSData {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSMutableData,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSMutableData,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -10814,7 +10923,7 @@ class NSNotification extends NSObject {
 
   /// Constructs a [NSNotification] that points to the same underlying object as [other].
   NSNotification.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSNotification] that wraps the given raw object pointer.
   NSNotification.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -10824,18 +10933,18 @@ class NSNotification extends NSObject {
   /// Returns whether [obj] is an instance of [NSNotification].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_NSNotification);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSNotification);
   }
 
   /// name
   NSString get name {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_name);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_name);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// object
   objc.ObjCObjectBase? get object {
-    final _ret = _objc_msgSend_16(this.pointer, _sel_object);
+    final _ret = _objc_msgSend_16(this.ref.pointer, _sel_object);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -10843,7 +10952,7 @@ class NSNotification extends NSObject {
 
   /// userInfo
   NSDictionary? get userInfo {
-    final _ret = _objc_msgSend_231(this.pointer, _sel_userInfo);
+    final _ret = _objc_msgSend_231(this.ref.pointer, _sel_userInfo);
     return _ret.address == 0
         ? null
         : NSDictionary.castFromPointer(_ret, retain: true, release: true);
@@ -10853,21 +10962,21 @@ class NSNotification extends NSObject {
   NSNotification initWithName_object_userInfo_(
       NSString name, objc.ObjCObjectBase? object, NSDictionary? userInfo) {
     final _ret = _objc_msgSend_271(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithName_object_userInfo_,
-        name.pointer,
-        object?.pointer ?? ffi.nullptr,
-        userInfo?.pointer ?? ffi.nullptr);
-    return NSNotification.castFromPointer(_ret, retain: true, release: true);
+        name.ref.pointer,
+        object?.ref.pointer ?? ffi.nullptr,
+        userInfo?.ref.pointer ?? ffi.nullptr);
+    return NSNotification.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
   NSNotification? initWithCoder_(NSCoder coder) {
-    final _ret =
-        _objc_msgSend_18(this.pointer, _sel_initWithCoder_, coder.pointer);
+    final _ret = _objc_msgSend_18(this.ref.retainAndReturnPointer(),
+        _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSNotification.castFromPointer(_ret, retain: true, release: true);
+        : NSNotification.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// notificationWithName:object:
@@ -10876,8 +10985,8 @@ class NSNotification extends NSObject {
     final _ret = _objc_msgSend_219(
         _class_NSNotification,
         _sel_notificationWithName_object_,
-        aName.pointer,
-        anObject?.pointer ?? ffi.nullptr);
+        aName.ref.pointer,
+        anObject?.ref.pointer ?? ffi.nullptr);
     return NSNotification.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -10887,16 +10996,16 @@ class NSNotification extends NSObject {
     final _ret = _objc_msgSend_271(
         _class_NSNotification,
         _sel_notificationWithName_object_userInfo_,
-        aName.pointer,
-        anObject?.pointer ?? ffi.nullptr,
-        aUserInfo?.pointer ?? ffi.nullptr);
+        aName.ref.pointer,
+        anObject?.ref.pointer ?? ffi.nullptr,
+        aUserInfo?.ref.pointer ?? ffi.nullptr);
     return NSNotification.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// init
   NSNotification init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSNotification.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSNotification.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// new
@@ -10921,14 +11030,14 @@ class NSNotification extends NSObject {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSNotification,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSNotification,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -10966,7 +11075,7 @@ class NSDate extends NSObject {
 
   /// Constructs a [NSDate] that points to the same underlying object as [other].
   NSDate.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSDate] that wraps the given raw object pointer.
   NSDate.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -10975,7 +11084,7 @@ class NSDate extends NSObject {
 
   /// Returns whether [obj] is an instance of [NSDate].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_0(obj.pointer, _sel_isKindOfClass_, _class_NSDate);
+    return _objc_msgSend_0(obj.ref.pointer, _sel_isKindOfClass_, _class_NSDate);
   }
 
   /// timeIntervalSinceReferenceDate
@@ -10988,92 +11097,93 @@ class NSDate extends NSObject {
 
   /// init
   NSDate init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSDate.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSDate.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithTimeIntervalSinceReferenceDate:
   NSDate initWithTimeIntervalSinceReferenceDate_(double ti) {
-    final _ret = _objc_msgSend_272(
-        this.pointer, _sel_initWithTimeIntervalSinceReferenceDate_, ti);
-    return NSDate.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_272(this.ref.retainAndReturnPointer(),
+        _sel_initWithTimeIntervalSinceReferenceDate_, ti);
+    return NSDate.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
   NSDate? initWithCoder_(NSCoder coder) {
-    final _ret =
-        _objc_msgSend_18(this.pointer, _sel_initWithCoder_, coder.pointer);
+    final _ret = _objc_msgSend_18(this.ref.retainAndReturnPointer(),
+        _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSDate.castFromPointer(_ret, retain: true, release: true);
+        : NSDate.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// timeIntervalSinceDate:
   double timeIntervalSinceDate_(NSDate anotherDate) {
     return objc.useMsgSendVariants
-        ? _objc_msgSend_273Fpret(
-            this.pointer, _sel_timeIntervalSinceDate_, anotherDate.pointer)
-        : _objc_msgSend_273(
-            this.pointer, _sel_timeIntervalSinceDate_, anotherDate.pointer);
+        ? _objc_msgSend_273Fpret(this.ref.pointer, _sel_timeIntervalSinceDate_,
+            anotherDate.ref.pointer)
+        : _objc_msgSend_273(this.ref.pointer, _sel_timeIntervalSinceDate_,
+            anotherDate.ref.pointer);
   }
 
   /// timeIntervalSinceNow
   double get timeIntervalSinceNow {
     return objc.useMsgSendVariants
-        ? _objc_msgSend_83Fpret(this.pointer, _sel_timeIntervalSinceNow)
-        : _objc_msgSend_83(this.pointer, _sel_timeIntervalSinceNow);
+        ? _objc_msgSend_83Fpret(this.ref.pointer, _sel_timeIntervalSinceNow)
+        : _objc_msgSend_83(this.ref.pointer, _sel_timeIntervalSinceNow);
   }
 
   /// timeIntervalSince1970
   double get timeIntervalSince1970 {
     return objc.useMsgSendVariants
-        ? _objc_msgSend_83Fpret(this.pointer, _sel_timeIntervalSince1970)
-        : _objc_msgSend_83(this.pointer, _sel_timeIntervalSince1970);
+        ? _objc_msgSend_83Fpret(this.ref.pointer, _sel_timeIntervalSince1970)
+        : _objc_msgSend_83(this.ref.pointer, _sel_timeIntervalSince1970);
   }
 
   /// dateByAddingTimeInterval:
   NSDate dateByAddingTimeInterval_(double ti) {
     final _ret =
-        _objc_msgSend_272(this.pointer, _sel_dateByAddingTimeInterval_, ti);
+        _objc_msgSend_272(this.ref.pointer, _sel_dateByAddingTimeInterval_, ti);
     return NSDate.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// earlierDate:
   NSDate earlierDate_(NSDate anotherDate) {
-    final _ret =
-        _objc_msgSend_274(this.pointer, _sel_earlierDate_, anotherDate.pointer);
+    final _ret = _objc_msgSend_274(
+        this.ref.pointer, _sel_earlierDate_, anotherDate.ref.pointer);
     return NSDate.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// laterDate:
   NSDate laterDate_(NSDate anotherDate) {
-    final _ret =
-        _objc_msgSend_274(this.pointer, _sel_laterDate_, anotherDate.pointer);
+    final _ret = _objc_msgSend_274(
+        this.ref.pointer, _sel_laterDate_, anotherDate.ref.pointer);
     return NSDate.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// compare:
   NSComparisonResult compare_(NSDate other) {
-    final _ret = _objc_msgSend_275(this.pointer, _sel_compare_, other.pointer);
+    final _ret =
+        _objc_msgSend_275(this.ref.pointer, _sel_compare_, other.ref.pointer);
     return NSComparisonResult.fromValue(_ret);
   }
 
   /// isEqualToDate:
   bool isEqualToDate_(NSDate otherDate) {
     return _objc_msgSend_276(
-        this.pointer, _sel_isEqualToDate_, otherDate.pointer);
+        this.ref.pointer, _sel_isEqualToDate_, otherDate.ref.pointer);
   }
 
   /// description
   NSString get description {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_description);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_description);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// descriptionWithLocale:
   NSString descriptionWithLocale_(objc.ObjCObjectBase? locale) {
-    final _ret = _objc_msgSend_86(this.pointer, _sel_descriptionWithLocale_,
-        locale?.pointer ?? ffi.nullptr);
+    final _ret = _objc_msgSend_86(this.ref.pointer, _sel_descriptionWithLocale_,
+        locale?.ref.pointer ?? ffi.nullptr);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -11108,7 +11218,7 @@ class NSDate extends NSObject {
   static NSDate dateWithTimeInterval_sinceDate_(
       double secsToBeAdded, NSDate date) {
     final _ret = _objc_msgSend_277(_class_NSDate,
-        _sel_dateWithTimeInterval_sinceDate_, secsToBeAdded, date.pointer);
+        _sel_dateWithTimeInterval_sinceDate_, secsToBeAdded, date.ref.pointer);
     return NSDate.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -11132,23 +11242,23 @@ class NSDate extends NSObject {
 
   /// initWithTimeIntervalSinceNow:
   NSDate initWithTimeIntervalSinceNow_(double secs) {
-    final _ret = _objc_msgSend_272(
-        this.pointer, _sel_initWithTimeIntervalSinceNow_, secs);
-    return NSDate.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_272(this.ref.retainAndReturnPointer(),
+        _sel_initWithTimeIntervalSinceNow_, secs);
+    return NSDate.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithTimeIntervalSince1970:
   NSDate initWithTimeIntervalSince1970_(double secs) {
-    final _ret = _objc_msgSend_272(
-        this.pointer, _sel_initWithTimeIntervalSince1970_, secs);
-    return NSDate.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_272(this.ref.retainAndReturnPointer(),
+        _sel_initWithTimeIntervalSince1970_, secs);
+    return NSDate.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithTimeInterval:sinceDate:
   NSDate initWithTimeInterval_sinceDate_(double secsToBeAdded, NSDate date) {
-    final _ret = _objc_msgSend_277(this.pointer,
-        _sel_initWithTimeInterval_sinceDate_, secsToBeAdded, date.pointer);
-    return NSDate.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_277(this.ref.retainAndReturnPointer(),
+        _sel_initWithTimeInterval_sinceDate_, secsToBeAdded, date.ref.pointer);
+    return NSDate.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// new
@@ -11172,14 +11282,14 @@ class NSDate extends NSObject {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSDate,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
-    return _objc_msgSend_26(
-        _class_NSDate, _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+    return _objc_msgSend_26(_class_NSDate,
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -11306,7 +11416,7 @@ class NSMutableDictionary extends NSDictionary {
 
   /// Constructs a [NSMutableDictionary] that points to the same underlying object as [other].
   NSMutableDictionary.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSMutableDictionary] that wraps the given raw object pointer.
   NSMutableDictionary.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -11316,74 +11426,75 @@ class NSMutableDictionary extends NSDictionary {
   /// Returns whether [obj] is an instance of [NSMutableDictionary].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_NSMutableDictionary);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSMutableDictionary);
   }
 
   /// removeObjectForKey:
   void removeObjectForKey_(objc.ObjCObjectBase aKey) {
-    _objc_msgSend_252(this.pointer, _sel_removeObjectForKey_, aKey.pointer);
+    _objc_msgSend_252(
+        this.ref.pointer, _sel_removeObjectForKey_, aKey.ref.pointer);
   }
 
   /// setObject:forKey:
   void setObject_forKey_(
       objc.ObjCObjectBase anObject, objc.ObjCObjectBase aKey) {
-    _objc_msgSend_279(
-        this.pointer, _sel_setObject_forKey_, anObject.pointer, aKey.pointer);
+    _objc_msgSend_279(this.ref.pointer, _sel_setObject_forKey_,
+        anObject.ref.pointer, aKey.ref.pointer);
   }
 
   /// init
   NSMutableDictionary init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
     return NSMutableDictionary.castFromPointer(_ret,
-        retain: true, release: true);
+        retain: false, release: true);
   }
 
   /// initWithCapacity:
   NSMutableDictionary initWithCapacity_(int numItems) {
-    final _ret =
-        _objc_msgSend_99(this.pointer, _sel_initWithCapacity_, numItems);
+    final _ret = _objc_msgSend_99(
+        this.ref.retainAndReturnPointer(), _sel_initWithCapacity_, numItems);
     return NSMutableDictionary.castFromPointer(_ret,
-        retain: true, release: true);
+        retain: false, release: true);
   }
 
   /// initWithCoder:
   NSMutableDictionary? initWithCoder_(NSCoder coder) {
-    final _ret =
-        _objc_msgSend_18(this.pointer, _sel_initWithCoder_, coder.pointer);
+    final _ret = _objc_msgSend_18(this.ref.retainAndReturnPointer(),
+        _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
         ? null
         : NSMutableDictionary.castFromPointer(_ret,
-            retain: true, release: true);
+            retain: false, release: true);
   }
 
   /// addEntriesFromDictionary:
   void addEntriesFromDictionary_(NSDictionary otherDictionary) {
-    _objc_msgSend_280(
-        this.pointer, _sel_addEntriesFromDictionary_, otherDictionary.pointer);
+    _objc_msgSend_280(this.ref.pointer, _sel_addEntriesFromDictionary_,
+        otherDictionary.ref.pointer);
   }
 
   /// removeAllObjects
   void removeAllObjects() {
-    _objc_msgSend_1(this.pointer, _sel_removeAllObjects);
+    _objc_msgSend_1(this.ref.pointer, _sel_removeAllObjects);
   }
 
   /// removeObjectsForKeys:
   void removeObjectsForKeys_(NSArray keyArray) {
     _objc_msgSend_255(
-        this.pointer, _sel_removeObjectsForKeys_, keyArray.pointer);
+        this.ref.pointer, _sel_removeObjectsForKeys_, keyArray.ref.pointer);
   }
 
   /// setDictionary:
   void setDictionary_(NSDictionary otherDictionary) {
     _objc_msgSend_280(
-        this.pointer, _sel_setDictionary_, otherDictionary.pointer);
+        this.ref.pointer, _sel_setDictionary_, otherDictionary.ref.pointer);
   }
 
   /// setObject:forKeyedSubscript:
   void setObject_forKeyedSubscript_(
       objc.ObjCObjectBase? obj, objc.ObjCObjectBase key) {
-    _objc_msgSend_281(this.pointer, _sel_setObject_forKeyedSubscript_,
-        obj?.pointer ?? ffi.nullptr, key.pointer);
+    _objc_msgSend_281(this.ref.pointer, _sel_setObject_forKeyedSubscript_,
+        obj?.ref.pointer ?? ffi.nullptr, key.ref.pointer);
   }
 
   /// dictionaryWithCapacity:
@@ -11397,7 +11508,7 @@ class NSMutableDictionary extends NSDictionary {
   /// dictionaryWithContentsOfFile:
   static NSDictionary? dictionaryWithContentsOfFile_(NSString path) {
     final _ret = _objc_msgSend_160(_class_NSMutableDictionary,
-        _sel_dictionaryWithContentsOfFile_, path.pointer);
+        _sel_dictionaryWithContentsOfFile_, path.ref.pointer);
     return _ret.address == 0
         ? null
         : NSDictionary.castFromPointer(_ret, retain: true, release: true);
@@ -11406,7 +11517,7 @@ class NSMutableDictionary extends NSDictionary {
   /// dictionaryWithContentsOfURL:
   static NSDictionary? dictionaryWithContentsOfURL_(NSURL url) {
     final _ret = _objc_msgSend_161(_class_NSMutableDictionary,
-        _sel_dictionaryWithContentsOfURL_, url.pointer);
+        _sel_dictionaryWithContentsOfURL_, url.ref.pointer);
     return _ret.address == 0
         ? null
         : NSDictionary.castFromPointer(_ret, retain: true, release: true);
@@ -11414,29 +11525,29 @@ class NSMutableDictionary extends NSDictionary {
 
   /// initWithContentsOfFile:
   NSMutableDictionary? initWithContentsOfFile_(NSString path) {
-    final _ret = _objc_msgSend_282(
-        this.pointer, _sel_initWithContentsOfFile_, path.pointer);
+    final _ret = _objc_msgSend_282(this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfFile_, path.ref.pointer);
     return _ret.address == 0
         ? null
         : NSMutableDictionary.castFromPointer(_ret,
-            retain: true, release: true);
+            retain: false, release: true);
   }
 
   /// initWithContentsOfURL:
   NSMutableDictionary? initWithContentsOfURL_(NSURL url) {
-    final _ret = _objc_msgSend_283(
-        this.pointer, _sel_initWithContentsOfURL_, url.pointer);
+    final _ret = _objc_msgSend_283(this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfURL_, url.ref.pointer);
     return _ret.address == 0
         ? null
         : NSMutableDictionary.castFromPointer(_ret,
-            retain: true, release: true);
+            retain: false, release: true);
   }
 
   /// dictionaryWithSharedKeySet:
   static NSMutableDictionary dictionaryWithSharedKeySet_(
       objc.ObjCObjectBase keyset) {
     final _ret = _objc_msgSend_284(_class_NSMutableDictionary,
-        _sel_dictionaryWithSharedKeySet_, keyset.pointer);
+        _sel_dictionaryWithSharedKeySet_, keyset.ref.pointer);
     return NSMutableDictionary.castFromPointer(_ret,
         retain: true, release: true);
   }
@@ -11446,10 +11557,10 @@ class NSMutableDictionary extends NSDictionary {
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> keys,
       int cnt) {
-    final _ret = _objc_msgSend_156(
-        this.pointer, _sel_initWithObjects_forKeys_count_, objects, keys, cnt);
+    final _ret = _objc_msgSend_156(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_forKeys_count_, objects, keys, cnt);
     return NSMutableDictionary.castFromPointer(_ret,
-        retain: true, release: true);
+        retain: false, release: true);
   }
 
   /// dictionary
@@ -11463,7 +11574,7 @@ class NSMutableDictionary extends NSDictionary {
   static NSMutableDictionary dictionaryWithObject_forKey_(
       objc.ObjCObjectBase object, objc.ObjCObjectBase key) {
     final _ret = _objc_msgSend_162(_class_NSMutableDictionary,
-        _sel_dictionaryWithObject_forKey_, object.pointer, key.pointer);
+        _sel_dictionaryWithObject_forKey_, object.ref.pointer, key.ref.pointer);
     return NSMutableDictionary.castFromPointer(_ret,
         retain: true, release: true);
   }
@@ -11483,7 +11594,7 @@ class NSMutableDictionary extends NSDictionary {
   static NSMutableDictionary dictionaryWithObjectsAndKeys_(
       objc.ObjCObjectBase firstObject) {
     final _ret = _objc_msgSend_126(_class_NSMutableDictionary,
-        _sel_dictionaryWithObjectsAndKeys_, firstObject.pointer);
+        _sel_dictionaryWithObjectsAndKeys_, firstObject.ref.pointer);
     return NSMutableDictionary.castFromPointer(_ret,
         retain: true, release: true);
   }
@@ -11491,7 +11602,7 @@ class NSMutableDictionary extends NSDictionary {
   /// dictionaryWithDictionary:
   static NSMutableDictionary dictionaryWithDictionary_(NSDictionary dict) {
     final _ret = _objc_msgSend_163(_class_NSMutableDictionary,
-        _sel_dictionaryWithDictionary_, dict.pointer);
+        _sel_dictionaryWithDictionary_, dict.ref.pointer);
     return NSMutableDictionary.castFromPointer(_ret,
         retain: true, release: true);
   }
@@ -11499,50 +11610,53 @@ class NSMutableDictionary extends NSDictionary {
   /// dictionaryWithObjects:forKeys:
   static NSMutableDictionary dictionaryWithObjects_forKeys_(
       NSArray objects, NSArray keys) {
-    final _ret = _objc_msgSend_164(_class_NSMutableDictionary,
-        _sel_dictionaryWithObjects_forKeys_, objects.pointer, keys.pointer);
+    final _ret = _objc_msgSend_164(
+        _class_NSMutableDictionary,
+        _sel_dictionaryWithObjects_forKeys_,
+        objects.ref.pointer,
+        keys.ref.pointer);
     return NSMutableDictionary.castFromPointer(_ret,
         retain: true, release: true);
   }
 
   /// initWithObjectsAndKeys:
   NSMutableDictionary initWithObjectsAndKeys_(objc.ObjCObjectBase firstObject) {
-    final _ret = _objc_msgSend_126(
-        this.pointer, _sel_initWithObjectsAndKeys_, firstObject.pointer);
+    final _ret = _objc_msgSend_126(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjectsAndKeys_, firstObject.ref.pointer);
     return NSMutableDictionary.castFromPointer(_ret,
-        retain: true, release: true);
+        retain: false, release: true);
   }
 
   /// initWithDictionary:
   NSMutableDictionary initWithDictionary_(NSDictionary otherDictionary) {
-    final _ret = _objc_msgSend_163(
-        this.pointer, _sel_initWithDictionary_, otherDictionary.pointer);
+    final _ret = _objc_msgSend_163(this.ref.retainAndReturnPointer(),
+        _sel_initWithDictionary_, otherDictionary.ref.pointer);
     return NSMutableDictionary.castFromPointer(_ret,
-        retain: true, release: true);
+        retain: false, release: true);
   }
 
   /// initWithDictionary:copyItems:
   NSMutableDictionary initWithDictionary_copyItems_(
       NSDictionary otherDictionary, bool flag) {
-    final _ret = _objc_msgSend_165(this.pointer,
-        _sel_initWithDictionary_copyItems_, otherDictionary.pointer, flag);
+    final _ret = _objc_msgSend_165(this.ref.retainAndReturnPointer(),
+        _sel_initWithDictionary_copyItems_, otherDictionary.ref.pointer, flag);
     return NSMutableDictionary.castFromPointer(_ret,
         retain: false, release: true);
   }
 
   /// initWithObjects:forKeys:
   NSMutableDictionary initWithObjects_forKeys_(NSArray objects, NSArray keys) {
-    final _ret = _objc_msgSend_164(this.pointer, _sel_initWithObjects_forKeys_,
-        objects.pointer, keys.pointer);
+    final _ret = _objc_msgSend_164(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_forKeys_, objects.ref.pointer, keys.ref.pointer);
     return NSMutableDictionary.castFromPointer(_ret,
-        retain: true, release: true);
+        retain: false, release: true);
   }
 
   /// dictionaryWithContentsOfURL:error:
   static NSDictionary? dictionaryWithContentsOfURL_error_(
       NSURL url, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     final _ret = _objc_msgSend_166(_class_NSMutableDictionary,
-        _sel_dictionaryWithContentsOfURL_error_, url.pointer, error);
+        _sel_dictionaryWithContentsOfURL_error_, url.ref.pointer, error);
     return _ret.address == 0
         ? null
         : NSDictionary.castFromPointer(_ret, retain: true, release: true);
@@ -11550,8 +11664,8 @@ class NSMutableDictionary extends NSDictionary {
 
   /// sharedKeySetForKeys:
   static objc.ObjCObjectBase sharedKeySetForKeys_(NSArray keys) {
-    final _ret = _objc_msgSend_127(
-        _class_NSMutableDictionary, _sel_sharedKeySetForKeys_, keys.pointer);
+    final _ret = _objc_msgSend_127(_class_NSMutableDictionary,
+        _sel_sharedKeySetForKeys_, keys.ref.pointer);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
@@ -11580,14 +11694,14 @@ class NSMutableDictionary extends NSDictionary {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSMutableDictionary,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSMutableDictionary,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -11682,7 +11796,7 @@ class NSOrderedSet extends NSObject {
 
   /// Constructs a [NSOrderedSet] that points to the same underlying object as [other].
   NSOrderedSet.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSOrderedSet] that wraps the given raw object pointer.
   NSOrderedSet.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -11692,64 +11806,65 @@ class NSOrderedSet extends NSObject {
   /// Returns whether [obj] is an instance of [NSOrderedSet].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_NSOrderedSet);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSOrderedSet);
   }
 
   /// count
   int get count {
-    return _objc_msgSend_11(this.pointer, _sel_count);
+    return _objc_msgSend_11(this.ref.pointer, _sel_count);
   }
 
   /// objectAtIndex:
   objc.ObjCObjectBase objectAtIndex_(int idx) {
-    final _ret = _objc_msgSend_99(this.pointer, _sel_objectAtIndex_, idx);
+    final _ret = _objc_msgSend_99(this.ref.pointer, _sel_objectAtIndex_, idx);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
   /// indexOfObject:
   int indexOfObject_(objc.ObjCObjectBase object) {
-    return _objc_msgSend_107(this.pointer, _sel_indexOfObject_, object.pointer);
+    return _objc_msgSend_107(
+        this.ref.pointer, _sel_indexOfObject_, object.ref.pointer);
   }
 
   /// init
   NSOrderedSet init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithObjects:count:
   NSOrderedSet initWithObjects_count_(
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
-    final _ret = _objc_msgSend_100(
-        this.pointer, _sel_initWithObjects_count_, objects, cnt);
-    return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_100(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_count_, objects, cnt);
+    return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
   NSOrderedSet? initWithCoder_(NSCoder coder) {
-    final _ret =
-        _objc_msgSend_18(this.pointer, _sel_initWithCoder_, coder.pointer);
+    final _ret = _objc_msgSend_18(this.ref.retainAndReturnPointer(),
+        _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
+        : NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// getObjects:range:
   void getObjects_range_(
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, NSRange range) {
-    _objc_msgSend_106(this.pointer, _sel_getObjects_range_, objects, range);
+    _objc_msgSend_106(this.ref.pointer, _sel_getObjects_range_, objects, range);
   }
 
   /// objectsAtIndexes:
   NSArray objectsAtIndexes_(NSIndexSet indexes) {
     final _ret = _objc_msgSend_125(
-        this.pointer, _sel_objectsAtIndexes_, indexes.pointer);
+        this.ref.pointer, _sel_objectsAtIndexes_, indexes.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// firstObject
   objc.ObjCObjectBase? get firstObject {
-    final _ret = _objc_msgSend_16(this.pointer, _sel_firstObject);
+    final _ret = _objc_msgSend_16(this.ref.pointer, _sel_firstObject);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -11757,7 +11872,7 @@ class NSOrderedSet extends NSObject {
 
   /// lastObject
   objc.ObjCObjectBase? get lastObject {
-    final _ret = _objc_msgSend_16(this.pointer, _sel_lastObject);
+    final _ret = _objc_msgSend_16(this.ref.pointer, _sel_lastObject);
     return _ret.address == 0
         ? null
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -11766,83 +11881,87 @@ class NSOrderedSet extends NSObject {
   /// isEqualToOrderedSet:
   bool isEqualToOrderedSet_(NSOrderedSet other) {
     return _objc_msgSend_285(
-        this.pointer, _sel_isEqualToOrderedSet_, other.pointer);
+        this.ref.pointer, _sel_isEqualToOrderedSet_, other.ref.pointer);
   }
 
   /// containsObject:
   bool containsObject_(objc.ObjCObjectBase object) {
-    return _objc_msgSend_0(this.pointer, _sel_containsObject_, object.pointer);
+    return _objc_msgSend_0(
+        this.ref.pointer, _sel_containsObject_, object.ref.pointer);
   }
 
   /// intersectsOrderedSet:
   bool intersectsOrderedSet_(NSOrderedSet other) {
     return _objc_msgSend_285(
-        this.pointer, _sel_intersectsOrderedSet_, other.pointer);
+        this.ref.pointer, _sel_intersectsOrderedSet_, other.ref.pointer);
   }
 
   /// intersectsSet:
   bool intersectsSet_(objc.ObjCObjectBase set) {
-    return _objc_msgSend_0(this.pointer, _sel_intersectsSet_, set.pointer);
+    return _objc_msgSend_0(
+        this.ref.pointer, _sel_intersectsSet_, set.ref.pointer);
   }
 
   /// isSubsetOfOrderedSet:
   bool isSubsetOfOrderedSet_(NSOrderedSet other) {
     return _objc_msgSend_285(
-        this.pointer, _sel_isSubsetOfOrderedSet_, other.pointer);
+        this.ref.pointer, _sel_isSubsetOfOrderedSet_, other.ref.pointer);
   }
 
   /// isSubsetOfSet:
   bool isSubsetOfSet_(objc.ObjCObjectBase set) {
-    return _objc_msgSend_0(this.pointer, _sel_isSubsetOfSet_, set.pointer);
+    return _objc_msgSend_0(
+        this.ref.pointer, _sel_isSubsetOfSet_, set.ref.pointer);
   }
 
   /// objectAtIndexedSubscript:
   objc.ObjCObjectBase objectAtIndexedSubscript_(int idx) {
     final _ret =
-        _objc_msgSend_99(this.pointer, _sel_objectAtIndexedSubscript_, idx);
+        _objc_msgSend_99(this.ref.pointer, _sel_objectAtIndexedSubscript_, idx);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
   /// objectEnumerator
   NSEnumerator objectEnumerator() {
-    final _ret = _objc_msgSend_110(this.pointer, _sel_objectEnumerator);
+    final _ret = _objc_msgSend_110(this.ref.pointer, _sel_objectEnumerator);
     return NSEnumerator.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// reverseObjectEnumerator
   NSEnumerator reverseObjectEnumerator() {
-    final _ret = _objc_msgSend_110(this.pointer, _sel_reverseObjectEnumerator);
+    final _ret =
+        _objc_msgSend_110(this.ref.pointer, _sel_reverseObjectEnumerator);
     return NSEnumerator.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// reversedOrderedSet
   NSOrderedSet get reversedOrderedSet {
-    final _ret = _objc_msgSend_286(this.pointer, _sel_reversedOrderedSet);
+    final _ret = _objc_msgSend_286(this.ref.pointer, _sel_reversedOrderedSet);
     return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// array
   NSArray get array {
-    final _ret = _objc_msgSend_142(this.pointer, _sel_array);
+    final _ret = _objc_msgSend_142(this.ref.pointer, _sel_array);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// set
   objc.ObjCObjectBase get set1 {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_set);
+    final _ret = _objc_msgSend_2(this.ref.pointer, _sel_set);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
   /// description
   NSString get description {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_description);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_description);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// descriptionWithLocale:
   NSString descriptionWithLocale_(objc.ObjCObjectBase? locale) {
-    final _ret = _objc_msgSend_86(this.pointer, _sel_descriptionWithLocale_,
-        locale?.pointer ?? ffi.nullptr);
+    final _ret = _objc_msgSend_86(this.ref.pointer, _sel_descriptionWithLocale_,
+        locale?.ref.pointer ?? ffi.nullptr);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -11850,9 +11969,9 @@ class NSOrderedSet extends NSObject {
   NSString descriptionWithLocale_indent_(
       objc.ObjCObjectBase? locale, int level) {
     final _ret = _objc_msgSend_104(
-        this.pointer,
+        this.ref.pointer,
         _sel_descriptionWithLocale_indent_,
-        locale?.pointer ?? ffi.nullptr,
+        locale?.ref.pointer ?? ffi.nullptr,
         level);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
@@ -11866,7 +11985,7 @@ class NSOrderedSet extends NSObject {
   /// orderedSetWithObject:
   static NSOrderedSet orderedSetWithObject_(objc.ObjCObjectBase object) {
     final _ret = _objc_msgSend_126(
-        _class_NSOrderedSet, _sel_orderedSetWithObject_, object.pointer);
+        _class_NSOrderedSet, _sel_orderedSetWithObject_, object.ref.pointer);
     return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -11881,14 +12000,14 @@ class NSOrderedSet extends NSObject {
   /// orderedSetWithObjects:
   static NSOrderedSet orderedSetWithObjects_(objc.ObjCObjectBase firstObj) {
     final _ret = _objc_msgSend_126(
-        _class_NSOrderedSet, _sel_orderedSetWithObjects_, firstObj.pointer);
+        _class_NSOrderedSet, _sel_orderedSetWithObjects_, firstObj.ref.pointer);
     return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// orderedSetWithOrderedSet:
   static NSOrderedSet orderedSetWithOrderedSet_(NSOrderedSet set) {
     final _ret = _objc_msgSend_287(
-        _class_NSOrderedSet, _sel_orderedSetWithOrderedSet_, set.pointer);
+        _class_NSOrderedSet, _sel_orderedSetWithOrderedSet_, set.ref.pointer);
     return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -11898,31 +12017,35 @@ class NSOrderedSet extends NSObject {
     final _ret = _objc_msgSend_288(
         _class_NSOrderedSet,
         _sel_orderedSetWithOrderedSet_range_copyItems_,
-        set.pointer,
+        set.ref.pointer,
         range,
         flag);
-    return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
+    return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// orderedSetWithArray:
   static NSOrderedSet orderedSetWithArray_(NSArray array) {
     final _ret = _objc_msgSend_127(
-        _class_NSOrderedSet, _sel_orderedSetWithArray_, array.pointer);
+        _class_NSOrderedSet, _sel_orderedSetWithArray_, array.ref.pointer);
     return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// orderedSetWithArray:range:copyItems:
   static NSOrderedSet orderedSetWithArray_range_copyItems_(
       NSArray array, NSRange range, bool flag) {
-    final _ret = _objc_msgSend_289(_class_NSOrderedSet,
-        _sel_orderedSetWithArray_range_copyItems_, array.pointer, range, flag);
-    return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
+    final _ret = _objc_msgSend_289(
+        _class_NSOrderedSet,
+        _sel_orderedSetWithArray_range_copyItems_,
+        array.ref.pointer,
+        range,
+        flag);
+    return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// orderedSetWithSet:
   static NSOrderedSet orderedSetWithSet_(objc.ObjCObjectBase set) {
     final _ret = _objc_msgSend_126(
-        _class_NSOrderedSet, _sel_orderedSetWithSet_, set.pointer);
+        _class_NSOrderedSet, _sel_orderedSetWithSet_, set.ref.pointer);
     return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -11930,79 +12053,79 @@ class NSOrderedSet extends NSObject {
   static NSOrderedSet orderedSetWithSet_copyItems_(
       objc.ObjCObjectBase set, bool flag) {
     final _ret = _objc_msgSend_290(_class_NSOrderedSet,
-        _sel_orderedSetWithSet_copyItems_, set.pointer, flag);
-    return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
+        _sel_orderedSetWithSet_copyItems_, set.ref.pointer, flag);
+    return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// initWithObject:
   NSOrderedSet initWithObject_(objc.ObjCObjectBase object) {
-    final _ret =
-        _objc_msgSend_126(this.pointer, _sel_initWithObject_, object.pointer);
-    return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_126(this.ref.retainAndReturnPointer(),
+        _sel_initWithObject_, object.ref.pointer);
+    return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithObjects:
   NSOrderedSet initWithObjects_(objc.ObjCObjectBase firstObj) {
-    final _ret = _objc_msgSend_126(
-        this.pointer, _sel_initWithObjects_, firstObj.pointer);
-    return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_126(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_, firstObj.ref.pointer);
+    return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithOrderedSet:
   NSOrderedSet initWithOrderedSet_(NSOrderedSet set) {
-    final _ret =
-        _objc_msgSend_287(this.pointer, _sel_initWithOrderedSet_, set.pointer);
-    return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_287(this.ref.retainAndReturnPointer(),
+        _sel_initWithOrderedSet_, set.ref.pointer);
+    return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithOrderedSet:copyItems:
   NSOrderedSet initWithOrderedSet_copyItems_(NSOrderedSet set, bool flag) {
-    final _ret = _objc_msgSend_291(
-        this.pointer, _sel_initWithOrderedSet_copyItems_, set.pointer, flag);
+    final _ret = _objc_msgSend_291(this.ref.retainAndReturnPointer(),
+        _sel_initWithOrderedSet_copyItems_, set.ref.pointer, flag);
     return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithOrderedSet:range:copyItems:
   NSOrderedSet initWithOrderedSet_range_copyItems_(
       NSOrderedSet set, NSRange range, bool flag) {
-    final _ret = _objc_msgSend_288(this.pointer,
-        _sel_initWithOrderedSet_range_copyItems_, set.pointer, range, flag);
+    final _ret = _objc_msgSend_288(this.ref.retainAndReturnPointer(),
+        _sel_initWithOrderedSet_range_copyItems_, set.ref.pointer, range, flag);
     return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithArray:
   NSOrderedSet initWithArray_(NSArray array) {
-    final _ret =
-        _objc_msgSend_127(this.pointer, _sel_initWithArray_, array.pointer);
-    return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_127(this.ref.retainAndReturnPointer(),
+        _sel_initWithArray_, array.ref.pointer);
+    return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithArray:copyItems:
   NSOrderedSet initWithArray_copyItems_(NSArray set, bool flag) {
-    final _ret = _objc_msgSend_128(
-        this.pointer, _sel_initWithArray_copyItems_, set.pointer, flag);
+    final _ret = _objc_msgSend_128(this.ref.retainAndReturnPointer(),
+        _sel_initWithArray_copyItems_, set.ref.pointer, flag);
     return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithArray:range:copyItems:
   NSOrderedSet initWithArray_range_copyItems_(
       NSArray set, NSRange range, bool flag) {
-    final _ret = _objc_msgSend_289(this.pointer,
-        _sel_initWithArray_range_copyItems_, set.pointer, range, flag);
+    final _ret = _objc_msgSend_289(this.ref.retainAndReturnPointer(),
+        _sel_initWithArray_range_copyItems_, set.ref.pointer, range, flag);
     return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithSet:
   NSOrderedSet initWithSet_(objc.ObjCObjectBase set) {
-    final _ret =
-        _objc_msgSend_126(this.pointer, _sel_initWithSet_, set.pointer);
-    return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_126(
+        this.ref.retainAndReturnPointer(), _sel_initWithSet_, set.ref.pointer);
+    return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithSet:copyItems:
   NSOrderedSet initWithSet_copyItems_(objc.ObjCObjectBase set, bool flag) {
-    final _ret = _objc_msgSend_290(
-        this.pointer, _sel_initWithSet_copyItems_, set.pointer, flag);
+    final _ret = _objc_msgSend_290(this.ref.retainAndReturnPointer(),
+        _sel_initWithSet_copyItems_, set.ref.pointer, flag);
     return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
@@ -12010,9 +12133,9 @@ class NSOrderedSet extends NSObject {
   objc.ObjCObjectBase differenceFromOrderedSet_withOptions_(NSOrderedSet other,
       NSOrderedCollectionDifferenceCalculationOptions options) {
     final _ret = _objc_msgSend_292(
-        this.pointer,
+        this.ref.pointer,
         _sel_differenceFromOrderedSet_withOptions_,
-        other.pointer,
+        other.ref.pointer,
         options.value);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
@@ -12020,15 +12143,15 @@ class NSOrderedSet extends NSObject {
   /// differenceFromOrderedSet:
   objc.ObjCObjectBase differenceFromOrderedSet_(NSOrderedSet other) {
     final _ret = _objc_msgSend_287(
-        this.pointer, _sel_differenceFromOrderedSet_, other.pointer);
+        this.ref.pointer, _sel_differenceFromOrderedSet_, other.ref.pointer);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
   /// orderedSetByApplyingDifference:
   NSOrderedSet? orderedSetByApplyingDifference_(
       objc.ObjCObjectBase difference) {
-    final _ret = _objc_msgSend_293(
-        this.pointer, _sel_orderedSetByApplyingDifference_, difference.pointer);
+    final _ret = _objc_msgSend_293(this.ref.pointer,
+        _sel_orderedSetByApplyingDifference_, difference.ref.pointer);
     return _ret.address == 0
         ? null
         : NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
@@ -12041,10 +12164,10 @@ class NSOrderedSet extends NSObject {
       NSKeyValueObservingOptions options,
       ffi.Pointer<ffi.Void> context) {
     _objc_msgSend_138(
-        this.pointer,
+        this.ref.pointer,
         _sel_addObserver_forKeyPath_options_context_,
-        observer.pointer,
-        keyPath.pointer,
+        observer.ref.pointer,
+        keyPath.ref.pointer,
         options.value,
         context);
   }
@@ -12052,14 +12175,14 @@ class NSOrderedSet extends NSObject {
   /// removeObserver:forKeyPath:context:
   void removeObserver_forKeyPath_context_(
       NSObject observer, NSString keyPath, ffi.Pointer<ffi.Void> context) {
-    _objc_msgSend_139(this.pointer, _sel_removeObserver_forKeyPath_context_,
-        observer.pointer, keyPath.pointer, context);
+    _objc_msgSend_139(this.ref.pointer, _sel_removeObserver_forKeyPath_context_,
+        observer.ref.pointer, keyPath.ref.pointer, context);
   }
 
   /// removeObserver:forKeyPath:
   void removeObserver_forKeyPath_(NSObject observer, NSString keyPath) {
-    _objc_msgSend_140(this.pointer, _sel_removeObserver_forKeyPath_,
-        observer.pointer, keyPath.pointer);
+    _objc_msgSend_140(this.ref.pointer, _sel_removeObserver_forKeyPath_,
+        observer.ref.pointer, keyPath.ref.pointer);
   }
 
   /// new
@@ -12084,14 +12207,14 @@ class NSOrderedSet extends NSObject {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSOrderedSet,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSOrderedSet,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -12256,7 +12379,7 @@ class NSMutableOrderedSet extends NSOrderedSet {
 
   /// Constructs a [NSMutableOrderedSet] that points to the same underlying object as [other].
   NSMutableOrderedSet.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSMutableOrderedSet] that wraps the given raw object pointer.
   NSMutableOrderedSet.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -12266,164 +12389,173 @@ class NSMutableOrderedSet extends NSOrderedSet {
   /// Returns whether [obj] is an instance of [NSMutableOrderedSet].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_NSMutableOrderedSet);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSMutableOrderedSet);
   }
 
   /// insertObject:atIndex:
   void insertObject_atIndex_(objc.ObjCObjectBase object, int idx) {
     _objc_msgSend_253(
-        this.pointer, _sel_insertObject_atIndex_, object.pointer, idx);
+        this.ref.pointer, _sel_insertObject_atIndex_, object.ref.pointer, idx);
   }
 
   /// removeObjectAtIndex:
   void removeObjectAtIndex_(int idx) {
-    _objc_msgSend_249(this.pointer, _sel_removeObjectAtIndex_, idx);
+    _objc_msgSend_249(this.ref.pointer, _sel_removeObjectAtIndex_, idx);
   }
 
   /// replaceObjectAtIndex:withObject:
   void replaceObjectAtIndex_withObject_(int idx, objc.ObjCObjectBase object) {
-    _objc_msgSend_254(this.pointer, _sel_replaceObjectAtIndex_withObject_, idx,
-        object.pointer);
+    _objc_msgSend_254(this.ref.pointer, _sel_replaceObjectAtIndex_withObject_,
+        idx, object.ref.pointer);
   }
 
   /// initWithCoder:
   NSMutableOrderedSet? initWithCoder_(NSCoder coder) {
-    final _ret =
-        _objc_msgSend_18(this.pointer, _sel_initWithCoder_, coder.pointer);
+    final _ret = _objc_msgSend_18(this.ref.retainAndReturnPointer(),
+        _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
         ? null
         : NSMutableOrderedSet.castFromPointer(_ret,
-            retain: true, release: true);
+            retain: false, release: true);
   }
 
   /// init
   NSMutableOrderedSet init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
     return NSMutableOrderedSet.castFromPointer(_ret,
-        retain: true, release: true);
+        retain: false, release: true);
   }
 
   /// initWithCapacity:
   NSMutableOrderedSet initWithCapacity_(int numItems) {
-    final _ret =
-        _objc_msgSend_99(this.pointer, _sel_initWithCapacity_, numItems);
+    final _ret = _objc_msgSend_99(
+        this.ref.retainAndReturnPointer(), _sel_initWithCapacity_, numItems);
     return NSMutableOrderedSet.castFromPointer(_ret,
-        retain: true, release: true);
+        retain: false, release: true);
   }
 
   /// addObject:
   void addObject_(objc.ObjCObjectBase object) {
-    _objc_msgSend_252(this.pointer, _sel_addObject_, object.pointer);
+    _objc_msgSend_252(this.ref.pointer, _sel_addObject_, object.ref.pointer);
   }
 
   /// addObjects:count:
   void addObjects_count_(
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int count) {
-    _objc_msgSend_294(this.pointer, _sel_addObjects_count_, objects, count);
+    _objc_msgSend_294(this.ref.pointer, _sel_addObjects_count_, objects, count);
   }
 
   /// addObjectsFromArray:
   void addObjectsFromArray_(NSArray array) {
-    _objc_msgSend_255(this.pointer, _sel_addObjectsFromArray_, array.pointer);
+    _objc_msgSend_255(
+        this.ref.pointer, _sel_addObjectsFromArray_, array.ref.pointer);
   }
 
   /// exchangeObjectAtIndex:withObjectAtIndex:
   void exchangeObjectAtIndex_withObjectAtIndex_(int idx1, int idx2) {
-    _objc_msgSend_256(this.pointer,
+    _objc_msgSend_256(this.ref.pointer,
         _sel_exchangeObjectAtIndex_withObjectAtIndex_, idx1, idx2);
   }
 
   /// moveObjectsAtIndexes:toIndex:
   void moveObjectsAtIndexes_toIndex_(NSIndexSet indexes, int idx) {
-    _objc_msgSend_295(
-        this.pointer, _sel_moveObjectsAtIndexes_toIndex_, indexes.pointer, idx);
+    _objc_msgSend_295(this.ref.pointer, _sel_moveObjectsAtIndexes_toIndex_,
+        indexes.ref.pointer, idx);
   }
 
   /// insertObjects:atIndexes:
   void insertObjects_atIndexes_(NSArray objects, NSIndexSet indexes) {
-    _objc_msgSend_261(this.pointer, _sel_insertObjects_atIndexes_,
-        objects.pointer, indexes.pointer);
+    _objc_msgSend_261(this.ref.pointer, _sel_insertObjects_atIndexes_,
+        objects.ref.pointer, indexes.ref.pointer);
   }
 
   /// setObject:atIndex:
   void setObject_atIndex_(objc.ObjCObjectBase obj, int idx) {
-    _objc_msgSend_253(this.pointer, _sel_setObject_atIndex_, obj.pointer, idx);
+    _objc_msgSend_253(
+        this.ref.pointer, _sel_setObject_atIndex_, obj.ref.pointer, idx);
   }
 
   /// setObject:atIndexedSubscript:
   void setObject_atIndexedSubscript_(objc.ObjCObjectBase obj, int idx) {
-    _objc_msgSend_253(
-        this.pointer, _sel_setObject_atIndexedSubscript_, obj.pointer, idx);
+    _objc_msgSend_253(this.ref.pointer, _sel_setObject_atIndexedSubscript_,
+        obj.ref.pointer, idx);
   }
 
   /// replaceObjectsInRange:withObjects:count:
   void replaceObjectsInRange_withObjects_count_(NSRange range,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int count) {
-    _objc_msgSend_296(this.pointer,
+    _objc_msgSend_296(this.ref.pointer,
         _sel_replaceObjectsInRange_withObjects_count_, range, objects, count);
   }
 
   /// replaceObjectsAtIndexes:withObjects:
   void replaceObjectsAtIndexes_withObjects_(
       NSIndexSet indexes, NSArray objects) {
-    _objc_msgSend_262(this.pointer, _sel_replaceObjectsAtIndexes_withObjects_,
-        indexes.pointer, objects.pointer);
+    _objc_msgSend_262(
+        this.ref.pointer,
+        _sel_replaceObjectsAtIndexes_withObjects_,
+        indexes.ref.pointer,
+        objects.ref.pointer);
   }
 
   /// removeObjectsInRange:
   void removeObjectsInRange_(NSRange range) {
-    _objc_msgSend_250(this.pointer, _sel_removeObjectsInRange_, range);
+    _objc_msgSend_250(this.ref.pointer, _sel_removeObjectsInRange_, range);
   }
 
   /// removeObjectsAtIndexes:
   void removeObjectsAtIndexes_(NSIndexSet indexes) {
     _objc_msgSend_248(
-        this.pointer, _sel_removeObjectsAtIndexes_, indexes.pointer);
+        this.ref.pointer, _sel_removeObjectsAtIndexes_, indexes.ref.pointer);
   }
 
   /// removeAllObjects
   void removeAllObjects() {
-    _objc_msgSend_1(this.pointer, _sel_removeAllObjects);
+    _objc_msgSend_1(this.ref.pointer, _sel_removeAllObjects);
   }
 
   /// removeObject:
   void removeObject_(objc.ObjCObjectBase object) {
-    _objc_msgSend_252(this.pointer, _sel_removeObject_, object.pointer);
+    _objc_msgSend_252(this.ref.pointer, _sel_removeObject_, object.ref.pointer);
   }
 
   /// removeObjectsInArray:
   void removeObjectsInArray_(NSArray array) {
-    _objc_msgSend_255(this.pointer, _sel_removeObjectsInArray_, array.pointer);
+    _objc_msgSend_255(
+        this.ref.pointer, _sel_removeObjectsInArray_, array.ref.pointer);
   }
 
   /// intersectOrderedSet:
   void intersectOrderedSet_(NSOrderedSet other) {
-    _objc_msgSend_297(this.pointer, _sel_intersectOrderedSet_, other.pointer);
+    _objc_msgSend_297(
+        this.ref.pointer, _sel_intersectOrderedSet_, other.ref.pointer);
   }
 
   /// minusOrderedSet:
   void minusOrderedSet_(NSOrderedSet other) {
-    _objc_msgSend_297(this.pointer, _sel_minusOrderedSet_, other.pointer);
+    _objc_msgSend_297(
+        this.ref.pointer, _sel_minusOrderedSet_, other.ref.pointer);
   }
 
   /// unionOrderedSet:
   void unionOrderedSet_(NSOrderedSet other) {
-    _objc_msgSend_297(this.pointer, _sel_unionOrderedSet_, other.pointer);
+    _objc_msgSend_297(
+        this.ref.pointer, _sel_unionOrderedSet_, other.ref.pointer);
   }
 
   /// intersectSet:
   void intersectSet_(objc.ObjCObjectBase other) {
-    _objc_msgSend_252(this.pointer, _sel_intersectSet_, other.pointer);
+    _objc_msgSend_252(this.ref.pointer, _sel_intersectSet_, other.ref.pointer);
   }
 
   /// minusSet:
   void minusSet_(objc.ObjCObjectBase other) {
-    _objc_msgSend_252(this.pointer, _sel_minusSet_, other.pointer);
+    _objc_msgSend_252(this.ref.pointer, _sel_minusSet_, other.ref.pointer);
   }
 
   /// unionSet:
   void unionSet_(objc.ObjCObjectBase other) {
-    _objc_msgSend_252(this.pointer, _sel_unionSet_, other.pointer);
+    _objc_msgSend_252(this.ref.pointer, _sel_unionSet_, other.ref.pointer);
   }
 
   /// orderedSetWithCapacity:
@@ -12436,16 +12568,17 @@ class NSMutableOrderedSet extends NSOrderedSet {
 
   /// applyDifference:
   void applyDifference_(objc.ObjCObjectBase difference) {
-    _objc_msgSend_252(this.pointer, _sel_applyDifference_, difference.pointer);
+    _objc_msgSend_252(
+        this.ref.pointer, _sel_applyDifference_, difference.ref.pointer);
   }
 
   /// initWithObjects:count:
   NSMutableOrderedSet initWithObjects_count_(
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
-    final _ret = _objc_msgSend_100(
-        this.pointer, _sel_initWithObjects_count_, objects, cnt);
+    final _ret = _objc_msgSend_100(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_count_, objects, cnt);
     return NSMutableOrderedSet.castFromPointer(_ret,
-        retain: true, release: true);
+        retain: false, release: true);
   }
 
   /// orderedSet
@@ -12457,8 +12590,8 @@ class NSMutableOrderedSet extends NSOrderedSet {
 
   /// orderedSetWithObject:
   static NSMutableOrderedSet orderedSetWithObject_(objc.ObjCObjectBase object) {
-    final _ret = _objc_msgSend_126(
-        _class_NSMutableOrderedSet, _sel_orderedSetWithObject_, object.pointer);
+    final _ret = _objc_msgSend_126(_class_NSMutableOrderedSet,
+        _sel_orderedSetWithObject_, object.ref.pointer);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: true, release: true);
   }
@@ -12476,7 +12609,7 @@ class NSMutableOrderedSet extends NSOrderedSet {
   static NSMutableOrderedSet orderedSetWithObjects_(
       objc.ObjCObjectBase firstObj) {
     final _ret = _objc_msgSend_126(_class_NSMutableOrderedSet,
-        _sel_orderedSetWithObjects_, firstObj.pointer);
+        _sel_orderedSetWithObjects_, firstObj.ref.pointer);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: true, release: true);
   }
@@ -12484,7 +12617,7 @@ class NSMutableOrderedSet extends NSOrderedSet {
   /// orderedSetWithOrderedSet:
   static NSMutableOrderedSet orderedSetWithOrderedSet_(NSOrderedSet set) {
     final _ret = _objc_msgSend_287(_class_NSMutableOrderedSet,
-        _sel_orderedSetWithOrderedSet_, set.pointer);
+        _sel_orderedSetWithOrderedSet_, set.ref.pointer);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: true, release: true);
   }
@@ -12495,17 +12628,17 @@ class NSMutableOrderedSet extends NSOrderedSet {
     final _ret = _objc_msgSend_288(
         _class_NSMutableOrderedSet,
         _sel_orderedSetWithOrderedSet_range_copyItems_,
-        set.pointer,
+        set.ref.pointer,
         range,
         flag);
     return NSMutableOrderedSet.castFromPointer(_ret,
-        retain: false, release: true);
+        retain: true, release: true);
   }
 
   /// orderedSetWithArray:
   static NSMutableOrderedSet orderedSetWithArray_(NSArray array) {
-    final _ret = _objc_msgSend_127(
-        _class_NSMutableOrderedSet, _sel_orderedSetWithArray_, array.pointer);
+    final _ret = _objc_msgSend_127(_class_NSMutableOrderedSet,
+        _sel_orderedSetWithArray_, array.ref.pointer);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: true, release: true);
   }
@@ -12513,16 +12646,20 @@ class NSMutableOrderedSet extends NSOrderedSet {
   /// orderedSetWithArray:range:copyItems:
   static NSMutableOrderedSet orderedSetWithArray_range_copyItems_(
       NSArray array, NSRange range, bool flag) {
-    final _ret = _objc_msgSend_289(_class_NSMutableOrderedSet,
-        _sel_orderedSetWithArray_range_copyItems_, array.pointer, range, flag);
+    final _ret = _objc_msgSend_289(
+        _class_NSMutableOrderedSet,
+        _sel_orderedSetWithArray_range_copyItems_,
+        array.ref.pointer,
+        range,
+        flag);
     return NSMutableOrderedSet.castFromPointer(_ret,
-        retain: false, release: true);
+        retain: true, release: true);
   }
 
   /// orderedSetWithSet:
   static NSMutableOrderedSet orderedSetWithSet_(objc.ObjCObjectBase set) {
     final _ret = _objc_msgSend_126(
-        _class_NSMutableOrderedSet, _sel_orderedSetWithSet_, set.pointer);
+        _class_NSMutableOrderedSet, _sel_orderedSetWithSet_, set.ref.pointer);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: true, release: true);
   }
@@ -12531,40 +12668,40 @@ class NSMutableOrderedSet extends NSOrderedSet {
   static NSMutableOrderedSet orderedSetWithSet_copyItems_(
       objc.ObjCObjectBase set, bool flag) {
     final _ret = _objc_msgSend_290(_class_NSMutableOrderedSet,
-        _sel_orderedSetWithSet_copyItems_, set.pointer, flag);
+        _sel_orderedSetWithSet_copyItems_, set.ref.pointer, flag);
     return NSMutableOrderedSet.castFromPointer(_ret,
-        retain: false, release: true);
+        retain: true, release: true);
   }
 
   /// initWithObject:
   NSMutableOrderedSet initWithObject_(objc.ObjCObjectBase object) {
-    final _ret =
-        _objc_msgSend_126(this.pointer, _sel_initWithObject_, object.pointer);
+    final _ret = _objc_msgSend_126(this.ref.retainAndReturnPointer(),
+        _sel_initWithObject_, object.ref.pointer);
     return NSMutableOrderedSet.castFromPointer(_ret,
-        retain: true, release: true);
+        retain: false, release: true);
   }
 
   /// initWithObjects:
   NSMutableOrderedSet initWithObjects_(objc.ObjCObjectBase firstObj) {
-    final _ret = _objc_msgSend_126(
-        this.pointer, _sel_initWithObjects_, firstObj.pointer);
+    final _ret = _objc_msgSend_126(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_, firstObj.ref.pointer);
     return NSMutableOrderedSet.castFromPointer(_ret,
-        retain: true, release: true);
+        retain: false, release: true);
   }
 
   /// initWithOrderedSet:
   NSMutableOrderedSet initWithOrderedSet_(NSOrderedSet set) {
-    final _ret =
-        _objc_msgSend_287(this.pointer, _sel_initWithOrderedSet_, set.pointer);
+    final _ret = _objc_msgSend_287(this.ref.retainAndReturnPointer(),
+        _sel_initWithOrderedSet_, set.ref.pointer);
     return NSMutableOrderedSet.castFromPointer(_ret,
-        retain: true, release: true);
+        retain: false, release: true);
   }
 
   /// initWithOrderedSet:copyItems:
   NSMutableOrderedSet initWithOrderedSet_copyItems_(
       NSOrderedSet set, bool flag) {
-    final _ret = _objc_msgSend_291(
-        this.pointer, _sel_initWithOrderedSet_copyItems_, set.pointer, flag);
+    final _ret = _objc_msgSend_291(this.ref.retainAndReturnPointer(),
+        _sel_initWithOrderedSet_copyItems_, set.ref.pointer, flag);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: false, release: true);
   }
@@ -12572,24 +12709,24 @@ class NSMutableOrderedSet extends NSOrderedSet {
   /// initWithOrderedSet:range:copyItems:
   NSMutableOrderedSet initWithOrderedSet_range_copyItems_(
       NSOrderedSet set, NSRange range, bool flag) {
-    final _ret = _objc_msgSend_288(this.pointer,
-        _sel_initWithOrderedSet_range_copyItems_, set.pointer, range, flag);
+    final _ret = _objc_msgSend_288(this.ref.retainAndReturnPointer(),
+        _sel_initWithOrderedSet_range_copyItems_, set.ref.pointer, range, flag);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: false, release: true);
   }
 
   /// initWithArray:
   NSMutableOrderedSet initWithArray_(NSArray array) {
-    final _ret =
-        _objc_msgSend_127(this.pointer, _sel_initWithArray_, array.pointer);
+    final _ret = _objc_msgSend_127(this.ref.retainAndReturnPointer(),
+        _sel_initWithArray_, array.ref.pointer);
     return NSMutableOrderedSet.castFromPointer(_ret,
-        retain: true, release: true);
+        retain: false, release: true);
   }
 
   /// initWithArray:copyItems:
   NSMutableOrderedSet initWithArray_copyItems_(NSArray set, bool flag) {
-    final _ret = _objc_msgSend_128(
-        this.pointer, _sel_initWithArray_copyItems_, set.pointer, flag);
+    final _ret = _objc_msgSend_128(this.ref.retainAndReturnPointer(),
+        _sel_initWithArray_copyItems_, set.ref.pointer, flag);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: false, release: true);
   }
@@ -12597,25 +12734,25 @@ class NSMutableOrderedSet extends NSOrderedSet {
   /// initWithArray:range:copyItems:
   NSMutableOrderedSet initWithArray_range_copyItems_(
       NSArray set, NSRange range, bool flag) {
-    final _ret = _objc_msgSend_289(this.pointer,
-        _sel_initWithArray_range_copyItems_, set.pointer, range, flag);
+    final _ret = _objc_msgSend_289(this.ref.retainAndReturnPointer(),
+        _sel_initWithArray_range_copyItems_, set.ref.pointer, range, flag);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: false, release: true);
   }
 
   /// initWithSet:
   NSMutableOrderedSet initWithSet_(objc.ObjCObjectBase set) {
-    final _ret =
-        _objc_msgSend_126(this.pointer, _sel_initWithSet_, set.pointer);
+    final _ret = _objc_msgSend_126(
+        this.ref.retainAndReturnPointer(), _sel_initWithSet_, set.ref.pointer);
     return NSMutableOrderedSet.castFromPointer(_ret,
-        retain: true, release: true);
+        retain: false, release: true);
   }
 
   /// initWithSet:copyItems:
   NSMutableOrderedSet initWithSet_copyItems_(
       objc.ObjCObjectBase set, bool flag) {
-    final _ret = _objc_msgSend_290(
-        this.pointer, _sel_initWithSet_copyItems_, set.pointer, flag);
+    final _ret = _objc_msgSend_290(this.ref.retainAndReturnPointer(),
+        _sel_initWithSet_copyItems_, set.ref.pointer, flag);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: false, release: true);
   }
@@ -12645,14 +12782,14 @@ class NSMutableOrderedSet extends NSOrderedSet {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSMutableOrderedSet,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSMutableOrderedSet,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -12735,7 +12872,7 @@ class NSMutableSet extends NSSet {
 
   /// Constructs a [NSMutableSet] that points to the same underlying object as [other].
   NSMutableSet.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSMutableSet] that wraps the given raw object pointer.
   NSMutableSet.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -12745,69 +12882,71 @@ class NSMutableSet extends NSSet {
   /// Returns whether [obj] is an instance of [NSMutableSet].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_NSMutableSet);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSMutableSet);
   }
 
   /// addObject:
   void addObject_(objc.ObjCObjectBase object) {
-    _objc_msgSend_252(this.pointer, _sel_addObject_, object.pointer);
+    _objc_msgSend_252(this.ref.pointer, _sel_addObject_, object.ref.pointer);
   }
 
   /// removeObject:
   void removeObject_(objc.ObjCObjectBase object) {
-    _objc_msgSend_252(this.pointer, _sel_removeObject_, object.pointer);
+    _objc_msgSend_252(this.ref.pointer, _sel_removeObject_, object.ref.pointer);
   }
 
   /// initWithCoder:
   NSMutableSet? initWithCoder_(NSCoder coder) {
-    final _ret =
-        _objc_msgSend_18(this.pointer, _sel_initWithCoder_, coder.pointer);
+    final _ret = _objc_msgSend_18(this.ref.retainAndReturnPointer(),
+        _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSMutableSet.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// init
   NSMutableSet init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSMutableSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSMutableSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCapacity:
   NSMutableSet initWithCapacity_(int numItems) {
-    final _ret =
-        _objc_msgSend_99(this.pointer, _sel_initWithCapacity_, numItems);
-    return NSMutableSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_99(
+        this.ref.retainAndReturnPointer(), _sel_initWithCapacity_, numItems);
+    return NSMutableSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// addObjectsFromArray:
   void addObjectsFromArray_(NSArray array) {
-    _objc_msgSend_255(this.pointer, _sel_addObjectsFromArray_, array.pointer);
+    _objc_msgSend_255(
+        this.ref.pointer, _sel_addObjectsFromArray_, array.ref.pointer);
   }
 
   /// intersectSet:
   void intersectSet_(NSSet otherSet) {
-    _objc_msgSend_298(this.pointer, _sel_intersectSet_, otherSet.pointer);
+    _objc_msgSend_298(
+        this.ref.pointer, _sel_intersectSet_, otherSet.ref.pointer);
   }
 
   /// minusSet:
   void minusSet_(NSSet otherSet) {
-    _objc_msgSend_298(this.pointer, _sel_minusSet_, otherSet.pointer);
+    _objc_msgSend_298(this.ref.pointer, _sel_minusSet_, otherSet.ref.pointer);
   }
 
   /// removeAllObjects
   void removeAllObjects() {
-    _objc_msgSend_1(this.pointer, _sel_removeAllObjects);
+    _objc_msgSend_1(this.ref.pointer, _sel_removeAllObjects);
   }
 
   /// unionSet:
   void unionSet_(NSSet otherSet) {
-    _objc_msgSend_298(this.pointer, _sel_unionSet_, otherSet.pointer);
+    _objc_msgSend_298(this.ref.pointer, _sel_unionSet_, otherSet.ref.pointer);
   }
 
   /// setSet:
   void setSet_(NSSet otherSet) {
-    _objc_msgSend_298(this.pointer, _sel_setSet_, otherSet.pointer);
+    _objc_msgSend_298(this.ref.pointer, _sel_setSet_, otherSet.ref.pointer);
   }
 
   /// setWithCapacity:
@@ -12820,9 +12959,9 @@ class NSMutableSet extends NSSet {
   /// initWithObjects:count:
   NSMutableSet initWithObjects_count_(
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
-    final _ret = _objc_msgSend_100(
-        this.pointer, _sel_initWithObjects_count_, objects, cnt);
-    return NSMutableSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_100(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_count_, objects, cnt);
+    return NSMutableSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// set
@@ -12834,7 +12973,7 @@ class NSMutableSet extends NSSet {
   /// setWithObject:
   static NSMutableSet setWithObject_(objc.ObjCObjectBase object) {
     final _ret = _objc_msgSend_126(
-        _class_NSMutableSet, _sel_setWithObject_, object.pointer);
+        _class_NSMutableSet, _sel_setWithObject_, object.ref.pointer);
     return NSMutableSet.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -12849,50 +12988,50 @@ class NSMutableSet extends NSSet {
   /// setWithObjects:
   static NSMutableSet setWithObjects_(objc.ObjCObjectBase firstObj) {
     final _ret = _objc_msgSend_126(
-        _class_NSMutableSet, _sel_setWithObjects_, firstObj.pointer);
+        _class_NSMutableSet, _sel_setWithObjects_, firstObj.ref.pointer);
     return NSMutableSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// setWithSet:
   static NSMutableSet setWithSet_(NSSet set) {
-    final _ret =
-        _objc_msgSend_238(_class_NSMutableSet, _sel_setWithSet_, set.pointer);
+    final _ret = _objc_msgSend_238(
+        _class_NSMutableSet, _sel_setWithSet_, set.ref.pointer);
     return NSMutableSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// setWithArray:
   static NSMutableSet setWithArray_(NSArray array) {
     final _ret = _objc_msgSend_127(
-        _class_NSMutableSet, _sel_setWithArray_, array.pointer);
+        _class_NSMutableSet, _sel_setWithArray_, array.ref.pointer);
     return NSMutableSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// initWithObjects:
   NSMutableSet initWithObjects_(objc.ObjCObjectBase firstObj) {
-    final _ret = _objc_msgSend_126(
-        this.pointer, _sel_initWithObjects_, firstObj.pointer);
-    return NSMutableSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_126(this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_, firstObj.ref.pointer);
+    return NSMutableSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithSet:
   NSMutableSet initWithSet_(NSSet set) {
-    final _ret =
-        _objc_msgSend_238(this.pointer, _sel_initWithSet_, set.pointer);
-    return NSMutableSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_238(
+        this.ref.retainAndReturnPointer(), _sel_initWithSet_, set.ref.pointer);
+    return NSMutableSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithSet:copyItems:
   NSMutableSet initWithSet_copyItems_(NSSet set, bool flag) {
-    final _ret = _objc_msgSend_239(
-        this.pointer, _sel_initWithSet_copyItems_, set.pointer, flag);
+    final _ret = _objc_msgSend_239(this.ref.retainAndReturnPointer(),
+        _sel_initWithSet_copyItems_, set.ref.pointer, flag);
     return NSMutableSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithArray:
   NSMutableSet initWithArray_(NSArray array) {
-    final _ret =
-        _objc_msgSend_127(this.pointer, _sel_initWithArray_, array.pointer);
-    return NSMutableSet.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_127(this.ref.retainAndReturnPointer(),
+        _sel_initWithArray_, array.ref.pointer);
+    return NSMutableSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// new
@@ -12917,14 +13056,14 @@ class NSMutableSet extends NSSet {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSMutableSet,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSMutableSet,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -12983,7 +13122,7 @@ class NSItemProvider extends NSObject {
 
   /// Constructs a [NSItemProvider] that points to the same underlying object as [other].
   NSItemProvider.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSItemProvider] that wraps the given raw object pointer.
   NSItemProvider.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -12993,49 +13132,49 @@ class NSItemProvider extends NSObject {
   /// Returns whether [obj] is an instance of [NSItemProvider].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_NSItemProvider);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSItemProvider);
   }
 
   /// init
   NSItemProvider init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSItemProvider.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSItemProvider.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// registeredTypeIdentifiers
   NSArray get registeredTypeIdentifiers {
     final _ret =
-        _objc_msgSend_142(this.pointer, _sel_registeredTypeIdentifiers);
+        _objc_msgSend_142(this.ref.pointer, _sel_registeredTypeIdentifiers);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// registeredTypeIdentifiersWithFileOptions:
   NSArray registeredTypeIdentifiersWithFileOptions_(
       NSItemProviderFileOptions fileOptions) {
-    final _ret = _objc_msgSend_299(this.pointer,
+    final _ret = _objc_msgSend_299(this.ref.pointer,
         _sel_registeredTypeIdentifiersWithFileOptions_, fileOptions.value);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// hasItemConformingToTypeIdentifier:
   bool hasItemConformingToTypeIdentifier_(NSString typeIdentifier) {
-    return _objc_msgSend_26(this.pointer,
-        _sel_hasItemConformingToTypeIdentifier_, typeIdentifier.pointer);
+    return _objc_msgSend_26(this.ref.pointer,
+        _sel_hasItemConformingToTypeIdentifier_, typeIdentifier.ref.pointer);
   }
 
   /// hasRepresentationConformingToTypeIdentifier:fileOptions:
   bool hasRepresentationConformingToTypeIdentifier_fileOptions_(
       NSString typeIdentifier, NSItemProviderFileOptions fileOptions) {
     return _objc_msgSend_300(
-        this.pointer,
+        this.ref.pointer,
         _sel_hasRepresentationConformingToTypeIdentifier_fileOptions_,
-        typeIdentifier.pointer,
+        typeIdentifier.ref.pointer,
         fileOptions.value);
   }
 
   /// suggestedName
   NSString? get suggestedName {
-    final _ret = _objc_msgSend_58(this.pointer, _sel_suggestedName);
+    final _ret = _objc_msgSend_58(this.ref.pointer, _sel_suggestedName);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -13043,48 +13182,48 @@ class NSItemProvider extends NSObject {
 
   /// setSuggestedName:
   set suggestedName(NSString? value) {
-    return _objc_msgSend_301(
-        this.pointer, _sel_setSuggestedName_, value?.pointer ?? ffi.nullptr);
+    return _objc_msgSend_301(this.ref.pointer, _sel_setSuggestedName_,
+        value?.ref.pointer ?? ffi.nullptr);
   }
 
   /// initWithObject:
   NSItemProvider initWithObject_(objc.ObjCObjectBase object) {
-    final _ret =
-        _objc_msgSend_126(this.pointer, _sel_initWithObject_, object.pointer);
-    return NSItemProvider.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_126(this.ref.retainAndReturnPointer(),
+        _sel_initWithObject_, object.ref.pointer);
+    return NSItemProvider.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// registerObject:visibility:
   void registerObject_visibility_(objc.ObjCObjectBase object,
       NSItemProviderRepresentationVisibility visibility) {
-    _objc_msgSend_302(this.pointer, _sel_registerObject_visibility_,
-        object.pointer, visibility.value);
+    _objc_msgSend_302(this.ref.pointer, _sel_registerObject_visibility_,
+        object.ref.pointer, visibility.value);
   }
 
   /// canLoadObjectOfClass:
   bool canLoadObjectOfClass_(objc.ObjCObjectBase aClass) {
     return _objc_msgSend_0(
-        this.pointer, _sel_canLoadObjectOfClass_, aClass.pointer);
+        this.ref.pointer, _sel_canLoadObjectOfClass_, aClass.ref.pointer);
   }
 
   /// initWithItem:typeIdentifier:
   NSItemProvider initWithItem_typeIdentifier_(
       objc.ObjCObjectBase? item, NSString? typeIdentifier) {
     final _ret = _objc_msgSend_303(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithItem_typeIdentifier_,
-        item?.pointer ?? ffi.nullptr,
-        typeIdentifier?.pointer ?? ffi.nullptr);
-    return NSItemProvider.castFromPointer(_ret, retain: true, release: true);
+        item?.ref.pointer ?? ffi.nullptr,
+        typeIdentifier?.ref.pointer ?? ffi.nullptr);
+    return NSItemProvider.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfURL:
   NSItemProvider? initWithContentsOfURL_(NSURL fileURL) {
-    final _ret = _objc_msgSend_179(
-        this.pointer, _sel_initWithContentsOfURL_, fileURL.pointer);
+    final _ret = _objc_msgSend_179(this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfURL_, fileURL.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSItemProvider.castFromPointer(_ret, retain: true, release: true);
+        : NSItemProvider.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// new
@@ -13109,14 +13248,14 @@ class NSItemProvider extends NSObject {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSItemProvider,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSItemProvider,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -13237,7 +13376,7 @@ class NSMutableString extends NSString {
 
   /// Constructs a [NSMutableString] that points to the same underlying object as [other].
   NSMutableString.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSMutableString] that wraps the given raw object pointer.
   NSMutableString.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -13247,39 +13386,40 @@ class NSMutableString extends NSString {
   /// Returns whether [obj] is an instance of [NSMutableString].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_NSMutableString);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSMutableString);
   }
 
   /// replaceCharactersInRange:withString:
   void replaceCharactersInRange_withString_(NSRange range, NSString aString) {
-    _objc_msgSend_304(this.pointer, _sel_replaceCharactersInRange_withString_,
-        range, aString.pointer);
+    _objc_msgSend_304(this.ref.pointer,
+        _sel_replaceCharactersInRange_withString_, range, aString.ref.pointer);
   }
 
   /// insertString:atIndex:
   void insertString_atIndex_(NSString aString, int loc) {
     _objc_msgSend_305(
-        this.pointer, _sel_insertString_atIndex_, aString.pointer, loc);
+        this.ref.pointer, _sel_insertString_atIndex_, aString.ref.pointer, loc);
   }
 
   /// deleteCharactersInRange:
   void deleteCharactersInRange_(NSRange range) {
-    _objc_msgSend_250(this.pointer, _sel_deleteCharactersInRange_, range);
+    _objc_msgSend_250(this.ref.pointer, _sel_deleteCharactersInRange_, range);
   }
 
   /// appendString:
   void appendString_(NSString aString) {
-    _objc_msgSend_148(this.pointer, _sel_appendString_, aString.pointer);
+    _objc_msgSend_148(
+        this.ref.pointer, _sel_appendString_, aString.ref.pointer);
   }
 
   /// appendFormat:
   void appendFormat_(NSString format) {
-    _objc_msgSend_148(this.pointer, _sel_appendFormat_, format.pointer);
+    _objc_msgSend_148(this.ref.pointer, _sel_appendFormat_, format.ref.pointer);
   }
 
   /// setString:
   void setString_(NSString aString) {
-    _objc_msgSend_148(this.pointer, _sel_setString_, aString.pointer);
+    _objc_msgSend_148(this.ref.pointer, _sel_setString_, aString.ref.pointer);
   }
 
   /// replaceOccurrencesOfString:withString:options:range:
@@ -13289,10 +13429,10 @@ class NSMutableString extends NSString {
       NSStringCompareOptions options,
       NSRange searchRange) {
     return _objc_msgSend_306(
-        this.pointer,
+        this.ref.pointer,
         _sel_replaceOccurrencesOfString_withString_options_range_,
-        target.pointer,
-        replacement.pointer,
+        target.ref.pointer,
+        replacement.ref.pointer,
         options.value,
         searchRange);
   }
@@ -13301,9 +13441,9 @@ class NSMutableString extends NSString {
   bool applyTransform_reverse_range_updatedRange_(NSString transform,
       bool reverse, NSRange range, ffi.Pointer<NSRange> resultingRange) {
     return _objc_msgSend_307(
-        this.pointer,
+        this.ref.pointer,
         _sel_applyTransform_reverse_range_updatedRange_,
-        transform.pointer,
+        transform.ref.pointer,
         reverse,
         range,
         resultingRange);
@@ -13311,9 +13451,9 @@ class NSMutableString extends NSString {
 
   /// initWithCapacity:
   NSMutableString initWithCapacity_(int capacity) {
-    final _ret =
-        _objc_msgSend_308(this.pointer, _sel_initWithCapacity_, capacity);
-    return NSMutableString.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_308(
+        this.ref.retainAndReturnPointer(), _sel_initWithCapacity_, capacity);
+    return NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// stringWithCapacity:
@@ -13325,17 +13465,17 @@ class NSMutableString extends NSString {
 
   /// init
   NSMutableString init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSMutableString.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
   NSMutableString? initWithCoder_(NSCoder coder) {
-    final _ret =
-        _objc_msgSend_18(this.pointer, _sel_initWithCoder_, coder.pointer);
+    final _ret = _objc_msgSend_18(this.ref.retainAndReturnPointer(),
+        _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
         ? null
-        : NSMutableString.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// availableStringEncodings
@@ -13361,7 +13501,7 @@ class NSMutableString extends NSString {
   NSMutableString initWithCharactersNoCopy_length_freeWhenDone_(
       ffi.Pointer<ffi.UnsignedShort> characters, int length, bool freeBuffer) {
     final _ret = _objc_msgSend_216(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithCharactersNoCopy_length_freeWhenDone_,
         characters,
         length,
@@ -13372,41 +13512,44 @@ class NSMutableString extends NSString {
   /// initWithCharacters:length:
   NSMutableString initWithCharacters_length_(
       ffi.Pointer<ffi.UnsignedShort> characters, int length) {
-    final _ret = _objc_msgSend_217(
-        this.pointer, _sel_initWithCharacters_length_, characters, length);
-    return NSMutableString.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_217(this.ref.retainAndReturnPointer(),
+        _sel_initWithCharacters_length_, characters, length);
+    return NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithUTF8String:
   NSMutableString? initWithUTF8String_(
       ffi.Pointer<ffi.Char> nullTerminatedCString) {
-    final _ret = _objc_msgSend_218(
-        this.pointer, _sel_initWithUTF8String_, nullTerminatedCString);
+    final _ret = _objc_msgSend_218(this.ref.retainAndReturnPointer(),
+        _sel_initWithUTF8String_, nullTerminatedCString);
     return _ret.address == 0
         ? null
-        : NSMutableString.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithString:
   NSMutableString initWithString_(NSString aString) {
-    final _ret =
-        _objc_msgSend_45(this.pointer, _sel_initWithString_, aString.pointer);
-    return NSMutableString.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_45(this.ref.retainAndReturnPointer(),
+        _sel_initWithString_, aString.ref.pointer);
+    return NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithFormat:
   NSMutableString initWithFormat_(NSString format) {
-    final _ret =
-        _objc_msgSend_45(this.pointer, _sel_initWithFormat_, format.pointer);
-    return NSMutableString.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_45(this.ref.retainAndReturnPointer(),
+        _sel_initWithFormat_, format.ref.pointer);
+    return NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithFormat:locale:
   NSMutableString initWithFormat_locale_(
       NSString format, objc.ObjCObjectBase? locale) {
-    final _ret = _objc_msgSend_219(this.pointer, _sel_initWithFormat_locale_,
-        format.pointer, locale?.pointer ?? ffi.nullptr);
-    return NSMutableString.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_219(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithFormat_locale_,
+        format.ref.pointer,
+        locale?.ref.pointer ?? ffi.nullptr);
+    return NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithValidatedFormat:validFormatSpecifiers:error:
@@ -13415,14 +13558,14 @@ class NSMutableString extends NSString {
       NSString validFormatSpecifiers,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     final _ret = _objc_msgSend_220(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithValidatedFormat_validFormatSpecifiers_error_,
-        format.pointer,
-        validFormatSpecifiers.pointer,
+        format.ref.pointer,
+        validFormatSpecifiers.ref.pointer,
         error);
     return _ret.address == 0
         ? null
-        : NSMutableString.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithValidatedFormat:validFormatSpecifiers:locale:error:
@@ -13432,41 +13575,41 @@ class NSMutableString extends NSString {
       objc.ObjCObjectBase? locale,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     final _ret = _objc_msgSend_221(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithValidatedFormat_validFormatSpecifiers_locale_error_,
-        format.pointer,
-        validFormatSpecifiers.pointer,
-        locale?.pointer ?? ffi.nullptr,
+        format.ref.pointer,
+        validFormatSpecifiers.ref.pointer,
+        locale?.ref.pointer ?? ffi.nullptr,
         error);
     return _ret.address == 0
         ? null
-        : NSMutableString.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithData:encoding:
   NSMutableString? initWithData_encoding_(NSData data, int encoding) {
-    final _ret = _objc_msgSend_222(
-        this.pointer, _sel_initWithData_encoding_, data.pointer, encoding);
+    final _ret = _objc_msgSend_222(this.ref.retainAndReturnPointer(),
+        _sel_initWithData_encoding_, data.ref.pointer, encoding);
     return _ret.address == 0
         ? null
-        : NSMutableString.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBytes:length:encoding:
   NSMutableString? initWithBytes_length_encoding_(
       ffi.Pointer<ffi.Void> bytes, int len, int encoding) {
-    final _ret = _objc_msgSend_223(this.pointer,
+    final _ret = _objc_msgSend_223(this.ref.retainAndReturnPointer(),
         _sel_initWithBytes_length_encoding_, bytes, len, encoding);
     return _ret.address == 0
         ? null
-        : NSMutableString.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBytesNoCopy:length:encoding:freeWhenDone:
   NSMutableString? initWithBytesNoCopy_length_encoding_freeWhenDone_(
       ffi.Pointer<ffi.Void> bytes, int len, int encoding, bool freeBuffer) {
     final _ret = _objc_msgSend_224(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithBytesNoCopy_length_encoding_freeWhenDone_,
         bytes,
         len,
@@ -13486,7 +13629,7 @@ class NSMutableString extends NSString {
   /// stringWithString:
   static NSMutableString stringWithString_(NSString string) {
     final _ret = _objc_msgSend_45(
-        _class_NSMutableString, _sel_stringWithString_, string.pointer);
+        _class_NSMutableString, _sel_stringWithString_, string.ref.pointer);
     return NSMutableString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -13511,14 +13654,14 @@ class NSMutableString extends NSString {
   /// stringWithFormat:
   static NSMutableString stringWithFormat_(NSString format) {
     final _ret = _objc_msgSend_45(
-        _class_NSMutableString, _sel_stringWithFormat_, format.pointer);
+        _class_NSMutableString, _sel_stringWithFormat_, format.ref.pointer);
     return NSMutableString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// localizedStringWithFormat:
   static NSMutableString localizedStringWithFormat_(NSString format) {
     final _ret = _objc_msgSend_45(_class_NSMutableString,
-        _sel_localizedStringWithFormat_, format.pointer);
+        _sel_localizedStringWithFormat_, format.ref.pointer);
     return NSMutableString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -13531,8 +13674,8 @@ class NSMutableString extends NSString {
     final _ret = _objc_msgSend_220(
         _class_NSMutableString,
         _sel_stringWithValidatedFormat_validFormatSpecifiers_error_,
-        format.pointer,
-        validFormatSpecifiers.pointer,
+        format.ref.pointer,
+        validFormatSpecifiers.ref.pointer,
         error);
     return _ret.address == 0
         ? null
@@ -13548,8 +13691,8 @@ class NSMutableString extends NSString {
     final _ret = _objc_msgSend_220(
         _class_NSMutableString,
         _sel_localizedStringWithValidatedFormat_validFormatSpecifiers_error_,
-        format.pointer,
-        validFormatSpecifiers.pointer,
+        format.ref.pointer,
+        validFormatSpecifiers.ref.pointer,
         error);
     return _ret.address == 0
         ? null
@@ -13559,11 +13702,11 @@ class NSMutableString extends NSString {
   /// initWithCString:encoding:
   NSMutableString? initWithCString_encoding_(
       ffi.Pointer<ffi.Char> nullTerminatedCString, int encoding) {
-    final _ret = _objc_msgSend_225(this.pointer, _sel_initWithCString_encoding_,
-        nullTerminatedCString, encoding);
+    final _ret = _objc_msgSend_225(this.ref.retainAndReturnPointer(),
+        _sel_initWithCString_encoding_, nullTerminatedCString, encoding);
     return _ret.address == 0
         ? null
-        : NSMutableString.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// stringWithCString:encoding:
@@ -13579,28 +13722,40 @@ class NSMutableString extends NSString {
   /// initWithContentsOfURL:encoding:error:
   NSMutableString? initWithContentsOfURL_encoding_error_(
       NSURL url, int enc, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    final _ret = _objc_msgSend_226(this.pointer,
-        _sel_initWithContentsOfURL_encoding_error_, url.pointer, enc, error);
+    final _ret = _objc_msgSend_226(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfURL_encoding_error_,
+        url.ref.pointer,
+        enc,
+        error);
     return _ret.address == 0
         ? null
-        : NSMutableString.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfFile:encoding:error:
   NSMutableString? initWithContentsOfFile_encoding_error_(
       NSString path, int enc, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    final _ret = _objc_msgSend_227(this.pointer,
-        _sel_initWithContentsOfFile_encoding_error_, path.pointer, enc, error);
+    final _ret = _objc_msgSend_227(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithContentsOfFile_encoding_error_,
+        path.ref.pointer,
+        enc,
+        error);
     return _ret.address == 0
         ? null
-        : NSMutableString.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// stringWithContentsOfURL:encoding:error:
   static NSMutableString? stringWithContentsOfURL_encoding_error_(
       NSURL url, int enc, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
-    final _ret = _objc_msgSend_226(_class_NSMutableString,
-        _sel_stringWithContentsOfURL_encoding_error_, url.pointer, enc, error);
+    final _ret = _objc_msgSend_226(
+        _class_NSMutableString,
+        _sel_stringWithContentsOfURL_encoding_error_,
+        url.ref.pointer,
+        enc,
+        error);
     return _ret.address == 0
         ? null
         : NSMutableString.castFromPointer(_ret, retain: true, release: true);
@@ -13612,7 +13767,7 @@ class NSMutableString extends NSString {
     final _ret = _objc_msgSend_227(
         _class_NSMutableString,
         _sel_stringWithContentsOfFile_encoding_error_,
-        path.pointer,
+        path.ref.pointer,
         enc,
         error);
     return _ret.address == 0
@@ -13626,14 +13781,14 @@ class NSMutableString extends NSString {
       ffi.Pointer<ffi.UnsignedLong> enc,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     final _ret = _objc_msgSend_228(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_usedEncoding_error_,
-        url.pointer,
+        url.ref.pointer,
         enc,
         error);
     return _ret.address == 0
         ? null
-        : NSMutableString.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfFile:usedEncoding:error:
@@ -13642,14 +13797,14 @@ class NSMutableString extends NSString {
       ffi.Pointer<ffi.UnsignedLong> enc,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     final _ret = _objc_msgSend_229(
-        this.pointer,
+        this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfFile_usedEncoding_error_,
-        path.pointer,
+        path.ref.pointer,
         enc,
         error);
     return _ret.address == 0
         ? null
-        : NSMutableString.castFromPointer(_ret, retain: true, release: true);
+        : NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// stringWithContentsOfURL:usedEncoding:error:
@@ -13660,7 +13815,7 @@ class NSMutableString extends NSString {
     final _ret = _objc_msgSend_228(
         _class_NSMutableString,
         _sel_stringWithContentsOfURL_usedEncoding_error_,
-        url.pointer,
+        url.ref.pointer,
         enc,
         error);
     return _ret.address == 0
@@ -13676,7 +13831,7 @@ class NSMutableString extends NSString {
     final _ret = _objc_msgSend_229(
         _class_NSMutableString,
         _sel_stringWithContentsOfFile_usedEncoding_error_,
-        path.pointer,
+        path.ref.pointer,
         enc,
         error);
     return _ret.address == 0
@@ -13694,8 +13849,8 @@ class NSMutableString extends NSString {
     return _objc_msgSend_230(
         _class_NSMutableString,
         _sel_stringEncodingForData_encodingOptions_convertedString_usedLossyConversion_,
-        data.pointer,
-        opts?.pointer ?? ffi.nullptr,
+        data.ref.pointer,
+        opts?.ref.pointer ?? ffi.nullptr,
         string,
         usedLossyConversion);
   }
@@ -13722,14 +13877,14 @@ class NSMutableString extends NSString {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSMutableString,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSMutableString,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -13847,7 +14002,7 @@ class NSURLHandle extends NSObject {
 
   /// Constructs a [NSURLHandle] that points to the same underlying object as [other].
   NSURLHandle.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSURLHandle] that wraps the given raw object pointer.
   NSURLHandle.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -13857,13 +14012,13 @@ class NSURLHandle extends NSObject {
   /// Returns whether [obj] is an instance of [NSURLHandle].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_NSURLHandle);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSURLHandle);
   }
 
   /// init
   NSURLHandle init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return NSURLHandle.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return NSURLHandle.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// new
@@ -13887,14 +14042,14 @@ class NSURLHandle extends NSObject {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_NSURLHandle,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_NSURLHandle,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -13908,7 +14063,7 @@ class NSProxy extends objc.ObjCObjectBase {
 
   /// Constructs a [NSProxy] that points to the same underlying object as [other].
   NSProxy.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [NSProxy] that wraps the given raw object pointer.
   NSProxy.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -13917,7 +14072,8 @@ class NSProxy extends objc.ObjCObjectBase {
 
   /// Returns whether [obj] is an instance of [NSProxy].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_0(obj.pointer, _sel_isKindOfClass_, _class_NSProxy);
+    return _objc_msgSend_0(
+        obj.ref.pointer, _sel_isKindOfClass_, _class_NSProxy);
   }
 
   /// alloc
@@ -13940,14 +14096,15 @@ class NSProxy extends objc.ObjCObjectBase {
 
   /// forwardInvocation:
   void forwardInvocation_(NSInvocation invocation) {
-    _objc_msgSend_9(this.pointer, _sel_forwardInvocation_, invocation.pointer);
+    _objc_msgSend_9(
+        this.ref.pointer, _sel_forwardInvocation_, invocation.ref.pointer);
   }
 
   /// methodSignatureForSelector:
   NSMethodSignature? methodSignatureForSelector_(
       ffi.Pointer<objc.ObjCSelector> sel) {
-    final _ret =
-        _objc_msgSend_309(this.pointer, _sel_methodSignatureForSelector_, sel);
+    final _ret = _objc_msgSend_309(
+        this.ref.pointer, _sel_methodSignatureForSelector_, sel);
     return _ret.address == 0
         ? null
         : NSMethodSignature.castFromPointer(_ret, retain: true, release: true);
@@ -13955,23 +14112,23 @@ class NSProxy extends objc.ObjCObjectBase {
 
   /// dealloc
   void dealloc() {
-    _objc_msgSend_1(this.pointer, _sel_dealloc);
+    _objc_msgSend_1(this.ref.pointer, _sel_dealloc);
   }
 
   /// finalize
   void finalize() {
-    _objc_msgSend_1(this.pointer, _sel_finalize);
+    _objc_msgSend_1(this.ref.pointer, _sel_finalize);
   }
 
   /// description
   NSString get description {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_description);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_description);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// debugDescription
   NSString get debugDescription {
-    final _ret = _objc_msgSend_36(this.pointer, _sel_debugDescription);
+    final _ret = _objc_msgSend_36(this.ref.pointer, _sel_debugDescription);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -14003,7 +14160,7 @@ class DartProxyBuilder extends NSObject {
 
   /// Constructs a [DartProxyBuilder] that points to the same underlying object as [other].
   DartProxyBuilder.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [DartProxyBuilder] that wraps the given raw object pointer.
   DartProxyBuilder.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -14013,7 +14170,7 @@ class DartProxyBuilder extends NSObject {
   /// Returns whether [obj] is an instance of [DartProxyBuilder].
   static bool isInstance(objc.ObjCObjectBase obj) {
     return _objc_msgSend_0(
-        obj.pointer, _sel_isKindOfClass_, _class_DartProxyBuilder);
+        obj.ref.pointer, _sel_isKindOfClass_, _class_DartProxyBuilder);
   }
 
   /// new
@@ -14024,8 +14181,8 @@ class DartProxyBuilder extends NSObject {
 
   /// init
   DartProxyBuilder init() {
-    final _ret = _objc_msgSend_2(this.pointer, _sel_init);
-    return DartProxyBuilder.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_2(this.ref.retainAndReturnPointer(), _sel_init);
+    return DartProxyBuilder.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// implementMethod:withSignature:andBlock:
@@ -14034,10 +14191,10 @@ class DartProxyBuilder extends NSObject {
       NSMethodSignature signature,
       ffi.Pointer<ffi.Void> block) {
     _objc_msgSend_310(
-        this.pointer,
+        this.ref.pointer,
         _sel_implementMethod_withSignature_andBlock_,
         sel,
-        signature.pointer,
+        signature.ref.pointer,
         block);
   }
 
@@ -14057,14 +14214,14 @@ class DartProxyBuilder extends NSObject {
   /// keyPathsForValuesAffectingValueForKey:
   static NSSet keyPathsForValuesAffectingValueForKey_(NSString key) {
     final _ret = _objc_msgSend_95(_class_DartProxyBuilder,
-        _sel_keyPathsForValuesAffectingValueForKey_, key.pointer);
+        _sel_keyPathsForValuesAffectingValueForKey_, key.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// automaticallyNotifiesObserversForKey:
   static bool automaticallyNotifiesObserversForKey_(NSString key) {
     return _objc_msgSend_26(_class_DartProxyBuilder,
-        _sel_automaticallyNotifiesObserversForKey_, key.pointer);
+        _sel_automaticallyNotifiesObserversForKey_, key.ref.pointer);
   }
 }
 
@@ -14096,7 +14253,7 @@ class DartProxy extends NSProxy {
 
   /// Constructs a [DartProxy] that points to the same underlying object as [other].
   DartProxy.castFrom(objc.ObjCObjectBase other)
-      : this._(other.pointer, retain: true, release: true);
+      : this._(other.ref.pointer, retain: true, release: true);
 
   /// Constructs a [DartProxy] that wraps the given raw object pointer.
   DartProxy.castFromPointer(ffi.Pointer<objc.ObjCObject> other,
@@ -14105,21 +14262,22 @@ class DartProxy extends NSProxy {
 
   /// Returns whether [obj] is an instance of [DartProxy].
   static bool isInstance(objc.ObjCObjectBase obj) {
-    return _objc_msgSend_0(obj.pointer, _sel_isKindOfClass_, _class_DartProxy);
+    return _objc_msgSend_0(
+        obj.ref.pointer, _sel_isKindOfClass_, _class_DartProxy);
   }
 
   /// newFromBuilder:
   static DartProxy newFromBuilder_(DartProxyBuilder builder) {
     final _ret = _objc_msgSend_311(
-        _class_DartProxy, _sel_newFromBuilder_, builder.pointer);
+        _class_DartProxy, _sel_newFromBuilder_, builder.ref.pointer);
     return DartProxy.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initFromBuilder:
   DartProxy initFromBuilder_(DartProxyBuilder builder) {
-    final _ret =
-        _objc_msgSend_311(this.pointer, _sel_initFromBuilder_, builder.pointer);
-    return DartProxy.castFromPointer(_ret, retain: true, release: true);
+    final _ret = _objc_msgSend_311(this.ref.retainAndReturnPointer(),
+        _sel_initFromBuilder_, builder.ref.pointer);
+    return DartProxy.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// respondsToSelector:
@@ -14131,14 +14289,15 @@ class DartProxy extends NSProxy {
   /// methodSignatureForSelector:
   NSMethodSignature methodSignatureForSelector_(
       ffi.Pointer<objc.ObjCSelector> sel) {
-    final _ret =
-        _objc_msgSend_240(this.pointer, _sel_methodSignatureForSelector_, sel);
+    final _ret = _objc_msgSend_240(
+        this.ref.pointer, _sel_methodSignatureForSelector_, sel);
     return NSMethodSignature.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// forwardInvocation:
   void forwardInvocation_(NSInvocation invocation) {
-    _objc_msgSend_9(this.pointer, _sel_forwardInvocation_, invocation.pointer);
+    _objc_msgSend_9(
+        this.ref.pointer, _sel_forwardInvocation_, invocation.ref.pointer);
   }
 
   /// alloc

--- a/pkgs/objective_c/lib/src/protocol_builder.dart
+++ b/pkgs/objective_c/lib/src/protocol_builder.dart
@@ -19,7 +19,7 @@ class ObjCProtocolBuilder {
   void implementMethod(Pointer<c.ObjCSelector> sel,
           objc.NSMethodSignature signature, ObjCBlockBase block) =>
       _builder.implementMethod_withSignature_andBlock_(
-          sel, signature, block.pointer.cast());
+          sel, signature, block.ref.pointer.cast());
 
   /// Builds the object.
   ///

--- a/pkgs/objective_c/pubspec.yaml
+++ b/pkgs/objective_c/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: objective_c
 description: 'A library to access Objective C from Flutter that acts as a support library for package:ffigen.'
-version: 1.2.0-wip
+version: 2.0.0-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/objective_c
 
 topics:

--- a/pkgs/objective_c/test/ns_mutable_data_test.dart
+++ b/pkgs/objective_c/test/ns_mutable_data_test.dart
@@ -23,7 +23,7 @@ void main() {
       test('empty', () {
         final data = <int>[].toNSMutableData();
         expect(data.length, 0);
-        data.release(); // Make sure that dealloc succeeds.
+        data.ref.release(); // Make sure that dealloc succeeds.
       });
 
       test('non empty', () {
@@ -32,14 +32,14 @@ void main() {
         expect(data.bytes.cast<Uint8>()[0], 1);
         expect(data.bytes.cast<Uint8>()[1], 2);
         expect(data.bytes.cast<Uint8>()[2], 3);
-        data.release(); // Make sure that dealloc succeeds.
+        data.ref.release(); // Make sure that dealloc succeeds.
       });
 
       test('non-byte', () {
         final data = [257].toNSMutableData();
         expect(data.length, 1);
         expect(data.bytes.cast<Uint8>().value, 1);
-        data.release(); // Make sure that dealloc succeeds.
+        data.ref.release(); // Make sure that dealloc succeeds.
       });
     });
 

--- a/pkgs/objective_c/test/nsdata_test.dart
+++ b/pkgs/objective_c/test/nsdata_test.dart
@@ -23,7 +23,7 @@ void main() {
       test('empty', () {
         final data = <int>[].toNSData();
         expect(data.length, 0);
-        data.release(); // Make sure that dealloc succeeds.
+        data.ref.release(); // Make sure that dealloc succeeds.
       });
 
       test('non empty', () {
@@ -32,14 +32,14 @@ void main() {
         expect(data.bytes.cast<Uint8>()[0], 1);
         expect(data.bytes.cast<Uint8>()[1], 2);
         expect(data.bytes.cast<Uint8>()[2], 3);
-        data.release(); // Make sure that dealloc succeeds.
+        data.ref.release(); // Make sure that dealloc succeeds.
       });
 
       test('non-byte', () {
         final data = [257].toNSData();
         expect(data.length, 1);
         expect(data.bytes.cast<Uint8>().value, 1);
-        data.release(); // Make sure that dealloc succeeds.
+        data.ref.release(); // Make sure that dealloc succeeds.
       });
     });
 


### PR DESCRIPTION
Remove convenience getters on `_ObjCRefHolder`, forcing `obj.pointer` etc to go through `ref` like `obj.ref.pointer`. This solves potential early GC issues where `obj` is collected while the pointer is still in use.