### PR TITLE
[tool] Swap dependencies to published at specific version

### DIFF
--- a/pkgs/native_assets_cli/tool/dependencies.dart
+++ b/pkgs/native_assets_cli/tool/dependencies.dart
@@ -87,6 +87,11 @@ String switchToPathDependency(String pubspec, String packageName) {
   return pubspec.replaceFirst(match.group(0)!, replacement);
 }
 
+/// Switches the pubspecs to to published dependency for a specific package.
+///
+/// Does not remove `publish_to: none`.
+///
+/// Does not modify changelog or version in pubspec.
 Future<void> switchAllToPublishedDependency(
   String packageName,
   String newVersion,
@@ -96,6 +101,9 @@ Future<void> switchAllToPublishedDependency(
         packageName,
         newVersion,
       )));
+  print('Switched $packageName to published dependency on $newVersion.');
+  print('Did not remove `publish_to: none`.');
+  print('Did not modify changelog or version in pubspec.');
 }
 
 Future<void> switchToPublishedDependency2(


### PR DESCRIPTION
Since we need a stack of PRs every time we publish, this step takes a package name as argument.