### PR TITLE
[native_assets_*] Validator

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.8.3-wip
 
-- Nothing yet.
+- Added a validation step on the output of the build and link hooks.
 
 ## 0.8.2
 

--- a/pkgs/native_assets_builder/test/build_runner/helpers.dart
+++ b/pkgs/native_assets_builder/test/build_runner/helpers.dart
@@ -47,6 +47,7 @@ Future<BuildResult> build(
   int? targetAndroidNdkApi,
   Target? target,
   bool linkingEnabled = false,
+  Iterable<String>? supportedAssetTypes,
 }) async =>
     await runWithLog(capturedLogs, () async {
       final result = await NativeAssetsBuildRunner(
@@ -66,6 +67,7 @@ Future<BuildResult> build(
         targetMacOSVersion: targetMacOSVersion,
         targetAndroidNdkApi: targetAndroidNdkApi,
         linkingEnabled: linkingEnabled,
+        supportedAssetTypes: supportedAssetTypes,
       );
 
       if (result.success) {
@@ -94,6 +96,7 @@ Future<LinkResult> link(
   int? targetMacOSVersion,
   int? targetAndroidNdkApi,
   Target? target,
+  Iterable<String>? supportedAssetTypes,
 }) async =>
     await runWithLog(capturedLogs, () async {
       final result = await NativeAssetsBuildRunner(
@@ -113,6 +116,7 @@ Future<LinkResult> link(
         targetIOSVersion: targetIOSVersion,
         targetMacOSVersion: targetMacOSVersion,
         targetAndroidNdkApi: targetAndroidNdkApi,
+        supportedAssetTypes: supportedAssetTypes,
       );
 
       if (result.success) {
@@ -138,6 +142,7 @@ Future<(BuildResult, LinkResult)> buildAndLink(
   int? targetAndroidNdkApi,
   Target? target,
   Uri? resourceIdentifiers,
+  Iterable<String>? supportedAssetTypes,
 }) async =>
     await runWithLog(capturedLogs, () async {
       final buildRunner = NativeAssetsBuildRunner(
@@ -158,6 +163,7 @@ Future<(BuildResult, LinkResult)> buildAndLink(
         targetMacOSVersion: targetMacOSVersion,
         targetAndroidNdkApi: targetAndroidNdkApi,
         linkingEnabled: true,
+        supportedAssetTypes: supportedAssetTypes,
       );
 
       if (!buildResult.success) {
@@ -183,6 +189,7 @@ Future<(BuildResult, LinkResult)> buildAndLink(
         targetIOSVersion: targetIOSVersion,
         targetMacOSVersion: targetMacOSVersion,
         targetAndroidNdkApi: targetAndroidNdkApi,
+        supportedAssetTypes: supportedAssetTypes,
       );
 
       if (linkResult.success) {
@@ -221,6 +228,7 @@ Future<BuildDryRunResult> buildDryRun(
   List<String>? capturedLogs,
   PackageLayout? packageLayout,
   required bool linkingEnabled,
+  Iterable<String>? supportedAssetTypes,
 }) async =>
     runWithLog(capturedLogs, () async {
       final result = await NativeAssetsBuildRunner(
@@ -233,6 +241,7 @@ Future<BuildDryRunResult> buildDryRun(
         includeParentEnvironment: includeParentEnvironment,
         packageLayout: packageLayout,
         linkingEnabled: linkingEnabled,
+        supportedAssetTypes: supportedAssetTypes,
       );
       return result;
     });
@@ -247,6 +256,7 @@ Future<LinkDryRunResult> linkDryRun(
   List<String>? capturedLogs,
   PackageLayout? packageLayout,
   required BuildDryRunResult buildDryRunResult,
+  Iterable<String>? supportedAssetTypes,
 }) async =>
     runWithLog(capturedLogs, () async {
       final result = await NativeAssetsBuildRunner(
@@ -259,6 +269,7 @@ Future<LinkDryRunResult> linkDryRun(
         includeParentEnvironment: includeParentEnvironment,
         packageLayout: packageLayout,
         buildDryRunResult: buildDryRunResult,
+        supportedAssetTypes: supportedAssetTypes,
       );
       return result;
     });

--- a/pkgs/native_assets_builder/test/build_runner/link_dry_run_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/link_dry_run_test.dart
@@ -12,6 +12,8 @@ import 'helpers.dart';
 const Timeout longTimeout = Timeout(Duration(minutes: 5));
 
 void main() async {
+  const supportedAssetTypes = [DataAsset.type];
+
   test(
     'simple_link linking',
     timeout: longTimeout,
@@ -31,6 +33,7 @@ void main() async {
           logger,
           dartExecutable,
           linkingEnabled: true,
+          supportedAssetTypes: supportedAssetTypes,
         );
         expect(buildResult.assets.length, 0);
 
@@ -39,6 +42,7 @@ void main() async {
           logger,
           dartExecutable,
           buildDryRunResult: buildResult,
+          supportedAssetTypes: supportedAssetTypes,
         );
         expect(linkResult.assets.length, 2);
       });
@@ -81,6 +85,7 @@ void main() async {
           logger,
           dartExecutable,
           linkingEnabled: true,
+          supportedAssetTypes: supportedAssetTypes,
         );
         expect(buildResult.success, true);
         expect(
@@ -95,6 +100,7 @@ void main() async {
           logger,
           dartExecutable,
           buildDryRunResult: buildResult,
+          supportedAssetTypes: supportedAssetTypes,
         );
         expect(linkResult.success, true);
 

--- a/pkgs/native_assets_builder/test/build_runner/link_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/link_test.dart
@@ -14,6 +14,8 @@ import 'helpers.dart';
 const Timeout longTimeout = Timeout(Duration(minutes: 5));
 
 void main() async {
+  const supportedAssetTypes = [DataAsset.type];
+
   test(
     'simple_link linking',
     timeout: longTimeout,
@@ -33,6 +35,7 @@ void main() async {
           logger,
           dartExecutable,
           linkingEnabled: true,
+          supportedAssetTypes: supportedAssetTypes,
         );
         expect(buildResult.assets.length, 0);
 
@@ -41,6 +44,7 @@ void main() async {
           logger,
           dartExecutable,
           buildResult: buildResult,
+          supportedAssetTypes: supportedAssetTypes,
         );
         expect(linkResult.assets.length, 2);
 
@@ -49,6 +53,7 @@ void main() async {
           logger,
           dartExecutable,
           linkingEnabled: false,
+          supportedAssetTypes: supportedAssetTypes,
         );
         expect(buildNoLinkResult.assets.length, 4);
       });
@@ -91,6 +96,7 @@ void main() async {
           logger,
           dartExecutable,
           linkingEnabled: true,
+          supportedAssetTypes: supportedAssetTypes,
         );
         expect(buildResult.success, true);
         expect(
@@ -105,6 +111,7 @@ void main() async {
           logger,
           dartExecutable,
           buildResult: buildResult,
+          supportedAssetTypes: supportedAssetTypes,
         );
         expect(linkResult.success, true);
 
@@ -129,6 +136,7 @@ void main() async {
         logger,
         dartExecutable,
         linkingEnabled: true,
+        supportedAssetTypes: supportedAssetTypes,
       );
       expect(buildResult.assets.length, 0);
       expect(buildResult.assetsForLinking.length, 0);
@@ -140,6 +148,7 @@ void main() async {
         dartExecutable,
         buildResult: buildResult,
         capturedLogs: logMessages,
+        supportedAssetTypes: supportedAssetTypes,
       );
       expect(linkResult.assets.length, 0);
       expect(

--- a/pkgs/native_assets_builder/test/build_runner/wrong_linker_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/wrong_linker_test.dart
@@ -11,10 +11,10 @@ import 'helpers.dart';
 const Timeout longTimeout = Timeout(Duration(minutes: 5));
 
 void main() async {
-  test('wrong asset id', timeout: longTimeout, () async {
+  test('wrong linker', timeout: longTimeout, () async {
     await inTempDir((tempUri) async {
       await copyTestProjects(targetUri: tempUri);
-      final packageUri = tempUri.resolve('wrong_namespace_asset/');
+      final packageUri = tempUri.resolve('wrong_linker/');
 
       await runPubGet(
         workingDirectory: packageUri,
@@ -32,35 +32,8 @@ void main() async {
         expect(result.success, false);
         expect(
           fullLog,
-          contains('does not start with "package:wrong_namespace_asset/"'),
+          contains('but that package does not have a link hook'),
         );
-      }
-    });
-  });
-
-  test('right asset id but other directory', timeout: longTimeout, () async {
-    await inTempDir((tempUri) async {
-      final packageUri = tempUri.resolve('different_root_dir/');
-      await copyTestProjects(
-        targetUri: tempUri,
-      );
-      await copyTestProjects(
-        sourceUri: testDataUri.resolve('native_add/'),
-        targetUri: packageUri,
-      );
-
-      await runPubGet(
-        workingDirectory: packageUri,
-        logger: logger,
-      );
-
-      {
-        final result = await build(
-          packageUri,
-          logger,
-          dartExecutable,
-        );
-        expect(result.success, true);
       }
     });
   });

--- a/pkgs/native_assets_builder/test_data/manifest.yaml
+++ b/pkgs/native_assets_builder/test_data/manifest.yaml
@@ -111,5 +111,7 @@
 - wrong_build_output_3/pubspec.yaml
 - wrong_build_output/hook/build.dart
 - wrong_build_output/pubspec.yaml
+- wrong_linker/hook/build.dart
+- wrong_linker/pubspec.yaml
 - wrong_namespace_asset/hook/build.dart
 - wrong_namespace_asset/pubspec.yaml

--- a/pkgs/native_assets_builder/test_data/wrong_linker/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/wrong_linker/hook/build.dart
@@ -18,13 +18,14 @@ void main(List<String> arguments) async {
 
     output.addAsset(
       NativeCodeAsset(
-        package: 'other_package',
+        package: config.packageName,
         name: 'foo',
         file: assetUri,
         linkMode: DynamicLoadingBundled(),
         os: OS.current,
         architecture: Architecture.current,
       ),
+      linkInPackage: 'a_package_that_does_not_exist',
     );
   });
 }

--- a/pkgs/native_assets_builder/test_data/wrong_linker/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_linker/pubspec.yaml
@@ -1,0 +1,18 @@
+name: wrong_namespace_asset
+description: Package that tries to add an asset with an id not prefixed by its package name.
+version: 0.1.0
+
+publish_to: none
+
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+
+dependencies:
+  # native_assets_cli: ^0.7.3
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+  yaml: ^3.1.1
+  yaml_edit: ^2.1.0
+
+dev_dependencies:
+  lints: ^3.0.0

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.8.0-wip
 
 - Add URI for the recorded usages file to the `LinkConfig`.
+- Added a validation step in the `build` and `link` methods.
 
 ## 0.7.3
 

--- a/pkgs/native_assets_cli/lib/native_assets_cli_internal.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli_internal.dart
@@ -41,3 +41,5 @@ export 'src/model/hook.dart';
 export 'src/model/metadata.dart';
 export 'src/model/resource_identifiers.dart';
 export 'src/model/target.dart';
+export 'src/validator/validator.dart'
+    show ValidateResult, validateBuild, validateLink;

--- a/pkgs/native_assets_cli/lib/src/api/build.dart
+++ b/pkgs/native_assets_cli/lib/src/api/build.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../validator/validator.dart';
 import 'build_config.dart';
 import 'build_output.dart';
 
@@ -90,5 +91,14 @@ Future<void> build(
   final config = BuildConfigImpl.fromArguments(arguments);
   final output = HookOutputImpl();
   await builder(config, output);
-  await output.writeToFile(config: config);
+  final validateResult = await validateBuild(config, output);
+  if (validateResult.success) {
+    await output.writeToFile(config: config);
+  } else {
+    final message = [
+      'The output contained unsupported output:',
+      for (final error in validateResult.errors) '- $error',
+    ].join('\n');
+    throw UnsupportedError(message);
+  }
 }

--- a/pkgs/native_assets_cli/lib/src/api/link.dart
+++ b/pkgs/native_assets_cli/lib/src/api/link.dart
@@ -2,7 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../../native_assets_cli_internal.dart';
+import '../model/dependencies.dart';
+import '../validator/validator.dart';
 import 'build_output.dart';
 import 'link_config.dart';
 
@@ -37,9 +38,18 @@ Future<void> link(
   // rerun if they change.
   final builtAssetsFiles =
       config.assets.map((asset) => asset.file).whereType<Uri>().toList();
-  final linkOutput = HookOutputImpl(
+  final output = HookOutputImpl(
     dependencies: Dependencies(builtAssetsFiles),
   );
-  await linker(config, linkOutput);
-  await linkOutput.writeToFile(config: config);
+  await linker(config, output);
+  final validateResult = await validateLink(config, output);
+  if (validateResult.success) {
+    await output.writeToFile(config: config);
+  } else {
+    final message = [
+      'The output contained unsupported output:',
+      for (final error in validateResult.errors) '- $error',
+    ].join('\n');
+    throw UnsupportedError(message);
+  }
 }

--- a/pkgs/native_assets_cli/lib/src/validator/validator.dart
+++ b/pkgs/native_assets_cli/lib/src/validator/validator.dart
@@ -1,0 +1,207 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import '../api/asset.dart';
+import '../api/build_config.dart';
+import '../api/build_output.dart';
+import '../api/hook_config.dart';
+import '../api/link_config.dart';
+import '../api/link_mode_preference.dart';
+
+typedef ValidateResult = ({
+  bool success,
+  List<String> errors,
+});
+
+// TODO(dacoharkes): More validation in the native_assets_builder.
+// TODO(dacoharkes): NativeCodeAssets and DataAssets should have a file if not
+// dry run.
+Future<ValidateResult> validateBuild(
+  BuildConfig config,
+  BuildOutput output,
+) async {
+  output as HookOutputImpl;
+  final errors = [
+    ...validateAssetsForLinking(config, output),
+    ...validateOutputAssetTypes(config, output),
+    if (!config.dryRun) ...await validateFilesExist(config, output),
+    ...validateNativeCodeAssets(config, output),
+    ...validateAssetId(config, output),
+    if (!config.dryRun) ...validateNoDuplicateAssetIds(output),
+  ];
+  return (
+    success: errors.isEmpty,
+    errors: errors,
+  );
+}
+
+Future<ValidateResult> validateLink(
+  LinkConfig config,
+  LinkOutput output,
+) async {
+  output as HookOutputImpl;
+  final errors = [
+    ...validateOutputAssetTypes(config, output),
+    if (!config.dryRun) ...await validateFilesExist(config, output),
+    ...validateNativeCodeAssets(config, output),
+    if (!config.dryRun) ...validateNoDuplicateAssetIds(output),
+  ];
+
+  return (
+    success: errors.isEmpty,
+    errors: errors,
+  );
+}
+
+/// AssetsForLinking should be empty if linking is not supported.
+List<String> validateAssetsForLinking(
+  BuildConfig config,
+  BuildOutput output,
+) {
+  final errors = <String>[];
+  if (!config.linkingEnabled) {
+    if (output.assetsForLinking.isNotEmpty) {
+      const error = 'BuildOutput.assetsForLinking is not empty while '
+          'BuildConfig.linkingEnabled is false';
+      errors.add(error);
+    }
+  }
+  return errors;
+}
+
+/// Only output asset types that are supported by the embedder.
+List<String> validateOutputAssetTypes(
+  HookConfig config,
+  HookOutputImpl output,
+) {
+  final errors = <String>[];
+  final supportedAssetTypes = config.supportedAssetTypes;
+  for (final asset in output.assets) {
+    if (!supportedAssetTypes.contains(asset.type)) {
+      final error =
+          'Asset "${asset.id}" has asset type "${asset.type}", which is '
+          'not in supportedAssetTypes';
+      errors.add(error);
+    }
+  }
+  return errors;
+}
+
+/// Files mentioned in assets must exist.
+Future<List<String>> validateFilesExist(
+  HookConfig config,
+  HookOutputImpl output,
+) async {
+  final errors = <String>[];
+
+  await Future.wait(output.allAssets.map((asset) async {
+    final file = asset.file;
+    if (file == null && !config.dryRun) {
+      final error = 'Asset "${asset.id}" has no file.';
+      errors.add(error);
+    }
+    if (file != null && !config.dryRun && !await File.fromUri(file).exists()) {
+      final error =
+          'Asset "${asset.id}" has a file "${asset.file!.toFilePath()}", which '
+          'does not exist.';
+      errors.add(error);
+    }
+  }));
+
+  return errors;
+}
+
+extension on Asset {
+  String get type {
+    switch (this) {
+      case NativeCodeAsset _:
+        return NativeCodeAsset.type;
+      case DataAsset _:
+        return DataAsset.type;
+    }
+    throw UnsupportedError('Unknown asset type');
+  }
+}
+
+extension on HookOutputImpl {
+  Iterable<Asset> get allAssets =>
+      [...assets, ...assetsForLinking.values.expand((e) => e)];
+}
+
+/// Native code assets for bundling should have a supported linking type.
+List<String> validateNativeCodeAssets(
+  HookConfig config,
+  HookOutputImpl output,
+) {
+  final errors = <String>[];
+  final linkModePreference = config.linkModePreference;
+  for (final asset in output.assets.whereType<NativeCodeAsset>()) {
+    final linkMode = asset.linkMode;
+    if ((linkMode is DynamicLoading &&
+            linkModePreference == LinkModePreference.static) ||
+        (linkMode is StaticLinking &&
+            linkModePreference == LinkModePreference.dynamic)) {
+      final error = 'Asset "${asset.id}" has a link mode "$linkMode", which '
+          'is not allowed by by the config link mode preference '
+          '"$linkModePreference".';
+      errors.add(error);
+    }
+
+    final os = asset.os;
+    if (config.targetOS != os) {
+      final error = 'Asset "${asset.id}" has a os "$os", which '
+          'is not the target os "${config.targetOS}".';
+      errors.add(error);
+    }
+
+    final architecture = asset.architecture;
+    if (!config.dryRun) {
+      if (architecture == null) {
+        final error = 'Asset "${asset.id}" has no architecture.';
+        errors.add(error);
+      } else if (architecture != config.targetArchitecture) {
+        final error =
+            'Asset "${asset.id}" has an architecture "$architecture", which '
+            'is not the target architecture "${config.targetArchitecture}".';
+        errors.add(error);
+      }
+    }
+  }
+  return errors;
+}
+
+/// Build hooks must only output assets in their own package namespace.
+List<String> validateAssetId(
+  HookConfig config,
+  BuildOutput output,
+) {
+  final errors = <String>[];
+  final packageName = config.packageName;
+  for (final asset in output.assets) {
+    if (!asset.id.startsWith('package:$packageName/')) {
+      final error = 'Asset "${asset.id}" does not start with '
+          '"package:$packageName/".';
+      errors.add(error);
+    }
+  }
+  return errors;
+}
+
+List<String> validateNoDuplicateAssetIds(
+  BuildOutput output,
+) {
+  final errors = <String>[];
+  final assetIds = <String>{};
+  for (final asset in output.assets) {
+    if (assetIds.contains(asset.id)) {
+      final error = 'Duplicate asset id: "${asset.id}".';
+      errors.add(error);
+    } else {
+      assetIds.add(asset.id);
+    }
+  }
+  return errors;
+}

--- a/pkgs/native_assets_cli/test/example/local_asset_test.dart
+++ b/pkgs/native_assets_cli/test/example/local_asset_test.dart
@@ -44,6 +44,7 @@ void main() async {
           '-Dpackage_root=${testPackageUri.toFilePath()}',
           '-Dtarget_os=${OSImpl.current}',
           '-Dversion=${HookConfigImpl.latestVersion}',
+          '-Dlinking_enabled=0',
           '-Dlink_mode_preference=dynamic',
           '-Ddry_run=$dryRun',
           if (!dryRun) ...[

--- a/pkgs/native_assets_cli/test/example/native_add_library_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_library_test.dart
@@ -44,6 +44,7 @@ void main() async {
           '-Dpackage_root=${testPackageUri.toFilePath()}',
           '-Dtarget_os=${OSImpl.current}',
           '-Dversion=${HookConfigImpl.latestVersion}',
+          '-Dlinking_enabled=0',
           '-Dlink_mode_preference=dynamic',
           '-Ddry_run=$dryRun',
           if (!dryRun) ...[

--- a/pkgs/native_assets_cli/test/example/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_dynamic_linking_test.dart
@@ -53,6 +53,7 @@ void main() async {
           '-Dpackage_root=${testPackageUri.toFilePath()}',
           '-Dtarget_os=${OSImpl.current}',
           '-Dversion=${HookConfigImpl.latestVersion}',
+          '-Dlinking_enabled=0',
           '-Dlink_mode_preference=dynamic',
           '-Ddry_run=$dryRun',
           if (!dryRun) ...[

--- a/pkgs/native_assets_cli/test/validator/validator_test.dart
+++ b/pkgs/native_assets_cli/test/validator/validator_test.dart
@@ -1,0 +1,395 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/src/validator/validator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Uri tempUri;
+  late Uri outDirUri;
+  late Uri outDir2Uri;
+  late String packageName;
+  late Uri packageRootUri;
+
+  setUp(() async {
+    tempUri = (await Directory.systemTemp.createTemp()).uri;
+    outDirUri = tempUri.resolve('out1/');
+    await Directory.fromUri(outDirUri).create();
+    outDir2Uri = tempUri.resolve('out2/');
+    packageName = 'my_package';
+    await Directory.fromUri(outDir2Uri).create();
+    packageRootUri = tempUri.resolve('$packageName/');
+    await Directory.fromUri(packageRootUri).create();
+  });
+
+  tearDown(() async {
+    await Directory.fromUri(tempUri).delete(recursive: true);
+  });
+
+  test('linking not enabled', () async {
+    final config = BuildConfig.build(
+      outputDirectory: outDirUri,
+      packageName: packageName,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.arm64,
+      targetOS: OS.iOS,
+      targetIOSSdk: IOSSdk.iPhoneOS,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.dynamic,
+      supportedAssetTypes: [NativeCodeAsset.type],
+      linkingEnabled: false,
+    );
+    final output = BuildOutput();
+    final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
+    await assetFile.writeAsBytes([1, 2, 3]);
+    output.addAsset(
+      NativeCodeAsset(
+        package: config.packageName,
+        name: 'foo.dart',
+        file: assetFile.uri,
+        linkMode: DynamicLoadingBundled(),
+        os: config.targetOS,
+        architecture: config.targetArchitecture,
+      ),
+      linkInPackage: 'bar',
+    );
+    final result = await validateBuild(config, output);
+    expect(result.success, isFalse);
+    expect(
+      result.errors,
+      contains(contains('linkingEnabled is false')),
+    );
+  });
+
+  test('supported asset type', () async {
+    final config = BuildConfig.build(
+      outputDirectory: outDirUri,
+      packageName: packageName,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.arm64,
+      targetOS: OS.iOS,
+      targetIOSSdk: IOSSdk.iPhoneOS,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.dynamic,
+      supportedAssetTypes: [NativeCodeAsset.type],
+      linkingEnabled: false,
+    );
+    final output = BuildOutput();
+    final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
+    await assetFile.writeAsBytes([1, 2, 3]);
+    output.addAsset(DataAsset(
+      package: config.packageName,
+      name: 'foo.txt',
+      file: assetFile.uri,
+    ));
+    final result = await validateBuild(config, output);
+    expect(result.success, isFalse);
+    expect(
+      result.errors,
+      contains(contains('which is not in supportedAssetTypes')),
+    );
+  });
+
+  test('file exists', () async {
+    final config = BuildConfig.build(
+      outputDirectory: outDirUri,
+      packageName: packageName,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.arm64,
+      targetOS: OS.iOS,
+      targetIOSSdk: IOSSdk.iPhoneOS,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.dynamic,
+      supportedAssetTypes: [DataAsset.type],
+      linkingEnabled: false,
+    );
+    final output = BuildOutput();
+    final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
+    output.addAsset(DataAsset(
+      package: config.packageName,
+      name: 'foo.txt',
+      file: assetFile.uri,
+    ));
+    final result = await validateBuild(config, output);
+    expect(result.success, isFalse);
+    expect(
+      result.errors,
+      contains(contains('which does not exist')),
+    );
+  });
+
+  test('file not set', () async {
+    final config = BuildConfig.build(
+      outputDirectory: outDirUri,
+      packageName: packageName,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.arm64,
+      targetOS: OS.iOS,
+      targetIOSSdk: IOSSdk.iPhoneOS,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.dynamic,
+      supportedAssetTypes: [NativeCodeAsset.type],
+      linkingEnabled: false,
+    );
+    final output = BuildOutput();
+    output.addAsset(NativeCodeAsset(
+      package: config.packageName,
+      name: 'foo.dylib',
+      architecture: config.targetArchitecture,
+      os: config.targetOS,
+      linkMode: DynamicLoadingBundled(),
+    ));
+    final result = await validateBuild(config, output);
+    expect(result.success, isFalse);
+    expect(
+      result.errors,
+      contains(contains('has no file')),
+    );
+  });
+
+  for (final (linkModePreference, linkMode) in [
+    (LinkModePreference.static, DynamicLoadingBundled()),
+    (LinkModePreference.dynamic, StaticLinking()),
+  ]) {
+    test('native code asset wrong linking $linkModePreference', () async {
+      final config = BuildConfig.build(
+        outputDirectory: outDirUri,
+        packageName: packageName,
+        packageRoot: tempUri,
+        targetArchitecture: Architecture.arm64,
+        targetOS: OS.iOS,
+        targetIOSSdk: IOSSdk.iPhoneOS,
+        buildMode: BuildMode.release,
+        linkModePreference: linkModePreference,
+        supportedAssetTypes: [NativeCodeAsset.type],
+        linkingEnabled: false,
+      );
+      final output = BuildOutput();
+      final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
+      await assetFile.writeAsBytes([1, 2, 3]);
+      output.addAsset(
+        NativeCodeAsset(
+          package: config.packageName,
+          name: 'foo.dart',
+          file: assetFile.uri,
+          linkMode: linkMode,
+          os: config.targetOS,
+          architecture: config.targetArchitecture,
+        ),
+      );
+      final result = await validateBuild(config, output);
+      expect(result.success, isFalse);
+      expect(
+        result.errors,
+        contains(contains(
+          'which is not allowed by by the config link mode preference',
+        )),
+      );
+    });
+  }
+
+  test('native code wrong architecture', () async {
+    final config = BuildConfig.build(
+      outputDirectory: outDirUri,
+      packageName: packageName,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.arm64,
+      targetOS: OS.iOS,
+      targetIOSSdk: IOSSdk.iPhoneOS,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.dynamic,
+      supportedAssetTypes: [NativeCodeAsset.type],
+      linkingEnabled: false,
+    );
+    final output = BuildOutput();
+    final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
+    await assetFile.writeAsBytes([1, 2, 3]);
+    output.addAsset(
+      NativeCodeAsset(
+        package: config.packageName,
+        name: 'foo.dart',
+        file: assetFile.uri,
+        linkMode: DynamicLoadingBundled(),
+        os: config.targetOS,
+        architecture: Architecture.x64,
+      ),
+    );
+    final result = await validateBuild(config, output);
+    expect(result.success, isFalse);
+    expect(
+      result.errors,
+      contains(contains(
+        'which is not the target architecture',
+      )),
+    );
+  });
+
+  test('native code no architecture', () async {
+    final config = BuildConfig.build(
+      outputDirectory: outDirUri,
+      packageName: packageName,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.arm64,
+      targetOS: OS.iOS,
+      targetIOSSdk: IOSSdk.iPhoneOS,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.dynamic,
+      supportedAssetTypes: [NativeCodeAsset.type],
+      linkingEnabled: false,
+    );
+    final output = BuildOutput();
+    final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
+    await assetFile.writeAsBytes([1, 2, 3]);
+    output.addAsset(
+      NativeCodeAsset(
+        package: config.packageName,
+        name: 'foo.dart',
+        file: assetFile.uri,
+        linkMode: DynamicLoadingBundled(),
+        os: config.targetOS,
+      ),
+    );
+    final result = await validateBuild(config, output);
+    expect(result.success, isFalse);
+    expect(
+      result.errors,
+      contains(contains(
+        'has no architecture',
+      )),
+    );
+  });
+
+  test('native code asset wrong os', () async {
+    final config = BuildConfig.build(
+      outputDirectory: outDirUri,
+      packageName: packageName,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.arm64,
+      targetOS: OS.iOS,
+      targetIOSSdk: IOSSdk.iPhoneOS,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.dynamic,
+      supportedAssetTypes: [NativeCodeAsset.type],
+      linkingEnabled: false,
+    );
+    final output = BuildOutput();
+    final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
+    await assetFile.writeAsBytes([1, 2, 3]);
+    output.addAsset(
+      NativeCodeAsset(
+        package: config.packageName,
+        name: 'foo.dart',
+        file: assetFile.uri,
+        linkMode: DynamicLoadingBundled(),
+        os: OS.windows,
+        architecture: config.targetArchitecture,
+      ),
+    );
+    final result = await validateBuild(config, output);
+    expect(result.success, isFalse);
+    expect(
+      result.errors,
+      contains(contains(
+        'which is not the target os',
+      )),
+    );
+  });
+
+  test('asset id in wrong package', () async {
+    final config = BuildConfig.build(
+      outputDirectory: outDirUri,
+      packageName: packageName,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.arm64,
+      targetOS: OS.iOS,
+      targetIOSSdk: IOSSdk.iPhoneOS,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.dynamic,
+      supportedAssetTypes: [DataAsset.type],
+      linkingEnabled: false,
+    );
+    final output = BuildOutput();
+    final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
+    await assetFile.writeAsBytes([1, 2, 3]);
+    output.addAsset(DataAsset(
+      package: 'different_package',
+      name: 'foo.txt',
+      file: assetFile.uri,
+    ));
+    final result = await validateBuild(config, output);
+    expect(result.success, isFalse);
+    expect(
+      result.errors,
+      contains(contains('does not start with')),
+    );
+  });
+
+  test('duplicate asset id', () async {
+    final config = BuildConfig.build(
+      outputDirectory: outDirUri,
+      packageName: packageName,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.arm64,
+      targetOS: OS.iOS,
+      targetIOSSdk: IOSSdk.iPhoneOS,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.dynamic,
+      supportedAssetTypes: [DataAsset.type],
+      linkingEnabled: false,
+    );
+    final output = BuildOutput();
+    final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
+    await assetFile.writeAsBytes([1, 2, 3]);
+    output.addAssets([
+      DataAsset(
+        package: config.packageName,
+        name: 'foo.txt',
+        file: assetFile.uri,
+      ),
+      DataAsset(
+        package: config.packageName,
+        name: 'foo.txt',
+        file: assetFile.uri,
+      ),
+    ]);
+    final result = await validateBuild(config, output);
+    expect(result.success, isFalse);
+    expect(
+      result.errors,
+      contains(contains('Duplicate asset id')),
+    );
+  });
+
+  test('link hook validation', () async {
+    final config = LinkConfig.build(
+      outputDirectory: outDirUri,
+      packageName: packageName,
+      packageRoot: tempUri,
+      targetArchitecture: Architecture.arm64,
+      targetOS: OS.iOS,
+      targetIOSSdk: IOSSdk.iPhoneOS,
+      buildMode: BuildMode.release,
+      linkModePreference: LinkModePreference.dynamic,
+      supportedAssetTypes: [NativeCodeAsset.type],
+      assets: [],
+    );
+    final output = LinkOutput();
+    final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
+    await assetFile.writeAsBytes([1, 2, 3]);
+    output.addAsset(DataAsset(
+      package: config.packageName,
+      name: 'foo.txt',
+      file: assetFile.uri,
+    ));
+    final result = await validateLink(config, output);
+    expect(result.success, isFalse);
+    expect(
+      result.errors,
+      contains(contains('which is not in supportedAssetTypes')),
+    );
+  });
+}


### PR DESCRIPTION
This PR adds validation to the hook outputs in two places:

1. In the `build` and `link` methods used in hook implementations.
2. In the `native_assets_builder` after invoking the hook.

In the native assets builder we also validate that assets for linking are routed to packages that have link hooks.

Also, fixes some bugs, some tests, and examples that were violating the invariants.

Closes: https://github.com/dart-lang/native/issues/1409
Closes: https://github.com/dart-lang/native/issues/1411
