### PR TITLE
[native_*] Unify `CCompilerConfig` handling in tests

### DIFF
--- a/pkgs/native_assets_builder/test/helpers.dart
+++ b/pkgs/native_assets_builder/test/helpers.dart
@@ -128,37 +128,48 @@ String unparseKey(String key) => key.replaceAll('.', '__').toUpperCase();
 /// Archiver provided by the environment.
 ///
 /// Provided on Dart CI.
-final Uri? ar = Platform
+final Uri? _ar = Platform
     .environment[unparseKey(internal.CCompilerConfigImpl.arConfigKeyFull)]
     ?.asFileUri();
 
 /// Compiler provided by the environment.
 ///
 /// Provided on Dart CI.
-final Uri? cc = Platform
+final Uri? _cc = Platform
     .environment[unparseKey(internal.CCompilerConfigImpl.ccConfigKeyFull)]
     ?.asFileUri();
 
 /// Linker provided by the environment.
 ///
 /// Provided on Dart CI.
-final Uri? ld = Platform
+final Uri? _ld = Platform
     .environment[unparseKey(internal.CCompilerConfigImpl.ldConfigKeyFull)]
     ?.asFileUri();
 
-/// Path to script that sets environment variables for [cc], [ld], and [ar].
+/// Path to script that sets environment variables for [_cc], [_ld], and [_ar].
 ///
 /// Provided on Dart CI.
-final Uri? envScript = Platform.environment[
+final Uri? _envScript = Platform.environment[
         unparseKey(internal.CCompilerConfigImpl.envScriptConfigKeyFull)]
     ?.asFileUri();
 
-/// Arguments for [envScript] provided by environment.
+/// Arguments for [_envScript] provided by environment.
 ///
 /// Provided on Dart CI.
-final List<String>? envScriptArgs = Platform.environment[
+final List<String>? _envScriptArgs = Platform.environment[
         unparseKey(internal.CCompilerConfigImpl.envScriptArgsConfigKeyFull)]
     ?.split(' ');
+
+/// Configuration for the native toolchain.
+///
+/// Provided on Dart CI.
+final cCompiler = internal.CCompilerConfigImpl(
+  compiler: _cc,
+  archiver: _ar,
+  linker: _ld,
+  envScript: _envScript,
+  envScriptArgs: _envScriptArgs,
+);
 
 extension on String {
   Uri asFileUri() => Uri.file(this);

--- a/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
@@ -40,13 +40,7 @@ void main() async {
           linkingEnabled: false,
           targetArchitecture: dryRun ? null : ArchitectureImpl.current,
           buildMode: dryRun ? null : BuildModeImpl.debug,
-          cCompiler: dryRun
-              ? null
-              : CCompilerConfigImpl(
-                  compiler: cc,
-                  envScript: envScript,
-                  envScriptArgs: envScriptArgs,
-                ),
+          cCompiler: dryRun ? null : cCompiler,
         );
 
         final buildConfigUri = testTempUri.resolve('build_config.json');

--- a/pkgs/native_assets_cli/test/example/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_dynamic_linking_test.dart
@@ -11,6 +11,7 @@
 @TestOn('!windows')
 library;
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:native_assets_cli/native_assets_cli_internal.dart';
@@ -44,29 +45,29 @@ void main() async {
       final testPackageUri = packageUri.resolve('example/build/$name/');
       final dartUri = Uri.file(Platform.resolvedExecutable);
 
+      final config = BuildConfigImpl(
+        outputDirectory: tempUri,
+        packageName: name,
+        packageRoot: testPackageUri,
+        targetOS: OSImpl.current,
+        version: HookConfigImpl.latestVersion,
+        linkModePreference: LinkModePreferenceImpl.dynamic,
+        dryRun: dryRun,
+        linkingEnabled: false,
+        targetArchitecture: dryRun ? null : ArchitectureImpl.current,
+        buildMode: dryRun ? null : BuildModeImpl.debug,
+        cCompiler: dryRun ? null : cCompiler,
+      );
+
+      final buildConfigUri = testTempUri.resolve('build_config.json');
+      File.fromUri(buildConfigUri)
+          .writeAsStringSync(jsonEncode(config.toJson()));
+
       final processResult = await Process.run(
         dartUri.toFilePath(),
         [
           'hook/build.dart',
-          '-Dout_dir=${tempUri.toFilePath()}',
-          '-Dpackage_name=$name',
-          '-Dpackage_root=${testPackageUri.toFilePath()}',
-          '-Dtarget_os=${OSImpl.current}',
-          '-Dversion=${HookConfigImpl.latestVersion}',
-          '-Dlinking_enabled=0',
-          '-Dlink_mode_preference=dynamic',
-          '-Ddry_run=$dryRun',
-          if (!dryRun) ...[
-            '-Dtarget_architecture=${ArchitectureImpl.current}',
-            '-Dbuild_mode=debug',
-            if (cc != null) '-Dcc=${cc!.toFilePath()}',
-            if (envScript != null)
-              '-D${CCompilerConfigImpl.envScriptConfigKeyFull}='
-                  '${envScript!.toFilePath()}',
-            if (envScriptArgs != null)
-              '-D${CCompilerConfigImpl.envScriptArgsConfigKeyFull}='
-                  '${envScriptArgs!.join(' ')}',
-          ],
+          '--config=${buildConfigUri.toFilePath()}',
         ],
         workingDirectory: testPackageUri.toFilePath(),
       );

--- a/pkgs/native_assets_cli/test/helpers.dart
+++ b/pkgs/native_assets_cli/test/helpers.dart
@@ -87,37 +87,48 @@ String unparseKey(String key) => key.replaceAll('.', '__').toUpperCase();
 /// Archiver provided by the environment.
 ///
 /// Provided on Dart CI.
-final Uri? ar = Platform
+final Uri? _ar = Platform
     .environment[unparseKey(internal.CCompilerConfigImpl.arConfigKeyFull)]
     ?.asFileUri();
 
 /// Compiler provided by the environment.
 ///
 /// Provided on Dart CI.
-final Uri? cc = Platform
+final Uri? _cc = Platform
     .environment[unparseKey(internal.CCompilerConfigImpl.ccConfigKeyFull)]
     ?.asFileUri();
 
 /// Linker provided by the environment.
 ///
 /// Provided on Dart CI.
-final Uri? ld = Platform
+final Uri? _ld = Platform
     .environment[unparseKey(internal.CCompilerConfigImpl.ldConfigKeyFull)]
     ?.asFileUri();
 
-/// Path to script that sets environment variables for [cc], [ld], and [ar].
+/// Path to script that sets environment variables for [_cc], [_ld], and [_ar].
 ///
 /// Provided on Dart CI.
-final Uri? envScript = Platform.environment[
+final Uri? _envScript = Platform.environment[
         unparseKey(internal.CCompilerConfigImpl.envScriptConfigKeyFull)]
     ?.asFileUri();
 
-/// Arguments for [envScript] provided by environment.
+/// Arguments for [_envScript] provided by environment.
 ///
 /// Provided on Dart CI.
-final List<String>? envScriptArgs = Platform.environment[
+final List<String>? _envScriptArgs = Platform.environment[
         unparseKey(internal.CCompilerConfigImpl.envScriptArgsConfigKeyFull)]
     ?.split(' ');
+
+/// Configuration for the native toolchain.
+///
+/// Provided on Dart CI.
+final cCompiler = internal.CCompilerConfigImpl(
+  compiler: _cc,
+  archiver: _ar,
+  linker: _ld,
+  envScript: _envScript,
+  envScriptArgs: _envScriptArgs,
+);
 
 extension on String {
   Uri asFileUri() => Uri.file(this);


### PR DESCRIPTION
This prevents us manually having to update the command-line invocations in tests when things change.