### PR TITLE
Fix numeric suffix rename

### DIFF
--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -1,12 +1,15 @@
-## 0.11.1-wip
+## 0.12.0-wip
 
+- **Breaking Change**([#1530](https://github.com/dart-lang/native/pull/1530)):
+  Changed the renaming strategy for method overloadings. Instead of adding a
+  numeric suffix, we add a dollar sign (`$`) and then the numeric suffix. This
+  is done to avoid name collision between methods that originally end with
+  numeric suffices and the renamed overloads. Similarly names that are Dart
+  keywords get a dollar sign suffix now. For more information, check out the
+  [documentation](https://github.com/dart-lang/native/tree/main/pkgs/jnigen/docs/java_differences.md#method_overloading).
 - Fixed an issue where inheriting a generic class could generate incorrect code.
 - No longer generating constructors for abstract classes.
 - No longer generating `protected` elements.
-- Adding a dollar sign (`$`) to the end of each Java element that ends with a
-  number to avoid name collisions that can happen with the numeric suffixes of
-  the overloaded methods.
-  ([[#1530](https://github.com/dart-lang/native/pull/1530)).
 
 ## 0.11.0
 

--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Fixed an issue where inheriting a generic class could generate incorrect code.
 - No longer generating constructors for abstract classes.
 - No longer generating `protected` elements.
+- Adding a dollar sign (`$`) to the end of each Java element that ends with a
+  number to avoid name collisions that can happen with the numeric suffixes of
+  the overloaded methods.
+  ([[#1530](https://github.com/dart-lang/native/pull/1530)).
 
 ## 0.11.0
 

--- a/pkgs/jnigen/docs/java_differences.md
+++ b/pkgs/jnigen/docs/java_differences.md
@@ -1,0 +1,86 @@
+## Syntax and semantic differences between Java and the generated Dart bindings
+
+### Method overloading
+
+Java supports overloading methods. This means that it can distinguish between
+two methods with the same name that have a different signature.
+
+```java
+public class Calculator {
+  public int add(int a, int b) {
+    return a + b;
+  }
+
+  public double add(double a, double b) {
+    return a + b;
+  }
+
+  public float add(float a, float b) {
+    return a + b;
+  }
+}
+```
+
+This is not the case for Dart. Each method of a class must have a different
+name. To overcome this limitation, JNIgen adds a numeric suffix to the end of
+the overloaded method name.
+
+```dart
+class Calculator extends JObject {
+  // Omitted for clarity.
+  int add(int a, int b) { /* ... */ }
+  double add1(double a, double b) { /* ... */ }
+  double add2(double a, double b) { /* ... */ }
+}
+```
+
+> [!WARNING]  
+> Running the code generator again on a different version of the library can map
+> the methods differently if the order of the methods change or another
+> overloading of the same method gets added.
+>
+> Double check the doc comments on the generated methods to make sure you are
+> calling your intended method.
+
+What if we have another two methods named `add1`?
+
+```java
+public class Calculator {
+  public int add(int a, int b) {
+    return a + b;
+  }
+
+  public double add(double a, double b) {
+    return a + b;
+  }
+
+  public float add(float a, float b) {
+    return a + b;
+  }
+
+  public int add1(int a) {
+    return a + 1;
+  }
+
+  public double add1(double a) {
+    return a + 1;
+  }
+}
+```
+
+> [!IMPORTANT]  
+> JNIgen adds a dollar sign (`$`) to all the methods ending with a number by
+> default.
+
+So the generated code will be:
+
+```dart
+class Calculator extends JObject {
+  // Omitted for clarity.
+  int add(int a, int b) { /* ... */ }
+  double add1(double a, double b) { /* ... */ }
+  double add2(double a, double b) { /* ... */ }
+  int add1$(int a) { /* ... */ }
+  double add1$1(double a) { /* ... */ }
+}
+```

--- a/pkgs/jnigen/docs/java_differences.md
+++ b/pkgs/jnigen/docs/java_differences.md
@@ -6,6 +6,7 @@ Java supports overloading methods. This means that it can distinguish between
 two methods with the same name that have a different signature.
 
 ```java
+// Java
 public class Calculator {
   public int add(int a, int b) {
     return a + b;
@@ -21,20 +22,21 @@ public class Calculator {
 }
 ```
 
-This is not the case for Dart. Each method of a class must have a different
-name. To overcome this limitation, JNIgen adds a numeric suffix to the end of
-the overloaded method name.
+This is not the case for Dart. Each method of a class must have a unique
+name. To overcome this limitation, JNIgen adds a dollar sign (`$`) and a numeric
+suffix to the end of the overloaded method name.
 
 ```dart
+// Dart Bindings
 class Calculator extends JObject {
   // Omitted for clarity.
   int add(int a, int b) { /* ... */ }
-  double add1(double a, double b) { /* ... */ }
-  double add2(double a, double b) { /* ... */ }
+  double add$1(double a, double b) { /* ... */ }
+  double add$2(double a, double b) { /* ... */ }
 }
 ```
 
-> [!WARNING]  
+> [!INFORMATION]  
 > Running the code generator again on a different version of the library can map
 > the methods differently if the order of the methods change or another
 > overloading of the same method gets added.
@@ -42,9 +44,10 @@ class Calculator extends JObject {
 > Double check the doc comments on the generated methods to make sure you are
 > calling your intended method.
 
-What if we have another two methods named `add1`?
+You might wonder why the method isn't renamed to `add1` instead of `add$1`. The reason is that a method named `add1` could already exist in the Java class.
 
 ```java
+// Java
 public class Calculator {
   public int add(int a, int b) {
     return a + b;
@@ -68,19 +71,16 @@ public class Calculator {
 }
 ```
 
-> [!IMPORTANT]  
-> JNIgen adds a dollar sign (`$`) to all the methods ending with a number by
-> default.
-
-So the generated code will be:
+In this case, the generated code will be:
 
 ```dart
+// Dart Bindings
 class Calculator extends JObject {
   // Omitted for clarity.
   int add(int a, int b) { /* ... */ }
-  double add1(double a, double b) { /* ... */ }
-  double add2(double a, double b) { /* ... */ }
-  int add1$(int a) { /* ... */ }
-  double add1$1(double a) { /* ... */ }
+  double add$1(double a, double b) { /* ... */ }
+  double add$2(double a, double b) { /* ... */ }
+  int add1(int a) { /* ... */ }
+  double add1$2(double a) { /* ... */ }
 }
 ```

--- a/pkgs/jnigen/docs/java_differences.md
+++ b/pkgs/jnigen/docs/java_differences.md
@@ -22,21 +22,22 @@ public class Calculator {
 }
 ```
 
-This is not the case for Dart. Each method of a class must have a unique
-name. To overcome this limitation, JNIgen adds a dollar sign (`$`) and a numeric
+This is not the case for Dart. Each method of a class must have a unique name.
+To overcome this limitation, JNIgen adds a dollar sign (`$`) and a numeric
 suffix to the end of the overloaded method name.
 
 ```dart
-// Dart Bindings
+// Dart Bindings - Boilerplate omitted for clarity.
 class Calculator extends JObject {
-  // Omitted for clarity.
   int add(int a, int b) { /* ... */ }
+
   double add$1(double a, double b) { /* ... */ }
+
   double add$2(double a, double b) { /* ... */ }
 }
 ```
 
-> [!INFORMATION]  
+> [!WARNING]  
 > Running the code generator again on a different version of the library can map
 > the methods differently if the order of the methods change or another
 > overloading of the same method gets added.
@@ -44,7 +45,9 @@ class Calculator extends JObject {
 > Double check the doc comments on the generated methods to make sure you are
 > calling your intended method.
 
-You might wonder why the method isn't renamed to `add1` instead of `add$1`. The reason is that a method named `add1` could already exist in the Java class.
+You might wonder why the method isn't renamed to `add1` instead of `add$1`. The
+reason is that a method named `add1` could already exist in the Java class. On
+the other hand, Java identifiers cannot contain dollar signs.
 
 ```java
 // Java
@@ -74,13 +77,90 @@ public class Calculator {
 In this case, the generated code will be:
 
 ```dart
-// Dart Bindings
+// Dart Bindings - Boilerplate omitted for clarity.
 class Calculator extends JObject {
-  // Omitted for clarity.
   int add(int a, int b) { /* ... */ }
+
   double add$1(double a, double b) { /* ... */ }
+
   double add$2(double a, double b) { /* ... */ }
+
   int add1(int a) { /* ... */ }
+
   double add1$2(double a) { /* ... */ }
+}
+```
+
+### Fields and methods with the same name
+
+In Java, we can have a field and a method with the same name. This is not
+possible in Dart.
+
+```java
+// Java
+public class Player {
+  // Player's personal duck!
+  public Duck duck;
+
+  // Lower your head!
+  public void duck() { /* ... */ }
+}
+```
+
+JNIgen handles this similarly to [method overloading](#method-overloading). The
+method with the same name as the field will be appended by a dollar sign (`$`)
+followed by a numeric suffix.
+
+```dart
+// Dart Bindings - Boilerplate omitted for clarity.
+class Player extends JObject {
+  Duck get duck { /* ... */ };
+  set duck(Duck value) { /* ... */ }
+
+  void duck$1() { /* ... */ }
+
+  // If there were more `duck` methods they would be named
+  // `duck$2`, `duck$3`, ...
+}
+```
+
+It is important to note that the order of renaming is fields-first
+methods-second. So when both a field named `duck` and a method named `duck`
+exist, the field keeps its original name as seen above.
+
+However the renaming happens for superclasses first. Consider this case.
+
+```java
+// Java
+public class Player {
+  // Lower your head!
+  public void duck() { /* ... */ }
+}
+
+public class DuckOwningPlayer extends Player {
+  // Player's personal duck!
+  public Duck duck;
+}
+```
+
+The `Player` class already has a method named `duck` and no field with the same
+name. So this will be the generated bindings for it:
+
+```dart
+// Dart Bindings - Boilerplate omitted for clarity.
+class Player extends JObject {
+  void duck() { /* ... */ }
+}
+```
+
+`DuckOwningPlayer` inherits the `duck()` method from `Player` and adds a field
+named `duck`. This time, the field will be renamed as the method is simply
+inherited.
+
+```dart
+// Dart Bindings - Boilerplate omitted for clarity.
+class DuckOwningPlayer extends Player {
+  Duck get duck$1 { /* ... */ };
+  set duck$1(Duck value) { /* ... */ }
 }
 ```

--- a/pkgs/jnigen/example/in_app_java/lib/android_utils.dart
+++ b/pkgs/jnigen/example/in_app_java/lib/android_utils.dart
@@ -191,12 +191,12 @@ class EmojiCompat_Config extends jni.JObject {
         .object(const $EmojiCompat_ConfigType());
   }
 
-  static final _id_setUseEmojiAsDefaultStyle1 = _class.instanceMethodId(
+  static final _id_setUseEmojiAsDefaultStyle$1 = _class.instanceMethodId(
     r'setUseEmojiAsDefaultStyle',
     r'(ZLjava/util/List;)Landroidx/emoji2/text/EmojiCompat$Config;',
   );
 
-  static final _setUseEmojiAsDefaultStyle1 = ProtectedJniExtensions.lookup<
+  static final _setUseEmojiAsDefaultStyle$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -209,13 +209,13 @@ class EmojiCompat_Config extends jni.JObject {
 
   /// from: `public androidx.emoji2.text.EmojiCompat$Config setUseEmojiAsDefaultStyle(boolean z, java.util.List list)`
   /// The returned object must be released after use, by calling the [release] method.
-  EmojiCompat_Config setUseEmojiAsDefaultStyle1(
+  EmojiCompat_Config setUseEmojiAsDefaultStyle$1(
     bool z,
     jni.JList<jni.JInteger> list,
   ) {
-    return _setUseEmojiAsDefaultStyle1(
+    return _setUseEmojiAsDefaultStyle$1(
             reference.pointer,
-            _id_setUseEmojiAsDefaultStyle1 as jni.JMethodIDPtr,
+            _id_setUseEmojiAsDefaultStyle$1 as jni.JMethodIDPtr,
             z ? 1 : 0,
             list.reference.pointer)
         .object(const $EmojiCompat_ConfigType());
@@ -1041,12 +1041,12 @@ class EmojiCompat extends jni.JObject {
         .object(const $EmojiCompatType());
   }
 
-  static final _id_init1 = _class.staticMethodId(
+  static final _id_init$1 = _class.staticMethodId(
     r'init',
     r'(Landroid/content/Context;Landroidx/emoji2/text/DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory;)Landroidx/emoji2/text/EmojiCompat;',
   );
 
-  static final _init1 = ProtectedJniExtensions.lookup<
+  static final _init$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1062,25 +1062,25 @@ class EmojiCompat extends jni.JObject {
 
   /// from: `static public androidx.emoji2.text.EmojiCompat init(android.content.Context context, androidx.emoji2.text.DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory defaultEmojiCompatConfigFactory)`
   /// The returned object must be released after use, by calling the [release] method.
-  static EmojiCompat init1(
+  static EmojiCompat init$1(
     jni.JObject context,
     DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory
         defaultEmojiCompatConfigFactory,
   ) {
-    return _init1(
+    return _init$1(
             _class.reference.pointer,
-            _id_init1 as jni.JMethodIDPtr,
+            _id_init$1 as jni.JMethodIDPtr,
             context.reference.pointer,
             defaultEmojiCompatConfigFactory.reference.pointer)
         .object(const $EmojiCompatType());
   }
 
-  static final _id_init2 = _class.staticMethodId(
+  static final _id_init$2 = _class.staticMethodId(
     r'init',
     r'(Landroidx/emoji2/text/EmojiCompat$Config;)Landroidx/emoji2/text/EmojiCompat;',
   );
 
-  static final _init2 = ProtectedJniExtensions.lookup<
+  static final _init$2 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1093,10 +1093,10 @@ class EmojiCompat extends jni.JObject {
 
   /// from: `static public androidx.emoji2.text.EmojiCompat init(androidx.emoji2.text.EmojiCompat$Config config)`
   /// The returned object must be released after use, by calling the [release] method.
-  static EmojiCompat init2(
+  static EmojiCompat init$2(
     EmojiCompat_Config config,
   ) {
-    return _init2(_class.reference.pointer, _id_init2 as jni.JMethodIDPtr,
+    return _init$2(_class.reference.pointer, _id_init$2 as jni.JMethodIDPtr,
             config.reference.pointer)
         .object(const $EmojiCompatType());
   }
@@ -1151,12 +1151,12 @@ class EmojiCompat extends jni.JObject {
         .object(const $EmojiCompatType());
   }
 
-  static final _id_reset1 = _class.staticMethodId(
+  static final _id_reset$1 = _class.staticMethodId(
     r'reset',
     r'(Landroidx/emoji2/text/EmojiCompat;)Landroidx/emoji2/text/EmojiCompat;',
   );
 
-  static final _reset1 = ProtectedJniExtensions.lookup<
+  static final _reset$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1169,10 +1169,10 @@ class EmojiCompat extends jni.JObject {
 
   /// from: `static public androidx.emoji2.text.EmojiCompat reset(androidx.emoji2.text.EmojiCompat emojiCompat)`
   /// The returned object must be released after use, by calling the [release] method.
-  static EmojiCompat reset1(
+  static EmojiCompat reset$1(
     EmojiCompat emojiCompat,
   ) {
-    return _reset1(_class.reference.pointer, _id_reset1 as jni.JMethodIDPtr,
+    return _reset$1(_class.reference.pointer, _id_reset$1 as jni.JMethodIDPtr,
             emojiCompat.reference.pointer)
         .object(const $EmojiCompatType());
   }
@@ -1531,12 +1531,12 @@ class EmojiCompat extends jni.JObject {
         .boolean;
   }
 
-  static final _id_hasEmojiGlyph1 = _class.instanceMethodId(
+  static final _id_hasEmojiGlyph$1 = _class.instanceMethodId(
     r'hasEmojiGlyph',
     r'(Ljava/lang/CharSequence;I)Z',
   );
 
-  static final _hasEmojiGlyph1 = ProtectedJniExtensions.lookup<
+  static final _hasEmojiGlyph$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1548,13 +1548,13 @@ class EmojiCompat extends jni.JObject {
               ffi.Pointer<ffi.Void>, int)>();
 
   /// from: `public boolean hasEmojiGlyph(java.lang.CharSequence charSequence, int i)`
-  bool hasEmojiGlyph1(
+  bool hasEmojiGlyph$1(
     jni.JObject charSequence,
     int i,
   ) {
-    return _hasEmojiGlyph1(
+    return _hasEmojiGlyph$1(
             reference.pointer,
-            _id_hasEmojiGlyph1 as jni.JMethodIDPtr,
+            _id_hasEmojiGlyph$1 as jni.JMethodIDPtr,
             charSequence.reference.pointer,
             i)
         .boolean;
@@ -1615,12 +1615,12 @@ class EmojiCompat extends jni.JObject {
         .object(const jni.JObjectType());
   }
 
-  static final _id_process1 = _class.instanceMethodId(
+  static final _id_process$1 = _class.instanceMethodId(
     r'process',
     r'(Ljava/lang/CharSequence;II)Ljava/lang/CharSequence;',
   );
 
-  static final _process1 = ProtectedJniExtensions.lookup<
+  static final _process$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1633,22 +1633,22 @@ class EmojiCompat extends jni.JObject {
 
   /// from: `public java.lang.CharSequence process(java.lang.CharSequence charSequence, int i, int i1)`
   /// The returned object must be released after use, by calling the [release] method.
-  jni.JObject process1(
+  jni.JObject process$1(
     jni.JObject charSequence,
     int i,
     int i1,
   ) {
-    return _process1(reference.pointer, _id_process1 as jni.JMethodIDPtr,
+    return _process$1(reference.pointer, _id_process$1 as jni.JMethodIDPtr,
             charSequence.reference.pointer, i, i1)
         .object(const jni.JObjectType());
   }
 
-  static final _id_process2 = _class.instanceMethodId(
+  static final _id_process$2 = _class.instanceMethodId(
     r'process',
     r'(Ljava/lang/CharSequence;III)Ljava/lang/CharSequence;',
   );
 
-  static final _process2 = ProtectedJniExtensions.lookup<
+  static final _process$2 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1666,23 +1666,23 @@ class EmojiCompat extends jni.JObject {
 
   /// from: `public java.lang.CharSequence process(java.lang.CharSequence charSequence, int i, int i1, int i2)`
   /// The returned object must be released after use, by calling the [release] method.
-  jni.JObject process2(
+  jni.JObject process$2(
     jni.JObject charSequence,
     int i,
     int i1,
     int i2,
   ) {
-    return _process2(reference.pointer, _id_process2 as jni.JMethodIDPtr,
+    return _process$2(reference.pointer, _id_process$2 as jni.JMethodIDPtr,
             charSequence.reference.pointer, i, i1, i2)
         .object(const jni.JObjectType());
   }
 
-  static final _id_process3 = _class.instanceMethodId(
+  static final _id_process$3 = _class.instanceMethodId(
     r'process',
     r'(Ljava/lang/CharSequence;IIII)Ljava/lang/CharSequence;',
   );
 
-  static final _process3 = ProtectedJniExtensions.lookup<
+  static final _process$3 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1701,14 +1701,14 @@ class EmojiCompat extends jni.JObject {
 
   /// from: `public java.lang.CharSequence process(java.lang.CharSequence charSequence, int i, int i1, int i2, int i3)`
   /// The returned object must be released after use, by calling the [release] method.
-  jni.JObject process3(
+  jni.JObject process$3(
     jni.JObject charSequence,
     int i,
     int i1,
     int i2,
     int i3,
   ) {
-    return _process3(reference.pointer, _id_process3 as jni.JMethodIDPtr,
+    return _process$3(reference.pointer, _id_process$3 as jni.JMethodIDPtr,
             charSequence.reference.pointer, i, i1, i2, i3)
         .object(const jni.JObjectType());
   }
@@ -2073,14 +2073,14 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelperType
 }
 
 /// from: `androidx.emoji2.text.DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19`
-class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$
+class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
     extends DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper {
   @override
   late final jni
-      .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$>
+      .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19>
       $type = type;
 
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$.fromReference(
+  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19.fromReference(
     jni.JReference reference,
   ) : super.fromReference(reference);
 
@@ -2089,7 +2089,7 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$
 
   /// The type which includes information such as the signature of this class.
   static const type =
-      $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type();
+      $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19Type();
   static final _id_new0 = _class.constructorId(
     r'()V',
   );
@@ -2108,8 +2108,8 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$
 
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
-  factory DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$() {
-    return DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$
+  factory DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19() {
+    return DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
         .fromReference(
             _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
                 .reference);
@@ -2180,19 +2180,19 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$
   }
 }
 
-final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type
+final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19Type
     extends jni
-    .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$> {
-  const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type();
+    .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19> {
+  const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19Type();
 
   @override
   String get signature =>
       r'Landroidx/emoji2/text/DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19;';
 
   @override
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$ fromReference(
+  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19 fromReference(
           jni.JReference reference) =>
-      DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$
+      DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
           .fromReference(reference);
 
   @override
@@ -2204,27 +2204,27 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type
 
   @override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type)
+      ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19Type)
           .hashCode;
 
   @override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type) &&
+            ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19Type) &&
         other
-            is $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type;
+            is $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19Type;
   }
 }
 
 /// from: `androidx.emoji2.text.DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28`
-class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$
-    extends DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$ {
+class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
+    extends DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19 {
   @override
   late final jni
-      .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$>
+      .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28>
       $type = type;
 
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$.fromReference(
+  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28.fromReference(
     jni.JReference reference,
   ) : super.fromReference(reference);
 
@@ -2233,7 +2233,7 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$
 
   /// The type which includes information such as the signature of this class.
   static const type =
-      $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type();
+      $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28Type();
   static final _id_new0 = _class.constructorId(
     r'()V',
   );
@@ -2252,19 +2252,19 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$
 
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
-  factory DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$() {
-    return DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$
+  factory DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28() {
+    return DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
         .fromReference(
             _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
                 .reference);
   }
 
-  static final _id_getSigningSignatures1 = _class.instanceMethodId(
+  static final _id_getSigningSignatures$1 = _class.instanceMethodId(
     r'getSigningSignatures',
     r'(Landroid/content/pm/PackageManager;Ljava/lang/String;)[Landroid/content/pm/Signature;',
   );
 
-  static final _getSigningSignatures1 = ProtectedJniExtensions.lookup<
+  static final _getSigningSignatures$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -2280,52 +2280,52 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$
 
   /// from: `public android.content.pm.Signature[] getSigningSignatures(android.content.pm.PackageManager packageManager, java.lang.String string)`
   /// The returned object must be released after use, by calling the [release] method.
-  jni.JArray<jni.JObject> getSigningSignatures1(
+  jni.JArray<jni.JObject> getSigningSignatures$1(
     jni.JObject packageManager,
     jni.JString string,
   ) {
-    return _getSigningSignatures1(
+    return _getSigningSignatures$1(
             reference.pointer,
-            _id_getSigningSignatures1 as jni.JMethodIDPtr,
+            _id_getSigningSignatures$1 as jni.JMethodIDPtr,
             packageManager.reference.pointer,
             string.reference.pointer)
         .object(const jni.JArrayType(jni.JObjectType()));
   }
 }
 
-final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type
+final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28Type
     extends jni
-    .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$> {
-  const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type();
+    .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28> {
+  const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28Type();
 
   @override
   String get signature =>
       r'Landroidx/emoji2/text/DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28;';
 
   @override
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$ fromReference(
+  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28 fromReference(
           jni.JReference reference) =>
-      DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$
+      DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
           .fromReference(reference);
 
   @override
   jni.JObjType get superType =>
-      const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type();
+      const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19Type();
 
   @override
   final superCount = 3;
 
   @override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type)
+      ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28Type)
           .hashCode;
 
   @override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type) &&
+            ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28Type) &&
         other
-            is $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type;
+            is $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28Type;
   }
 }
 
@@ -2518,12 +2518,12 @@ class Build_Partition extends jni.JObject {
         .boolean;
   }
 
-  static final _id_hashCode1 = _class.instanceMethodId(
+  static final _id_hashCode$1 = _class.instanceMethodId(
     r'hashCode',
     r'()I',
   );
 
-  static final _hashCode1 = ProtectedJniExtensions.lookup<
+  static final _hashCode$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -2536,8 +2536,8 @@ class Build_Partition extends jni.JObject {
           )>();
 
   /// from: `public int hashCode()`
-  int hashCode1() {
-    return _hashCode1(reference.pointer, _id_hashCode1 as jni.JMethodIDPtr)
+  int hashCode$1() {
+    return _hashCode$1(reference.pointer, _id_hashCode$1 as jni.JMethodIDPtr)
         .integer;
   }
 }
@@ -2755,7 +2755,7 @@ class Build_VERSION_CODES extends jni.JObject {
   static const BASE = 1;
 
   /// from: `static public final int BASE_1_1`
-  static const BASE_1_1$ = 2;
+  static const BASE_1_1 = 2;
 
   /// from: `static public final int CUPCAKE`
   static const CUPCAKE = 3;
@@ -2770,10 +2770,10 @@ class Build_VERSION_CODES extends jni.JObject {
   static const ECLAIR = 5;
 
   /// from: `static public final int ECLAIR_0_1`
-  static const ECLAIR_0_1$ = 6;
+  static const ECLAIR_0_1 = 6;
 
   /// from: `static public final int ECLAIR_MR1`
-  static const ECLAIR_MR1$ = 7;
+  static const ECLAIR_MR1 = 7;
 
   /// from: `static public final int FROYO`
   static const FROYO = 8;
@@ -2782,31 +2782,31 @@ class Build_VERSION_CODES extends jni.JObject {
   static const GINGERBREAD = 9;
 
   /// from: `static public final int GINGERBREAD_MR1`
-  static const GINGERBREAD_MR1$ = 10;
+  static const GINGERBREAD_MR1 = 10;
 
   /// from: `static public final int HONEYCOMB`
   static const HONEYCOMB = 11;
 
   /// from: `static public final int HONEYCOMB_MR1`
-  static const HONEYCOMB_MR1$ = 12;
+  static const HONEYCOMB_MR1 = 12;
 
   /// from: `static public final int HONEYCOMB_MR2`
-  static const HONEYCOMB_MR2$ = 13;
+  static const HONEYCOMB_MR2 = 13;
 
   /// from: `static public final int ICE_CREAM_SANDWICH`
   static const ICE_CREAM_SANDWICH = 14;
 
   /// from: `static public final int ICE_CREAM_SANDWICH_MR1`
-  static const ICE_CREAM_SANDWICH_MR1$ = 15;
+  static const ICE_CREAM_SANDWICH_MR1 = 15;
 
   /// from: `static public final int JELLY_BEAN`
   static const JELLY_BEAN = 16;
 
   /// from: `static public final int JELLY_BEAN_MR1`
-  static const JELLY_BEAN_MR1$ = 17;
+  static const JELLY_BEAN_MR1 = 17;
 
   /// from: `static public final int JELLY_BEAN_MR2`
-  static const JELLY_BEAN_MR2$ = 18;
+  static const JELLY_BEAN_MR2 = 18;
 
   /// from: `static public final int KITKAT`
   static const KITKAT = 19;
@@ -2818,7 +2818,7 @@ class Build_VERSION_CODES extends jni.JObject {
   static const LOLLIPOP = 21;
 
   /// from: `static public final int LOLLIPOP_MR1`
-  static const LOLLIPOP_MR1$ = 22;
+  static const LOLLIPOP_MR1 = 22;
 
   /// from: `static public final int M`
   static const M = 23;
@@ -2827,13 +2827,13 @@ class Build_VERSION_CODES extends jni.JObject {
   static const N = 24;
 
   /// from: `static public final int N_MR1`
-  static const N_MR1$ = 25;
+  static const N_MR1 = 25;
 
   /// from: `static public final int O`
   static const O = 26;
 
   /// from: `static public final int O_MR1`
-  static const O_MR1$ = 27;
+  static const O_MR1 = 27;
 
   /// from: `static public final int P`
   static const P = 28;
@@ -2848,7 +2848,7 @@ class Build_VERSION_CODES extends jni.JObject {
   static const S = 31;
 
   /// from: `static public final int S_V2`
-  static const S_V2$ = 32;
+  static const S_V2 = 32;
 
   /// from: `static public final int TIRAMISU`
   static const TIRAMISU = 33;
@@ -2959,15 +2959,15 @@ class Build extends jni.JObject {
   static jni.JString get CPU_ABI =>
       _id_CPU_ABI.get(_class, const jni.JStringType());
 
-  static final _id_CPU_ABI2$ = _class.staticFieldId(
+  static final _id_CPU_ABI2 = _class.staticFieldId(
     r'CPU_ABI2',
     r'Ljava/lang/String;',
   );
 
   /// from: `static public final java.lang.String CPU_ABI2`
   /// The returned object must be released after use, by calling the [release] method.
-  static jni.JString get CPU_ABI2$ =>
-      _id_CPU_ABI2$.get(_class, const jni.JStringType());
+  static jni.JString get CPU_ABI2 =>
+      _id_CPU_ABI2.get(_class, const jni.JStringType());
 
   static final _id_DEVICE = _class.staticFieldId(
     r'DEVICE',
@@ -3374,11 +3374,11 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
             .reference);
   }
 
-  static final _id_new1 = _class.constructorId(
+  static final _id_new$1 = _class.constructorId(
     r'(I)V',
   );
 
-  static final _new1 = ProtectedJniExtensions.lookup<
+  static final _new$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
                   ffi.VarArgs<($Int32,)>)>>('globalEnv_NewObject')
@@ -3388,7 +3388,7 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
 
   /// from: `public void <init>(int i)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory HashMap.new1(
+  factory HashMap.new$1(
     int i, {
     required jni.JObjType<$K> K,
     required jni.JObjType<$V> V,
@@ -3396,15 +3396,15 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
     return HashMap.fromReference(
         K,
         V,
-        _new1(_class.reference.pointer, _id_new1 as jni.JMethodIDPtr, i)
+        _new$1(_class.reference.pointer, _id_new$1 as jni.JMethodIDPtr, i)
             .reference);
   }
 
-  static final _id_new2 = _class.constructorId(
+  static final _id_new$2 = _class.constructorId(
     r'()V',
   );
 
-  static final _new2 = ProtectedJniExtensions.lookup<
+  static final _new$2 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -3418,22 +3418,22 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
 
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
-  factory HashMap.new2({
+  factory HashMap.new$2({
     required jni.JObjType<$K> K,
     required jni.JObjType<$V> V,
   }) {
     return HashMap.fromReference(
         K,
         V,
-        _new2(_class.reference.pointer, _id_new2 as jni.JMethodIDPtr)
+        _new$2(_class.reference.pointer, _id_new$2 as jni.JMethodIDPtr)
             .reference);
   }
 
-  static final _id_new3 = _class.constructorId(
+  static final _id_new$3 = _class.constructorId(
     r'(Ljava/util/Map;)V',
   );
 
-  static final _new3 = ProtectedJniExtensions.lookup<
+  static final _new$3 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -3446,7 +3446,7 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
 
   /// from: `public void <init>(java.util.Map map)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory HashMap.new3(
+  factory HashMap.new$3(
     jni.JMap<$K, $V> map, {
     jni.JObjType<$K>? K,
     jni.JObjType<$V>? V,
@@ -3460,7 +3460,7 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
     return HashMap.fromReference(
         K,
         V,
-        _new3(_class.reference.pointer, _id_new3 as jni.JMethodIDPtr,
+        _new$3(_class.reference.pointer, _id_new$3 as jni.JMethodIDPtr,
                 map.reference.pointer)
             .reference);
   }
@@ -3823,12 +3823,12 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
         .object(V);
   }
 
-  static final _id_remove1 = _class.instanceMethodId(
+  static final _id_remove$1 = _class.instanceMethodId(
     r'remove',
     r'(Ljava/lang/Object;Ljava/lang/Object;)Z',
   );
 
-  static final _remove1 = ProtectedJniExtensions.lookup<
+  static final _remove$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -3843,11 +3843,11 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
               ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
 
   /// from: `public boolean remove(java.lang.Object object, java.lang.Object object1)`
-  bool remove1(
+  bool remove$1(
     jni.JObject object,
     jni.JObject object1,
   ) {
-    return _remove1(reference.pointer, _id_remove1 as jni.JMethodIDPtr,
+    return _remove$1(reference.pointer, _id_remove$1 as jni.JMethodIDPtr,
             object.reference.pointer, object1.reference.pointer)
         .boolean;
   }
@@ -3891,12 +3891,12 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
         .boolean;
   }
 
-  static final _id_replace1 = _class.instanceMethodId(
+  static final _id_replace$1 = _class.instanceMethodId(
     r'replace',
     r'(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;',
   );
 
-  static final _replace1 = ProtectedJniExtensions.lookup<
+  static final _replace$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -3912,11 +3912,11 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
 
   /// from: `public V replace(K object, V object1)`
   /// The returned object must be released after use, by calling the [release] method.
-  $V replace1(
+  $V replace$1(
     $K object,
     $V object1,
   ) {
-    return _replace1(reference.pointer, _id_replace1 as jni.JMethodIDPtr,
+    return _replace$1(reference.pointer, _id_replace$1 as jni.JMethodIDPtr,
             object.reference.pointer, object1.reference.pointer)
         .object(V);
   }

--- a/pkgs/jnigen/example/in_app_java/lib/android_utils.dart
+++ b/pkgs/jnigen/example/in_app_java/lib/android_utils.dart
@@ -2073,14 +2073,14 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelperType
 }
 
 /// from: `androidx.emoji2.text.DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19`
-class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
+class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$
     extends DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper {
   @override
   late final jni
-      .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19>
+      .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$>
       $type = type;
 
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19.fromReference(
+  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$.fromReference(
     jni.JReference reference,
   ) : super.fromReference(reference);
 
@@ -2089,7 +2089,7 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
 
   /// The type which includes information such as the signature of this class.
   static const type =
-      $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19Type();
+      $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type();
   static final _id_new0 = _class.constructorId(
     r'()V',
   );
@@ -2108,8 +2108,8 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
 
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
-  factory DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19() {
-    return DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
+  factory DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$() {
+    return DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$
         .fromReference(
             _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
                 .reference);
@@ -2180,19 +2180,19 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
   }
 }
 
-final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19Type
+final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type
     extends jni
-    .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19> {
-  const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19Type();
+    .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$> {
+  const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type();
 
   @override
   String get signature =>
       r'Landroidx/emoji2/text/DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19;';
 
   @override
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19 fromReference(
+  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$ fromReference(
           jni.JReference reference) =>
-      DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
+      DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$
           .fromReference(reference);
 
   @override
@@ -2204,27 +2204,27 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19Type
 
   @override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19Type)
+      ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type)
           .hashCode;
 
   @override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19Type) &&
+            ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type) &&
         other
-            is $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19Type;
+            is $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type;
   }
 }
 
 /// from: `androidx.emoji2.text.DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28`
-class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
-    extends DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19 {
+class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$
+    extends DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$ {
   @override
   late final jni
-      .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28>
+      .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$>
       $type = type;
 
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28.fromReference(
+  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$.fromReference(
     jni.JReference reference,
   ) : super.fromReference(reference);
 
@@ -2233,7 +2233,7 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
 
   /// The type which includes information such as the signature of this class.
   static const type =
-      $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28Type();
+      $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type();
   static final _id_new0 = _class.constructorId(
     r'()V',
   );
@@ -2252,8 +2252,8 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
 
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
-  factory DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28() {
-    return DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
+  factory DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$() {
+    return DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$
         .fromReference(
             _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
                 .reference);
@@ -2293,39 +2293,39 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
   }
 }
 
-final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28Type
+final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type
     extends jni
-    .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28> {
-  const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28Type();
+    .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$> {
+  const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type();
 
   @override
   String get signature =>
       r'Landroidx/emoji2/text/DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28;';
 
   @override
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28 fromReference(
+  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$ fromReference(
           jni.JReference reference) =>
-      DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
+      DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$
           .fromReference(reference);
 
   @override
   jni.JObjType get superType =>
-      const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19Type();
+      const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type();
 
   @override
   final superCount = 3;
 
   @override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28Type)
+      ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type)
           .hashCode;
 
   @override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28Type) &&
+            ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type) &&
         other
-            is $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28Type;
+            is $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type;
   }
 }
 
@@ -2755,7 +2755,7 @@ class Build_VERSION_CODES extends jni.JObject {
   static const BASE = 1;
 
   /// from: `static public final int BASE_1_1`
-  static const BASE_1_1 = 2;
+  static const BASE_1_1$ = 2;
 
   /// from: `static public final int CUPCAKE`
   static const CUPCAKE = 3;
@@ -2770,10 +2770,10 @@ class Build_VERSION_CODES extends jni.JObject {
   static const ECLAIR = 5;
 
   /// from: `static public final int ECLAIR_0_1`
-  static const ECLAIR_0_1 = 6;
+  static const ECLAIR_0_1$ = 6;
 
   /// from: `static public final int ECLAIR_MR1`
-  static const ECLAIR_MR1 = 7;
+  static const ECLAIR_MR1$ = 7;
 
   /// from: `static public final int FROYO`
   static const FROYO = 8;
@@ -2782,31 +2782,31 @@ class Build_VERSION_CODES extends jni.JObject {
   static const GINGERBREAD = 9;
 
   /// from: `static public final int GINGERBREAD_MR1`
-  static const GINGERBREAD_MR1 = 10;
+  static const GINGERBREAD_MR1$ = 10;
 
   /// from: `static public final int HONEYCOMB`
   static const HONEYCOMB = 11;
 
   /// from: `static public final int HONEYCOMB_MR1`
-  static const HONEYCOMB_MR1 = 12;
+  static const HONEYCOMB_MR1$ = 12;
 
   /// from: `static public final int HONEYCOMB_MR2`
-  static const HONEYCOMB_MR2 = 13;
+  static const HONEYCOMB_MR2$ = 13;
 
   /// from: `static public final int ICE_CREAM_SANDWICH`
   static const ICE_CREAM_SANDWICH = 14;
 
   /// from: `static public final int ICE_CREAM_SANDWICH_MR1`
-  static const ICE_CREAM_SANDWICH_MR1 = 15;
+  static const ICE_CREAM_SANDWICH_MR1$ = 15;
 
   /// from: `static public final int JELLY_BEAN`
   static const JELLY_BEAN = 16;
 
   /// from: `static public final int JELLY_BEAN_MR1`
-  static const JELLY_BEAN_MR1 = 17;
+  static const JELLY_BEAN_MR1$ = 17;
 
   /// from: `static public final int JELLY_BEAN_MR2`
-  static const JELLY_BEAN_MR2 = 18;
+  static const JELLY_BEAN_MR2$ = 18;
 
   /// from: `static public final int KITKAT`
   static const KITKAT = 19;
@@ -2818,7 +2818,7 @@ class Build_VERSION_CODES extends jni.JObject {
   static const LOLLIPOP = 21;
 
   /// from: `static public final int LOLLIPOP_MR1`
-  static const LOLLIPOP_MR1 = 22;
+  static const LOLLIPOP_MR1$ = 22;
 
   /// from: `static public final int M`
   static const M = 23;
@@ -2827,13 +2827,13 @@ class Build_VERSION_CODES extends jni.JObject {
   static const N = 24;
 
   /// from: `static public final int N_MR1`
-  static const N_MR1 = 25;
+  static const N_MR1$ = 25;
 
   /// from: `static public final int O`
   static const O = 26;
 
   /// from: `static public final int O_MR1`
-  static const O_MR1 = 27;
+  static const O_MR1$ = 27;
 
   /// from: `static public final int P`
   static const P = 28;
@@ -2848,7 +2848,7 @@ class Build_VERSION_CODES extends jni.JObject {
   static const S = 31;
 
   /// from: `static public final int S_V2`
-  static const S_V2 = 32;
+  static const S_V2$ = 32;
 
   /// from: `static public final int TIRAMISU`
   static const TIRAMISU = 33;
@@ -2959,15 +2959,15 @@ class Build extends jni.JObject {
   static jni.JString get CPU_ABI =>
       _id_CPU_ABI.get(_class, const jni.JStringType());
 
-  static final _id_CPU_ABI2 = _class.staticFieldId(
+  static final _id_CPU_ABI2$ = _class.staticFieldId(
     r'CPU_ABI2',
     r'Ljava/lang/String;',
   );
 
   /// from: `static public final java.lang.String CPU_ABI2`
   /// The returned object must be released after use, by calling the [release] method.
-  static jni.JString get CPU_ABI2 =>
-      _id_CPU_ABI2.get(_class, const jni.JStringType());
+  static jni.JString get CPU_ABI2$ =>
+      _id_CPU_ABI2$.get(_class, const jni.JStringType());
 
   static final _id_DEVICE = _class.staticFieldId(
     r'DEVICE',

--- a/pkgs/jnigen/example/in_app_java/lib/android_utils.dart
+++ b/pkgs/jnigen/example/in_app_java/lib/android_utils.dart
@@ -387,11 +387,11 @@ class EmojiCompat_DefaultSpanFactory extends jni.JObject {
 
   /// The type which includes information such as the signature of this class.
   static const type = $EmojiCompat_DefaultSpanFactoryType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -407,7 +407,7 @@ class EmojiCompat_DefaultSpanFactory extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory EmojiCompat_DefaultSpanFactory() {
     return EmojiCompat_DefaultSpanFactory.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 
@@ -1201,12 +1201,12 @@ class EmojiCompat extends jni.JObject {
         .check();
   }
 
-  static final _id_get0 = _class.staticMethodId(
+  static final _id_get$ = _class.staticMethodId(
     r'get',
     r'()Landroidx/emoji2/text/EmojiCompat;',
   );
 
-  static final _get0 = ProtectedJniExtensions.lookup<
+  static final _get$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -1220,8 +1220,8 @@ class EmojiCompat extends jni.JObject {
 
   /// from: `static public androidx.emoji2.text.EmojiCompat get()`
   /// The returned object must be released after use, by calling the [release] method.
-  static EmojiCompat get0() {
-    return _get0(_class.reference.pointer, _id_get0 as jni.JMethodIDPtr)
+  static EmojiCompat get$() {
+    return _get$(_class.reference.pointer, _id_get$ as jni.JMethodIDPtr)
         .object(const $EmojiCompatType());
   }
 
@@ -1809,11 +1809,11 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory
   /// The type which includes information such as the signature of this class.
   static const type =
       $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactoryType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'(Landroidx/emoji2/text/DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper;)V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1831,9 +1831,9 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory
         defaultEmojiCompatConfigHelper,
   ) {
     return DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory
-        .fromReference(_new0(
+        .fromReference(_new$(
                 _class.reference.pointer,
-                _id_new0 as jni.JMethodIDPtr,
+                _id_new$ as jni.JMethodIDPtr,
                 defaultEmojiCompatConfigHelper.reference.pointer)
             .reference);
   }
@@ -1916,11 +1916,11 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper
   /// The type which includes information such as the signature of this class.
   static const type =
       $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelperType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -1937,7 +1937,7 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper
   factory DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper() {
     return DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper
         .fromReference(
-            _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
                 .reference);
   }
 
@@ -2090,11 +2090,11 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
   /// The type which includes information such as the signature of this class.
   static const type =
       $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19Type();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -2111,7 +2111,7 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
   factory DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19() {
     return DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
         .fromReference(
-            _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
                 .reference);
   }
 
@@ -2234,11 +2234,11 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
   /// The type which includes information such as the signature of this class.
   static const type =
       $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28Type();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -2255,7 +2255,7 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
   factory DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28() {
     return DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
         .fromReference(
-            _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+            _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
                 .reference);
   }
 
@@ -2686,11 +2686,11 @@ class Build_VERSION extends jni.JObject {
   static jni.JString get SECURITY_PATCH =>
       _id_SECURITY_PATCH.get(_class, const jni.JStringType());
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -2706,7 +2706,7 @@ class Build_VERSION extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory Build_VERSION() {
     return Build_VERSION.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 }
@@ -2855,11 +2855,11 @@ class Build_VERSION_CODES extends jni.JObject {
 
   /// from: `static public final int UPSIDE_DOWN_CAKE`
   static const UPSIDE_DOWN_CAKE = 34;
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -2875,7 +2875,7 @@ class Build_VERSION_CODES extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory Build_VERSION_CODES() {
     return Build_VERSION_CODES.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 }
@@ -3193,11 +3193,11 @@ class Build extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   static jni.JString get USER => _id_USER.get(_class, const jni.JStringType());
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -3213,7 +3213,7 @@ class Build extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory Build() {
     return Build.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 
@@ -3347,11 +3347,11 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
     );
   }
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'(IF)V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
                   ffi.VarArgs<($Int32, ffi.Double)>)>>('globalEnv_NewObject')
@@ -3370,7 +3370,7 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
     return HashMap.fromReference(
         K,
         V,
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr, i, f)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr, i, f)
             .reference);
   }
 
@@ -3509,12 +3509,12 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
     return _isEmpty(reference.pointer, _id_isEmpty as jni.JMethodIDPtr).boolean;
   }
 
-  static final _id_get0 = _class.instanceMethodId(
+  static final _id_get$ = _class.instanceMethodId(
     r'get',
     r'(Ljava/lang/Object;)Ljava/lang/Object;',
   );
 
-  static final _get0 = ProtectedJniExtensions.lookup<
+  static final _get$ = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -3527,10 +3527,10 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
 
   /// from: `public V get(java.lang.Object object)`
   /// The returned object must be released after use, by calling the [release] method.
-  $V get0(
+  $V get$(
     jni.JObject object,
   ) {
-    return _get0(reference.pointer, _id_get0 as jni.JMethodIDPtr,
+    return _get$(reference.pointer, _id_get$ as jni.JMethodIDPtr,
             object.reference.pointer)
         .object(V);
   }

--- a/pkgs/jnigen/example/in_app_java/lib/main.dart
+++ b/pkgs/jnigen/example/in_app_java/lib/main.dart
@@ -12,9 +12,9 @@ import 'android_utils.dart';
 JObject activity = JObject.fromReference(Jni.getCurrentActivity());
 JObject context = JObject.fromReference(Jni.getCachedApplicationContext());
 
-final hashmap = HashMap.new2(K: JString.type, V: JString.type);
+final hashmap = HashMap.new$2(K: JString.type, V: JString.type);
 
-final emojiCompat = EmojiCompat.get0();
+final emojiCompat = EmojiCompat.get$();
 
 extension IntX on int {
   JString toJString() {

--- a/pkgs/jnigen/example/kotlin_plugin/lib/kotlin_bindings.dart
+++ b/pkgs/jnigen/example/kotlin_plugin/lib/kotlin_bindings.dart
@@ -41,11 +41,11 @@ class Example extends jni.JObject {
 
   /// The type which includes information such as the signature of this class.
   static const type = $ExampleType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -61,7 +61,7 @@ class Example extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory Example() {
     return Example.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 

--- a/pkgs/jnigen/example/notification_plugin/lib/notifications.dart
+++ b/pkgs/jnigen/example/notification_plugin/lib/notifications.dart
@@ -46,11 +46,11 @@ class Notifications extends jni.JObject {
 
   /// The type which includes information such as the signature of this class.
   static const type = $NotificationsType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -66,7 +66,7 @@ class Notifications extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory Notifications() {
     return Notifications.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 

--- a/pkgs/jnigen/example/pdfbox_plugin/dart_example/bin/pdf_info.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/dart_example/bin/pdf_info.dart
@@ -14,7 +14,7 @@ void writeInfo(String file) {
   final inputFile = fileInputStreamClass
       .constructorId("(Ljava/lang/String;)V")
       .call(fileInputStreamClass, JObject.type, [file.toJString()]);
-  final pdDoc = PDDocument.load6(inputFile);
+  final pdDoc = PDDocument.load$6(inputFile);
   int pages = pdDoc.getNumberOfPages();
   final info = pdDoc.getDocumentInformation();
   final title = info.getTitle();

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
@@ -66,11 +66,11 @@ class PDDocument extends jni.JObject {
 
   /// The type which includes information such as the signature of this class.
   static const type = $PDDocumentType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -89,7 +89,7 @@ class PDDocument extends jni.JObject {
   /// You need to add at least one page for the document to be valid.
   factory PDDocument() {
     return PDDocument.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
@@ -93,11 +93,11 @@ class PDDocument extends jni.JObject {
             .reference);
   }
 
-  static final _id_new1 = _class.constructorId(
+  static final _id_new$1 = _class.constructorId(
     r'(Lorg/apache/pdfbox/io/MemoryUsageSetting;)V',
   );
 
-  static final _new1 = ProtectedJniExtensions.lookup<
+  static final _new$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -114,19 +114,19 @@ class PDDocument extends jni.JObject {
   /// Creates an empty PDF document.
   /// You need to add at least one page for the document to be valid.
   ///@param memUsageSetting defines how memory is used for buffering PDF streams
-  factory PDDocument.new1(
+  factory PDDocument.new$1(
     jni.JObject memUsageSetting,
   ) {
-    return PDDocument.fromReference(_new1(_class.reference.pointer,
-            _id_new1 as jni.JMethodIDPtr, memUsageSetting.reference.pointer)
+    return PDDocument.fromReference(_new$1(_class.reference.pointer,
+            _id_new$1 as jni.JMethodIDPtr, memUsageSetting.reference.pointer)
         .reference);
   }
 
-  static final _id_new2 = _class.constructorId(
+  static final _id_new$2 = _class.constructorId(
     r'(Lorg/apache/pdfbox/cos/COSDocument;)V',
   );
 
-  static final _new2 = ProtectedJniExtensions.lookup<
+  static final _new$2 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -142,19 +142,19 @@ class PDDocument extends jni.JObject {
   ///
   /// Constructor that uses an existing document. The COSDocument that is passed in must be valid.
   ///@param doc The COSDocument that this document wraps.
-  factory PDDocument.new2(
+  factory PDDocument.new$2(
     jni.JObject doc,
   ) {
-    return PDDocument.fromReference(_new2(_class.reference.pointer,
-            _id_new2 as jni.JMethodIDPtr, doc.reference.pointer)
+    return PDDocument.fromReference(_new$2(_class.reference.pointer,
+            _id_new$2 as jni.JMethodIDPtr, doc.reference.pointer)
         .reference);
   }
 
-  static final _id_new3 = _class.constructorId(
+  static final _id_new$3 = _class.constructorId(
     r'(Lorg/apache/pdfbox/cos/COSDocument;Lorg/apache/pdfbox/io/RandomAccessRead;)V',
   );
 
-  static final _new3 = ProtectedJniExtensions.lookup<
+  static final _new$3 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -174,23 +174,23 @@ class PDDocument extends jni.JObject {
   /// Constructor that uses an existing document. The COSDocument that is passed in must be valid.
   ///@param doc The COSDocument that this document wraps.
   ///@param source the parser which is used to read the pdf
-  factory PDDocument.new3(
+  factory PDDocument.new$3(
     jni.JObject doc,
     jni.JObject source,
   ) {
-    return PDDocument.fromReference(_new3(
+    return PDDocument.fromReference(_new$3(
             _class.reference.pointer,
-            _id_new3 as jni.JMethodIDPtr,
+            _id_new$3 as jni.JMethodIDPtr,
             doc.reference.pointer,
             source.reference.pointer)
         .reference);
   }
 
-  static final _id_new4 = _class.constructorId(
+  static final _id_new$4 = _class.constructorId(
     r'(Lorg/apache/pdfbox/cos/COSDocument;Lorg/apache/pdfbox/io/RandomAccessRead;Lorg/apache/pdfbox/pdmodel/encryption/AccessPermission;)V',
   );
 
-  static final _new4 = ProtectedJniExtensions.lookup<
+  static final _new$4 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -216,14 +216,14 @@ class PDDocument extends jni.JObject {
   ///@param doc The COSDocument that this document wraps.
   ///@param source the parser which is used to read the pdf
   ///@param permission he access permissions of the pdf
-  factory PDDocument.new4(
+  factory PDDocument.new$4(
     jni.JObject doc,
     jni.JObject source,
     jni.JObject permission,
   ) {
-    return PDDocument.fromReference(_new4(
+    return PDDocument.fromReference(_new$4(
             _class.reference.pointer,
-            _id_new4 as jni.JMethodIDPtr,
+            _id_new$4 as jni.JMethodIDPtr,
             doc.reference.pointer,
             source.reference.pointer,
             permission.reference.pointer)
@@ -295,12 +295,12 @@ class PDDocument extends jni.JObject {
         .check();
   }
 
-  static final _id_addSignature1 = _class.instanceMethodId(
+  static final _id_addSignature$1 = _class.instanceMethodId(
     r'addSignature',
     r'(Lorg/apache/pdfbox/pdmodel/interactive/digitalsignature/PDSignature;Lorg/apache/pdfbox/pdmodel/interactive/digitalsignature/SignatureOptions;)V',
   );
 
-  static final _addSignature1 = ProtectedJniExtensions.lookup<
+  static final _addSignature$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
@@ -327,21 +327,21 @@ class PDDocument extends jni.JObject {
   ///@throws IOException if there is an error creating required fields
   ///@throws IllegalStateException if one attempts to add several signature
   /// fields.
-  void addSignature1(
+  void addSignature$1(
     jni.JObject sigObject,
     jni.JObject options,
   ) {
-    _addSignature1(reference.pointer, _id_addSignature1 as jni.JMethodIDPtr,
+    _addSignature$1(reference.pointer, _id_addSignature$1 as jni.JMethodIDPtr,
             sigObject.reference.pointer, options.reference.pointer)
         .check();
   }
 
-  static final _id_addSignature2 = _class.instanceMethodId(
+  static final _id_addSignature$2 = _class.instanceMethodId(
     r'addSignature',
     r'(Lorg/apache/pdfbox/pdmodel/interactive/digitalsignature/PDSignature;Lorg/apache/pdfbox/pdmodel/interactive/digitalsignature/SignatureInterface;)V',
   );
 
-  static final _addSignature2 = ProtectedJniExtensions.lookup<
+  static final _addSignature$2 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
@@ -367,21 +367,21 @@ class PDDocument extends jni.JObject {
   ///@throws IOException if there is an error creating required fields
   ///@throws IllegalStateException if one attempts to add several signature
   /// fields.
-  void addSignature2(
+  void addSignature$2(
     jni.JObject sigObject,
     jni.JObject signatureInterface,
   ) {
-    _addSignature2(reference.pointer, _id_addSignature2 as jni.JMethodIDPtr,
+    _addSignature$2(reference.pointer, _id_addSignature$2 as jni.JMethodIDPtr,
             sigObject.reference.pointer, signatureInterface.reference.pointer)
         .check();
   }
 
-  static final _id_addSignature3 = _class.instanceMethodId(
+  static final _id_addSignature$3 = _class.instanceMethodId(
     r'addSignature',
     r'(Lorg/apache/pdfbox/pdmodel/interactive/digitalsignature/PDSignature;Lorg/apache/pdfbox/pdmodel/interactive/digitalsignature/SignatureInterface;Lorg/apache/pdfbox/pdmodel/interactive/digitalsignature/SignatureOptions;)V',
   );
 
-  static final _addSignature3 = ProtectedJniExtensions.lookup<
+  static final _addSignature$3 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
@@ -415,14 +415,14 @@ class PDDocument extends jni.JObject {
   ///@throws IOException if there is an error creating required fields
   ///@throws IllegalStateException if one attempts to add several signature
   /// fields.
-  void addSignature3(
+  void addSignature$3(
     jni.JObject sigObject,
     jni.JObject signatureInterface,
     jni.JObject options,
   ) {
-    _addSignature3(
+    _addSignature$3(
             reference.pointer,
-            _id_addSignature3 as jni.JMethodIDPtr,
+            _id_addSignature$3 as jni.JMethodIDPtr,
             sigObject.reference.pointer,
             signatureInterface.reference.pointer,
             options.reference.pointer)
@@ -505,12 +505,12 @@ class PDDocument extends jni.JObject {
         .check();
   }
 
-  static final _id_removePage1 = _class.instanceMethodId(
+  static final _id_removePage$1 = _class.instanceMethodId(
     r'removePage',
     r'(I)V',
   );
 
-  static final _removePage1 = ProtectedJniExtensions.lookup<
+  static final _removePage$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
@@ -524,11 +524,11 @@ class PDDocument extends jni.JObject {
   ///
   /// Remove the page from the document.
   ///@param pageNumber 0 based index to page number.
-  void removePage1(
+  void removePage$1(
     int pageNumber,
   ) {
-    _removePage1(
-            reference.pointer, _id_removePage1 as jni.JMethodIDPtr, pageNumber)
+    _removePage$1(
+            reference.pointer, _id_removePage$1 as jni.JMethodIDPtr, pageNumber)
         .check();
   }
 
@@ -942,12 +942,12 @@ class PDDocument extends jni.JObject {
         .object(const $PDDocumentType());
   }
 
-  static final _id_load1 = _class.staticMethodId(
+  static final _id_load$1 = _class.staticMethodId(
     r'load',
     r'(Ljava/io/File;Lorg/apache/pdfbox/io/MemoryUsageSetting;)Lorg/apache/pdfbox/pdmodel/PDDocument;',
   );
 
-  static final _load1 = ProtectedJniExtensions.lookup<
+  static final _load$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -970,21 +970,21 @@ class PDDocument extends jni.JObject {
   ///@return loaded document
   ///@throws InvalidPasswordException If the file required a non-empty password.
   ///@throws IOException in case of a file reading or parsing error
-  static PDDocument load1(
+  static PDDocument load$1(
     jni.JObject file,
     jni.JObject memUsageSetting,
   ) {
-    return _load1(_class.reference.pointer, _id_load1 as jni.JMethodIDPtr,
+    return _load$1(_class.reference.pointer, _id_load$1 as jni.JMethodIDPtr,
             file.reference.pointer, memUsageSetting.reference.pointer)
         .object(const $PDDocumentType());
   }
 
-  static final _id_load2 = _class.staticMethodId(
+  static final _id_load$2 = _class.staticMethodId(
     r'load',
     r'(Ljava/io/File;Ljava/lang/String;)Lorg/apache/pdfbox/pdmodel/PDDocument;',
   );
 
-  static final _load2 = ProtectedJniExtensions.lookup<
+  static final _load$2 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1007,21 +1007,21 @@ class PDDocument extends jni.JObject {
   ///@return loaded document
   ///@throws InvalidPasswordException If the password is incorrect.
   ///@throws IOException in case of a file reading or parsing error
-  static PDDocument load2(
+  static PDDocument load$2(
     jni.JObject file,
     jni.JString password,
   ) {
-    return _load2(_class.reference.pointer, _id_load2 as jni.JMethodIDPtr,
+    return _load$2(_class.reference.pointer, _id_load$2 as jni.JMethodIDPtr,
             file.reference.pointer, password.reference.pointer)
         .object(const $PDDocumentType());
   }
 
-  static final _id_load3 = _class.staticMethodId(
+  static final _id_load$3 = _class.staticMethodId(
     r'load',
     r'(Ljava/io/File;Ljava/lang/String;Lorg/apache/pdfbox/io/MemoryUsageSetting;)Lorg/apache/pdfbox/pdmodel/PDDocument;',
   );
 
-  static final _load3 = ProtectedJniExtensions.lookup<
+  static final _load$3 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1050,26 +1050,26 @@ class PDDocument extends jni.JObject {
   ///@return loaded document
   ///@throws InvalidPasswordException If the password is incorrect.
   ///@throws IOException in case of a file reading or parsing error
-  static PDDocument load3(
+  static PDDocument load$3(
     jni.JObject file,
     jni.JString password,
     jni.JObject memUsageSetting,
   ) {
-    return _load3(
+    return _load$3(
             _class.reference.pointer,
-            _id_load3 as jni.JMethodIDPtr,
+            _id_load$3 as jni.JMethodIDPtr,
             file.reference.pointer,
             password.reference.pointer,
             memUsageSetting.reference.pointer)
         .object(const $PDDocumentType());
   }
 
-  static final _id_load4 = _class.staticMethodId(
+  static final _id_load$4 = _class.staticMethodId(
     r'load',
     r'(Ljava/io/File;Ljava/lang/String;Ljava/io/InputStream;Ljava/lang/String;)Lorg/apache/pdfbox/pdmodel/PDDocument;',
   );
 
-  static final _load4 = ProtectedJniExtensions.lookup<
+  static final _load$4 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1100,15 +1100,15 @@ class PDDocument extends jni.JObject {
   ///@param alias alias to be used for decryption when using public key security
   ///@return loaded document
   ///@throws IOException in case of a file reading or parsing error
-  static PDDocument load4(
+  static PDDocument load$4(
     jni.JObject file,
     jni.JString password,
     jni.JObject keyStore,
     jni.JString alias,
   ) {
-    return _load4(
+    return _load$4(
             _class.reference.pointer,
-            _id_load4 as jni.JMethodIDPtr,
+            _id_load$4 as jni.JMethodIDPtr,
             file.reference.pointer,
             password.reference.pointer,
             keyStore.reference.pointer,
@@ -1116,12 +1116,12 @@ class PDDocument extends jni.JObject {
         .object(const $PDDocumentType());
   }
 
-  static final _id_load5 = _class.staticMethodId(
+  static final _id_load$5 = _class.staticMethodId(
     r'load',
     r'(Ljava/io/File;Ljava/lang/String;Ljava/io/InputStream;Ljava/lang/String;Lorg/apache/pdfbox/io/MemoryUsageSetting;)Lorg/apache/pdfbox/pdmodel/PDDocument;',
   );
 
-  static final _load5 = ProtectedJniExtensions.lookup<
+  static final _load$5 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1155,16 +1155,16 @@ class PDDocument extends jni.JObject {
   ///@param memUsageSetting defines how memory is used for buffering PDF streams
   ///@return loaded document
   ///@throws IOException in case of a file reading or parsing error
-  static PDDocument load5(
+  static PDDocument load$5(
     jni.JObject file,
     jni.JString password,
     jni.JObject keyStore,
     jni.JString alias,
     jni.JObject memUsageSetting,
   ) {
-    return _load5(
+    return _load$5(
             _class.reference.pointer,
-            _id_load5 as jni.JMethodIDPtr,
+            _id_load$5 as jni.JMethodIDPtr,
             file.reference.pointer,
             password.reference.pointer,
             keyStore.reference.pointer,
@@ -1173,12 +1173,12 @@ class PDDocument extends jni.JObject {
         .object(const $PDDocumentType());
   }
 
-  static final _id_load6 = _class.staticMethodId(
+  static final _id_load$6 = _class.staticMethodId(
     r'load',
     r'(Ljava/io/InputStream;)Lorg/apache/pdfbox/pdmodel/PDDocument;',
   );
 
-  static final _load6 = ProtectedJniExtensions.lookup<
+  static final _load$6 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1198,20 +1198,20 @@ class PDDocument extends jni.JObject {
   ///@return loaded document
   ///@throws InvalidPasswordException If the PDF required a non-empty password.
   ///@throws IOException In case of a reading or parsing error.
-  static PDDocument load6(
+  static PDDocument load$6(
     jni.JObject input,
   ) {
-    return _load6(_class.reference.pointer, _id_load6 as jni.JMethodIDPtr,
+    return _load$6(_class.reference.pointer, _id_load$6 as jni.JMethodIDPtr,
             input.reference.pointer)
         .object(const $PDDocumentType());
   }
 
-  static final _id_load7 = _class.staticMethodId(
+  static final _id_load$7 = _class.staticMethodId(
     r'load',
     r'(Ljava/io/InputStream;Lorg/apache/pdfbox/io/MemoryUsageSetting;)Lorg/apache/pdfbox/pdmodel/PDDocument;',
   );
 
-  static final _load7 = ProtectedJniExtensions.lookup<
+  static final _load$7 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1235,21 +1235,21 @@ class PDDocument extends jni.JObject {
   ///@return loaded document
   ///@throws InvalidPasswordException If the PDF required a non-empty password.
   ///@throws IOException In case of a reading or parsing error.
-  static PDDocument load7(
+  static PDDocument load$7(
     jni.JObject input,
     jni.JObject memUsageSetting,
   ) {
-    return _load7(_class.reference.pointer, _id_load7 as jni.JMethodIDPtr,
+    return _load$7(_class.reference.pointer, _id_load$7 as jni.JMethodIDPtr,
             input.reference.pointer, memUsageSetting.reference.pointer)
         .object(const $PDDocumentType());
   }
 
-  static final _id_load8 = _class.staticMethodId(
+  static final _id_load$8 = _class.staticMethodId(
     r'load',
     r'(Ljava/io/InputStream;Ljava/lang/String;)Lorg/apache/pdfbox/pdmodel/PDDocument;',
   );
 
-  static final _load8 = ProtectedJniExtensions.lookup<
+  static final _load$8 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1273,21 +1273,21 @@ class PDDocument extends jni.JObject {
   ///@return loaded document
   ///@throws InvalidPasswordException If the password is incorrect.
   ///@throws IOException In case of a reading or parsing error.
-  static PDDocument load8(
+  static PDDocument load$8(
     jni.JObject input,
     jni.JString password,
   ) {
-    return _load8(_class.reference.pointer, _id_load8 as jni.JMethodIDPtr,
+    return _load$8(_class.reference.pointer, _id_load$8 as jni.JMethodIDPtr,
             input.reference.pointer, password.reference.pointer)
         .object(const $PDDocumentType());
   }
 
-  static final _id_load9 = _class.staticMethodId(
+  static final _id_load$9 = _class.staticMethodId(
     r'load',
     r'(Ljava/io/InputStream;Ljava/lang/String;Ljava/io/InputStream;Ljava/lang/String;)Lorg/apache/pdfbox/pdmodel/PDDocument;',
   );
 
-  static final _load9 = ProtectedJniExtensions.lookup<
+  static final _load$9 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1319,15 +1319,15 @@ class PDDocument extends jni.JObject {
   ///@param alias alias to be used for decryption when using public key security
   ///@return loaded document
   ///@throws IOException In case of a reading or parsing error.
-  static PDDocument load9(
+  static PDDocument load$9(
     jni.JObject input,
     jni.JString password,
     jni.JObject keyStore,
     jni.JString alias,
   ) {
-    return _load9(
+    return _load$9(
             _class.reference.pointer,
-            _id_load9 as jni.JMethodIDPtr,
+            _id_load$9 as jni.JMethodIDPtr,
             input.reference.pointer,
             password.reference.pointer,
             keyStore.reference.pointer,
@@ -1335,12 +1335,12 @@ class PDDocument extends jni.JObject {
         .object(const $PDDocumentType());
   }
 
-  static final _id_load10 = _class.staticMethodId(
+  static final _id_load$10 = _class.staticMethodId(
     r'load',
     r'(Ljava/io/InputStream;Ljava/lang/String;Lorg/apache/pdfbox/io/MemoryUsageSetting;)Lorg/apache/pdfbox/pdmodel/PDDocument;',
   );
 
-  static final _load10 = ProtectedJniExtensions.lookup<
+  static final _load$10 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1370,26 +1370,26 @@ class PDDocument extends jni.JObject {
   ///@return loaded document
   ///@throws InvalidPasswordException If the password is incorrect.
   ///@throws IOException In case of a reading or parsing error.
-  static PDDocument load10(
+  static PDDocument load$10(
     jni.JObject input,
     jni.JString password,
     jni.JObject memUsageSetting,
   ) {
-    return _load10(
+    return _load$10(
             _class.reference.pointer,
-            _id_load10 as jni.JMethodIDPtr,
+            _id_load$10 as jni.JMethodIDPtr,
             input.reference.pointer,
             password.reference.pointer,
             memUsageSetting.reference.pointer)
         .object(const $PDDocumentType());
   }
 
-  static final _id_load11 = _class.staticMethodId(
+  static final _id_load$11 = _class.staticMethodId(
     r'load',
     r'(Ljava/io/InputStream;Ljava/lang/String;Ljava/io/InputStream;Ljava/lang/String;Lorg/apache/pdfbox/io/MemoryUsageSetting;)Lorg/apache/pdfbox/pdmodel/PDDocument;',
   );
 
-  static final _load11 = ProtectedJniExtensions.lookup<
+  static final _load$11 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1425,16 +1425,16 @@ class PDDocument extends jni.JObject {
   ///@return loaded document
   ///@throws InvalidPasswordException If the password is incorrect.
   ///@throws IOException In case of a reading or parsing error.
-  static PDDocument load11(
+  static PDDocument load$11(
     jni.JObject input,
     jni.JString password,
     jni.JObject keyStore,
     jni.JString alias,
     jni.JObject memUsageSetting,
   ) {
-    return _load11(
+    return _load$11(
             _class.reference.pointer,
-            _id_load11 as jni.JMethodIDPtr,
+            _id_load$11 as jni.JMethodIDPtr,
             input.reference.pointer,
             password.reference.pointer,
             keyStore.reference.pointer,
@@ -1443,12 +1443,12 @@ class PDDocument extends jni.JObject {
         .object(const $PDDocumentType());
   }
 
-  static final _id_load12 = _class.staticMethodId(
+  static final _id_load$12 = _class.staticMethodId(
     r'load',
     r'([B)Lorg/apache/pdfbox/pdmodel/PDDocument;',
   );
 
-  static final _load12 = ProtectedJniExtensions.lookup<
+  static final _load$12 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1467,20 +1467,20 @@ class PDDocument extends jni.JObject {
   ///@return loaded document
   ///@throws InvalidPasswordException If the PDF required a non-empty password.
   ///@throws IOException In case of a reading or parsing error.
-  static PDDocument load12(
+  static PDDocument load$12(
     jni.JArray<jni.jbyte> input,
   ) {
-    return _load12(_class.reference.pointer, _id_load12 as jni.JMethodIDPtr,
+    return _load$12(_class.reference.pointer, _id_load$12 as jni.JMethodIDPtr,
             input.reference.pointer)
         .object(const $PDDocumentType());
   }
 
-  static final _id_load13 = _class.staticMethodId(
+  static final _id_load$13 = _class.staticMethodId(
     r'load',
     r'([BLjava/lang/String;)Lorg/apache/pdfbox/pdmodel/PDDocument;',
   );
 
-  static final _load13 = ProtectedJniExtensions.lookup<
+  static final _load$13 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1503,21 +1503,21 @@ class PDDocument extends jni.JObject {
   ///@return loaded document
   ///@throws InvalidPasswordException If the password is incorrect.
   ///@throws IOException In case of a reading or parsing error.
-  static PDDocument load13(
+  static PDDocument load$13(
     jni.JArray<jni.jbyte> input,
     jni.JString password,
   ) {
-    return _load13(_class.reference.pointer, _id_load13 as jni.JMethodIDPtr,
+    return _load$13(_class.reference.pointer, _id_load$13 as jni.JMethodIDPtr,
             input.reference.pointer, password.reference.pointer)
         .object(const $PDDocumentType());
   }
 
-  static final _id_load14 = _class.staticMethodId(
+  static final _id_load$14 = _class.staticMethodId(
     r'load',
     r'([BLjava/lang/String;Ljava/io/InputStream;Ljava/lang/String;)Lorg/apache/pdfbox/pdmodel/PDDocument;',
   );
 
-  static final _load14 = ProtectedJniExtensions.lookup<
+  static final _load$14 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1549,15 +1549,15 @@ class PDDocument extends jni.JObject {
   ///@return loaded document
   ///@throws InvalidPasswordException If the password is incorrect.
   ///@throws IOException In case of a reading or parsing error.
-  static PDDocument load14(
+  static PDDocument load$14(
     jni.JArray<jni.jbyte> input,
     jni.JString password,
     jni.JObject keyStore,
     jni.JString alias,
   ) {
-    return _load14(
+    return _load$14(
             _class.reference.pointer,
-            _id_load14 as jni.JMethodIDPtr,
+            _id_load$14 as jni.JMethodIDPtr,
             input.reference.pointer,
             password.reference.pointer,
             keyStore.reference.pointer,
@@ -1565,12 +1565,12 @@ class PDDocument extends jni.JObject {
         .object(const $PDDocumentType());
   }
 
-  static final _id_load15 = _class.staticMethodId(
+  static final _id_load$15 = _class.staticMethodId(
     r'load',
     r'([BLjava/lang/String;Ljava/io/InputStream;Ljava/lang/String;Lorg/apache/pdfbox/io/MemoryUsageSetting;)Lorg/apache/pdfbox/pdmodel/PDDocument;',
   );
 
-  static final _load15 = ProtectedJniExtensions.lookup<
+  static final _load$15 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1605,16 +1605,16 @@ class PDDocument extends jni.JObject {
   ///@return loaded document
   ///@throws InvalidPasswordException If the password is incorrect.
   ///@throws IOException In case of a reading or parsing error.
-  static PDDocument load15(
+  static PDDocument load$15(
     jni.JArray<jni.jbyte> input,
     jni.JString password,
     jni.JObject keyStore,
     jni.JString alias,
     jni.JObject memUsageSetting,
   ) {
-    return _load15(
+    return _load$15(
             _class.reference.pointer,
-            _id_load15 as jni.JMethodIDPtr,
+            _id_load$15 as jni.JMethodIDPtr,
             input.reference.pointer,
             password.reference.pointer,
             keyStore.reference.pointer,
@@ -1656,12 +1656,12 @@ class PDDocument extends jni.JObject {
         .check();
   }
 
-  static final _id_save1 = _class.instanceMethodId(
+  static final _id_save$1 = _class.instanceMethodId(
     r'save',
     r'(Ljava/io/File;)V',
   );
 
-  static final _save1 = ProtectedJniExtensions.lookup<
+  static final _save$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JThrowablePtr Function(
                       ffi.Pointer<ffi.Void>,
@@ -1681,20 +1681,20 @@ class PDDocument extends jni.JObject {
   /// do not use the document after saving because the contents are now encrypted.
   ///@param file The file to save as.
   ///@throws IOException if the output could not be written
-  void save1(
+  void save$1(
     jni.JObject file,
   ) {
-    _save1(reference.pointer, _id_save1 as jni.JMethodIDPtr,
+    _save$1(reference.pointer, _id_save$1 as jni.JMethodIDPtr,
             file.reference.pointer)
         .check();
   }
 
-  static final _id_save2 = _class.instanceMethodId(
+  static final _id_save$2 = _class.instanceMethodId(
     r'save',
     r'(Ljava/io/OutputStream;)V',
   );
 
-  static final _save2 = ProtectedJniExtensions.lookup<
+  static final _save$2 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JThrowablePtr Function(
                       ffi.Pointer<ffi.Void>,
@@ -1715,10 +1715,10 @@ class PDDocument extends jni.JObject {
   ///@param output The stream to write to. It will be closed when done. It is recommended to wrap
   /// it in a java.io.BufferedOutputStream, unless it is already buffered.
   ///@throws IOException if the output could not be written
-  void save2(
+  void save$2(
     jni.JObject output,
   ) {
-    _save2(reference.pointer, _id_save2 as jni.JMethodIDPtr,
+    _save$2(reference.pointer, _id_save$2 as jni.JMethodIDPtr,
             output.reference.pointer)
         .check();
   }
@@ -1762,12 +1762,12 @@ class PDDocument extends jni.JObject {
         .check();
   }
 
-  static final _id_saveIncremental1 = _class.instanceMethodId(
+  static final _id_saveIncremental$1 = _class.instanceMethodId(
     r'saveIncremental',
     r'(Ljava/io/OutputStream;Ljava/util/Set;)V',
   );
 
-  static final _saveIncremental1 = ProtectedJniExtensions.lookup<
+  static final _saveIncremental$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
@@ -1801,13 +1801,13 @@ class PDDocument extends jni.JObject {
   ///@param objectsToWrite objects that __must__ be part of the incremental saving.
   ///@throws IOException if the output could not be written
   ///@throws IllegalStateException if the document was not loaded from a file or a stream.
-  void saveIncremental1(
+  void saveIncremental$1(
     jni.JObject output,
     jni.JSet<jni.JObject> objectsToWrite,
   ) {
-    _saveIncremental1(
+    _saveIncremental$1(
             reference.pointer,
-            _id_saveIncremental1 as jni.JMethodIDPtr,
+            _id_saveIncremental$1 as jni.JMethodIDPtr,
             output.reference.pointer,
             objectsToWrite.reference.pointer)
         .check();

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocumentInformation.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocumentInformation.dart
@@ -92,11 +92,11 @@ class PDDocumentInformation extends jni.JObject {
             .reference);
   }
 
-  static final _id_new1 = _class.constructorId(
+  static final _id_new$1 = _class.constructorId(
     r'(Lorg/apache/pdfbox/cos/COSDictionary;)V',
   );
 
-  static final _new1 = ProtectedJniExtensions.lookup<
+  static final _new$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -112,11 +112,11 @@ class PDDocumentInformation extends jni.JObject {
   ///
   /// Constructor that is used for a preexisting dictionary.
   ///@param dic The underlying dictionary.
-  factory PDDocumentInformation.new1(
+  factory PDDocumentInformation.new$1(
     jni.JObject dic,
   ) {
-    return PDDocumentInformation.fromReference(_new1(_class.reference.pointer,
-            _id_new1 as jni.JMethodIDPtr, dic.reference.pointer)
+    return PDDocumentInformation.fromReference(_new$1(_class.reference.pointer,
+            _id_new$1 as jni.JMethodIDPtr, dic.reference.pointer)
         .reference);
   }
 

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocumentInformation.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocumentInformation.dart
@@ -66,11 +66,11 @@ class PDDocumentInformation extends jni.JObject {
 
   /// The type which includes information such as the signature of this class.
   static const type = $PDDocumentInformationType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -88,7 +88,7 @@ class PDDocumentInformation extends jni.JObject {
   /// Default Constructor.
   factory PDDocumentInformation() {
     return PDDocumentInformation.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/text/PDFTextStripper.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/text/PDFTextStripper.dart
@@ -70,11 +70,11 @@ class PDFTextStripper extends jni.JObject {
 
   /// The type which includes information such as the signature of this class.
   static const type = $PDFTextStripperType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -93,7 +93,7 @@ class PDFTextStripper extends jni.JObject {
   ///@throws IOException If there is an error loading the properties.
   factory PDFTextStripper() {
     return PDFTextStripper.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 

--- a/pkgs/jnigen/lib/src/bindings/excluder.dart
+++ b/pkgs/jnigen/lib/src/bindings/excluder.dart
@@ -45,7 +45,7 @@ class _ClassExcluder extends Visitor<ClassDecl, void> {
     node.methods = node.methods.where((method) {
       final isPrivate = method.isPrivate;
       final hasPrivateName = method.hasPrivateName;
-      final isAbstractCtor = method.isCtor && node.isAbstract;
+      final isAbstractCtor = method.isConstructor && node.isAbstract;
       final isBridgeMethod = method.isSynthetic && method.isBridge;
       final isExcludedInConfig =
           config.exclude?.methods?.included(node, method) ?? false;

--- a/pkgs/jnigen/lib/src/bindings/renamer.dart
+++ b/pkgs/jnigen/lib/src/bindings/renamer.dart
@@ -65,7 +65,6 @@ const Set<String> _keywords = {
   'throw',
   'true',
   'try',
-  'type', // Is used for type classes.
   'typedef',
   'var',
   'void',
@@ -91,15 +90,16 @@ const Map<String, int> _definedSyms = {
   'release': 1,
   'releasedBy': 1,
   'jClass': 1,
+  'type': 1,
 };
 
-/// Appends 0 to [name] if [name] is a keyword.
+/// Appends $ to [name] if [name] is a keyword.
 ///
 /// Examples:
-/// * `int` -> `int0`
+/// * `int` -> `int$`
 /// * `i` -> `i`
 String _keywordRename(String name) =>
-    _keywords.contains(name) ? '${name}0' : name;
+    _keywords.contains(name) ? '$name\$' : name;
 
 String _renameConflict(Map<String, int> counts, String name) {
   if (counts.containsKey(name)) {
@@ -167,17 +167,21 @@ class _ClassRenamer implements Visitor<ClassDecl, void> {
     final superClass = (node.superclass!.type as DeclaredType).classDecl;
     superClass.accept(this);
     nameCounts[node]!.addAll(nameCounts[superClass] ?? {});
+
+    // Rename fields before renaming methods. In case a method and a field have
+    // identical names, the field will keep its original name and the
+    // method will be renamed.
+    final fieldRenamer = _FieldRenamer(config, nameCounts[node]!);
+    for (final field in node.fields) {
+      field.accept(fieldRenamer);
+    }
+
     final methodRenamer = _MethodRenamer(
       config,
       nameCounts[node]!,
     );
     for (final method in node.methods) {
       method.accept(methodRenamer);
-    }
-
-    final fieldRenamer = _FieldRenamer(config, nameCounts[node]!);
-    for (final field in node.fields) {
-      field.accept(fieldRenamer);
     }
   }
 }
@@ -190,7 +194,7 @@ class _MethodRenamer implements Visitor<Method, void> {
 
   @override
   void visit(Method node) {
-    final name = node.name == '<init>' ? 'new' : node.name;
+    final name = node.isConstructor ? 'new' : node.name;
     final sig = node.javaSig;
     // If node is in super class, assign its number, overriding it.
     final superClass =

--- a/pkgs/jnigen/lib/src/bindings/unnester.dart
+++ b/pkgs/jnigen/lib/src/bindings/unnester.dart
@@ -58,7 +58,7 @@ class _MethodUnnester extends Visitor<Method, void> {
     // TODO(#319): Unnest the methods in APISummarizer itself.
     // For now the nullity of [node.descriptor] identifies if the doclet
     // backend was used and the method would potentially need "unnesting".
-    if ((node.isCtor || node.isStatic) && node.descriptor == null) {
+    if ((node.isConstructor || node.isStatic) && node.descriptor == null) {
       // Non-static nested classes take an instance of their outer class as the
       // first parameter.
       //

--- a/pkgs/jnigen/lib/src/elements/elements.dart
+++ b/pkgs/jnigen/lib/src/elements/elements.dart
@@ -505,7 +505,7 @@ class Method extends ClassMember implements Element<Method> {
   @JsonKey(includeFromJson: false)
   late final String javaSig = '$name$descriptor';
 
-  bool get isCtor => name == '<init>';
+  bool get isConstructor => name == '<init>';
 
   factory Method.fromJson(Map<String, dynamic> json) => _$MethodFromJson(json);
 

--- a/pkgs/jnigen/pubspec.yaml
+++ b/pkgs/jnigen/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jnigen
 description: A Dart bindings generator for Java and Kotlin that uses JNI under the hood to interop with Java virtual machine.
-version: 0.11.1-wip
+version: 0.12.0-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jnigen
 
 environment:

--- a/pkgs/jnigen/test/jackson_core_test/runtime_test_registrant.dart
+++ b/pkgs/jnigen/test/jackson_core_test/runtime_test_registrant.dart
@@ -17,7 +17,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
       final json = JString.fromString('[1, true, false, 2, 4]');
       JsonFactory factory;
       factory = JsonFactory();
-      final parser = factory.createParser6(json);
+      final parser = factory.createParser$6(json);
       final values = <bool>[];
       while (!parser.isClosed()) {
         final next = parser.nextToken();
@@ -34,7 +34,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
       using((arena) {
         final factory = JsonFactory()..releasedBy(arena);
         final erroneous = factory
-            .createParser6('<html>'.toJString()..releasedBy(arena))
+            .createParser$6('<html>'.toJString()..releasedBy(arena))
           ..releasedBy(arena);
         expect(erroneous.nextToken, throwsA(isA<JniException>()));
       });

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
@@ -329,11 +329,11 @@ class JsonFactory extends jni.JObject {
             .reference);
   }
 
-  static final _id_new1 = _class.constructorId(
+  static final _id_new$1 = _class.constructorId(
     r'(Lcom/fasterxml/jackson/core/ObjectCodec;)V',
   );
 
-  static final _new1 = ProtectedJniExtensions.lookup<
+  static final _new$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -346,19 +346,19 @@ class JsonFactory extends jni.JObject {
 
   /// from: `public void <init>(com.fasterxml.jackson.core.ObjectCodec oc)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory JsonFactory.new1(
+  factory JsonFactory.new$1(
     jni.JObject oc,
   ) {
-    return JsonFactory.fromReference(_new1(_class.reference.pointer,
-            _id_new1 as jni.JMethodIDPtr, oc.reference.pointer)
+    return JsonFactory.fromReference(_new$1(_class.reference.pointer,
+            _id_new$1 as jni.JMethodIDPtr, oc.reference.pointer)
         .reference);
   }
 
-  static final _id_new2 = _class.constructorId(
+  static final _id_new$2 = _class.constructorId(
     r'(Lcom/fasterxml/jackson/core/JsonFactoryBuilder;)V',
   );
 
-  static final _new2 = ProtectedJniExtensions.lookup<
+  static final _new$2 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -375,11 +375,11 @@ class JsonFactory extends jni.JObject {
   /// Constructor used by JsonFactoryBuilder for instantiation.
   ///@param b Builder that contains settings to use
   ///@since 2.10
-  factory JsonFactory.new2(
+  factory JsonFactory.new$2(
     jni.JObject b,
   ) {
-    return JsonFactory.fromReference(_new2(_class.reference.pointer,
-            _id_new2 as jni.JMethodIDPtr, b.reference.pointer)
+    return JsonFactory.fromReference(_new$2(_class.reference.pointer,
+            _id_new$2 as jni.JMethodIDPtr, b.reference.pointer)
         .reference);
   }
 
@@ -1049,12 +1049,12 @@ class JsonFactory extends jni.JObject {
         .integer;
   }
 
-  static final _id_configure1 = _class.instanceMethodId(
+  static final _id_configure$1 = _class.instanceMethodId(
     r'configure',
     r'(Lcom/fasterxml/jackson/core/JsonParser$Feature;Z)Lcom/fasterxml/jackson/core/JsonFactory;',
   );
 
-  static final _configure1 = ProtectedJniExtensions.lookup<
+  static final _configure$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1073,21 +1073,21 @@ class JsonFactory extends jni.JObject {
   ///@param f Feature to enable/disable
   ///@param state Whether to enable or disable the feature
   ///@return This factory instance (to allow call chaining)
-  JsonFactory configure1(
+  JsonFactory configure$1(
     jsonparser_.JsonParser_Feature f,
     bool state,
   ) {
-    return _configure1(reference.pointer, _id_configure1 as jni.JMethodIDPtr,
+    return _configure$1(reference.pointer, _id_configure$1 as jni.JMethodIDPtr,
             f.reference.pointer, state ? 1 : 0)
         .object(const $JsonFactoryType());
   }
 
-  static final _id_enable1 = _class.instanceMethodId(
+  static final _id_enable$1 = _class.instanceMethodId(
     r'enable',
     r'(Lcom/fasterxml/jackson/core/JsonParser$Feature;)Lcom/fasterxml/jackson/core/JsonFactory;',
   );
 
-  static final _enable1 = ProtectedJniExtensions.lookup<
+  static final _enable$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1105,20 +1105,20 @@ class JsonFactory extends jni.JObject {
   /// (check JsonParser.Feature for list of features)
   ///@param f Feature to enable
   ///@return This factory instance (to allow call chaining)
-  JsonFactory enable1(
+  JsonFactory enable$1(
     jsonparser_.JsonParser_Feature f,
   ) {
-    return _enable1(reference.pointer, _id_enable1 as jni.JMethodIDPtr,
+    return _enable$1(reference.pointer, _id_enable$1 as jni.JMethodIDPtr,
             f.reference.pointer)
         .object(const $JsonFactoryType());
   }
 
-  static final _id_disable1 = _class.instanceMethodId(
+  static final _id_disable$1 = _class.instanceMethodId(
     r'disable',
     r'(Lcom/fasterxml/jackson/core/JsonParser$Feature;)Lcom/fasterxml/jackson/core/JsonFactory;',
   );
 
-  static final _disable1 = ProtectedJniExtensions.lookup<
+  static final _disable$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1136,20 +1136,20 @@ class JsonFactory extends jni.JObject {
   /// (check JsonParser.Feature for list of features)
   ///@param f Feature to disable
   ///@return This factory instance (to allow call chaining)
-  JsonFactory disable1(
+  JsonFactory disable$1(
     jsonparser_.JsonParser_Feature f,
   ) {
-    return _disable1(reference.pointer, _id_disable1 as jni.JMethodIDPtr,
+    return _disable$1(reference.pointer, _id_disable$1 as jni.JMethodIDPtr,
             f.reference.pointer)
         .object(const $JsonFactoryType());
   }
 
-  static final _id_isEnabled1 = _class.instanceMethodId(
+  static final _id_isEnabled$1 = _class.instanceMethodId(
     r'isEnabled',
     r'(Lcom/fasterxml/jackson/core/JsonParser$Feature;)Z',
   );
 
-  static final _isEnabled1 = ProtectedJniExtensions.lookup<
+  static final _isEnabled$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1165,20 +1165,20 @@ class JsonFactory extends jni.JObject {
   /// Method for checking if the specified parser feature is enabled.
   ///@param f Feature to check
   ///@return True if specified feature is enabled
-  bool isEnabled1(
+  bool isEnabled$1(
     jsonparser_.JsonParser_Feature f,
   ) {
-    return _isEnabled1(reference.pointer, _id_isEnabled1 as jni.JMethodIDPtr,
+    return _isEnabled$1(reference.pointer, _id_isEnabled$1 as jni.JMethodIDPtr,
             f.reference.pointer)
         .boolean;
   }
 
-  static final _id_isEnabled2 = _class.instanceMethodId(
+  static final _id_isEnabled$2 = _class.instanceMethodId(
     r'isEnabled',
     r'(Lcom/fasterxml/jackson/core/StreamReadFeature;)Z',
   );
 
-  static final _isEnabled2 = ProtectedJniExtensions.lookup<
+  static final _isEnabled$2 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1195,10 +1195,10 @@ class JsonFactory extends jni.JObject {
   ///@param f Feature to check
   ///@return True if specified feature is enabled
   ///@since 2.10
-  bool isEnabled2(
+  bool isEnabled$2(
     jni.JObject f,
   ) {
-    return _isEnabled2(reference.pointer, _id_isEnabled2 as jni.JMethodIDPtr,
+    return _isEnabled$2(reference.pointer, _id_isEnabled$2 as jni.JMethodIDPtr,
             f.reference.pointer)
         .boolean;
   }
@@ -1263,12 +1263,12 @@ class JsonFactory extends jni.JObject {
         .object(const $JsonFactoryType());
   }
 
-  static final _id_configure2 = _class.instanceMethodId(
+  static final _id_configure$2 = _class.instanceMethodId(
     r'configure',
     r'(Lcom/fasterxml/jackson/core/JsonGenerator$Feature;Z)Lcom/fasterxml/jackson/core/JsonFactory;',
   );
 
-  static final _configure2 = ProtectedJniExtensions.lookup<
+  static final _configure$2 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1287,21 +1287,21 @@ class JsonFactory extends jni.JObject {
   ///@param f Feature to enable/disable
   ///@param state Whether to enable or disable the feature
   ///@return This factory instance (to allow call chaining)
-  JsonFactory configure2(
+  JsonFactory configure$2(
     jni.JObject f,
     bool state,
   ) {
-    return _configure2(reference.pointer, _id_configure2 as jni.JMethodIDPtr,
+    return _configure$2(reference.pointer, _id_configure$2 as jni.JMethodIDPtr,
             f.reference.pointer, state ? 1 : 0)
         .object(const $JsonFactoryType());
   }
 
-  static final _id_enable2 = _class.instanceMethodId(
+  static final _id_enable$2 = _class.instanceMethodId(
     r'enable',
     r'(Lcom/fasterxml/jackson/core/JsonGenerator$Feature;)Lcom/fasterxml/jackson/core/JsonFactory;',
   );
 
-  static final _enable2 = ProtectedJniExtensions.lookup<
+  static final _enable$2 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1319,20 +1319,20 @@ class JsonFactory extends jni.JObject {
   /// (check JsonGenerator.Feature for list of features)
   ///@param f Feature to enable
   ///@return This factory instance (to allow call chaining)
-  JsonFactory enable2(
+  JsonFactory enable$2(
     jni.JObject f,
   ) {
-    return _enable2(reference.pointer, _id_enable2 as jni.JMethodIDPtr,
+    return _enable$2(reference.pointer, _id_enable$2 as jni.JMethodIDPtr,
             f.reference.pointer)
         .object(const $JsonFactoryType());
   }
 
-  static final _id_disable2 = _class.instanceMethodId(
+  static final _id_disable$2 = _class.instanceMethodId(
     r'disable',
     r'(Lcom/fasterxml/jackson/core/JsonGenerator$Feature;)Lcom/fasterxml/jackson/core/JsonFactory;',
   );
 
-  static final _disable2 = ProtectedJniExtensions.lookup<
+  static final _disable$2 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1350,20 +1350,20 @@ class JsonFactory extends jni.JObject {
   /// (check JsonGenerator.Feature for list of features)
   ///@param f Feature to disable
   ///@return This factory instance (to allow call chaining)
-  JsonFactory disable2(
+  JsonFactory disable$2(
     jni.JObject f,
   ) {
-    return _disable2(reference.pointer, _id_disable2 as jni.JMethodIDPtr,
+    return _disable$2(reference.pointer, _id_disable$2 as jni.JMethodIDPtr,
             f.reference.pointer)
         .object(const $JsonFactoryType());
   }
 
-  static final _id_isEnabled3 = _class.instanceMethodId(
+  static final _id_isEnabled$3 = _class.instanceMethodId(
     r'isEnabled',
     r'(Lcom/fasterxml/jackson/core/JsonGenerator$Feature;)Z',
   );
 
-  static final _isEnabled3 = ProtectedJniExtensions.lookup<
+  static final _isEnabled$3 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1379,20 +1379,20 @@ class JsonFactory extends jni.JObject {
   /// Check whether specified generator feature is enabled.
   ///@param f Feature to check
   ///@return Whether specified feature is enabled
-  bool isEnabled3(
+  bool isEnabled$3(
     jni.JObject f,
   ) {
-    return _isEnabled3(reference.pointer, _id_isEnabled3 as jni.JMethodIDPtr,
+    return _isEnabled$3(reference.pointer, _id_isEnabled$3 as jni.JMethodIDPtr,
             f.reference.pointer)
         .boolean;
   }
 
-  static final _id_isEnabled4 = _class.instanceMethodId(
+  static final _id_isEnabled$4 = _class.instanceMethodId(
     r'isEnabled',
     r'(Lcom/fasterxml/jackson/core/StreamWriteFeature;)Z',
   );
 
-  static final _isEnabled4 = ProtectedJniExtensions.lookup<
+  static final _isEnabled$4 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1409,10 +1409,10 @@ class JsonFactory extends jni.JObject {
   ///@param f Feature to check
   ///@return Whether specified feature is enabled
   ///@since 2.10
-  bool isEnabled4(
+  bool isEnabled$4(
     jni.JObject f,
   ) {
-    return _isEnabled4(reference.pointer, _id_isEnabled4 as jni.JMethodIDPtr,
+    return _isEnabled$4(reference.pointer, _id_isEnabled$4 as jni.JMethodIDPtr,
             f.reference.pointer)
         .boolean;
   }
@@ -1700,12 +1700,12 @@ class JsonFactory extends jni.JObject {
         .object(const jsonparser_.$JsonParserType());
   }
 
-  static final _id_createParser1 = _class.instanceMethodId(
+  static final _id_createParser$1 = _class.instanceMethodId(
     r'createParser',
     r'(Ljava/net/URL;)Lcom/fasterxml/jackson/core/JsonParser;',
   );
 
-  static final _createParser1 = ProtectedJniExtensions.lookup<
+  static final _createParser$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1733,20 +1733,20 @@ class JsonFactory extends jni.JObject {
   /// the parser, since caller has no access to it.
   ///@param url URL pointing to resource that contains JSON content to parse
   ///@since 2.1
-  jsonparser_.JsonParser createParser1(
+  jsonparser_.JsonParser createParser$1(
     jni.JObject url,
   ) {
-    return _createParser1(reference.pointer,
-            _id_createParser1 as jni.JMethodIDPtr, url.reference.pointer)
+    return _createParser$1(reference.pointer,
+            _id_createParser$1 as jni.JMethodIDPtr, url.reference.pointer)
         .object(const jsonparser_.$JsonParserType());
   }
 
-  static final _id_createParser2 = _class.instanceMethodId(
+  static final _id_createParser$2 = _class.instanceMethodId(
     r'createParser',
     r'(Ljava/io/InputStream;)Lcom/fasterxml/jackson/core/JsonParser;',
   );
 
-  static final _createParser2 = ProtectedJniExtensions.lookup<
+  static final _createParser$2 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1777,20 +1777,20 @@ class JsonFactory extends jni.JObject {
   /// For other charsets use \#createParser(java.io.Reader).
   ///@param in InputStream to use for reading JSON content to parse
   ///@since 2.1
-  jsonparser_.JsonParser createParser2(
+  jsonparser_.JsonParser createParser$2(
     jni.JObject in0,
   ) {
-    return _createParser2(reference.pointer,
-            _id_createParser2 as jni.JMethodIDPtr, in0.reference.pointer)
+    return _createParser$2(reference.pointer,
+            _id_createParser$2 as jni.JMethodIDPtr, in0.reference.pointer)
         .object(const jsonparser_.$JsonParserType());
   }
 
-  static final _id_createParser3 = _class.instanceMethodId(
+  static final _id_createParser$3 = _class.instanceMethodId(
     r'createParser',
     r'(Ljava/io/Reader;)Lcom/fasterxml/jackson/core/JsonParser;',
   );
 
-  static final _createParser3 = ProtectedJniExtensions.lookup<
+  static final _createParser$3 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1814,20 +1814,20 @@ class JsonFactory extends jni.JObject {
   /// is enabled.
   ///@param r Reader to use for reading JSON content to parse
   ///@since 2.1
-  jsonparser_.JsonParser createParser3(
+  jsonparser_.JsonParser createParser$3(
     jni.JObject r,
   ) {
-    return _createParser3(reference.pointer,
-            _id_createParser3 as jni.JMethodIDPtr, r.reference.pointer)
+    return _createParser$3(reference.pointer,
+            _id_createParser$3 as jni.JMethodIDPtr, r.reference.pointer)
         .object(const jsonparser_.$JsonParserType());
   }
 
-  static final _id_createParser4 = _class.instanceMethodId(
+  static final _id_createParser$4 = _class.instanceMethodId(
     r'createParser',
     r'([B)Lcom/fasterxml/jackson/core/JsonParser;',
   );
 
-  static final _createParser4 = ProtectedJniExtensions.lookup<
+  static final _createParser$4 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1844,20 +1844,20 @@ class JsonFactory extends jni.JObject {
   /// Method for constructing parser for parsing
   /// the contents of given byte array.
   ///@since 2.1
-  jsonparser_.JsonParser createParser4(
+  jsonparser_.JsonParser createParser$4(
     jni.JArray<jni.jbyte> data,
   ) {
-    return _createParser4(reference.pointer,
-            _id_createParser4 as jni.JMethodIDPtr, data.reference.pointer)
+    return _createParser$4(reference.pointer,
+            _id_createParser$4 as jni.JMethodIDPtr, data.reference.pointer)
         .object(const jsonparser_.$JsonParserType());
   }
 
-  static final _id_createParser5 = _class.instanceMethodId(
+  static final _id_createParser$5 = _class.instanceMethodId(
     r'createParser',
     r'([BII)Lcom/fasterxml/jackson/core/JsonParser;',
   );
 
-  static final _createParser5 = ProtectedJniExtensions.lookup<
+  static final _createParser$5 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1877,26 +1877,26 @@ class JsonFactory extends jni.JObject {
   ///@param offset Offset of the first data byte within buffer
   ///@param len Length of contents to parse within buffer
   ///@since 2.1
-  jsonparser_.JsonParser createParser5(
+  jsonparser_.JsonParser createParser$5(
     jni.JArray<jni.jbyte> data,
     int offset,
     int len,
   ) {
-    return _createParser5(
+    return _createParser$5(
             reference.pointer,
-            _id_createParser5 as jni.JMethodIDPtr,
+            _id_createParser$5 as jni.JMethodIDPtr,
             data.reference.pointer,
             offset,
             len)
         .object(const jsonparser_.$JsonParserType());
   }
 
-  static final _id_createParser6 = _class.instanceMethodId(
+  static final _id_createParser$6 = _class.instanceMethodId(
     r'createParser',
     r'(Ljava/lang/String;)Lcom/fasterxml/jackson/core/JsonParser;',
   );
 
-  static final _createParser6 = ProtectedJniExtensions.lookup<
+  static final _createParser$6 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1913,20 +1913,20 @@ class JsonFactory extends jni.JObject {
   /// Method for constructing parser for parsing
   /// contents of given String.
   ///@since 2.1
-  jsonparser_.JsonParser createParser6(
+  jsonparser_.JsonParser createParser$6(
     jni.JString content,
   ) {
-    return _createParser6(reference.pointer,
-            _id_createParser6 as jni.JMethodIDPtr, content.reference.pointer)
+    return _createParser$6(reference.pointer,
+            _id_createParser$6 as jni.JMethodIDPtr, content.reference.pointer)
         .object(const jsonparser_.$JsonParserType());
   }
 
-  static final _id_createParser7 = _class.instanceMethodId(
+  static final _id_createParser$7 = _class.instanceMethodId(
     r'createParser',
     r'([C)Lcom/fasterxml/jackson/core/JsonParser;',
   );
 
-  static final _createParser7 = ProtectedJniExtensions.lookup<
+  static final _createParser$7 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1943,20 +1943,20 @@ class JsonFactory extends jni.JObject {
   /// Method for constructing parser for parsing
   /// contents of given char array.
   ///@since 2.4
-  jsonparser_.JsonParser createParser7(
+  jsonparser_.JsonParser createParser$7(
     jni.JArray<jni.jchar> content,
   ) {
-    return _createParser7(reference.pointer,
-            _id_createParser7 as jni.JMethodIDPtr, content.reference.pointer)
+    return _createParser$7(reference.pointer,
+            _id_createParser$7 as jni.JMethodIDPtr, content.reference.pointer)
         .object(const jsonparser_.$JsonParserType());
   }
 
-  static final _id_createParser8 = _class.instanceMethodId(
+  static final _id_createParser$8 = _class.instanceMethodId(
     r'createParser',
     r'([CII)Lcom/fasterxml/jackson/core/JsonParser;',
   );
 
-  static final _createParser8 = ProtectedJniExtensions.lookup<
+  static final _createParser$8 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1972,26 +1972,26 @@ class JsonFactory extends jni.JObject {
   ///
   /// Method for constructing parser for parsing contents of given char array.
   ///@since 2.4
-  jsonparser_.JsonParser createParser8(
+  jsonparser_.JsonParser createParser$8(
     jni.JArray<jni.jchar> content,
     int offset,
     int len,
   ) {
-    return _createParser8(
+    return _createParser$8(
             reference.pointer,
-            _id_createParser8 as jni.JMethodIDPtr,
+            _id_createParser$8 as jni.JMethodIDPtr,
             content.reference.pointer,
             offset,
             len)
         .object(const jsonparser_.$JsonParserType());
   }
 
-  static final _id_createParser9 = _class.instanceMethodId(
+  static final _id_createParser$9 = _class.instanceMethodId(
     r'createParser',
     r'(Ljava/io/DataInput;)Lcom/fasterxml/jackson/core/JsonParser;',
   );
 
-  static final _createParser9 = ProtectedJniExtensions.lookup<
+  static final _createParser$9 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2011,11 +2011,11 @@ class JsonFactory extends jni.JObject {
   /// If this factory does not support DataInput as source,
   /// will throw UnsupportedOperationException
   ///@since 2.8
-  jsonparser_.JsonParser createParser9(
+  jsonparser_.JsonParser createParser$9(
     jni.JObject in0,
   ) {
-    return _createParser9(reference.pointer,
-            _id_createParser9 as jni.JMethodIDPtr, in0.reference.pointer)
+    return _createParser$9(reference.pointer,
+            _id_createParser$9 as jni.JMethodIDPtr, in0.reference.pointer)
         .object(const jsonparser_.$JsonParserType());
   }
 
@@ -2111,12 +2111,12 @@ class JsonFactory extends jni.JObject {
         .object(const jni.JObjectType());
   }
 
-  static final _id_createGenerator1 = _class.instanceMethodId(
+  static final _id_createGenerator$1 = _class.instanceMethodId(
     r'createGenerator',
     r'(Ljava/io/OutputStream;)Lcom/fasterxml/jackson/core/JsonGenerator;',
   );
 
-  static final _createGenerator1 = ProtectedJniExtensions.lookup<
+  static final _createGenerator$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2135,20 +2135,20 @@ class JsonFactory extends jni.JObject {
   ///
   /// Note: there are formats that use fixed encoding (like most binary data formats).
   ///@since 2.1
-  jni.JObject createGenerator1(
+  jni.JObject createGenerator$1(
     jni.JObject out,
   ) {
-    return _createGenerator1(reference.pointer,
-            _id_createGenerator1 as jni.JMethodIDPtr, out.reference.pointer)
+    return _createGenerator$1(reference.pointer,
+            _id_createGenerator$1 as jni.JMethodIDPtr, out.reference.pointer)
         .object(const jni.JObjectType());
   }
 
-  static final _id_createGenerator2 = _class.instanceMethodId(
+  static final _id_createGenerator$2 = _class.instanceMethodId(
     r'createGenerator',
     r'(Ljava/io/Writer;)Lcom/fasterxml/jackson/core/JsonGenerator;',
   );
 
-  static final _createGenerator2 = ProtectedJniExtensions.lookup<
+  static final _createGenerator$2 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2173,20 +2173,20 @@ class JsonFactory extends jni.JObject {
   /// Using application needs to close it explicitly.
   ///@since 2.1
   ///@param w Writer to use for writing JSON content
-  jni.JObject createGenerator2(
+  jni.JObject createGenerator$2(
     jni.JObject w,
   ) {
-    return _createGenerator2(reference.pointer,
-            _id_createGenerator2 as jni.JMethodIDPtr, w.reference.pointer)
+    return _createGenerator$2(reference.pointer,
+            _id_createGenerator$2 as jni.JMethodIDPtr, w.reference.pointer)
         .object(const jni.JObjectType());
   }
 
-  static final _id_createGenerator3 = _class.instanceMethodId(
+  static final _id_createGenerator$3 = _class.instanceMethodId(
     r'createGenerator',
     r'(Ljava/io/File;Lcom/fasterxml/jackson/core/JsonEncoding;)Lcom/fasterxml/jackson/core/JsonGenerator;',
   );
 
-  static final _createGenerator3 = ProtectedJniExtensions.lookup<
+  static final _createGenerator$3 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -2215,24 +2215,24 @@ class JsonFactory extends jni.JObject {
   ///@param f File to write contents to
   ///@param enc Character encoding to use
   ///@since 2.1
-  jni.JObject createGenerator3(
+  jni.JObject createGenerator$3(
     jni.JObject f,
     jni.JObject enc,
   ) {
-    return _createGenerator3(
+    return _createGenerator$3(
             reference.pointer,
-            _id_createGenerator3 as jni.JMethodIDPtr,
+            _id_createGenerator$3 as jni.JMethodIDPtr,
             f.reference.pointer,
             enc.reference.pointer)
         .object(const jni.JObjectType());
   }
 
-  static final _id_createGenerator4 = _class.instanceMethodId(
+  static final _id_createGenerator$4 = _class.instanceMethodId(
     r'createGenerator',
     r'(Ljava/io/DataOutput;Lcom/fasterxml/jackson/core/JsonEncoding;)Lcom/fasterxml/jackson/core/JsonGenerator;',
   );
 
-  static final _createGenerator4 = ProtectedJniExtensions.lookup<
+  static final _createGenerator$4 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -2252,24 +2252,24 @@ class JsonFactory extends jni.JObject {
   /// Method for constructing generator for writing content using specified
   /// DataOutput instance.
   ///@since 2.8
-  jni.JObject createGenerator4(
+  jni.JObject createGenerator$4(
     jni.JObject out,
     jni.JObject enc,
   ) {
-    return _createGenerator4(
+    return _createGenerator$4(
             reference.pointer,
-            _id_createGenerator4 as jni.JMethodIDPtr,
+            _id_createGenerator$4 as jni.JMethodIDPtr,
             out.reference.pointer,
             enc.reference.pointer)
         .object(const jni.JObjectType());
   }
 
-  static final _id_createGenerator5 = _class.instanceMethodId(
+  static final _id_createGenerator$5 = _class.instanceMethodId(
     r'createGenerator',
     r'(Ljava/io/DataOutput;)Lcom/fasterxml/jackson/core/JsonGenerator;',
   );
 
-  static final _createGenerator5 = ProtectedJniExtensions.lookup<
+  static final _createGenerator$5 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2288,11 +2288,11 @@ class JsonFactory extends jni.JObject {
   ///
   /// Note: there are formats that use fixed encoding (like most binary data formats).
   ///@since 2.8
-  jni.JObject createGenerator5(
+  jni.JObject createGenerator$5(
     jni.JObject out,
   ) {
-    return _createGenerator5(reference.pointer,
-            _id_createGenerator5 as jni.JMethodIDPtr, out.reference.pointer)
+    return _createGenerator$5(reference.pointer,
+            _id_createGenerator$5 as jni.JMethodIDPtr, out.reference.pointer)
         .object(const jni.JObjectType());
   }
 
@@ -2341,12 +2341,12 @@ class JsonFactory extends jni.JObject {
         .object(const jsonparser_.$JsonParserType());
   }
 
-  static final _id_createJsonParser1 = _class.instanceMethodId(
+  static final _id_createJsonParser$1 = _class.instanceMethodId(
     r'createJsonParser',
     r'(Ljava/net/URL;)Lcom/fasterxml/jackson/core/JsonParser;',
   );
 
-  static final _createJsonParser1 = ProtectedJniExtensions.lookup<
+  static final _createJsonParser$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2377,20 +2377,20 @@ class JsonFactory extends jni.JObject {
   ///@throws IOException if parser initialization fails due to I/O (read) problem
   ///@throws JsonParseException if parser initialization fails due to content decoding problem
   ///@deprecated Since 2.2, use \#createParser(URL) instead.
-  jsonparser_.JsonParser createJsonParser1(
+  jsonparser_.JsonParser createJsonParser$1(
     jni.JObject url,
   ) {
-    return _createJsonParser1(reference.pointer,
-            _id_createJsonParser1 as jni.JMethodIDPtr, url.reference.pointer)
+    return _createJsonParser$1(reference.pointer,
+            _id_createJsonParser$1 as jni.JMethodIDPtr, url.reference.pointer)
         .object(const jsonparser_.$JsonParserType());
   }
 
-  static final _id_createJsonParser2 = _class.instanceMethodId(
+  static final _id_createJsonParser$2 = _class.instanceMethodId(
     r'createJsonParser',
     r'(Ljava/io/InputStream;)Lcom/fasterxml/jackson/core/JsonParser;',
   );
 
-  static final _createJsonParser2 = ProtectedJniExtensions.lookup<
+  static final _createJsonParser$2 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2424,20 +2424,20 @@ class JsonFactory extends jni.JObject {
   ///@throws IOException if parser initialization fails due to I/O (read) problem
   ///@throws JsonParseException if parser initialization fails due to content decoding problem
   ///@deprecated Since 2.2, use \#createParser(InputStream) instead.
-  jsonparser_.JsonParser createJsonParser2(
+  jsonparser_.JsonParser createJsonParser$2(
     jni.JObject in0,
   ) {
-    return _createJsonParser2(reference.pointer,
-            _id_createJsonParser2 as jni.JMethodIDPtr, in0.reference.pointer)
+    return _createJsonParser$2(reference.pointer,
+            _id_createJsonParser$2 as jni.JMethodIDPtr, in0.reference.pointer)
         .object(const jsonparser_.$JsonParserType());
   }
 
-  static final _id_createJsonParser3 = _class.instanceMethodId(
+  static final _id_createJsonParser$3 = _class.instanceMethodId(
     r'createJsonParser',
     r'(Ljava/io/Reader;)Lcom/fasterxml/jackson/core/JsonParser;',
   );
 
-  static final _createJsonParser3 = ProtectedJniExtensions.lookup<
+  static final _createJsonParser$3 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2464,20 +2464,20 @@ class JsonFactory extends jni.JObject {
   ///@throws IOException if parser initialization fails due to I/O (read) problem
   ///@throws JsonParseException if parser initialization fails due to content decoding problem
   ///@deprecated Since 2.2, use \#createParser(Reader) instead.
-  jsonparser_.JsonParser createJsonParser3(
+  jsonparser_.JsonParser createJsonParser$3(
     jni.JObject r,
   ) {
-    return _createJsonParser3(reference.pointer,
-            _id_createJsonParser3 as jni.JMethodIDPtr, r.reference.pointer)
+    return _createJsonParser$3(reference.pointer,
+            _id_createJsonParser$3 as jni.JMethodIDPtr, r.reference.pointer)
         .object(const jsonparser_.$JsonParserType());
   }
 
-  static final _id_createJsonParser4 = _class.instanceMethodId(
+  static final _id_createJsonParser$4 = _class.instanceMethodId(
     r'createJsonParser',
     r'([B)Lcom/fasterxml/jackson/core/JsonParser;',
   );
 
-  static final _createJsonParser4 = ProtectedJniExtensions.lookup<
+  static final _createJsonParser$4 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2497,20 +2497,20 @@ class JsonFactory extends jni.JObject {
   ///@throws IOException if parser initialization fails due to I/O (read) problem
   ///@throws JsonParseException if parser initialization fails due to content decoding problem
   ///@deprecated Since 2.2, use \#createParser(byte[]) instead.
-  jsonparser_.JsonParser createJsonParser4(
+  jsonparser_.JsonParser createJsonParser$4(
     jni.JArray<jni.jbyte> data,
   ) {
-    return _createJsonParser4(reference.pointer,
-            _id_createJsonParser4 as jni.JMethodIDPtr, data.reference.pointer)
+    return _createJsonParser$4(reference.pointer,
+            _id_createJsonParser$4 as jni.JMethodIDPtr, data.reference.pointer)
         .object(const jsonparser_.$JsonParserType());
   }
 
-  static final _id_createJsonParser5 = _class.instanceMethodId(
+  static final _id_createJsonParser$5 = _class.instanceMethodId(
     r'createJsonParser',
     r'([BII)Lcom/fasterxml/jackson/core/JsonParser;',
   );
 
-  static final _createJsonParser5 = ProtectedJniExtensions.lookup<
+  static final _createJsonParser$5 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2533,26 +2533,26 @@ class JsonFactory extends jni.JObject {
   ///@throws IOException if parser initialization fails due to I/O (read) problem
   ///@throws JsonParseException if parser initialization fails due to content decoding problem
   ///@deprecated Since 2.2, use \#createParser(byte[],int,int) instead.
-  jsonparser_.JsonParser createJsonParser5(
+  jsonparser_.JsonParser createJsonParser$5(
     jni.JArray<jni.jbyte> data,
     int offset,
     int len,
   ) {
-    return _createJsonParser5(
+    return _createJsonParser$5(
             reference.pointer,
-            _id_createJsonParser5 as jni.JMethodIDPtr,
+            _id_createJsonParser$5 as jni.JMethodIDPtr,
             data.reference.pointer,
             offset,
             len)
         .object(const jsonparser_.$JsonParserType());
   }
 
-  static final _id_createJsonParser6 = _class.instanceMethodId(
+  static final _id_createJsonParser$6 = _class.instanceMethodId(
     r'createJsonParser',
     r'(Ljava/lang/String;)Lcom/fasterxml/jackson/core/JsonParser;',
   );
 
-  static final _createJsonParser6 = ProtectedJniExtensions.lookup<
+  static final _createJsonParser$6 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2573,12 +2573,12 @@ class JsonFactory extends jni.JObject {
   ///@throws IOException if parser initialization fails due to I/O (read) problem
   ///@throws JsonParseException if parser initialization fails due to content decoding problem
   ///@deprecated Since 2.2, use \#createParser(String) instead.
-  jsonparser_.JsonParser createJsonParser6(
+  jsonparser_.JsonParser createJsonParser$6(
     jni.JString content,
   ) {
-    return _createJsonParser6(
+    return _createJsonParser$6(
             reference.pointer,
-            _id_createJsonParser6 as jni.JMethodIDPtr,
+            _id_createJsonParser$6 as jni.JMethodIDPtr,
             content.reference.pointer)
         .object(const jsonparser_.$JsonParserType());
   }
@@ -2637,12 +2637,12 @@ class JsonFactory extends jni.JObject {
         .object(const jni.JObjectType());
   }
 
-  static final _id_createJsonGenerator1 = _class.instanceMethodId(
+  static final _id_createJsonGenerator$1 = _class.instanceMethodId(
     r'createJsonGenerator',
     r'(Ljava/io/Writer;)Lcom/fasterxml/jackson/core/JsonGenerator;',
   );
 
-  static final _createJsonGenerator1 = ProtectedJniExtensions.lookup<
+  static final _createJsonGenerator$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2669,20 +2669,22 @@ class JsonFactory extends jni.JObject {
   ///@return Generator constructed
   ///@throws IOException if parser initialization fails due to I/O (write) problem
   ///@deprecated Since 2.2, use \#createGenerator(Writer) instead.
-  jni.JObject createJsonGenerator1(
+  jni.JObject createJsonGenerator$1(
     jni.JObject out,
   ) {
-    return _createJsonGenerator1(reference.pointer,
-            _id_createJsonGenerator1 as jni.JMethodIDPtr, out.reference.pointer)
+    return _createJsonGenerator$1(
+            reference.pointer,
+            _id_createJsonGenerator$1 as jni.JMethodIDPtr,
+            out.reference.pointer)
         .object(const jni.JObjectType());
   }
 
-  static final _id_createJsonGenerator2 = _class.instanceMethodId(
+  static final _id_createJsonGenerator$2 = _class.instanceMethodId(
     r'createJsonGenerator',
     r'(Ljava/io/OutputStream;)Lcom/fasterxml/jackson/core/JsonGenerator;',
   );
 
-  static final _createJsonGenerator2 = ProtectedJniExtensions.lookup<
+  static final _createJsonGenerator$2 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2704,11 +2706,13 @@ class JsonFactory extends jni.JObject {
   ///@return Generator constructed
   ///@throws IOException if parser initialization fails due to I/O (write) problem
   ///@deprecated Since 2.2, use \#createGenerator(OutputStream) instead.
-  jni.JObject createJsonGenerator2(
+  jni.JObject createJsonGenerator$2(
     jni.JObject out,
   ) {
-    return _createJsonGenerator2(reference.pointer,
-            _id_createJsonGenerator2 as jni.JMethodIDPtr, out.reference.pointer)
+    return _createJsonGenerator$2(
+            reference.pointer,
+            _id_createJsonGenerator$2 as jni.JMethodIDPtr,
+            out.reference.pointer)
         .object(const jni.JObjectType());
   }
 }

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
@@ -296,11 +296,11 @@ class JsonFactory extends jni.JObject {
   ///
   /// @since 2.10
   static const DEFAULT_QUOTE_CHAR = 34;
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -325,7 +325,7 @@ class JsonFactory extends jni.JObject {
   /// factory instance.
   factory JsonFactory() {
     return JsonFactory.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 
@@ -1778,10 +1778,10 @@ class JsonFactory extends jni.JObject {
   ///@param in InputStream to use for reading JSON content to parse
   ///@since 2.1
   jsonparser_.JsonParser createParser$2(
-    jni.JObject in0,
+    jni.JObject in$,
   ) {
     return _createParser$2(reference.pointer,
-            _id_createParser$2 as jni.JMethodIDPtr, in0.reference.pointer)
+            _id_createParser$2 as jni.JMethodIDPtr, in$.reference.pointer)
         .object(const jsonparser_.$JsonParserType());
   }
 
@@ -2012,10 +2012,10 @@ class JsonFactory extends jni.JObject {
   /// will throw UnsupportedOperationException
   ///@since 2.8
   jsonparser_.JsonParser createParser$9(
-    jni.JObject in0,
+    jni.JObject in$,
   ) {
     return _createParser$9(reference.pointer,
-            _id_createParser$9 as jni.JMethodIDPtr, in0.reference.pointer)
+            _id_createParser$9 as jni.JMethodIDPtr, in$.reference.pointer)
         .object(const jsonparser_.$JsonParserType());
   }
 
@@ -2425,10 +2425,10 @@ class JsonFactory extends jni.JObject {
   ///@throws JsonParseException if parser initialization fails due to content decoding problem
   ///@deprecated Since 2.2, use \#createParser(InputStream) instead.
   jsonparser_.JsonParser createJsonParser$2(
-    jni.JObject in0,
+    jni.JObject in$,
   ) {
     return _createJsonParser$2(reference.pointer,
-            _id_createJsonParser$2 as jni.JMethodIDPtr, in0.reference.pointer)
+            _id_createJsonParser$2 as jni.JMethodIDPtr, in$.reference.pointer)
         .object(const jsonparser_.$JsonParserType());
   }
 

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonParser.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonParser.dart
@@ -480,12 +480,12 @@ class JsonParser extends jni.JObject {
         .check();
   }
 
-  static final _id_setRequestPayloadOnError1 = _class.instanceMethodId(
+  static final _id_setRequestPayloadOnError$1 = _class.instanceMethodId(
     r'setRequestPayloadOnError',
     r'([BLjava/lang/String;)V',
   );
 
-  static final _setRequestPayloadOnError1 = ProtectedJniExtensions.lookup<
+  static final _setRequestPayloadOnError$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
@@ -505,24 +505,24 @@ class JsonParser extends jni.JObject {
   ///@param payload Payload to pass
   ///@param charset Character encoding for (lazily) decoding payload
   ///@since 2.8
-  void setRequestPayloadOnError1(
+  void setRequestPayloadOnError$1(
     jni.JArray<jni.jbyte> payload,
     jni.JString charset,
   ) {
-    _setRequestPayloadOnError1(
+    _setRequestPayloadOnError$1(
             reference.pointer,
-            _id_setRequestPayloadOnError1 as jni.JMethodIDPtr,
+            _id_setRequestPayloadOnError$1 as jni.JMethodIDPtr,
             payload.reference.pointer,
             charset.reference.pointer)
         .check();
   }
 
-  static final _id_setRequestPayloadOnError2 = _class.instanceMethodId(
+  static final _id_setRequestPayloadOnError$2 = _class.instanceMethodId(
     r'setRequestPayloadOnError',
     r'(Ljava/lang/String;)V',
   );
 
-  static final _setRequestPayloadOnError2 = ProtectedJniExtensions.lookup<
+  static final _setRequestPayloadOnError$2 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JThrowablePtr Function(
                       ffi.Pointer<ffi.Void>,
@@ -538,12 +538,12 @@ class JsonParser extends jni.JObject {
   /// Sets the String request payload
   ///@param payload Payload to pass
   ///@since 2.8
-  void setRequestPayloadOnError2(
+  void setRequestPayloadOnError$2(
     jni.JString payload,
   ) {
-    _setRequestPayloadOnError2(
+    _setRequestPayloadOnError$2(
             reference.pointer,
-            _id_setRequestPayloadOnError2 as jni.JMethodIDPtr,
+            _id_setRequestPayloadOnError$2 as jni.JMethodIDPtr,
             payload.reference.pointer)
         .check();
   }
@@ -1203,12 +1203,12 @@ class JsonParser extends jni.JObject {
         .integer;
   }
 
-  static final _id_releaseBuffered1 = _class.instanceMethodId(
+  static final _id_releaseBuffered$1 = _class.instanceMethodId(
     r'releaseBuffered',
     r'(Ljava/io/Writer;)I',
   );
 
-  static final _releaseBuffered1 = ProtectedJniExtensions.lookup<
+  static final _releaseBuffered$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1233,11 +1233,11 @@ class JsonParser extends jni.JObject {
   ///    (that is, input can not be sent to Writer;
   ///    otherwise number of chars released (0 if there was nothing to release)
   ///@throws IOException if write using Writer threw exception
-  int releaseBuffered1(
+  int releaseBuffered$1(
     jni.JObject w,
   ) {
-    return _releaseBuffered1(reference.pointer,
-            _id_releaseBuffered1 as jni.JMethodIDPtr, w.reference.pointer)
+    return _releaseBuffered$1(reference.pointer,
+            _id_releaseBuffered$1 as jni.JMethodIDPtr, w.reference.pointer)
         .integer;
   }
 
@@ -1365,12 +1365,12 @@ class JsonParser extends jni.JObject {
         .boolean;
   }
 
-  static final _id_isEnabled1 = _class.instanceMethodId(
+  static final _id_isEnabled$1 = _class.instanceMethodId(
     r'isEnabled',
     r'(Lcom/fasterxml/jackson/core/StreamReadFeature;)Z',
   );
 
-  static final _isEnabled1 = ProtectedJniExtensions.lookup<
+  static final _isEnabled$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1387,10 +1387,10 @@ class JsonParser extends jni.JObject {
   ///@param f Feature to check
   ///@return {@code True} if feature is enabled; {@code false} otherwise
   ///@since 2.10
-  bool isEnabled1(
+  bool isEnabled$1(
     jni.JObject f,
   ) {
-    return _isEnabled1(reference.pointer, _id_isEnabled1 as jni.JMethodIDPtr,
+    return _isEnabled$1(reference.pointer, _id_isEnabled$1 as jni.JMethodIDPtr,
             f.reference.pointer)
         .boolean;
   }
@@ -1668,12 +1668,12 @@ class JsonParser extends jni.JObject {
         .boolean;
   }
 
-  static final _id_nextFieldName1 = _class.instanceMethodId(
+  static final _id_nextFieldName$1 = _class.instanceMethodId(
     r'nextFieldName',
     r'()Ljava/lang/String;',
   );
 
-  static final _nextFieldName1 = ProtectedJniExtensions.lookup<
+  static final _nextFieldName$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -1696,9 +1696,9 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   ///@since 2.5
-  jni.JString nextFieldName1() {
-    return _nextFieldName1(
-            reference.pointer, _id_nextFieldName1 as jni.JMethodIDPtr)
+  jni.JString nextFieldName$1() {
+    return _nextFieldName$1(
+            reference.pointer, _id_nextFieldName$1 as jni.JMethodIDPtr)
         .object(const jni.JStringType());
   }
 
@@ -2513,12 +2513,12 @@ class JsonParser extends jni.JObject {
         .object(const jni.JStringType());
   }
 
-  static final _id_getText1 = _class.instanceMethodId(
+  static final _id_getText$1 = _class.instanceMethodId(
     r'getText',
     r'(Ljava/io/Writer;)I',
   );
 
-  static final _getText1 = ProtectedJniExtensions.lookup<
+  static final _getText$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2546,10 +2546,10 @@ class JsonParser extends jni.JObject {
   ///   {@code writer}, or
   ///   JsonParseException for decoding problems
   ///@since 2.8
-  int getText1(
+  int getText$1(
     jni.JObject writer,
   ) {
-    return _getText1(reference.pointer, _id_getText1 as jni.JMethodIDPtr,
+    return _getText$1(reference.pointer, _id_getText$1 as jni.JMethodIDPtr,
             writer.reference.pointer)
         .integer;
   }
@@ -3258,12 +3258,12 @@ class JsonParser extends jni.JObject {
         .object(const jni.JArrayType(jni.jbyteType()));
   }
 
-  static final _id_getBinaryValue1 = _class.instanceMethodId(
+  static final _id_getBinaryValue$1 = _class.instanceMethodId(
     r'getBinaryValue',
     r'()[B',
   );
 
-  static final _getBinaryValue1 = ProtectedJniExtensions.lookup<
+  static final _getBinaryValue$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -3284,9 +3284,9 @@ class JsonParser extends jni.JObject {
   ///@return Decoded binary data
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
-  jni.JArray<jni.jbyte> getBinaryValue1() {
-    return _getBinaryValue1(
-            reference.pointer, _id_getBinaryValue1 as jni.JMethodIDPtr)
+  jni.JArray<jni.jbyte> getBinaryValue$1() {
+    return _getBinaryValue$1(
+            reference.pointer, _id_getBinaryValue$1 as jni.JMethodIDPtr)
         .object(const jni.JArrayType(jni.jbyteType()));
   }
 
@@ -3327,12 +3327,12 @@ class JsonParser extends jni.JObject {
         .integer;
   }
 
-  static final _id_readBinaryValue1 = _class.instanceMethodId(
+  static final _id_readBinaryValue$1 = _class.instanceMethodId(
     r'readBinaryValue',
     r'(Lcom/fasterxml/jackson/core/Base64Variant;Ljava/io/OutputStream;)I',
   );
 
-  static final _readBinaryValue1 = ProtectedJniExtensions.lookup<
+  static final _readBinaryValue$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -3356,13 +3356,13 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   ///@since 2.1
-  int readBinaryValue1(
+  int readBinaryValue$1(
     jni.JObject bv,
     jni.JObject out,
   ) {
-    return _readBinaryValue1(
+    return _readBinaryValue$1(
             reference.pointer,
-            _id_readBinaryValue1 as jni.JMethodIDPtr,
+            _id_readBinaryValue$1 as jni.JMethodIDPtr,
             bv.reference.pointer,
             out.reference.pointer)
         .integer;
@@ -3406,12 +3406,12 @@ class JsonParser extends jni.JObject {
         .integer;
   }
 
-  static final _id_getValueAsInt1 = _class.instanceMethodId(
+  static final _id_getValueAsInt$1 = _class.instanceMethodId(
     r'getValueAsInt',
     r'(I)I',
   );
 
-  static final _getValueAsInt1 = ProtectedJniExtensions.lookup<
+  static final _getValueAsInt$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
                   ffi.VarArgs<($Int32,)>)>>('globalEnv_CallIntMethod')
@@ -3434,11 +3434,11 @@ class JsonParser extends jni.JObject {
   ///@return {@code int} value current token is converted to, if possible; {@code def} otherwise
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
-  int getValueAsInt1(
+  int getValueAsInt$1(
     int def,
   ) {
-    return _getValueAsInt1(
-            reference.pointer, _id_getValueAsInt1 as jni.JMethodIDPtr, def)
+    return _getValueAsInt$1(
+            reference.pointer, _id_getValueAsInt$1 as jni.JMethodIDPtr, def)
         .integer;
   }
 
@@ -3480,12 +3480,12 @@ class JsonParser extends jni.JObject {
         .long;
   }
 
-  static final _id_getValueAsLong1 = _class.instanceMethodId(
+  static final _id_getValueAsLong$1 = _class.instanceMethodId(
     r'getValueAsLong',
     r'(J)J',
   );
 
-  static final _getValueAsLong1 = ProtectedJniExtensions.lookup<
+  static final _getValueAsLong$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
                   ffi.VarArgs<(ffi.Int64,)>)>>('globalEnv_CallLongMethod')
@@ -3508,11 +3508,11 @@ class JsonParser extends jni.JObject {
   ///@return {@code long} value current token is converted to, if possible; {@code def} otherwise
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
-  int getValueAsLong1(
+  int getValueAsLong$1(
     int def,
   ) {
-    return _getValueAsLong1(
-            reference.pointer, _id_getValueAsLong1 as jni.JMethodIDPtr, def)
+    return _getValueAsLong$1(
+            reference.pointer, _id_getValueAsLong$1 as jni.JMethodIDPtr, def)
         .long;
   }
 
@@ -3554,12 +3554,12 @@ class JsonParser extends jni.JObject {
         .doubleFloat;
   }
 
-  static final _id_getValueAsDouble1 = _class.instanceMethodId(
+  static final _id_getValueAsDouble$1 = _class.instanceMethodId(
     r'getValueAsDouble',
     r'(D)D',
   );
 
-  static final _getValueAsDouble1 = ProtectedJniExtensions.lookup<
+  static final _getValueAsDouble$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
                   ffi.VarArgs<(ffi.Double,)>)>>('globalEnv_CallDoubleMethod')
@@ -3582,11 +3582,11 @@ class JsonParser extends jni.JObject {
   ///@return {@code double} value current token is converted to, if possible; {@code def} otherwise
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
-  double getValueAsDouble1(
+  double getValueAsDouble$1(
     double def,
   ) {
-    return _getValueAsDouble1(
-            reference.pointer, _id_getValueAsDouble1 as jni.JMethodIDPtr, def)
+    return _getValueAsDouble$1(
+            reference.pointer, _id_getValueAsDouble$1 as jni.JMethodIDPtr, def)
         .doubleFloat;
   }
 
@@ -3628,12 +3628,12 @@ class JsonParser extends jni.JObject {
         .boolean;
   }
 
-  static final _id_getValueAsBoolean1 = _class.instanceMethodId(
+  static final _id_getValueAsBoolean$1 = _class.instanceMethodId(
     r'getValueAsBoolean',
     r'(Z)Z',
   );
 
-  static final _getValueAsBoolean1 = ProtectedJniExtensions.lookup<
+  static final _getValueAsBoolean$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
                   ffi.VarArgs<($Int32,)>)>>('globalEnv_CallBooleanMethod')
@@ -3656,11 +3656,11 @@ class JsonParser extends jni.JObject {
   ///@return {@code boolean} value current token is converted to, if possible; {@code def} otherwise
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
-  bool getValueAsBoolean1(
+  bool getValueAsBoolean$1(
     bool def,
   ) {
-    return _getValueAsBoolean1(reference.pointer,
-            _id_getValueAsBoolean1 as jni.JMethodIDPtr, def ? 1 : 0)
+    return _getValueAsBoolean$1(reference.pointer,
+            _id_getValueAsBoolean$1 as jni.JMethodIDPtr, def ? 1 : 0)
         .boolean;
   }
 
@@ -3701,12 +3701,12 @@ class JsonParser extends jni.JObject {
         .object(const jni.JStringType());
   }
 
-  static final _id_getValueAsString1 = _class.instanceMethodId(
+  static final _id_getValueAsString$1 = _class.instanceMethodId(
     r'getValueAsString',
     r'(Ljava/lang/String;)Ljava/lang/String;',
   );
 
-  static final _getValueAsString1 = ProtectedJniExtensions.lookup<
+  static final _getValueAsString$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -3732,11 +3732,11 @@ class JsonParser extends jni.JObject {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   ///@since 2.1
-  jni.JString getValueAsString1(
+  jni.JString getValueAsString$1(
     jni.JString def,
   ) {
-    return _getValueAsString1(reference.pointer,
-            _id_getValueAsString1 as jni.JMethodIDPtr, def.reference.pointer)
+    return _getValueAsString$1(reference.pointer,
+            _id_getValueAsString$1 as jni.JMethodIDPtr, def.reference.pointer)
         .object(const jni.JStringType());
   }
 
@@ -3941,12 +3941,12 @@ class JsonParser extends jni.JObject {
         .object(T);
   }
 
-  static final _id_readValueAs1 = _class.instanceMethodId(
+  static final _id_readValueAs$1 = _class.instanceMethodId(
     r'readValueAs',
     r'(Lcom/fasterxml/jackson/core/type/TypeReference;)Ljava/lang/Object;',
   );
 
-  static final _readValueAs1 = ProtectedJniExtensions.lookup<
+  static final _readValueAs$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -3982,13 +3982,13 @@ class JsonParser extends jni.JObject {
   ///@return Java value read from content
   ///@throws IOException if there is either an underlying I/O problem or decoding
   ///    issue at format layer
-  $T readValueAs1<$T extends jni.JObject>(
+  $T readValueAs$1<$T extends jni.JObject>(
     jni.JObject valueTypeRef, {
     required jni.JObjType<$T> T,
   }) {
-    return _readValueAs1(
+    return _readValueAs$1(
             reference.pointer,
-            _id_readValueAs1 as jni.JMethodIDPtr,
+            _id_readValueAs$1 as jni.JMethodIDPtr,
             valueTypeRef.reference.pointer)
         .object(T);
   }
@@ -4029,12 +4029,12 @@ class JsonParser extends jni.JObject {
         .object(jni.JIteratorType(T));
   }
 
-  static final _id_readValuesAs1 = _class.instanceMethodId(
+  static final _id_readValuesAs$1 = _class.instanceMethodId(
     r'readValuesAs',
     r'(Lcom/fasterxml/jackson/core/type/TypeReference;)Ljava/util/Iterator;',
   );
 
-  static final _readValuesAs1 = ProtectedJniExtensions.lookup<
+  static final _readValuesAs$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -4056,13 +4056,13 @@ class JsonParser extends jni.JObject {
   ///@return Iterator for reading multiple Java values from content
   ///@throws IOException if there is either an underlying I/O problem or decoding
   ///    issue at format layer
-  jni.JIterator<$T> readValuesAs1<$T extends jni.JObject>(
+  jni.JIterator<$T> readValuesAs$1<$T extends jni.JObject>(
     jni.JObject valueTypeRef, {
     required jni.JObjType<$T> T,
   }) {
-    return _readValuesAs1(
+    return _readValuesAs$1(
             reference.pointer,
-            _id_readValuesAs1 as jni.JMethodIDPtr,
+            _id_readValuesAs$1 as jni.JMethodIDPtr,
             valueTypeRef.reference.pointer)
         .object(jni.JIteratorType(T));
   }

--- a/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
+++ b/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
@@ -262,11 +262,11 @@ class Speed extends Measure<SpeedUnit> {
 
   /// The type which includes information such as the signature of this class.
   static const type = $SpeedType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'(FLcom/github/dart_lang/jnigen/SpeedUnit;)V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -283,8 +283,8 @@ class Speed extends Measure<SpeedUnit> {
     double f,
     SpeedUnit speedUnit,
   ) {
-    return Speed.fromReference(_new0(_class.reference.pointer,
-            _id_new0 as jni.JMethodIDPtr, f, speedUnit.reference.pointer)
+    return Speed.fromReference(_new$(_class.reference.pointer,
+            _id_new$ as jni.JMethodIDPtr, f, speedUnit.reference.pointer)
         .reference);
   }
 
@@ -678,11 +678,11 @@ class SuspendFun extends jni.JObject {
 
   /// The type which includes information such as the signature of this class.
   static const type = $SuspendFunType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -698,7 +698,7 @@ class SuspendFun extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory SuspendFun() {
     return SuspendFun.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 

--- a/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
+++ b/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
@@ -358,12 +358,12 @@ class Speed extends Measure<SpeedUnit> {
         .object(const jni.JStringType());
   }
 
-  static final _id_component1 = _class.instanceMethodId(
+  static final _id_component1$ = _class.instanceMethodId(
     r'component1',
     r'()F',
   );
 
-  static final _component1 = ProtectedJniExtensions.lookup<
+  static final _component1$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -376,17 +376,17 @@ class Speed extends Measure<SpeedUnit> {
           )>();
 
   /// from: `public final float component1()`
-  double component1() {
-    return _component1(reference.pointer, _id_component1 as jni.JMethodIDPtr)
+  double component1$() {
+    return _component1$(reference.pointer, _id_component1$ as jni.JMethodIDPtr)
         .float;
   }
 
-  static final _id_component2 = _class.instanceMethodId(
+  static final _id_component2$ = _class.instanceMethodId(
     r'component2',
     r'()Lcom/github/dart_lang/jnigen/SpeedUnit;',
   );
 
-  static final _component2 = ProtectedJniExtensions.lookup<
+  static final _component2$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -400,8 +400,8 @@ class Speed extends Measure<SpeedUnit> {
 
   /// from: `public final com.github.dart_lang.jnigen.SpeedUnit component2()`
   /// The returned object must be released after use, by calling the [release] method.
-  SpeedUnit component2() {
-    return _component2(reference.pointer, _id_component2 as jni.JMethodIDPtr)
+  SpeedUnit component2$() {
+    return _component2$(reference.pointer, _id_component2$ as jni.JMethodIDPtr)
         .object(const $SpeedUnitType());
   }
 

--- a/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
+++ b/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
@@ -310,12 +310,12 @@ class Speed extends Measure<SpeedUnit> {
     return _getValue(reference.pointer, _id_getValue as jni.JMethodIDPtr).float;
   }
 
-  static final _id_getUnit1 = _class.instanceMethodId(
+  static final _id_getUnit$1 = _class.instanceMethodId(
     r'getUnit',
     r'()Lcom/github/dart_lang/jnigen/SpeedUnit;',
   );
 
-  static final _getUnit1 = ProtectedJniExtensions.lookup<
+  static final _getUnit$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -329,17 +329,17 @@ class Speed extends Measure<SpeedUnit> {
 
   /// from: `public com.github.dart_lang.jnigen.SpeedUnit getUnit()`
   /// The returned object must be released after use, by calling the [release] method.
-  SpeedUnit getUnit1() {
-    return _getUnit1(reference.pointer, _id_getUnit1 as jni.JMethodIDPtr)
+  SpeedUnit getUnit$1() {
+    return _getUnit$1(reference.pointer, _id_getUnit$1 as jni.JMethodIDPtr)
         .object(const $SpeedUnitType());
   }
 
-  static final _id_toString1 = _class.instanceMethodId(
+  static final _id_toString$1 = _class.instanceMethodId(
     r'toString',
     r'()Ljava/lang/String;',
   );
 
-  static final _toString1 = ProtectedJniExtensions.lookup<
+  static final _toString$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -353,17 +353,17 @@ class Speed extends Measure<SpeedUnit> {
 
   /// from: `public java.lang.String toString()`
   /// The returned object must be released after use, by calling the [release] method.
-  jni.JString toString1() {
-    return _toString1(reference.pointer, _id_toString1 as jni.JMethodIDPtr)
+  jni.JString toString$1() {
+    return _toString$1(reference.pointer, _id_toString$1 as jni.JMethodIDPtr)
         .object(const jni.JStringType());
   }
 
-  static final _id_component1$ = _class.instanceMethodId(
+  static final _id_component1 = _class.instanceMethodId(
     r'component1',
     r'()F',
   );
 
-  static final _component1$ = ProtectedJniExtensions.lookup<
+  static final _component1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -376,17 +376,17 @@ class Speed extends Measure<SpeedUnit> {
           )>();
 
   /// from: `public final float component1()`
-  double component1$() {
-    return _component1$(reference.pointer, _id_component1$ as jni.JMethodIDPtr)
+  double component1() {
+    return _component1(reference.pointer, _id_component1 as jni.JMethodIDPtr)
         .float;
   }
 
-  static final _id_component2$ = _class.instanceMethodId(
+  static final _id_component2 = _class.instanceMethodId(
     r'component2',
     r'()Lcom/github/dart_lang/jnigen/SpeedUnit;',
   );
 
-  static final _component2$ = ProtectedJniExtensions.lookup<
+  static final _component2 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -400,8 +400,8 @@ class Speed extends Measure<SpeedUnit> {
 
   /// from: `public final com.github.dart_lang.jnigen.SpeedUnit component2()`
   /// The returned object must be released after use, by calling the [release] method.
-  SpeedUnit component2$() {
-    return _component2$(reference.pointer, _id_component2$ as jni.JMethodIDPtr)
+  SpeedUnit component2() {
+    return _component2(reference.pointer, _id_component2 as jni.JMethodIDPtr)
         .object(const $SpeedUnitType());
   }
 
@@ -432,12 +432,12 @@ class Speed extends Measure<SpeedUnit> {
         .object(const $SpeedType());
   }
 
-  static final _id_hashCode1 = _class.instanceMethodId(
+  static final _id_hashCode$1 = _class.instanceMethodId(
     r'hashCode',
     r'()I',
   );
 
-  static final _hashCode1 = ProtectedJniExtensions.lookup<
+  static final _hashCode$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -450,8 +450,8 @@ class Speed extends Measure<SpeedUnit> {
           )>();
 
   /// from: `public int hashCode()`
-  int hashCode1() {
-    return _hashCode1(reference.pointer, _id_hashCode1 as jni.JMethodIDPtr)
+  int hashCode$1() {
+    return _hashCode$1(reference.pointer, _id_hashCode$1 as jni.JMethodIDPtr)
         .integer;
   }
 
@@ -735,12 +735,12 @@ class SuspendFun extends jni.JObject {
     return const jni.JStringType().fromReference($o);
   }
 
-  static final _id_sayHello1 = _class.instanceMethodId(
+  static final _id_sayHello$1 = _class.instanceMethodId(
     r'sayHello',
     r'(Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;',
   );
 
-  static final _sayHello1 = ProtectedJniExtensions.lookup<
+  static final _sayHello$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -756,13 +756,13 @@ class SuspendFun extends jni.JObject {
 
   /// from: `public final java.lang.Object sayHello(java.lang.String string, kotlin.coroutines.Continuation continuation)`
   /// The returned object must be released after use, by calling the [release] method.
-  Future<jni.JString> sayHello1(
+  Future<jni.JString> sayHello$1(
     jni.JString string,
   ) async {
     final $p = ReceivePort();
     final $c = jni.JObject.fromReference(
         ProtectedJniExtensions.newPortContinuation($p));
-    _sayHello1(reference.pointer, _id_sayHello1 as jni.JMethodIDPtr,
+    _sayHello$1(reference.pointer, _id_sayHello$1 as jni.JMethodIDPtr,
             string.reference.pointer, $c.reference.pointer)
         .object(const jni.JObjectType());
     final $o = jni.JGlobalReference(jni.JObjectPtr.fromAddress(await $p.first));

--- a/pkgs/jnigen/test/kotlin_test/runtime_test_registrant.dart
+++ b/pkgs/jnigen/test/kotlin_test/runtime_test_registrant.dart
@@ -17,7 +17,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
         expect(hello.toDartString(releaseOriginal: true), 'Hello!');
         const name = 'Bob';
         final helloBob =
-            await suspendFun.sayHello1(name.toJString()..releasedBy(arena));
+            await suspendFun.sayHello$1(name.toJString()..releasedBy(arena));
         expect(helloBob.toDartString(releaseOriginal: true), 'Hello $name!');
       });
     });

--- a/pkgs/jnigen/test/renamer_test.dart
+++ b/pkgs/jnigen/test/renamer_test.dart
@@ -1,0 +1,107 @@
+import 'package:jnigen/src/bindings/linker.dart';
+import 'package:jnigen/src/bindings/renamer.dart';
+import 'package:jnigen/src/config/config.dart';
+import 'package:jnigen/src/elements/elements.dart';
+import 'package:test/test.dart';
+
+Future<Config> testConfig() async {
+  final config = Config(
+    outputConfig: OutputConfig(
+      dartConfig: DartCodeOutputConfig(
+        path: Uri.file('test.dart'),
+        structure: OutputStructure.singleFile,
+      ),
+    ),
+    classes: ['Foo'],
+  );
+  return config;
+}
+
+void main() {
+  test('Overloading elements that end with a number', () async {
+    final classes = Classes({
+      'Foo': ClassDecl(
+        binaryName: 'Foo',
+        declKind: DeclKind.classKind,
+        superclass: TypeUsage.object,
+        methods: [
+          Method(name: 'foo', returnType: TypeUsage.object),
+          Method(name: 'foo', returnType: TypeUsage.object),
+          Method(name: 'foo', returnType: TypeUsage.object),
+          Method(name: 'foo1', returnType: TypeUsage.object),
+          Method(name: 'foo1', returnType: TypeUsage.object),
+          Method(name: 'foo1', returnType: TypeUsage.object),
+        ],
+      ),
+      'x.Foo': ClassDecl(
+        binaryName: 'x.Foo',
+        declKind: DeclKind.classKind,
+        superclass: TypeUsage.object,
+        fields: [
+          Field(name: 'foo', type: TypeUsage.object),
+          Field(name: 'foo', type: TypeUsage.object),
+          Field(name: 'foo', type: TypeUsage.object),
+          Field(name: 'foo1', type: TypeUsage.object),
+          Field(name: 'foo1', type: TypeUsage.object),
+          Field(name: 'foo1', type: TypeUsage.object),
+        ],
+      ),
+      'y.Foo': ClassDecl(
+        binaryName: 'y.Foo',
+        declKind: DeclKind.classKind,
+        superclass: TypeUsage.object,
+      ),
+      'Foo1': ClassDecl(
+        binaryName: 'Foo1',
+        declKind: DeclKind.classKind,
+        superclass: TypeUsage.object,
+      ),
+      'x.Foo1': ClassDecl(
+        binaryName: 'x.Foo1',
+        declKind: DeclKind.classKind,
+        superclass: TypeUsage.object,
+      ),
+      'y.Foo1': ClassDecl(
+        binaryName: 'y.Foo1',
+        declKind: DeclKind.classKind,
+        superclass: TypeUsage.object,
+      ),
+    });
+    final config = await testConfig();
+    await classes.accept(Linker(config));
+    classes.accept(Renamer(config));
+
+    final renamedClasses =
+        classes.decls.values.map((c) => c.finalName).toList();
+    expect(renamedClasses, [
+      'Foo',
+      'Foo1',
+      'Foo2',
+      'Foo1\$',
+      'Foo1\$1',
+      'Foo1\$2',
+    ]);
+
+    final renamedMethods =
+        classes.decls['Foo']!.methods.map((m) => m.finalName).toList();
+    expect(renamedMethods, [
+      'foo',
+      'foo1',
+      'foo2',
+      'foo1\$',
+      'foo1\$1',
+      'foo1\$2',
+    ]);
+
+    final renamedFields =
+        classes.decls['x.Foo']!.fields.map((f) => f.finalName).toList();
+    expect(renamedFields, [
+      'foo',
+      'foo1',
+      'foo2',
+      'foo1\$',
+      'foo1\$1',
+      'foo1\$2',
+    ]);
+  });
+}

--- a/pkgs/jnigen/test/renamer_test.dart
+++ b/pkgs/jnigen/test/renamer_test.dart
@@ -37,12 +37,14 @@ void main() {
         binaryName: 'x.Foo',
         declKind: DeclKind.classKind,
         superclass: TypeUsage.object,
+        methods: [
+          Method(name: 'foo', returnType: TypeUsage.object),
+          Method(name: 'foo', returnType: TypeUsage.object),
+          Method(name: 'foo1', returnType: TypeUsage.object),
+          Method(name: 'foo1', returnType: TypeUsage.object),
+        ],
         fields: [
           Field(name: 'foo', type: TypeUsage.object),
-          Field(name: 'foo', type: TypeUsage.object),
-          Field(name: 'foo', type: TypeUsage.object),
-          Field(name: 'foo1', type: TypeUsage.object),
-          Field(name: 'foo1', type: TypeUsage.object),
           Field(name: 'foo1', type: TypeUsage.object),
         ],
       ),
@@ -95,13 +97,18 @@ void main() {
 
     final renamedFields =
         classes.decls['x.Foo']!.fields.map((f) => f.finalName).toList();
+    // Fields are renamed after methods in the current implementation.
     expect(renamedFields, [
+      'foo2',
+      'foo1\$2',
+    ]);
+    final xFooMethods =
+        classes.decls['x.Foo']!.methods.map((m) => m.finalName).toList();
+    expect(xFooMethods, [
       'foo',
       'foo1',
-      'foo2',
       'foo1\$',
       'foo1\$1',
-      'foo1\$2',
     ]);
   });
 }

--- a/pkgs/jnigen/test/renamer_test.dart
+++ b/pkgs/jnigen/test/renamer_test.dart
@@ -97,18 +97,90 @@ void main() {
 
     final renamedFields =
         classes.decls['x.Foo']!.fields.map((f) => f.finalName).toList();
-    // Fields are renamed after methods in the current implementation.
+    // Fields are renamed before methods. So they always keep their original
+    // name (if not renamed for a different reason).
     expect(renamedFields, [
-      'foo\$2',
-      'foo1\$2',
+      'foo',
+      'foo1',
     ]);
     final xFooMethods =
         classes.decls['x.Foo']!.methods.map((m) => m.finalName).toList();
     expect(xFooMethods, [
-      'foo',
       'foo\$1',
-      'foo1',
+      'foo\$2',
       'foo1\$1',
+      'foo1\$2',
     ]);
+  });
+
+  test('Field with the same name as inherited method gets renamed', () async {
+    final classes = Classes({
+      'Player': ClassDecl(
+        binaryName: 'Player',
+        declKind: DeclKind.classKind,
+        superclass: TypeUsage.object,
+        methods: [
+          Method(name: 'duck', returnType: TypeUsage.object),
+        ],
+      ),
+      'DuckOwningPlayer': ClassDecl(
+        binaryName: 'DuckOwningPlayer',
+        declKind: DeclKind.classKind,
+        superclass:
+            TypeUsage(shorthand: 'Player', kind: Kind.declared, typeJson: {})
+              ..type = DeclaredType(binaryName: 'Player'),
+        fields: [
+          Field(name: 'duck', type: TypeUsage.object),
+        ],
+      ),
+    });
+    final config = await testConfig();
+    await classes.accept(Linker(config));
+    classes.accept(Renamer(config));
+
+    final renamedMethods =
+        classes.decls['Player']!.methods.map((m) => m.finalName).toList();
+    expect(renamedMethods, ['duck']);
+    final renamedFields = classes.decls['DuckOwningPlayer']!.fields
+        .map((f) => f.finalName)
+        .toList();
+    expect(renamedFields, ['duck\$1']);
+  });
+
+  test('Keywords in names', () async {
+    final classes = Classes({
+      'Foo': ClassDecl(
+        binaryName: 'Foo',
+        declKind: DeclKind.classKind,
+        superclass: TypeUsage.object,
+        methods: [
+          Method(name: 'yield', returnType: TypeUsage.object),
+          Method(name: 'const', returnType: TypeUsage.object),
+          Method(name: 'const', returnType: TypeUsage.object),
+        ],
+        fields: [
+          Field(name: 'const', type: TypeUsage.object),
+        ],
+      ),
+      'Function': ClassDecl(
+        binaryName: 'Function',
+        declKind: DeclKind.classKind,
+        superclass: TypeUsage.object,
+      ),
+    });
+    final config = await testConfig();
+    await classes.accept(Linker(config));
+    classes.accept(Renamer(config));
+
+    final renamedMethods =
+        classes.decls['Foo']!.methods.map((m) => m.finalName).toList();
+    expect(renamedMethods, ['yield\$', 'const\$1', 'const\$2']);
+    final renamedFields =
+        classes.decls['Foo']!.fields.map((f) => f.finalName).toList();
+
+    expect(renamedFields, ['const\$']);
+    final renamedClasses =
+        classes.decls.values.map((c) => c.finalName).toList();
+    expect(renamedClasses, ['Foo', 'Function\$']);
   });
 }

--- a/pkgs/jnigen/test/renamer_test.dart
+++ b/pkgs/jnigen/test/renamer_test.dart
@@ -77,9 +77,9 @@ void main() {
         classes.decls.values.map((c) => c.finalName).toList();
     expect(renamedClasses, [
       'Foo',
+      'Foo\$1',
+      'Foo\$2',
       'Foo1',
-      'Foo2',
-      'Foo1\$',
       'Foo1\$1',
       'Foo1\$2',
     ]);
@@ -88,9 +88,9 @@ void main() {
         classes.decls['Foo']!.methods.map((m) => m.finalName).toList();
     expect(renamedMethods, [
       'foo',
+      'foo\$1',
+      'foo\$2',
       'foo1',
-      'foo2',
-      'foo1\$',
       'foo1\$1',
       'foo1\$2',
     ]);
@@ -99,15 +99,15 @@ void main() {
         classes.decls['x.Foo']!.fields.map((f) => f.finalName).toList();
     // Fields are renamed after methods in the current implementation.
     expect(renamedFields, [
-      'foo2',
+      'foo\$2',
       'foo1\$2',
     ]);
     final xFooMethods =
         classes.decls['x.Foo']!.methods.map((m) => m.finalName).toList();
     expect(xFooMethods, [
       'foo',
+      'foo\$1',
       'foo1',
-      'foo1\$',
       'foo1\$1',
     ]);
   });

--- a/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
@@ -567,12 +567,12 @@ class Example extends jni.JObject {
         .check();
   }
 
-  static final _id_max4$ = _class.staticMethodId(
+  static final _id_max4 = _class.staticMethodId(
     r'max4',
     r'(IIII)I',
   );
 
-  static final _max4$ = ProtectedJniExtensions.lookup<
+  static final _max4 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -584,23 +584,23 @@ class Example extends jni.JObject {
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int, int, int, int)>();
 
   /// from: `static public int max4(int a, int b, int c, int d)`
-  static int max4$(
+  static int max4(
     int a,
     int b,
     int c,
     int d,
   ) {
-    return _max4$(
-            _class.reference.pointer, _id_max4$ as jni.JMethodIDPtr, a, b, c, d)
+    return _max4(
+            _class.reference.pointer, _id_max4 as jni.JMethodIDPtr, a, b, c, d)
         .integer;
   }
 
-  static final _id_max8$ = _class.staticMethodId(
+  static final _id_max8 = _class.staticMethodId(
     r'max8',
     r'(IIIIIIII)I',
   );
 
-  static final _max8$ = ProtectedJniExtensions.lookup<
+  static final _max8 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -621,7 +621,7 @@ class Example extends jni.JObject {
               int, int, int, int, int, int, int)>();
 
   /// from: `static public int max8(int a, int b, int c, int d, int e, int f, int g, int h)`
-  static int max8$(
+  static int max8(
     int a,
     int b,
     int c,
@@ -631,7 +631,7 @@ class Example extends jni.JObject {
     int g,
     int h,
   ) {
-    return _max8$(_class.reference.pointer, _id_max8$ as jni.JMethodIDPtr, a, b,
+    return _max8(_class.reference.pointer, _id_max8 as jni.JMethodIDPtr, a, b,
             c, d, e, f, g, h)
         .integer;
   }
@@ -1110,11 +1110,11 @@ class Example extends jni.JObject {
             .reference);
   }
 
-  static final _id_new1 = _class.constructorId(
+  static final _id_new$1 = _class.constructorId(
     r'(I)V',
   );
 
-  static final _new1 = ProtectedJniExtensions.lookup<
+  static final _new$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
                   ffi.VarArgs<($Int32,)>)>>('globalEnv_NewObject')
@@ -1124,19 +1124,19 @@ class Example extends jni.JObject {
 
   /// from: `public void <init>(int number)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory Example.new1(
+  factory Example.new$1(
     int number,
   ) {
     return Example.fromReference(
-        _new1(_class.reference.pointer, _id_new1 as jni.JMethodIDPtr, number)
+        _new$1(_class.reference.pointer, _id_new$1 as jni.JMethodIDPtr, number)
             .reference);
   }
 
-  static final _id_new2 = _class.constructorId(
+  static final _id_new$2 = _class.constructorId(
     r'(IZ)V',
   );
 
-  static final _new2 = ProtectedJniExtensions.lookup<
+  static final _new$2 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
                   ffi.VarArgs<($Int32, $Int32)>)>>('globalEnv_NewObject')
@@ -1146,20 +1146,20 @@ class Example extends jni.JObject {
 
   /// from: `public void <init>(int number, boolean isUp)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory Example.new2(
+  factory Example.new$2(
     int number,
     bool isUp,
   ) {
-    return Example.fromReference(_new2(_class.reference.pointer,
-            _id_new2 as jni.JMethodIDPtr, number, isUp ? 1 : 0)
+    return Example.fromReference(_new$2(_class.reference.pointer,
+            _id_new$2 as jni.JMethodIDPtr, number, isUp ? 1 : 0)
         .reference);
   }
 
-  static final _id_new3 = _class.constructorId(
+  static final _id_new$3 = _class.constructorId(
     r'(IZLjava/lang/String;)V',
   );
 
-  static final _new3 = ProtectedJniExtensions.lookup<
+  static final _new$3 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -1172,25 +1172,25 @@ class Example extends jni.JObject {
 
   /// from: `public void <init>(int number, boolean isUp, java.lang.String codename)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory Example.new3(
+  factory Example.new$3(
     int number,
     bool isUp,
     jni.JString codename,
   ) {
-    return Example.fromReference(_new3(
+    return Example.fromReference(_new$3(
             _class.reference.pointer,
-            _id_new3 as jni.JMethodIDPtr,
+            _id_new$3 as jni.JMethodIDPtr,
             number,
             isUp ? 1 : 0,
             codename.reference.pointer)
         .reference);
   }
 
-  static final _id_new4 = _class.constructorId(
+  static final _id_new$4 = _class.constructorId(
     r'(IIIIIIII)V',
   );
 
-  static final _new4 = ProtectedJniExtensions.lookup<
+  static final _new$4 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1212,7 +1212,7 @@ class Example extends jni.JObject {
 
   /// from: `public void <init>(int a, int b, int c, int d, int e, int f, int g, int h)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory Example.new4(
+  factory Example.new$4(
     int a,
     int b,
     int c,
@@ -1222,8 +1222,8 @@ class Example extends jni.JObject {
     int g,
     int h,
   ) {
-    return Example.fromReference(_new4(_class.reference.pointer,
-            _id_new4 as jni.JMethodIDPtr, a, b, c, d, e, f, g, h)
+    return Example.fromReference(_new$4(_class.reference.pointer,
+            _id_new$4 as jni.JMethodIDPtr, a, b, c, d, e, f, g, h)
         .reference);
   }
 
@@ -1394,12 +1394,12 @@ class Example extends jni.JObject {
     _overloaded(reference.pointer, _id_overloaded as jni.JMethodIDPtr).check();
   }
 
-  static final _id_overloaded1 = _class.instanceMethodId(
+  static final _id_overloaded$1 = _class.instanceMethodId(
     r'overloaded',
     r'(ILjava/lang/String;)V',
   );
 
-  static final _overloaded1 = ProtectedJniExtensions.lookup<
+  static final _overloaded$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JThrowablePtr Function(
                       ffi.Pointer<ffi.Void>,
@@ -1411,21 +1411,21 @@ class Example extends jni.JObject {
               int, ffi.Pointer<ffi.Void>)>();
 
   /// from: `public void overloaded(int a, java.lang.String b)`
-  void overloaded1(
+  void overloaded$1(
     int a,
     jni.JString b,
   ) {
-    _overloaded1(reference.pointer, _id_overloaded1 as jni.JMethodIDPtr, a,
+    _overloaded$1(reference.pointer, _id_overloaded$1 as jni.JMethodIDPtr, a,
             b.reference.pointer)
         .check();
   }
 
-  static final _id_overloaded2 = _class.instanceMethodId(
+  static final _id_overloaded$2 = _class.instanceMethodId(
     r'overloaded',
     r'(I)V',
   );
 
-  static final _overloaded2 = ProtectedJniExtensions.lookup<
+  static final _overloaded$2 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
@@ -1436,19 +1436,19 @@ class Example extends jni.JObject {
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
 
   /// from: `public void overloaded(int a)`
-  void overloaded2(
+  void overloaded$2(
     int a,
   ) {
-    _overloaded2(reference.pointer, _id_overloaded2 as jni.JMethodIDPtr, a)
+    _overloaded$2(reference.pointer, _id_overloaded$2 as jni.JMethodIDPtr, a)
         .check();
   }
 
-  static final _id_overloaded3 = _class.instanceMethodId(
+  static final _id_overloaded$3 = _class.instanceMethodId(
     r'overloaded',
     r'(Ljava/util/List;Ljava/lang/String;)V',
   );
 
-  static final _overloaded3 = ProtectedJniExtensions.lookup<
+  static final _overloaded$3 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JThrowablePtr Function(
                   ffi.Pointer<ffi.Void>,
@@ -1463,21 +1463,21 @@ class Example extends jni.JObject {
               ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
 
   /// from: `public void overloaded(java.util.List<java.lang.Integer> a, java.lang.String b)`
-  void overloaded3(
+  void overloaded$3(
     jni.JList<jni.JInteger> a,
     jni.JString b,
   ) {
-    _overloaded3(reference.pointer, _id_overloaded3 as jni.JMethodIDPtr,
+    _overloaded$3(reference.pointer, _id_overloaded$3 as jni.JMethodIDPtr,
             a.reference.pointer, b.reference.pointer)
         .check();
   }
 
-  static final _id_overloaded4 = _class.instanceMethodId(
+  static final _id_overloaded$4 = _class.instanceMethodId(
     r'overloaded',
     r'(Ljava/util/List;)V',
   );
 
-  static final _overloaded4 = ProtectedJniExtensions.lookup<
+  static final _overloaded$4 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JThrowablePtr Function(
                       ffi.Pointer<ffi.Void>,
@@ -1489,10 +1489,10 @@ class Example extends jni.JObject {
               ffi.Pointer<ffi.Void>)>();
 
   /// from: `public void overloaded(java.util.List<java.lang.Integer> a)`
-  void overloaded4(
+  void overloaded$4(
     jni.JList<jni.JInteger> a,
   ) {
-    _overloaded4(reference.pointer, _id_overloaded4 as jni.JMethodIDPtr,
+    _overloaded$4(reference.pointer, _id_overloaded$4 as jni.JMethodIDPtr,
             a.reference.pointer)
         .check();
   }
@@ -1525,11 +1525,11 @@ final class $ExampleType extends jni.JObjType<Example> {
 }
 
 /// from: `com.github.dart_lang.jnigen.pkg2.C2`
-class C2$ extends jni.JObject {
+class C2 extends jni.JObject {
   @override
-  late final jni.JObjType<C2$> $type = type;
+  late final jni.JObjType<C2> $type = type;
 
-  C2$.fromReference(
+  C2.fromReference(
     jni.JReference reference,
   ) : super.fromReference(reference);
 
@@ -1537,7 +1537,7 @@ class C2$ extends jni.JObject {
       jni.JClass.forName(r'com/github/dart_lang/jnigen/pkg2/C2');
 
   /// The type which includes information such as the signature of this class.
-  static const type = $C2$Type();
+  static const type = $C2Type();
   static final _id_CONSTANT = _class.staticFieldId(
     r'CONSTANT',
     r'I',
@@ -1568,21 +1568,21 @@ class C2$ extends jni.JObject {
 
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
-  factory C2$() {
-    return C2$.fromReference(
+  factory C2() {
+    return C2.fromReference(
         _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
             .reference);
   }
 }
 
-final class $C2$Type extends jni.JObjType<C2$> {
-  const $C2$Type();
+final class $C2Type extends jni.JObjType<C2> {
+  const $C2Type();
 
   @override
   String get signature => r'Lcom/github/dart_lang/jnigen/pkg2/C2;';
 
   @override
-  C2$ fromReference(jni.JReference reference) => C2$.fromReference(reference);
+  C2 fromReference(jni.JReference reference) => C2.fromReference(reference);
 
   @override
   jni.JObjType get superType => const jni.JObjectType();
@@ -1591,20 +1591,20 @@ final class $C2$Type extends jni.JObjType<C2$> {
   final superCount = 1;
 
   @override
-  int get hashCode => ($C2$Type).hashCode;
+  int get hashCode => ($C2Type).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == ($C2$Type) && other is $C2$Type;
+    return other.runtimeType == ($C2Type) && other is $C2Type;
   }
 }
 
 /// from: `com.github.dart_lang.jnigen.pkg2.Example`
-class Example1 extends jni.JObject {
+class Example$1 extends jni.JObject {
   @override
-  late final jni.JObjType<Example1> $type = type;
+  late final jni.JObjType<Example$1> $type = type;
 
-  Example1.fromReference(
+  Example$1.fromReference(
     jni.JReference reference,
   ) : super.fromReference(reference);
 
@@ -1612,7 +1612,7 @@ class Example1 extends jni.JObject {
       jni.JClass.forName(r'com/github/dart_lang/jnigen/pkg2/Example');
 
   /// The type which includes information such as the signature of this class.
-  static const type = $Example1Type();
+  static const type = $Example$1Type();
   static final _id_new0 = _class.constructorId(
     r'()V',
   );
@@ -1631,8 +1631,8 @@ class Example1 extends jni.JObject {
 
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
-  factory Example1() {
-    return Example1.fromReference(
+  factory Example$1() {
+    return Example$1.fromReference(
         _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
             .reference);
   }
@@ -1662,15 +1662,15 @@ class Example1 extends jni.JObject {
   }
 }
 
-final class $Example1Type extends jni.JObjType<Example1> {
-  const $Example1Type();
+final class $Example$1Type extends jni.JObjType<Example$1> {
+  const $Example$1Type();
 
   @override
   String get signature => r'Lcom/github/dart_lang/jnigen/pkg2/Example;';
 
   @override
-  Example1 fromReference(jni.JReference reference) =>
-      Example1.fromReference(reference);
+  Example$1 fromReference(jni.JReference reference) =>
+      Example$1.fromReference(reference);
 
   @override
   jni.JObjType get superType => const jni.JObjectType();
@@ -1679,11 +1679,11 @@ final class $Example1Type extends jni.JObjType<Example1> {
   final superCount = 1;
 
   @override
-  int get hashCode => ($Example1Type).hashCode;
+  int get hashCode => ($Example$1Type).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example1Type) && other is $Example1Type;
+    return other.runtimeType == ($Example$1Type) && other is $Example$1Type;
   }
 }
 
@@ -2930,12 +2930,12 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
         .object($MyStackType(T));
   }
 
-  static final _id_of1 = _class.staticMethodId(
+  static final _id_of$1 = _class.staticMethodId(
     r'of',
     r'(Ljava/lang/Object;)Lcom/github/dart_lang/jnigen/generics/MyStack;',
   );
 
-  static final _of1 = ProtectedJniExtensions.lookup<
+  static final _of$1 = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2948,24 +2948,24 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
 
   /// from: `static public com.github.dart_lang.jnigen.generics.MyStack<T> of(T obj)`
   /// The returned object must be released after use, by calling the [release] method.
-  static MyStack<$T> of1<$T extends jni.JObject>(
+  static MyStack<$T> of$1<$T extends jni.JObject>(
     $T obj, {
     jni.JObjType<$T>? T,
   }) {
     T ??= jni.lowestCommonSuperType([
       obj.$type,
     ]) as jni.JObjType<$T>;
-    return _of1(_class.reference.pointer, _id_of1 as jni.JMethodIDPtr,
+    return _of$1(_class.reference.pointer, _id_of$1 as jni.JMethodIDPtr,
             obj.reference.pointer)
         .object($MyStackType(T));
   }
 
-  static final _id_of2 = _class.staticMethodId(
+  static final _id_of$2 = _class.staticMethodId(
     r'of',
     r'(Ljava/lang/Object;Ljava/lang/Object;)Lcom/github/dart_lang/jnigen/generics/MyStack;',
   );
 
-  static final _of2 = ProtectedJniExtensions.lookup<
+  static final _of$2 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -2981,7 +2981,7 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
 
   /// from: `static public com.github.dart_lang.jnigen.generics.MyStack<T> of(T obj, T obj2)`
   /// The returned object must be released after use, by calling the [release] method.
-  static MyStack<$T> of2<$T extends jni.JObject>(
+  static MyStack<$T> of$2<$T extends jni.JObject>(
     $T obj,
     $T obj2, {
     jni.JObjType<$T>? T,
@@ -2990,7 +2990,7 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
       obj2.$type,
       obj.$type,
     ]) as jni.JObjType<$T>;
-    return _of2(_class.reference.pointer, _id_of2 as jni.JMethodIDPtr,
+    return _of$2(_class.reference.pointer, _id_of$2 as jni.JMethodIDPtr,
             obj.reference.pointer, obj2.reference.pointer)
         .object($MyStackType(T));
   }
@@ -4926,11 +4926,11 @@ class Exceptions extends jni.JObject {
             .reference);
   }
 
-  static final _id_new1 = _class.constructorId(
+  static final _id_new$1 = _class.constructorId(
     r'(F)V',
   );
 
-  static final _new1 = ProtectedJniExtensions.lookup<
+  static final _new$1 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
                   ffi.VarArgs<(ffi.Double,)>)>>('globalEnv_NewObject')
@@ -4940,19 +4940,19 @@ class Exceptions extends jni.JObject {
 
   /// from: `public void <init>(float x)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory Exceptions.new1(
+  factory Exceptions.new$1(
     double x,
   ) {
     return Exceptions.fromReference(
-        _new1(_class.reference.pointer, _id_new1 as jni.JMethodIDPtr, x)
+        _new$1(_class.reference.pointer, _id_new$1 as jni.JMethodIDPtr, x)
             .reference);
   }
 
-  static final _id_new2 = _class.constructorId(
+  static final _id_new$2 = _class.constructorId(
     r'(IIIIII)V',
   );
 
-  static final _new2 = ProtectedJniExtensions.lookup<
+  static final _new$2 = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -4972,7 +4972,7 @@ class Exceptions extends jni.JObject {
 
   /// from: `public void <init>(int a, int b, int c, int d, int e, int f)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory Exceptions.new2(
+  factory Exceptions.new$2(
     int a,
     int b,
     int c,
@@ -4980,8 +4980,8 @@ class Exceptions extends jni.JObject {
     int e,
     int f,
   ) {
-    return Exceptions.fromReference(_new2(_class.reference.pointer,
-            _id_new2 as jni.JMethodIDPtr, a, b, c, d, e, f)
+    return Exceptions.fromReference(_new$2(_class.reference.pointer,
+            _id_new$2 as jni.JMethodIDPtr, a, b, c, d, e, f)
         .reference);
   }
 

--- a/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
@@ -58,11 +58,11 @@ class Example_Nested_NestedTwice extends jni.JObject {
   static set ZERO(int value) =>
       _id_ZERO.set(_class, const jni.jintType(), value);
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -78,7 +78,7 @@ class Example_Nested_NestedTwice extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory Example_Nested_NestedTwice() {
     return Example_Nested_NestedTwice.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 }
@@ -125,11 +125,11 @@ class Example_Nested extends jni.JObject {
 
   /// The type which includes information such as the signature of this class.
   static const type = $Example_NestedType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'(Z)V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
                   ffi.VarArgs<($Int32,)>)>>('globalEnv_NewObject')
@@ -142,8 +142,8 @@ class Example_Nested extends jni.JObject {
   factory Example_Nested(
     bool value,
   ) {
-    return Example_Nested.fromReference(_new0(_class.reference.pointer,
-            _id_new0 as jni.JMethodIDPtr, value ? 1 : 0)
+    return Example_Nested.fromReference(_new$(_class.reference.pointer,
+            _id_new$ as jni.JMethodIDPtr, value ? 1 : 0)
         .reference);
   }
 
@@ -271,11 +271,11 @@ class Example_NonStaticNested extends jni.JObject {
   /// from: `public boolean ok`
   set ok(bool value) => _id_ok.set(this, const jni.jbooleanType(), value);
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'(Lcom/github/dart_lang/jnigen/simple_package/Example;)V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -291,8 +291,8 @@ class Example_NonStaticNested extends jni.JObject {
   factory Example_NonStaticNested(
     Example $parent,
   ) {
-    return Example_NonStaticNested.fromReference(_new0(_class.reference.pointer,
-            _id_new0 as jni.JMethodIDPtr, $parent.reference.pointer)
+    return Example_NonStaticNested.fromReference(_new$(_class.reference.pointer,
+            _id_new$ as jni.JMethodIDPtr, $parent.reference.pointer)
         .reference);
   }
 }
@@ -1086,11 +1086,11 @@ class Example extends jni.JObject {
         .check();
   }
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -1106,7 +1106,7 @@ class Example extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory Example() {
     return Example.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 
@@ -1550,11 +1550,11 @@ class C2 extends jni.JObject {
   static set CONSTANT(int value) =>
       _id_CONSTANT.set(_class, const jni.jintType(), value);
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -1570,7 +1570,7 @@ class C2 extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory C2() {
     return C2.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 }
@@ -1613,11 +1613,11 @@ class Example$1 extends jni.JObject {
 
   /// The type which includes information such as the signature of this class.
   static const type = $Example$1Type();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -1633,7 +1633,7 @@ class Example$1 extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory Example$1() {
     return Example$1.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 
@@ -1761,11 +1761,11 @@ class GrandParent_Parent_Child<$T extends jni.JObject, $S extends jni.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   set value($U value) => _id_value.set(this, U, value);
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'(Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent;Ljava/lang/Object;)V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1801,7 +1801,7 @@ class GrandParent_Parent_Child<$T extends jni.JObject, $S extends jni.JObject,
         T,
         S,
         U,
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr,
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr,
                 $parent.reference.pointer, newValue.reference.pointer)
             .reference);
   }
@@ -1904,11 +1904,11 @@ class GrandParent_Parent<$T extends jni.JObject, $S extends jni.JObject>
   /// The returned object must be released after use, by calling the [release] method.
   set value($S value) => _id_value.set(this, S, value);
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'(Lcom/github/dart_lang/jnigen/generics/GrandParent;Ljava/lang/Object;)V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -1939,7 +1939,7 @@ class GrandParent_Parent<$T extends jni.JObject, $S extends jni.JObject>
     return GrandParent_Parent.fromReference(
         T,
         S,
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr,
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr,
                 $parent.reference.pointer, newValue.reference.pointer)
             .reference);
   }
@@ -2038,11 +2038,11 @@ class GrandParent_StaticParent_Child<$S extends jni.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   set value($U value) => _id_value.set(this, U, value);
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'(Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent;Ljava/lang/Object;Ljava/lang/Object;)V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -2080,9 +2080,9 @@ class GrandParent_StaticParent_Child<$S extends jni.JObject,
     return GrandParent_StaticParent_Child.fromReference(
         S,
         U,
-        _new0(
+        _new$(
                 _class.reference.pointer,
-                _id_new0 as jni.JMethodIDPtr,
+                _id_new$ as jni.JMethodIDPtr,
                 $parent.reference.pointer,
                 parentValue.reference.pointer,
                 value.reference.pointer)
@@ -2165,11 +2165,11 @@ class GrandParent_StaticParent<$S extends jni.JObject> extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   set value($S value) => _id_value.set(this, S, value);
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'(Ljava/lang/Object;)V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2191,7 +2191,7 @@ class GrandParent_StaticParent<$S extends jni.JObject> extends jni.JObject {
     ]) as jni.JObjType<$S>;
     return GrandParent_StaticParent.fromReference(
         S,
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr,
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr,
                 value.reference.pointer)
             .reference);
   }
@@ -2267,11 +2267,11 @@ class GrandParent<$T extends jni.JObject> extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   set value($T value) => _id_value.set(this, T, value);
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'(Ljava/lang/Object;)V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2293,7 +2293,7 @@ class GrandParent<$T extends jni.JObject> extends jni.JObject {
     ]) as jni.JObjType<$T>;
     return GrandParent.fromReference(
         T,
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr,
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr,
                 value.reference.pointer)
             .reference);
   }
@@ -2523,11 +2523,11 @@ class MyMap_MyEntry<$K extends jni.JObject, $V extends jni.JObject>
   /// The returned object must be released after use, by calling the [release] method.
   set value($V value) => _id_value.set(this, V, value);
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'(Lcom/github/dart_lang/jnigen/generics/MyMap;Ljava/lang/Object;Ljava/lang/Object;)V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -2566,9 +2566,9 @@ class MyMap_MyEntry<$K extends jni.JObject, $V extends jni.JObject>
     return MyMap_MyEntry.fromReference(
         K,
         V,
-        _new0(
+        _new$(
                 _class.reference.pointer,
-                _id_new0 as jni.JMethodIDPtr,
+                _id_new$ as jni.JMethodIDPtr,
                 $parent.reference.pointer,
                 key.reference.pointer,
                 value.reference.pointer)
@@ -2642,11 +2642,11 @@ class MyMap<$K extends jni.JObject, $V extends jni.JObject>
     );
   }
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -2667,16 +2667,16 @@ class MyMap<$K extends jni.JObject, $V extends jni.JObject>
     return MyMap.fromReference(
         K,
         V,
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 
-  static final _id_get0 = _class.instanceMethodId(
+  static final _id_get$ = _class.instanceMethodId(
     r'get',
     r'(Ljava/lang/Object;)Ljava/lang/Object;',
   );
 
-  static final _get0 = ProtectedJniExtensions.lookup<
+  static final _get$ = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -2689,10 +2689,10 @@ class MyMap<$K extends jni.JObject, $V extends jni.JObject>
 
   /// from: `public V get(K key)`
   /// The returned object must be released after use, by calling the [release] method.
-  $V get0(
+  $V get$(
     $K key,
   ) {
-    return _get0(reference.pointer, _id_get0 as jni.JMethodIDPtr,
+    return _get$(reference.pointer, _id_get$ as jni.JMethodIDPtr,
             key.reference.pointer)
         .object(V);
   }
@@ -2812,11 +2812,11 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
     );
   }
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -2835,7 +2835,7 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
   }) {
     return MyStack.fromReference(
         T,
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 
@@ -3122,11 +3122,11 @@ class StringKeyedMap<$V extends jni.JObject> extends MyMap<jni.JString, $V> {
     );
   }
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -3145,7 +3145,7 @@ class StringKeyedMap<$V extends jni.JObject> extends MyMap<jni.JString, $V> {
   }) {
     return StringKeyedMap.fromReference(
         V,
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 }
@@ -3197,11 +3197,11 @@ class StringStack extends MyStack<jni.JString> {
 
   /// The type which includes information such as the signature of this class.
   static const type = $StringStackType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -3217,7 +3217,7 @@ class StringStack extends MyStack<jni.JString> {
   /// The returned object must be released after use, by calling the [release] method.
   factory StringStack() {
     return StringStack.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 }
@@ -3271,11 +3271,11 @@ class StringValuedMap<$K extends jni.JObject> extends MyMap<$K, jni.JString> {
     );
   }
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -3294,7 +3294,7 @@ class StringValuedMap<$K extends jni.JObject> extends MyMap<$K, jni.JString> {
   }) {
     return StringValuedMap.fromReference(
         K,
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 }
@@ -3671,11 +3671,11 @@ class MyInterfaceConsumer extends jni.JObject {
 
   /// The type which includes information such as the signature of this class.
   static const type = $MyInterfaceConsumerType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -3691,7 +3691,7 @@ class MyInterfaceConsumer extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory MyInterfaceConsumer() {
     return MyInterfaceConsumer.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 
@@ -4022,11 +4022,11 @@ class MyRunnableRunner extends jni.JObject {
   set error(jni.JObject value) =>
       _id_error.set(this, const jni.JObjectType(), value);
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'(Lcom/github/dart_lang/jnigen/interfaces/MyRunnable;)V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -4042,8 +4042,8 @@ class MyRunnableRunner extends jni.JObject {
   factory MyRunnableRunner(
     MyRunnable runnable,
   ) {
-    return MyRunnableRunner.fromReference(_new0(_class.reference.pointer,
-            _id_new0 as jni.JMethodIDPtr, runnable.reference.pointer)
+    return MyRunnableRunner.fromReference(_new$(_class.reference.pointer,
+            _id_new$ as jni.JMethodIDPtr, runnable.reference.pointer)
         .reference);
   }
 
@@ -4136,11 +4136,11 @@ class StringConversionException extends jni.JObject {
 
   /// The type which includes information such as the signature of this class.
   static const type = $StringConversionExceptionType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'(Ljava/lang/String;)V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -4156,9 +4156,9 @@ class StringConversionException extends jni.JObject {
   factory StringConversionException(
     jni.JString message,
   ) {
-    return StringConversionException.fromReference(_new0(
+    return StringConversionException.fromReference(_new$(
             _class.reference.pointer,
-            _id_new0 as jni.JMethodIDPtr,
+            _id_new$ as jni.JMethodIDPtr,
             message.reference.pointer)
         .reference);
   }
@@ -4363,11 +4363,11 @@ class StringConverterConsumer extends jni.JObject {
 
   /// The type which includes information such as the signature of this class.
   static const type = $StringConverterConsumerType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -4383,7 +4383,7 @@ class StringConverterConsumer extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory StringConverterConsumer() {
     return StringConverterConsumer.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 
@@ -4747,11 +4747,11 @@ class MyDataClass extends jni.JObject {
 
   /// The type which includes information such as the signature of this class.
   static const type = $MyDataClassType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -4767,7 +4767,7 @@ class MyDataClass extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory MyDataClass() {
     return MyDataClass.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 }
@@ -4902,11 +4902,11 @@ class Exceptions extends jni.JObject {
 
   /// The type which includes information such as the signature of this class.
   static const type = $ExceptionsType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -4922,7 +4922,7 @@ class Exceptions extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory Exceptions() {
     return Exceptions.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 
@@ -5499,11 +5499,11 @@ class Fields extends jni.JObject {
   static set euroSymbol(int value) =>
       _id_euroSymbol.set(_class, const jni.jcharType(), value);
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -5519,7 +5519,7 @@ class Fields extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory Fields() {
     return Fields.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 }
@@ -5590,11 +5590,11 @@ class Fields_Nested extends jni.JObject {
   static set BEST_GOD(jni.JString value) =>
       _id_BEST_GOD.set(_class, const jni.JStringType(), value);
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -5610,7 +5610,7 @@ class Fields_Nested extends jni.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory Fields_Nested() {
     return Fields_Nested.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 }
@@ -5672,11 +5672,11 @@ class GenericTypeParams<$S extends jni.JObject, $K extends jni.JObject>
     );
   }
 
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -5697,7 +5697,7 @@ class GenericTypeParams<$S extends jni.JObject, $K extends jni.JObject>
     return GenericTypeParams.fromReference(
         S,
         K,
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 }
@@ -5752,11 +5752,11 @@ class StringMap extends StringKeyedMap<jni.JString> {
 
   /// The type which includes information such as the signature of this class.
   static const type = $StringMapType();
-  static final _id_new0 = _class.constructorId(
+  static final _id_new$ = _class.constructorId(
     r'()V',
   );
 
-  static final _new0 = ProtectedJniExtensions.lookup<
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 ffi.Pointer<ffi.Void>,
@@ -5772,7 +5772,7 @@ class StringMap extends StringKeyedMap<jni.JString> {
   /// The returned object must be released after use, by calling the [release] method.
   factory StringMap() {
     return StringMap.fromReference(
-        _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
             .reference);
   }
 }

--- a/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
@@ -567,12 +567,12 @@ class Example extends jni.JObject {
         .check();
   }
 
-  static final _id_max4 = _class.staticMethodId(
+  static final _id_max4$ = _class.staticMethodId(
     r'max4',
     r'(IIII)I',
   );
 
-  static final _max4 = ProtectedJniExtensions.lookup<
+  static final _max4$ = ProtectedJniExtensions.lookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       ffi.Pointer<ffi.Void>,
@@ -584,23 +584,23 @@ class Example extends jni.JObject {
               ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int, int, int, int)>();
 
   /// from: `static public int max4(int a, int b, int c, int d)`
-  static int max4(
+  static int max4$(
     int a,
     int b,
     int c,
     int d,
   ) {
-    return _max4(
-            _class.reference.pointer, _id_max4 as jni.JMethodIDPtr, a, b, c, d)
+    return _max4$(
+            _class.reference.pointer, _id_max4$ as jni.JMethodIDPtr, a, b, c, d)
         .integer;
   }
 
-  static final _id_max8 = _class.staticMethodId(
+  static final _id_max8$ = _class.staticMethodId(
     r'max8',
     r'(IIIIIIII)I',
   );
 
-  static final _max8 = ProtectedJniExtensions.lookup<
+  static final _max8$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                   ffi.Pointer<ffi.Void>,
@@ -621,7 +621,7 @@ class Example extends jni.JObject {
               int, int, int, int, int, int, int)>();
 
   /// from: `static public int max8(int a, int b, int c, int d, int e, int f, int g, int h)`
-  static int max8(
+  static int max8$(
     int a,
     int b,
     int c,
@@ -631,7 +631,7 @@ class Example extends jni.JObject {
     int g,
     int h,
   ) {
-    return _max8(_class.reference.pointer, _id_max8 as jni.JMethodIDPtr, a, b,
+    return _max8$(_class.reference.pointer, _id_max8$ as jni.JMethodIDPtr, a, b,
             c, d, e, f, g, h)
         .integer;
   }
@@ -1525,11 +1525,11 @@ final class $ExampleType extends jni.JObjType<Example> {
 }
 
 /// from: `com.github.dart_lang.jnigen.pkg2.C2`
-class C2 extends jni.JObject {
+class C2$ extends jni.JObject {
   @override
-  late final jni.JObjType<C2> $type = type;
+  late final jni.JObjType<C2$> $type = type;
 
-  C2.fromReference(
+  C2$.fromReference(
     jni.JReference reference,
   ) : super.fromReference(reference);
 
@@ -1537,7 +1537,7 @@ class C2 extends jni.JObject {
       jni.JClass.forName(r'com/github/dart_lang/jnigen/pkg2/C2');
 
   /// The type which includes information such as the signature of this class.
-  static const type = $C2Type();
+  static const type = $C2$Type();
   static final _id_CONSTANT = _class.staticFieldId(
     r'CONSTANT',
     r'I',
@@ -1568,21 +1568,21 @@ class C2 extends jni.JObject {
 
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
-  factory C2() {
-    return C2.fromReference(
+  factory C2$() {
+    return C2$.fromReference(
         _new0(_class.reference.pointer, _id_new0 as jni.JMethodIDPtr)
             .reference);
   }
 }
 
-final class $C2Type extends jni.JObjType<C2> {
-  const $C2Type();
+final class $C2$Type extends jni.JObjType<C2$> {
+  const $C2$Type();
 
   @override
   String get signature => r'Lcom/github/dart_lang/jnigen/pkg2/C2;';
 
   @override
-  C2 fromReference(jni.JReference reference) => C2.fromReference(reference);
+  C2$ fromReference(jni.JReference reference) => C2$.fromReference(reference);
 
   @override
   jni.JObjType get superType => const jni.JObjectType();
@@ -1591,11 +1591,11 @@ final class $C2Type extends jni.JObjType<C2> {
   final superCount = 1;
 
   @override
-  int get hashCode => ($C2Type).hashCode;
+  int get hashCode => ($C2$Type).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == ($C2Type) && other is $C2Type;
+    return other.runtimeType == ($C2$Type) && other is $C2$Type;
   }
 }
 

--- a/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
+++ b/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
@@ -50,7 +50,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
       Example.setAmount(1012);
       expect(Example.getAmount(), equals(1012));
       expect(Example.getAsterisk(), equals('*'.codeUnitAt(0)));
-      expect(C2$.CONSTANT, equals(12));
+      expect(C2.CONSTANT, equals(12));
     });
 
     test('Static fields & methods - string', () {
@@ -74,8 +74,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
 
     test('static methods with several arguments', () {
       expect(Example.addInts(10, 15), equals(25));
-      expect(Example.max4$(-1, 15, 30, 12), equals(30));
-      expect(Example.max8$(1, 4, 8, 2, 4, 10, 8, 6), equals(10));
+      expect(Example.max4(-1, 15, 30, 12), equals(30));
+      expect(Example.max8(1, 4, 8, 2, 4, 10, 8, 6), equals(10));
     });
 
     test('Instance methods (getters & setters)', () {
@@ -129,15 +129,15 @@ void registerTests(String groupName, TestRunnerCallback test) {
       expect(e0.getNumber(), 0);
       expect(e0.getIsUp(), true);
       expect(e0.getCodename().toDartString(), equals('achilles'));
-      final e1 = Example.new1(111);
+      final e1 = Example.new$1(111);
       expect(e1.getNumber(), equals(111));
       expect(e1.getIsUp(), true);
       expect(e1.getCodename().toDartString(), 'achilles');
-      final e2 = Example.new2(122, false);
+      final e2 = Example.new$2(122, false);
       expect(e2.getNumber(), equals(122));
       expect(e2.getIsUp(), false);
       expect(e2.getCodename().toDartString(), 'achilles');
-      final e3 = Example.new3(133, false, 'spartan'.toJString());
+      final e3 = Example.new$3(133, false, 'spartan'.toJString());
       expect(e3.getNumber(), equals(133));
       expect(e3.getIsUp(), false);
       expect(e3.getCodename().toDartString(), 'spartan');
@@ -211,7 +211,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
 
     test('Check bindings for same-named classes', () {
       expect(Example().whichExample(), 0);
-      expect(Example1().whichExample(), 1);
+      expect(Example$1().whichExample(), 1);
     });
 
     test('Unicode char', () {
@@ -244,8 +244,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
       });
 
       test('Exception from constructor', () {
-        throwsException(() => Exceptions.new1(6.8));
-        throwsException(() => Exceptions.new2(1, 2, 3, 4, 5, 6));
+        throwsException(() => Exceptions.new$1(6.8));
+        throwsException(() => Exceptions.new$2(1, 2, 3, 4, 5, 6));
       });
 
       test('Exception contains error message & stack trace', () {
@@ -307,8 +307,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
         using((arena) {
           final map = MyMap(K: JString.type, V: Example.type)
             ..releasedBy(arena);
-          final helloExample = Example.new1(1)..releasedBy(arena);
-          final worldExample = Example.new1(2)..releasedBy(arena);
+          final helloExample = Example.new$1(1)..releasedBy(arena);
+          final worldExample = Example.new$1(2)..releasedBy(arena);
           map.put('Hello'.toJString()..releasedBy(arena), helloExample);
           map.put('World'.toJString()..releasedBy(arena), worldExample);
           expect(
@@ -462,7 +462,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
         using((arena) {
           final emptyStack = MyStack(T: JString.type)..releasedBy(arena);
           expect(emptyStack.size(), 0);
-          final stack = MyStack.of1(
+          final stack = MyStack.of$1(
             'Hello'.toJString()..releasedBy(arena),
           )..releasedBy(arena);
           expect(stack, isA<MyStack<JString>>());
@@ -475,7 +475,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
       });
       test('MyStack.of 2 strings', () {
         using((arena) {
-          final stack = MyStack.of2(
+          final stack = MyStack.of$2(
             'Hello'.toJString()..releasedBy(arena),
             'World'.toJString()..releasedBy(arena),
           )..releasedBy(arena);
@@ -495,7 +495,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
         using((arena) {
           final array = JArray.filled(1, 'World'.toJString()..releasedBy(arena))
             ..releasedBy(arena);
-          final stack = MyStack.of2(
+          final stack = MyStack.of$2(
             'Hello'.toJString()..releasedBy(arena),
             array,
           )..releasedBy(arena);
@@ -757,14 +757,14 @@ void registerTests(String groupName, TestRunnerCallback test) {
     const k256 = 256 * 1024;
     test('Create large number of JNI references without deleting', () {
       for (var i = 0; i < k4; i++) {
-        final e = Example.new1(i);
+        final e = Example.new$1(i);
         expect(e.getNumber(), equals(i));
       }
     });
     test('Create many JNI refs with scoped deletion', () {
       for (var i = 0; i < k256; i++) {
         using((arena) {
-          final e = Example.new1(i)..releasedBy(arena);
+          final e = Example.new$1(i)..releasedBy(arena);
           expect(e.getNumber(), equals(i));
         });
       }
@@ -773,7 +773,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
       for (var i = 0; i < 256; i++) {
         using((arena) {
           for (var i = 0; i < 1024; i++) {
-            final e = Example.new1(i)..releasedBy(arena);
+            final e = Example.new$1(i)..releasedBy(arena);
             expect(e.getNumber(), equals(i));
           }
         });
@@ -781,14 +781,14 @@ void registerTests(String groupName, TestRunnerCallback test) {
     });
     test('Create large number of JNI refs with manual delete', () {
       for (var i = 0; i < k256; i++) {
-        final e = Example.new1(i);
+        final e = Example.new$1(i);
         expect(e.getNumber(), equals(i));
         e.release();
       }
     });
     test('Method returning primitive type does not create references', () {
       using((arena) {
-        final e = Example.new1(64)..releasedBy(arena);
+        final e = Example.new$1(64)..releasedBy(arena);
         for (var i = 0; i < k256; i++) {
           expect(e.getNumber(), equals(64));
         }

--- a/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
+++ b/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
@@ -50,7 +50,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
       Example.setAmount(1012);
       expect(Example.getAmount(), equals(1012));
       expect(Example.getAsterisk(), equals('*'.codeUnitAt(0)));
-      expect(C2.CONSTANT, equals(12));
+      expect(C2$.CONSTANT, equals(12));
     });
 
     test('Static fields & methods - string', () {
@@ -74,8 +74,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
 
     test('static methods with several arguments', () {
       expect(Example.addInts(10, 15), equals(25));
-      expect(Example.max4(-1, 15, 30, 12), equals(30));
-      expect(Example.max8(1, 4, 8, 2, 4, 10, 8, 6), equals(10));
+      expect(Example.max4$(-1, 15, 30, 12), equals(30));
+      expect(Example.max8$(1, 4, 8, 2, 4, 10, 8, 6), equals(10));
     });
 
     test('Instance methods (getters & setters)', () {

--- a/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
+++ b/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
@@ -312,13 +312,13 @@ void registerTests(String groupName, TestRunnerCallback test) {
           map.put('Hello'.toJString()..releasedBy(arena), helloExample);
           map.put('World'.toJString()..releasedBy(arena), worldExample);
           expect(
-            (map.get0('Hello'.toJString()..releasedBy(arena))
+            (map.get$('Hello'.toJString()..releasedBy(arena))
                   ..releasedBy(arena))
                 .getNumber(),
             1,
           );
           expect(
-            (map.get0('World'.toJString()..releasedBy(arena))
+            (map.get$('World'.toJString()..releasedBy(arena))
                   ..releasedBy(arena))
                 .getNumber(),
             2,
@@ -347,7 +347,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
             final example = Example()..releasedBy(arena);
             map.put('Hello'.toJString()..releasedBy(arena), example);
             expect(
-              (map.get0('Hello'.toJString()..releasedBy(arena))
+              (map.get$('Hello'.toJString()..releasedBy(arena))
                     ..releasedBy(arena))
                   .getNumber(),
               0,
@@ -360,7 +360,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
             final example = Example()..releasedBy(arena);
             map.put(example, 'Hello'.toJString()..releasedBy(arena));
             expect(
-              map.get0(example).toDartString(releaseOriginal: true),
+              map.get$(example).toDartString(releaseOriginal: true),
               'Hello',
             );
           });
@@ -372,7 +372,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
                 'world'.toJString()..releasedBy(arena));
             expect(
               map
-                  .get0('hello'.toJString()..releasedBy(arena))
+                  .get$('hello'.toJString()..releasedBy(arena))
                   .toDartString(releaseOriginal: true),
               'world',
             );


### PR DESCRIPTION
Closes #571. 

Adding a `$K` to the end of the `K`–th overload of a method. 
To be consistent, instead of adding a zero to the end of the keywords such as `new` we add a `$`.

In short, the renaming becomes:

`foo`, `foo`, foo1`, foo1` -> `foo`, `foo$1`, `foo1`, `foo1$1`
`yield`, `yield`,  -> `yield$`, `yield$1`

Wrote a doc in `java_differences.md` explaining the renaming for method overloading.
