### PR TITLE
[native_assets_builder] Test data for dylib name conflict

### DIFF
--- a/pkgs/native_assets_builder/test/build_runner/conflicting_dylib_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/conflicting_dylib_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:logging/logging.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';
@@ -35,6 +36,39 @@ void main() async {
           contains('Duplicate dynamic library file name'),
         );
       }
+    });
+  });
+
+  test('conflicting dylib name between link and build', timeout: longTimeout,
+      () async {
+    await inTempDir((tempUri) async {
+      await copyTestProjects(targetUri: tempUri);
+      final packageUri = tempUri.resolve('native_add_duplicate/');
+
+      await runPubGet(
+        workingDirectory: packageUri,
+        logger: logger,
+      );
+
+      final buildResult = await build(
+        packageUri,
+        logger,
+        linkingEnabled: true,
+        dartExecutable,
+      );
+      expect(buildResult.success, isTrue);
+
+      final linkResult = await link(
+        packageUri,
+        logger,
+        dartExecutable,
+        buildResult: buildResult,
+      );
+      expect(linkResult.success, isTrue);
+
+      final allAssets = [...buildResult.assets, ...linkResult.assets];
+      final validateResult = validateNoDuplicateDylibs(allAssets);
+      expect(validateResult, isNotEmpty);
     });
   });
 }

--- a/pkgs/native_assets_builder/test_data/manifest.yaml
+++ b/pkgs/native_assets_builder/test_data/manifest.yaml
@@ -63,7 +63,9 @@
 - native_add/src/native_add.c
 - native_add/src/native_add.h
 - native_add/test/native_add_test.dart
+- native_add_duplicate/bin/native_add_duplicate.dart
 - native_add_duplicate/hook/build.dart
+- native_add_duplicate/hook/link.dart
 - native_add_duplicate/pubspec.yaml
 - native_add_duplicate/src/native_add.c
 - native_add_duplicate/src/native_add.h

--- a/pkgs/native_assets_builder/test_data/native_add_duplicate/bin/native_add_duplicate.dart
+++ b/pkgs/native_assets_builder/test_data/native_add_duplicate/bin/native_add_duplicate.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+void main() {
+  print('Compiling this with `dart build` should fail due to dylib conflict.');
+}

--- a/pkgs/native_assets_builder/test_data/native_add_duplicate/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/native_add_duplicate/hook/build.dart
@@ -17,14 +17,24 @@ void main(List<String> arguments) async {
         'src/$duplicatedPackageName.c',
       ],
     );
+    // Temp output to prevent outputting the dylib for bundling.
+    final tempBuildOutput = BuildOutput();
     await cbuilder.run(
       config: config,
-      output: output,
+      output: tempBuildOutput,
       logger: Logger('')
         ..level = Level.ALL
         ..onRecord.listen((record) {
           print('${record.level.name}: ${record.time}: ${record.message}');
         }),
+    );
+    output.addAsset(
+      tempBuildOutput.assets.single,
+      // Send dylib to linking if linking is enabled.
+      linkInPackage: config.linkingEnabled ? packageName : null,
+    );
+    output.addDependencies(
+      tempBuildOutput.dependencies,
     );
   });
 }

--- a/pkgs/native_assets_builder/test_data/native_add_duplicate/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/native_add_duplicate/hook/link.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:native_assets_cli/native_assets_cli.dart';
+
+void main(List<String> args) async {
+  await link(args, (config, output) async {
+    // Simply output the dylib in the link hook.
+    output.addAssets(config.assets);
+  });
+}


### PR DESCRIPTION
A test case to be used in dartdev in https://dart-review.googlesource.com/c/sdk/+/383986.