### PR TITLE
[native_assets_cli] asset ids option 1

### DIFF
--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -845,6 +845,8 @@ ${compileResult.stdout}
         if (!packagesWithLink.contains(targetPackage)) {
           for (final asset in output.assetsForLinking[targetPackage]!) {
             success &= false;
+            // Note that DataAssets don't have an ID in their API, so error
+            // messages might be confusing.
             errors.add(
               'Asset "${asset.id}" is sent to package "$targetPackage" for'
               ' linking, but that package does not have a link hook.',

--- a/pkgs/native_assets_builder/lib/src/model/hook_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/hook_result.dart
@@ -59,6 +59,8 @@ final class HookResult
         final twoInOne = assets1.where((asset) => assets2.contains(asset));
         final oneInTwo = assets2.where((asset) => assets1.contains(asset));
         if (twoInOne.isNotEmpty || oneInTwo.isNotEmpty) {
+          // Note that DataAssets don't have an ID in their API, so error
+          // messages might be confusing.
           throw ArgumentError(
               'Found duplicate IDs, ${oneInTwo.map((e) => e.id).toList()}');
         }

--- a/pkgs/native_assets_builder/test_data/add_asset_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/add_asset_link/hook/link.dart
@@ -10,8 +10,7 @@ void main(List<String> arguments) async {
     output
       ..addAsset(
         NativeCodeAsset(
-          package: 'add_asset_link',
-          name: 'dylib_add_link',
+          id: 'package:add_asset_link/dylib_add_link',
           linkMode: builtDylib.linkMode,
           os: builtDylib.os,
           architecture: builtDylib.architecture,

--- a/pkgs/native_assets_builder/test_data/complex_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/complex_link/hook/link.dart
@@ -7,9 +7,10 @@ import 'package:native_assets_cli/native_assets_cli.dart';
 void main(List<String> args) async {
   await link(
     args,
-    (config, output) async => output.addAssets(treeshake(config.assets)),
+    (config, output) async =>
+        output.addAssets(treeshake(config.assets.whereType<DataAsset>())),
   );
 }
 
-Iterable<Asset> treeshake(Iterable<Asset> assets) =>
-    assets.where((asset) => !asset.id.endsWith('assets/data_helper_2.json'));
+Iterable<Asset> treeshake(Iterable<DataAsset> assets) =>
+    assets.where((asset) => !asset.name.endsWith('assets/data_helper_2.json'));

--- a/pkgs/native_assets_builder/test_data/drop_dylib_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/drop_dylib_link/hook/link.dart
@@ -6,12 +6,13 @@ import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> arguments) async {
   await link(arguments, (config, output) async {
+    final dataAssets = config.assets.whereType<DataAsset>();
     print('''
-Received ${config.assets.length} assets: ${config.assets.map((e) => e.id)}.
+Received ${dataAssets.length} assets: ${dataAssets.map((e) => '${e.package} ${e.name}')}.
 ''');
-    output.addAssets(config.assets.where((asset) => asset.id.endsWith('add')));
+    output.addAssets(dataAssets.where((asset) => asset.name.endsWith('add')));
     print('''
-Keeping only ${output.assets.map((e) => e.id)}.
+Keeping only ${dataAssets.map((e) => '${e.package} ${e.name}')}.
 ''');
     output.addDependency(config.packageRoot.resolve('hook/link.dart'));
   });

--- a/pkgs/native_assets_builder/test_data/treeshaking_native_libs/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/treeshaking_native_libs/hook/link.dart
@@ -10,11 +10,12 @@ void main(List<String> arguments) async {
   await link(
     arguments,
     (config, output) async {
+      final asset = config.assets.single as NativeCodeAsset;
       final linker = CLinker.library(
         name: config.packageName,
-        assetName: config.assets.single.id.split('/').skip(1).join('/'),
+        assetName: asset.id.split('/').skip(1).join('/'),
         linkerOptions: LinkerOptions.treeshake(symbols: ['add']),
-        sources: [config.assets.single.file!.toFilePath()],
+        sources: [asset.file!.toFilePath()],
       );
       await linker.run(
         config: config,

--- a/pkgs/native_assets_builder/test_data/wrong_linker/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/wrong_linker/hook/build.dart
@@ -18,8 +18,7 @@ void main(List<String> arguments) async {
 
     output.addAsset(
       NativeCodeAsset(
-        package: config.packageName,
-        name: 'foo',
+        id: 'package:${config.packageName}/foo',
         file: assetUri,
         linkMode: DynamicLoadingBundled(),
         os: OS.current,

--- a/pkgs/native_assets_builder/test_data/wrong_namespace_asset/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/wrong_namespace_asset/hook/build.dart
@@ -18,8 +18,7 @@ void main(List<String> arguments) async {
 
     output.addAsset(
       NativeCodeAsset(
-        package: 'other_package',
-        name: 'foo',
+        id: 'package:other_package/foo',
         file: assetUri,
         linkMode: DynamicLoadingBundled(),
         os: OS.current,

--- a/pkgs/native_assets_cli/example/build/local_asset/hook/build.dart
+++ b/pkgs/native_assets_cli/example/build/local_asset/hook/build.dart
@@ -33,8 +33,7 @@ Future<void> main(List<String> args) async {
     output.addAsset(
       // TODO: Change to DataAsset once the Dart/Flutter SDK can consume it.
       NativeCodeAsset(
-        package: packageName,
-        name: 'asset.txt',
+        id: 'package:$packageName/asset.txt',
         file: assetPath,
         linkMode: DynamicLoadingBundled(),
         os: config.targetOS,

--- a/pkgs/native_assets_cli/lib/src/api/asset.dart
+++ b/pkgs/native_assets_cli/lib/src/api/asset.dart
@@ -21,37 +21,8 @@ part 'native_code_asset.dart';
 /// Data or code bundled with a Dart or Flutter application.
 ///
 /// An asset is data or code which is accessible from a Dart or Flutter
-/// application. To access an asset at runtime, the asset [id] is used.
+/// application.
 abstract final class Asset {
-  /// The identifier for this asset.
-  ///
-  /// An [Asset] has a string identifier called "asset id". Dart code that uses
-  /// an asset references the asset using this asset id.
-  ///
-  /// An asset identifier consists of two elements, the `package` and `name`,
-  /// which together make a library uri `package:<package>/<name>`. The package
-  /// being part of the identifer prevents name collisions between assets of
-  /// different packages.
-  ///
-  /// The default asset id for an asset reference from `lib/src/foo.dart` is
-  /// `'package:foo/src/foo.dart'`. For example a [NativeCodeAsset] can be accessed
-  /// via `@Native` with the `assetId` argument omitted:
-  ///
-  /// ```dart
-  /// // file package:foo/src/foo.dart
-  /// @Native<Int Function(Int, Int)>()
-  /// external int add(int a, int b);
-  /// ```
-  ///
-  /// This will be then automatically expanded to
-  ///
-  /// ```dart
-  /// // file package:foo/src/foo.dart
-  /// @Native<Int Function(Int, Int)>(assetId: 'package:foo/src/foo.dart')
-  /// external int add(int a, int b);
-  /// ```
-  String get id;
-
   /// The file to be bundled with the Dart or Flutter application.
   ///
   /// How this file is bundled depends on the kind of asset, represented by a

--- a/pkgs/native_assets_cli/lib/src/api/data_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/api/data_asset.dart
@@ -6,17 +6,12 @@ part of 'asset.dart';
 
 /// Data bundled with a Dart or Flutter application.
 ///
-/// A data asset is accessible in a Dart or Flutter application. To retrieve an
-/// asset at runtime, the [id] is used. This enables access to the asset
-/// irrespective of how and where the application is run.
+/// A data asset is accessible in a Dart or Flutter application.
 ///
 /// An data asset must provide a [Asset.file]. The Dart and Flutter SDK will
 /// bundle this code in the final application.
 abstract final class DataAsset implements Asset {
   /// Constructs a data asset.
-  ///
-  /// The unique [id] of this asset is a uri `package:<package>/<name>` from
-  /// [package] and [name].
   factory DataAsset({
     required String package,
     required String name,

--- a/pkgs/native_assets_cli/lib/src/api/native_code_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/api/native_code_asset.dart
@@ -46,6 +46,35 @@ part of 'asset.dart';
 /// [file] from its specified location on the current system into the
 /// application bundle.
 abstract final class NativeCodeAsset implements Asset {
+  /// The identifier for this asset.
+  ///
+  /// An [Asset] has a string identifier called "asset id". Dart code that uses
+  /// an asset references the asset using this asset id.
+  ///
+  /// An asset identifier consists of two elements, the `package` and `name`,
+  /// which together make a library uri `package:<package>/<name>`. The package
+  /// being part of the identifer prevents name collisions between assets of
+  /// different packages.
+  ///
+  /// The default asset id for an asset reference from `lib/src/foo.dart` is
+  /// `'package:foo/src/foo.dart'`. For example a [NativeCodeAsset] can be accessed
+  /// via `@Native` with the `assetId` argument omitted:
+  ///
+  /// ```dart
+  /// // file package:foo/src/foo.dart
+  /// @Native<Int Function(Int, Int)>()
+  /// external int add(int a, int b);
+  /// ```
+  ///
+  /// This will be then automatically expanded to
+  ///
+  /// ```dart
+  /// // file package:foo/src/foo.dart
+  /// @Native<Int Function(Int, Int)>(assetId: 'package:foo/src/foo.dart')
+  /// external int add(int a, int b);
+  /// ```
+  String get id;
+
   /// The operating system this asset can run on.
   OS get os;
 
@@ -77,18 +106,16 @@ abstract final class NativeCodeAsset implements Asset {
 
   /// Constructs a native code asset.
   ///
-  /// The [id] of this asset is a uri `package:<package>/<name>` from [package]
-  /// and [name].
+  /// The [id] of this asset is a uri `package:<package>/<name>`.
   factory NativeCodeAsset({
-    required String package,
-    required String name,
+    required String id,
     required LinkMode linkMode,
     required OS os,
     Uri? file,
     Architecture? architecture,
   }) =>
       NativeCodeAssetImpl(
-        id: 'package:$package/$name',
+        id: id,
         linkMode: linkMode as LinkModeImpl,
         os: os as OSImpl,
         architecture: architecture as ArchitectureImpl?,

--- a/pkgs/native_assets_cli/lib/src/model/asset.dart
+++ b/pkgs/native_assets_cli/lib/src/model/asset.dart
@@ -7,6 +7,8 @@ part of '../api/asset.dart';
 abstract final class AssetImpl implements Asset {
   Map<String, Object> toJson(Version version);
 
+  String get id;
+
   static List<AssetImpl> listFromJson(List<Object?>? list) {
     final assets = <AssetImpl>[];
     if (list == null) return assets;

--- a/pkgs/native_assets_cli/lib/src/validator/validator.dart
+++ b/pkgs/native_assets_cli/lib/src/validator/validator.dart
@@ -80,6 +80,8 @@ List<String> validateOutputAssetTypes(
   final supportedAssetTypes = config.supportedAssetTypes;
   for (final asset in output.assets) {
     if (!supportedAssetTypes.contains(asset.type)) {
+      // Note that DataAssets don't have an ID in their API, so error messages
+      // might be confusing.
       final error =
           'Asset "${asset.id}" has asset type "${asset.type}", which is '
           'not in supportedAssetTypes';
@@ -98,6 +100,9 @@ Future<List<String>> validateFilesExist(
 
   await Future.wait(output.allAssets.map((asset) async {
     final file = asset.file;
+    asset as AssetImpl;
+    // Note that DataAssets don't have an ID in their API, so error messages
+    // might be confusing.
     if (file == null && !config.dryRun) {
       final error = 'Asset "${asset.id}" has no file.';
       errors.add(error);
@@ -180,6 +185,9 @@ List<String> validateAssetId(
   final errors = <String>[];
   final packageName = config.packageName;
   for (final asset in output.assets) {
+    asset as AssetImpl;
+    // Note that DataAssets don't have an ID in their API, so error messages
+    // might be confusing.
     if (!asset.id.startsWith('package:$packageName/')) {
       final error = 'Asset "${asset.id}" does not start with '
           '"package:$packageName/".';
@@ -195,6 +203,9 @@ List<String> validateNoDuplicateAssetIds(
   final errors = <String>[];
   final assetIds = <String>{};
   for (final asset in output.assets) {
+    asset as AssetImpl;
+    // Note that DataAssets don't have an ID in their API, so error messages
+    // might be confusing.
     if (assetIds.contains(asset.id)) {
       final error = 'Duplicate asset id: "${asset.id}".';
       errors.add(error);

--- a/pkgs/native_assets_cli/test/api/asset_test.dart
+++ b/pkgs/native_assets_cli/test/api/asset_test.dart
@@ -9,45 +9,39 @@ void main() {
   test('Asset constructors', () async {
     final assets = [
       NativeCodeAsset(
-        package: 'my_package',
-        name: 'foo',
+        id: 'package:my_package/foo',
         file: Uri.file('path/to/libfoo.so'),
         linkMode: DynamicLoadingBundled(),
         os: OS.android,
         architecture: Architecture.x64,
       ),
       NativeCodeAsset(
-        package: 'my_package',
-        name: 'foo3',
+        id: 'package:my_package/foo3',
         linkMode: DynamicLoadingSystem(Uri(path: 'libfoo3.so')),
         os: OS.android,
         architecture: Architecture.x64,
       ),
       NativeCodeAsset(
-        package: 'my_package',
-        name: 'foo4',
+        id: 'package:my_package/foo4',
         linkMode: LookupInExecutable(),
         os: OS.android,
         architecture: Architecture.x64,
       ),
       NativeCodeAsset(
-        package: 'my_package',
-        name: 'foo5',
+        id: 'package:my_package/foo5',
         linkMode: LookupInProcess(),
         os: OS.android,
         architecture: Architecture.x64,
       ),
       NativeCodeAsset(
-        package: 'my_package',
-        name: 'bar',
+        id: 'package:my_package/bar',
         file: Uri(path: 'path/to/libbar.a'),
         os: OS.linux,
         architecture: Architecture.arm64,
         linkMode: StaticLinking(),
       ),
       NativeCodeAsset(
-        package: 'my_package',
-        name: 'bla',
+        id: 'package:my_package/bla',
         file: Uri(path: 'path/with spaces/bla.dll'),
         linkMode: DynamicLoadingBundled(),
         os: OS.windows,
@@ -73,8 +67,7 @@ void main() {
   test('Errors', () {
     expect(
       () => NativeCodeAsset(
-        package: 'my_package',
-        name: 'foo',
+        id: 'package:my_package/foo',
         file: Uri.file('path/to/libfoo.so'),
         linkMode: LookupInExecutable(),
         os: OS.android,

--- a/pkgs/native_assets_cli/test/api/build_output_test.dart
+++ b/pkgs/native_assets_cli/test/api/build_output_test.dart
@@ -23,16 +23,14 @@ void main() {
       timestamp: DateTime.parse('2022-11-10 13:25:01.000'),
       assets: [
         NativeCodeAsset(
-          package: 'my_package',
-          name: 'foo',
+          id: 'package:my_package/foo',
           file: Uri(path: 'path/to/libfoo.so'),
           linkMode: DynamicLoadingBundled(),
           os: OS.android,
           architecture: Architecture.x64,
         ),
         NativeCodeAsset(
-          package: 'my_package',
-          name: 'foo2',
+          id: 'package:my_package/foo2',
           linkMode: DynamicLoadingSystem(Uri(path: 'path/to/libfoo2.so')),
           os: OS.android,
           architecture: Architecture.x64,

--- a/pkgs/native_assets_cli/test/model/link_config_test.dart
+++ b/pkgs/native_assets_cli/test/model/link_config_test.dart
@@ -28,8 +28,7 @@ void main() async {
       file: Uri.file('nonexistent'),
     ),
     NativeCodeAsset(
-      package: packageName,
-      name: 'name2',
+      id: 'package:$packageName/name2',
       linkMode: DynamicLoadingBundled(),
       os: OS.android,
       file: Uri.file('not there'),

--- a/pkgs/native_assets_cli/test/validator/validator_test.dart
+++ b/pkgs/native_assets_cli/test/validator/validator_test.dart
@@ -48,8 +48,7 @@ void main() {
     await assetFile.writeAsBytes([1, 2, 3]);
     output.addAsset(
       NativeCodeAsset(
-        package: config.packageName,
-        name: 'foo.dart',
+        id: 'package:${config.packageName}/foo.dart',
         file: assetFile.uri,
         linkMode: DynamicLoadingBundled(),
         os: config.targetOS,
@@ -137,8 +136,7 @@ void main() {
     );
     final output = BuildOutput();
     output.addAsset(NativeCodeAsset(
-      package: config.packageName,
-      name: 'foo.dylib',
+      id: 'package:${config.packageName}/foo.dylib',
       architecture: config.targetArchitecture,
       os: config.targetOS,
       linkMode: DynamicLoadingBundled(),
@@ -173,8 +171,7 @@ void main() {
       await assetFile.writeAsBytes([1, 2, 3]);
       output.addAsset(
         NativeCodeAsset(
-          package: config.packageName,
-          name: 'foo.dart',
+          id: 'package:${config.packageName}/foo.dart',
           file: assetFile.uri,
           linkMode: linkMode,
           os: config.targetOS,
@@ -210,8 +207,7 @@ void main() {
     await assetFile.writeAsBytes([1, 2, 3]);
     output.addAsset(
       NativeCodeAsset(
-        package: config.packageName,
-        name: 'foo.dart',
+        id: 'package:${config.packageName}/foo.dart',
         file: assetFile.uri,
         linkMode: DynamicLoadingBundled(),
         os: config.targetOS,
@@ -246,8 +242,7 @@ void main() {
     await assetFile.writeAsBytes([1, 2, 3]);
     output.addAsset(
       NativeCodeAsset(
-        package: config.packageName,
-        name: 'foo.dart',
+        id: 'package:${config.packageName}/foo.dart',
         file: assetFile.uri,
         linkMode: DynamicLoadingBundled(),
         os: config.targetOS,
@@ -281,8 +276,7 @@ void main() {
     await assetFile.writeAsBytes([1, 2, 3]);
     output.addAsset(
       NativeCodeAsset(
-        package: config.packageName,
-        name: 'foo.dart',
+        id: 'package:${config.packageName}/foo.dart',
         file: assetFile.uri,
         linkMode: DynamicLoadingBundled(),
         os: OS.windows,
@@ -412,16 +406,14 @@ void main() {
     await assetFile.writeAsBytes([1, 2, 3]);
     output.addAssets([
       NativeCodeAsset(
-        package: config.packageName,
-        name: 'src/foo.dart',
+        id: 'package:${config.packageName}/src/foo.dart',
         file: assetFile.uri,
         linkMode: DynamicLoadingBundled(),
         os: config.targetOS,
         architecture: config.targetArchitecture,
       ),
       NativeCodeAsset(
-        package: config.packageName,
-        name: 'src/bar.dart',
+        id: 'package:${config.packageName}/src/bar.dart',
         file: assetFile.uri,
         linkMode: DynamicLoadingBundled(),
         os: config.targetOS,

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -165,8 +165,7 @@ class CBuilder extends CTool implements Builder {
       output.addAssets(
         [
           NativeCodeAsset(
-            package: config.packageName,
-            name: assetName!,
+            id: 'package:${config.packageName}/$assetName',
             file: libUri,
             linkMode: linkMode,
             os: config.targetOS,

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
@@ -94,8 +94,7 @@ class CLinker extends CTool implements Linker {
       output.addAssets(
         [
           NativeCodeAsset(
-            package: config.packageName,
-            name: assetName!,
+            id: 'package:${config.packageName}/${assetName!}',
             file: libUri,
             linkMode: linkMode,
             os: config.targetOS,


### PR DESCRIPTION
This PR explores a solution to https://github.com/dart-lang/native/issues/1410:

* `CodeAsset` with a `String id`
* `DataAsset` with a `String package` and `String name`
* No shared getters in `Asset`.

This leads to the following quirks:

* Validation on all assets communicates errors in terms of assetIDs, which data assets do not have.
  * Could be mitigated if we add a 🥁  `String get id;` that produces a string representation of the `package` and `name`.
* `package:native_toolchain_c` still only takes an asset name, because the `package` is already read from the config.

If we have a use case for having the combined string for data assets, and need for the individual components of name and package in native code assets, maybe we should embrace having both.

1. `AssetId` extension type on `String`. Enables passing around the combination and get out both `package` and `name`. And the logic can be explained on the extension type. But, verbose constructor calls for `DataAsset` and `NativeCodeAsset`.
  https://github.com/dart-lang/native/pull/1539
2. `String get package`, `String get name`, `String get id => 'package:$package/$name';` on `Asset`. More concise, in use. The logic needs to be explained on the getters. (Constructors take `package` and `name` to facilitate correct by construction.)
   https://github.com/dart-lang/native/pull/1538


At the risk of more bike shedding. cc @mkustermann @mosuem @HosseinYousefi (Feel free to continue the discussion on https://github.com/dart-lang/native/issues/1410 instead of this PR.)