### PR TITLE
[native_assets_cli] asset ids option 2

### DIFF
--- a/pkgs/native_assets_builder/test_data/treeshaking_native_libs/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/treeshaking_native_libs/hook/link.dart
@@ -12,7 +12,7 @@ void main(List<String> arguments) async {
     (config, output) async {
       final linker = CLinker.library(
         name: config.packageName,
-        assetName: config.assets.single.id.split('/').skip(1).join('/'),
+        assetName: config.assets.single.name,
         linkerOptions: LinkerOptions.treeshake(symbols: ['add']),
         sources: [config.assets.single.file!.toFilePath()],
       );

--- a/pkgs/native_assets_cli/lib/src/api/asset.dart
+++ b/pkgs/native_assets_cli/lib/src/api/asset.dart
@@ -28,12 +28,12 @@ abstract final class Asset {
   /// An [Asset] has a string identifier called "asset id". Dart code that uses
   /// an asset references the asset using this asset id.
   ///
-  /// An asset identifier consists of two elements, the `package` and `name`,
-  /// which together make a library uri `package:<package>/<name>`. The package
+  /// An asset identifier consists of two elements, the [package] and [name],
+  /// which together make a library uri `package:$package/$name`. The [package]
   /// being part of the identifer prevents name collisions between assets of
   /// different packages.
   ///
-  /// The default asset id for an asset reference from `lib/src/foo.dart` is
+  /// The default asset id for an asset referenced from `lib/src/foo.dart` is
   /// `'package:foo/src/foo.dart'`. For example a [NativeCodeAsset] can be accessed
   /// via `@Native` with the `assetId` argument omitted:
   ///
@@ -50,7 +50,15 @@ abstract final class Asset {
   /// @Native<Int Function(Int, Int)>(assetId: 'package:foo/src/foo.dart')
   /// external int add(int a, int b);
   /// ```
-  String get id;
+  String get id => 'package:$package/$name';
+
+  /// The package which contains this asset.
+  String get package;
+
+  /// The name of this asset.
+  ///
+  /// The name must be unique for the [package].
+  String get name;
 
   /// The file to be bundled with the Dart or Flutter application.
   ///

--- a/pkgs/native_assets_cli/lib/src/api/data_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/api/data_asset.dart
@@ -28,11 +28,5 @@ abstract final class DataAsset implements Asset {
         file: file,
       );
 
-  /// The package which contains this asset.
-  String get package;
-
-  /// The name of this asset, which must be unique for the package.
-  String get name;
-
   static const String type = 'data';
 }

--- a/pkgs/native_assets_cli/lib/src/model/native_code_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/model/native_code_asset.dart
@@ -376,4 +376,10 @@ final class NativeCodeAssetImpl implements NativeCodeAsset, AssetImpl {
   @override
   String toString() =>
       'NativeCodeAsset(${toJson(HookOutputImpl.latestVersion)})';
+
+  @override
+  String get name => id.split('/').skip(1).join('/');
+
+  @override
+  String get package => 'package:${id.split('/').first}';
 }


### PR DESCRIPTION
This PR explores a solution to https://github.com/dart-lang/native/issues/1410:

* `Asset` with a `String get package`, `String get name` and `String get id => ...;`
* Constructors take `package` and `name`

This leads to the following quirks:

* `id` is used in error messages, while `package` and `name` are used in constructors.