### PR TITLE
[native_assets_cli] asset ids option 3

### DIFF
--- a/pkgs/native_assets_builder/test/build_runner/link_dry_run_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/link_dry_run_test.dart
@@ -111,4 +111,4 @@ void main() async {
 }
 
 Iterable<String> _getNames(List<AssetImpl> assets) =>
-    assets.whereType<cli.DataAsset>().map((asset) => asset.name);
+    assets.whereType<cli.DataAsset>().map((asset) => asset.id.name);

--- a/pkgs/native_assets_builder/test/build_runner/link_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/link_test.dart
@@ -205,4 +205,4 @@ void main() async {
 }
 
 Iterable<String> _getNames(List<AssetImpl> assets) =>
-    assets.whereType<cli.DataAsset>().map((asset) => asset.name);
+    assets.whereType<cli.DataAsset>().map((asset) => asset.id.name);

--- a/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
@@ -83,7 +83,7 @@ void main() async {
           );
 
           final addLibraryPath = assets
-              .firstWhere((asset) => asset.id.endsWith('add.dart'))
+              .firstWhere((asset) => asset.id.string.endsWith('add.dart'))
               .file!
               .toFilePath();
           final addResult = await runProcess(

--- a/pkgs/native_assets_builder/test_data/add_asset_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/add_asset_link/hook/link.dart
@@ -10,8 +10,7 @@ void main(List<String> arguments) async {
     output
       ..addAsset(
         NativeCodeAsset(
-          package: 'add_asset_link',
-          name: 'dylib_add_link',
+          id: AssetId('add_asset_link', 'dylib_add_link'),
           linkMode: builtDylib.linkMode,
           os: builtDylib.os,
           architecture: builtDylib.architecture,

--- a/pkgs/native_assets_builder/test_data/complex_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/complex_link/hook/build.dart
@@ -26,8 +26,7 @@ void main(List<String> args) async {
 
       output.addAsset(
         DataAsset(
-          package: packageName,
-          name: name,
+          id: AssetId(packageName, name),
           file: dataAsset.uri,
         ),
         linkInPackage: config.linkingEnabled ? packageName : null,

--- a/pkgs/native_assets_builder/test_data/complex_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/complex_link/hook/link.dart
@@ -11,5 +11,5 @@ void main(List<String> args) async {
   );
 }
 
-Iterable<Asset> treeshake(Iterable<Asset> assets) =>
-    assets.where((asset) => !asset.id.endsWith('assets/data_helper_2.json'));
+Iterable<Asset> treeshake(Iterable<Asset> assets) => assets
+    .where((asset) => !asset.id.string.endsWith('assets/data_helper_2.json'));

--- a/pkgs/native_assets_builder/test_data/complex_link_helper/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/complex_link_helper/hook/build.dart
@@ -27,8 +27,7 @@ void main(List<String> args) async {
       final forLinking = name.contains('2') || name.contains('3');
       output.addAsset(
         DataAsset(
-          package: packageName,
-          name: name,
+          id: AssetId(packageName, name),
           file: dataAsset.uri,
         ),
         linkInPackage:

--- a/pkgs/native_assets_builder/test_data/drop_dylib_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/drop_dylib_link/hook/link.dart
@@ -9,7 +9,8 @@ void main(List<String> arguments) async {
     print('''
 Received ${config.assets.length} assets: ${config.assets.map((e) => e.id)}.
 ''');
-    output.addAssets(config.assets.where((asset) => asset.id.endsWith('add')));
+    output.addAssets(
+        config.assets.where((asset) => asset.id.string.endsWith('add')));
     print('''
 Keeping only ${output.assets.map((e) => e.id)}.
 ''');

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/hook/build.dart
@@ -8,9 +8,8 @@ void main(List<String> arguments) async {
   await build(arguments, (config, output) async {
     output.addAsset(
       DataAsset(
-        name: 'data',
+        id: AssetId(config.packageName, 'data'),
         file: config.packageRoot.resolve('assets/data.json'),
-        package: config.packageName,
       ),
       linkInPackage:
           config.linkingEnabled ? 'fail_on_os_sdk_version_linker' : null,

--- a/pkgs/native_assets_builder/test_data/simple_data_asset/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/simple_data_asset/hook/build.dart
@@ -26,8 +26,7 @@ void main(List<String> args) async {
 
         output.addAsset(
           DataAsset(
-            package: config.packageName,
-            name: name,
+            id: AssetId(config.packageName, name),
             file: dataAsset.uri,
           ),
         );

--- a/pkgs/native_assets_builder/test_data/simple_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/simple_link/hook/build.dart
@@ -26,8 +26,7 @@ void main(List<String> args) async {
 
       output.addAsset(
         DataAsset(
-          package: packageName,
-          name: name,
+          id: AssetId(packageName, name),
           file: dataAsset.uri,
         ),
         linkInPackage: config.linkingEnabled ? packageName : null,

--- a/pkgs/native_assets_builder/test_data/treeshaking_native_libs/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/treeshaking_native_libs/hook/link.dart
@@ -12,7 +12,7 @@ void main(List<String> arguments) async {
     (config, output) async {
       final linker = CLinker.library(
         name: config.packageName,
-        assetName: config.assets.single.id.split('/').skip(1).join('/'),
+        assetName: config.assets.single.id.name,
         linkerOptions: LinkerOptions.treeshake(symbols: ['add']),
         sources: [config.assets.single.file!.toFilePath()],
       );

--- a/pkgs/native_assets_builder/test_data/wrong_linker/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/wrong_linker/hook/build.dart
@@ -18,8 +18,7 @@ void main(List<String> arguments) async {
 
     output.addAsset(
       NativeCodeAsset(
-        package: config.packageName,
-        name: 'foo',
+        id: AssetId(config.packageName, 'foo'),
         file: assetUri,
         linkMode: DynamicLoadingBundled(),
         os: OS.current,

--- a/pkgs/native_assets_builder/test_data/wrong_namespace_asset/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/wrong_namespace_asset/hook/build.dart
@@ -18,8 +18,7 @@ void main(List<String> arguments) async {
 
     output.addAsset(
       NativeCodeAsset(
-        package: 'other_package',
-        name: 'foo',
+        id: AssetId('other_package', 'foo'),
         file: assetUri,
         linkMode: DynamicLoadingBundled(),
         os: OS.current,

--- a/pkgs/native_assets_cli/example/build/local_asset/hook/build.dart
+++ b/pkgs/native_assets_cli/example/build/local_asset/hook/build.dart
@@ -33,8 +33,7 @@ Future<void> main(List<String> args) async {
     output.addAsset(
       // TODO: Change to DataAsset once the Dart/Flutter SDK can consume it.
       NativeCodeAsset(
-        package: packageName,
-        name: 'asset.txt',
+        id: AssetId(packageName, 'asset.txt'),
         file: assetPath,
         linkMode: DynamicLoadingBundled(),
         os: config.targetOS,

--- a/pkgs/native_assets_cli/example/link/package_with_assets/hook/build.dart
+++ b/pkgs/native_assets_cli/example/link/package_with_assets/hook/build.dart
@@ -26,8 +26,7 @@ void main(List<String> args) async {
 
       output.addAsset(
         DataAsset(
-          package: packageName,
-          name: name,
+          id: AssetId(packageName, name),
           file: dataAsset.uri,
         ),
         linkInPackage: config.linkingEnabled ? packageName : null,

--- a/pkgs/native_assets_cli/lib/native_assets_cli.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli.dart
@@ -10,6 +10,7 @@ export 'src/api/architecture.dart' show Architecture;
 export 'src/api/asset.dart'
     show
         Asset,
+        AssetId,
         DataAsset,
         DynamicLoadingBundled,
         DynamicLoadingSystem,

--- a/pkgs/native_assets_cli/lib/src/api/asset.dart
+++ b/pkgs/native_assets_cli/lib/src/api/asset.dart
@@ -50,7 +50,7 @@ abstract final class Asset {
   /// @Native<Int Function(Int, Int)>(assetId: 'package:foo/src/foo.dart')
   /// external int add(int a, int b);
   /// ```
-  String get id;
+  AssetId get id;
 
   /// The file to be bundled with the Dart or Flutter application.
   ///
@@ -63,4 +63,41 @@ abstract final class Asset {
   /// already present on the target system or an asset already present in Dart
   /// or Flutter.
   Uri? get file;
+}
+
+/// The identifier for an [Asset].
+///
+/// An [Asset] has a string identifier called "asset id". Dart code that uses
+/// an asset references the asset using this asset id.
+///
+/// An asset identifier consists of two elements, the `package` and `name`,
+/// which together make a library uri `package:<package>/<name>`. The package
+/// being part of the identifer prevents name collisions between assets of
+/// different packages.
+///
+/// The default asset id for an asset reference from `lib/src/foo.dart` is
+/// `'package:foo/src/foo.dart'`. For example a [NativeCodeAsset] can be accessed
+/// via `@Native` with the `assetId` argument omitted:
+///
+/// ```dart
+/// // file package:foo/src/foo.dart
+/// @Native<Int Function(Int, Int)>()
+/// external int add(int a, int b);
+/// ```
+///
+/// This will be then automatically expanded to
+///
+/// ```dart
+/// // file package:foo/src/foo.dart
+/// @Native<Int Function(Int, Int)>(assetId: 'package:foo/src/foo.dart')
+/// external int add(int a, int b);
+/// ```
+extension type AssetId._(String string) {
+  AssetId.fromString(this.string);
+
+  AssetId(String package, String name) : string = 'package:$package/$name';
+
+  String get name => string.split('/').skip(1).join('/');
+
+  String get package => string.split('/').first.replaceFirst('package:', '');
 }

--- a/pkgs/native_assets_cli/lib/src/api/data_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/api/data_asset.dart
@@ -14,25 +14,15 @@ part of 'asset.dart';
 /// bundle this code in the final application.
 abstract final class DataAsset implements Asset {
   /// Constructs a data asset.
-  ///
-  /// The unique [id] of this asset is a uri `package:<package>/<name>` from
-  /// [package] and [name].
   factory DataAsset({
-    required String package,
-    required String name,
+    required AssetId id,
     required Uri file,
   }) =>
       DataAssetImpl(
-        name: name,
-        package: package,
+        name: id.name,
+        package: id.package,
         file: file,
       );
-
-  /// The package which contains this asset.
-  String get package;
-
-  /// The name of this asset, which must be unique for the package.
-  String get name;
 
   static const String type = 'data';
 }

--- a/pkgs/native_assets_cli/lib/src/api/native_code_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/api/native_code_asset.dart
@@ -76,19 +76,15 @@ abstract final class NativeCodeAsset implements Asset {
   Uri? get file;
 
   /// Constructs a native code asset.
-  ///
-  /// The [id] of this asset is a uri `package:<package>/<name>` from [package]
-  /// and [name].
   factory NativeCodeAsset({
-    required String package,
-    required String name,
+    required AssetId id,
     required LinkMode linkMode,
     required OS os,
     Uri? file,
     Architecture? architecture,
   }) =>
       NativeCodeAssetImpl(
-        id: 'package:$package/$name',
+        id: id,
         linkMode: linkMode as LinkModeImpl,
         os: os as OSImpl,
         architecture: architecture as ArchitectureImpl?,

--- a/pkgs/native_assets_cli/lib/src/model/data_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/model/data_asset.dart
@@ -8,14 +8,12 @@ final class DataAssetImpl implements DataAsset, AssetImpl {
   @override
   final Uri file;
 
-  @override
   final String name;
 
-  @override
   final String package;
 
   @override
-  String get id => 'package:$package/$name';
+  AssetId get id => AssetId(package, name);
 
   DataAssetImpl({
     required this.file,

--- a/pkgs/native_assets_cli/lib/src/model/native_code_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/model/native_code_asset.dart
@@ -221,7 +221,7 @@ final class NativeCodeAssetImpl implements NativeCodeAsset, AssetImpl {
   final LinkModeImpl linkMode;
 
   @override
-  final String id;
+  final AssetId id;
 
   @override
   final OSImpl os;
@@ -301,7 +301,7 @@ final class NativeCodeAssetImpl implements NativeCodeAsset, AssetImpl {
     }
 
     return NativeCodeAssetImpl(
-      id: get<String>(jsonMap, _idKey),
+      id: AssetId.fromString(get<String>(jsonMap, _idKey)),
       os: os,
       architecture: architecture,
       linkMode: linkMode,
@@ -311,7 +311,7 @@ final class NativeCodeAssetImpl implements NativeCodeAsset, AssetImpl {
 
   NativeCodeAssetImpl copyWith({
     LinkModeImpl? linkMode,
-    String? id,
+    AssetId? id,
     OSImpl? os,
     ArchitectureImpl? architecture,
     Uri? file,
@@ -349,7 +349,7 @@ final class NativeCodeAssetImpl implements NativeCodeAsset, AssetImpl {
   Map<String, Object> toJson(Version version) {
     if (version == Version(1, 0, 0)) {
       return {
-        _idKey: id,
+        _idKey: id.string,
         ...linkMode.toJsonV1_0_0(file),
         _targetKey: Target.fromArchitectureAndOS(architecture!, os).toString(),
       }..sortOnKey();
@@ -357,7 +357,7 @@ final class NativeCodeAssetImpl implements NativeCodeAsset, AssetImpl {
     return {
       if (architecture != null) _architectureKey: architecture.toString(),
       if (file != null) _fileKey: file!.toFilePath(),
-      _idKey: id,
+      _idKey: id.string,
       _linkModeKey: linkMode.toJson(),
       _osKey: os.toString(),
       typeKey: NativeCodeAsset.type,

--- a/pkgs/native_assets_cli/lib/src/validator/validator.dart
+++ b/pkgs/native_assets_cli/lib/src/validator/validator.dart
@@ -180,7 +180,7 @@ List<String> validateAssetId(
   final errors = <String>[];
   final packageName = config.packageName;
   for (final asset in output.assets) {
-    if (!asset.id.startsWith('package:$packageName/')) {
+    if (!asset.id.string.startsWith('package:$packageName/')) {
       final error = 'Asset "${asset.id}" does not start with '
           '"package:$packageName/".';
       errors.add(error);
@@ -193,7 +193,7 @@ List<String> validateNoDuplicateAssetIds(
   BuildOutput output,
 ) {
   final errors = <String>[];
-  final assetIds = <String>{};
+  final assetIds = <AssetId>{};
   for (final asset in output.assets) {
     if (assetIds.contains(asset.id)) {
       final error = 'Duplicate asset id: "${asset.id}".';
@@ -209,7 +209,7 @@ List<String> validateNoDuplicateDylibs(
   Iterable<Asset> assets,
 ) {
   final errors = <String>[];
-  final fileNameToAssetId = <String, Set<String>>{};
+  final fileNameToAssetId = <String, Set<AssetId>>{};
   for (final asset in assets.whereType<NativeCodeAsset>()) {
     if (asset.linkMode is! DynamicLoadingBundled) {
       continue;

--- a/pkgs/native_assets_cli/test/api/asset_test.dart
+++ b/pkgs/native_assets_cli/test/api/asset_test.dart
@@ -9,53 +9,46 @@ void main() {
   test('Asset constructors', () async {
     final assets = [
       NativeCodeAsset(
-        package: 'my_package',
-        name: 'foo',
+        id: AssetId('my_package', 'foo'),
         file: Uri.file('path/to/libfoo.so'),
         linkMode: DynamicLoadingBundled(),
         os: OS.android,
         architecture: Architecture.x64,
       ),
       NativeCodeAsset(
-        package: 'my_package',
-        name: 'foo3',
+        id: AssetId('my_package', 'foo3'),
         linkMode: DynamicLoadingSystem(Uri(path: 'libfoo3.so')),
         os: OS.android,
         architecture: Architecture.x64,
       ),
       NativeCodeAsset(
-        package: 'my_package',
-        name: 'foo4',
+        id: AssetId('my_package', 'foo4'),
         linkMode: LookupInExecutable(),
         os: OS.android,
         architecture: Architecture.x64,
       ),
       NativeCodeAsset(
-        package: 'my_package',
-        name: 'foo5',
+        id: AssetId('my_package', 'foo5'),
         linkMode: LookupInProcess(),
         os: OS.android,
         architecture: Architecture.x64,
       ),
       NativeCodeAsset(
-        package: 'my_package',
-        name: 'bar',
+        id: AssetId('my_package', 'bar'),
         file: Uri(path: 'path/to/libbar.a'),
         os: OS.linux,
         architecture: Architecture.arm64,
         linkMode: StaticLinking(),
       ),
       NativeCodeAsset(
-        package: 'my_package',
-        name: 'bla',
+        id: AssetId('my_package', 'bla'),
         file: Uri(path: 'path/with spaces/bla.dll'),
         linkMode: DynamicLoadingBundled(),
         os: OS.windows,
         architecture: Architecture.x64,
       ),
       DataAsset(
-        package: 'my_package',
-        name: 'data/some_text.txt',
+        id: AssetId('my_package', 'data/some_text.txt'),
         file: Uri(path: 'data/some_text.txt'),
       ),
     ];
@@ -73,8 +66,7 @@ void main() {
   test('Errors', () {
     expect(
       () => NativeCodeAsset(
-        package: 'my_package',
-        name: 'foo',
+        id: AssetId('my_package', 'foo'),
         file: Uri.file('path/to/libfoo.so'),
         linkMode: LookupInExecutable(),
         os: OS.android,

--- a/pkgs/native_assets_cli/test/api/build_output_test.dart
+++ b/pkgs/native_assets_cli/test/api/build_output_test.dart
@@ -23,16 +23,14 @@ void main() {
       timestamp: DateTime.parse('2022-11-10 13:25:01.000'),
       assets: [
         NativeCodeAsset(
-          package: 'my_package',
-          name: 'foo',
+          id: AssetId('my_package', 'foo'),
           file: Uri(path: 'path/to/libfoo.so'),
           linkMode: DynamicLoadingBundled(),
           os: OS.android,
           architecture: Architecture.x64,
         ),
         NativeCodeAsset(
-          package: 'my_package',
-          name: 'foo2',
+          id: AssetId('my_package', 'foo2'),
           linkMode: DynamicLoadingSystem(Uri(path: 'path/to/libfoo2.so')),
           os: OS.android,
           architecture: Architecture.x64,

--- a/pkgs/native_assets_cli/test/model/asset_test.dart
+++ b/pkgs/native_assets_cli/test/model/asset_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:collection/collection.dart';
 import 'package:native_assets_cli/native_assets_cli_internal.dart';
+import 'package:native_assets_cli/src/api/asset.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 
@@ -16,39 +17,39 @@ void main() {
   final data2Uri = Uri.file('path/to/data.json');
   final nativeCodeAssets = [
     NativeCodeAssetImpl(
-      id: 'package:my_package/foo',
+      id: AssetId('my_package', 'foo'),
       file: fooUri,
       linkMode: DynamicLoadingBundledImpl(),
       os: OSImpl.android,
       architecture: ArchitectureImpl.x64,
     ),
     NativeCodeAssetImpl(
-      id: 'package:my_package/foo3',
+      id: AssetId('my_package', 'foo3'),
       linkMode: DynamicLoadingSystemImpl(foo3Uri),
       os: OSImpl.android,
       architecture: ArchitectureImpl.x64,
     ),
     NativeCodeAssetImpl(
-      id: 'package:my_package/foo4',
+      id: AssetId('my_package', 'foo4'),
       linkMode: LookupInExecutableImpl(),
       os: OSImpl.android,
       architecture: ArchitectureImpl.x64,
     ),
     NativeCodeAssetImpl(
-      id: 'package:my_package/foo5',
+      id: AssetId('my_package', 'foo5'),
       linkMode: LookupInProcessImpl(),
       os: OSImpl.android,
       architecture: ArchitectureImpl.x64,
     ),
     NativeCodeAssetImpl(
-      id: 'package:my_package/bar',
+      id: AssetId('my_package', 'bar'),
       file: barUri,
       os: OSImpl.linux,
       architecture: ArchitectureImpl.arm64,
       linkMode: StaticLinkingImpl(),
     ),
     NativeCodeAssetImpl(
-      id: 'package:my_package/bla',
+      id: AssetId('my_package', 'bla'),
       file: blaUri,
       linkMode: DynamicLoadingBundledImpl(),
       os: OSImpl.windows,
@@ -196,7 +197,7 @@ void main() {
 
   test('Asset hashCode copyWith', () async {
     final asset = nativeCodeAssets.first;
-    final asset2 = asset.copyWith(id: 'foo321');
+    final asset2 = asset.copyWith(id: AssetId('foo', 'foo321'));
     expect(asset.hashCode != asset2.hashCode, true);
 
     final asset3 = asset.copyWith();

--- a/pkgs/native_assets_cli/test/model/build_output_test.dart
+++ b/pkgs/native_assets_cli/test/model/build_output_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:native_assets_cli/native_assets_cli_internal.dart';
+import 'package:native_assets_cli/src/api/asset.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 import '../helpers.dart';
@@ -24,7 +25,7 @@ void main() {
     timestamp: DateTime.parse('2022-11-10 13:25:01.000'),
     assets: [
       NativeCodeAssetImpl(
-        id: 'package:my_package/foo',
+        id: AssetId('my_package', 'foo'),
         file: Uri(path: 'path/to/libfoo.so'),
         linkMode: DynamicLoadingBundledImpl(),
         os: OSImpl.android,
@@ -327,14 +328,14 @@ version: 1.0.0'''),
       timestamp: DateTime.parse('2022-11-10 13:25:01.000'),
       assets: [
         NativeCodeAssetImpl(
-          id: 'package:my_package/foo',
+          id: AssetId('my_package', 'foo'),
           file: Uri(path: 'path/to/libfoo.so'),
           linkMode: DynamicLoadingBundledImpl(),
           os: OSImpl.android,
           architecture: ArchitectureImpl.x64,
         ),
         NativeCodeAssetImpl(
-          id: 'package:my_package/foo2',
+          id: AssetId('my_package', 'foo2'),
           linkMode: DynamicLoadingSystemImpl(Uri(path: 'path/to/libfoo2.so')),
           os: OSImpl.android,
           architecture: ArchitectureImpl.x64,
@@ -355,7 +356,7 @@ version: 1.0.0'''),
     );
     buildOutput2.addAsset(
       NativeCodeAssetImpl(
-        id: 'package:my_package/foo',
+        id: AssetId('my_package', 'foo'),
         file: Uri(path: 'path/to/libfoo.so'),
         linkMode: DynamicLoadingBundledImpl(),
         os: OSImpl.android,
@@ -364,7 +365,7 @@ version: 1.0.0'''),
     );
     buildOutput2.addAssets([
       NativeCodeAssetImpl(
-        id: 'package:my_package/foo2',
+        id: AssetId('my_package', 'foo2'),
         linkMode: DynamicLoadingSystemImpl(Uri(path: 'path/to/libfoo2.so')),
         os: OSImpl.android,
         architecture: ArchitectureImpl.x64,
@@ -392,26 +393,26 @@ HookOutputImpl getBuildOutput({bool withLinkedAssets = true}) => HookOutputImpl(
       timestamp: DateTime.parse('2022-11-10 13:25:01.000'),
       assets: [
         NativeCodeAssetImpl(
-          id: 'package:my_package/foo',
+          id: AssetId('my_package', 'foo'),
           file: Uri(path: 'path/to/libfoo.so'),
           linkMode: DynamicLoadingBundledImpl(),
           os: OSImpl.android,
           architecture: ArchitectureImpl.x64,
         ),
         NativeCodeAssetImpl(
-          id: 'package:my_package/foo2',
+          id: AssetId('my_package', 'foo2'),
           linkMode: DynamicLoadingSystemImpl(Uri(path: 'path/to/libfoo2.so')),
           os: OSImpl.android,
           architecture: ArchitectureImpl.x64,
         ),
         NativeCodeAssetImpl(
-          id: 'package:my_package/foo3',
+          id: AssetId('my_package', 'foo3'),
           linkMode: LookupInProcessImpl(),
           os: OSImpl.android,
           architecture: ArchitectureImpl.x64,
         ),
         NativeCodeAssetImpl(
-          id: 'package:my_package/foo4',
+          id: AssetId('my_package', 'foo4'),
           linkMode: LookupInExecutableImpl(),
           os: OSImpl.android,
           architecture: ArchitectureImpl.x64,

--- a/pkgs/native_assets_cli/test/model/link_config_test.dart
+++ b/pkgs/native_assets_cli/test/model/link_config_test.dart
@@ -23,13 +23,11 @@ void main() async {
   late Uri recordedUsagesFile;
   final assets = [
     DataAsset(
-      package: packageName,
-      name: 'name',
+      id: AssetId(packageName, 'name'),
       file: Uri.file('nonexistent'),
     ),
     NativeCodeAsset(
-      package: packageName,
-      name: 'name2',
+      id: AssetId(packageName, 'name2'),
       linkMode: DynamicLoadingBundled(),
       os: OS.android,
       file: Uri.file('not there'),

--- a/pkgs/native_assets_cli/test/validator/validator_test.dart
+++ b/pkgs/native_assets_cli/test/validator/validator_test.dart
@@ -48,8 +48,7 @@ void main() {
     await assetFile.writeAsBytes([1, 2, 3]);
     output.addAsset(
       NativeCodeAsset(
-        package: config.packageName,
-        name: 'foo.dart',
+        id: AssetId(config.packageName, 'foo.dart'),
         file: assetFile.uri,
         linkMode: DynamicLoadingBundled(),
         os: config.targetOS,
@@ -82,8 +81,7 @@ void main() {
     final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
     await assetFile.writeAsBytes([1, 2, 3]);
     output.addAsset(DataAsset(
-      package: config.packageName,
-      name: 'foo.txt',
+      id: AssetId(config.packageName, 'foo.txt'),
       file: assetFile.uri,
     ));
     final result = await validateBuild(config, output);
@@ -110,8 +108,7 @@ void main() {
     final output = BuildOutput();
     final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
     output.addAsset(DataAsset(
-      package: config.packageName,
-      name: 'foo.txt',
+      id: AssetId(config.packageName, 'foo.txt'),
       file: assetFile.uri,
     ));
     final result = await validateBuild(config, output);
@@ -137,8 +134,7 @@ void main() {
     );
     final output = BuildOutput();
     output.addAsset(NativeCodeAsset(
-      package: config.packageName,
-      name: 'foo.dylib',
+      id: AssetId(config.packageName, 'foo.dylib'),
       architecture: config.targetArchitecture,
       os: config.targetOS,
       linkMode: DynamicLoadingBundled(),
@@ -173,8 +169,7 @@ void main() {
       await assetFile.writeAsBytes([1, 2, 3]);
       output.addAsset(
         NativeCodeAsset(
-          package: config.packageName,
-          name: 'foo.dart',
+          id: AssetId(config.packageName, 'foo.dart'),
           file: assetFile.uri,
           linkMode: linkMode,
           os: config.targetOS,
@@ -210,8 +205,7 @@ void main() {
     await assetFile.writeAsBytes([1, 2, 3]);
     output.addAsset(
       NativeCodeAsset(
-        package: config.packageName,
-        name: 'foo.dart',
+        id: AssetId(config.packageName, 'foo.dart'),
         file: assetFile.uri,
         linkMode: DynamicLoadingBundled(),
         os: config.targetOS,
@@ -246,8 +240,7 @@ void main() {
     await assetFile.writeAsBytes([1, 2, 3]);
     output.addAsset(
       NativeCodeAsset(
-        package: config.packageName,
-        name: 'foo.dart',
+        id: AssetId(config.packageName, 'foo.dart'),
         file: assetFile.uri,
         linkMode: DynamicLoadingBundled(),
         os: config.targetOS,
@@ -281,8 +274,7 @@ void main() {
     await assetFile.writeAsBytes([1, 2, 3]);
     output.addAsset(
       NativeCodeAsset(
-        package: config.packageName,
-        name: 'foo.dart',
+        id: AssetId(config.packageName, 'foo.dart'),
         file: assetFile.uri,
         linkMode: DynamicLoadingBundled(),
         os: OS.windows,
@@ -316,8 +308,7 @@ void main() {
     final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
     await assetFile.writeAsBytes([1, 2, 3]);
     output.addAsset(DataAsset(
-      package: 'different_package',
-      name: 'foo.txt',
+      id: AssetId('different_package', 'foo.txt'),
       file: assetFile.uri,
     ));
     final result = await validateBuild(config, output);
@@ -346,13 +337,11 @@ void main() {
     await assetFile.writeAsBytes([1, 2, 3]);
     output.addAssets([
       DataAsset(
-        package: config.packageName,
-        name: 'foo.txt',
+        id: AssetId(config.packageName, 'foo.txt'),
         file: assetFile.uri,
       ),
       DataAsset(
-        package: config.packageName,
-        name: 'foo.txt',
+        id: AssetId(config.packageName, 'foo.txt'),
         file: assetFile.uri,
       ),
     ]);
@@ -381,8 +370,7 @@ void main() {
     final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
     await assetFile.writeAsBytes([1, 2, 3]);
     output.addAsset(DataAsset(
-      package: config.packageName,
-      name: 'foo.txt',
+      id: AssetId(config.packageName, 'foo.txt'),
       file: assetFile.uri,
     ));
     final result = await validateLink(config, output);
@@ -412,16 +400,14 @@ void main() {
     await assetFile.writeAsBytes([1, 2, 3]);
     output.addAssets([
       NativeCodeAsset(
-        package: config.packageName,
-        name: 'src/foo.dart',
+        id: AssetId(config.packageName, 'src/foo.dart'),
         file: assetFile.uri,
         linkMode: DynamicLoadingBundled(),
         os: config.targetOS,
         architecture: config.targetArchitecture,
       ),
       NativeCodeAsset(
-        package: config.packageName,
-        name: 'src/bar.dart',
+        id: AssetId(config.packageName, 'src/bar.dart'),
         file: assetFile.uri,
         linkMode: DynamicLoadingBundled(),
         os: config.targetOS,

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -165,8 +165,7 @@ class CBuilder extends CTool implements Builder {
       output.addAssets(
         [
           NativeCodeAsset(
-            package: config.packageName,
-            name: assetName!,
+            id: AssetId(config.packageName, assetName!),
             file: libUri,
             linkMode: linkMode,
             os: config.targetOS,

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
@@ -94,8 +94,7 @@ class CLinker extends CTool implements Linker {
       output.addAssets(
         [
           NativeCodeAsset(
-            package: config.packageName,
-            name: assetName!,
+            id: AssetId(config.packageName, assetName!),
             file: libUri,
             linkMode: linkMode,
             os: config.targetOS,


### PR DESCRIPTION
This PR explores a solution to https://github.com/dart-lang/native/issues/1410:

* Introduces `AssetId` extension type for asset ids.

This leads to the following quirks:

* Somewhat more verbose constructors and member access.