### PR TITLE
[ffigen] Fix bug in nullable block arguments

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 14.1.0-wip
+
+- Fix bug with nullable types in `ObjCBlock`'s type arguments.
+
 ## 14.0.0
 
 - Create a public facing API for ffigen that can be invoked as a library:

--- a/pkgs/ffigen/lib/src/code_generator/objc_nullable.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_nullable.dart
@@ -41,6 +41,10 @@ class ObjCNullable extends Type {
       child.getNativeType(varName: varName);
 
   @override
+  String getObjCBlockSignatureType(Writer w) =>
+      '${child.getObjCBlockSignatureType(w)}?';
+
+  @override
   bool get sameFfiDartAndCType => child.sameFfiDartAndCType;
 
   @override

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 14.0.0
+version: 14.1.0-wip
 description: >
   Generator for FFI bindings, using LibClang to parse C, Objective-C, and Swift
   files.

--- a/pkgs/ffigen/test/native_objc_test/block_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test.dart
@@ -29,6 +29,7 @@ typedef DoubleBlock = ObjCBlock_ffiDouble_ffiDouble;
 typedef Vec4Block = ObjCBlock_Vec4_Vec4;
 typedef ObjectBlock = ObjCBlock_DummyObject_DummyObject;
 typedef NullableObjectBlock = ObjCBlock_DummyObject_DummyObject1;
+typedef NullableStringBlock = ObjCBlock_NSString_NSString;
 typedef ObjectListenerBlock = ObjCBlock_ffiVoid_DummyObject;
 typedef NullableListenerBlock = ObjCBlock_ffiVoid_DummyObject1;
 typedef StructListenerBlock = ObjCBlock_ffiVoid_Vec2_Vec4_NSObject;
@@ -203,6 +204,21 @@ void main() {
       final result3 = BlockTester.callNullableObjectBlock_(block);
       expect(result3, isNull);
       expect(isCalled, isTrue);
+    });
+
+    test('Nullable string block', () {
+      // Regression test for https://github.com/dart-lang/native/issues/1537.
+      final block = NullableStringBlock.fromFunction(
+          (NSString? x) => '$x Cat'.toNSString());
+
+      final result1 = block('Dog'.toNSString());
+      expect(result1.toString(), 'Dog Cat');
+
+      final result2 = block(null);
+      expect(result2.toString(), 'null Cat');
+
+      final result3 = BlockTester.callNullableStringBlock_(block);
+      expect(result3.toString(), 'Lizard Cat');
     });
 
     test('Object listener block', () async {

--- a/pkgs/ffigen/test/native_objc_test/block_test.h
+++ b/pkgs/ffigen/test/native_objc_test/block_test.h
@@ -37,6 +37,7 @@ typedef Vec4 (^Vec4Block)(Vec4);
 typedef void (^VoidBlock)();
 typedef DummyObject* (^ObjectBlock)(DummyObject*);
 typedef DummyObject* _Nullable (^NullableObjectBlock)(DummyObject* _Nullable);
+typedef NSString* _Nullable (^NullableStringBlock)(NSString* _Nullable);
 typedef IntBlock (^BlockBlock)(IntBlock);
 typedef void (^ListenerBlock)(IntBlock);
 typedef void (^ObjectListenerBlock)(DummyObject*);
@@ -63,6 +64,8 @@ typedef void (^NoTrampolineListenerBlock)(int32_t, Vec4, const char*);
 + (Vec4)callVec4Block:(Vec4Block)block;
 + (DummyObject*)callObjectBlock:(ObjectBlock)block NS_RETURNS_RETAINED;
 + (nullable DummyObject*)callNullableObjectBlock:(NullableObjectBlock)block
+    NS_RETURNS_RETAINED;
++ (nullable NSString*)callNullableStringBlock:(NullableStringBlock)block
     NS_RETURNS_RETAINED;
 + (void)callListener:(ListenerBlock)block;
 + (void)callObjectListener:(ObjectListenerBlock)block;

--- a/pkgs/ffigen/test/native_objc_test/block_test.m
+++ b/pkgs/ffigen/test/native_objc_test/block_test.m
@@ -157,6 +157,11 @@ void objc_release(id value);
   return block(nil);
 }
 
++ (nullable NSString*)callNullableStringBlock:(NullableStringBlock)block
+    NS_RETURNS_RETAINED {
+  return block(@"Lizard");
+}
+
 + (IntBlock)newBlock:(BlockBlock)block withMult:(int)mult NS_RETURNS_RETAINED {
   IntBlock inputBlock = ^int(int x) {
     return mult * x;


### PR DESCRIPTION
Nullable block args were being represented as `Pointer<ObjCObject>`, so if you have multiple blocks that have the same signature after this conversion, their extension methods will collide. The fix is to represent these args as `DartWrapper?`

Fixes https://github.com/dart-lang/native/issues/1537