### PR TITLE
[jnigen] Rename names with dollar signs

### DIFF
--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -7,6 +7,8 @@
   numeric suffices and the renamed overloads. Similarly names that are Dart
   keywords get a dollar sign suffix now. For more information, check out the
   [documentation](https://github.com/dart-lang/native/tree/main/pkgs/jnigen/docs/java_differences.md#method_overloading).
+- **Breaking Change**: Each single dollar sign is replaced with two dollar signs
+  in the identifier names.
 - Fixed an issue where inheriting a generic class could generate incorrect code.
 - No longer generating constructors for abstract classes.
 - No longer generating `protected` elements.

--- a/pkgs/jnigen/docs/java_differences.md
+++ b/pkgs/jnigen/docs/java_differences.md
@@ -1,4 +1,7 @@
-## Syntax and semantic differences between Java and the generated Dart bindings
+## Syntactic and semantic differences between Java and the generated Dart bindings
+
+This document highlights the key syntactic and semantic variations between Java
+and Dart and how JNIgen addresses them to ensure smooth interoperability.
 
 ### Method overloading
 
@@ -47,7 +50,12 @@ class Calculator extends JObject {
 
 You might wonder why the method isn't renamed to `add1` instead of `add$1`. The
 reason is that a method named `add1` could already exist in the Java class. On
-the other hand, Java identifiers cannot contain dollar signs.
+the other hand, Java identifiers normally do not contain dollar signs.
+
+> [!NOTE]  
+> See
+> [Identifiers containing dollar signs](#identifiers-containing-dollar-signs) to
+> see what JNIgen does when identifiers contain dollar signs.
 
 ```java
 // Java
@@ -87,7 +95,7 @@ class Calculator extends JObject {
 
   int add1(int a) { /* ... */ }
 
-  double add1$2(double a) { /* ... */ }
+  double add1$1(double a) { /* ... */ }
 }
 ```
 
@@ -164,3 +172,17 @@ class DuckOwningPlayer extends Player {
   set duck$1(Duck value) { /* ... */ }
 }
 ```
+
+### Identifiers containing dollar signs
+
+JNIgen uses dollar signs in the generated code to fill the syntactic and
+semantic gaps between Java and Dart. This normally does not cause a problem as
+the
+[Java language specificifaction](https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-3.8)
+suggests dollar signs should be used only in the generated code or, rarely, to
+access pre-existing names on legacy systems.
+
+JNIgen replaces each single dollar sign with two dollar signs. For example
+`generated$method$2` will turn into `generated$$method$$2`. This prevents name
+collision as JNIgen-renamed identifiers will end with an odd number of dollar
+signs (optionally followed by a numeric suffix).

--- a/pkgs/jnigen/lib/src/bindings/renamer.dart
+++ b/pkgs/jnigen/lib/src/bindings/renamer.dart
@@ -105,7 +105,7 @@ String _doubleDollarSigns(String name) {
 /// Appends `$` to [name] if [name] is a Dart keyword.
 ///
 /// Examples:
-/// * `yields` -> `yields$`
+/// * `yield` -> `yield$`
 /// * `i` -> `i`
 String _keywordRename(String name) =>
     _keywords.contains(name) ? '$name\$' : name;

--- a/pkgs/jnigen/lib/src/elements/elements.dart
+++ b/pkgs/jnigen/lib/src/elements/elements.dart
@@ -445,7 +445,7 @@ abstract class ClassMember {
   String get name;
   ClassDecl get classDecl;
   Set<String> get modifiers;
-  abstract String finalName;
+  String get finalName;
 
   bool get isAbstract => modifiers.contains('abstract');
   bool get isStatic => modifiers.contains('static');

--- a/pkgs/jnigen/lib/src/elements/elements.dart
+++ b/pkgs/jnigen/lib/src/elements/elements.dart
@@ -119,6 +119,7 @@ class ClassDecl extends ClassMember implements Element<ClassDecl> {
   ///
   /// Populated by [Renamer].
   @JsonKey(includeFromJson: false)
+  @override
   late final String finalName;
 
   /// Name of the type class.
@@ -168,6 +169,8 @@ class ClassDecl extends ClassMember implements Element<ClassDecl> {
 
   bool get isObject => superCount == 0;
 
+  // TODO(https://github.com/dart-lang/native/issues/1544): Use a better
+  // heuristic. Class names can have dollar signs without being nested.
   @JsonKey(includeFromJson: false)
   late final String? parentName = binaryName.contains(r'$')
       ? binaryName.splitMapJoin(RegExp(r'\$[^$]+$'), onMatch: (_) => '')
@@ -442,6 +445,7 @@ abstract class ClassMember {
   String get name;
   ClassDecl get classDecl;
   Set<String> get modifiers;
+  abstract String finalName;
 
   bool get isAbstract => modifiers.contains('abstract');
   bool get isStatic => modifiers.contains('static');
@@ -491,6 +495,7 @@ class Method extends ClassMember implements Element<Method> {
 
   /// Populated by [Renamer].
   @JsonKey(includeFromJson: false)
+  @override
   late String finalName;
 
   @JsonKey(includeFromJson: false)
@@ -571,6 +576,7 @@ class Field extends ClassMember implements Element<Field> {
 
   /// Populated by [Renamer].
   @JsonKey(includeFromJson: false)
+  @override
   late final String finalName;
 
   factory Field.fromJson(Map<String, dynamic> json) => _$FieldFromJson(json);

--- a/pkgs/jnigen/test/renamer_test.dart
+++ b/pkgs/jnigen/test/renamer_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:jnigen/jnigen.dart';
 import 'package:jnigen/src/bindings/linker.dart';
 import 'package:jnigen/src/bindings/renamer.dart';

--- a/pkgs/jnigen/test/renamer_test.dart
+++ b/pkgs/jnigen/test/renamer_test.dart
@@ -1,8 +1,11 @@
+import 'package:jnigen/jnigen.dart';
 import 'package:jnigen/src/bindings/linker.dart';
 import 'package:jnigen/src/bindings/renamer.dart';
-import 'package:jnigen/src/config/config.dart';
-import 'package:jnigen/src/elements/elements.dart';
 import 'package:test/test.dart';
+
+extension on Iterable<ClassMember> {
+  List<String> get finalNames => map((c) => c.finalName).toList();
+}
 
 Future<Config> testConfig() async {
   final config = Config(
@@ -73,43 +76,39 @@ void main() {
     await classes.accept(Linker(config));
     classes.accept(Renamer(config));
 
-    final renamedClasses =
-        classes.decls.values.map((c) => c.finalName).toList();
+    final renamedClasses = classes.decls.values.finalNames;
     expect(renamedClasses, [
       'Foo',
-      'Foo\$1',
-      'Foo\$2',
+      r'Foo$1',
+      r'Foo$2',
       'Foo1',
-      'Foo1\$1',
-      'Foo1\$2',
+      r'Foo1$1',
+      r'Foo1$2',
     ]);
 
-    final renamedMethods =
-        classes.decls['Foo']!.methods.map((m) => m.finalName).toList();
+    final renamedMethods = classes.decls['Foo']!.methods.finalNames;
     expect(renamedMethods, [
       'foo',
-      'foo\$1',
-      'foo\$2',
+      r'foo$1',
+      r'foo$2',
       'foo1',
-      'foo1\$1',
-      'foo1\$2',
+      r'foo1$1',
+      r'foo1$2',
     ]);
 
-    final renamedFields =
-        classes.decls['x.Foo']!.fields.map((f) => f.finalName).toList();
+    final renamedFields = classes.decls['x.Foo']!.fields.finalNames;
     // Fields are renamed before methods. So they always keep their original
     // name (if not renamed for a different reason).
     expect(renamedFields, [
       'foo',
       'foo1',
     ]);
-    final xFooMethods =
-        classes.decls['x.Foo']!.methods.map((m) => m.finalName).toList();
+    final xFooMethods = classes.decls['x.Foo']!.methods.finalNames;
     expect(xFooMethods, [
-      'foo\$1',
-      'foo\$2',
-      'foo1\$1',
-      'foo1\$2',
+      r'foo$1',
+      r'foo$2',
+      r'foo1$1',
+      r'foo1$2',
     ]);
   });
 
@@ -138,13 +137,10 @@ void main() {
     await classes.accept(Linker(config));
     classes.accept(Renamer(config));
 
-    final renamedMethods =
-        classes.decls['Player']!.methods.map((m) => m.finalName).toList();
+    final renamedMethods = classes.decls['Player']!.methods.finalNames;
     expect(renamedMethods, ['duck']);
-    final renamedFields = classes.decls['DuckOwningPlayer']!.fields
-        .map((f) => f.finalName)
-        .toList();
-    expect(renamedFields, ['duck\$1']);
+    final renamedFields = classes.decls['DuckOwningPlayer']!.fields.finalNames;
+    expect(renamedFields, [r'duck$1']);
   });
 
   test('Keywords in names', () async {
@@ -172,15 +168,55 @@ void main() {
     await classes.accept(Linker(config));
     classes.accept(Renamer(config));
 
-    final renamedMethods =
-        classes.decls['Foo']!.methods.map((m) => m.finalName).toList();
-    expect(renamedMethods, ['yield\$', 'const\$1', 'const\$2']);
-    final renamedFields =
-        classes.decls['Foo']!.fields.map((f) => f.finalName).toList();
+    final renamedMethods = classes.decls['Foo']!.methods.finalNames;
+    expect(renamedMethods, [r'yield$', r'const$1', r'const$2']);
+    final renamedFields = classes.decls['Foo']!.fields.finalNames;
 
-    expect(renamedFields, ['const\$']);
-    final renamedClasses =
-        classes.decls.values.map((c) => c.finalName).toList();
-    expect(renamedClasses, ['Foo', 'Function\$']);
+    expect(renamedFields, [r'const$']);
+    final renamedClasses = classes.decls.values.finalNames;
+    expect(renamedClasses, ['Foo', r'Function$']);
+  });
+
+  test('Names with existing dollar signs', () async {
+    // TODO(https://github.com/dart-lang/native/issues/1544): Test class names
+    // containing dollar signs.
+    final classes = Classes({
+      'Foo': ClassDecl(
+        binaryName: 'Foo',
+        declKind: DeclKind.classKind,
+        superclass: TypeUsage.object,
+        methods: [
+          Method(name: 'foo', returnType: TypeUsage.object),
+          Method(name: 'foo', returnType: TypeUsage.object),
+          Method(name: r'foo$1', returnType: TypeUsage.object),
+          Method(name: r'$$Many$Dollar$$Signs$', returnType: TypeUsage.object),
+          Method(name: 'alsoAField', returnType: TypeUsage.object),
+          Method(name: 'alsoAField', returnType: TypeUsage.object),
+        ],
+        fields: [
+          Field(name: r'alsoAField', type: TypeUsage.object),
+          Field(name: r'alsoAField$1', type: TypeUsage.object),
+        ],
+      ),
+    });
+    final config = await testConfig();
+    await classes.accept(Linker(config));
+    classes.accept(Renamer(config));
+
+    final renamedMethods = classes.decls['Foo']!.methods.finalNames;
+    expect(renamedMethods, [
+      'foo',
+      r'foo$1',
+      r'foo$$1',
+      r'$$$$Many$$Dollar$$$$Signs$$',
+      r'alsoAField$1',
+      r'alsoAField$2',
+    ]);
+
+    final renamedFields = classes.decls['Foo']!.fields.finalNames;
+    expect(renamedFields, [
+      'alsoAField',
+      r'alsoAField$$1',
+    ]);
   });
 }


### PR DESCRIPTION
Address @lrhn's comments in https://github.com/dart-lang/native/pull/1530. 

Now we replace each dollar sign with two to prevent name collisions between original names and the JNIgen-renamed ones as JNIgen uses single dollar signs to address syntactic and semantic changes.
