### PR TITLE
[ffigen] Fix path normalization bug

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 14.0.1
 
-- Fix bug with nullable types in `ObjCBlock`'s type arguments.
-- Fix a path normalization bug.
+- Fix bug with nullable types in `ObjCBlock`'s type arguments:
+  https://github.com/dart-lang/native/issues/1537
+- Fix a path normalization bug: https://github.com/dart-lang/native/issues/1543
 
 ## 14.0.0
 

--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 14.1.0-wip
+## 14.0.1
 
 - Fix bug with nullable types in `ObjCBlock`'s type arguments.
+- Fix a path normalization bug.
 
 ## 14.0.0
 

--- a/pkgs/ffigen/lib/src/code_generator/utils.dart
+++ b/pkgs/ffigen/lib/src/code_generator/utils.dart
@@ -134,7 +134,7 @@ String findDart() {
   final dartExe = 'dart${p.extension(path)}';
   while (path.isNotEmpty) {
     path = p.dirname(path);
-    final dartPath = p.join(path, dartExe);
+    final dartPath = p.normalize(p.join(path, dartExe));
     if (File(dartPath).existsSync()) return dartPath;
   }
   throw Exception(

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/macro_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/macro_parser.dart
@@ -168,7 +168,7 @@ late Set<String> _macroVarNames;
 
 /// Creates a temporary file for parsing macros in current directory.
 File createFileForMacros() {
-  final fileNameBase = p.join(strings.tmpDir, 'temp_for_macros');
+  final fileNameBase = p.normalize(p.join(strings.tmpDir, 'temp_for_macros'));
   final fileExt = 'hpp';
 
   // Find a filename which doesn't already exist.

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 14.1.0-wip
+version: 14.0.1
 description: >
   Generator for FFI bindings, using LibClang to parse C, Objective-C, and Swift
   files.

--- a/pkgs/ffigen/test/unit_tests/normalize_path_test.dart
+++ b/pkgs/ffigen/test/unit_tests/normalize_path_test.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:ffigen/src/config_provider/spec_utils.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  final abs = Platform.isWindows ? r'\\' : '/';
+  final config = p.joinAll([abs, 'foo', 'package', 'ffigen.yaml']);
+
+  group('normalizePath', () {
+    test('All separators replaced with platform separators', () {
+      // Unix style.
+      expect(normalizePath('relative/header.h', null),
+             p.joinAll(['relative', 'header.h']));
+
+      // Windows style.
+      expect(normalizePath(r'relative\header.h', null),
+             p.joinAll(['relative', 'header.h']));
+    });
+
+    test('Relative path normalized and resolved relative to config', () {
+      expect(normalizePath('relative/src/header.h', config),
+             p.joinAll([abs, 'foo', 'package', 'relative', 'src', 'header.h']));
+      expect(normalizePath('../src/header.h', config),
+             p.joinAll([abs, 'foo', 'src', 'header.h']));
+      expect(normalizePath('./././src/header.h', config),
+             p.joinAll([abs, 'foo', 'package', 'src', 'header.h']));
+      expect(normalizePath('.././src/.././header.h', config),
+             p.joinAll([abs, 'foo', 'header.h']));
+    });
+
+    test('Absolute path normalized but not resolved', () {
+      expect(normalizePath(p.joinAll([abs, 'absolute/src/header.h']), config),
+             p.joinAll([abs, 'absolute', 'src', 'header.h']));
+      expect(normalizePath(p.joinAll([abs, './src/.././header.h']), config),
+             p.joinAll([abs, 'header.h']));
+    });
+
+    test('Glob path normalized but not resolved', () {
+      expect(normalizePath('**/glob/*/header.h', config),
+             p.joinAll(['**', 'glob', '*', 'header.h']));
+      expect(normalizePath('**/glob/./*/../header.h', config),
+             p.joinAll(['**', 'glob', 'header.h']));
+    });
+
+    test('Null configFilename normalized but not resolved', () {
+      expect(normalizePath(p.joinAll(['relative/src/header.h']), null),
+             p.joinAll(['relative', 'src', 'header.h']));
+      expect(normalizePath(p.joinAll(['./src/.././header.h']), null),
+             p.joinAll(['header.h']));
+    });
+  });
+}

--- a/pkgs/ffigen/test/unit_tests/normalize_path_test.dart
+++ b/pkgs/ffigen/test/unit_tests/normalize_path_test.dart
@@ -26,11 +26,11 @@ void main() {
     test('Relative path normalized and resolved relative to config', () {
       expect(normalizePath('relative/src/header.h', config),
           p.joinAll([abs, 'foo', 'package', 'relative', 'src', 'header.h']));
-      expect(normalizePath('../src/header.h', config),
+      expect(normalizePath('./../src/header.h', config),
           p.joinAll([abs, 'foo', 'src', 'header.h']));
       expect(normalizePath('./././src/header.h', config),
           p.joinAll([abs, 'foo', 'package', 'src', 'header.h']));
-      expect(normalizePath('.././src/.././header.h', config),
+      expect(normalizePath('./../src/.././header.h', config),
           p.joinAll([abs, 'foo', 'header.h']));
     });
 

--- a/pkgs/ffigen/test/unit_tests/normalize_path_test.dart
+++ b/pkgs/ffigen/test/unit_tests/normalize_path_test.dart
@@ -9,7 +9,7 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
-  final abs = Platform.isWindows ? r'\\' : '/';
+  final abs = Platform.isWindows ? r'C:\' : '/';
   final config = p.joinAll([abs, 'foo', 'package', 'ffigen.yaml']);
 
   group('normalizePath', () {
@@ -26,11 +26,11 @@ void main() {
     test('Relative path normalized and resolved relative to config', () {
       expect(normalizePath('relative/src/header.h', config),
           p.joinAll([abs, 'foo', 'package', 'relative', 'src', 'header.h']));
-      expect(normalizePath('./../src/header.h', config),
+      expect(normalizePath('../src/header.h', config),
           p.joinAll([abs, 'foo', 'src', 'header.h']));
       expect(normalizePath('./././src/header.h', config),
           p.joinAll([abs, 'foo', 'package', 'src', 'header.h']));
-      expect(normalizePath('./../src/.././header.h', config),
+      expect(normalizePath('.././src/.././header.h', config),
           p.joinAll([abs, 'foo', 'header.h']));
     });
 

--- a/pkgs/ffigen/test/unit_tests/normalize_path_test.dart
+++ b/pkgs/ffigen/test/unit_tests/normalize_path_test.dart
@@ -3,9 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:io';
-import 'package:test/test.dart';
+
 import 'package:ffigen/src/config_provider/spec_utils.dart';
 import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
 
 void main() {
   final abs = Platform.isWindows ? r'\\' : '/';

--- a/pkgs/ffigen/test/unit_tests/normalize_path_test.dart
+++ b/pkgs/ffigen/test/unit_tests/normalize_path_test.dart
@@ -15,43 +15,43 @@ void main() {
     test('All separators replaced with platform separators', () {
       // Unix style.
       expect(normalizePath('relative/header.h', null),
-             p.joinAll(['relative', 'header.h']));
+          p.joinAll(['relative', 'header.h']));
 
       // Windows style.
       expect(normalizePath(r'relative\header.h', null),
-             p.joinAll(['relative', 'header.h']));
+          p.joinAll(['relative', 'header.h']));
     });
 
     test('Relative path normalized and resolved relative to config', () {
       expect(normalizePath('relative/src/header.h', config),
-             p.joinAll([abs, 'foo', 'package', 'relative', 'src', 'header.h']));
+          p.joinAll([abs, 'foo', 'package', 'relative', 'src', 'header.h']));
       expect(normalizePath('../src/header.h', config),
-             p.joinAll([abs, 'foo', 'src', 'header.h']));
+          p.joinAll([abs, 'foo', 'src', 'header.h']));
       expect(normalizePath('./././src/header.h', config),
-             p.joinAll([abs, 'foo', 'package', 'src', 'header.h']));
+          p.joinAll([abs, 'foo', 'package', 'src', 'header.h']));
       expect(normalizePath('.././src/.././header.h', config),
-             p.joinAll([abs, 'foo', 'header.h']));
+          p.joinAll([abs, 'foo', 'header.h']));
     });
 
     test('Absolute path normalized but not resolved', () {
       expect(normalizePath(p.joinAll([abs, 'absolute/src/header.h']), config),
-             p.joinAll([abs, 'absolute', 'src', 'header.h']));
+          p.joinAll([abs, 'absolute', 'src', 'header.h']));
       expect(normalizePath(p.joinAll([abs, './src/.././header.h']), config),
-             p.joinAll([abs, 'header.h']));
+          p.joinAll([abs, 'header.h']));
     });
 
     test('Glob path normalized but not resolved', () {
       expect(normalizePath('**/glob/*/header.h', config),
-             p.joinAll(['**', 'glob', '*', 'header.h']));
+          p.joinAll(['**', 'glob', '*', 'header.h']));
       expect(normalizePath('**/glob/./*/../header.h', config),
-             p.joinAll(['**', 'glob', 'header.h']));
+          p.joinAll(['**', 'glob', 'header.h']));
     });
 
     test('Null configFilename normalized but not resolved', () {
       expect(normalizePath(p.joinAll(['relative/src/header.h']), null),
-             p.joinAll(['relative', 'src', 'header.h']));
+          p.joinAll(['relative', 'src', 'header.h']));
       expect(normalizePath(p.joinAll(['./src/.././header.h']), null),
-             p.joinAll(['header.h']));
+          p.joinAll(['header.h']));
     });
   });
 }


### PR DESCRIPTION
When I added Dart API to ffigen (#1372) I switched a bunch of strings to be Uris. This started inserting `.` into the paths in some circumstances, causing some file matching checks to fail. The fix is just to add a `p.normalize` call to our existing `normalizePath` function (we probably should have been doing this already).

I'll publish ffigen 14.0.1 after this fix, since it's a regression.

Fixes #1543