### PR TITLE
[jnigen] Do not fail when synthetic parameters don't have names

### DIFF
--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed an issue where inheriting a generic class could generate incorrect code.
 - No longer generating constructors for abstract classes.
 - No longer generating `protected` elements.
+- Fixed an issue where synthetic methods caused code generation to fail.
 
 ## 0.11.0
 

--- a/pkgs/jnigen/lib/src/elements/elements.dart
+++ b/pkgs/jnigen/lib/src/elements/elements.dart
@@ -531,7 +531,11 @@ class Param implements Element<Param> {
 
   final List<Annotation> annotations;
   final JavaDocComment? javadoc;
+
+  // Synthetic methods might not have parameter names.
+  @JsonKey(defaultValue: 'synthetic')
   final String name;
+
   final TypeUsage type;
 
   /// Populated by [Renamer].

--- a/pkgs/jnigen/lib/src/elements/elements.g.dart
+++ b/pkgs/jnigen/lib/src/elements/elements.g.dart
@@ -131,7 +131,7 @@ Param _$ParamFromJson(Map<String, dynamic> json) => Param(
       javadoc: json['javadoc'] == null
           ? null
           : JavaDocComment.fromJson(json['javadoc'] as Map<String, dynamic>),
-      name: json['name'] as String,
+      name: json['name'] as String? ?? 'synthetic',
       type: TypeUsage.fromJson(json['type'] as Map<String, dynamic>),
     );
 


### PR DESCRIPTION
Close #1354.

Synthetic bridge methods are not generated. Relax the JSON parsing to not require a non-null name for the parameters as sometimes they might not have any name.