### PR TITLE
[ffigen] Add protocol methods to interfaces

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 14.1.0-wip
+## 15.0.0-wip
 
 - Dedupe `ObjCBlock` trampolines to reduce generated ObjC code.
+- ObjC objects now include the methods from the protocols they implement. Both
+  required and optional methods are included. Optional methods will throw an
+  exception if the method isn't implemented.
 
 ## 14.0.1
 

--- a/pkgs/ffigen/lib/src/code_generator/objc_built_in_functions.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_built_in_functions.dart
@@ -21,6 +21,7 @@ class ObjCBuiltInFunctions {
   static const msgSendFpretPointer = ObjCImport('msgSendFpretPointer');
   static const msgSendStretPointer = ObjCImport('msgSendStretPointer');
   static const useMsgSendVariants = ObjCImport('useMsgSendVariants');
+  static const respondsToSelector = ObjCImport('respondsToSelector');
   static const newPointerBlock = ObjCImport('newPointerBlock');
   static const newClosureBlock = ObjCImport('newClosureBlock');
   static const getBlockClosure = ObjCImport('getBlockClosure');
@@ -37,6 +38,8 @@ class ObjCBuiltInFunctions {
       ObjCImport('ObjCProtocolListenableMethod');
   static const protocolBuilder = ObjCImport('ObjCProtocolBuilder');
   static const dartProxy = ObjCImport('DartProxy');
+  static const unimplementedOptionalMethodException =
+      ObjCImport('UnimplementedOptionalMethodException');
 
   // Keep in sync with pkgs/objective_c/ffigen_objc.yaml.
   static const builtInInterfaces = {

--- a/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
@@ -41,6 +41,7 @@ class ObjCInterface extends BindingType with ObjCMethods {
   late final ObjCInternalGlobal _classObject;
   late final ObjCInternalGlobal _isKindOfClass;
   late final ObjCMsgSendFunc _isKindOfClassMsgSend;
+  final _protocols = <ObjCProtocol>[];
 
   @override
   final ObjCBuiltInFunctions builtInFunctions;
@@ -55,6 +56,7 @@ class ObjCInterface extends BindingType with ObjCMethods {
   })  : lookupName = lookupName ?? originalName,
         super(name: name ?? originalName);
 
+  void addProtocol(ObjCProtocol proto) => _protocols.add(proto);
   bool get _isBuiltIn => builtInFunctions.isBuiltInInterface(originalName);
 
   @override
@@ -185,6 +187,15 @@ class ObjCInterface extends BindingType with ObjCMethods {
       s.write(' {\n');
 
       // Implementation.
+      final sel = m.selObject!.name;
+      if (m.isOptional) {
+        s.write('''
+    if (!${ObjCBuiltInFunctions.respondsToSelector.gen(w)}(ref.pointer, $sel)) {
+      throw ${ObjCBuiltInFunctions.unimplementedOptionalMethodException.gen(w)}(
+          '$originalName', '${m.originalName}');
+    }
+''');
+      }
       final convertReturn = m.kind != ObjCMethodKind.propertySetter &&
           !returnType.sameDartAndFfiDartType;
 
@@ -201,7 +212,7 @@ class ObjCInterface extends BindingType with ObjCMethods {
                   objCRetain: m.consumesSelf,
                   objCAutorelease: false,
                 ),
-          m.selObject!.name,
+          sel,
           m.params.map((p) => p.type.convertDartTypeToFfiDartType(
                 w,
                 p.name,
@@ -252,10 +263,17 @@ class ObjCInterface extends BindingType with ObjCMethods {
       superType!.addDependencies(dependencies);
       _copyMethodsFromSuperType();
       _fixNullabilityOfOverriddenMethods();
-
-      // Add dependencies for any methods that were added.
-      addMethodDependencies(dependencies, needMsgSend: true);
     }
+
+    for (final proto in _protocols) {
+      proto.addDependencies(dependencies);
+      for (final m in proto.methods) {
+        addMethod(m);
+      }
+    }
+
+    // Add dependencies for any methods that were added.
+    addMethodDependencies(dependencies, needMsgSend: true);
   }
 
   void _copyMethodsFromSuperType() {

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
@@ -12,6 +12,7 @@ import '../data.dart';
 import '../includer.dart';
 import '../utils.dart';
 import 'api_availability.dart';
+import 'objcprotocoldecl_parser.dart';
 
 final _logger = Logger('ffigen.header_parser.objcinterfacedecl_parser');
 
@@ -76,6 +77,9 @@ void _fillInterface(ObjCInterface itf, clang_types.CXCursor cursor) {
       case clang_types.CXCursorKind.CXCursor_ObjCSuperClassRef:
         _parseSuperType(child, itf);
         break;
+      case clang_types.CXCursorKind.CXCursor_ObjCProtocolRef:
+        _parseProtocol(child, itf);
+        break;
       case clang_types.CXCursorKind.CXCursor_ObjCPropertyDecl:
         _parseProperty(child, itf, itfDecl);
         break;
@@ -109,6 +113,14 @@ void _parseSuperType(clang_types.CXCursor cursor, ObjCInterface itf) {
   } else {
     _logger.severe(
         'Super type of $itf is $superType, which is not a valid interface.');
+  }
+}
+
+void _parseProtocol(clang_types.CXCursor cursor, ObjCInterface itf) {
+  final protoCursor = clang.clang_getCursorDefinition(cursor);
+  final proto = parseObjCProtocolDeclaration(protoCursor);
+  if (proto != null) {
+    itf.addProtocol(proto);
   }
 }
 

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 14.1.0-wip
+version: 15.0.0-wip
 description: >
   Generator for FFI bindings, using LibClang to parse C, Objective-C, and Swift
   files.

--- a/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
+++ b/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
@@ -6,7 +6,7 @@
 @TestOn('mac-os')
 
 // This is a slow test.
-@Timeout(Duration(minutes: 2))
+@Timeout(Duration(minutes: 5))
 library;
 
 import 'dart:async';
@@ -28,7 +28,7 @@ Future<int> run(String exe, List<String> args) async {
 
 void main() {
   test('Large ObjC integration test', () async {
-    // Reducing the bindings to a random subset to that the test completes in a
+    // Reducing the bindings to a random subset so that the test completes in a
     // reasonable amount of time.
     // TODO(https://github.com/dart-lang/sdk/issues/56247): Remove this.
     const inclusionRatio = 0.1;
@@ -41,10 +41,12 @@ void main() {
 
     // TODO(https://github.com/dart-lang/native/issues/1220): Allow these.
     const disallowedMethods = {
-      'cachePolicy',
+      'accessKey',
       'allowsConstrainedNetworkAccess',
-      'tag',
+      'attributedString',
+      'cachePolicy',
       'hyphenationFactor',
+      'tag',
     };
     final interfaceFilter = DeclarationFilters(
       shouldInclude: randInclude,

--- a/pkgs/ffigen/test/native_objc_test/protocol_config.yaml
+++ b/pkgs/ffigen/test/native_objc_test/protocol_config.yaml
@@ -15,6 +15,6 @@ objc-protocols:
     - SecondaryProtocol
 headers:
   entry-points:
-    - 'protocol_test.m'
+    - 'protocol_test.h'
 preamble: |
   // ignore_for_file: camel_case_types, non_constant_identifier_names, unnecessary_non_null_assertion, unused_element, unused_field

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.h
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
+#include "util.h"
+
+typedef struct {
+  int32_t x;
+  int32_t y;
+} SomeStruct;
+
+@protocol SuperProtocol<NSObject>
+
+@required
+- (NSString*)instanceMethod:(NSString*)s withDouble:(double)x;
+
+@end
+
+@protocol MyProtocol<SuperProtocol>
+
+@optional
+- (int32_t)optionalMethod:(SomeStruct)s;
+
+@optional
+- (void)voidMethod:(int32_t)x;
+
+@end
+
+
+@protocol SecondaryProtocol<NSObject>
+
+@required
+- (int32_t)otherMethod:(int32_t)a b:(int32_t)b c:(int32_t)c d:(int32_t)d;
+
+@optional
+- (nullable instancetype)returnsInstanceType;
+
+@end
+
+@protocol EmptyProtocol
+@end
+
+
+@interface ProtocolConsumer : NSObject
+- (NSString*)callInstanceMethod:(id<MyProtocol>)protocol;
+- (int32_t)callOptionalMethod:(id<MyProtocol>)protocol;
+- (int32_t)callOtherMethod:(id<SecondaryProtocol>)protocol;
+- (void)callMethodOnRandomThread:(id<SecondaryProtocol>)protocol;
+@end
+
+
+@interface ObjCProtocolImpl : NSObject<MyProtocol, SecondaryProtocol>
+@end
+
+
+@interface ObjCProtocolImplMissingMethod : NSObject<MyProtocol>
+@end

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.m
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.m
@@ -3,54 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 #import <dispatch/dispatch.h>
-#import <Foundation/NSObject.h>
-#import <Foundation/NSString.h>
 
+#include "protocol_test.h"
 #include "util.h"
-
-typedef struct {
-  int32_t x;
-  int32_t y;
-} SomeStruct;
-
-@protocol SuperProtocol<NSObject>
-
-@required
-- (NSString*)instanceMethod:(NSString*)s withDouble:(double)x;
-
-@end
-
-@protocol MyProtocol<SuperProtocol>
-
-@optional
-- (int32_t)optionalMethod:(SomeStruct)s;
-
-@optional
-- (void)voidMethod:(int32_t)x;
-
-@end
-
-
-@protocol SecondaryProtocol<NSObject>
-
-@required
-- (int32_t)otherMethod:(int32_t)a b:(int32_t)b c:(int32_t)c d:(int32_t)d;
-
-@optional
-- (nullable instancetype)returnsInstanceType;
-
-@end
-
-@protocol EmptyProtocol
-@end
-
-
-@interface ProtocolConsumer : NSObject
-- (NSString*)callInstanceMethod:(id<MyProtocol>)protocol;
-- (int32_t)callOptionalMethod:(id<MyProtocol>)protocol;
-- (int32_t)callOtherMethod:(id<SecondaryProtocol>)protocol;
-- (void)callMethodOnRandomThread:(id<SecondaryProtocol>)protocol;
-@end
 
 @implementation ProtocolConsumer : NSObject
 - (NSString*)callInstanceMethod:(id<MyProtocol>)protocol {
@@ -78,9 +33,6 @@ typedef struct {
 @end
 
 
-@interface ObjCProtocolImpl : NSObject<MyProtocol, SecondaryProtocol>
-@end
-
 @implementation ObjCProtocolImpl
 - (NSString *)instanceMethod:(NSString *)s withDouble:(double)x {
   return [NSString stringWithFormat:@"ObjCProtocolImpl: %@: %.2f", s, x];
@@ -96,9 +48,6 @@ typedef struct {
 
 @end
 
-
-@interface ObjCProtocolImplMissingMethod : NSObject<MyProtocol>
-@end
 
 @implementation ObjCProtocolImplMissingMethod
 - (NSString *)instanceMethod:(NSString *)s withDouble:(double)x {

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0-wip
+
+- Add `UnimplementedOptionalMethodException`, which is thrown by the ObjC
+  bindings if an optional method is invoked, and the instance doesn't implement
+  the method.
+
 ## 2.0.0
 
 - Drop API methods that are deprecated in the oldest versions of iOS and macOS

--- a/pkgs/objective_c/lib/src/internal.dart
+++ b/pkgs/objective_c/lib/src/internal.dart
@@ -18,6 +18,15 @@ final class DoubleReleaseError extends StateError {
   DoubleReleaseError() : super('Double release error');
 }
 
+final class UnimplementedOptionalMethodException implements Exception {
+  String clazz;
+  String method;
+  UnimplementedOptionalMethodException(this.clazz, this.method);
+
+  @override
+  String toString() => 'Instance of $clazz does not implement $method';
+}
+
 /// Only for use by ffigen bindings.
 Pointer<c.ObjCSelector> registerName(String name) {
   final cstr = name.toNativeUtf8();
@@ -83,6 +92,20 @@ final msgSendStretPointer =
 /// Only for use by ffigen bindings.
 final useMsgSendVariants =
     Abi.current() == Abi.iosX64 || Abi.current() == Abi.macosX64;
+
+/// Only for use by ffigen bindings.
+bool respondsToSelector(
+        Pointer<c.ObjCObject> obj, Pointer<c.ObjCSelector> sel) =>
+    _objcMsgSendRespondsToSelector(obj, _selRespondsToSelector, sel);
+final _selRespondsToSelector = registerName('respondsToSelector:');
+final _objcMsgSendRespondsToSelector = msgSendPointer
+    .cast<
+        NativeFunction<
+            Bool Function(Pointer<c.ObjCObject>, Pointer<c.ObjCSelector>,
+                Pointer<c.ObjCSelector> aSelector)>>()
+    .asFunction<
+        bool Function(Pointer<c.ObjCObject>, Pointer<c.ObjCSelector>,
+            Pointer<c.ObjCSelector>)>();
 
 // _FinalizablePointer exists because we can't access `this` in the initializers
 // of _ObjCReference's constructor, and we have to have an owner to attach the

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -474,17 +474,6 @@ class Protocol extends objc.ObjCObjectBase {
 }
 
 late final _class_Protocol = objc.getClass("Protocol");
-final _objc_msgSend_0 = objc.msgSendPointer
-    .cast<
-        ffi.NativeFunction<
-            ffi.Bool Function(
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCObject> clazz)>>()
-    .asFunction<
-        bool Function(ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCObject>)>();
-late final _sel_isKindOfClass_ = objc.registerName("isKindOfClass:");
 late final _sel_conformsToProtocol_ = objc.registerName("conformsToProtocol:");
 final _objc_msgSend_5 = objc.msgSendPointer
     .cast<
@@ -6339,6 +6328,16 @@ final _objc_msgSend_103 = objc.msgSendPointer
         ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCObject>)>();
 late final _sel_containsObject_ = objc.registerName("containsObject:");
+final _objc_msgSend_0 = objc.msgSendPointer
+    .cast<
+        ffi.NativeFunction<
+            ffi.Bool Function(
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCObject> clazz)>>()
+    .asFunction<
+        bool Function(ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCObject>)>();
 late final _sel_descriptionWithLocale_indent_ =
     objc.registerName("descriptionWithLocale:indent:");
 final _objc_msgSend_104 = objc.msgSendPointer
@@ -14337,3 +14336,4 @@ final _objc_msgSend_311 = objc.msgSendPointer
         instancetype Function(ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCObject>)>();
 late final _sel_initFromBuilder_ = objc.registerName("initFromBuilder:");
+late final _sel_isKindOfClass_ = objc.registerName("isKindOfClass:");

--- a/pkgs/objective_c/pubspec.yaml
+++ b/pkgs/objective_c/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: objective_c
 description: 'A library to access Objective C from Flutter that acts as a support library for package:ffigen.'
-version: 2.0.0
+version: 2.1.0-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/objective_c
 
 topics:


### PR DESCRIPTION
If an interface implements a protocol, but doesn't declare or implement the protocol's methods in the same file, then they won't appear as methods directly on the interface in the AST. This is actually the typical case in most APIs, where the implementation is in a separate file to the interface. This means we don't codegen those methods, so they aren't invocable from Dart, even though they do have implementations and are invocable from ObjC.

The fix is just to parse all the protocols that the interface implements, and copy their methods to the interface.

The only wrinkle is that protocols can have optional methods, which the interface might not implement. If we generate the same Dart bindings for optional methods as we do for required methods, then invoking these methods may cause a crash at runtime with no useful stack trace. There's a special message we can send to the object to check if it has an implementation for a method: `respondsToSelector:`. So we just have to check if the object responds to the selector, and throw an exception if it doesn't.

Fixes https://github.com/dart-lang/native/issues/1487