### PR TITLE
Update dependencies and use `@internal` annotation

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -1,9 +1,12 @@
+## 0.12.0-wip
+
+- Renamed library `internal_helpers_for_jnigen` to `_internal`.
+
 ## 0.11.0
 
 - **Breaking Change** Removed `Jni.accessors`.
 - Made most `Jni.env` methods into leaf functions to speed up their execution.
 - Removed the dependency on `kotlin_gradle_plugin`.
-- Renamed library internal_helpers_for_jnigen to \_internal.
 
 ## 0.10.1
 

--- a/pkgs/jni/example/lib/main.dart
+++ b/pkgs/jni/example/lib/main.dart
@@ -4,11 +4,10 @@
 
 // ignore_for_file: library_private_types_in_public_api
 
-import 'package:flutter/material.dart';
-
-import 'dart:io';
 import 'dart:ffi';
+import 'dart:io';
 
+import 'package:flutter/material.dart';
 import 'package:jni/jni.dart';
 
 // An example of calling JNI methods using low level primitives.

--- a/pkgs/jni/lib/_internal.dart
+++ b/pkgs/jni/lib/_internal.dart
@@ -2,9 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: invalid_export_of_internal_element
+
 /// This library exports the methods meant for use by generated code only, and
 /// not to be used directly.
-library _internal;
+library;
 
 import 'dart:ffi' as ffi;
 

--- a/pkgs/jni/lib/jni.dart
+++ b/pkgs/jni/lib/jni.dart
@@ -58,7 +58,7 @@
 /// reason for NoClassDefFound error is missing classes in classpath.
 
 /// This library provides classes and functions for JNI interop from Dart.
-library jni;
+library;
 
 export 'dart:ffi' show nullptr;
 
@@ -67,7 +67,7 @@ export 'package:ffi/ffi.dart' show Arena, using;
 export 'src/errors.dart';
 export 'src/jni.dart' hide ProtectedJniExtensions;
 export 'src/jobject.dart';
-export 'src/jreference.dart';
+export 'src/jreference.dart' hide ProtectedJReference;
 export 'src/jvalues.dart';
 export 'src/lang/lang.dart';
 export 'src/nio/nio.dart';

--- a/pkgs/jni/lib/src/accessors.dart
+++ b/pkgs/jni/lib/src/accessors.dart
@@ -4,6 +4,8 @@
 
 import 'dart:ffi';
 
+import 'package:meta/meta.dart' show internal;
+
 import '../jni.dart';
 
 void _check(JThrowablePtr exception) {
@@ -12,6 +14,7 @@ void _check(JThrowablePtr exception) {
   }
 }
 
+@internal
 extension JniResultMethods on JniResult {
   void check() => _check(exception);
 
@@ -69,6 +72,7 @@ extension JniResultMethods on JniResult {
   }
 }
 
+@internal
 extension JniIdLookupResultMethods on JniPointerResult {
   JMethodIDPtr get methodID {
     _check(exception);
@@ -90,6 +94,7 @@ extension JniIdLookupResultMethods on JniPointerResult {
   }
 }
 
+@internal
 extension JniClassLookupResultMethods on JniClassLookupResult {
   JClassPtr get checkedClassRef {
     _check(exception);
@@ -97,6 +102,7 @@ extension JniClassLookupResultMethods on JniClassLookupResult {
   }
 }
 
+@internal
 extension JThrowableCheckMethod on JThrowablePtr {
   void check() {
     _check(this);

--- a/pkgs/jni/lib/src/jarray.dart
+++ b/pkgs/jni/lib/src/jarray.dart
@@ -374,8 +374,8 @@ extension ObjectArray<T extends JObject> on JArray<T> {
     RangeError.checkValidRange(start, end, length);
     final rangeLength = end - start;
     final it = iterable.skip(skipCount).take(rangeLength);
-    it.forEachIndexed((index, element) {
+    for (final (index, element) in it.indexed) {
       this[index] = element;
-    });
+    }
   }
 }

--- a/pkgs/jni/lib/src/jni.dart
+++ b/pkgs/jni/lib/src/jni.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart' show internal;
 import 'package:path/path.dart';
 
 import '../jni.dart';
@@ -239,6 +240,7 @@ typedef _SetJniGettersNativeType = Void Function(Pointer<Void>, Pointer<Void>);
 typedef _SetJniGettersDartType = void Function(Pointer<Void>, Pointer<Void>);
 
 /// Extensions for use by `jnigen` generated code.
+@internal
 extension ProtectedJniExtensions on Jni {
   static final _jThrowableClass = JClass.forName('java/lang/Throwable');
 
@@ -367,7 +369,7 @@ extension AdditionalEnvMethods on GlobalJniEnv {
 }
 
 extension StringMethodsForJni on String {
-  /// Returns a Utf-8 encoded Pointer<Char> with contents same as this string.
+  /// Returns a Utf-8 encoded `Pointer<Char>` with contents same as this string.
   Pointer<Char> toNativeChars([Allocator allocator = malloc]) {
     return toNativeUtf8(allocator: allocator).cast<Char>();
   }

--- a/pkgs/jni/lib/src/jreference.dart
+++ b/pkgs/jni/lib/src/jreference.dart
@@ -5,11 +5,13 @@
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart' show internal;
 
 import 'errors.dart';
 import 'jni.dart';
 import 'third_party/generated_bindings.dart';
 
+@internal
 extension ProtectedJReference on JReference {
   void setAsReleased() {
     _setAsReleased();

--- a/pkgs/jni/lib/src/method_invocation.dart
+++ b/pkgs/jni/lib/src/method_invocation.dart
@@ -4,12 +4,15 @@
 
 import 'dart:ffi';
 
+import 'package:meta/meta.dart' show internal;
+
 import 'jobject.dart';
 import 'jreference.dart';
 import 'lang/jstring.dart';
 import 'third_party/generated_bindings.dart';
 import 'types.dart';
 
+@internal
 class $MethodInvocation {
   final Pointer<CallbackResult> result;
   final JString methodDescriptor;

--- a/pkgs/jni/lib/src/third_party/global_env_extensions.dart
+++ b/pkgs/jni/lib/src/third_party/global_env_extensions.dart
@@ -37,7 +37,7 @@ import 'dart:ffi' as ffi;
 import '../accessors.dart';
 import 'jni_bindings_generated.dart';
 
-/// Wraps over Pointer<GlobalJniEnvStruct> and exposes function pointer fields
+/// Wraps over `Pointer<GlobalJniEnvStruct>` and exposes function pointer fields
 /// as methods.
 class GlobalJniEnv {
   final ffi.Pointer<GlobalJniEnvStruct> ptr;

--- a/pkgs/jni/lib/src/types.dart
+++ b/pkgs/jni/lib/src/types.dart
@@ -5,8 +5,8 @@
 import 'dart:ffi';
 import 'dart:typed_data';
 
-import 'package:collection/collection.dart';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart' show internal;
 
 import '../_internal.dart';
 import 'jni.dart';
@@ -56,6 +56,7 @@ mixin JArrayElementType<JavaT> on JType<JavaT> {
 /// Makes constructing objects easier inside the generated bindings by allowing
 /// a [JReference] to be created. This allows [JObject]s to use constructors
 /// that call `super.fromReference` instead of factories.
+@internal
 const referenceType = _ReferenceType();
 
 final class _ReferenceType extends JType<JReference>

--- a/pkgs/jni/pubspec.yaml
+++ b/pkgs/jni/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jni
 description: A library to access JNI from Dart and Flutter that acts as a support library for package:jnigen.
-version: 0.11.0
+version: 0.12.0-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jni
 
 topics:
@@ -19,20 +19,19 @@ environment:
   flutter: '>=2.11.0'
 
 dependencies:
-  args: ^2.3.1
-  collection: ^1.0.0
+  args: ^2.5.0
   ffi: ^2.1.3
+  meta: ^1.15.0
   package_config: ^2.1.0
-  path: ^1.8.0
-  plugin_platform_interface: ^2.0.2
+  path: ^1.9.0
+  plugin_platform_interface: ^2.1.8
 
 dev_dependencies:
-  dart_flutter_team_lints: ^2.0.0
+  dart_flutter_team_lints: ^3.2.0
   ## Pin ffigen version because we are depending on internal APIs.
   ffigen: 8.0.2
-  flutter_lints: ^2.0.0
-  logging: ^1.1.1
-  test: ^1.21.1
+  logging: ^1.2.0
+  test: ^1.25.8
 
 # The following section is specific to Flutter packages.
 flutter:

--- a/pkgs/jni/tool/wrapper_generators/generate_c_extensions.dart
+++ b/pkgs/jni/tool/wrapper_generators/generate_c_extensions.dart
@@ -249,7 +249,7 @@ String? getWrapperFunc(Member field) {
     }
     final callParams = [
       'jniEnv',
-      ...outerFunctionType.parameters.map((param) => param.name).toList(),
+      ...outerFunctionType.parameters.map((param) => param.name),
       if (withVarArgs) 'args',
     ].join(', ');
     final resultWrapper = getResultWrapper(returnType);

--- a/pkgs/jni/tool/wrapper_generators/generate_dart_extensions.dart
+++ b/pkgs/jni/tool/wrapper_generators/generate_dart_extensions.dart
@@ -264,7 +264,7 @@ String getGlobalEnvExtension(
   final generatedFunctions =
       primitiveArrayHelperFunctions.map((f) => f.dartCode).join('\n');
   return '''
-/// Wraps over Pointer<GlobalJniEnvStruct> and exposes function pointer fields
+/// Wraps over `Pointer<GlobalJniEnvStruct>` and exposes function pointer fields
 /// as methods.
 class GlobalJniEnv {
   final ffi.Pointer<GlobalJniEnvStruct> ptr;

--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -15,7 +15,7 @@
 - No longer generating constructors for abstract classes.
 - No longer generating `protected` elements.
 - Fixed an issue where synthetic methods caused code generation to fail.
-- Renamed library internal_helpers_for_jnigen to \_internal.
+- Renamed library `internal_helpers_for_jnigen` to `_internal`.
 
 ## 0.11.0
 

--- a/pkgs/jnigen/example/in_app_java/lib/android_utils.dart
+++ b/pkgs/jnigen/example/in_app_java/lib/android_utils.dart
@@ -7,12 +7,14 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: doc_directive_unknown
 // ignore_for_file: file_names
+// ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 // ignore_for_file: non_constant_identifier_names
 // ignore_for_file: only_throw_errors
 // ignore_for_file: overridden_fields
 // ignore_for_file: prefer_double_quotes
+// ignore_for_file: unintended_html_in_doc_comment
 // ignore_for_file: unnecessary_cast
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: unused_element

--- a/pkgs/jnigen/example/kotlin_plugin/lib/kotlin_bindings.dart
+++ b/pkgs/jnigen/example/kotlin_plugin/lib/kotlin_bindings.dart
@@ -7,12 +7,14 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: doc_directive_unknown
 // ignore_for_file: file_names
+// ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 // ignore_for_file: non_constant_identifier_names
 // ignore_for_file: only_throw_errors
 // ignore_for_file: overridden_fields
 // ignore_for_file: prefer_double_quotes
+// ignore_for_file: unintended_html_in_doc_comment
 // ignore_for_file: unnecessary_cast
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: unused_element

--- a/pkgs/jnigen/example/notification_plugin/lib/notifications.dart
+++ b/pkgs/jnigen/example/notification_plugin/lib/notifications.dart
@@ -11,12 +11,14 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: doc_directive_unknown
 // ignore_for_file: file_names
+// ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 // ignore_for_file: non_constant_identifier_names
 // ignore_for_file: only_throw_errors
 // ignore_for_file: overridden_fields
 // ignore_for_file: prefer_double_quotes
+// ignore_for_file: unintended_html_in_doc_comment
 // ignore_for_file: unnecessary_cast
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: unused_element

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
@@ -25,12 +25,14 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: doc_directive_unknown
 // ignore_for_file: file_names
+// ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 // ignore_for_file: non_constant_identifier_names
 // ignore_for_file: only_throw_errors
 // ignore_for_file: overridden_fields
 // ignore_for_file: prefer_double_quotes
+// ignore_for_file: unintended_html_in_doc_comment
 // ignore_for_file: unnecessary_cast
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: unused_element

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocumentInformation.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocumentInformation.dart
@@ -25,12 +25,14 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: doc_directive_unknown
 // ignore_for_file: file_names
+// ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 // ignore_for_file: non_constant_identifier_names
 // ignore_for_file: only_throw_errors
 // ignore_for_file: overridden_fields
 // ignore_for_file: prefer_double_quotes
+// ignore_for_file: unintended_html_in_doc_comment
 // ignore_for_file: unnecessary_cast
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: unused_element

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/text/PDFTextStripper.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/text/PDFTextStripper.dart
@@ -25,12 +25,14 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: doc_directive_unknown
 // ignore_for_file: file_names
+// ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 // ignore_for_file: non_constant_identifier_names
 // ignore_for_file: only_throw_errors
 // ignore_for_file: overridden_fields
 // ignore_for_file: prefer_double_quotes
+// ignore_for_file: unintended_html_in_doc_comment
 // ignore_for_file: unnecessary_cast
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: unused_element

--- a/pkgs/jnigen/lib/jnigen.dart
+++ b/pkgs/jnigen/lib/jnigen.dart
@@ -5,7 +5,7 @@
 /// This library exports a high level programmatic API to jnigen, the entry
 /// point of which is runJniGenTask function, which takes run configuration as
 /// a JniGenTask.
-library jnigen;
+library;
 
 export 'src/config/config.dart';
 export 'src/config/filters.dart';

--- a/pkgs/jnigen/lib/src/bindings/dart_generator.dart
+++ b/pkgs/jnigen/lib/src/bindings/dart_generator.dart
@@ -141,12 +141,14 @@ import 'package:jni/jni.dart' as jni;
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: doc_directive_unknown
 // ignore_for_file: file_names
+// ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 // ignore_for_file: non_constant_identifier_names
 // ignore_for_file: only_throw_errors
 // ignore_for_file: overridden_fields
 // ignore_for_file: prefer_double_quotes
+// ignore_for_file: unintended_html_in_doc_comment
 // ignore_for_file: unnecessary_cast
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: unused_element

--- a/pkgs/jnigen/pubspec.yaml
+++ b/pkgs/jnigen/pubspec.yaml
@@ -18,20 +18,20 @@ topics:
   - jni
 
 dependencies:
-  args: ^2.3.0
+  args: ^2.5.0
   cli_config: '>=0.1.0 <0.3.0'
   json_annotation: ^4.9.0
-  logging: ^1.0.2
-  meta: ^1.8.0
+  logging: ^1.2.0
+  meta: ^1.15.0
   package_config: ^2.1.0
-  path: ^1.8.0
+  path: ^1.9.0
   pub_semver: ^2.1.4
-  yaml: ^3.1.0
+  yaml: ^3.1.2
 
 dev_dependencies:
-  build_runner: ^2.2.0
-  dart_flutter_team_lints: ^2.0.0
+  build_runner: ^2.4.12
+  dart_flutter_team_lints: ^3.2.0
   jni:
     path: ../jni
   json_serializable: ^6.8.0
-  test: ^1.24.1
+  test: ^1.25.8

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
@@ -24,12 +24,14 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: doc_directive_unknown
 // ignore_for_file: file_names
+// ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 // ignore_for_file: non_constant_identifier_names
 // ignore_for_file: only_throw_errors
 // ignore_for_file: overridden_fields
 // ignore_for_file: prefer_double_quotes
+// ignore_for_file: unintended_html_in_doc_comment
 // ignore_for_file: unnecessary_cast
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: unused_element

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonParser.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonParser.dart
@@ -24,12 +24,14 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: doc_directive_unknown
 // ignore_for_file: file_names
+// ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 // ignore_for_file: non_constant_identifier_names
 // ignore_for_file: only_throw_errors
 // ignore_for_file: overridden_fields
 // ignore_for_file: prefer_double_quotes
+// ignore_for_file: unintended_html_in_doc_comment
 // ignore_for_file: unnecessary_cast
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: unused_element

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonToken.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonToken.dart
@@ -24,12 +24,14 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: doc_directive_unknown
 // ignore_for_file: file_names
+// ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 // ignore_for_file: non_constant_identifier_names
 // ignore_for_file: only_throw_errors
 // ignore_for_file: overridden_fields
 // ignore_for_file: prefer_double_quotes
+// ignore_for_file: unintended_html_in_doc_comment
 // ignore_for_file: unnecessary_cast
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: unused_element

--- a/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
+++ b/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
@@ -11,12 +11,14 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: doc_directive_unknown
 // ignore_for_file: file_names
+// ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 // ignore_for_file: non_constant_identifier_names
 // ignore_for_file: only_throw_errors
 // ignore_for_file: overridden_fields
 // ignore_for_file: prefer_double_quotes
+// ignore_for_file: unintended_html_in_doc_comment
 // ignore_for_file: unnecessary_cast
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: unused_element

--- a/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
@@ -11,12 +11,14 @@
 // ignore_for_file: constant_identifier_names
 // ignore_for_file: doc_directive_unknown
 // ignore_for_file: file_names
+// ignore_for_file: invalid_use_of_internal_member
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 // ignore_for_file: non_constant_identifier_names
 // ignore_for_file: only_throw_errors
 // ignore_for_file: overridden_fields
 // ignore_for_file: prefer_double_quotes
+// ignore_for_file: unintended_html_in_doc_comment
 // ignore_for_file: unnecessary_cast
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: unused_element
@@ -31,6 +33,96 @@ import 'dart:isolate' show ReceivePort;
 
 import 'package:jni/_internal.dart';
 import 'package:jni/jni.dart' as jni;
+
+/// from: `com.github.dart_lang.jnigen.simple_package.Color`
+class Color extends jni.JObject {
+  @override
+  late final jni.JObjType<Color> $type = type;
+
+  Color.fromReference(
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class =
+      jni.JClass.forName(r'com/github/dart_lang/jnigen/simple_package/Color');
+
+  /// The type which includes information such as the signature of this class.
+  static const type = $ColorType();
+  static final _id_values = _class.staticMethodId(
+    r'values',
+    r'()[Lcom/github/dart_lang/jnigen/simple_package/Color;',
+  );
+
+  static final _values = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallStaticObjectMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `static public com.github.dart_lang.jnigen.simple_package.Color[] values()`
+  /// The returned object must be released after use, by calling the [release] method.
+  static jni.JArray<Color> values() {
+    return _values(_class.reference.pointer, _id_values as jni.JMethodIDPtr)
+        .object(const jni.JArrayType($ColorType()));
+  }
+
+  static final _id_valueOf = _class.staticMethodId(
+    r'valueOf',
+    r'(Ljava/lang/String;)Lcom/github/dart_lang/jnigen/simple_package/Color;',
+  );
+
+  static final _valueOf = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          'globalEnv_CallStaticObjectMethod')
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
+  /// from: `static public com.github.dart_lang.jnigen.simple_package.Color valueOf(java.lang.String name)`
+  /// The returned object must be released after use, by calling the [release] method.
+  static Color valueOf(
+    jni.JString name,
+  ) {
+    return _valueOf(_class.reference.pointer, _id_valueOf as jni.JMethodIDPtr,
+            name.reference.pointer)
+        .object(const $ColorType());
+  }
+}
+
+final class $ColorType extends jni.JObjType<Color> {
+  const $ColorType();
+
+  @override
+  String get signature => r'Lcom/github/dart_lang/jnigen/simple_package/Color;';
+
+  @override
+  Color fromReference(jni.JReference reference) =>
+      Color.fromReference(reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => ($ColorType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($ColorType) && other is $ColorType;
+  }
+}
 
 /// from: `com.github.dart_lang.jnigen.simple_package.Example$Nested$NestedTwice`
 class Example_Nested_NestedTwice extends jni.JObject {
@@ -1524,6 +1616,760 @@ final class $ExampleType extends jni.JObjType<Example> {
   }
 }
 
+/// from: `com.github.dart_lang.jnigen.simple_package.Exceptions`
+class Exceptions extends jni.JObject {
+  @override
+  late final jni.JObjType<Exceptions> $type = type;
+
+  Exceptions.fromReference(
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/simple_package/Exceptions');
+
+  /// The type which includes information such as the signature of this class.
+  static const type = $ExceptionsType();
+  static final _id_new$ = _class.constructorId(
+    r'()V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public void <init>()`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory Exceptions() {
+    return Exceptions.fromReference(
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
+            .reference);
+  }
+
+  static final _id_new$1 = _class.constructorId(
+    r'(F)V',
+  );
+
+  static final _new$1 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<(ffi.Double,)>)>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, double)>();
+
+  /// from: `public void <init>(float x)`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory Exceptions.new$1(
+    double x,
+  ) {
+    return Exceptions.fromReference(
+        _new$1(_class.reference.pointer, _id_new$1 as jni.JMethodIDPtr, x)
+            .reference);
+  }
+
+  static final _id_new$2 = _class.constructorId(
+    r'(IIIIII)V',
+  );
+
+  static final _new$2 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32,
+                        $Int32
+                      )>)>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int,
+              int, int, int, int, int)>();
+
+  /// from: `public void <init>(int a, int b, int c, int d, int e, int f)`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory Exceptions.new$2(
+    int a,
+    int b,
+    int c,
+    int d,
+    int e,
+    int f,
+  ) {
+    return Exceptions.fromReference(_new$2(_class.reference.pointer,
+            _id_new$2 as jni.JMethodIDPtr, a, b, c, d, e, f)
+        .reference);
+  }
+
+  static final _id_staticObjectMethod = _class.staticMethodId(
+    r'staticObjectMethod',
+    r'()Ljava/lang/Object;',
+  );
+
+  static final _staticObjectMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallStaticObjectMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `static public java.lang.Object staticObjectMethod()`
+  /// The returned object must be released after use, by calling the [release] method.
+  static jni.JObject staticObjectMethod() {
+    return _staticObjectMethod(_class.reference.pointer,
+            _id_staticObjectMethod as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
+  }
+
+  static final _id_staticIntMethod = _class.staticMethodId(
+    r'staticIntMethod',
+    r'()I',
+  );
+
+  static final _staticIntMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallStaticIntMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `static public int staticIntMethod()`
+  static int staticIntMethod() {
+    return _staticIntMethod(
+            _class.reference.pointer, _id_staticIntMethod as jni.JMethodIDPtr)
+        .integer;
+  }
+
+  static final _id_staticObjectArrayMethod = _class.staticMethodId(
+    r'staticObjectArrayMethod',
+    r'()[Ljava/lang/Object;',
+  );
+
+  static final _staticObjectArrayMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallStaticObjectMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `static public java.lang.Object[] staticObjectArrayMethod()`
+  /// The returned object must be released after use, by calling the [release] method.
+  static jni.JArray<jni.JObject> staticObjectArrayMethod() {
+    return _staticObjectArrayMethod(_class.reference.pointer,
+            _id_staticObjectArrayMethod as jni.JMethodIDPtr)
+        .object(const jni.JArrayType(jni.JObjectType()));
+  }
+
+  static final _id_staticIntArrayMethod = _class.staticMethodId(
+    r'staticIntArrayMethod',
+    r'()[I',
+  );
+
+  static final _staticIntArrayMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallStaticObjectMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `static public int[] staticIntArrayMethod()`
+  /// The returned object must be released after use, by calling the [release] method.
+  static jni.JArray<jni.jint> staticIntArrayMethod() {
+    return _staticIntArrayMethod(_class.reference.pointer,
+            _id_staticIntArrayMethod as jni.JMethodIDPtr)
+        .object(const jni.JArrayType(jni.jintType()));
+  }
+
+  static final _id_objectMethod = _class.instanceMethodId(
+    r'objectMethod',
+    r'()Ljava/lang/Object;',
+  );
+
+  static final _objectMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallObjectMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public java.lang.Object objectMethod()`
+  /// The returned object must be released after use, by calling the [release] method.
+  jni.JObject objectMethod() {
+    return _objectMethod(
+            reference.pointer, _id_objectMethod as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
+  }
+
+  static final _id_intMethod = _class.instanceMethodId(
+    r'intMethod',
+    r'()I',
+  );
+
+  static final _intMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallIntMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public int intMethod()`
+  int intMethod() {
+    return _intMethod(reference.pointer, _id_intMethod as jni.JMethodIDPtr)
+        .integer;
+  }
+
+  static final _id_objectArrayMethod = _class.instanceMethodId(
+    r'objectArrayMethod',
+    r'()[Ljava/lang/Object;',
+  );
+
+  static final _objectArrayMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallObjectMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public java.lang.Object[] objectArrayMethod()`
+  /// The returned object must be released after use, by calling the [release] method.
+  jni.JArray<jni.JObject> objectArrayMethod() {
+    return _objectArrayMethod(
+            reference.pointer, _id_objectArrayMethod as jni.JMethodIDPtr)
+        .object(const jni.JArrayType(jni.JObjectType()));
+  }
+
+  static final _id_intArrayMethod = _class.instanceMethodId(
+    r'intArrayMethod',
+    r'()[I',
+  );
+
+  static final _intArrayMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallObjectMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public int[] intArrayMethod()`
+  /// The returned object must be released after use, by calling the [release] method.
+  jni.JArray<jni.jint> intArrayMethod() {
+    return _intArrayMethod(
+            reference.pointer, _id_intArrayMethod as jni.JMethodIDPtr)
+        .object(const jni.JArrayType(jni.jintType()));
+  }
+
+  static final _id_throwNullPointerException = _class.instanceMethodId(
+    r'throwNullPointerException',
+    r'()I',
+  );
+
+  static final _throwNullPointerException = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallIntMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public int throwNullPointerException()`
+  int throwNullPointerException() {
+    return _throwNullPointerException(reference.pointer,
+            _id_throwNullPointerException as jni.JMethodIDPtr)
+        .integer;
+  }
+
+  static final _id_throwFileNotFoundException = _class.instanceMethodId(
+    r'throwFileNotFoundException',
+    r'()Ljava/io/InputStream;',
+  );
+
+  static final _throwFileNotFoundException = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallObjectMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public java.io.InputStream throwFileNotFoundException()`
+  /// The returned object must be released after use, by calling the [release] method.
+  jni.JObject throwFileNotFoundException() {
+    return _throwFileNotFoundException(reference.pointer,
+            _id_throwFileNotFoundException as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
+  }
+
+  static final _id_throwClassCastException = _class.instanceMethodId(
+    r'throwClassCastException',
+    r'()Ljava/io/FileInputStream;',
+  );
+
+  static final _throwClassCastException = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallObjectMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public java.io.FileInputStream throwClassCastException()`
+  /// The returned object must be released after use, by calling the [release] method.
+  jni.JObject throwClassCastException() {
+    return _throwClassCastException(
+            reference.pointer, _id_throwClassCastException as jni.JMethodIDPtr)
+        .object(const jni.JObjectType());
+  }
+
+  static final _id_throwArrayIndexException = _class.instanceMethodId(
+    r'throwArrayIndexException',
+    r'()I',
+  );
+
+  static final _throwArrayIndexException = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallIntMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public int throwArrayIndexException()`
+  int throwArrayIndexException() {
+    return _throwArrayIndexException(
+            reference.pointer, _id_throwArrayIndexException as jni.JMethodIDPtr)
+        .integer;
+  }
+
+  static final _id_throwArithmeticException = _class.instanceMethodId(
+    r'throwArithmeticException',
+    r'()I',
+  );
+
+  static final _throwArithmeticException = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallIntMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public int throwArithmeticException()`
+  int throwArithmeticException() {
+    return _throwArithmeticException(
+            reference.pointer, _id_throwArithmeticException as jni.JMethodIDPtr)
+        .integer;
+  }
+
+  static final _id_throwLoremIpsum = _class.staticMethodId(
+    r'throwLoremIpsum',
+    r'()V',
+  );
+
+  static final _throwLoremIpsum = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallStaticVoidMethod')
+      .asFunction<
+          jni.JThrowablePtr Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `static public void throwLoremIpsum()`
+  static void throwLoremIpsum() {
+    _throwLoremIpsum(
+            _class.reference.pointer, _id_throwLoremIpsum as jni.JMethodIDPtr)
+        .check();
+  }
+}
+
+final class $ExceptionsType extends jni.JObjType<Exceptions> {
+  const $ExceptionsType();
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/simple_package/Exceptions;';
+
+  @override
+  Exceptions fromReference(jni.JReference reference) =>
+      Exceptions.fromReference(reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => ($ExceptionsType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($ExceptionsType) && other is $ExceptionsType;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.simple_package.Fields$Nested`
+class Fields_Nested extends jni.JObject {
+  @override
+  late final jni.JObjType<Fields_Nested> $type = type;
+
+  Fields_Nested.fromReference(
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/simple_package/Fields$Nested');
+
+  /// The type which includes information such as the signature of this class.
+  static const type = $Fields_NestedType();
+  static final _id_hundred = _class.instanceFieldId(
+    r'hundred',
+    r'J',
+  );
+
+  /// from: `public long hundred`
+  int get hundred => _id_hundred.get(this, const jni.jlongType());
+
+  /// from: `public long hundred`
+  set hundred(int value) => _id_hundred.set(this, const jni.jlongType(), value);
+
+  static final _id_BEST_GOD = _class.staticFieldId(
+    r'BEST_GOD',
+    r'Ljava/lang/String;',
+  );
+
+  /// from: `static public java.lang.String BEST_GOD`
+  /// The returned object must be released after use, by calling the [release] method.
+  static jni.JString get BEST_GOD =>
+      _id_BEST_GOD.get(_class, const jni.JStringType());
+
+  /// from: `static public java.lang.String BEST_GOD`
+  /// The returned object must be released after use, by calling the [release] method.
+  static set BEST_GOD(jni.JString value) =>
+      _id_BEST_GOD.set(_class, const jni.JStringType(), value);
+
+  static final _id_new$ = _class.constructorId(
+    r'()V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public void <init>()`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory Fields_Nested() {
+    return Fields_Nested.fromReference(
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
+            .reference);
+  }
+}
+
+final class $Fields_NestedType extends jni.JObjType<Fields_Nested> {
+  const $Fields_NestedType();
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/simple_package/Fields$Nested;';
+
+  @override
+  Fields_Nested fromReference(jni.JReference reference) =>
+      Fields_Nested.fromReference(reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => ($Fields_NestedType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($Fields_NestedType) &&
+        other is $Fields_NestedType;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.simple_package.Fields`
+class Fields extends jni.JObject {
+  @override
+  late final jni.JObjType<Fields> $type = type;
+
+  Fields.fromReference(
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class =
+      jni.JClass.forName(r'com/github/dart_lang/jnigen/simple_package/Fields');
+
+  /// The type which includes information such as the signature of this class.
+  static const type = $FieldsType();
+  static final _id_amount = _class.staticFieldId(
+    r'amount',
+    r'I',
+  );
+
+  /// from: `static public int amount`
+  static int get amount => _id_amount.get(_class, const jni.jintType());
+
+  /// from: `static public int amount`
+  static set amount(int value) =>
+      _id_amount.set(_class, const jni.jintType(), value);
+
+  static final _id_pi = _class.staticFieldId(
+    r'pi',
+    r'D',
+  );
+
+  /// from: `static public double pi`
+  static double get pi => _id_pi.get(_class, const jni.jdoubleType());
+
+  /// from: `static public double pi`
+  static set pi(double value) =>
+      _id_pi.set(_class, const jni.jdoubleType(), value);
+
+  static final _id_asterisk = _class.staticFieldId(
+    r'asterisk',
+    r'C',
+  );
+
+  /// from: `static public char asterisk`
+  static int get asterisk => _id_asterisk.get(_class, const jni.jcharType());
+
+  /// from: `static public char asterisk`
+  static set asterisk(int value) =>
+      _id_asterisk.set(_class, const jni.jcharType(), value);
+
+  static final _id_name = _class.staticFieldId(
+    r'name',
+    r'Ljava/lang/String;',
+  );
+
+  /// from: `static public java.lang.String name`
+  /// The returned object must be released after use, by calling the [release] method.
+  static jni.JString get name => _id_name.get(_class, const jni.JStringType());
+
+  /// from: `static public java.lang.String name`
+  /// The returned object must be released after use, by calling the [release] method.
+  static set name(jni.JString value) =>
+      _id_name.set(_class, const jni.JStringType(), value);
+
+  static final _id_i = _class.instanceFieldId(
+    r'i',
+    r'Ljava/lang/Integer;',
+  );
+
+  /// from: `public java.lang.Integer i`
+  /// The returned object must be released after use, by calling the [release] method.
+  jni.JInteger get i => _id_i.get(this, const jni.JIntegerType());
+
+  /// from: `public java.lang.Integer i`
+  /// The returned object must be released after use, by calling the [release] method.
+  set i(jni.JInteger value) => _id_i.set(this, const jni.JIntegerType(), value);
+
+  static final _id_trillion = _class.instanceFieldId(
+    r'trillion',
+    r'J',
+  );
+
+  /// from: `public long trillion`
+  int get trillion => _id_trillion.get(this, const jni.jlongType());
+
+  /// from: `public long trillion`
+  set trillion(int value) =>
+      _id_trillion.set(this, const jni.jlongType(), value);
+
+  static final _id_isAchillesDead = _class.instanceFieldId(
+    r'isAchillesDead',
+    r'Z',
+  );
+
+  /// from: `public boolean isAchillesDead`
+  bool get isAchillesDead =>
+      _id_isAchillesDead.get(this, const jni.jbooleanType());
+
+  /// from: `public boolean isAchillesDead`
+  set isAchillesDead(bool value) =>
+      _id_isAchillesDead.set(this, const jni.jbooleanType(), value);
+
+  static final _id_bestFighterInGreece = _class.instanceFieldId(
+    r'bestFighterInGreece',
+    r'Ljava/lang/String;',
+  );
+
+  /// from: `public java.lang.String bestFighterInGreece`
+  /// The returned object must be released after use, by calling the [release] method.
+  jni.JString get bestFighterInGreece =>
+      _id_bestFighterInGreece.get(this, const jni.JStringType());
+
+  /// from: `public java.lang.String bestFighterInGreece`
+  /// The returned object must be released after use, by calling the [release] method.
+  set bestFighterInGreece(jni.JString value) =>
+      _id_bestFighterInGreece.set(this, const jni.JStringType(), value);
+
+  static final _id_random = _class.instanceFieldId(
+    r'random',
+    r'Ljava/util/Random;',
+  );
+
+  /// from: `public java.util.Random random`
+  /// The returned object must be released after use, by calling the [release] method.
+  jni.JObject get random => _id_random.get(this, const jni.JObjectType());
+
+  /// from: `public java.util.Random random`
+  /// The returned object must be released after use, by calling the [release] method.
+  set random(jni.JObject value) =>
+      _id_random.set(this, const jni.JObjectType(), value);
+
+  static final _id_euroSymbol = _class.staticFieldId(
+    r'euroSymbol',
+    r'C',
+  );
+
+  /// from: `static public char euroSymbol`
+  static int get euroSymbol =>
+      _id_euroSymbol.get(_class, const jni.jcharType());
+
+  /// from: `static public char euroSymbol`
+  static set euroSymbol(int value) =>
+      _id_euroSymbol.set(_class, const jni.jcharType(), value);
+
+  static final _id_new$ = _class.constructorId(
+    r'()V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public void <init>()`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory Fields() {
+    return Fields.fromReference(
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
+            .reference);
+  }
+}
+
+final class $FieldsType extends jni.JObjType<Fields> {
+  const $FieldsType();
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/simple_package/Fields;';
+
+  @override
+  Fields fromReference(jni.JReference reference) =>
+      Fields.fromReference(reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => ($FieldsType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($FieldsType) && other is $FieldsType;
+  }
+}
+
 /// from: `com.github.dart_lang.jnigen.pkg2.C2`
 class C2 extends jni.JObject {
   @override
@@ -1684,6 +2530,102 @@ final class $Example$1Type extends jni.JObjType<Example$1> {
   @override
   bool operator ==(Object other) {
     return other.runtimeType == ($Example$1Type) && other is $Example$1Type;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.generics.GenericTypeParams`
+class GenericTypeParams<$S extends jni.JObject, $K extends jni.JObject>
+    extends jni.JObject {
+  @override
+  late final jni.JObjType<GenericTypeParams<$S, $K>> $type = type(S, K);
+
+  final jni.JObjType<$S> S;
+  final jni.JObjType<$K> K;
+
+  GenericTypeParams.fromReference(
+    this.S,
+    this.K,
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/generics/GenericTypeParams');
+
+  /// The type which includes information such as the signature of this class.
+  static $GenericTypeParamsType<$S, $K>
+      type<$S extends jni.JObject, $K extends jni.JObject>(
+    jni.JObjType<$S> S,
+    jni.JObjType<$K> K,
+  ) {
+    return $GenericTypeParamsType(
+      S,
+      K,
+    );
+  }
+
+  static final _id_new$ = _class.constructorId(
+    r'()V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public void <init>()`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory GenericTypeParams({
+    required jni.JObjType<$S> S,
+    required jni.JObjType<$K> K,
+  }) {
+    return GenericTypeParams.fromReference(
+        S,
+        K,
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
+            .reference);
+  }
+}
+
+final class $GenericTypeParamsType<$S extends jni.JObject,
+    $K extends jni.JObject> extends jni.JObjType<GenericTypeParams<$S, $K>> {
+  final jni.JObjType<$S> S;
+  final jni.JObjType<$K> K;
+
+  const $GenericTypeParamsType(
+    this.S,
+    this.K,
+  );
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/generics/GenericTypeParams;';
+
+  @override
+  GenericTypeParams<$S, $K> fromReference(jni.JReference reference) =>
+      GenericTypeParams.fromReference(S, K, reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => Object.hash($GenericTypeParamsType, S, K);
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($GenericTypeParamsType<$S, $K>) &&
+        other is $GenericTypeParamsType<$S, $K> &&
+        S == other.S &&
+        K == other.K;
   }
 }
 
@@ -3183,6 +4125,70 @@ final class $StringKeyedMapType<$V extends jni.JObject>
   }
 }
 
+/// from: `com.github.dart_lang.jnigen.generics.StringMap`
+class StringMap extends StringKeyedMap<jni.JString> {
+  @override
+  late final jni.JObjType<StringMap> $type = type;
+
+  StringMap.fromReference(
+    jni.JReference reference,
+  ) : super.fromReference(const jni.JStringType(), reference);
+
+  static final _class =
+      jni.JClass.forName(r'com/github/dart_lang/jnigen/generics/StringMap');
+
+  /// The type which includes information such as the signature of this class.
+  static const type = $StringMapType();
+  static final _id_new$ = _class.constructorId(
+    r'()V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public void <init>()`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory StringMap() {
+    return StringMap.fromReference(
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
+            .reference);
+  }
+}
+
+final class $StringMapType extends jni.JObjType<StringMap> {
+  const $StringMapType();
+
+  @override
+  String get signature => r'Lcom/github/dart_lang/jnigen/generics/StringMap;';
+
+  @override
+  StringMap fromReference(jni.JReference reference) =>
+      StringMap.fromReference(reference);
+
+  @override
+  jni.JObjType get superType => const $StringKeyedMapType(jni.JStringType());
+
+  @override
+  final superCount = 3;
+
+  @override
+  int get hashCode => ($StringMapType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($StringMapType) && other is $StringMapType;
+  }
+}
+
 /// from: `com.github.dart_lang.jnigen.generics.StringStack`
 class StringStack extends MyStack<jni.JString> {
   @override
@@ -4482,6 +5488,283 @@ final class $StringConverterConsumerType
   }
 }
 
+/// from: `com.github.dart_lang.jnigen.interfaces.WithDefault`
+class WithDefault extends jni.JObject {
+  @override
+  late final jni.JObjType<WithDefault> $type = type;
+
+  WithDefault.fromReference(
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class =
+      jni.JClass.forName(r'com/github/dart_lang/jnigen/interfaces/WithDefault');
+
+  /// The type which includes information such as the signature of this class.
+  static const type = $WithDefaultType();
+  static final _id_normalMethod = _class.instanceMethodId(
+    r'normalMethod',
+    r'()I',
+  );
+
+  static final _normalMethod = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallIntMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public abstract int normalMethod()`
+  int normalMethod() {
+    return _normalMethod(
+            reference.pointer, _id_normalMethod as jni.JMethodIDPtr)
+        .integer;
+  }
+
+  static final _id_default42 = _class.instanceMethodId(
+    r'default42',
+    r'()I',
+  );
+
+  static final _default42 = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallIntMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public int default42()`
+  int default42() {
+    return _default42(reference.pointer, _id_default42 as jni.JMethodIDPtr)
+        .integer;
+  }
+
+  static final _id_greet = _class.instanceMethodId(
+    r'greet',
+    r'(Ljava/lang/String;)Ljava/lang/String;',
+  );
+
+  static final _greet = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          'globalEnv_CallObjectMethod')
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
+  /// from: `public abstract java.lang.String greet(java.lang.String string)`
+  /// The returned object must be released after use, by calling the [release] method.
+  jni.JString greet(
+    jni.JString string,
+  ) {
+    return _greet(reference.pointer, _id_greet as jni.JMethodIDPtr,
+            string.reference.pointer)
+        .object(const jni.JStringType());
+  }
+
+  static final _id_defaultGreet = _class.instanceMethodId(
+    r'defaultGreet',
+    r'(Ljava/lang/String;)Ljava/lang/String;',
+  );
+
+  static final _defaultGreet = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          'globalEnv_CallObjectMethod')
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
+  /// from: `public java.lang.String defaultGreet(java.lang.String string)`
+  /// The returned object must be released after use, by calling the [release] method.
+  jni.JString defaultGreet(
+    jni.JString string,
+  ) {
+    return _defaultGreet(reference.pointer,
+            _id_defaultGreet as jni.JMethodIDPtr, string.reference.pointer)
+        .object(const jni.JStringType());
+  }
+
+  /// Maps a specific port to the implemented interface.
+  static final Map<int, $WithDefaultImpl> _$impls = {};
+  ReceivePort? _$p;
+
+  static jni.JObjectPtr _$invoke(
+    int port,
+    jni.JObjectPtr descriptor,
+    jni.JObjectPtr args,
+  ) {
+    return _$invokeMethod(
+      port,
+      $MethodInvocation.fromAddresses(
+        0,
+        descriptor.address,
+        args.address,
+      ),
+    );
+  }
+
+  static final ffi.Pointer<
+          ffi.NativeFunction<
+              jni.JObjectPtr Function(
+                  ffi.Uint64, jni.JObjectPtr, jni.JObjectPtr)>>
+      _$invokePointer = ffi.Pointer.fromFunction(_$invoke);
+
+  static ffi.Pointer<ffi.Void> _$invokeMethod(
+    int $p,
+    $MethodInvocation $i,
+  ) {
+    try {
+      final $d = $i.methodDescriptor.toDartString(releaseOriginal: true);
+      final $a = $i.args;
+      if ($d == r'normalMethod()I') {
+        final $r = _$impls[$p]!.normalMethod();
+        return jni.JInteger($r).reference.toPointer();
+      }
+      if ($d == r'default42()I') {
+        final $r = _$impls[$p]!.default42();
+        return jni.JInteger($r).reference.toPointer();
+      }
+      if ($d == r'greet(Ljava/lang/String;)Ljava/lang/String;') {
+        final $r = _$impls[$p]!.greet(
+          $a[0].castTo(const jni.JStringType(), releaseOriginal: true),
+        );
+        return ($r as jni.JObject)
+            .castTo(const jni.JObjectType())
+            .reference
+            .toPointer();
+      }
+      if ($d == r'defaultGreet(Ljava/lang/String;)Ljava/lang/String;') {
+        final $r = _$impls[$p]!.defaultGreet(
+          $a[0].castTo(const jni.JStringType(), releaseOriginal: true),
+        );
+        return ($r as jni.JObject)
+            .castTo(const jni.JObjectType())
+            .reference
+            .toPointer();
+      }
+    } catch (e) {
+      return ProtectedJniExtensions.newDartException(e);
+    }
+    return jni.nullptr;
+  }
+
+  factory WithDefault.implement(
+    $WithDefaultImpl $impl,
+  ) {
+    final $p = ReceivePort();
+    final $x = WithDefault.fromReference(
+      ProtectedJniExtensions.newPortProxy(
+        r'com.github.dart_lang.jnigen.interfaces.WithDefault',
+        $p,
+        _$invokePointer,
+      ),
+    ).._$p = $p;
+    final $a = $p.sendPort.nativePort;
+    _$impls[$a] = $impl;
+    $p.listen(($m) {
+      if ($m == null) {
+        _$impls.remove($p.sendPort.nativePort);
+        $p.close();
+        return;
+      }
+      final $i = $MethodInvocation.fromMessage($m as List<dynamic>);
+      final $r = _$invokeMethod($p.sendPort.nativePort, $i);
+      ProtectedJniExtensions.returnResult($i.result, $r);
+    });
+    return $x;
+  }
+}
+
+abstract interface class $WithDefaultImpl {
+  factory $WithDefaultImpl({
+    required int Function() normalMethod,
+    required int Function() default42,
+    required jni.JString Function(jni.JString string) greet,
+    required jni.JString Function(jni.JString string) defaultGreet,
+  }) = _$WithDefaultImpl;
+
+  int normalMethod();
+  int default42();
+  jni.JString greet(jni.JString string);
+  jni.JString defaultGreet(jni.JString string);
+}
+
+class _$WithDefaultImpl implements $WithDefaultImpl {
+  _$WithDefaultImpl({
+    required int Function() normalMethod,
+    required int Function() default42,
+    required jni.JString Function(jni.JString string) greet,
+    required jni.JString Function(jni.JString string) defaultGreet,
+  })  : _normalMethod = normalMethod,
+        _default42 = default42,
+        _greet = greet,
+        _defaultGreet = defaultGreet;
+
+  final int Function() _normalMethod;
+  final int Function() _default42;
+  final jni.JString Function(jni.JString string) _greet;
+  final jni.JString Function(jni.JString string) _defaultGreet;
+
+  int normalMethod() {
+    return _normalMethod();
+  }
+
+  int default42() {
+    return _default42();
+  }
+
+  jni.JString greet(jni.JString string) {
+    return _greet(string);
+  }
+
+  jni.JString defaultGreet(jni.JString string) {
+    return _defaultGreet(string);
+  }
+}
+
+final class $WithDefaultType extends jni.JObjType<WithDefault> {
+  const $WithDefaultType();
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/interfaces/WithDefault;';
+
+  @override
+  WithDefault fromReference(jni.JReference reference) =>
+      WithDefault.fromReference(reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => ($WithDefaultType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($WithDefaultType) && other is $WithDefaultType;
+  }
+}
+
 /// from: `com.github.dart_lang.jnigen.annotations.JsonSerializable$Case`
 class JsonSerializable_Case extends jni.JObject {
   @override
@@ -4795,1009 +6078,5 @@ final class $MyDataClassType extends jni.JObjType<MyDataClass> {
   @override
   bool operator ==(Object other) {
     return other.runtimeType == ($MyDataClassType) && other is $MyDataClassType;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.simple_package.Color`
-class Color extends jni.JObject {
-  @override
-  late final jni.JObjType<Color> $type = type;
-
-  Color.fromReference(
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class =
-      jni.JClass.forName(r'com/github/dart_lang/jnigen/simple_package/Color');
-
-  /// The type which includes information such as the signature of this class.
-  static const type = $ColorType();
-  static final _id_values = _class.staticMethodId(
-    r'values',
-    r'()[Lcom/github/dart_lang/jnigen/simple_package/Color;',
-  );
-
-  static final _values = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallStaticObjectMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `static public com.github.dart_lang.jnigen.simple_package.Color[] values()`
-  /// The returned object must be released after use, by calling the [release] method.
-  static jni.JArray<Color> values() {
-    return _values(_class.reference.pointer, _id_values as jni.JMethodIDPtr)
-        .object(const jni.JArrayType($ColorType()));
-  }
-
-  static final _id_valueOf = _class.staticMethodId(
-    r'valueOf',
-    r'(Ljava/lang/String;)Lcom/github/dart_lang/jnigen/simple_package/Color;',
-  );
-
-  static final _valueOf = ProtectedJniExtensions.lookup<
-              ffi.NativeFunction<
-                  jni.JniResult Function(
-                      ffi.Pointer<ffi.Void>,
-                      jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
-          'globalEnv_CallStaticObjectMethod')
-      .asFunction<
-          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>();
-
-  /// from: `static public com.github.dart_lang.jnigen.simple_package.Color valueOf(java.lang.String name)`
-  /// The returned object must be released after use, by calling the [release] method.
-  static Color valueOf(
-    jni.JString name,
-  ) {
-    return _valueOf(_class.reference.pointer, _id_valueOf as jni.JMethodIDPtr,
-            name.reference.pointer)
-        .object(const $ColorType());
-  }
-}
-
-final class $ColorType extends jni.JObjType<Color> {
-  const $ColorType();
-
-  @override
-  String get signature => r'Lcom/github/dart_lang/jnigen/simple_package/Color;';
-
-  @override
-  Color fromReference(jni.JReference reference) =>
-      Color.fromReference(reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => ($ColorType).hashCode;
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($ColorType) && other is $ColorType;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.simple_package.Exceptions`
-class Exceptions extends jni.JObject {
-  @override
-  late final jni.JObjType<Exceptions> $type = type;
-
-  Exceptions.fromReference(
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/simple_package/Exceptions');
-
-  /// The type which includes information such as the signature of this class.
-  static const type = $ExceptionsType();
-  static final _id_new$ = _class.constructorId(
-    r'()V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public void <init>()`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory Exceptions() {
-    return Exceptions.fromReference(
-        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
-            .reference);
-  }
-
-  static final _id_new$1 = _class.constructorId(
-    r'(F)V',
-  );
-
-  static final _new$1 = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<(ffi.Double,)>)>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(
-              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, double)>();
-
-  /// from: `public void <init>(float x)`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory Exceptions.new$1(
-    double x,
-  ) {
-    return Exceptions.fromReference(
-        _new$1(_class.reference.pointer, _id_new$1 as jni.JMethodIDPtr, x)
-            .reference);
-  }
-
-  static final _id_new$2 = _class.constructorId(
-    r'(IIIIII)V',
-  );
-
-  static final _new$2 = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                  ffi.Pointer<ffi.Void>,
-                  jni.JMethodIDPtr,
-                  ffi.VarArgs<
-                      (
-                        $Int32,
-                        $Int32,
-                        $Int32,
-                        $Int32,
-                        $Int32,
-                        $Int32
-                      )>)>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int,
-              int, int, int, int, int)>();
-
-  /// from: `public void <init>(int a, int b, int c, int d, int e, int f)`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory Exceptions.new$2(
-    int a,
-    int b,
-    int c,
-    int d,
-    int e,
-    int f,
-  ) {
-    return Exceptions.fromReference(_new$2(_class.reference.pointer,
-            _id_new$2 as jni.JMethodIDPtr, a, b, c, d, e, f)
-        .reference);
-  }
-
-  static final _id_staticObjectMethod = _class.staticMethodId(
-    r'staticObjectMethod',
-    r'()Ljava/lang/Object;',
-  );
-
-  static final _staticObjectMethod = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallStaticObjectMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `static public java.lang.Object staticObjectMethod()`
-  /// The returned object must be released after use, by calling the [release] method.
-  static jni.JObject staticObjectMethod() {
-    return _staticObjectMethod(_class.reference.pointer,
-            _id_staticObjectMethod as jni.JMethodIDPtr)
-        .object(const jni.JObjectType());
-  }
-
-  static final _id_staticIntMethod = _class.staticMethodId(
-    r'staticIntMethod',
-    r'()I',
-  );
-
-  static final _staticIntMethod = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallStaticIntMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `static public int staticIntMethod()`
-  static int staticIntMethod() {
-    return _staticIntMethod(
-            _class.reference.pointer, _id_staticIntMethod as jni.JMethodIDPtr)
-        .integer;
-  }
-
-  static final _id_staticObjectArrayMethod = _class.staticMethodId(
-    r'staticObjectArrayMethod',
-    r'()[Ljava/lang/Object;',
-  );
-
-  static final _staticObjectArrayMethod = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallStaticObjectMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `static public java.lang.Object[] staticObjectArrayMethod()`
-  /// The returned object must be released after use, by calling the [release] method.
-  static jni.JArray<jni.JObject> staticObjectArrayMethod() {
-    return _staticObjectArrayMethod(_class.reference.pointer,
-            _id_staticObjectArrayMethod as jni.JMethodIDPtr)
-        .object(const jni.JArrayType(jni.JObjectType()));
-  }
-
-  static final _id_staticIntArrayMethod = _class.staticMethodId(
-    r'staticIntArrayMethod',
-    r'()[I',
-  );
-
-  static final _staticIntArrayMethod = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallStaticObjectMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `static public int[] staticIntArrayMethod()`
-  /// The returned object must be released after use, by calling the [release] method.
-  static jni.JArray<jni.jint> staticIntArrayMethod() {
-    return _staticIntArrayMethod(_class.reference.pointer,
-            _id_staticIntArrayMethod as jni.JMethodIDPtr)
-        .object(const jni.JArrayType(jni.jintType()));
-  }
-
-  static final _id_objectMethod = _class.instanceMethodId(
-    r'objectMethod',
-    r'()Ljava/lang/Object;',
-  );
-
-  static final _objectMethod = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallObjectMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public java.lang.Object objectMethod()`
-  /// The returned object must be released after use, by calling the [release] method.
-  jni.JObject objectMethod() {
-    return _objectMethod(
-            reference.pointer, _id_objectMethod as jni.JMethodIDPtr)
-        .object(const jni.JObjectType());
-  }
-
-  static final _id_intMethod = _class.instanceMethodId(
-    r'intMethod',
-    r'()I',
-  );
-
-  static final _intMethod = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallIntMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public int intMethod()`
-  int intMethod() {
-    return _intMethod(reference.pointer, _id_intMethod as jni.JMethodIDPtr)
-        .integer;
-  }
-
-  static final _id_objectArrayMethod = _class.instanceMethodId(
-    r'objectArrayMethod',
-    r'()[Ljava/lang/Object;',
-  );
-
-  static final _objectArrayMethod = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallObjectMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public java.lang.Object[] objectArrayMethod()`
-  /// The returned object must be released after use, by calling the [release] method.
-  jni.JArray<jni.JObject> objectArrayMethod() {
-    return _objectArrayMethod(
-            reference.pointer, _id_objectArrayMethod as jni.JMethodIDPtr)
-        .object(const jni.JArrayType(jni.JObjectType()));
-  }
-
-  static final _id_intArrayMethod = _class.instanceMethodId(
-    r'intArrayMethod',
-    r'()[I',
-  );
-
-  static final _intArrayMethod = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallObjectMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public int[] intArrayMethod()`
-  /// The returned object must be released after use, by calling the [release] method.
-  jni.JArray<jni.jint> intArrayMethod() {
-    return _intArrayMethod(
-            reference.pointer, _id_intArrayMethod as jni.JMethodIDPtr)
-        .object(const jni.JArrayType(jni.jintType()));
-  }
-
-  static final _id_throwNullPointerException = _class.instanceMethodId(
-    r'throwNullPointerException',
-    r'()I',
-  );
-
-  static final _throwNullPointerException = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallIntMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public int throwNullPointerException()`
-  int throwNullPointerException() {
-    return _throwNullPointerException(reference.pointer,
-            _id_throwNullPointerException as jni.JMethodIDPtr)
-        .integer;
-  }
-
-  static final _id_throwFileNotFoundException = _class.instanceMethodId(
-    r'throwFileNotFoundException',
-    r'()Ljava/io/InputStream;',
-  );
-
-  static final _throwFileNotFoundException = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallObjectMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public java.io.InputStream throwFileNotFoundException()`
-  /// The returned object must be released after use, by calling the [release] method.
-  jni.JObject throwFileNotFoundException() {
-    return _throwFileNotFoundException(reference.pointer,
-            _id_throwFileNotFoundException as jni.JMethodIDPtr)
-        .object(const jni.JObjectType());
-  }
-
-  static final _id_throwClassCastException = _class.instanceMethodId(
-    r'throwClassCastException',
-    r'()Ljava/io/FileInputStream;',
-  );
-
-  static final _throwClassCastException = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallObjectMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public java.io.FileInputStream throwClassCastException()`
-  /// The returned object must be released after use, by calling the [release] method.
-  jni.JObject throwClassCastException() {
-    return _throwClassCastException(
-            reference.pointer, _id_throwClassCastException as jni.JMethodIDPtr)
-        .object(const jni.JObjectType());
-  }
-
-  static final _id_throwArrayIndexException = _class.instanceMethodId(
-    r'throwArrayIndexException',
-    r'()I',
-  );
-
-  static final _throwArrayIndexException = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallIntMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public int throwArrayIndexException()`
-  int throwArrayIndexException() {
-    return _throwArrayIndexException(
-            reference.pointer, _id_throwArrayIndexException as jni.JMethodIDPtr)
-        .integer;
-  }
-
-  static final _id_throwArithmeticException = _class.instanceMethodId(
-    r'throwArithmeticException',
-    r'()I',
-  );
-
-  static final _throwArithmeticException = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallIntMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public int throwArithmeticException()`
-  int throwArithmeticException() {
-    return _throwArithmeticException(
-            reference.pointer, _id_throwArithmeticException as jni.JMethodIDPtr)
-        .integer;
-  }
-
-  static final _id_throwLoremIpsum = _class.staticMethodId(
-    r'throwLoremIpsum',
-    r'()V',
-  );
-
-  static final _throwLoremIpsum = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JThrowablePtr Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallStaticVoidMethod')
-      .asFunction<
-          jni.JThrowablePtr Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `static public void throwLoremIpsum()`
-  static void throwLoremIpsum() {
-    _throwLoremIpsum(
-            _class.reference.pointer, _id_throwLoremIpsum as jni.JMethodIDPtr)
-        .check();
-  }
-}
-
-final class $ExceptionsType extends jni.JObjType<Exceptions> {
-  const $ExceptionsType();
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/simple_package/Exceptions;';
-
-  @override
-  Exceptions fromReference(jni.JReference reference) =>
-      Exceptions.fromReference(reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => ($ExceptionsType).hashCode;
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($ExceptionsType) && other is $ExceptionsType;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.simple_package.Fields`
-class Fields extends jni.JObject {
-  @override
-  late final jni.JObjType<Fields> $type = type;
-
-  Fields.fromReference(
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class =
-      jni.JClass.forName(r'com/github/dart_lang/jnigen/simple_package/Fields');
-
-  /// The type which includes information such as the signature of this class.
-  static const type = $FieldsType();
-  static final _id_amount = _class.staticFieldId(
-    r'amount',
-    r'I',
-  );
-
-  /// from: `static public int amount`
-  static int get amount => _id_amount.get(_class, const jni.jintType());
-
-  /// from: `static public int amount`
-  static set amount(int value) =>
-      _id_amount.set(_class, const jni.jintType(), value);
-
-  static final _id_pi = _class.staticFieldId(
-    r'pi',
-    r'D',
-  );
-
-  /// from: `static public double pi`
-  static double get pi => _id_pi.get(_class, const jni.jdoubleType());
-
-  /// from: `static public double pi`
-  static set pi(double value) =>
-      _id_pi.set(_class, const jni.jdoubleType(), value);
-
-  static final _id_asterisk = _class.staticFieldId(
-    r'asterisk',
-    r'C',
-  );
-
-  /// from: `static public char asterisk`
-  static int get asterisk => _id_asterisk.get(_class, const jni.jcharType());
-
-  /// from: `static public char asterisk`
-  static set asterisk(int value) =>
-      _id_asterisk.set(_class, const jni.jcharType(), value);
-
-  static final _id_name = _class.staticFieldId(
-    r'name',
-    r'Ljava/lang/String;',
-  );
-
-  /// from: `static public java.lang.String name`
-  /// The returned object must be released after use, by calling the [release] method.
-  static jni.JString get name => _id_name.get(_class, const jni.JStringType());
-
-  /// from: `static public java.lang.String name`
-  /// The returned object must be released after use, by calling the [release] method.
-  static set name(jni.JString value) =>
-      _id_name.set(_class, const jni.JStringType(), value);
-
-  static final _id_i = _class.instanceFieldId(
-    r'i',
-    r'Ljava/lang/Integer;',
-  );
-
-  /// from: `public java.lang.Integer i`
-  /// The returned object must be released after use, by calling the [release] method.
-  jni.JInteger get i => _id_i.get(this, const jni.JIntegerType());
-
-  /// from: `public java.lang.Integer i`
-  /// The returned object must be released after use, by calling the [release] method.
-  set i(jni.JInteger value) => _id_i.set(this, const jni.JIntegerType(), value);
-
-  static final _id_trillion = _class.instanceFieldId(
-    r'trillion',
-    r'J',
-  );
-
-  /// from: `public long trillion`
-  int get trillion => _id_trillion.get(this, const jni.jlongType());
-
-  /// from: `public long trillion`
-  set trillion(int value) =>
-      _id_trillion.set(this, const jni.jlongType(), value);
-
-  static final _id_isAchillesDead = _class.instanceFieldId(
-    r'isAchillesDead',
-    r'Z',
-  );
-
-  /// from: `public boolean isAchillesDead`
-  bool get isAchillesDead =>
-      _id_isAchillesDead.get(this, const jni.jbooleanType());
-
-  /// from: `public boolean isAchillesDead`
-  set isAchillesDead(bool value) =>
-      _id_isAchillesDead.set(this, const jni.jbooleanType(), value);
-
-  static final _id_bestFighterInGreece = _class.instanceFieldId(
-    r'bestFighterInGreece',
-    r'Ljava/lang/String;',
-  );
-
-  /// from: `public java.lang.String bestFighterInGreece`
-  /// The returned object must be released after use, by calling the [release] method.
-  jni.JString get bestFighterInGreece =>
-      _id_bestFighterInGreece.get(this, const jni.JStringType());
-
-  /// from: `public java.lang.String bestFighterInGreece`
-  /// The returned object must be released after use, by calling the [release] method.
-  set bestFighterInGreece(jni.JString value) =>
-      _id_bestFighterInGreece.set(this, const jni.JStringType(), value);
-
-  static final _id_random = _class.instanceFieldId(
-    r'random',
-    r'Ljava/util/Random;',
-  );
-
-  /// from: `public java.util.Random random`
-  /// The returned object must be released after use, by calling the [release] method.
-  jni.JObject get random => _id_random.get(this, const jni.JObjectType());
-
-  /// from: `public java.util.Random random`
-  /// The returned object must be released after use, by calling the [release] method.
-  set random(jni.JObject value) =>
-      _id_random.set(this, const jni.JObjectType(), value);
-
-  static final _id_euroSymbol = _class.staticFieldId(
-    r'euroSymbol',
-    r'C',
-  );
-
-  /// from: `static public char euroSymbol`
-  static int get euroSymbol =>
-      _id_euroSymbol.get(_class, const jni.jcharType());
-
-  /// from: `static public char euroSymbol`
-  static set euroSymbol(int value) =>
-      _id_euroSymbol.set(_class, const jni.jcharType(), value);
-
-  static final _id_new$ = _class.constructorId(
-    r'()V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public void <init>()`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory Fields() {
-    return Fields.fromReference(
-        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
-            .reference);
-  }
-}
-
-final class $FieldsType extends jni.JObjType<Fields> {
-  const $FieldsType();
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/simple_package/Fields;';
-
-  @override
-  Fields fromReference(jni.JReference reference) =>
-      Fields.fromReference(reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => ($FieldsType).hashCode;
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($FieldsType) && other is $FieldsType;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.simple_package.Fields$Nested`
-class Fields_Nested extends jni.JObject {
-  @override
-  late final jni.JObjType<Fields_Nested> $type = type;
-
-  Fields_Nested.fromReference(
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/simple_package/Fields$Nested');
-
-  /// The type which includes information such as the signature of this class.
-  static const type = $Fields_NestedType();
-  static final _id_hundred = _class.instanceFieldId(
-    r'hundred',
-    r'J',
-  );
-
-  /// from: `public long hundred`
-  int get hundred => _id_hundred.get(this, const jni.jlongType());
-
-  /// from: `public long hundred`
-  set hundred(int value) => _id_hundred.set(this, const jni.jlongType(), value);
-
-  static final _id_BEST_GOD = _class.staticFieldId(
-    r'BEST_GOD',
-    r'Ljava/lang/String;',
-  );
-
-  /// from: `static public java.lang.String BEST_GOD`
-  /// The returned object must be released after use, by calling the [release] method.
-  static jni.JString get BEST_GOD =>
-      _id_BEST_GOD.get(_class, const jni.JStringType());
-
-  /// from: `static public java.lang.String BEST_GOD`
-  /// The returned object must be released after use, by calling the [release] method.
-  static set BEST_GOD(jni.JString value) =>
-      _id_BEST_GOD.set(_class, const jni.JStringType(), value);
-
-  static final _id_new$ = _class.constructorId(
-    r'()V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public void <init>()`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory Fields_Nested() {
-    return Fields_Nested.fromReference(
-        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
-            .reference);
-  }
-}
-
-final class $Fields_NestedType extends jni.JObjType<Fields_Nested> {
-  const $Fields_NestedType();
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/simple_package/Fields$Nested;';
-
-  @override
-  Fields_Nested fromReference(jni.JReference reference) =>
-      Fields_Nested.fromReference(reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => ($Fields_NestedType).hashCode;
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($Fields_NestedType) &&
-        other is $Fields_NestedType;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.generics.GenericTypeParams`
-class GenericTypeParams<$S extends jni.JObject, $K extends jni.JObject>
-    extends jni.JObject {
-  @override
-  late final jni.JObjType<GenericTypeParams<$S, $K>> $type = type(S, K);
-
-  final jni.JObjType<$S> S;
-  final jni.JObjType<$K> K;
-
-  GenericTypeParams.fromReference(
-    this.S,
-    this.K,
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/generics/GenericTypeParams');
-
-  /// The type which includes information such as the signature of this class.
-  static $GenericTypeParamsType<$S, $K>
-      type<$S extends jni.JObject, $K extends jni.JObject>(
-    jni.JObjType<$S> S,
-    jni.JObjType<$K> K,
-  ) {
-    return $GenericTypeParamsType(
-      S,
-      K,
-    );
-  }
-
-  static final _id_new$ = _class.constructorId(
-    r'()V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public void <init>()`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory GenericTypeParams({
-    required jni.JObjType<$S> S,
-    required jni.JObjType<$K> K,
-  }) {
-    return GenericTypeParams.fromReference(
-        S,
-        K,
-        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
-            .reference);
-  }
-}
-
-final class $GenericTypeParamsType<$S extends jni.JObject,
-    $K extends jni.JObject> extends jni.JObjType<GenericTypeParams<$S, $K>> {
-  final jni.JObjType<$S> S;
-  final jni.JObjType<$K> K;
-
-  const $GenericTypeParamsType(
-    this.S,
-    this.K,
-  );
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/generics/GenericTypeParams;';
-
-  @override
-  GenericTypeParams<$S, $K> fromReference(jni.JReference reference) =>
-      GenericTypeParams.fromReference(S, K, reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => Object.hash($GenericTypeParamsType, S, K);
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($GenericTypeParamsType<$S, $K>) &&
-        other is $GenericTypeParamsType<$S, $K> &&
-        S == other.S &&
-        K == other.K;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.generics.StringMap`
-class StringMap extends StringKeyedMap<jni.JString> {
-  @override
-  late final jni.JObjType<StringMap> $type = type;
-
-  StringMap.fromReference(
-    jni.JReference reference,
-  ) : super.fromReference(const jni.JStringType(), reference);
-
-  static final _class =
-      jni.JClass.forName(r'com/github/dart_lang/jnigen/generics/StringMap');
-
-  /// The type which includes information such as the signature of this class.
-  static const type = $StringMapType();
-  static final _id_new$ = _class.constructorId(
-    r'()V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public void <init>()`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory StringMap() {
-    return StringMap.fromReference(
-        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
-            .reference);
-  }
-}
-
-final class $StringMapType extends jni.JObjType<StringMap> {
-  const $StringMapType();
-
-  @override
-  String get signature => r'Lcom/github/dart_lang/jnigen/generics/StringMap;';
-
-  @override
-  StringMap fromReference(jni.JReference reference) =>
-      StringMap.fromReference(reference);
-
-  @override
-  jni.JObjType get superType => const $StringKeyedMapType(jni.JStringType());
-
-  @override
-  final superCount = 3;
-
-  @override
-  int get hashCode => ($StringMapType).hashCode;
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($StringMapType) && other is $StringMapType;
   }
 }

--- a/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
@@ -124,299 +124,6 @@ final class $ColorType extends jni.JObjType<Color> {
   }
 }
 
-/// from: `com.github.dart_lang.jnigen.simple_package.Example$Nested$NestedTwice`
-class Example_Nested_NestedTwice extends jni.JObject {
-  @override
-  late final jni.JObjType<Example_Nested_NestedTwice> $type = type;
-
-  Example_Nested_NestedTwice.fromReference(
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/simple_package/Example$Nested$NestedTwice');
-
-  /// The type which includes information such as the signature of this class.
-  static const type = $Example_Nested_NestedTwiceType();
-  static final _id_ZERO = _class.staticFieldId(
-    r'ZERO',
-    r'I',
-  );
-
-  /// from: `static public int ZERO`
-  static int get ZERO => _id_ZERO.get(_class, const jni.jintType());
-
-  /// from: `static public int ZERO`
-  static set ZERO(int value) =>
-      _id_ZERO.set(_class, const jni.jintType(), value);
-
-  static final _id_new$ = _class.constructorId(
-    r'()V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public void <init>()`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory Example_Nested_NestedTwice() {
-    return Example_Nested_NestedTwice.fromReference(
-        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
-            .reference);
-  }
-}
-
-final class $Example_Nested_NestedTwiceType
-    extends jni.JObjType<Example_Nested_NestedTwice> {
-  const $Example_Nested_NestedTwiceType();
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/simple_package/Example$Nested$NestedTwice;';
-
-  @override
-  Example_Nested_NestedTwice fromReference(jni.JReference reference) =>
-      Example_Nested_NestedTwice.fromReference(reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => ($Example_Nested_NestedTwiceType).hashCode;
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($Example_Nested_NestedTwiceType) &&
-        other is $Example_Nested_NestedTwiceType;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.simple_package.Example$Nested`
-class Example_Nested extends jni.JObject {
-  @override
-  late final jni.JObjType<Example_Nested> $type = type;
-
-  Example_Nested.fromReference(
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/simple_package/Example$Nested');
-
-  /// The type which includes information such as the signature of this class.
-  static const type = $Example_NestedType();
-  static final _id_new$ = _class.constructorId(
-    r'(Z)V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<($Int32,)>)>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(
-              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
-
-  /// from: `public void <init>(boolean value)`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory Example_Nested(
-    bool value,
-  ) {
-    return Example_Nested.fromReference(_new$(_class.reference.pointer,
-            _id_new$ as jni.JMethodIDPtr, value ? 1 : 0)
-        .reference);
-  }
-
-  static final _id_usesAnonymousInnerClass = _class.instanceMethodId(
-    r'usesAnonymousInnerClass',
-    r'()V',
-  );
-
-  static final _usesAnonymousInnerClass = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JThrowablePtr Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallVoidMethod')
-      .asFunction<
-          jni.JThrowablePtr Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public void usesAnonymousInnerClass()`
-  void usesAnonymousInnerClass() {
-    _usesAnonymousInnerClass(
-            reference.pointer, _id_usesAnonymousInnerClass as jni.JMethodIDPtr)
-        .check();
-  }
-
-  static final _id_getValue = _class.instanceMethodId(
-    r'getValue',
-    r'()Z',
-  );
-
-  static final _getValue = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallBooleanMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public boolean getValue()`
-  bool getValue() {
-    return _getValue(reference.pointer, _id_getValue as jni.JMethodIDPtr)
-        .boolean;
-  }
-
-  static final _id_setValue = _class.instanceMethodId(
-    r'setValue',
-    r'(Z)V',
-  );
-
-  static final _setValue = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JThrowablePtr Function(
-                  ffi.Pointer<ffi.Void>,
-                  jni.JMethodIDPtr,
-                  ffi.VarArgs<($Int32,)>)>>('globalEnv_CallVoidMethod')
-      .asFunction<
-          jni.JThrowablePtr Function(
-              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
-
-  /// from: `public void setValue(boolean value)`
-  void setValue(
-    bool value,
-  ) {
-    _setValue(
-            reference.pointer, _id_setValue as jni.JMethodIDPtr, value ? 1 : 0)
-        .check();
-  }
-}
-
-final class $Example_NestedType extends jni.JObjType<Example_Nested> {
-  const $Example_NestedType();
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/simple_package/Example$Nested;';
-
-  @override
-  Example_Nested fromReference(jni.JReference reference) =>
-      Example_Nested.fromReference(reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => ($Example_NestedType).hashCode;
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($Example_NestedType) &&
-        other is $Example_NestedType;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.simple_package.Example$NonStaticNested`
-class Example_NonStaticNested extends jni.JObject {
-  @override
-  late final jni.JObjType<Example_NonStaticNested> $type = type;
-
-  Example_NonStaticNested.fromReference(
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/simple_package/Example$NonStaticNested');
-
-  /// The type which includes information such as the signature of this class.
-  static const type = $Example_NonStaticNestedType();
-  static final _id_ok = _class.instanceFieldId(
-    r'ok',
-    r'Z',
-  );
-
-  /// from: `public boolean ok`
-  bool get ok => _id_ok.get(this, const jni.jbooleanType());
-
-  /// from: `public boolean ok`
-  set ok(bool value) => _id_ok.set(this, const jni.jbooleanType(), value);
-
-  static final _id_new$ = _class.constructorId(
-    r'(Lcom/github/dart_lang/jnigen/simple_package/Example;)V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-              ffi.NativeFunction<
-                  jni.JniResult Function(
-                      ffi.Pointer<ffi.Void>,
-                      jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
-          'globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>();
-
-  /// from: `public void <init>(com.github.dart_lang.jnigen.simple_package.Example $parent)`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory Example_NonStaticNested(
-    Example $parent,
-  ) {
-    return Example_NonStaticNested.fromReference(_new$(_class.reference.pointer,
-            _id_new$ as jni.JMethodIDPtr, $parent.reference.pointer)
-        .reference);
-  }
-}
-
-final class $Example_NonStaticNestedType
-    extends jni.JObjType<Example_NonStaticNested> {
-  const $Example_NonStaticNestedType();
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/simple_package/Example$NonStaticNested;';
-
-  @override
-  Example_NonStaticNested fromReference(jni.JReference reference) =>
-      Example_NonStaticNested.fromReference(reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => ($Example_NonStaticNestedType).hashCode;
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($Example_NonStaticNestedType) &&
-        other is $Example_NonStaticNestedType;
-  }
-}
-
 /// from: `com.github.dart_lang.jnigen.simple_package.Example`
 class Example extends jni.JObject {
   @override
@@ -1616,6 +1323,299 @@ final class $ExampleType extends jni.JObjType<Example> {
   }
 }
 
+/// from: `com.github.dart_lang.jnigen.simple_package.Example$Nested`
+class Example_Nested extends jni.JObject {
+  @override
+  late final jni.JObjType<Example_Nested> $type = type;
+
+  Example_Nested.fromReference(
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/simple_package/Example$Nested');
+
+  /// The type which includes information such as the signature of this class.
+  static const type = $Example_NestedType();
+  static final _id_new$ = _class.constructorId(
+    r'(Z)V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<($Int32,)>)>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
+
+  /// from: `public void <init>(boolean value)`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory Example_Nested(
+    bool value,
+  ) {
+    return Example_Nested.fromReference(_new$(_class.reference.pointer,
+            _id_new$ as jni.JMethodIDPtr, value ? 1 : 0)
+        .reference);
+  }
+
+  static final _id_usesAnonymousInnerClass = _class.instanceMethodId(
+    r'usesAnonymousInnerClass',
+    r'()V',
+  );
+
+  static final _usesAnonymousInnerClass = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallVoidMethod')
+      .asFunction<
+          jni.JThrowablePtr Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public void usesAnonymousInnerClass()`
+  void usesAnonymousInnerClass() {
+    _usesAnonymousInnerClass(
+            reference.pointer, _id_usesAnonymousInnerClass as jni.JMethodIDPtr)
+        .check();
+  }
+
+  static final _id_getValue = _class.instanceMethodId(
+    r'getValue',
+    r'()Z',
+  );
+
+  static final _getValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallBooleanMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public boolean getValue()`
+  bool getValue() {
+    return _getValue(reference.pointer, _id_getValue as jni.JMethodIDPtr)
+        .boolean;
+  }
+
+  static final _id_setValue = _class.instanceMethodId(
+    r'setValue',
+    r'(Z)V',
+  );
+
+  static final _setValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<($Int32,)>)>>('globalEnv_CallVoidMethod')
+      .asFunction<
+          jni.JThrowablePtr Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
+
+  /// from: `public void setValue(boolean value)`
+  void setValue(
+    bool value,
+  ) {
+    _setValue(
+            reference.pointer, _id_setValue as jni.JMethodIDPtr, value ? 1 : 0)
+        .check();
+  }
+}
+
+final class $Example_NestedType extends jni.JObjType<Example_Nested> {
+  const $Example_NestedType();
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/simple_package/Example$Nested;';
+
+  @override
+  Example_Nested fromReference(jni.JReference reference) =>
+      Example_Nested.fromReference(reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => ($Example_NestedType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($Example_NestedType) &&
+        other is $Example_NestedType;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.simple_package.Example$Nested$NestedTwice`
+class Example_Nested_NestedTwice extends jni.JObject {
+  @override
+  late final jni.JObjType<Example_Nested_NestedTwice> $type = type;
+
+  Example_Nested_NestedTwice.fromReference(
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/simple_package/Example$Nested$NestedTwice');
+
+  /// The type which includes information such as the signature of this class.
+  static const type = $Example_Nested_NestedTwiceType();
+  static final _id_ZERO = _class.staticFieldId(
+    r'ZERO',
+    r'I',
+  );
+
+  /// from: `static public int ZERO`
+  static int get ZERO => _id_ZERO.get(_class, const jni.jintType());
+
+  /// from: `static public int ZERO`
+  static set ZERO(int value) =>
+      _id_ZERO.set(_class, const jni.jintType(), value);
+
+  static final _id_new$ = _class.constructorId(
+    r'()V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public void <init>()`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory Example_Nested_NestedTwice() {
+    return Example_Nested_NestedTwice.fromReference(
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
+            .reference);
+  }
+}
+
+final class $Example_Nested_NestedTwiceType
+    extends jni.JObjType<Example_Nested_NestedTwice> {
+  const $Example_Nested_NestedTwiceType();
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/simple_package/Example$Nested$NestedTwice;';
+
+  @override
+  Example_Nested_NestedTwice fromReference(jni.JReference reference) =>
+      Example_Nested_NestedTwice.fromReference(reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => ($Example_Nested_NestedTwiceType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($Example_Nested_NestedTwiceType) &&
+        other is $Example_Nested_NestedTwiceType;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.simple_package.Example$NonStaticNested`
+class Example_NonStaticNested extends jni.JObject {
+  @override
+  late final jni.JObjType<Example_NonStaticNested> $type = type;
+
+  Example_NonStaticNested.fromReference(
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/simple_package/Example$NonStaticNested');
+
+  /// The type which includes information such as the signature of this class.
+  static const type = $Example_NonStaticNestedType();
+  static final _id_ok = _class.instanceFieldId(
+    r'ok',
+    r'Z',
+  );
+
+  /// from: `public boolean ok`
+  bool get ok => _id_ok.get(this, const jni.jbooleanType());
+
+  /// from: `public boolean ok`
+  set ok(bool value) => _id_ok.set(this, const jni.jbooleanType(), value);
+
+  static final _id_new$ = _class.constructorId(
+    r'(Lcom/github/dart_lang/jnigen/simple_package/Example;)V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          'globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
+  /// from: `public void <init>(com.github.dart_lang.jnigen.simple_package.Example $parent)`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory Example_NonStaticNested(
+    Example $parent,
+  ) {
+    return Example_NonStaticNested.fromReference(_new$(_class.reference.pointer,
+            _id_new$ as jni.JMethodIDPtr, $parent.reference.pointer)
+        .reference);
+  }
+}
+
+final class $Example_NonStaticNestedType
+    extends jni.JObjType<Example_NonStaticNested> {
+  const $Example_NonStaticNestedType();
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/simple_package/Example$NonStaticNested;';
+
+  @override
+  Example_NonStaticNested fromReference(jni.JReference reference) =>
+      Example_NonStaticNested.fromReference(reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => ($Example_NonStaticNestedType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($Example_NonStaticNestedType) &&
+        other is $Example_NonStaticNestedType;
+  }
+}
+
 /// from: `com.github.dart_lang.jnigen.simple_package.Exceptions`
 class Exceptions extends jni.JObject {
   @override
@@ -2083,98 +2083,6 @@ final class $ExceptionsType extends jni.JObjType<Exceptions> {
   }
 }
 
-/// from: `com.github.dart_lang.jnigen.simple_package.Fields$Nested`
-class Fields_Nested extends jni.JObject {
-  @override
-  late final jni.JObjType<Fields_Nested> $type = type;
-
-  Fields_Nested.fromReference(
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/simple_package/Fields$Nested');
-
-  /// The type which includes information such as the signature of this class.
-  static const type = $Fields_NestedType();
-  static final _id_hundred = _class.instanceFieldId(
-    r'hundred',
-    r'J',
-  );
-
-  /// from: `public long hundred`
-  int get hundred => _id_hundred.get(this, const jni.jlongType());
-
-  /// from: `public long hundred`
-  set hundred(int value) => _id_hundred.set(this, const jni.jlongType(), value);
-
-  static final _id_BEST_GOD = _class.staticFieldId(
-    r'BEST_GOD',
-    r'Ljava/lang/String;',
-  );
-
-  /// from: `static public java.lang.String BEST_GOD`
-  /// The returned object must be released after use, by calling the [release] method.
-  static jni.JString get BEST_GOD =>
-      _id_BEST_GOD.get(_class, const jni.JStringType());
-
-  /// from: `static public java.lang.String BEST_GOD`
-  /// The returned object must be released after use, by calling the [release] method.
-  static set BEST_GOD(jni.JString value) =>
-      _id_BEST_GOD.set(_class, const jni.JStringType(), value);
-
-  static final _id_new$ = _class.constructorId(
-    r'()V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public void <init>()`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory Fields_Nested() {
-    return Fields_Nested.fromReference(
-        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
-            .reference);
-  }
-}
-
-final class $Fields_NestedType extends jni.JObjType<Fields_Nested> {
-  const $Fields_NestedType();
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/simple_package/Fields$Nested;';
-
-  @override
-  Fields_Nested fromReference(jni.JReference reference) =>
-      Fields_Nested.fromReference(reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => ($Fields_NestedType).hashCode;
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($Fields_NestedType) &&
-        other is $Fields_NestedType;
-  }
-}
-
 /// from: `com.github.dart_lang.jnigen.simple_package.Fields`
 class Fields extends jni.JObject {
   @override
@@ -2367,6 +2275,98 @@ final class $FieldsType extends jni.JObjType<Fields> {
   @override
   bool operator ==(Object other) {
     return other.runtimeType == ($FieldsType) && other is $FieldsType;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.simple_package.Fields$Nested`
+class Fields_Nested extends jni.JObject {
+  @override
+  late final jni.JObjType<Fields_Nested> $type = type;
+
+  Fields_Nested.fromReference(
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/simple_package/Fields$Nested');
+
+  /// The type which includes information such as the signature of this class.
+  static const type = $Fields_NestedType();
+  static final _id_hundred = _class.instanceFieldId(
+    r'hundred',
+    r'J',
+  );
+
+  /// from: `public long hundred`
+  int get hundred => _id_hundred.get(this, const jni.jlongType());
+
+  /// from: `public long hundred`
+  set hundred(int value) => _id_hundred.set(this, const jni.jlongType(), value);
+
+  static final _id_BEST_GOD = _class.staticFieldId(
+    r'BEST_GOD',
+    r'Ljava/lang/String;',
+  );
+
+  /// from: `static public java.lang.String BEST_GOD`
+  /// The returned object must be released after use, by calling the [release] method.
+  static jni.JString get BEST_GOD =>
+      _id_BEST_GOD.get(_class, const jni.JStringType());
+
+  /// from: `static public java.lang.String BEST_GOD`
+  /// The returned object must be released after use, by calling the [release] method.
+  static set BEST_GOD(jni.JString value) =>
+      _id_BEST_GOD.set(_class, const jni.JStringType(), value);
+
+  static final _id_new$ = _class.constructorId(
+    r'()V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public void <init>()`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory Fields_Nested() {
+    return Fields_Nested.fromReference(
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
+            .reference);
+  }
+}
+
+final class $Fields_NestedType extends jni.JObjType<Fields_Nested> {
+  const $Fields_NestedType();
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/simple_package/Fields$Nested;';
+
+  @override
+  Fields_Nested fromReference(jni.JReference reference) =>
+      Fields_Nested.fromReference(reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => ($Fields_NestedType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($Fields_NestedType) &&
+        other is $Fields_NestedType;
   }
 }
 
@@ -2629,549 +2629,6 @@ final class $GenericTypeParamsType<$S extends jni.JObject,
   }
 }
 
-/// from: `com.github.dart_lang.jnigen.generics.GrandParent$Parent$Child`
-class GrandParent_Parent_Child<$T extends jni.JObject, $S extends jni.JObject,
-    $U extends jni.JObject> extends jni.JObject {
-  @override
-  late final jni.JObjType<GrandParent_Parent_Child<$T, $S, $U>> $type =
-      type(T, S, U);
-
-  final jni.JObjType<$T> T;
-  final jni.JObjType<$S> S;
-  final jni.JObjType<$U> U;
-
-  GrandParent_Parent_Child.fromReference(
-    this.T,
-    this.S,
-    this.U,
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/generics/GrandParent$Parent$Child');
-
-  /// The type which includes information such as the signature of this class.
-  static $GrandParent_Parent_ChildType<$T, $S, $U> type<$T extends jni.JObject,
-      $S extends jni.JObject, $U extends jni.JObject>(
-    jni.JObjType<$T> T,
-    jni.JObjType<$S> S,
-    jni.JObjType<$U> U,
-  ) {
-    return $GrandParent_Parent_ChildType(
-      T,
-      S,
-      U,
-    );
-  }
-
-  static final _id_grandParentValue = _class.instanceFieldId(
-    r'grandParentValue',
-    r'Ljava/lang/Object;',
-  );
-
-  /// from: `public T grandParentValue`
-  /// The returned object must be released after use, by calling the [release] method.
-  $T get grandParentValue => _id_grandParentValue.get(this, T);
-
-  /// from: `public T grandParentValue`
-  /// The returned object must be released after use, by calling the [release] method.
-  set grandParentValue($T value) => _id_grandParentValue.set(this, T, value);
-
-  static final _id_parentValue = _class.instanceFieldId(
-    r'parentValue',
-    r'Ljava/lang/Object;',
-  );
-
-  /// from: `public S parentValue`
-  /// The returned object must be released after use, by calling the [release] method.
-  $S get parentValue => _id_parentValue.get(this, S);
-
-  /// from: `public S parentValue`
-  /// The returned object must be released after use, by calling the [release] method.
-  set parentValue($S value) => _id_parentValue.set(this, S, value);
-
-  static final _id_value = _class.instanceFieldId(
-    r'value',
-    r'Ljava/lang/Object;',
-  );
-
-  /// from: `public U value`
-  /// The returned object must be released after use, by calling the [release] method.
-  $U get value => _id_value.get(this, U);
-
-  /// from: `public U value`
-  /// The returned object must be released after use, by calling the [release] method.
-  set value($U value) => _id_value.set(this, U, value);
-
-  static final _id_new$ = _class.constructorId(
-    r'(Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent;Ljava/lang/Object;)V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                  ffi.Pointer<ffi.Void>,
-                  jni.JMethodIDPtr,
-                  ffi.VarArgs<
-                      (
-                        ffi.Pointer<ffi.Void>,
-                        ffi.Pointer<ffi.Void>
-                      )>)>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
-
-  /// from: `public void <init>(com.github.dart_lang.jnigen.generics.GrandParent$Parent $parent, U newValue)`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory GrandParent_Parent_Child(
-    GrandParent_Parent<$T, $S> $parent,
-    $U newValue, {
-    jni.JObjType<$T>? T,
-    jni.JObjType<$S>? S,
-    jni.JObjType<$U>? U,
-  }) {
-    T ??= jni.lowestCommonSuperType([
-      ($parent.$type as $GrandParent_ParentType).T,
-    ]) as jni.JObjType<$T>;
-    S ??= jni.lowestCommonSuperType([
-      ($parent.$type as $GrandParent_ParentType).S,
-    ]) as jni.JObjType<$S>;
-    U ??= jni.lowestCommonSuperType([
-      newValue.$type,
-    ]) as jni.JObjType<$U>;
-    return GrandParent_Parent_Child.fromReference(
-        T,
-        S,
-        U,
-        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr,
-                $parent.reference.pointer, newValue.reference.pointer)
-            .reference);
-  }
-}
-
-final class $GrandParent_Parent_ChildType<$T extends jni.JObject,
-        $S extends jni.JObject, $U extends jni.JObject>
-    extends jni.JObjType<GrandParent_Parent_Child<$T, $S, $U>> {
-  final jni.JObjType<$T> T;
-  final jni.JObjType<$S> S;
-  final jni.JObjType<$U> U;
-
-  const $GrandParent_Parent_ChildType(
-    this.T,
-    this.S,
-    this.U,
-  );
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent$Child;';
-
-  @override
-  GrandParent_Parent_Child<$T, $S, $U> fromReference(
-          jni.JReference reference) =>
-      GrandParent_Parent_Child.fromReference(T, S, U, reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => Object.hash($GrandParent_Parent_ChildType, T, S, U);
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent_Parent_ChildType<$T, $S, $U>) &&
-        other is $GrandParent_Parent_ChildType<$T, $S, $U> &&
-        T == other.T &&
-        S == other.S &&
-        U == other.U;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.generics.GrandParent$Parent`
-class GrandParent_Parent<$T extends jni.JObject, $S extends jni.JObject>
-    extends jni.JObject {
-  @override
-  late final jni.JObjType<GrandParent_Parent<$T, $S>> $type = type(T, S);
-
-  final jni.JObjType<$T> T;
-  final jni.JObjType<$S> S;
-
-  GrandParent_Parent.fromReference(
-    this.T,
-    this.S,
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/generics/GrandParent$Parent');
-
-  /// The type which includes information such as the signature of this class.
-  static $GrandParent_ParentType<$T, $S>
-      type<$T extends jni.JObject, $S extends jni.JObject>(
-    jni.JObjType<$T> T,
-    jni.JObjType<$S> S,
-  ) {
-    return $GrandParent_ParentType(
-      T,
-      S,
-    );
-  }
-
-  static final _id_parentValue = _class.instanceFieldId(
-    r'parentValue',
-    r'Ljava/lang/Object;',
-  );
-
-  /// from: `public T parentValue`
-  /// The returned object must be released after use, by calling the [release] method.
-  $T get parentValue => _id_parentValue.get(this, T);
-
-  /// from: `public T parentValue`
-  /// The returned object must be released after use, by calling the [release] method.
-  set parentValue($T value) => _id_parentValue.set(this, T, value);
-
-  static final _id_value = _class.instanceFieldId(
-    r'value',
-    r'Ljava/lang/Object;',
-  );
-
-  /// from: `public S value`
-  /// The returned object must be released after use, by calling the [release] method.
-  $S get value => _id_value.get(this, S);
-
-  /// from: `public S value`
-  /// The returned object must be released after use, by calling the [release] method.
-  set value($S value) => _id_value.set(this, S, value);
-
-  static final _id_new$ = _class.constructorId(
-    r'(Lcom/github/dart_lang/jnigen/generics/GrandParent;Ljava/lang/Object;)V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                  ffi.Pointer<ffi.Void>,
-                  jni.JMethodIDPtr,
-                  ffi.VarArgs<
-                      (
-                        ffi.Pointer<ffi.Void>,
-                        ffi.Pointer<ffi.Void>
-                      )>)>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
-
-  /// from: `public void <init>(com.github.dart_lang.jnigen.generics.GrandParent $parent, S newValue)`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory GrandParent_Parent(
-    GrandParent<$T> $parent,
-    $S newValue, {
-    jni.JObjType<$T>? T,
-    jni.JObjType<$S>? S,
-  }) {
-    T ??= jni.lowestCommonSuperType([
-      ($parent.$type as $GrandParentType).T,
-    ]) as jni.JObjType<$T>;
-    S ??= jni.lowestCommonSuperType([
-      newValue.$type,
-    ]) as jni.JObjType<$S>;
-    return GrandParent_Parent.fromReference(
-        T,
-        S,
-        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr,
-                $parent.reference.pointer, newValue.reference.pointer)
-            .reference);
-  }
-}
-
-final class $GrandParent_ParentType<$T extends jni.JObject,
-    $S extends jni.JObject> extends jni.JObjType<GrandParent_Parent<$T, $S>> {
-  final jni.JObjType<$T> T;
-  final jni.JObjType<$S> S;
-
-  const $GrandParent_ParentType(
-    this.T,
-    this.S,
-  );
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent;';
-
-  @override
-  GrandParent_Parent<$T, $S> fromReference(jni.JReference reference) =>
-      GrandParent_Parent.fromReference(T, S, reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => Object.hash($GrandParent_ParentType, T, S);
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent_ParentType<$T, $S>) &&
-        other is $GrandParent_ParentType<$T, $S> &&
-        T == other.T &&
-        S == other.S;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.generics.GrandParent$StaticParent$Child`
-class GrandParent_StaticParent_Child<$S extends jni.JObject,
-    $U extends jni.JObject> extends jni.JObject {
-  @override
-  late final jni.JObjType<GrandParent_StaticParent_Child<$S, $U>> $type =
-      type(S, U);
-
-  final jni.JObjType<$S> S;
-  final jni.JObjType<$U> U;
-
-  GrandParent_StaticParent_Child.fromReference(
-    this.S,
-    this.U,
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/generics/GrandParent$StaticParent$Child');
-
-  /// The type which includes information such as the signature of this class.
-  static $GrandParent_StaticParent_ChildType<$S, $U>
-      type<$S extends jni.JObject, $U extends jni.JObject>(
-    jni.JObjType<$S> S,
-    jni.JObjType<$U> U,
-  ) {
-    return $GrandParent_StaticParent_ChildType(
-      S,
-      U,
-    );
-  }
-
-  static final _id_parentValue = _class.instanceFieldId(
-    r'parentValue',
-    r'Ljava/lang/Object;',
-  );
-
-  /// from: `public S parentValue`
-  /// The returned object must be released after use, by calling the [release] method.
-  $S get parentValue => _id_parentValue.get(this, S);
-
-  /// from: `public S parentValue`
-  /// The returned object must be released after use, by calling the [release] method.
-  set parentValue($S value) => _id_parentValue.set(this, S, value);
-
-  static final _id_value = _class.instanceFieldId(
-    r'value',
-    r'Ljava/lang/Object;',
-  );
-
-  /// from: `public U value`
-  /// The returned object must be released after use, by calling the [release] method.
-  $U get value => _id_value.get(this, U);
-
-  /// from: `public U value`
-  /// The returned object must be released after use, by calling the [release] method.
-  set value($U value) => _id_value.set(this, U, value);
-
-  static final _id_new$ = _class.constructorId(
-    r'(Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent;Ljava/lang/Object;Ljava/lang/Object;)V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                  ffi.Pointer<ffi.Void>,
-                  jni.JMethodIDPtr,
-                  ffi.VarArgs<
-                      (
-                        ffi.Pointer<ffi.Void>,
-                        ffi.Pointer<ffi.Void>,
-                        ffi.Pointer<ffi.Void>
-                      )>)>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(
-              ffi.Pointer<ffi.Void>,
-              jni.JMethodIDPtr,
-              ffi.Pointer<ffi.Void>,
-              ffi.Pointer<ffi.Void>,
-              ffi.Pointer<ffi.Void>)>();
-
-  /// from: `public void <init>(com.github.dart_lang.jnigen.generics.GrandParent$StaticParent $parent, S parentValue, U value)`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory GrandParent_StaticParent_Child(
-    GrandParent_StaticParent<$S> $parent,
-    $S parentValue,
-    $U value, {
-    jni.JObjType<$S>? S,
-    jni.JObjType<$U>? U,
-  }) {
-    S ??= jni.lowestCommonSuperType([
-      parentValue.$type,
-      ($parent.$type as $GrandParent_StaticParentType).S,
-    ]) as jni.JObjType<$S>;
-    U ??= jni.lowestCommonSuperType([
-      value.$type,
-    ]) as jni.JObjType<$U>;
-    return GrandParent_StaticParent_Child.fromReference(
-        S,
-        U,
-        _new$(
-                _class.reference.pointer,
-                _id_new$ as jni.JMethodIDPtr,
-                $parent.reference.pointer,
-                parentValue.reference.pointer,
-                value.reference.pointer)
-            .reference);
-  }
-}
-
-final class $GrandParent_StaticParent_ChildType<$S extends jni.JObject,
-        $U extends jni.JObject>
-    extends jni.JObjType<GrandParent_StaticParent_Child<$S, $U>> {
-  final jni.JObjType<$S> S;
-  final jni.JObjType<$U> U;
-
-  const $GrandParent_StaticParent_ChildType(
-    this.S,
-    this.U,
-  );
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent$Child;';
-
-  @override
-  GrandParent_StaticParent_Child<$S, $U> fromReference(
-          jni.JReference reference) =>
-      GrandParent_StaticParent_Child.fromReference(S, U, reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => Object.hash($GrandParent_StaticParent_ChildType, S, U);
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent_StaticParent_ChildType<$S, $U>) &&
-        other is $GrandParent_StaticParent_ChildType<$S, $U> &&
-        S == other.S &&
-        U == other.U;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.generics.GrandParent$StaticParent`
-class GrandParent_StaticParent<$S extends jni.JObject> extends jni.JObject {
-  @override
-  late final jni.JObjType<GrandParent_StaticParent<$S>> $type = type(S);
-
-  final jni.JObjType<$S> S;
-
-  GrandParent_StaticParent.fromReference(
-    this.S,
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/generics/GrandParent$StaticParent');
-
-  /// The type which includes information such as the signature of this class.
-  static $GrandParent_StaticParentType<$S> type<$S extends jni.JObject>(
-    jni.JObjType<$S> S,
-  ) {
-    return $GrandParent_StaticParentType(
-      S,
-    );
-  }
-
-  static final _id_value = _class.instanceFieldId(
-    r'value',
-    r'Ljava/lang/Object;',
-  );
-
-  /// from: `public S value`
-  /// The returned object must be released after use, by calling the [release] method.
-  $S get value => _id_value.get(this, S);
-
-  /// from: `public S value`
-  /// The returned object must be released after use, by calling the [release] method.
-  set value($S value) => _id_value.set(this, S, value);
-
-  static final _id_new$ = _class.constructorId(
-    r'(Ljava/lang/Object;)V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-              ffi.NativeFunction<
-                  jni.JniResult Function(
-                      ffi.Pointer<ffi.Void>,
-                      jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
-          'globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>();
-
-  /// from: `public void <init>(S value)`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory GrandParent_StaticParent(
-    $S value, {
-    jni.JObjType<$S>? S,
-  }) {
-    S ??= jni.lowestCommonSuperType([
-      value.$type,
-    ]) as jni.JObjType<$S>;
-    return GrandParent_StaticParent.fromReference(
-        S,
-        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr,
-                value.reference.pointer)
-            .reference);
-  }
-}
-
-final class $GrandParent_StaticParentType<$S extends jni.JObject>
-    extends jni.JObjType<GrandParent_StaticParent<$S>> {
-  final jni.JObjType<$S> S;
-
-  const $GrandParent_StaticParentType(
-    this.S,
-  );
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent;';
-
-  @override
-  GrandParent_StaticParent<$S> fromReference(jni.JReference reference) =>
-      GrandParent_StaticParent.fromReference(S, reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => Object.hash($GrandParent_StaticParentType, S);
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent_StaticParentType<$S>) &&
-        other is $GrandParent_StaticParentType<$S> &&
-        S == other.S;
-  }
-}
-
 /// from: `com.github.dart_lang.jnigen.generics.GrandParent`
 class GrandParent<$T extends jni.JObject> extends jni.JObject {
   @override
@@ -3409,64 +2866,461 @@ final class $GrandParentType<$T extends jni.JObject>
   }
 }
 
-/// from: `com.github.dart_lang.jnigen.generics.MyMap$MyEntry`
-class MyMap_MyEntry<$K extends jni.JObject, $V extends jni.JObject>
+/// from: `com.github.dart_lang.jnigen.generics.GrandParent$Parent`
+class GrandParent_Parent<$T extends jni.JObject, $S extends jni.JObject>
     extends jni.JObject {
   @override
-  late final jni.JObjType<MyMap_MyEntry<$K, $V>> $type = type(K, V);
+  late final jni.JObjType<GrandParent_Parent<$T, $S>> $type = type(T, S);
 
-  final jni.JObjType<$K> K;
-  final jni.JObjType<$V> V;
+  final jni.JObjType<$T> T;
+  final jni.JObjType<$S> S;
 
-  MyMap_MyEntry.fromReference(
-    this.K,
-    this.V,
+  GrandParent_Parent.fromReference(
+    this.T,
+    this.S,
     jni.JReference reference,
   ) : super.fromReference(reference);
 
-  static final _class =
-      jni.JClass.forName(r'com/github/dart_lang/jnigen/generics/MyMap$MyEntry');
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/generics/GrandParent$Parent');
 
   /// The type which includes information such as the signature of this class.
-  static $MyMap_MyEntryType<$K, $V>
-      type<$K extends jni.JObject, $V extends jni.JObject>(
-    jni.JObjType<$K> K,
-    jni.JObjType<$V> V,
+  static $GrandParent_ParentType<$T, $S>
+      type<$T extends jni.JObject, $S extends jni.JObject>(
+    jni.JObjType<$T> T,
+    jni.JObjType<$S> S,
   ) {
-    return $MyMap_MyEntryType(
-      K,
-      V,
+    return $GrandParent_ParentType(
+      T,
+      S,
     );
   }
 
-  static final _id_key = _class.instanceFieldId(
-    r'key',
+  static final _id_parentValue = _class.instanceFieldId(
+    r'parentValue',
     r'Ljava/lang/Object;',
   );
 
-  /// from: `public K key`
+  /// from: `public T parentValue`
   /// The returned object must be released after use, by calling the [release] method.
-  $K get key => _id_key.get(this, K);
+  $T get parentValue => _id_parentValue.get(this, T);
 
-  /// from: `public K key`
+  /// from: `public T parentValue`
   /// The returned object must be released after use, by calling the [release] method.
-  set key($K value) => _id_key.set(this, K, value);
+  set parentValue($T value) => _id_parentValue.set(this, T, value);
 
   static final _id_value = _class.instanceFieldId(
     r'value',
     r'Ljava/lang/Object;',
   );
 
-  /// from: `public V value`
+  /// from: `public S value`
   /// The returned object must be released after use, by calling the [release] method.
-  $V get value => _id_value.get(this, V);
+  $S get value => _id_value.get(this, S);
 
-  /// from: `public V value`
+  /// from: `public S value`
   /// The returned object must be released after use, by calling the [release] method.
-  set value($V value) => _id_value.set(this, V, value);
+  set value($S value) => _id_value.set(this, S, value);
 
   static final _id_new$ = _class.constructorId(
-    r'(Lcom/github/dart_lang/jnigen/generics/MyMap;Ljava/lang/Object;Ljava/lang/Object;)V',
+    r'(Lcom/github/dart_lang/jnigen/generics/GrandParent;Ljava/lang/Object;)V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+
+  /// from: `public void <init>(com.github.dart_lang.jnigen.generics.GrandParent $parent, S newValue)`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory GrandParent_Parent(
+    GrandParent<$T> $parent,
+    $S newValue, {
+    jni.JObjType<$T>? T,
+    jni.JObjType<$S>? S,
+  }) {
+    T ??= jni.lowestCommonSuperType([
+      ($parent.$type as $GrandParentType).T,
+    ]) as jni.JObjType<$T>;
+    S ??= jni.lowestCommonSuperType([
+      newValue.$type,
+    ]) as jni.JObjType<$S>;
+    return GrandParent_Parent.fromReference(
+        T,
+        S,
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr,
+                $parent.reference.pointer, newValue.reference.pointer)
+            .reference);
+  }
+}
+
+final class $GrandParent_ParentType<$T extends jni.JObject,
+    $S extends jni.JObject> extends jni.JObjType<GrandParent_Parent<$T, $S>> {
+  final jni.JObjType<$T> T;
+  final jni.JObjType<$S> S;
+
+  const $GrandParent_ParentType(
+    this.T,
+    this.S,
+  );
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent;';
+
+  @override
+  GrandParent_Parent<$T, $S> fromReference(jni.JReference reference) =>
+      GrandParent_Parent.fromReference(T, S, reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => Object.hash($GrandParent_ParentType, T, S);
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($GrandParent_ParentType<$T, $S>) &&
+        other is $GrandParent_ParentType<$T, $S> &&
+        T == other.T &&
+        S == other.S;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.generics.GrandParent$Parent$Child`
+class GrandParent_Parent_Child<$T extends jni.JObject, $S extends jni.JObject,
+    $U extends jni.JObject> extends jni.JObject {
+  @override
+  late final jni.JObjType<GrandParent_Parent_Child<$T, $S, $U>> $type =
+      type(T, S, U);
+
+  final jni.JObjType<$T> T;
+  final jni.JObjType<$S> S;
+  final jni.JObjType<$U> U;
+
+  GrandParent_Parent_Child.fromReference(
+    this.T,
+    this.S,
+    this.U,
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/generics/GrandParent$Parent$Child');
+
+  /// The type which includes information such as the signature of this class.
+  static $GrandParent_Parent_ChildType<$T, $S, $U> type<$T extends jni.JObject,
+      $S extends jni.JObject, $U extends jni.JObject>(
+    jni.JObjType<$T> T,
+    jni.JObjType<$S> S,
+    jni.JObjType<$U> U,
+  ) {
+    return $GrandParent_Parent_ChildType(
+      T,
+      S,
+      U,
+    );
+  }
+
+  static final _id_grandParentValue = _class.instanceFieldId(
+    r'grandParentValue',
+    r'Ljava/lang/Object;',
+  );
+
+  /// from: `public T grandParentValue`
+  /// The returned object must be released after use, by calling the [release] method.
+  $T get grandParentValue => _id_grandParentValue.get(this, T);
+
+  /// from: `public T grandParentValue`
+  /// The returned object must be released after use, by calling the [release] method.
+  set grandParentValue($T value) => _id_grandParentValue.set(this, T, value);
+
+  static final _id_parentValue = _class.instanceFieldId(
+    r'parentValue',
+    r'Ljava/lang/Object;',
+  );
+
+  /// from: `public S parentValue`
+  /// The returned object must be released after use, by calling the [release] method.
+  $S get parentValue => _id_parentValue.get(this, S);
+
+  /// from: `public S parentValue`
+  /// The returned object must be released after use, by calling the [release] method.
+  set parentValue($S value) => _id_parentValue.set(this, S, value);
+
+  static final _id_value = _class.instanceFieldId(
+    r'value',
+    r'Ljava/lang/Object;',
+  );
+
+  /// from: `public U value`
+  /// The returned object must be released after use, by calling the [release] method.
+  $U get value => _id_value.get(this, U);
+
+  /// from: `public U value`
+  /// The returned object must be released after use, by calling the [release] method.
+  set value($U value) => _id_value.set(this, U, value);
+
+  static final _id_new$ = _class.constructorId(
+    r'(Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent;Ljava/lang/Object;)V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+
+  /// from: `public void <init>(com.github.dart_lang.jnigen.generics.GrandParent$Parent $parent, U newValue)`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory GrandParent_Parent_Child(
+    GrandParent_Parent<$T, $S> $parent,
+    $U newValue, {
+    jni.JObjType<$T>? T,
+    jni.JObjType<$S>? S,
+    jni.JObjType<$U>? U,
+  }) {
+    T ??= jni.lowestCommonSuperType([
+      ($parent.$type as $GrandParent_ParentType).T,
+    ]) as jni.JObjType<$T>;
+    S ??= jni.lowestCommonSuperType([
+      ($parent.$type as $GrandParent_ParentType).S,
+    ]) as jni.JObjType<$S>;
+    U ??= jni.lowestCommonSuperType([
+      newValue.$type,
+    ]) as jni.JObjType<$U>;
+    return GrandParent_Parent_Child.fromReference(
+        T,
+        S,
+        U,
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr,
+                $parent.reference.pointer, newValue.reference.pointer)
+            .reference);
+  }
+}
+
+final class $GrandParent_Parent_ChildType<$T extends jni.JObject,
+        $S extends jni.JObject, $U extends jni.JObject>
+    extends jni.JObjType<GrandParent_Parent_Child<$T, $S, $U>> {
+  final jni.JObjType<$T> T;
+  final jni.JObjType<$S> S;
+  final jni.JObjType<$U> U;
+
+  const $GrandParent_Parent_ChildType(
+    this.T,
+    this.S,
+    this.U,
+  );
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent$Child;';
+
+  @override
+  GrandParent_Parent_Child<$T, $S, $U> fromReference(
+          jni.JReference reference) =>
+      GrandParent_Parent_Child.fromReference(T, S, U, reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => Object.hash($GrandParent_Parent_ChildType, T, S, U);
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($GrandParent_Parent_ChildType<$T, $S, $U>) &&
+        other is $GrandParent_Parent_ChildType<$T, $S, $U> &&
+        T == other.T &&
+        S == other.S &&
+        U == other.U;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.generics.GrandParent$StaticParent`
+class GrandParent_StaticParent<$S extends jni.JObject> extends jni.JObject {
+  @override
+  late final jni.JObjType<GrandParent_StaticParent<$S>> $type = type(S);
+
+  final jni.JObjType<$S> S;
+
+  GrandParent_StaticParent.fromReference(
+    this.S,
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/generics/GrandParent$StaticParent');
+
+  /// The type which includes information such as the signature of this class.
+  static $GrandParent_StaticParentType<$S> type<$S extends jni.JObject>(
+    jni.JObjType<$S> S,
+  ) {
+    return $GrandParent_StaticParentType(
+      S,
+    );
+  }
+
+  static final _id_value = _class.instanceFieldId(
+    r'value',
+    r'Ljava/lang/Object;',
+  );
+
+  /// from: `public S value`
+  /// The returned object must be released after use, by calling the [release] method.
+  $S get value => _id_value.get(this, S);
+
+  /// from: `public S value`
+  /// The returned object must be released after use, by calling the [release] method.
+  set value($S value) => _id_value.set(this, S, value);
+
+  static final _id_new$ = _class.constructorId(
+    r'(Ljava/lang/Object;)V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          'globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
+  /// from: `public void <init>(S value)`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory GrandParent_StaticParent(
+    $S value, {
+    jni.JObjType<$S>? S,
+  }) {
+    S ??= jni.lowestCommonSuperType([
+      value.$type,
+    ]) as jni.JObjType<$S>;
+    return GrandParent_StaticParent.fromReference(
+        S,
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr,
+                value.reference.pointer)
+            .reference);
+  }
+}
+
+final class $GrandParent_StaticParentType<$S extends jni.JObject>
+    extends jni.JObjType<GrandParent_StaticParent<$S>> {
+  final jni.JObjType<$S> S;
+
+  const $GrandParent_StaticParentType(
+    this.S,
+  );
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent;';
+
+  @override
+  GrandParent_StaticParent<$S> fromReference(jni.JReference reference) =>
+      GrandParent_StaticParent.fromReference(S, reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => Object.hash($GrandParent_StaticParentType, S);
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($GrandParent_StaticParentType<$S>) &&
+        other is $GrandParent_StaticParentType<$S> &&
+        S == other.S;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.generics.GrandParent$StaticParent$Child`
+class GrandParent_StaticParent_Child<$S extends jni.JObject,
+    $U extends jni.JObject> extends jni.JObject {
+  @override
+  late final jni.JObjType<GrandParent_StaticParent_Child<$S, $U>> $type =
+      type(S, U);
+
+  final jni.JObjType<$S> S;
+  final jni.JObjType<$U> U;
+
+  GrandParent_StaticParent_Child.fromReference(
+    this.S,
+    this.U,
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/generics/GrandParent$StaticParent$Child');
+
+  /// The type which includes information such as the signature of this class.
+  static $GrandParent_StaticParent_ChildType<$S, $U>
+      type<$S extends jni.JObject, $U extends jni.JObject>(
+    jni.JObjType<$S> S,
+    jni.JObjType<$U> U,
+  ) {
+    return $GrandParent_StaticParent_ChildType(
+      S,
+      U,
+    );
+  }
+
+  static final _id_parentValue = _class.instanceFieldId(
+    r'parentValue',
+    r'Ljava/lang/Object;',
+  );
+
+  /// from: `public S parentValue`
+  /// The returned object must be released after use, by calling the [release] method.
+  $S get parentValue => _id_parentValue.get(this, S);
+
+  /// from: `public S parentValue`
+  /// The returned object must be released after use, by calling the [release] method.
+  set parentValue($S value) => _id_parentValue.set(this, S, value);
+
+  static final _id_value = _class.instanceFieldId(
+    r'value',
+    r'Ljava/lang/Object;',
+  );
+
+  /// from: `public U value`
+  /// The returned object must be released after use, by calling the [release] method.
+  $U get value => _id_value.get(this, U);
+
+  /// from: `public U value`
+  /// The returned object must be released after use, by calling the [release] method.
+  set value($U value) => _id_value.set(this, U, value);
+
+  static final _id_new$ = _class.constructorId(
+    r'(Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent;Ljava/lang/Object;Ljava/lang/Object;)V',
   );
 
   static final _new$ = ProtectedJniExtensions.lookup<
@@ -3488,53 +3342,54 @@ class MyMap_MyEntry<$K extends jni.JObject, $V extends jni.JObject>
               ffi.Pointer<ffi.Void>,
               ffi.Pointer<ffi.Void>)>();
 
-  /// from: `public void <init>(com.github.dart_lang.jnigen.generics.MyMap $parent, K key, V value)`
+  /// from: `public void <init>(com.github.dart_lang.jnigen.generics.GrandParent$StaticParent $parent, S parentValue, U value)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory MyMap_MyEntry(
-    MyMap<$K, $V> $parent,
-    $K key,
-    $V value, {
-    jni.JObjType<$K>? K,
-    jni.JObjType<$V>? V,
+  factory GrandParent_StaticParent_Child(
+    GrandParent_StaticParent<$S> $parent,
+    $S parentValue,
+    $U value, {
+    jni.JObjType<$S>? S,
+    jni.JObjType<$U>? U,
   }) {
-    K ??= jni.lowestCommonSuperType([
-      key.$type,
-      ($parent.$type as $MyMapType).K,
-    ]) as jni.JObjType<$K>;
-    V ??= jni.lowestCommonSuperType([
+    S ??= jni.lowestCommonSuperType([
+      parentValue.$type,
+      ($parent.$type as $GrandParent_StaticParentType).S,
+    ]) as jni.JObjType<$S>;
+    U ??= jni.lowestCommonSuperType([
       value.$type,
-      ($parent.$type as $MyMapType).V,
-    ]) as jni.JObjType<$V>;
-    return MyMap_MyEntry.fromReference(
-        K,
-        V,
+    ]) as jni.JObjType<$U>;
+    return GrandParent_StaticParent_Child.fromReference(
+        S,
+        U,
         _new$(
                 _class.reference.pointer,
                 _id_new$ as jni.JMethodIDPtr,
                 $parent.reference.pointer,
-                key.reference.pointer,
+                parentValue.reference.pointer,
                 value.reference.pointer)
             .reference);
   }
 }
 
-final class $MyMap_MyEntryType<$K extends jni.JObject, $V extends jni.JObject>
-    extends jni.JObjType<MyMap_MyEntry<$K, $V>> {
-  final jni.JObjType<$K> K;
-  final jni.JObjType<$V> V;
+final class $GrandParent_StaticParent_ChildType<$S extends jni.JObject,
+        $U extends jni.JObject>
+    extends jni.JObjType<GrandParent_StaticParent_Child<$S, $U>> {
+  final jni.JObjType<$S> S;
+  final jni.JObjType<$U> U;
 
-  const $MyMap_MyEntryType(
-    this.K,
-    this.V,
+  const $GrandParent_StaticParent_ChildType(
+    this.S,
+    this.U,
   );
 
   @override
   String get signature =>
-      r'Lcom/github/dart_lang/jnigen/generics/MyMap$MyEntry;';
+      r'Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent$Child;';
 
   @override
-  MyMap_MyEntry<$K, $V> fromReference(jni.JReference reference) =>
-      MyMap_MyEntry.fromReference(K, V, reference);
+  GrandParent_StaticParent_Child<$S, $U> fromReference(
+          jni.JReference reference) =>
+      GrandParent_StaticParent_Child.fromReference(S, U, reference);
 
   @override
   jni.JObjType get superType => const jni.JObjectType();
@@ -3543,14 +3398,14 @@ final class $MyMap_MyEntryType<$K extends jni.JObject, $V extends jni.JObject>
   final superCount = 1;
 
   @override
-  int get hashCode => Object.hash($MyMap_MyEntryType, K, V);
+  int get hashCode => Object.hash($GrandParent_StaticParent_ChildType, S, U);
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyMap_MyEntryType<$K, $V>) &&
-        other is $MyMap_MyEntryType<$K, $V> &&
-        K == other.K &&
-        V == other.V;
+    return other.runtimeType == ($GrandParent_StaticParent_ChildType<$S, $U>) &&
+        other is $GrandParent_StaticParent_ChildType<$S, $U> &&
+        S == other.S &&
+        U == other.U;
   }
 }
 
@@ -3725,6 +3580,151 @@ final class $MyMapType<$K extends jni.JObject, $V extends jni.JObject>
   bool operator ==(Object other) {
     return other.runtimeType == ($MyMapType<$K, $V>) &&
         other is $MyMapType<$K, $V> &&
+        K == other.K &&
+        V == other.V;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.generics.MyMap$MyEntry`
+class MyMap_MyEntry<$K extends jni.JObject, $V extends jni.JObject>
+    extends jni.JObject {
+  @override
+  late final jni.JObjType<MyMap_MyEntry<$K, $V>> $type = type(K, V);
+
+  final jni.JObjType<$K> K;
+  final jni.JObjType<$V> V;
+
+  MyMap_MyEntry.fromReference(
+    this.K,
+    this.V,
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class =
+      jni.JClass.forName(r'com/github/dart_lang/jnigen/generics/MyMap$MyEntry');
+
+  /// The type which includes information such as the signature of this class.
+  static $MyMap_MyEntryType<$K, $V>
+      type<$K extends jni.JObject, $V extends jni.JObject>(
+    jni.JObjType<$K> K,
+    jni.JObjType<$V> V,
+  ) {
+    return $MyMap_MyEntryType(
+      K,
+      V,
+    );
+  }
+
+  static final _id_key = _class.instanceFieldId(
+    r'key',
+    r'Ljava/lang/Object;',
+  );
+
+  /// from: `public K key`
+  /// The returned object must be released after use, by calling the [release] method.
+  $K get key => _id_key.get(this, K);
+
+  /// from: `public K key`
+  /// The returned object must be released after use, by calling the [release] method.
+  set key($K value) => _id_key.set(this, K, value);
+
+  static final _id_value = _class.instanceFieldId(
+    r'value',
+    r'Ljava/lang/Object;',
+  );
+
+  /// from: `public V value`
+  /// The returned object must be released after use, by calling the [release] method.
+  $V get value => _id_value.get(this, V);
+
+  /// from: `public V value`
+  /// The returned object must be released after use, by calling the [release] method.
+  set value($V value) => _id_value.set(this, V, value);
+
+  static final _id_new$ = _class.constructorId(
+    r'(Lcom/github/dart_lang/jnigen/generics/MyMap;Ljava/lang/Object;Ljava/lang/Object;)V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>,
+              jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Void>)>();
+
+  /// from: `public void <init>(com.github.dart_lang.jnigen.generics.MyMap $parent, K key, V value)`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory MyMap_MyEntry(
+    MyMap<$K, $V> $parent,
+    $K key,
+    $V value, {
+    jni.JObjType<$K>? K,
+    jni.JObjType<$V>? V,
+  }) {
+    K ??= jni.lowestCommonSuperType([
+      key.$type,
+      ($parent.$type as $MyMapType).K,
+    ]) as jni.JObjType<$K>;
+    V ??= jni.lowestCommonSuperType([
+      value.$type,
+      ($parent.$type as $MyMapType).V,
+    ]) as jni.JObjType<$V>;
+    return MyMap_MyEntry.fromReference(
+        K,
+        V,
+        _new$(
+                _class.reference.pointer,
+                _id_new$ as jni.JMethodIDPtr,
+                $parent.reference.pointer,
+                key.reference.pointer,
+                value.reference.pointer)
+            .reference);
+  }
+}
+
+final class $MyMap_MyEntryType<$K extends jni.JObject, $V extends jni.JObject>
+    extends jni.JObjType<MyMap_MyEntry<$K, $V>> {
+  final jni.JObjType<$K> K;
+  final jni.JObjType<$V> V;
+
+  const $MyMap_MyEntryType(
+    this.K,
+    this.V,
+  );
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/generics/MyMap$MyEntry;';
+
+  @override
+  MyMap_MyEntry<$K, $V> fromReference(jni.JReference reference) =>
+      MyMap_MyEntry.fromReference(K, V, reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => Object.hash($MyMap_MyEntryType, K, V);
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($MyMap_MyEntryType<$K, $V>) &&
+        other is $MyMap_MyEntryType<$K, $V> &&
         K == other.K &&
         V == other.V;
   }
@@ -5488,267 +5488,73 @@ final class $StringConverterConsumerType
   }
 }
 
-/// from: `com.github.dart_lang.jnigen.interfaces.WithDefault`
-class WithDefault extends jni.JObject {
+/// from: `com.github.dart_lang.jnigen.inheritance.BaseClass`
+class BaseClass<$T extends jni.JObject> extends jni.JObject {
   @override
-  late final jni.JObjType<WithDefault> $type = type;
+  late final jni.JObjType<BaseClass<$T>> $type = type(T);
 
-  WithDefault.fromReference(
+  final jni.JObjType<$T> T;
+
+  BaseClass.fromReference(
+    this.T,
     jni.JReference reference,
   ) : super.fromReference(reference);
 
   static final _class =
-      jni.JClass.forName(r'com/github/dart_lang/jnigen/interfaces/WithDefault');
+      jni.JClass.forName(r'com/github/dart_lang/jnigen/inheritance/BaseClass');
 
   /// The type which includes information such as the signature of this class.
-  static const type = $WithDefaultType();
-  static final _id_normalMethod = _class.instanceMethodId(
-    r'normalMethod',
-    r'()I',
-  );
-
-  static final _normalMethod = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallIntMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public abstract int normalMethod()`
-  int normalMethod() {
-    return _normalMethod(
-            reference.pointer, _id_normalMethod as jni.JMethodIDPtr)
-        .integer;
-  }
-
-  static final _id_default42 = _class.instanceMethodId(
-    r'default42',
-    r'()I',
-  );
-
-  static final _default42 = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallIntMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public int default42()`
-  int default42() {
-    return _default42(reference.pointer, _id_default42 as jni.JMethodIDPtr)
-        .integer;
-  }
-
-  static final _id_greet = _class.instanceMethodId(
-    r'greet',
-    r'(Ljava/lang/String;)Ljava/lang/String;',
-  );
-
-  static final _greet = ProtectedJniExtensions.lookup<
-              ffi.NativeFunction<
-                  jni.JniResult Function(
-                      ffi.Pointer<ffi.Void>,
-                      jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
-          'globalEnv_CallObjectMethod')
-      .asFunction<
-          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>();
-
-  /// from: `public abstract java.lang.String greet(java.lang.String string)`
-  /// The returned object must be released after use, by calling the [release] method.
-  jni.JString greet(
-    jni.JString string,
+  static $BaseClassType<$T> type<$T extends jni.JObject>(
+    jni.JObjType<$T> T,
   ) {
-    return _greet(reference.pointer, _id_greet as jni.JMethodIDPtr,
-            string.reference.pointer)
-        .object(const jni.JStringType());
-  }
-
-  static final _id_defaultGreet = _class.instanceMethodId(
-    r'defaultGreet',
-    r'(Ljava/lang/String;)Ljava/lang/String;',
-  );
-
-  static final _defaultGreet = ProtectedJniExtensions.lookup<
-              ffi.NativeFunction<
-                  jni.JniResult Function(
-                      ffi.Pointer<ffi.Void>,
-                      jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
-          'globalEnv_CallObjectMethod')
-      .asFunction<
-          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>();
-
-  /// from: `public java.lang.String defaultGreet(java.lang.String string)`
-  /// The returned object must be released after use, by calling the [release] method.
-  jni.JString defaultGreet(
-    jni.JString string,
-  ) {
-    return _defaultGreet(reference.pointer,
-            _id_defaultGreet as jni.JMethodIDPtr, string.reference.pointer)
-        .object(const jni.JStringType());
-  }
-
-  /// Maps a specific port to the implemented interface.
-  static final Map<int, $WithDefaultImpl> _$impls = {};
-  ReceivePort? _$p;
-
-  static jni.JObjectPtr _$invoke(
-    int port,
-    jni.JObjectPtr descriptor,
-    jni.JObjectPtr args,
-  ) {
-    return _$invokeMethod(
-      port,
-      $MethodInvocation.fromAddresses(
-        0,
-        descriptor.address,
-        args.address,
-      ),
+    return $BaseClassType(
+      T,
     );
   }
 
-  static final ffi.Pointer<
+  static final _id_new$ = _class.constructorId(
+    r'()V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
           ffi.NativeFunction<
-              jni.JObjectPtr Function(
-                  ffi.Uint64, jni.JObjectPtr, jni.JObjectPtr)>>
-      _$invokePointer = ffi.Pointer.fromFunction(_$invoke);
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
 
-  static ffi.Pointer<ffi.Void> _$invokeMethod(
-    int $p,
-    $MethodInvocation $i,
-  ) {
-    try {
-      final $d = $i.methodDescriptor.toDartString(releaseOriginal: true);
-      final $a = $i.args;
-      if ($d == r'normalMethod()I') {
-        final $r = _$impls[$p]!.normalMethod();
-        return jni.JInteger($r).reference.toPointer();
-      }
-      if ($d == r'default42()I') {
-        final $r = _$impls[$p]!.default42();
-        return jni.JInteger($r).reference.toPointer();
-      }
-      if ($d == r'greet(Ljava/lang/String;)Ljava/lang/String;') {
-        final $r = _$impls[$p]!.greet(
-          $a[0].castTo(const jni.JStringType(), releaseOriginal: true),
-        );
-        return ($r as jni.JObject)
-            .castTo(const jni.JObjectType())
-            .reference
-            .toPointer();
-      }
-      if ($d == r'defaultGreet(Ljava/lang/String;)Ljava/lang/String;') {
-        final $r = _$impls[$p]!.defaultGreet(
-          $a[0].castTo(const jni.JStringType(), releaseOriginal: true),
-        );
-        return ($r as jni.JObject)
-            .castTo(const jni.JObjectType())
-            .reference
-            .toPointer();
-      }
-    } catch (e) {
-      return ProtectedJniExtensions.newDartException(e);
-    }
-    return jni.nullptr;
-  }
-
-  factory WithDefault.implement(
-    $WithDefaultImpl $impl,
-  ) {
-    final $p = ReceivePort();
-    final $x = WithDefault.fromReference(
-      ProtectedJniExtensions.newPortProxy(
-        r'com.github.dart_lang.jnigen.interfaces.WithDefault',
-        $p,
-        _$invokePointer,
-      ),
-    ).._$p = $p;
-    final $a = $p.sendPort.nativePort;
-    _$impls[$a] = $impl;
-    $p.listen(($m) {
-      if ($m == null) {
-        _$impls.remove($p.sendPort.nativePort);
-        $p.close();
-        return;
-      }
-      final $i = $MethodInvocation.fromMessage($m as List<dynamic>);
-      final $r = _$invokeMethod($p.sendPort.nativePort, $i);
-      ProtectedJniExtensions.returnResult($i.result, $r);
-    });
-    return $x;
+  /// from: `public void <init>()`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory BaseClass({
+    required jni.JObjType<$T> T,
+  }) {
+    return BaseClass.fromReference(
+        T,
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
+            .reference);
   }
 }
 
-abstract interface class $WithDefaultImpl {
-  factory $WithDefaultImpl({
-    required int Function() normalMethod,
-    required int Function() default42,
-    required jni.JString Function(jni.JString string) greet,
-    required jni.JString Function(jni.JString string) defaultGreet,
-  }) = _$WithDefaultImpl;
+final class $BaseClassType<$T extends jni.JObject>
+    extends jni.JObjType<BaseClass<$T>> {
+  final jni.JObjType<$T> T;
 
-  int normalMethod();
-  int default42();
-  jni.JString greet(jni.JString string);
-  jni.JString defaultGreet(jni.JString string);
-}
-
-class _$WithDefaultImpl implements $WithDefaultImpl {
-  _$WithDefaultImpl({
-    required int Function() normalMethod,
-    required int Function() default42,
-    required jni.JString Function(jni.JString string) greet,
-    required jni.JString Function(jni.JString string) defaultGreet,
-  })  : _normalMethod = normalMethod,
-        _default42 = default42,
-        _greet = greet,
-        _defaultGreet = defaultGreet;
-
-  final int Function() _normalMethod;
-  final int Function() _default42;
-  final jni.JString Function(jni.JString string) _greet;
-  final jni.JString Function(jni.JString string) _defaultGreet;
-
-  int normalMethod() {
-    return _normalMethod();
-  }
-
-  int default42() {
-    return _default42();
-  }
-
-  jni.JString greet(jni.JString string) {
-    return _greet(string);
-  }
-
-  jni.JString defaultGreet(jni.JString string) {
-    return _defaultGreet(string);
-  }
-}
-
-final class $WithDefaultType extends jni.JObjType<WithDefault> {
-  const $WithDefaultType();
+  const $BaseClassType(
+    this.T,
+  );
 
   @override
   String get signature =>
-      r'Lcom/github/dart_lang/jnigen/interfaces/WithDefault;';
+      r'Lcom/github/dart_lang/jnigen/inheritance/BaseClass;';
 
   @override
-  WithDefault fromReference(jni.JReference reference) =>
-      WithDefault.fromReference(reference);
+  BaseClass<$T> fromReference(jni.JReference reference) =>
+      BaseClass.fromReference(T, reference);
 
   @override
   jni.JObjType get superType => const jni.JObjectType();
@@ -5757,11 +5563,165 @@ final class $WithDefaultType extends jni.JObjType<WithDefault> {
   final superCount = 1;
 
   @override
-  int get hashCode => ($WithDefaultType).hashCode;
+  int get hashCode => Object.hash($BaseClassType, T);
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == ($WithDefaultType) && other is $WithDefaultType;
+    return other.runtimeType == ($BaseClassType<$T>) &&
+        other is $BaseClassType<$T> &&
+        T == other.T;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.inheritance.GenericDerivedClass`
+class GenericDerivedClass<$T extends jni.JObject> extends BaseClass<$T> {
+  @override
+  late final jni.JObjType<GenericDerivedClass<$T>> $type = type(T);
+
+  final jni.JObjType<$T> T;
+
+  GenericDerivedClass.fromReference(
+    this.T,
+    jni.JReference reference,
+  ) : super.fromReference(T, reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/inheritance/GenericDerivedClass');
+
+  /// The type which includes information such as the signature of this class.
+  static $GenericDerivedClassType<$T> type<$T extends jni.JObject>(
+    jni.JObjType<$T> T,
+  ) {
+    return $GenericDerivedClassType(
+      T,
+    );
+  }
+
+  static final _id_new$ = _class.constructorId(
+    r'()V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public void <init>()`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory GenericDerivedClass({
+    required jni.JObjType<$T> T,
+  }) {
+    return GenericDerivedClass.fromReference(
+        T,
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
+            .reference);
+  }
+}
+
+final class $GenericDerivedClassType<$T extends jni.JObject>
+    extends jni.JObjType<GenericDerivedClass<$T>> {
+  final jni.JObjType<$T> T;
+
+  const $GenericDerivedClassType(
+    this.T,
+  );
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/inheritance/GenericDerivedClass;';
+
+  @override
+  GenericDerivedClass<$T> fromReference(jni.JReference reference) =>
+      GenericDerivedClass.fromReference(T, reference);
+
+  @override
+  jni.JObjType get superType => $BaseClassType(T);
+
+  @override
+  final superCount = 2;
+
+  @override
+  int get hashCode => Object.hash($GenericDerivedClassType, T);
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($GenericDerivedClassType<$T>) &&
+        other is $GenericDerivedClassType<$T> &&
+        T == other.T;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.inheritance.SpecificDerivedClass`
+class SpecificDerivedClass extends BaseClass<jni.JString> {
+  @override
+  late final jni.JObjType<SpecificDerivedClass> $type = type;
+
+  SpecificDerivedClass.fromReference(
+    jni.JReference reference,
+  ) : super.fromReference(const jni.JStringType(), reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/inheritance/SpecificDerivedClass');
+
+  /// The type which includes information such as the signature of this class.
+  static const type = $SpecificDerivedClassType();
+  static final _id_new$ = _class.constructorId(
+    r'()V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public void <init>()`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory SpecificDerivedClass() {
+    return SpecificDerivedClass.fromReference(
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
+            .reference);
+  }
+}
+
+final class $SpecificDerivedClassType
+    extends jni.JObjType<SpecificDerivedClass> {
+  const $SpecificDerivedClassType();
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/inheritance/SpecificDerivedClass;';
+
+  @override
+  SpecificDerivedClass fromReference(jni.JReference reference) =>
+      SpecificDerivedClass.fromReference(reference);
+
+  @override
+  jni.JObjType get superType => const $BaseClassType(jni.JStringType());
+
+  @override
+  final superCount = 2;
+
+  @override
+  int get hashCode => ($SpecificDerivedClassType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($SpecificDerivedClassType) &&
+        other is $SpecificDerivedClassType;
   }
 }
 
@@ -5855,164 +5815,6 @@ final class $JsonSerializable_CaseType
   bool operator ==(Object other) {
     return other.runtimeType == ($JsonSerializable_CaseType) &&
         other is $JsonSerializable_CaseType;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.annotations.JsonSerializable`
-class JsonSerializable extends jni.JObject {
-  @override
-  late final jni.JObjType<JsonSerializable> $type = type;
-
-  JsonSerializable.fromReference(
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/annotations/JsonSerializable');
-
-  /// The type which includes information such as the signature of this class.
-  static const type = $JsonSerializableType();
-  static final _id_value = _class.instanceMethodId(
-    r'value',
-    r'()Lcom/github/dart_lang/jnigen/annotations/JsonSerializable$Case;',
-  );
-
-  static final _value = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallObjectMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public abstract com.github.dart_lang.jnigen.annotations.JsonSerializable$Case value()`
-  /// The returned object must be released after use, by calling the [release] method.
-  JsonSerializable_Case value() {
-    return _value(reference.pointer, _id_value as jni.JMethodIDPtr)
-        .object(const $JsonSerializable_CaseType());
-  }
-
-  /// Maps a specific port to the implemented interface.
-  static final Map<int, $JsonSerializableImpl> _$impls = {};
-  ReceivePort? _$p;
-
-  static jni.JObjectPtr _$invoke(
-    int port,
-    jni.JObjectPtr descriptor,
-    jni.JObjectPtr args,
-  ) {
-    return _$invokeMethod(
-      port,
-      $MethodInvocation.fromAddresses(
-        0,
-        descriptor.address,
-        args.address,
-      ),
-    );
-  }
-
-  static final ffi.Pointer<
-          ffi.NativeFunction<
-              jni.JObjectPtr Function(
-                  ffi.Uint64, jni.JObjectPtr, jni.JObjectPtr)>>
-      _$invokePointer = ffi.Pointer.fromFunction(_$invoke);
-
-  static ffi.Pointer<ffi.Void> _$invokeMethod(
-    int $p,
-    $MethodInvocation $i,
-  ) {
-    try {
-      final $d = $i.methodDescriptor.toDartString(releaseOriginal: true);
-      final $a = $i.args;
-      if ($d ==
-          r'value()Lcom/github/dart_lang/jnigen/annotations/JsonSerializable$Case;') {
-        final $r = _$impls[$p]!.value();
-        return ($r as jni.JObject)
-            .castTo(const jni.JObjectType())
-            .reference
-            .toPointer();
-      }
-    } catch (e) {
-      return ProtectedJniExtensions.newDartException(e);
-    }
-    return jni.nullptr;
-  }
-
-  factory JsonSerializable.implement(
-    $JsonSerializableImpl $impl,
-  ) {
-    final $p = ReceivePort();
-    final $x = JsonSerializable.fromReference(
-      ProtectedJniExtensions.newPortProxy(
-        r'com.github.dart_lang.jnigen.annotations.JsonSerializable',
-        $p,
-        _$invokePointer,
-      ),
-    ).._$p = $p;
-    final $a = $p.sendPort.nativePort;
-    _$impls[$a] = $impl;
-    $p.listen(($m) {
-      if ($m == null) {
-        _$impls.remove($p.sendPort.nativePort);
-        $p.close();
-        return;
-      }
-      final $i = $MethodInvocation.fromMessage($m as List<dynamic>);
-      final $r = _$invokeMethod($p.sendPort.nativePort, $i);
-      ProtectedJniExtensions.returnResult($i.result, $r);
-    });
-    return $x;
-  }
-}
-
-abstract interface class $JsonSerializableImpl {
-  factory $JsonSerializableImpl({
-    required JsonSerializable_Case Function() value,
-  }) = _$JsonSerializableImpl;
-
-  JsonSerializable_Case value();
-}
-
-class _$JsonSerializableImpl implements $JsonSerializableImpl {
-  _$JsonSerializableImpl({
-    required JsonSerializable_Case Function() value,
-  }) : _value = value;
-
-  final JsonSerializable_Case Function() _value;
-
-  JsonSerializable_Case value() {
-    return _value();
-  }
-}
-
-final class $JsonSerializableType extends jni.JObjType<JsonSerializable> {
-  const $JsonSerializableType();
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/annotations/JsonSerializable;';
-
-  @override
-  JsonSerializable fromReference(jni.JReference reference) =>
-      JsonSerializable.fromReference(reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => ($JsonSerializableType).hashCode;
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($JsonSerializableType) &&
-        other is $JsonSerializableType;
   }
 }
 

--- a/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
@@ -124,6 +124,299 @@ final class $ColorType extends jni.JObjType<Color> {
   }
 }
 
+/// from: `com.github.dart_lang.jnigen.simple_package.Example$Nested$NestedTwice`
+class Example_Nested_NestedTwice extends jni.JObject {
+  @override
+  late final jni.JObjType<Example_Nested_NestedTwice> $type = type;
+
+  Example_Nested_NestedTwice.fromReference(
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/simple_package/Example$Nested$NestedTwice');
+
+  /// The type which includes information such as the signature of this class.
+  static const type = $Example_Nested_NestedTwiceType();
+  static final _id_ZERO = _class.staticFieldId(
+    r'ZERO',
+    r'I',
+  );
+
+  /// from: `static public int ZERO`
+  static int get ZERO => _id_ZERO.get(_class, const jni.jintType());
+
+  /// from: `static public int ZERO`
+  static set ZERO(int value) =>
+      _id_ZERO.set(_class, const jni.jintType(), value);
+
+  static final _id_new$ = _class.constructorId(
+    r'()V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public void <init>()`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory Example_Nested_NestedTwice() {
+    return Example_Nested_NestedTwice.fromReference(
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
+            .reference);
+  }
+}
+
+final class $Example_Nested_NestedTwiceType
+    extends jni.JObjType<Example_Nested_NestedTwice> {
+  const $Example_Nested_NestedTwiceType();
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/simple_package/Example$Nested$NestedTwice;';
+
+  @override
+  Example_Nested_NestedTwice fromReference(jni.JReference reference) =>
+      Example_Nested_NestedTwice.fromReference(reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => ($Example_Nested_NestedTwiceType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($Example_Nested_NestedTwiceType) &&
+        other is $Example_Nested_NestedTwiceType;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.simple_package.Example$Nested`
+class Example_Nested extends jni.JObject {
+  @override
+  late final jni.JObjType<Example_Nested> $type = type;
+
+  Example_Nested.fromReference(
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/simple_package/Example$Nested');
+
+  /// The type which includes information such as the signature of this class.
+  static const type = $Example_NestedType();
+  static final _id_new$ = _class.constructorId(
+    r'(Z)V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+                  ffi.VarArgs<($Int32,)>)>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
+
+  /// from: `public void <init>(boolean value)`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory Example_Nested(
+    bool value,
+  ) {
+    return Example_Nested.fromReference(_new$(_class.reference.pointer,
+            _id_new$ as jni.JMethodIDPtr, value ? 1 : 0)
+        .reference);
+  }
+
+  static final _id_usesAnonymousInnerClass = _class.instanceMethodId(
+    r'usesAnonymousInnerClass',
+    r'()V',
+  );
+
+  static final _usesAnonymousInnerClass = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallVoidMethod')
+      .asFunction<
+          jni.JThrowablePtr Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public void usesAnonymousInnerClass()`
+  void usesAnonymousInnerClass() {
+    _usesAnonymousInnerClass(
+            reference.pointer, _id_usesAnonymousInnerClass as jni.JMethodIDPtr)
+        .check();
+  }
+
+  static final _id_getValue = _class.instanceMethodId(
+    r'getValue',
+    r'()Z',
+  );
+
+  static final _getValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallBooleanMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public boolean getValue()`
+  bool getValue() {
+    return _getValue(reference.pointer, _id_getValue as jni.JMethodIDPtr)
+        .boolean;
+  }
+
+  static final _id_setValue = _class.instanceMethodId(
+    r'setValue',
+    r'(Z)V',
+  );
+
+  static final _setValue = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JThrowablePtr Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<($Int32,)>)>>('globalEnv_CallVoidMethod')
+      .asFunction<
+          jni.JThrowablePtr Function(
+              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
+
+  /// from: `public void setValue(boolean value)`
+  void setValue(
+    bool value,
+  ) {
+    _setValue(
+            reference.pointer, _id_setValue as jni.JMethodIDPtr, value ? 1 : 0)
+        .check();
+  }
+}
+
+final class $Example_NestedType extends jni.JObjType<Example_Nested> {
+  const $Example_NestedType();
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/simple_package/Example$Nested;';
+
+  @override
+  Example_Nested fromReference(jni.JReference reference) =>
+      Example_Nested.fromReference(reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => ($Example_NestedType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($Example_NestedType) &&
+        other is $Example_NestedType;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.simple_package.Example$NonStaticNested`
+class Example_NonStaticNested extends jni.JObject {
+  @override
+  late final jni.JObjType<Example_NonStaticNested> $type = type;
+
+  Example_NonStaticNested.fromReference(
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/simple_package/Example$NonStaticNested');
+
+  /// The type which includes information such as the signature of this class.
+  static const type = $Example_NonStaticNestedType();
+  static final _id_ok = _class.instanceFieldId(
+    r'ok',
+    r'Z',
+  );
+
+  /// from: `public boolean ok`
+  bool get ok => _id_ok.get(this, const jni.jbooleanType());
+
+  /// from: `public boolean ok`
+  set ok(bool value) => _id_ok.set(this, const jni.jbooleanType(), value);
+
+  static final _id_new$ = _class.constructorId(
+    r'(Lcom/github/dart_lang/jnigen/simple_package/Example;)V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          'globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
+  /// from: `public void <init>(com.github.dart_lang.jnigen.simple_package.Example $parent)`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory Example_NonStaticNested(
+    Example $parent,
+  ) {
+    return Example_NonStaticNested.fromReference(_new$(_class.reference.pointer,
+            _id_new$ as jni.JMethodIDPtr, $parent.reference.pointer)
+        .reference);
+  }
+}
+
+final class $Example_NonStaticNestedType
+    extends jni.JObjType<Example_NonStaticNested> {
+  const $Example_NonStaticNestedType();
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/simple_package/Example$NonStaticNested;';
+
+  @override
+  Example_NonStaticNested fromReference(jni.JReference reference) =>
+      Example_NonStaticNested.fromReference(reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => ($Example_NonStaticNestedType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($Example_NonStaticNestedType) &&
+        other is $Example_NonStaticNestedType;
+  }
+}
+
 /// from: `com.github.dart_lang.jnigen.simple_package.Example`
 class Example extends jni.JObject {
   @override
@@ -1323,299 +1616,6 @@ final class $ExampleType extends jni.JObjType<Example> {
   }
 }
 
-/// from: `com.github.dart_lang.jnigen.simple_package.Example$Nested`
-class Example_Nested extends jni.JObject {
-  @override
-  late final jni.JObjType<Example_Nested> $type = type;
-
-  Example_Nested.fromReference(
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/simple_package/Example$Nested');
-
-  /// The type which includes information such as the signature of this class.
-  static const type = $Example_NestedType();
-  static final _id_new$ = _class.constructorId(
-    r'(Z)V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-                  ffi.VarArgs<($Int32,)>)>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(
-              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
-
-  /// from: `public void <init>(boolean value)`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory Example_Nested(
-    bool value,
-  ) {
-    return Example_Nested.fromReference(_new$(_class.reference.pointer,
-            _id_new$ as jni.JMethodIDPtr, value ? 1 : 0)
-        .reference);
-  }
-
-  static final _id_usesAnonymousInnerClass = _class.instanceMethodId(
-    r'usesAnonymousInnerClass',
-    r'()V',
-  );
-
-  static final _usesAnonymousInnerClass = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JThrowablePtr Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallVoidMethod')
-      .asFunction<
-          jni.JThrowablePtr Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public void usesAnonymousInnerClass()`
-  void usesAnonymousInnerClass() {
-    _usesAnonymousInnerClass(
-            reference.pointer, _id_usesAnonymousInnerClass as jni.JMethodIDPtr)
-        .check();
-  }
-
-  static final _id_getValue = _class.instanceMethodId(
-    r'getValue',
-    r'()Z',
-  );
-
-  static final _getValue = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_CallBooleanMethod')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public boolean getValue()`
-  bool getValue() {
-    return _getValue(reference.pointer, _id_getValue as jni.JMethodIDPtr)
-        .boolean;
-  }
-
-  static final _id_setValue = _class.instanceMethodId(
-    r'setValue',
-    r'(Z)V',
-  );
-
-  static final _setValue = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JThrowablePtr Function(
-                  ffi.Pointer<ffi.Void>,
-                  jni.JMethodIDPtr,
-                  ffi.VarArgs<($Int32,)>)>>('globalEnv_CallVoidMethod')
-      .asFunction<
-          jni.JThrowablePtr Function(
-              ffi.Pointer<ffi.Void>, jni.JMethodIDPtr, int)>();
-
-  /// from: `public void setValue(boolean value)`
-  void setValue(
-    bool value,
-  ) {
-    _setValue(
-            reference.pointer, _id_setValue as jni.JMethodIDPtr, value ? 1 : 0)
-        .check();
-  }
-}
-
-final class $Example_NestedType extends jni.JObjType<Example_Nested> {
-  const $Example_NestedType();
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/simple_package/Example$Nested;';
-
-  @override
-  Example_Nested fromReference(jni.JReference reference) =>
-      Example_Nested.fromReference(reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => ($Example_NestedType).hashCode;
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($Example_NestedType) &&
-        other is $Example_NestedType;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.simple_package.Example$Nested$NestedTwice`
-class Example_Nested_NestedTwice extends jni.JObject {
-  @override
-  late final jni.JObjType<Example_Nested_NestedTwice> $type = type;
-
-  Example_Nested_NestedTwice.fromReference(
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/simple_package/Example$Nested$NestedTwice');
-
-  /// The type which includes information such as the signature of this class.
-  static const type = $Example_Nested_NestedTwiceType();
-  static final _id_ZERO = _class.staticFieldId(
-    r'ZERO',
-    r'I',
-  );
-
-  /// from: `static public int ZERO`
-  static int get ZERO => _id_ZERO.get(_class, const jni.jintType());
-
-  /// from: `static public int ZERO`
-  static set ZERO(int value) =>
-      _id_ZERO.set(_class, const jni.jintType(), value);
-
-  static final _id_new$ = _class.constructorId(
-    r'()V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public void <init>()`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory Example_Nested_NestedTwice() {
-    return Example_Nested_NestedTwice.fromReference(
-        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
-            .reference);
-  }
-}
-
-final class $Example_Nested_NestedTwiceType
-    extends jni.JObjType<Example_Nested_NestedTwice> {
-  const $Example_Nested_NestedTwiceType();
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/simple_package/Example$Nested$NestedTwice;';
-
-  @override
-  Example_Nested_NestedTwice fromReference(jni.JReference reference) =>
-      Example_Nested_NestedTwice.fromReference(reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => ($Example_Nested_NestedTwiceType).hashCode;
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($Example_Nested_NestedTwiceType) &&
-        other is $Example_Nested_NestedTwiceType;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.simple_package.Example$NonStaticNested`
-class Example_NonStaticNested extends jni.JObject {
-  @override
-  late final jni.JObjType<Example_NonStaticNested> $type = type;
-
-  Example_NonStaticNested.fromReference(
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/simple_package/Example$NonStaticNested');
-
-  /// The type which includes information such as the signature of this class.
-  static const type = $Example_NonStaticNestedType();
-  static final _id_ok = _class.instanceFieldId(
-    r'ok',
-    r'Z',
-  );
-
-  /// from: `public boolean ok`
-  bool get ok => _id_ok.get(this, const jni.jbooleanType());
-
-  /// from: `public boolean ok`
-  set ok(bool value) => _id_ok.set(this, const jni.jbooleanType(), value);
-
-  static final _id_new$ = _class.constructorId(
-    r'(Lcom/github/dart_lang/jnigen/simple_package/Example;)V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-              ffi.NativeFunction<
-                  jni.JniResult Function(
-                      ffi.Pointer<ffi.Void>,
-                      jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
-          'globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>();
-
-  /// from: `public void <init>(com.github.dart_lang.jnigen.simple_package.Example $parent)`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory Example_NonStaticNested(
-    Example $parent,
-  ) {
-    return Example_NonStaticNested.fromReference(_new$(_class.reference.pointer,
-            _id_new$ as jni.JMethodIDPtr, $parent.reference.pointer)
-        .reference);
-  }
-}
-
-final class $Example_NonStaticNestedType
-    extends jni.JObjType<Example_NonStaticNested> {
-  const $Example_NonStaticNestedType();
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/simple_package/Example$NonStaticNested;';
-
-  @override
-  Example_NonStaticNested fromReference(jni.JReference reference) =>
-      Example_NonStaticNested.fromReference(reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => ($Example_NonStaticNestedType).hashCode;
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($Example_NonStaticNestedType) &&
-        other is $Example_NonStaticNestedType;
-  }
-}
-
 /// from: `com.github.dart_lang.jnigen.simple_package.Exceptions`
 class Exceptions extends jni.JObject {
   @override
@@ -2083,6 +2083,98 @@ final class $ExceptionsType extends jni.JObjType<Exceptions> {
   }
 }
 
+/// from: `com.github.dart_lang.jnigen.simple_package.Fields$Nested`
+class Fields_Nested extends jni.JObject {
+  @override
+  late final jni.JObjType<Fields_Nested> $type = type;
+
+  Fields_Nested.fromReference(
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/simple_package/Fields$Nested');
+
+  /// The type which includes information such as the signature of this class.
+  static const type = $Fields_NestedType();
+  static final _id_hundred = _class.instanceFieldId(
+    r'hundred',
+    r'J',
+  );
+
+  /// from: `public long hundred`
+  int get hundred => _id_hundred.get(this, const jni.jlongType());
+
+  /// from: `public long hundred`
+  set hundred(int value) => _id_hundred.set(this, const jni.jlongType(), value);
+
+  static final _id_BEST_GOD = _class.staticFieldId(
+    r'BEST_GOD',
+    r'Ljava/lang/String;',
+  );
+
+  /// from: `static public java.lang.String BEST_GOD`
+  /// The returned object must be released after use, by calling the [release] method.
+  static jni.JString get BEST_GOD =>
+      _id_BEST_GOD.get(_class, const jni.JStringType());
+
+  /// from: `static public java.lang.String BEST_GOD`
+  /// The returned object must be released after use, by calling the [release] method.
+  static set BEST_GOD(jni.JString value) =>
+      _id_BEST_GOD.set(_class, const jni.JStringType(), value);
+
+  static final _id_new$ = _class.constructorId(
+    r'()V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public void <init>()`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory Fields_Nested() {
+    return Fields_Nested.fromReference(
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
+            .reference);
+  }
+}
+
+final class $Fields_NestedType extends jni.JObjType<Fields_Nested> {
+  const $Fields_NestedType();
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/simple_package/Fields$Nested;';
+
+  @override
+  Fields_Nested fromReference(jni.JReference reference) =>
+      Fields_Nested.fromReference(reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => ($Fields_NestedType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($Fields_NestedType) &&
+        other is $Fields_NestedType;
+  }
+}
+
 /// from: `com.github.dart_lang.jnigen.simple_package.Fields`
 class Fields extends jni.JObject {
   @override
@@ -2275,98 +2367,6 @@ final class $FieldsType extends jni.JObjType<Fields> {
   @override
   bool operator ==(Object other) {
     return other.runtimeType == ($FieldsType) && other is $FieldsType;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.simple_package.Fields$Nested`
-class Fields_Nested extends jni.JObject {
-  @override
-  late final jni.JObjType<Fields_Nested> $type = type;
-
-  Fields_Nested.fromReference(
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/simple_package/Fields$Nested');
-
-  /// The type which includes information such as the signature of this class.
-  static const type = $Fields_NestedType();
-  static final _id_hundred = _class.instanceFieldId(
-    r'hundred',
-    r'J',
-  );
-
-  /// from: `public long hundred`
-  int get hundred => _id_hundred.get(this, const jni.jlongType());
-
-  /// from: `public long hundred`
-  set hundred(int value) => _id_hundred.set(this, const jni.jlongType(), value);
-
-  static final _id_BEST_GOD = _class.staticFieldId(
-    r'BEST_GOD',
-    r'Ljava/lang/String;',
-  );
-
-  /// from: `static public java.lang.String BEST_GOD`
-  /// The returned object must be released after use, by calling the [release] method.
-  static jni.JString get BEST_GOD =>
-      _id_BEST_GOD.get(_class, const jni.JStringType());
-
-  /// from: `static public java.lang.String BEST_GOD`
-  /// The returned object must be released after use, by calling the [release] method.
-  static set BEST_GOD(jni.JString value) =>
-      _id_BEST_GOD.set(_class, const jni.JStringType(), value);
-
-  static final _id_new$ = _class.constructorId(
-    r'()V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                ffi.Pointer<ffi.Void>,
-                jni.JMethodIDPtr,
-              )>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(
-            ffi.Pointer<ffi.Void>,
-            jni.JMethodIDPtr,
-          )>();
-
-  /// from: `public void <init>()`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory Fields_Nested() {
-    return Fields_Nested.fromReference(
-        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr)
-            .reference);
-  }
-}
-
-final class $Fields_NestedType extends jni.JObjType<Fields_Nested> {
-  const $Fields_NestedType();
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/simple_package/Fields$Nested;';
-
-  @override
-  Fields_Nested fromReference(jni.JReference reference) =>
-      Fields_Nested.fromReference(reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => ($Fields_NestedType).hashCode;
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($Fields_NestedType) &&
-        other is $Fields_NestedType;
   }
 }
 
@@ -2629,6 +2629,549 @@ final class $GenericTypeParamsType<$S extends jni.JObject,
   }
 }
 
+/// from: `com.github.dart_lang.jnigen.generics.GrandParent$Parent$Child`
+class GrandParent_Parent_Child<$T extends jni.JObject, $S extends jni.JObject,
+    $U extends jni.JObject> extends jni.JObject {
+  @override
+  late final jni.JObjType<GrandParent_Parent_Child<$T, $S, $U>> $type =
+      type(T, S, U);
+
+  final jni.JObjType<$T> T;
+  final jni.JObjType<$S> S;
+  final jni.JObjType<$U> U;
+
+  GrandParent_Parent_Child.fromReference(
+    this.T,
+    this.S,
+    this.U,
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/generics/GrandParent$Parent$Child');
+
+  /// The type which includes information such as the signature of this class.
+  static $GrandParent_Parent_ChildType<$T, $S, $U> type<$T extends jni.JObject,
+      $S extends jni.JObject, $U extends jni.JObject>(
+    jni.JObjType<$T> T,
+    jni.JObjType<$S> S,
+    jni.JObjType<$U> U,
+  ) {
+    return $GrandParent_Parent_ChildType(
+      T,
+      S,
+      U,
+    );
+  }
+
+  static final _id_grandParentValue = _class.instanceFieldId(
+    r'grandParentValue',
+    r'Ljava/lang/Object;',
+  );
+
+  /// from: `public T grandParentValue`
+  /// The returned object must be released after use, by calling the [release] method.
+  $T get grandParentValue => _id_grandParentValue.get(this, T);
+
+  /// from: `public T grandParentValue`
+  /// The returned object must be released after use, by calling the [release] method.
+  set grandParentValue($T value) => _id_grandParentValue.set(this, T, value);
+
+  static final _id_parentValue = _class.instanceFieldId(
+    r'parentValue',
+    r'Ljava/lang/Object;',
+  );
+
+  /// from: `public S parentValue`
+  /// The returned object must be released after use, by calling the [release] method.
+  $S get parentValue => _id_parentValue.get(this, S);
+
+  /// from: `public S parentValue`
+  /// The returned object must be released after use, by calling the [release] method.
+  set parentValue($S value) => _id_parentValue.set(this, S, value);
+
+  static final _id_value = _class.instanceFieldId(
+    r'value',
+    r'Ljava/lang/Object;',
+  );
+
+  /// from: `public U value`
+  /// The returned object must be released after use, by calling the [release] method.
+  $U get value => _id_value.get(this, U);
+
+  /// from: `public U value`
+  /// The returned object must be released after use, by calling the [release] method.
+  set value($U value) => _id_value.set(this, U, value);
+
+  static final _id_new$ = _class.constructorId(
+    r'(Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent;Ljava/lang/Object;)V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+
+  /// from: `public void <init>(com.github.dart_lang.jnigen.generics.GrandParent$Parent $parent, U newValue)`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory GrandParent_Parent_Child(
+    GrandParent_Parent<$T, $S> $parent,
+    $U newValue, {
+    jni.JObjType<$T>? T,
+    jni.JObjType<$S>? S,
+    jni.JObjType<$U>? U,
+  }) {
+    T ??= jni.lowestCommonSuperType([
+      ($parent.$type as $GrandParent_ParentType).T,
+    ]) as jni.JObjType<$T>;
+    S ??= jni.lowestCommonSuperType([
+      ($parent.$type as $GrandParent_ParentType).S,
+    ]) as jni.JObjType<$S>;
+    U ??= jni.lowestCommonSuperType([
+      newValue.$type,
+    ]) as jni.JObjType<$U>;
+    return GrandParent_Parent_Child.fromReference(
+        T,
+        S,
+        U,
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr,
+                $parent.reference.pointer, newValue.reference.pointer)
+            .reference);
+  }
+}
+
+final class $GrandParent_Parent_ChildType<$T extends jni.JObject,
+        $S extends jni.JObject, $U extends jni.JObject>
+    extends jni.JObjType<GrandParent_Parent_Child<$T, $S, $U>> {
+  final jni.JObjType<$T> T;
+  final jni.JObjType<$S> S;
+  final jni.JObjType<$U> U;
+
+  const $GrandParent_Parent_ChildType(
+    this.T,
+    this.S,
+    this.U,
+  );
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent$Child;';
+
+  @override
+  GrandParent_Parent_Child<$T, $S, $U> fromReference(
+          jni.JReference reference) =>
+      GrandParent_Parent_Child.fromReference(T, S, U, reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => Object.hash($GrandParent_Parent_ChildType, T, S, U);
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($GrandParent_Parent_ChildType<$T, $S, $U>) &&
+        other is $GrandParent_Parent_ChildType<$T, $S, $U> &&
+        T == other.T &&
+        S == other.S &&
+        U == other.U;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.generics.GrandParent$Parent`
+class GrandParent_Parent<$T extends jni.JObject, $S extends jni.JObject>
+    extends jni.JObject {
+  @override
+  late final jni.JObjType<GrandParent_Parent<$T, $S>> $type = type(T, S);
+
+  final jni.JObjType<$T> T;
+  final jni.JObjType<$S> S;
+
+  GrandParent_Parent.fromReference(
+    this.T,
+    this.S,
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/generics/GrandParent$Parent');
+
+  /// The type which includes information such as the signature of this class.
+  static $GrandParent_ParentType<$T, $S>
+      type<$T extends jni.JObject, $S extends jni.JObject>(
+    jni.JObjType<$T> T,
+    jni.JObjType<$S> S,
+  ) {
+    return $GrandParent_ParentType(
+      T,
+      S,
+    );
+  }
+
+  static final _id_parentValue = _class.instanceFieldId(
+    r'parentValue',
+    r'Ljava/lang/Object;',
+  );
+
+  /// from: `public T parentValue`
+  /// The returned object must be released after use, by calling the [release] method.
+  $T get parentValue => _id_parentValue.get(this, T);
+
+  /// from: `public T parentValue`
+  /// The returned object must be released after use, by calling the [release] method.
+  set parentValue($T value) => _id_parentValue.set(this, T, value);
+
+  static final _id_value = _class.instanceFieldId(
+    r'value',
+    r'Ljava/lang/Object;',
+  );
+
+  /// from: `public S value`
+  /// The returned object must be released after use, by calling the [release] method.
+  $S get value => _id_value.get(this, S);
+
+  /// from: `public S value`
+  /// The returned object must be released after use, by calling the [release] method.
+  set value($S value) => _id_value.set(this, S, value);
+
+  static final _id_new$ = _class.constructorId(
+    r'(Lcom/github/dart_lang/jnigen/generics/GrandParent;Ljava/lang/Object;)V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+
+  /// from: `public void <init>(com.github.dart_lang.jnigen.generics.GrandParent $parent, S newValue)`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory GrandParent_Parent(
+    GrandParent<$T> $parent,
+    $S newValue, {
+    jni.JObjType<$T>? T,
+    jni.JObjType<$S>? S,
+  }) {
+    T ??= jni.lowestCommonSuperType([
+      ($parent.$type as $GrandParentType).T,
+    ]) as jni.JObjType<$T>;
+    S ??= jni.lowestCommonSuperType([
+      newValue.$type,
+    ]) as jni.JObjType<$S>;
+    return GrandParent_Parent.fromReference(
+        T,
+        S,
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr,
+                $parent.reference.pointer, newValue.reference.pointer)
+            .reference);
+  }
+}
+
+final class $GrandParent_ParentType<$T extends jni.JObject,
+    $S extends jni.JObject> extends jni.JObjType<GrandParent_Parent<$T, $S>> {
+  final jni.JObjType<$T> T;
+  final jni.JObjType<$S> S;
+
+  const $GrandParent_ParentType(
+    this.T,
+    this.S,
+  );
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent;';
+
+  @override
+  GrandParent_Parent<$T, $S> fromReference(jni.JReference reference) =>
+      GrandParent_Parent.fromReference(T, S, reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => Object.hash($GrandParent_ParentType, T, S);
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($GrandParent_ParentType<$T, $S>) &&
+        other is $GrandParent_ParentType<$T, $S> &&
+        T == other.T &&
+        S == other.S;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.generics.GrandParent$StaticParent$Child`
+class GrandParent_StaticParent_Child<$S extends jni.JObject,
+    $U extends jni.JObject> extends jni.JObject {
+  @override
+  late final jni.JObjType<GrandParent_StaticParent_Child<$S, $U>> $type =
+      type(S, U);
+
+  final jni.JObjType<$S> S;
+  final jni.JObjType<$U> U;
+
+  GrandParent_StaticParent_Child.fromReference(
+    this.S,
+    this.U,
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/generics/GrandParent$StaticParent$Child');
+
+  /// The type which includes information such as the signature of this class.
+  static $GrandParent_StaticParent_ChildType<$S, $U>
+      type<$S extends jni.JObject, $U extends jni.JObject>(
+    jni.JObjType<$S> S,
+    jni.JObjType<$U> U,
+  ) {
+    return $GrandParent_StaticParent_ChildType(
+      S,
+      U,
+    );
+  }
+
+  static final _id_parentValue = _class.instanceFieldId(
+    r'parentValue',
+    r'Ljava/lang/Object;',
+  );
+
+  /// from: `public S parentValue`
+  /// The returned object must be released after use, by calling the [release] method.
+  $S get parentValue => _id_parentValue.get(this, S);
+
+  /// from: `public S parentValue`
+  /// The returned object must be released after use, by calling the [release] method.
+  set parentValue($S value) => _id_parentValue.set(this, S, value);
+
+  static final _id_value = _class.instanceFieldId(
+    r'value',
+    r'Ljava/lang/Object;',
+  );
+
+  /// from: `public U value`
+  /// The returned object must be released after use, by calling the [release] method.
+  $U get value => _id_value.get(this, U);
+
+  /// from: `public U value`
+  /// The returned object must be released after use, by calling the [release] method.
+  set value($U value) => _id_value.set(this, U, value);
+
+  static final _id_new$ = _class.constructorId(
+    r'(Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent;Ljava/lang/Object;Ljava/lang/Object;)V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  jni.JMethodIDPtr,
+                  ffi.VarArgs<
+                      (
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>,
+                        ffi.Pointer<ffi.Void>
+                      )>)>>('globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>,
+              jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Void>)>();
+
+  /// from: `public void <init>(com.github.dart_lang.jnigen.generics.GrandParent$StaticParent $parent, S parentValue, U value)`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory GrandParent_StaticParent_Child(
+    GrandParent_StaticParent<$S> $parent,
+    $S parentValue,
+    $U value, {
+    jni.JObjType<$S>? S,
+    jni.JObjType<$U>? U,
+  }) {
+    S ??= jni.lowestCommonSuperType([
+      parentValue.$type,
+      ($parent.$type as $GrandParent_StaticParentType).S,
+    ]) as jni.JObjType<$S>;
+    U ??= jni.lowestCommonSuperType([
+      value.$type,
+    ]) as jni.JObjType<$U>;
+    return GrandParent_StaticParent_Child.fromReference(
+        S,
+        U,
+        _new$(
+                _class.reference.pointer,
+                _id_new$ as jni.JMethodIDPtr,
+                $parent.reference.pointer,
+                parentValue.reference.pointer,
+                value.reference.pointer)
+            .reference);
+  }
+}
+
+final class $GrandParent_StaticParent_ChildType<$S extends jni.JObject,
+        $U extends jni.JObject>
+    extends jni.JObjType<GrandParent_StaticParent_Child<$S, $U>> {
+  final jni.JObjType<$S> S;
+  final jni.JObjType<$U> U;
+
+  const $GrandParent_StaticParent_ChildType(
+    this.S,
+    this.U,
+  );
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent$Child;';
+
+  @override
+  GrandParent_StaticParent_Child<$S, $U> fromReference(
+          jni.JReference reference) =>
+      GrandParent_StaticParent_Child.fromReference(S, U, reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => Object.hash($GrandParent_StaticParent_ChildType, S, U);
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($GrandParent_StaticParent_ChildType<$S, $U>) &&
+        other is $GrandParent_StaticParent_ChildType<$S, $U> &&
+        S == other.S &&
+        U == other.U;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.generics.GrandParent$StaticParent`
+class GrandParent_StaticParent<$S extends jni.JObject> extends jni.JObject {
+  @override
+  late final jni.JObjType<GrandParent_StaticParent<$S>> $type = type(S);
+
+  final jni.JObjType<$S> S;
+
+  GrandParent_StaticParent.fromReference(
+    this.S,
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/generics/GrandParent$StaticParent');
+
+  /// The type which includes information such as the signature of this class.
+  static $GrandParent_StaticParentType<$S> type<$S extends jni.JObject>(
+    jni.JObjType<$S> S,
+  ) {
+    return $GrandParent_StaticParentType(
+      S,
+    );
+  }
+
+  static final _id_value = _class.instanceFieldId(
+    r'value',
+    r'Ljava/lang/Object;',
+  );
+
+  /// from: `public S value`
+  /// The returned object must be released after use, by calling the [release] method.
+  $S get value => _id_value.get(this, S);
+
+  /// from: `public S value`
+  /// The returned object must be released after use, by calling the [release] method.
+  set value($S value) => _id_value.set(this, S, value);
+
+  static final _id_new$ = _class.constructorId(
+    r'(Ljava/lang/Object;)V',
+  );
+
+  static final _new$ = ProtectedJniExtensions.lookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      ffi.Pointer<ffi.Void>,
+                      jni.JMethodIDPtr,
+                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
+          'globalEnv_NewObject')
+      .asFunction<
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
+              ffi.Pointer<ffi.Void>)>();
+
+  /// from: `public void <init>(S value)`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory GrandParent_StaticParent(
+    $S value, {
+    jni.JObjType<$S>? S,
+  }) {
+    S ??= jni.lowestCommonSuperType([
+      value.$type,
+    ]) as jni.JObjType<$S>;
+    return GrandParent_StaticParent.fromReference(
+        S,
+        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr,
+                value.reference.pointer)
+            .reference);
+  }
+}
+
+final class $GrandParent_StaticParentType<$S extends jni.JObject>
+    extends jni.JObjType<GrandParent_StaticParent<$S>> {
+  final jni.JObjType<$S> S;
+
+  const $GrandParent_StaticParentType(
+    this.S,
+  );
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent;';
+
+  @override
+  GrandParent_StaticParent<$S> fromReference(jni.JReference reference) =>
+      GrandParent_StaticParent.fromReference(S, reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => Object.hash($GrandParent_StaticParentType, S);
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($GrandParent_StaticParentType<$S>) &&
+        other is $GrandParent_StaticParentType<$S> &&
+        S == other.S;
+  }
+}
+
 /// from: `com.github.dart_lang.jnigen.generics.GrandParent`
 class GrandParent<$T extends jni.JObject> extends jni.JObject {
   @override
@@ -2866,461 +3409,64 @@ final class $GrandParentType<$T extends jni.JObject>
   }
 }
 
-/// from: `com.github.dart_lang.jnigen.generics.GrandParent$Parent`
-class GrandParent_Parent<$T extends jni.JObject, $S extends jni.JObject>
+/// from: `com.github.dart_lang.jnigen.generics.MyMap$MyEntry`
+class MyMap_MyEntry<$K extends jni.JObject, $V extends jni.JObject>
     extends jni.JObject {
   @override
-  late final jni.JObjType<GrandParent_Parent<$T, $S>> $type = type(T, S);
+  late final jni.JObjType<MyMap_MyEntry<$K, $V>> $type = type(K, V);
 
-  final jni.JObjType<$T> T;
-  final jni.JObjType<$S> S;
+  final jni.JObjType<$K> K;
+  final jni.JObjType<$V> V;
 
-  GrandParent_Parent.fromReference(
-    this.T,
-    this.S,
+  MyMap_MyEntry.fromReference(
+    this.K,
+    this.V,
     jni.JReference reference,
   ) : super.fromReference(reference);
 
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/generics/GrandParent$Parent');
+  static final _class =
+      jni.JClass.forName(r'com/github/dart_lang/jnigen/generics/MyMap$MyEntry');
 
   /// The type which includes information such as the signature of this class.
-  static $GrandParent_ParentType<$T, $S>
-      type<$T extends jni.JObject, $S extends jni.JObject>(
-    jni.JObjType<$T> T,
-    jni.JObjType<$S> S,
+  static $MyMap_MyEntryType<$K, $V>
+      type<$K extends jni.JObject, $V extends jni.JObject>(
+    jni.JObjType<$K> K,
+    jni.JObjType<$V> V,
   ) {
-    return $GrandParent_ParentType(
-      T,
-      S,
+    return $MyMap_MyEntryType(
+      K,
+      V,
     );
   }
 
-  static final _id_parentValue = _class.instanceFieldId(
-    r'parentValue',
+  static final _id_key = _class.instanceFieldId(
+    r'key',
     r'Ljava/lang/Object;',
   );
 
-  /// from: `public T parentValue`
+  /// from: `public K key`
   /// The returned object must be released after use, by calling the [release] method.
-  $T get parentValue => _id_parentValue.get(this, T);
+  $K get key => _id_key.get(this, K);
 
-  /// from: `public T parentValue`
+  /// from: `public K key`
   /// The returned object must be released after use, by calling the [release] method.
-  set parentValue($T value) => _id_parentValue.set(this, T, value);
+  set key($K value) => _id_key.set(this, K, value);
 
   static final _id_value = _class.instanceFieldId(
     r'value',
     r'Ljava/lang/Object;',
   );
 
-  /// from: `public S value`
+  /// from: `public V value`
   /// The returned object must be released after use, by calling the [release] method.
-  $S get value => _id_value.get(this, S);
+  $V get value => _id_value.get(this, V);
 
-  /// from: `public S value`
+  /// from: `public V value`
   /// The returned object must be released after use, by calling the [release] method.
-  set value($S value) => _id_value.set(this, S, value);
+  set value($V value) => _id_value.set(this, V, value);
 
   static final _id_new$ = _class.constructorId(
-    r'(Lcom/github/dart_lang/jnigen/generics/GrandParent;Ljava/lang/Object;)V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                  ffi.Pointer<ffi.Void>,
-                  jni.JMethodIDPtr,
-                  ffi.VarArgs<
-                      (
-                        ffi.Pointer<ffi.Void>,
-                        ffi.Pointer<ffi.Void>
-                      )>)>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
-
-  /// from: `public void <init>(com.github.dart_lang.jnigen.generics.GrandParent $parent, S newValue)`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory GrandParent_Parent(
-    GrandParent<$T> $parent,
-    $S newValue, {
-    jni.JObjType<$T>? T,
-    jni.JObjType<$S>? S,
-  }) {
-    T ??= jni.lowestCommonSuperType([
-      ($parent.$type as $GrandParentType).T,
-    ]) as jni.JObjType<$T>;
-    S ??= jni.lowestCommonSuperType([
-      newValue.$type,
-    ]) as jni.JObjType<$S>;
-    return GrandParent_Parent.fromReference(
-        T,
-        S,
-        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr,
-                $parent.reference.pointer, newValue.reference.pointer)
-            .reference);
-  }
-}
-
-final class $GrandParent_ParentType<$T extends jni.JObject,
-    $S extends jni.JObject> extends jni.JObjType<GrandParent_Parent<$T, $S>> {
-  final jni.JObjType<$T> T;
-  final jni.JObjType<$S> S;
-
-  const $GrandParent_ParentType(
-    this.T,
-    this.S,
-  );
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent;';
-
-  @override
-  GrandParent_Parent<$T, $S> fromReference(jni.JReference reference) =>
-      GrandParent_Parent.fromReference(T, S, reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => Object.hash($GrandParent_ParentType, T, S);
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent_ParentType<$T, $S>) &&
-        other is $GrandParent_ParentType<$T, $S> &&
-        T == other.T &&
-        S == other.S;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.generics.GrandParent$Parent$Child`
-class GrandParent_Parent_Child<$T extends jni.JObject, $S extends jni.JObject,
-    $U extends jni.JObject> extends jni.JObject {
-  @override
-  late final jni.JObjType<GrandParent_Parent_Child<$T, $S, $U>> $type =
-      type(T, S, U);
-
-  final jni.JObjType<$T> T;
-  final jni.JObjType<$S> S;
-  final jni.JObjType<$U> U;
-
-  GrandParent_Parent_Child.fromReference(
-    this.T,
-    this.S,
-    this.U,
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/generics/GrandParent$Parent$Child');
-
-  /// The type which includes information such as the signature of this class.
-  static $GrandParent_Parent_ChildType<$T, $S, $U> type<$T extends jni.JObject,
-      $S extends jni.JObject, $U extends jni.JObject>(
-    jni.JObjType<$T> T,
-    jni.JObjType<$S> S,
-    jni.JObjType<$U> U,
-  ) {
-    return $GrandParent_Parent_ChildType(
-      T,
-      S,
-      U,
-    );
-  }
-
-  static final _id_grandParentValue = _class.instanceFieldId(
-    r'grandParentValue',
-    r'Ljava/lang/Object;',
-  );
-
-  /// from: `public T grandParentValue`
-  /// The returned object must be released after use, by calling the [release] method.
-  $T get grandParentValue => _id_grandParentValue.get(this, T);
-
-  /// from: `public T grandParentValue`
-  /// The returned object must be released after use, by calling the [release] method.
-  set grandParentValue($T value) => _id_grandParentValue.set(this, T, value);
-
-  static final _id_parentValue = _class.instanceFieldId(
-    r'parentValue',
-    r'Ljava/lang/Object;',
-  );
-
-  /// from: `public S parentValue`
-  /// The returned object must be released after use, by calling the [release] method.
-  $S get parentValue => _id_parentValue.get(this, S);
-
-  /// from: `public S parentValue`
-  /// The returned object must be released after use, by calling the [release] method.
-  set parentValue($S value) => _id_parentValue.set(this, S, value);
-
-  static final _id_value = _class.instanceFieldId(
-    r'value',
-    r'Ljava/lang/Object;',
-  );
-
-  /// from: `public U value`
-  /// The returned object must be released after use, by calling the [release] method.
-  $U get value => _id_value.get(this, U);
-
-  /// from: `public U value`
-  /// The returned object must be released after use, by calling the [release] method.
-  set value($U value) => _id_value.set(this, U, value);
-
-  static final _id_new$ = _class.constructorId(
-    r'(Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent;Ljava/lang/Object;)V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                  ffi.Pointer<ffi.Void>,
-                  jni.JMethodIDPtr,
-                  ffi.VarArgs<
-                      (
-                        ffi.Pointer<ffi.Void>,
-                        ffi.Pointer<ffi.Void>
-                      )>)>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
-
-  /// from: `public void <init>(com.github.dart_lang.jnigen.generics.GrandParent$Parent $parent, U newValue)`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory GrandParent_Parent_Child(
-    GrandParent_Parent<$T, $S> $parent,
-    $U newValue, {
-    jni.JObjType<$T>? T,
-    jni.JObjType<$S>? S,
-    jni.JObjType<$U>? U,
-  }) {
-    T ??= jni.lowestCommonSuperType([
-      ($parent.$type as $GrandParent_ParentType).T,
-    ]) as jni.JObjType<$T>;
-    S ??= jni.lowestCommonSuperType([
-      ($parent.$type as $GrandParent_ParentType).S,
-    ]) as jni.JObjType<$S>;
-    U ??= jni.lowestCommonSuperType([
-      newValue.$type,
-    ]) as jni.JObjType<$U>;
-    return GrandParent_Parent_Child.fromReference(
-        T,
-        S,
-        U,
-        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr,
-                $parent.reference.pointer, newValue.reference.pointer)
-            .reference);
-  }
-}
-
-final class $GrandParent_Parent_ChildType<$T extends jni.JObject,
-        $S extends jni.JObject, $U extends jni.JObject>
-    extends jni.JObjType<GrandParent_Parent_Child<$T, $S, $U>> {
-  final jni.JObjType<$T> T;
-  final jni.JObjType<$S> S;
-  final jni.JObjType<$U> U;
-
-  const $GrandParent_Parent_ChildType(
-    this.T,
-    this.S,
-    this.U,
-  );
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent$Child;';
-
-  @override
-  GrandParent_Parent_Child<$T, $S, $U> fromReference(
-          jni.JReference reference) =>
-      GrandParent_Parent_Child.fromReference(T, S, U, reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => Object.hash($GrandParent_Parent_ChildType, T, S, U);
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent_Parent_ChildType<$T, $S, $U>) &&
-        other is $GrandParent_Parent_ChildType<$T, $S, $U> &&
-        T == other.T &&
-        S == other.S &&
-        U == other.U;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.generics.GrandParent$StaticParent`
-class GrandParent_StaticParent<$S extends jni.JObject> extends jni.JObject {
-  @override
-  late final jni.JObjType<GrandParent_StaticParent<$S>> $type = type(S);
-
-  final jni.JObjType<$S> S;
-
-  GrandParent_StaticParent.fromReference(
-    this.S,
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/generics/GrandParent$StaticParent');
-
-  /// The type which includes information such as the signature of this class.
-  static $GrandParent_StaticParentType<$S> type<$S extends jni.JObject>(
-    jni.JObjType<$S> S,
-  ) {
-    return $GrandParent_StaticParentType(
-      S,
-    );
-  }
-
-  static final _id_value = _class.instanceFieldId(
-    r'value',
-    r'Ljava/lang/Object;',
-  );
-
-  /// from: `public S value`
-  /// The returned object must be released after use, by calling the [release] method.
-  $S get value => _id_value.get(this, S);
-
-  /// from: `public S value`
-  /// The returned object must be released after use, by calling the [release] method.
-  set value($S value) => _id_value.set(this, S, value);
-
-  static final _id_new$ = _class.constructorId(
-    r'(Ljava/lang/Object;)V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-              ffi.NativeFunction<
-                  jni.JniResult Function(
-                      ffi.Pointer<ffi.Void>,
-                      jni.JMethodIDPtr,
-                      ffi.VarArgs<(ffi.Pointer<ffi.Void>,)>)>>(
-          'globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(ffi.Pointer<ffi.Void>, jni.JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>();
-
-  /// from: `public void <init>(S value)`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory GrandParent_StaticParent(
-    $S value, {
-    jni.JObjType<$S>? S,
-  }) {
-    S ??= jni.lowestCommonSuperType([
-      value.$type,
-    ]) as jni.JObjType<$S>;
-    return GrandParent_StaticParent.fromReference(
-        S,
-        _new$(_class.reference.pointer, _id_new$ as jni.JMethodIDPtr,
-                value.reference.pointer)
-            .reference);
-  }
-}
-
-final class $GrandParent_StaticParentType<$S extends jni.JObject>
-    extends jni.JObjType<GrandParent_StaticParent<$S>> {
-  final jni.JObjType<$S> S;
-
-  const $GrandParent_StaticParentType(
-    this.S,
-  );
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent;';
-
-  @override
-  GrandParent_StaticParent<$S> fromReference(jni.JReference reference) =>
-      GrandParent_StaticParent.fromReference(S, reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => Object.hash($GrandParent_StaticParentType, S);
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent_StaticParentType<$S>) &&
-        other is $GrandParent_StaticParentType<$S> &&
-        S == other.S;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.generics.GrandParent$StaticParent$Child`
-class GrandParent_StaticParent_Child<$S extends jni.JObject,
-    $U extends jni.JObject> extends jni.JObject {
-  @override
-  late final jni.JObjType<GrandParent_StaticParent_Child<$S, $U>> $type =
-      type(S, U);
-
-  final jni.JObjType<$S> S;
-  final jni.JObjType<$U> U;
-
-  GrandParent_StaticParent_Child.fromReference(
-    this.S,
-    this.U,
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class = jni.JClass.forName(
-      r'com/github/dart_lang/jnigen/generics/GrandParent$StaticParent$Child');
-
-  /// The type which includes information such as the signature of this class.
-  static $GrandParent_StaticParent_ChildType<$S, $U>
-      type<$S extends jni.JObject, $U extends jni.JObject>(
-    jni.JObjType<$S> S,
-    jni.JObjType<$U> U,
-  ) {
-    return $GrandParent_StaticParent_ChildType(
-      S,
-      U,
-    );
-  }
-
-  static final _id_parentValue = _class.instanceFieldId(
-    r'parentValue',
-    r'Ljava/lang/Object;',
-  );
-
-  /// from: `public S parentValue`
-  /// The returned object must be released after use, by calling the [release] method.
-  $S get parentValue => _id_parentValue.get(this, S);
-
-  /// from: `public S parentValue`
-  /// The returned object must be released after use, by calling the [release] method.
-  set parentValue($S value) => _id_parentValue.set(this, S, value);
-
-  static final _id_value = _class.instanceFieldId(
-    r'value',
-    r'Ljava/lang/Object;',
-  );
-
-  /// from: `public U value`
-  /// The returned object must be released after use, by calling the [release] method.
-  $U get value => _id_value.get(this, U);
-
-  /// from: `public U value`
-  /// The returned object must be released after use, by calling the [release] method.
-  set value($U value) => _id_value.set(this, U, value);
-
-  static final _id_new$ = _class.constructorId(
-    r'(Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent;Ljava/lang/Object;Ljava/lang/Object;)V',
+    r'(Lcom/github/dart_lang/jnigen/generics/MyMap;Ljava/lang/Object;Ljava/lang/Object;)V',
   );
 
   static final _new$ = ProtectedJniExtensions.lookup<
@@ -3342,54 +3488,53 @@ class GrandParent_StaticParent_Child<$S extends jni.JObject,
               ffi.Pointer<ffi.Void>,
               ffi.Pointer<ffi.Void>)>();
 
-  /// from: `public void <init>(com.github.dart_lang.jnigen.generics.GrandParent$StaticParent $parent, S parentValue, U value)`
+  /// from: `public void <init>(com.github.dart_lang.jnigen.generics.MyMap $parent, K key, V value)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory GrandParent_StaticParent_Child(
-    GrandParent_StaticParent<$S> $parent,
-    $S parentValue,
-    $U value, {
-    jni.JObjType<$S>? S,
-    jni.JObjType<$U>? U,
+  factory MyMap_MyEntry(
+    MyMap<$K, $V> $parent,
+    $K key,
+    $V value, {
+    jni.JObjType<$K>? K,
+    jni.JObjType<$V>? V,
   }) {
-    S ??= jni.lowestCommonSuperType([
-      parentValue.$type,
-      ($parent.$type as $GrandParent_StaticParentType).S,
-    ]) as jni.JObjType<$S>;
-    U ??= jni.lowestCommonSuperType([
+    K ??= jni.lowestCommonSuperType([
+      key.$type,
+      ($parent.$type as $MyMapType).K,
+    ]) as jni.JObjType<$K>;
+    V ??= jni.lowestCommonSuperType([
       value.$type,
-    ]) as jni.JObjType<$U>;
-    return GrandParent_StaticParent_Child.fromReference(
-        S,
-        U,
+      ($parent.$type as $MyMapType).V,
+    ]) as jni.JObjType<$V>;
+    return MyMap_MyEntry.fromReference(
+        K,
+        V,
         _new$(
                 _class.reference.pointer,
                 _id_new$ as jni.JMethodIDPtr,
                 $parent.reference.pointer,
-                parentValue.reference.pointer,
+                key.reference.pointer,
                 value.reference.pointer)
             .reference);
   }
 }
 
-final class $GrandParent_StaticParent_ChildType<$S extends jni.JObject,
-        $U extends jni.JObject>
-    extends jni.JObjType<GrandParent_StaticParent_Child<$S, $U>> {
-  final jni.JObjType<$S> S;
-  final jni.JObjType<$U> U;
+final class $MyMap_MyEntryType<$K extends jni.JObject, $V extends jni.JObject>
+    extends jni.JObjType<MyMap_MyEntry<$K, $V>> {
+  final jni.JObjType<$K> K;
+  final jni.JObjType<$V> V;
 
-  const $GrandParent_StaticParent_ChildType(
-    this.S,
-    this.U,
+  const $MyMap_MyEntryType(
+    this.K,
+    this.V,
   );
 
   @override
   String get signature =>
-      r'Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent$Child;';
+      r'Lcom/github/dart_lang/jnigen/generics/MyMap$MyEntry;';
 
   @override
-  GrandParent_StaticParent_Child<$S, $U> fromReference(
-          jni.JReference reference) =>
-      GrandParent_StaticParent_Child.fromReference(S, U, reference);
+  MyMap_MyEntry<$K, $V> fromReference(jni.JReference reference) =>
+      MyMap_MyEntry.fromReference(K, V, reference);
 
   @override
   jni.JObjType get superType => const jni.JObjectType();
@@ -3398,14 +3543,14 @@ final class $GrandParent_StaticParent_ChildType<$S extends jni.JObject,
   final superCount = 1;
 
   @override
-  int get hashCode => Object.hash($GrandParent_StaticParent_ChildType, S, U);
+  int get hashCode => Object.hash($MyMap_MyEntryType, K, V);
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent_StaticParent_ChildType<$S, $U>) &&
-        other is $GrandParent_StaticParent_ChildType<$S, $U> &&
-        S == other.S &&
-        U == other.U;
+    return other.runtimeType == ($MyMap_MyEntryType<$K, $V>) &&
+        other is $MyMap_MyEntryType<$K, $V> &&
+        K == other.K &&
+        V == other.V;
   }
 }
 
@@ -3580,151 +3725,6 @@ final class $MyMapType<$K extends jni.JObject, $V extends jni.JObject>
   bool operator ==(Object other) {
     return other.runtimeType == ($MyMapType<$K, $V>) &&
         other is $MyMapType<$K, $V> &&
-        K == other.K &&
-        V == other.V;
-  }
-}
-
-/// from: `com.github.dart_lang.jnigen.generics.MyMap$MyEntry`
-class MyMap_MyEntry<$K extends jni.JObject, $V extends jni.JObject>
-    extends jni.JObject {
-  @override
-  late final jni.JObjType<MyMap_MyEntry<$K, $V>> $type = type(K, V);
-
-  final jni.JObjType<$K> K;
-  final jni.JObjType<$V> V;
-
-  MyMap_MyEntry.fromReference(
-    this.K,
-    this.V,
-    jni.JReference reference,
-  ) : super.fromReference(reference);
-
-  static final _class =
-      jni.JClass.forName(r'com/github/dart_lang/jnigen/generics/MyMap$MyEntry');
-
-  /// The type which includes information such as the signature of this class.
-  static $MyMap_MyEntryType<$K, $V>
-      type<$K extends jni.JObject, $V extends jni.JObject>(
-    jni.JObjType<$K> K,
-    jni.JObjType<$V> V,
-  ) {
-    return $MyMap_MyEntryType(
-      K,
-      V,
-    );
-  }
-
-  static final _id_key = _class.instanceFieldId(
-    r'key',
-    r'Ljava/lang/Object;',
-  );
-
-  /// from: `public K key`
-  /// The returned object must be released after use, by calling the [release] method.
-  $K get key => _id_key.get(this, K);
-
-  /// from: `public K key`
-  /// The returned object must be released after use, by calling the [release] method.
-  set key($K value) => _id_key.set(this, K, value);
-
-  static final _id_value = _class.instanceFieldId(
-    r'value',
-    r'Ljava/lang/Object;',
-  );
-
-  /// from: `public V value`
-  /// The returned object must be released after use, by calling the [release] method.
-  $V get value => _id_value.get(this, V);
-
-  /// from: `public V value`
-  /// The returned object must be released after use, by calling the [release] method.
-  set value($V value) => _id_value.set(this, V, value);
-
-  static final _id_new$ = _class.constructorId(
-    r'(Lcom/github/dart_lang/jnigen/generics/MyMap;Ljava/lang/Object;Ljava/lang/Object;)V',
-  );
-
-  static final _new$ = ProtectedJniExtensions.lookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                  ffi.Pointer<ffi.Void>,
-                  jni.JMethodIDPtr,
-                  ffi.VarArgs<
-                      (
-                        ffi.Pointer<ffi.Void>,
-                        ffi.Pointer<ffi.Void>,
-                        ffi.Pointer<ffi.Void>
-                      )>)>>('globalEnv_NewObject')
-      .asFunction<
-          jni.JniResult Function(
-              ffi.Pointer<ffi.Void>,
-              jni.JMethodIDPtr,
-              ffi.Pointer<ffi.Void>,
-              ffi.Pointer<ffi.Void>,
-              ffi.Pointer<ffi.Void>)>();
-
-  /// from: `public void <init>(com.github.dart_lang.jnigen.generics.MyMap $parent, K key, V value)`
-  /// The returned object must be released after use, by calling the [release] method.
-  factory MyMap_MyEntry(
-    MyMap<$K, $V> $parent,
-    $K key,
-    $V value, {
-    jni.JObjType<$K>? K,
-    jni.JObjType<$V>? V,
-  }) {
-    K ??= jni.lowestCommonSuperType([
-      key.$type,
-      ($parent.$type as $MyMapType).K,
-    ]) as jni.JObjType<$K>;
-    V ??= jni.lowestCommonSuperType([
-      value.$type,
-      ($parent.$type as $MyMapType).V,
-    ]) as jni.JObjType<$V>;
-    return MyMap_MyEntry.fromReference(
-        K,
-        V,
-        _new$(
-                _class.reference.pointer,
-                _id_new$ as jni.JMethodIDPtr,
-                $parent.reference.pointer,
-                key.reference.pointer,
-                value.reference.pointer)
-            .reference);
-  }
-}
-
-final class $MyMap_MyEntryType<$K extends jni.JObject, $V extends jni.JObject>
-    extends jni.JObjType<MyMap_MyEntry<$K, $V>> {
-  final jni.JObjType<$K> K;
-  final jni.JObjType<$V> V;
-
-  const $MyMap_MyEntryType(
-    this.K,
-    this.V,
-  );
-
-  @override
-  String get signature =>
-      r'Lcom/github/dart_lang/jnigen/generics/MyMap$MyEntry;';
-
-  @override
-  MyMap_MyEntry<$K, $V> fromReference(jni.JReference reference) =>
-      MyMap_MyEntry.fromReference(K, V, reference);
-
-  @override
-  jni.JObjType get superType => const jni.JObjectType();
-
-  @override
-  final superCount = 1;
-
-  @override
-  int get hashCode => Object.hash($MyMap_MyEntryType, K, V);
-
-  @override
-  bool operator ==(Object other) {
-    return other.runtimeType == ($MyMap_MyEntryType<$K, $V>) &&
-        other is $MyMap_MyEntryType<$K, $V> &&
         K == other.K &&
         V == other.V;
   }
@@ -5815,6 +5815,164 @@ final class $JsonSerializable_CaseType
   bool operator ==(Object other) {
     return other.runtimeType == ($JsonSerializable_CaseType) &&
         other is $JsonSerializable_CaseType;
+  }
+}
+
+/// from: `com.github.dart_lang.jnigen.annotations.JsonSerializable`
+class JsonSerializable extends jni.JObject {
+  @override
+  late final jni.JObjType<JsonSerializable> $type = type;
+
+  JsonSerializable.fromReference(
+    jni.JReference reference,
+  ) : super.fromReference(reference);
+
+  static final _class = jni.JClass.forName(
+      r'com/github/dart_lang/jnigen/annotations/JsonSerializable');
+
+  /// The type which includes information such as the signature of this class.
+  static const type = $JsonSerializableType();
+  static final _id_value = _class.instanceMethodId(
+    r'value',
+    r'()Lcom/github/dart_lang/jnigen/annotations/JsonSerializable$Case;',
+  );
+
+  static final _value = ProtectedJniExtensions.lookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                ffi.Pointer<ffi.Void>,
+                jni.JMethodIDPtr,
+              )>>('globalEnv_CallObjectMethod')
+      .asFunction<
+          jni.JniResult Function(
+            ffi.Pointer<ffi.Void>,
+            jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public abstract com.github.dart_lang.jnigen.annotations.JsonSerializable$Case value()`
+  /// The returned object must be released after use, by calling the [release] method.
+  JsonSerializable_Case value() {
+    return _value(reference.pointer, _id_value as jni.JMethodIDPtr)
+        .object(const $JsonSerializable_CaseType());
+  }
+
+  /// Maps a specific port to the implemented interface.
+  static final Map<int, $JsonSerializableImpl> _$impls = {};
+  ReceivePort? _$p;
+
+  static jni.JObjectPtr _$invoke(
+    int port,
+    jni.JObjectPtr descriptor,
+    jni.JObjectPtr args,
+  ) {
+    return _$invokeMethod(
+      port,
+      $MethodInvocation.fromAddresses(
+        0,
+        descriptor.address,
+        args.address,
+      ),
+    );
+  }
+
+  static final ffi.Pointer<
+          ffi.NativeFunction<
+              jni.JObjectPtr Function(
+                  ffi.Uint64, jni.JObjectPtr, jni.JObjectPtr)>>
+      _$invokePointer = ffi.Pointer.fromFunction(_$invoke);
+
+  static ffi.Pointer<ffi.Void> _$invokeMethod(
+    int $p,
+    $MethodInvocation $i,
+  ) {
+    try {
+      final $d = $i.methodDescriptor.toDartString(releaseOriginal: true);
+      final $a = $i.args;
+      if ($d ==
+          r'value()Lcom/github/dart_lang/jnigen/annotations/JsonSerializable$Case;') {
+        final $r = _$impls[$p]!.value();
+        return ($r as jni.JObject)
+            .castTo(const jni.JObjectType())
+            .reference
+            .toPointer();
+      }
+    } catch (e) {
+      return ProtectedJniExtensions.newDartException(e);
+    }
+    return jni.nullptr;
+  }
+
+  factory JsonSerializable.implement(
+    $JsonSerializableImpl $impl,
+  ) {
+    final $p = ReceivePort();
+    final $x = JsonSerializable.fromReference(
+      ProtectedJniExtensions.newPortProxy(
+        r'com.github.dart_lang.jnigen.annotations.JsonSerializable',
+        $p,
+        _$invokePointer,
+      ),
+    ).._$p = $p;
+    final $a = $p.sendPort.nativePort;
+    _$impls[$a] = $impl;
+    $p.listen(($m) {
+      if ($m == null) {
+        _$impls.remove($p.sendPort.nativePort);
+        $p.close();
+        return;
+      }
+      final $i = $MethodInvocation.fromMessage($m as List<dynamic>);
+      final $r = _$invokeMethod($p.sendPort.nativePort, $i);
+      ProtectedJniExtensions.returnResult($i.result, $r);
+    });
+    return $x;
+  }
+}
+
+abstract interface class $JsonSerializableImpl {
+  factory $JsonSerializableImpl({
+    required JsonSerializable_Case Function() value,
+  }) = _$JsonSerializableImpl;
+
+  JsonSerializable_Case value();
+}
+
+class _$JsonSerializableImpl implements $JsonSerializableImpl {
+  _$JsonSerializableImpl({
+    required JsonSerializable_Case Function() value,
+  }) : _value = value;
+
+  final JsonSerializable_Case Function() _value;
+
+  JsonSerializable_Case value() {
+    return _value();
+  }
+}
+
+final class $JsonSerializableType extends jni.JObjType<JsonSerializable> {
+  const $JsonSerializableType();
+
+  @override
+  String get signature =>
+      r'Lcom/github/dart_lang/jnigen/annotations/JsonSerializable;';
+
+  @override
+  JsonSerializable fromReference(jni.JReference reference) =>
+      JsonSerializable.fromReference(reference);
+
+  @override
+  jni.JObjType get superType => const jni.JObjectType();
+
+  @override
+  final superCount = 1;
+
+  @override
+  int get hashCode => ($JsonSerializableType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($JsonSerializableType) &&
+        other is $JsonSerializableType;
   }
 }
 

--- a/pkgs/jnigen/test/simple_package_test/generate.dart
+++ b/pkgs/jnigen/test/simple_package_test/generate.dart
@@ -67,7 +67,7 @@ Config getConfig() {
   );
   final config = Config(
     sourcePath: [Uri.directory(javaPath)],
-    classPath: null, // Not passing in classpath as source path is prioritized.
+    classPath: [Uri.directory(javaPath)],
     classes: [
       'com.github.dart_lang.jnigen.simple_package',
       'com.github.dart_lang.jnigen.pkg2',

--- a/pkgs/jnigen/test/simple_package_test/generate.dart
+++ b/pkgs/jnigen/test/simple_package_test/generate.dart
@@ -24,24 +24,32 @@ const preamble = '''
 final javaPrefix = join('com', 'github', 'dart_lang', 'jnigen');
 
 final javaFiles = [
+  join(javaPrefix, 'annotations', 'JsonSerializable.java'),
+  join(javaPrefix, 'annotations', 'MyDataClass.java'),
+  join(javaPrefix, 'simple_package', 'Color.java'),
   join(javaPrefix, 'simple_package', 'Example.java'),
+  join(javaPrefix, 'simple_package', 'Exceptions.java'),
+  join(javaPrefix, 'simple_package', 'Fields.java'),
   join(javaPrefix, 'pkg2', 'C2.java'),
   join(javaPrefix, 'pkg2', 'Example.java'),
   join(javaPrefix, 'generics', 'MyStack.java'),
   join(javaPrefix, 'generics', 'MyMap.java'),
+  join(javaPrefix, 'generics', 'GenericTypeParams.java'),
   join(javaPrefix, 'generics', 'GrandParent.java'),
   join(javaPrefix, 'generics', 'StringStack.java'),
-  join(javaPrefix, 'generics', 'StringValuedMap.java'),
   join(javaPrefix, 'generics', 'StringKeyedMap.java'),
-  join(javaPrefix, 'interfaces', 'MyRunnable.java'),
-  join(javaPrefix, 'interfaces', 'MyRunnableRunner.java'),
+  join(javaPrefix, 'generics', 'StringMap.java'),
+  join(javaPrefix, 'generics', 'StringValuedMap.java'),
+  join(javaPrefix, 'inheritance', 'BaseClass.java'),
+  join(javaPrefix, 'inheritance', 'GenericDerivedClass.java'),
+  join(javaPrefix, 'inheritance', 'SpecificDerivedClass.java'),
   join(javaPrefix, 'interfaces', 'MyInterface.java'),
   join(javaPrefix, 'interfaces', 'MyInterfaceConsumer.java'),
+  join(javaPrefix, 'interfaces', 'MyRunnable.java'),
+  join(javaPrefix, 'interfaces', 'MyRunnableRunner.java'),
   join(javaPrefix, 'interfaces', 'StringConversionException.java'),
   join(javaPrefix, 'interfaces', 'StringConverter.java'),
   join(javaPrefix, 'interfaces', 'StringConverterConsumer.java'),
-  join(javaPrefix, 'annotations', 'JsonSerializable.java'),
-  join(javaPrefix, 'annotations', 'MyDataClass.java'),
 ];
 
 void compileJavaSources(String workingDir, List<String> files) async {
@@ -59,12 +67,13 @@ Config getConfig() {
   );
   final config = Config(
     sourcePath: [Uri.directory(javaPath)],
-    classPath: [Uri.directory(javaPath)],
+    classPath: null, // Not passing in classpath as source path is prioritized.
     classes: [
       'com.github.dart_lang.jnigen.simple_package',
       'com.github.dart_lang.jnigen.pkg2',
       'com.github.dart_lang.jnigen.generics',
       'com.github.dart_lang.jnigen.interfaces',
+      'com.github.dart_lang.jnigen.inheritance',
       'com.github.dart_lang.jnigen.annotations',
     ],
     logLevel: Level.INFO,


### PR DESCRIPTION
Updated the dependencies including lints.
Fixed new lint errors.
Added `@internal` annotation on elements that should only be exported from `_internal.dart`.
Ignore the correct lints in the JNIgen generated code.