### PR TITLE
[ffigen] Run ObjC tests on flutter test

### DIFF
--- a/.github/workflows/ffigen.yml
+++ b/.github/workflows/ffigen.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Build test dylib and bindings
         run: dart test/setup.dart
       - name: Run VM tests and collect coverage
-        run: dart run coverage:test_with_coverage --scope-output=ffigen --scope-output=objective_c
+        run: flutter test --coverage --coverage-path=coverage/lcov.info
       - name: Upload coverage
         uses: coverallsapp/github-action@643bc377ffa44ace6394b2b5d0d3950076de9f63
         with:

--- a/.github/workflows/ffigen.yml
+++ b/.github/workflows/ffigen.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Build test dylib and bindings
         run: dart test/setup.dart
       - name: Run VM tests and collect coverage
-        run: flutter test --coverage --coverage-path=coverage/lcov.info
+        run: dart run coverage:test_with_coverage --scope-output=ffigen --scope-output=objective_c
       - name: Upload coverage
         uses: coverallsapp/github-action@643bc377ffa44ace6394b2b5d0d3950076de9f63
         with:
@@ -97,6 +97,24 @@ jobs:
           carryforward: "ffigen,jni,jnigen,native_assets_builder_macos,native_assets_builder_ubuntu,native_assets_builder_windows,native_assets_cli_macos,native_assets_cli_ubuntu,native_assets_cli_windows,native_toolchain_c_macos,native_toolchain_c_ubuntu,native_toolchain_c_windows,objective_c,swift2objc"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
+
+  test-mac-flutter:
+    needs: analyze
+    runs-on: 'macos-latest'
+    defaults:
+      run:
+        working-directory: pkgs/ffigen/
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - uses: subosito/flutter-action@44ac965b96f18d999802d4b807e3256d5a3f9fa1
+        with:
+          channel: 'stable'
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Build test dylib and bindings
+        run: dart test/setup.dart
+      - name: Run Flutter tests
+        run: flutter test
 
   test-windows:
     needs: analyze

--- a/.github/workflows/ffigen_weekly.yml
+++ b/.github/workflows/ffigen_weekly.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Build test dylib and bindings
         run: dart test/setup.dart
       - name: Run VM tests
-        run: dart test
+        run: flutter test

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   ffi: ^2.0.1
   file: ^7.0.0
   glob: ^2.0.0
-  leak_tracker: ^10.0.7
   logging: ^1.0.0
   package_config: ^2.1.0
   path: ^1.8.0
@@ -37,6 +36,7 @@ dev_dependencies:
   coverage: ^1.8.0
   dart_flutter_team_lints: ^2.0.0
   json_schema: ^5.1.1
+  leak_tracker: ^10.0.7
   meta: ^1.11.0
   objective_c: ^2.0.0
   test: ^1.16.2

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -36,7 +36,6 @@ dev_dependencies:
   coverage: ^1.8.0
   dart_flutter_team_lints: ^2.0.0
   json_schema: ^5.1.1
-  leak_tracker: ^10.0.7
   meta: ^1.11.0
   objective_c: ^2.0.0
   test: ^1.16.2

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   ffi: ^2.0.1
   file: ^7.0.0
   glob: ^2.0.0
+  leak_tracker: ^10.0.7
   logging: ^1.0.0
   package_config: ^2.1.0
   path: ^1.8.0

--- a/pkgs/ffigen/test/header_parser_tests/dart_handle_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/dart_handle_test.dart
@@ -41,5 +41,5 @@ ${strings.headers}:
         '_expected_dart_handle_bindings.dart'
       ]);
     });
-  });
+  }, skip: isFlutterTester);
 }

--- a/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
+++ b/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
@@ -45,6 +45,7 @@ void main() {
       'allowsConstrainedNetworkAccess',
       'attributedString',
       'cachePolicy',
+      'candidateListTouchBarItem',
       'hyphenationFactor',
       'tag',
     };

--- a/pkgs/ffigen/test/native_objc_test/arc_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/arc_test.dart
@@ -61,18 +61,18 @@ void main() {
       return (obj1raw, obj2raw);
     }
 
-    test('new methods ref count correctly', () async {
+    test('new methods ref count correctly', () {
       // To get the GC to work correctly, the references to the objects all have
       // to be in a separate function.
       final counter = calloc<Int32>();
       counter.value = 0;
       final (obj1raw, obj2raw) = newMethodsInner(counter);
-      await doGC();
+      doGC();
       expect(objectRetainCount(obj1raw), 0);
       expect(objectRetainCount(obj2raw), 0);
       expect(counter.value, 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
     (Pointer<ObjCObject>, Pointer<ObjCObject>, Pointer<ObjCObject>)
         allocMethodsInner(Pointer<Int32> counter) {
@@ -99,17 +99,17 @@ void main() {
       return (obj1raw, obj2raw, obj3raw);
     }
 
-    test('alloc and init methods ref count correctly', () async {
+    test('alloc and init methods ref count correctly', () {
       final counter = calloc<Int32>();
       counter.value = 0;
       final (obj1raw, obj2raw, obj3raw) = allocMethodsInner(counter);
-      await doGC();
+      doGC();
       expect(objectRetainCount(obj1raw), 0);
       expect(objectRetainCount(obj2raw), 0);
       expect(objectRetainCount(obj3raw), 0);
       expect(counter.value, 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
     (
       Pointer<ObjCObject>,
@@ -186,7 +186,7 @@ void main() {
       );
     }
 
-    test('copy methods ref count correctly', () async {
+    test('copy methods ref count correctly', () {
       final counter = calloc<Int32>();
       counter.value = 0;
       final (
@@ -200,7 +200,7 @@ void main() {
         obj8raw,
         obj9raw
       ) = copyMethodsInner(counter);
-      await doGC();
+      doGC();
       expect(objectRetainCount(obj1raw), 0);
       expect(objectRetainCount(obj2raw), 0);
       expect(objectRetainCount(obj3raw), 0);
@@ -212,7 +212,7 @@ void main() {
       expect(objectRetainCount(obj9raw), 0);
       expect(counter.value, 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
     Pointer<ObjCObject> autoreleaseMethodsInner(Pointer<Int32> counter) {
       final obj1 = ArcTestObject.makeAndAutorelease_(counter);
@@ -223,13 +223,13 @@ void main() {
       return obj1raw;
     }
 
-    test('autorelease methods ref count correctly', () async {
+    test('autorelease methods ref count correctly', () {
       final counter = calloc<Int32>();
       counter.value = 0;
 
       final pool1 = lib.objc_autoreleasePoolPush();
       final obj1raw = autoreleaseMethodsInner(counter);
-      await doGC();
+      doGC();
       // The autorelease pool is still holding a reference to the object.
       expect(counter.value, 1);
       expect(objectRetainCount(obj1raw), 1);
@@ -242,7 +242,7 @@ void main() {
       final obj2raw = obj2.ref.pointer;
       expect(counter.value, 1);
       expect(objectRetainCount(obj2raw), 2);
-      await doGC();
+      doGC();
       expect(counter.value, 1);
       expect(objectRetainCount(obj2raw), 2);
       lib.objc_autoreleasePoolPop(pool2);
@@ -254,7 +254,7 @@ void main() {
       expect(objectRetainCount(obj2raw), 0);
 
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
     Pointer<ObjCObject> assignPropertiesInnerInner(
         Pointer<Int32> counter, ArcTestObject outerObj) {
@@ -273,14 +273,14 @@ void main() {
       return assignObjRaw;
     }
 
-    Future<(Pointer<ObjCObject>, Pointer<ObjCObject>)> assignPropertiesInner(
-        Pointer<Int32> counter) async {
+    (Pointer<ObjCObject>, Pointer<ObjCObject>) assignPropertiesInner(
+        Pointer<Int32> counter) {
       final outerObj = ArcTestObject.newWithCounter_(counter);
       expect(counter.value, 1);
       final outerObjRaw = outerObj.ref.pointer;
       expect(objectRetainCount(outerObjRaw), 1);
       final assignObjRaw = assignPropertiesInnerInner(counter, outerObj);
-      await doGC();
+      doGC();
       // assignObj has been cleaned up.
       expect(counter.value, 1);
       expect(objectRetainCount(assignObjRaw), 0);
@@ -289,16 +289,16 @@ void main() {
       return (outerObjRaw, assignObjRaw);
     }
 
-    test('assign properties ref count correctly', () async {
+    test('assign properties ref count correctly', () {
       final counter = calloc<Int32>();
       counter.value = 0;
-      final (outerObjRaw, assignObjRaw) = await assignPropertiesInner(counter);
-      await doGC();
+      final (outerObjRaw, assignObjRaw) = assignPropertiesInner(counter);
+      doGC();
       expect(counter.value, 0);
       expect(objectRetainCount(assignObjRaw), 0);
       expect(objectRetainCount(outerObjRaw), 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
     Pointer<ObjCObject> retainPropertiesInnerInner(
         Pointer<Int32> counter, ArcTestObject outerObj) {
@@ -313,14 +313,14 @@ void main() {
       return retainObjRaw;
     }
 
-    Future<(Pointer<ObjCObject>, Pointer<ObjCObject>)> retainPropertiesInner(
-        Pointer<Int32> counter) async {
+    (Pointer<ObjCObject>, Pointer<ObjCObject>) retainPropertiesInner(
+        Pointer<Int32> counter) {
       final outerObj = ArcTestObject.newWithCounter_(counter);
       expect(counter.value, 1);
       final outerObjRaw = outerObj.ref.pointer;
       expect(objectRetainCount(outerObjRaw), 1);
       final retainObjRaw = retainPropertiesInnerInner(counter, outerObj);
-      await doGC();
+      doGC();
       // retainObj is still around, because outerObj retains a reference to it.
       expect(objectRetainCount(retainObjRaw), 2);
       expect(objectRetainCount(outerObjRaw), 1);
@@ -329,14 +329,14 @@ void main() {
       return (outerObjRaw, retainObjRaw);
     }
 
-    test('retain properties ref count correctly', () async {
+    test('retain properties ref count correctly', () {
       final counter = calloc<Int32>();
       counter.value = 0;
       // The getters of retain properties retain+autorelease the value. So we
       // need an autorelease pool.
       final pool = lib.objc_autoreleasePoolPush();
-      final (outerObjRaw, retainObjRaw) = await retainPropertiesInner(counter);
-      await doGC();
+      final (outerObjRaw, retainObjRaw) = retainPropertiesInner(counter);
+      doGC();
       expect(objectRetainCount(retainObjRaw), 1);
       expect(objectRetainCount(outerObjRaw), 0);
       expect(counter.value, 1);
@@ -345,7 +345,7 @@ void main() {
       expect(objectRetainCount(outerObjRaw), 0);
       expect(counter.value, 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
     (Pointer<ObjCObject>, Pointer<ObjCObject>, Pointer<ObjCObject>)
         copyPropertiesInner(Pointer<Int32> counter) {
@@ -375,7 +375,7 @@ void main() {
       return (outerObjRaw, copyObjRaw, anotherCopyRaw);
     }
 
-    test('copy properties ref count correctly', () async {
+    test('copy properties ref count correctly', () {
       final counter = calloc<Int32>();
       counter.value = 0;
       // The getters of copy properties retain+autorelease the value. So we need
@@ -383,7 +383,7 @@ void main() {
       final pool = lib.objc_autoreleasePoolPush();
       final (outerObjRaw, copyObjRaw, anotherCopyRaw) =
           copyPropertiesInner(counter);
-      await doGC();
+      doGC();
       expect(counter.value, 1);
       expect(objectRetainCount(outerObjRaw), 0);
       expect(objectRetainCount(copyObjRaw), 0);
@@ -394,7 +394,7 @@ void main() {
       expect(objectRetainCount(copyObjRaw), 0);
       expect(objectRetainCount(anotherCopyRaw), 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
     test('Manual release', () {
       final counter = calloc<Int32>();
@@ -441,7 +441,7 @@ void main() {
       expect(counter.value, 1);
     }
 
-    test('Consumed arguments', () async {
+    test('Consumed arguments', () {
       final counter = calloc<Int32>();
       ArcTestObject? obj1 = ArcTestObject.newWithCounter_(counter);
       final obj1raw = obj1.ref.pointer;
@@ -455,13 +455,13 @@ void main() {
       expect(counter.value, 1);
 
       obj1 = null;
-      await doGC();
+      doGC();
       expect(objectRetainCount(obj1raw), 0);
       expect(counter.value, 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
-    test('objectRetainCount large ref count', () async {
+    test('objectRetainCount large ref count', () {
       // Most ObjC API methods return us a reference without incrementing the
       // ref count (ie, returns us a reference we don't own). So the wrapper
       // object has to take ownership by calling retain. This test verifies that
@@ -470,9 +470,9 @@ void main() {
       final counter = calloc<Int32>();
       counter.value = 0;
       largeRefCountInner(counter);
-      await doGC();
+      doGC();
       expect(counter.value, 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/block_annotation_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_annotation_test.dart
@@ -11,10 +11,7 @@ import 'dart:async';
 import 'dart:ffi';
 import 'dart:io';
 
-import 'package:ffi/ffi.dart';
 import 'package:objective_c/objective_c.dart';
-import 'package:objective_c/src/internal.dart' as internal_for_testing
-    show blockHasRegisteredClosure;
 import 'package:test/test.dart';
 
 import '../test_utils.dart';
@@ -46,29 +43,29 @@ void main() {
       generateBindingsForCoverage('block_annotation');
     });
 
-    void objectProducerTest(EmptyObject producer()) {
+    Future<void> objectProducerTest(EmptyObject producer()) async {
       final pool = lib.objc_autoreleasePoolPush();
       EmptyObject? obj = producer();
       final ptr = obj.ref.pointer;
       lib.objc_autoreleasePoolPop(pool);
-      doGC();
+      await doGC();
       expect(objectRetainCount(ptr), 1);
       expect(obj, isNotNull);
       obj = null;
-      doGC();
+      await doGC();
       expect(objectRetainCount(ptr), 0);
     }
 
-    test('ObjectProducer, defined objC, invoked dart', () {
-      objectProducerTest(() {
+    test('ObjectProducer, defined objC, invoked dart', () async {
+      await objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>)> blk =
             BlockAnnotationTest.newObjectProducer();
         return blk(nullptr);
       });
     });
 
-    test('ObjectProducer, defined dart, invoked dart', () {
-      objectProducerTest(() {
+    test('ObjectProducer, defined dart, invoked dart', () async {
+      await objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyObject_ffiVoid.fromFunction(
                 (Pointer<Void> _) => EmptyObject.alloc().init());
@@ -76,8 +73,8 @@ void main() {
       });
     });
 
-    test('ObjectProducer, defined dart, invoked objC', () {
-      objectProducerTest(() {
+    test('ObjectProducer, defined dart, invoked objC', () async {
+      await objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyObject_ffiVoid.fromFunction(
                 (Pointer<Void> _) => EmptyObject.alloc().init());
@@ -85,8 +82,8 @@ void main() {
       });
     });
 
-    test('RetainedObjectProducer, defined objC, invoked dart', () {
-      objectProducerTest(() {
+    test('RetainedObjectProducer, defined objC, invoked dart', () async {
+      await objectProducerTest(() {
         ObjCBlock<Retained<EmptyObject> Function(Pointer<Void>)> blk =
             ObjCBlock<Retained<EmptyObject> Function(Pointer<Void>)>(
                 BlockAnnotationTest.newRetainedObjectProducer().ref.pointer,
@@ -96,8 +93,8 @@ void main() {
       });
     });
 
-    test('RetainedObjectProducer, defined dart, invoked dart', () {
-      objectProducerTest(() {
+    test('RetainedObjectProducer, defined dart, invoked dart', () async {
+      await objectProducerTest(() {
         ObjCBlock<Retained<EmptyObject> Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyObject_ffiVoid1.fromFunction(
                 (Pointer<Void> _) => EmptyObject.alloc().init());
@@ -105,8 +102,8 @@ void main() {
       });
     });
 
-    test('RetainedObjectProducer, defined dart, invoked objC', () {
-      objectProducerTest(() {
+    test('RetainedObjectProducer, defined dart, invoked objC', () async {
+      await objectProducerTest(() {
         ObjCBlock<Retained<EmptyObject> Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyObject_ffiVoid1.fromFunction(
                 (Pointer<Void> _) => EmptyObject.alloc().init());
@@ -116,16 +113,16 @@ void main() {
       });
     });
 
-    test('ObjectReceiver, defined objC, invoked dart', () {
-      objectProducerTest(() {
+    test('ObjectReceiver, defined objC, invoked dart', () async {
+      await objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>, EmptyObject)> blk =
             BlockAnnotationTest.newObjectReceiver();
         return blk(nullptr, EmptyObject.alloc().init());
       });
     });
 
-    test('ObjectReceiver, defined dart, invoked dart', () {
-      objectProducerTest(() {
+    test('ObjectReceiver, defined dart, invoked dart', () async {
+      await objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>, EmptyObject)> blk =
             ObjCBlock_EmptyObject_ffiVoid_EmptyObject.fromFunction(
                 (Pointer<Void> _, EmptyObject obj) => obj);
@@ -133,8 +130,8 @@ void main() {
       });
     });
 
-    test('ObjectReceiver, defined dart, invoked objC', () {
-      objectProducerTest(() {
+    test('ObjectReceiver, defined dart, invoked objC', () async {
+      await objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>, EmptyObject)> blk =
             ObjCBlock_EmptyObject_ffiVoid_EmptyObject.fromFunction(
                 (Pointer<Void> _, EmptyObject obj) => obj);
@@ -142,8 +139,8 @@ void main() {
       });
     });
 
-    test('ConsumedObjectReceiver, defined objC, invoked dart', () {
-      objectProducerTest(() {
+    test('ConsumedObjectReceiver, defined objC, invoked dart', () async {
+      await objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>, Consumed<EmptyObject>)>
             blk = ObjCBlock<
                     EmptyObject Function(Pointer<Void>, Consumed<EmptyObject>)>(
@@ -154,8 +151,8 @@ void main() {
       });
     });
 
-    test('ConsumedObjectReceiver, defined dart, invoked dart', () {
-      objectProducerTest(() {
+    test('ConsumedObjectReceiver, defined dart, invoked dart', () async {
+      await objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>, Consumed<EmptyObject>)>
             blk = ObjCBlock_EmptyObject_ffiVoid_EmptyObject1.fromFunction(
                 (Pointer<Void> _, EmptyObject obj) => obj);
@@ -163,8 +160,8 @@ void main() {
       });
     });
 
-    test('ConsumedObjectReceiver, defined dart, invoked objC', () {
-      objectProducerTest(() {
+    test('ConsumedObjectReceiver, defined dart, invoked objC', () async {
+      await objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>, Consumed<EmptyObject>)>
             blk = ObjCBlock_EmptyObject_ffiVoid_EmptyObject1.fromFunction(
                 (Pointer<Void> _, EmptyObject obj) => obj);
@@ -184,14 +181,14 @@ void main() {
       EmptyObject? obj = await completer.future;
       final ptr = obj.ref.pointer;
       lib.objc_autoreleasePoolPop(pool);
-      doGC();
+      await doGC();
       expect(objectRetainCount(ptr), 1);
       expect(obj, isNotNull);
       obj = null;
       completer = null;
-      doGC();
+      await doGC();
       await Future<void>.delayed(Duration.zero); // Let dispose message arrive.
-      doGC();
+      await doGC();
       expect(objectRetainCount(ptr), 0);
     }
 
@@ -260,29 +257,29 @@ void main() {
       });
     });
 
-    void blockProducerTest(DartEmptyBlock producer()) {
+    Future<void> blockProducerTest(DartEmptyBlock producer()) async {
       final pool = lib.objc_autoreleasePoolPush();
       DartEmptyBlock? obj = producer();
       final ptr = obj.ref.pointer;
       lib.objc_autoreleasePoolPop(pool);
-      doGC();
+      await doGC();
       expect(blockRetainCount(ptr), 1);
       expect(obj, isNotNull);
       obj = null;
-      doGC();
+      await doGC();
       expect(blockRetainCount(ptr), 0);
     }
 
-    test('BlockProducer, defined objC, invoked dart', () {
-      blockProducerTest(() {
+    test('BlockProducer, defined objC, invoked dart', () async {
+      await blockProducerTest(() {
         ObjCBlock<DartEmptyBlock Function(Pointer<Void>)> blk =
             BlockAnnotationTest.newBlockProducer();
         return blk(nullptr);
       });
     });
 
-    test('BlockProducer, defined dart, invoked dart', () {
-      blockProducerTest(() {
+    test('BlockProducer, defined dart, invoked dart', () async {
+      await blockProducerTest(() {
         ObjCBlock<DartEmptyBlock Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyBlock_ffiVoid.fromFunction(
                 (Pointer<Void> _) => ObjCBlock_ffiVoid.fromFunction(() {}));
@@ -290,8 +287,8 @@ void main() {
       });
     });
 
-    test('BlockProducer, defined dart, invoked objC', () {
-      blockProducerTest(() {
+    test('BlockProducer, defined dart, invoked objC', () async {
+      await blockProducerTest(() {
         ObjCBlock<DartEmptyBlock Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyBlock_ffiVoid.fromFunction(
                 (Pointer<Void> _) => ObjCBlock_ffiVoid.fromFunction(() {}));
@@ -299,8 +296,8 @@ void main() {
       });
     });
 
-    test('RetainedBlockProducer, defined objC, invoked dart', () {
-      blockProducerTest(() {
+    test('RetainedBlockProducer, defined objC, invoked dart', () async {
+      await blockProducerTest(() {
         ObjCBlock<Retained<DartEmptyBlock> Function(Pointer<Void>)> blk =
             ObjCBlock<Retained<DartEmptyBlock> Function(Pointer<Void>)>(
                 BlockAnnotationTest.newRetainedBlockProducer().ref.pointer,
@@ -310,8 +307,8 @@ void main() {
       });
     });
 
-    test('RetainedBlockProducer, defined dart, invoked dart', () {
-      blockProducerTest(() {
+    test('RetainedBlockProducer, defined dart, invoked dart', () async {
+      await blockProducerTest(() {
         ObjCBlock<Retained<DartEmptyBlock> Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyBlock_ffiVoid1.fromFunction(
                 (Pointer<Void> _) => ObjCBlock_ffiVoid.fromFunction(() {}));
@@ -319,8 +316,8 @@ void main() {
       });
     });
 
-    test('RetainedBlockProducer, defined dart, invoked objC', () {
-      blockProducerTest(() {
+    test('RetainedBlockProducer, defined dart, invoked objC', () async {
+      await blockProducerTest(() {
         ObjCBlock<Retained<DartEmptyBlock> Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyBlock_ffiVoid1.fromFunction(
                 (Pointer<Void> _) => ObjCBlock_ffiVoid.fromFunction(() {}));

--- a/pkgs/ffigen/test/native_objc_test/block_annotation_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_annotation_test.dart
@@ -11,7 +11,10 @@ import 'dart:async';
 import 'dart:ffi';
 import 'dart:io';
 
+import 'package:ffi/ffi.dart';
 import 'package:objective_c/objective_c.dart';
+import 'package:objective_c/src/internal.dart' as internal_for_testing
+    show blockHasRegisteredClosure;
 import 'package:test/test.dart';
 
 import '../test_utils.dart';
@@ -43,47 +46,47 @@ void main() {
       generateBindingsForCoverage('block_annotation');
     });
 
-    Future<void> objectProducerTest(EmptyObject producer()) async {
+    void objectProducerTest(EmptyObject producer()) {
       final pool = lib.objc_autoreleasePoolPush();
       EmptyObject? obj = producer();
       final ptr = obj.ref.pointer;
       lib.objc_autoreleasePoolPop(pool);
-      await doGC();
+      doGC();
       expect(objectRetainCount(ptr), 1);
       expect(obj, isNotNull);
       obj = null;
-      await doGC();
+      doGC();
       expect(objectRetainCount(ptr), 0);
     }
 
-    test('ObjectProducer, defined objC, invoked dart', () async {
-      await objectProducerTest(() {
+    test('ObjectProducer, defined objC, invoked dart', () {
+      objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>)> blk =
             BlockAnnotationTest.newObjectProducer();
         return blk(nullptr);
       });
-    });
+    }, skip: !canDoGC);
 
-    test('ObjectProducer, defined dart, invoked dart', () async {
-      await objectProducerTest(() {
+    test('ObjectProducer, defined dart, invoked dart', () {
+      objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyObject_ffiVoid.fromFunction(
                 (Pointer<Void> _) => EmptyObject.alloc().init());
         return blk(nullptr);
       });
-    });
+    }, skip: !canDoGC);
 
-    test('ObjectProducer, defined dart, invoked objC', () async {
-      await objectProducerTest(() {
+    test('ObjectProducer, defined dart, invoked objC', () {
+      objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyObject_ffiVoid.fromFunction(
                 (Pointer<Void> _) => EmptyObject.alloc().init());
         return BlockAnnotationTest.invokeObjectProducer_(blk);
       });
-    });
+    }, skip: !canDoGC);
 
-    test('RetainedObjectProducer, defined objC, invoked dart', () async {
-      await objectProducerTest(() {
+    test('RetainedObjectProducer, defined objC, invoked dart', () {
+      objectProducerTest(() {
         ObjCBlock<Retained<EmptyObject> Function(Pointer<Void>)> blk =
             ObjCBlock<Retained<EmptyObject> Function(Pointer<Void>)>(
                 BlockAnnotationTest.newRetainedObjectProducer().ref.pointer,
@@ -91,19 +94,19 @@ void main() {
                 release: true);
         return blk(nullptr);
       });
-    });
+    }, skip: !canDoGC);
 
-    test('RetainedObjectProducer, defined dart, invoked dart', () async {
-      await objectProducerTest(() {
+    test('RetainedObjectProducer, defined dart, invoked dart', () {
+      objectProducerTest(() {
         ObjCBlock<Retained<EmptyObject> Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyObject_ffiVoid1.fromFunction(
                 (Pointer<Void> _) => EmptyObject.alloc().init());
         return blk(nullptr);
       });
-    });
+    }, skip: !canDoGC);
 
-    test('RetainedObjectProducer, defined dart, invoked objC', () async {
-      await objectProducerTest(() {
+    test('RetainedObjectProducer, defined dart, invoked objC', () {
+      objectProducerTest(() {
         ObjCBlock<Retained<EmptyObject> Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyObject_ffiVoid1.fromFunction(
                 (Pointer<Void> _) => EmptyObject.alloc().init());
@@ -111,36 +114,36 @@ void main() {
             ObjCBlock<EmptyObject Function(Pointer<Void>)>(blk.ref.pointer,
                 retain: true, release: true));
       });
-    });
+    }, skip: !canDoGC);
 
-    test('ObjectReceiver, defined objC, invoked dart', () async {
-      await objectProducerTest(() {
+    test('ObjectReceiver, defined objC, invoked dart', () {
+      objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>, EmptyObject)> blk =
             BlockAnnotationTest.newObjectReceiver();
         return blk(nullptr, EmptyObject.alloc().init());
       });
-    });
+    }, skip: !canDoGC);
 
-    test('ObjectReceiver, defined dart, invoked dart', () async {
-      await objectProducerTest(() {
+    test('ObjectReceiver, defined dart, invoked dart', () {
+      objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>, EmptyObject)> blk =
             ObjCBlock_EmptyObject_ffiVoid_EmptyObject.fromFunction(
                 (Pointer<Void> _, EmptyObject obj) => obj);
         return blk(nullptr, EmptyObject.alloc().init());
       });
-    });
+    }, skip: !canDoGC);
 
-    test('ObjectReceiver, defined dart, invoked objC', () async {
-      await objectProducerTest(() {
+    test('ObjectReceiver, defined dart, invoked objC', () {
+      objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>, EmptyObject)> blk =
             ObjCBlock_EmptyObject_ffiVoid_EmptyObject.fromFunction(
                 (Pointer<Void> _, EmptyObject obj) => obj);
         return BlockAnnotationTest.invokeObjectReceiver_(blk);
       });
-    });
+    }, skip: !canDoGC);
 
-    test('ConsumedObjectReceiver, defined objC, invoked dart', () async {
-      await objectProducerTest(() {
+    test('ConsumedObjectReceiver, defined objC, invoked dart', () {
+      objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>, Consumed<EmptyObject>)>
             blk = ObjCBlock<
                     EmptyObject Function(Pointer<Void>, Consumed<EmptyObject>)>(
@@ -149,19 +152,19 @@ void main() {
                 release: true);
         return blk(nullptr, EmptyObject.alloc().init());
       });
-    });
+    }, skip: !canDoGC);
 
-    test('ConsumedObjectReceiver, defined dart, invoked dart', () async {
-      await objectProducerTest(() {
+    test('ConsumedObjectReceiver, defined dart, invoked dart', () {
+      objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>, Consumed<EmptyObject>)>
             blk = ObjCBlock_EmptyObject_ffiVoid_EmptyObject1.fromFunction(
                 (Pointer<Void> _, EmptyObject obj) => obj);
         return blk(nullptr, EmptyObject.alloc().init());
       });
-    });
+    }, skip: !canDoGC);
 
-    test('ConsumedObjectReceiver, defined dart, invoked objC', () async {
-      await objectProducerTest(() {
+    test('ConsumedObjectReceiver, defined dart, invoked objC', () {
+      objectProducerTest(() {
         ObjCBlock<EmptyObject Function(Pointer<Void>, Consumed<EmptyObject>)>
             blk = ObjCBlock_EmptyObject_ffiVoid_EmptyObject1.fromFunction(
                 (Pointer<Void> _, EmptyObject obj) => obj);
@@ -171,7 +174,7 @@ void main() {
                 retain: true,
                 release: true));
       });
-    });
+    }, skip: !canDoGC);
 
     Future<void> objectListenerTest(
         void Function(Completer<EmptyObject>) producer) async {
@@ -181,14 +184,14 @@ void main() {
       EmptyObject? obj = await completer.future;
       final ptr = obj.ref.pointer;
       lib.objc_autoreleasePoolPop(pool);
-      await doGC();
+      doGC();
       expect(objectRetainCount(ptr), 1);
       expect(obj, isNotNull);
       obj = null;
       completer = null;
-      await doGC();
+      doGC();
       await Future<void>.delayed(Duration.zero); // Let dispose message arrive.
-      await doGC();
+      doGC();
       expect(objectRetainCount(ptr), 0);
     }
 
@@ -199,7 +202,7 @@ void main() {
                 (Pointer<Void> _, EmptyObject obj) => completer.complete(obj));
         blk(nullptr, EmptyObject.alloc().init());
       });
-    });
+    }, skip: !canDoGC);
 
     test('ObjectListener, defined dart, invoked objC sync', () async {
       await objectListenerTest((Completer<EmptyObject> completer) {
@@ -208,7 +211,7 @@ void main() {
                 (Pointer<Void> _, EmptyObject obj) => completer.complete(obj));
         BlockAnnotationTest.invokeObjectListenerSync_(blk);
       });
-    });
+    }, skip: !canDoGC);
 
     test('ObjectListener, defined dart, invoked objC async', () async {
       await objectListenerTest((Completer<EmptyObject> completer) {
@@ -218,7 +221,7 @@ void main() {
         final thread = BlockAnnotationTest.invokeObjectListenerAsync_(blk);
         thread.start();
       });
-    });
+    }, skip: !canDoGC);
 
     // TODO(https://github.com/dart-lang/native/issues/1505): Fix this case.
     /*test('ConsumedObjectListener, defined dart, invoked dart', () async {
@@ -228,7 +231,7 @@ void main() {
                 (Pointer<Void> _, EmptyObject obj) => completer.complete(obj));
         blk(nullptr, EmptyObject.alloc().init());
       });
-    });*/
+    }, skip: !canDoGC);*/
 
     test('ConsumedObjectListener, defined dart, invoked objC sync', () async {
       await objectListenerTest((Completer<EmptyObject> completer) {
@@ -241,7 +244,7 @@ void main() {
                 retain: true,
                 release: true));
       });
-    });
+    }, skip: !canDoGC);
 
     test('ConsumedObjectListener, defined dart, invoked objC async', () async {
       await objectListenerTest((Completer<EmptyObject> completer) {
@@ -255,49 +258,49 @@ void main() {
                 release: true));
         thread.start();
       });
-    });
+    }, skip: !canDoGC);
 
-    Future<void> blockProducerTest(DartEmptyBlock producer()) async {
+    void blockProducerTest(DartEmptyBlock producer()) {
       final pool = lib.objc_autoreleasePoolPush();
       DartEmptyBlock? obj = producer();
       final ptr = obj.ref.pointer;
       lib.objc_autoreleasePoolPop(pool);
-      await doGC();
+      doGC();
       expect(blockRetainCount(ptr), 1);
       expect(obj, isNotNull);
       obj = null;
-      await doGC();
+      doGC();
       expect(blockRetainCount(ptr), 0);
     }
 
-    test('BlockProducer, defined objC, invoked dart', () async {
-      await blockProducerTest(() {
+    test('BlockProducer, defined objC, invoked dart', () {
+      blockProducerTest(() {
         ObjCBlock<DartEmptyBlock Function(Pointer<Void>)> blk =
             BlockAnnotationTest.newBlockProducer();
         return blk(nullptr);
       });
-    });
+    }, skip: !canDoGC);
 
-    test('BlockProducer, defined dart, invoked dart', () async {
-      await blockProducerTest(() {
+    test('BlockProducer, defined dart, invoked dart', () {
+      blockProducerTest(() {
         ObjCBlock<DartEmptyBlock Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyBlock_ffiVoid.fromFunction(
                 (Pointer<Void> _) => ObjCBlock_ffiVoid.fromFunction(() {}));
         return blk(nullptr);
       });
-    });
+    }, skip: !canDoGC);
 
-    test('BlockProducer, defined dart, invoked objC', () async {
-      await blockProducerTest(() {
+    test('BlockProducer, defined dart, invoked objC', () {
+      blockProducerTest(() {
         ObjCBlock<DartEmptyBlock Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyBlock_ffiVoid.fromFunction(
                 (Pointer<Void> _) => ObjCBlock_ffiVoid.fromFunction(() {}));
         return BlockAnnotationTest.invokeBlockProducer_(blk);
       });
-    });
+    }, skip: !canDoGC);
 
-    test('RetainedBlockProducer, defined objC, invoked dart', () async {
-      await blockProducerTest(() {
+    test('RetainedBlockProducer, defined objC, invoked dart', () {
+      blockProducerTest(() {
         ObjCBlock<Retained<DartEmptyBlock> Function(Pointer<Void>)> blk =
             ObjCBlock<Retained<DartEmptyBlock> Function(Pointer<Void>)>(
                 BlockAnnotationTest.newRetainedBlockProducer().ref.pointer,
@@ -305,19 +308,19 @@ void main() {
                 release: true);
         return blk(nullptr);
       });
-    });
+    }, skip: !canDoGC);
 
-    test('RetainedBlockProducer, defined dart, invoked dart', () async {
-      await blockProducerTest(() {
+    test('RetainedBlockProducer, defined dart, invoked dart', () {
+      blockProducerTest(() {
         ObjCBlock<Retained<DartEmptyBlock> Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyBlock_ffiVoid1.fromFunction(
                 (Pointer<Void> _) => ObjCBlock_ffiVoid.fromFunction(() {}));
         return blk(nullptr);
       });
-    });
+    }, skip: !canDoGC);
 
-    test('RetainedBlockProducer, defined dart, invoked objC', () async {
-      await blockProducerTest(() {
+    test('RetainedBlockProducer, defined dart, invoked objC', () {
+      blockProducerTest(() {
         ObjCBlock<Retained<DartEmptyBlock> Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyBlock_ffiVoid1.fromFunction(
                 (Pointer<Void> _) => ObjCBlock_ffiVoid.fromFunction(() {}));
@@ -325,6 +328,6 @@ void main() {
             ObjCBlock<DartEmptyBlock Function(Pointer<Void>)>(blk.ref.pointer,
                 retain: true, release: true));
       });
-    });
+    }, skip: !canDoGC);
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/block_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test.dart
@@ -506,8 +506,12 @@ void main() {
           false);
     });
 
-    Future<(Pointer<ObjCBlockImpl>, Pointer<ObjCBlockImpl>, Pointer<ObjCBlockImpl>)>
-        nativeBlockBlockDartCallRefCountTest() async {
+    Future<
+        (
+          Pointer<ObjCBlockImpl>,
+          Pointer<ObjCBlockImpl>,
+          Pointer<ObjCBlockImpl>
+        )> nativeBlockBlockDartCallRefCountTest() async {
       final pool = lib.objc_autoreleasePoolPush();
       final inputBlock = IntBlock.fromFunction((int x) {
         return 5 * x;
@@ -555,7 +559,8 @@ void main() {
 
     test('Calling a native block block from ObjC has correct ref counting',
         () async {
-      final (blockBlock, outputBlock) = await nativeBlockBlockObjCCallRefCountTest();
+      final (blockBlock, outputBlock) =
+          await nativeBlockBlockObjCCallRefCountTest();
       await doGC();
       expect(blockRetainCount(blockBlock), 0);
       expect(blockRetainCount(outputBlock), 0);

--- a/pkgs/ffigen/test/native_objc_test/global_native_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_native_test.dart
@@ -52,9 +52,9 @@ void main() {
       return (obj1raw, obj2raw);
     }
 
-    test('Global object ref counting', () {
+    test('Global object ref counting', () async {
       final (obj1raw, obj2raw) = globalObjectRefCountingInner();
-      doGC();
+      await doGC();
 
       expect(objectRetainCount(obj2raw), 1); // Just the global variable.
       expect(objectRetainCount(obj1raw), 0);
@@ -90,9 +90,9 @@ void main() {
       return (blk1raw, blk2raw);
     }
 
-    test('Global block ref counting', () {
+    test('Global block ref counting', () async {
       final (blk1raw, blk2raw) = globalBlockRefCountingInner();
-      doGC();
+      await doGC();
 
       expect(blockRetainCount(blk2raw), 1); // Just the global variable.
       expect(blockRetainCount(blk1raw), 0);

--- a/pkgs/ffigen/test/native_objc_test/global_native_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_native_test.dart
@@ -52,9 +52,9 @@ void main() {
       return (obj1raw, obj2raw);
     }
 
-    test('Global object ref counting', () async {
+    test('Global object ref counting', () {
       final (obj1raw, obj2raw) = globalObjectRefCountingInner();
-      await doGC();
+      doGC();
 
       expect(objectRetainCount(obj2raw), 1); // Just the global variable.
       expect(objectRetainCount(obj1raw), 0);
@@ -62,7 +62,7 @@ void main() {
       globalNativeObject = null;
       expect(objectRetainCount(obj2raw), 0);
       expect(objectRetainCount(obj1raw), 0);
-    });
+    }, skip: !canDoGC);
 
     test('Global block', () {
       globalNativeBlock = ObjCBlock_Int32_Int32.fromFunction((int x) => x * 10);
@@ -90,9 +90,9 @@ void main() {
       return (blk1raw, blk2raw);
     }
 
-    test('Global block ref counting', () async {
+    test('Global block ref counting', () {
       final (blk1raw, blk2raw) = globalBlockRefCountingInner();
-      await doGC();
+      doGC();
 
       expect(blockRetainCount(blk2raw), 1); // Just the global variable.
       expect(blockRetainCount(blk1raw), 0);
@@ -100,6 +100,6 @@ void main() {
       globalNativeBlock = null;
       expect(blockRetainCount(blk2raw), 0);
       expect(blockRetainCount(blk1raw), 0);
-    });
+    }, skip: !canDoGC);
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/global_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_test.dart
@@ -54,9 +54,9 @@ void main() {
       return (obj1raw, obj2raw);
     }
 
-    test('Global object ref counting', () {
+    test('Global object ref counting', () async {
       final (obj1raw, obj2raw) = globalObjectRefCountingInner();
-      doGC();
+      await doGC();
 
       expect(objectRetainCount(obj2raw), 1); // Just the global variable.
       expect(objectRetainCount(obj1raw), 0);
@@ -91,9 +91,9 @@ void main() {
       return (blk1raw, blk2raw);
     }
 
-    test('Global block ref counting', () {
+    test('Global block ref counting', () async {
       final (blk1raw, blk2raw) = globalBlockRefCountingInner();
-      doGC();
+      await doGC();
 
       expect(blockRetainCount(blk2raw), 1); // Just the global variable.
       expect(blockRetainCount(blk1raw), 0);

--- a/pkgs/ffigen/test/native_objc_test/global_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/global_test.dart
@@ -54,9 +54,9 @@ void main() {
       return (obj1raw, obj2raw);
     }
 
-    test('Global object ref counting', () async {
+    test('Global object ref counting', () {
       final (obj1raw, obj2raw) = globalObjectRefCountingInner();
-      await doGC();
+      doGC();
 
       expect(objectRetainCount(obj2raw), 1); // Just the global variable.
       expect(objectRetainCount(obj1raw), 0);
@@ -64,7 +64,7 @@ void main() {
       lib.globalObject = null;
       expect(objectRetainCount(obj2raw), 0);
       expect(objectRetainCount(obj1raw), 0);
-    });
+    }, skip: !canDoGC);
 
     test('Global block', () {
       lib.globalBlock = ObjCBlock_Int32_Int32.fromFunction((int x) => x * 10);
@@ -91,9 +91,9 @@ void main() {
       return (blk1raw, blk2raw);
     }
 
-    test('Global block ref counting', () async {
+    test('Global block ref counting', () {
       final (blk1raw, blk2raw) = globalBlockRefCountingInner();
-      await doGC();
+      doGC();
 
       expect(blockRetainCount(blk2raw), 1); // Just the global variable.
       expect(blockRetainCount(blk1raw), 0);
@@ -101,6 +101,6 @@ void main() {
       lib.globalBlock = null;
       expect(blockRetainCount(blk2raw), 0);
       expect(blockRetainCount(blk1raw), 0);
-    });
+    }, skip: !canDoGC);
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/isolate_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/isolate_test.dart
@@ -30,7 +30,7 @@ Future<R> isolateRun<R>(FutureOr<R> computation()) async {
 
   final port = ReceivePort();
   final queue = StreamQueue(port);
-  await Isolate.spawn(run, port.sendPort);
+  final isolate = await Isolate.spawn(run, port.sendPort);
   final result = await queue.next as R;
   await queue.next; // Wait for isolate to release its reference to comp.
   port.close();
@@ -72,7 +72,7 @@ void main() {
 
       final port = ReceivePort();
       final queue = StreamQueue(port);
-      await Isolate.spawn(sendingObjectTest, port.sendPort,
+      final isolate = await Isolate.spawn(sendingObjectTest, port.sendPort,
           onExit: port.sendPort);
 
       final sendPort = await queue.next as SendPort;
@@ -89,10 +89,10 @@ void main() {
       port.close();
 
       sendable = null;
-      await doGC();
+      doGC();
       // TODO(https://github.com/dart-lang/coverage/issues/472): Re-enable.
       // expect(objectRetainCount(pointer), 0);
-    });
+    }, skip: !canDoGC);
 
     test('Capturing object in closure', () async {
       Sendable? sendable = Sendable.new1();
@@ -100,7 +100,7 @@ void main() {
 
       final oldValue = await isolateRun(() {
         final oldValue = sendable!.value;
-        sendable.value = 456;
+        sendable!.value = 456;
         return oldValue;
       });
 
@@ -111,9 +111,9 @@ void main() {
       expect(objectRetainCount(pointer), 1);
 
       sendable = null;
-      await doGC();
+      doGC();
       expect(objectRetainCount(pointer), 0);
-    });
+    }, skip: !canDoGC);
 
     // Runs on other isolate (can't use expect function).
     void sendingBlockTest(SendPort sendPort) async {
@@ -139,7 +139,7 @@ void main() {
 
       final port = ReceivePort();
       final queue = StreamQueue(port);
-      await Isolate.spawn(sendingBlockTest, port.sendPort,
+      final isolate = await Isolate.spawn(sendingBlockTest, port.sendPort,
           onExit: port.sendPort);
 
       final sendPort = await queue.next as SendPort;
@@ -155,10 +155,10 @@ void main() {
       port.close();
 
       block = null;
-      await doGC();
+      doGC();
       // TODO(https://github.com/dart-lang/coverage/issues/472): Re-enable.
       // expect(blockRetainCount(pointer), 0);
-    });
+    }, skip: !canDoGC);
 
     ObjCBlock<Void Function(Int32)> makeBlock(Completer<int> completer) {
       // Creating this block in a separate function to make sure completer is
@@ -182,9 +182,9 @@ void main() {
       expect(blockRetainCount(pointer), 1);
 
       block = null;
-      await doGC();
+      doGC();
       expect(blockRetainCount(pointer), 0);
-    });
+    }, skip: !canDoGC);
 
     test('Manual release across isolates', () async {
       final sendable = Sendable.new1();
@@ -195,7 +195,7 @@ void main() {
 
       final (oldIsReleased, newIsReleased) = await isolateRun(() {
         final oldIsReleased = sendable.ref.isReleased;
-        sendable.ref.release();
+        sendable!.ref.release();
         return (oldIsReleased, sendable.ref.isReleased);
       });
 
@@ -209,11 +209,12 @@ void main() {
     test('Use after release and double release', () async {
       final sendable = Sendable.new1();
       sendable.value = 123;
+      final pointer = sendable.ref.pointer;
 
       expect(sendable.ref.isReleased, isFalse);
 
       await isolateRun(() {
-        sendable.ref.release();
+        sendable!.ref.release();
       });
 
       expect(sendable.ref.isReleased, isTrue);

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -323,8 +323,7 @@ void main() {
         expect(count, 1000);
       });
 
-      Future<(DartProxy, Pointer<ObjCBlockImpl>)>
-          blockRefCountTestInner() async {
+      (DartProxy, Pointer<ObjCBlockImpl>) blockRefCountTestInner() {
         final proxyBuilder = DartProxyBuilder.new1();
         final protocol = getProtocol('MyProtocol');
 
@@ -344,36 +343,35 @@ void main() {
         // There are 2 references to the block. One owned by the Dart wrapper
         // object, and the other owned by the proxy. The method signature is
         // also an ObjC object, so the same is true for it.
-        await doGC();
+        doGC();
         expect(objectRetainCount(proxyPtr), 1);
         expect(blockRetainCount(blockPtr), 2);
 
         return (proxy, blockPtr);
       }
 
-      Future<(Pointer<ObjCObject>, Pointer<ObjCBlockImpl>)>
-          blockRefCountTest() async {
-        final (proxy, blockPtr) = await blockRefCountTestInner();
+      (Pointer<ObjCObject>, Pointer<ObjCBlockImpl>) blockRefCountTest() {
+        final (proxy, blockPtr) = blockRefCountTestInner();
         final proxyPtr = proxy.ref.pointer;
 
         // The Dart side block pointer has gone out of scope, but the proxy
         // still owns a reference to it. Same for the signature.
-        await doGC();
+        doGC();
         expect(objectRetainCount(proxyPtr), 1);
         expect(blockRetainCount(blockPtr), 1);
 
         return (proxyPtr, blockPtr);
       }
 
-      test('Block ref counting', () async {
-        final (proxyPtr, blockPtr) = await blockRefCountTest();
+      test('Block ref counting', () {
+        final (proxyPtr, blockPtr) = blockRefCountTest();
 
         // The proxy object has gone out of scope, so it should be cleaned up.
         // So should the block and the signature.
-        await doGC();
+        doGC();
         expect(objectRetainCount(proxyPtr), 0);
         expect(blockRetainCount(blockPtr), 0);
-      });
+      }, skip: !canDoGC);
     });
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/ref_count_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/ref_count_test.dart
@@ -61,18 +61,18 @@ void main() {
       return (obj1raw, obj2raw);
     }
 
-    test('new methods ref count correctly', () async {
+    test('new methods ref count correctly', () {
       // To get the GC to work correctly, the references to the objects all have
       // to be in a separate function.
       final counter = calloc<Int32>();
       counter.value = 0;
       final (obj1raw, obj2raw) = newMethodsInner(counter);
-      await doGC();
+      doGC();
       expect(objectRetainCount(obj1raw), 0);
       expect(objectRetainCount(obj2raw), 0);
       expect(counter.value, 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
     (Pointer<ObjCObject>, Pointer<ObjCObject>, Pointer<ObjCObject>)
         allocMethodsInner(Pointer<Int32> counter) {
@@ -100,17 +100,17 @@ void main() {
       return (obj1raw, obj2raw, obj3raw);
     }
 
-    test('alloc and init methods ref count correctly', () async {
+    test('alloc and init methods ref count correctly', () {
       final counter = calloc<Int32>();
       counter.value = 0;
       final (obj1raw, obj2raw, obj3raw) = allocMethodsInner(counter);
-      await doGC();
+      doGC();
       expect(objectRetainCount(obj1raw), 0);
       expect(objectRetainCount(obj2raw), 0);
       expect(objectRetainCount(obj3raw), 0);
       expect(counter.value, 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
     (
       Pointer<ObjCObject>,
@@ -187,7 +187,7 @@ void main() {
       );
     }
 
-    test('copy methods ref count correctly', () async {
+    test('copy methods ref count correctly', () {
       final counter = calloc<Int32>();
       counter.value = 0;
       final (
@@ -201,7 +201,7 @@ void main() {
         obj8raw,
         obj9raw
       ) = copyMethodsInner(counter);
-      await doGC();
+      doGC();
       expect(objectRetainCount(obj1raw), 0);
       expect(objectRetainCount(obj2raw), 0);
       expect(objectRetainCount(obj3raw), 0);
@@ -213,7 +213,7 @@ void main() {
       expect(objectRetainCount(obj9raw), 0);
       expect(counter.value, 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
     Pointer<ObjCObject> autoreleaseMethodsInner(Pointer<Int32> counter) {
       final obj1 = RefCountTestObject.makeAndAutorelease_(counter);
@@ -224,13 +224,13 @@ void main() {
       return obj1raw;
     }
 
-    test('autorelease methods ref count correctly', () async {
+    test('autorelease methods ref count correctly', () {
       final counter = calloc<Int32>();
       counter.value = 0;
 
       final pool1 = lib.objc_autoreleasePoolPush();
       final obj1raw = autoreleaseMethodsInner(counter);
-      await doGC();
+      doGC();
       // The autorelease pool is still holding a reference to the object.
       expect(counter.value, 1);
       expect(objectRetainCount(obj1raw), 1);
@@ -243,7 +243,7 @@ void main() {
       final obj2raw = obj2.ref.pointer;
       expect(counter.value, 1);
       expect(objectRetainCount(obj2raw), 2);
-      await doGC();
+      doGC();
       expect(counter.value, 1);
       expect(objectRetainCount(obj2raw), 2);
       lib.objc_autoreleasePoolPop(pool2);
@@ -255,7 +255,7 @@ void main() {
       expect(objectRetainCount(obj2raw), 0);
 
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
     Pointer<ObjCObject> assignPropertiesInnerInner(
         Pointer<Int32> counter, RefCountTestObject outerObj) {
@@ -274,14 +274,14 @@ void main() {
       return assignObjRaw;
     }
 
-    Future<(Pointer<ObjCObject>, Pointer<ObjCObject>)> assignPropertiesInner(
-        Pointer<Int32> counter) async {
+    (Pointer<ObjCObject>, Pointer<ObjCObject>) assignPropertiesInner(
+        Pointer<Int32> counter) {
       final outerObj = RefCountTestObject.newWithCounter_(counter);
       expect(counter.value, 1);
       final outerObjRaw = outerObj.ref.pointer;
       expect(objectRetainCount(outerObjRaw), 1);
       final assignObjRaw = assignPropertiesInnerInner(counter, outerObj);
-      await doGC();
+      doGC();
       // assignObj has been cleaned up.
       expect(counter.value, 1);
       expect(objectRetainCount(assignObjRaw), 0);
@@ -290,16 +290,16 @@ void main() {
       return (outerObjRaw, assignObjRaw);
     }
 
-    test('assign properties ref count correctly', () async {
+    test('assign properties ref count correctly', () {
       final counter = calloc<Int32>();
       counter.value = 0;
-      final (outerObjRaw, assignObjRaw) = await assignPropertiesInner(counter);
-      await doGC();
+      final (outerObjRaw, assignObjRaw) = assignPropertiesInner(counter);
+      doGC();
       expect(counter.value, 0);
       expect(objectRetainCount(assignObjRaw), 0);
       expect(objectRetainCount(outerObjRaw), 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
     Pointer<ObjCObject> retainPropertiesInnerInner(
         Pointer<Int32> counter, RefCountTestObject outerObj) {
@@ -314,14 +314,14 @@ void main() {
       return retainObjRaw;
     }
 
-    Future<(Pointer<ObjCObject>, Pointer<ObjCObject>)> retainPropertiesInner(
-        Pointer<Int32> counter) async {
+    (Pointer<ObjCObject>, Pointer<ObjCObject>) retainPropertiesInner(
+        Pointer<Int32> counter) {
       final outerObj = RefCountTestObject.newWithCounter_(counter);
       expect(counter.value, 1);
       final outerObjRaw = outerObj.ref.pointer;
       expect(objectRetainCount(outerObjRaw), 1);
       final retainObjRaw = retainPropertiesInnerInner(counter, outerObj);
-      await doGC();
+      doGC();
       // retainObj is still around, because outerObj retains a reference to it.
       expect(objectRetainCount(retainObjRaw), 2);
       expect(objectRetainCount(outerObjRaw), 1);
@@ -330,14 +330,14 @@ void main() {
       return (outerObjRaw, retainObjRaw);
     }
 
-    test('retain properties ref count correctly', () async {
+    test('retain properties ref count correctly', () {
       final counter = calloc<Int32>();
       counter.value = 0;
       // The getters of retain properties retain+autorelease the value. So we
       // need an autorelease pool.
       final pool = lib.objc_autoreleasePoolPush();
-      final (outerObjRaw, retainObjRaw) = await retainPropertiesInner(counter);
-      await doGC();
+      final (outerObjRaw, retainObjRaw) = retainPropertiesInner(counter);
+      doGC();
       expect(objectRetainCount(retainObjRaw), 1);
       expect(objectRetainCount(outerObjRaw), 0);
       expect(counter.value, 1);
@@ -346,7 +346,7 @@ void main() {
       expect(objectRetainCount(outerObjRaw), 0);
       expect(counter.value, 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
     (Pointer<ObjCObject>, Pointer<ObjCObject>, Pointer<ObjCObject>)
         copyPropertiesInner(Pointer<Int32> counter) {
@@ -376,7 +376,7 @@ void main() {
       return (outerObjRaw, copyObjRaw, anotherCopyRaw);
     }
 
-    test('copy properties ref count correctly', () async {
+    test('copy properties ref count correctly', () {
       final counter = calloc<Int32>();
       counter.value = 0;
       // The getters of copy properties retain+autorelease the value. So we need
@@ -384,7 +384,7 @@ void main() {
       final pool = lib.objc_autoreleasePoolPush();
       final (outerObjRaw, copyObjRaw, anotherCopyRaw) =
           copyPropertiesInner(counter);
-      await doGC();
+      doGC();
       expect(counter.value, 1);
       expect(objectRetainCount(outerObjRaw), 0);
       expect(objectRetainCount(copyObjRaw), 0);
@@ -395,7 +395,7 @@ void main() {
       expect(objectRetainCount(copyObjRaw), 0);
       expect(objectRetainCount(anotherCopyRaw), 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
     castFromPointerInnerReleaseAndRetain(int address) {
       final fromCast = RefCounted.castFromPointer(
@@ -405,14 +405,14 @@ void main() {
       expect(fromCast.refCount, 2);
     }
 
-    test('castFromPointer - release and retain', () async {
+    test('castFromPointer - release and retain', () {
       final obj1 = RefCounted.new1();
       expect(obj1.refCount, 1);
 
       castFromPointerInnerReleaseAndRetain(obj1.meAsInt());
-      await doGC();
+      doGC();
       expect(obj1.refCount, 1);
-    });
+    }, skip: !canDoGC);
 
     castFromPointerInnerNoReleaseAndRetain(int address) {
       final fromCast = RefCounted.castFromPointer(
@@ -422,14 +422,14 @@ void main() {
       expect(fromCast.refCount, 1);
     }
 
-    test('castFromPointer - no release and retain', () async {
+    test('castFromPointer - no release and retain', () {
       final obj1 = RefCounted.new1();
       expect(obj1.refCount, 1);
 
       castFromPointerInnerNoReleaseAndRetain(obj1.meAsInt());
-      await doGC();
+      doGC();
       expect(obj1.refCount, 1);
-    });
+    }, skip: !canDoGC);
 
     test('Manual release', () {
       final counter = calloc<Int32>();
@@ -478,20 +478,20 @@ void main() {
       expect(objectRetainCount(objRaw), 1);
     }
 
-    test('Manual retain', () async {
+    test('Manual retain', () {
       final counter = calloc<Int32>();
       final objRaw = manualRetainInner(counter);
-      await doGC();
+      doGC();
       expect(counter.value, 1);
       expect(objectRetainCount(objRaw), 1);
 
       manualRetainInner2(counter, objRaw);
-      await doGC();
+      doGC();
       expect(counter.value, 0);
       expect(objectRetainCount(objRaw), 0);
 
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
     RefCountTestObject unownedReferenceInner2(Pointer<Int32> counter) {
       final obj1 = RefCountTestObject.new1();
@@ -513,10 +513,9 @@ void main() {
       return obj1b;
     }
 
-    Future<Pointer<ObjCObject>> unownedReferenceInner(
-        Pointer<Int32> counter) async {
+    Pointer<ObjCObject> unownedReferenceInner(Pointer<Int32> counter) {
       final obj1b = unownedReferenceInner2(counter);
-      await doGC(); // Collect obj1 and obj2.
+      doGC(); // Collect obj1 and obj2.
       // The underlying object obj1 and obj1b points to still exists, because
       // obj1b took a reference to it. So we still have 1 object.
       expect(counter.value, 1);
@@ -524,19 +523,19 @@ void main() {
       return obj1b.ref.pointer;
     }
 
-    test("Method that returns a reference we don't own", () async {
+    test("Method that returns a reference we don't own", () {
       // Most ObjC API methods return us a reference without incrementing the
       // ref count (ie, returns us a reference we don't own). So the wrapper
       // object has to take ownership by calling retain. This test verifies that
       // is working correctly by holding a reference to an object returned by a
       // method, after the original wrapper object is gone.
       final counter = calloc<Int32>();
-      final obj1bRaw = await unownedReferenceInner(counter);
-      await doGC();
+      final obj1bRaw = unownedReferenceInner(counter);
+      doGC();
       expect(counter.value, 0);
       expect(objectRetainCount(obj1bRaw), 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
     void largeRefCountInner(Pointer<Int32> counter) {
       final obj = RefCountTestObject.newWithCounter_(counter);
@@ -551,7 +550,7 @@ void main() {
       expect(counter.value, 1);
     }
 
-    test('Consumed arguments', () async {
+    test('Consumed arguments', () {
       final counter = calloc<Int32>();
       RefCountTestObject? obj1 = RefCountTestObject.newWithCounter_(counter);
       final obj1raw = obj1.ref.pointer;
@@ -565,13 +564,13 @@ void main() {
       expect(counter.value, 1);
 
       obj1 = null;
-      await doGC();
+      doGC();
       expect(objectRetainCount(obj1raw), 0);
       expect(counter.value, 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
 
-    test('objectRetainCount large ref count', () async {
+    test('objectRetainCount large ref count', () {
       // Most ObjC API methods return us a reference without incrementing the
       // ref count (ie, returns us a reference we don't own). So the wrapper
       // object has to take ownership by calling retain. This test verifies that
@@ -580,9 +579,9 @@ void main() {
       final counter = calloc<Int32>();
       counter.value = 0;
       largeRefCountInner(counter);
-      await doGC();
+      doGC();
       expect(counter.value, 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/static_func_native_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_native_test.dart
@@ -52,12 +52,12 @@ void main() {
     }
 
     test('Objects passed through static functions have correct ref counts', () {
-      using((Arena arena) async {
+      using((Arena arena) {
         final (counter) = staticFuncOfObjectRefCountTest(arena);
-        await doGC();
+        doGC();
         expect(counter.value, 0);
       });
-    });
+    }, skip: !canDoGC);
 
     Pointer<Int32> staticFuncOfNullableObjectRefCountTest(Allocator alloc) {
       final counter = alloc<Int32>();
@@ -77,14 +77,14 @@ void main() {
 
     test('Nullables passed through static functions have correct ref counts',
         () {
-      using((Arena arena) async {
+      using((Arena arena) {
         final (counter) = staticFuncOfNullableObjectRefCountTest(arena);
-        await doGC();
+        doGC();
         expect(counter.value, 0);
 
         expect(staticFuncOfNullableObject(null), isNull);
       });
-    });
+    }, skip: !canDoGC);
 
     Pointer<ObjCBlockImpl> staticFuncOfBlockRefCountTest() {
       final block = IntBlock.fromFunction((int x) => 2 * x);
@@ -99,12 +99,11 @@ void main() {
       return block.ref.pointer;
     }
 
-    test('Blocks passed through static functions have correct ref counts',
-        () async {
+    test('Blocks passed through static functions have correct ref counts', () {
       final rawBlock = staticFuncOfBlockRefCountTest();
-      await doGC();
+      doGC();
       expect(blockRetainCount(rawBlock), 0);
-    });
+    }, skip: !canDoGC);
 
     Pointer<Int32> staticFuncReturnsRetainedRefCountTest(Allocator alloc) {
       final counter = alloc<Int32>();
@@ -119,12 +118,12 @@ void main() {
     test(
         'Objects returned from static functions with NS_RETURNS_RETAINED '
         'have correct ref counts', () {
-      using((Arena arena) async {
+      using((Arena arena) {
         final (counter) = staticFuncReturnsRetainedRefCountTest(arena);
-        await doGC();
+        doGC();
         expect(counter.value, 0);
       });
-    });
+    }, skip: !canDoGC);
 
     Pointer<Int32> staticFuncOfObjectReturnsRetainedRefCountTest(
         Allocator alloc) {
@@ -144,16 +143,16 @@ void main() {
     test(
         'Objects passed through static functions with NS_RETURNS_RETAINED '
         'have correct ref counts', () {
-      using((Arena arena) async {
+      using((Arena arena) {
         final (counter) = staticFuncOfObjectReturnsRetainedRefCountTest(arena);
-        await doGC();
+        doGC();
         expect(counter.value, 0);
       });
-    });
+    }, skip: !canDoGC);
 
     test(
         'Objects passed to static functions that consume them '
-        'have correct ref counts', () async {
+        'have correct ref counts', () {
       final counter = calloc<Int32>();
       StaticFuncTestObj? obj1 = StaticFuncTestObj.newWithCounter_(counter);
       final obj1raw = obj1.ref.pointer;
@@ -167,10 +166,10 @@ void main() {
       expect(counter.value, 1);
 
       obj1 = null;
-      await doGC();
+      doGC();
       expect(objectRetainCount(obj1raw), 0);
       expect(counter.value, 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/static_func_native_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_native_test.dart
@@ -51,8 +51,7 @@ void main() {
       return counter;
     }
 
-    test('Objects passed through static functions have correct ref counts',
-        () {
+    test('Objects passed through static functions have correct ref counts', () {
       using((Arena arena) async {
         final (counter) = staticFuncOfObjectRefCountTest(arena);
         await doGC();

--- a/pkgs/ffigen/test/native_objc_test/static_func_native_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_native_test.dart
@@ -51,10 +51,11 @@ void main() {
       return counter;
     }
 
-    test('Objects passed through static functions have correct ref counts', () {
-      using((Arena arena) {
+    test('Objects passed through static functions have correct ref counts',
+        () {
+      using((Arena arena) async {
         final (counter) = staticFuncOfObjectRefCountTest(arena);
-        doGC();
+        await doGC();
         expect(counter.value, 0);
       });
     });
@@ -77,9 +78,9 @@ void main() {
 
     test('Nullables passed through static functions have correct ref counts',
         () {
-      using((Arena arena) {
+      using((Arena arena) async {
         final (counter) = staticFuncOfNullableObjectRefCountTest(arena);
-        doGC();
+        await doGC();
         expect(counter.value, 0);
 
         expect(staticFuncOfNullableObject(null), isNull);
@@ -99,9 +100,10 @@ void main() {
       return block.ref.pointer;
     }
 
-    test('Blocks passed through static functions have correct ref counts', () {
+    test('Blocks passed through static functions have correct ref counts',
+        () async {
       final rawBlock = staticFuncOfBlockRefCountTest();
-      doGC();
+      await doGC();
       expect(blockRetainCount(rawBlock), 0);
     });
 
@@ -118,9 +120,9 @@ void main() {
     test(
         'Objects returned from static functions with NS_RETURNS_RETAINED '
         'have correct ref counts', () {
-      using((Arena arena) {
+      using((Arena arena) async {
         final (counter) = staticFuncReturnsRetainedRefCountTest(arena);
-        doGC();
+        await doGC();
         expect(counter.value, 0);
       });
     });
@@ -143,16 +145,16 @@ void main() {
     test(
         'Objects passed through static functions with NS_RETURNS_RETAINED '
         'have correct ref counts', () {
-      using((Arena arena) {
+      using((Arena arena) async {
         final (counter) = staticFuncOfObjectReturnsRetainedRefCountTest(arena);
-        doGC();
+        await doGC();
         expect(counter.value, 0);
       });
     });
 
     test(
         'Objects passed to static functions that consume them '
-        'have correct ref counts', () {
+        'have correct ref counts', () async {
       final counter = calloc<Int32>();
       StaticFuncTestObj? obj1 = StaticFuncTestObj.newWithCounter_(counter);
       final obj1raw = obj1.ref.pointer;
@@ -166,7 +168,7 @@ void main() {
       expect(counter.value, 1);
 
       obj1 = null;
-      doGC();
+      await doGC();
       expect(objectRetainCount(obj1raw), 0);
       expect(counter.value, 0);
       calloc.free(counter);

--- a/pkgs/ffigen/test/native_objc_test/static_func_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_test.dart
@@ -54,12 +54,12 @@ void main() {
     }
 
     test('Objects passed through static functions have correct ref counts', () {
-      using((Arena arena) async {
+      using((Arena arena) {
         final (counter) = staticFuncOfObjectRefCountTest(arena);
-        await doGC();
+        doGC();
         expect(counter.value, 0);
       });
-    });
+    }, skip: !canDoGC);
 
     Pointer<Int32> staticFuncOfNullableObjectRefCountTest(Allocator alloc) {
       final counter = alloc<Int32>();
@@ -79,14 +79,14 @@ void main() {
 
     test('Nullables passed through static functions have correct ref counts',
         () {
-      using((Arena arena) async {
+      using((Arena arena) {
         final (counter) = staticFuncOfNullableObjectRefCountTest(arena);
-        await doGC();
+        doGC();
         expect(counter.value, 0);
 
         expect(lib.staticFuncOfNullableObject(null), isNull);
       });
-    });
+    }, skip: !canDoGC);
 
     Pointer<ObjCBlockImpl> staticFuncOfBlockRefCountTest() {
       final block = IntBlock.fromFunction((int x) => 2 * x);
@@ -101,12 +101,11 @@ void main() {
       return block.ref.pointer;
     }
 
-    test('Blocks passed through static functions have correct ref counts',
-        () async {
+    test('Blocks passed through static functions have correct ref counts', () {
       final (rawBlock) = staticFuncOfBlockRefCountTest();
-      await doGC();
+      doGC();
       expect(blockRetainCount(rawBlock), 0);
-    });
+    }, skip: !canDoGC);
 
     Pointer<Int32> staticFuncReturnsRetainedRefCountTest(Allocator alloc) {
       final counter = alloc<Int32>();
@@ -121,12 +120,12 @@ void main() {
     test(
         'Objects returned from static functions with NS_RETURNS_RETAINED '
         'have correct ref counts', () {
-      using((Arena arena) async {
+      using((Arena arena) {
         final (counter) = staticFuncReturnsRetainedRefCountTest(arena);
-        await doGC();
+        doGC();
         expect(counter.value, 0);
       });
-    });
+    }, skip: !canDoGC);
 
     Pointer<Int32> staticFuncOfObjectReturnsRetainedRefCountTest(
         Allocator alloc) {
@@ -146,16 +145,16 @@ void main() {
     test(
         'Objects passed through static functions with NS_RETURNS_RETAINED '
         'have correct ref counts', () {
-      using((Arena arena) async {
+      using((Arena arena) {
         final (counter) = staticFuncOfObjectReturnsRetainedRefCountTest(arena);
-        await doGC();
+        doGC();
         expect(counter.value, 0);
       });
-    });
+    }, skip: !canDoGC);
 
     test(
         'Objects passed to static functions that consume them '
-        'have correct ref counts', () async {
+        'have correct ref counts', () {
       final counter = calloc<Int32>();
       StaticFuncTestObj? obj1 = StaticFuncTestObj.newWithCounter_(counter);
       final obj1raw = obj1.ref.pointer;
@@ -169,10 +168,10 @@ void main() {
       expect(counter.value, 1);
 
       obj1 = null;
-      await doGC();
+      doGC();
       expect(objectRetainCount(obj1raw), 0);
       expect(counter.value, 0);
       calloc.free(counter);
-    });
+    }, skip: !canDoGC);
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/static_func_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_test.dart
@@ -54,9 +54,9 @@ void main() {
     }
 
     test('Objects passed through static functions have correct ref counts', () {
-      using((Arena arena) {
+      using((Arena arena) async {
         final (counter) = staticFuncOfObjectRefCountTest(arena);
-        doGC();
+        await doGC();
         expect(counter.value, 0);
       });
     });
@@ -79,9 +79,9 @@ void main() {
 
     test('Nullables passed through static functions have correct ref counts',
         () {
-      using((Arena arena) {
+      using((Arena arena) async {
         final (counter) = staticFuncOfNullableObjectRefCountTest(arena);
-        doGC();
+        await doGC();
         expect(counter.value, 0);
 
         expect(lib.staticFuncOfNullableObject(null), isNull);
@@ -101,9 +101,10 @@ void main() {
       return block.ref.pointer;
     }
 
-    test('Blocks passed through static functions have correct ref counts', () {
+    test('Blocks passed through static functions have correct ref counts',
+        () async {
       final (rawBlock) = staticFuncOfBlockRefCountTest();
-      doGC();
+      await doGC();
       expect(blockRetainCount(rawBlock), 0);
     });
 
@@ -120,9 +121,9 @@ void main() {
     test(
         'Objects returned from static functions with NS_RETURNS_RETAINED '
         'have correct ref counts', () {
-      using((Arena arena) {
+      using((Arena arena) async {
         final (counter) = staticFuncReturnsRetainedRefCountTest(arena);
-        doGC();
+        await doGC();
         expect(counter.value, 0);
       });
     });
@@ -145,16 +146,16 @@ void main() {
     test(
         'Objects passed through static functions with NS_RETURNS_RETAINED '
         'have correct ref counts', () {
-      using((Arena arena) {
+      using((Arena arena) async {
         final (counter) = staticFuncOfObjectReturnsRetainedRefCountTest(arena);
-        doGC();
+        await doGC();
         expect(counter.value, 0);
       });
     });
 
     test(
         'Objects passed to static functions that consume them '
-        'have correct ref counts', () {
+        'have correct ref counts', () async {
       final counter = calloc<Int32>();
       StaticFuncTestObj? obj1 = StaticFuncTestObj.newWithCounter_(counter);
       final obj1raw = obj1.ref.pointer;
@@ -168,7 +169,7 @@ void main() {
       expect(counter.value, 1);
 
       obj1 = null;
-      doGC();
+      await doGC();
       expect(objectRetainCount(obj1raw), 0);
       expect(counter.value, 0);
       calloc.free(counter);

--- a/pkgs/ffigen/test/native_objc_test/util.dart
+++ b/pkgs/ffigen/test/native_objc_test/util.dart
@@ -27,9 +27,10 @@ void generateBindingsForCoverage(String testName) {
 
 final _executeInternalCommand = () {
   try {
-    return DynamicLibrary.process().lookup
-      <NativeFunction<Void Function(Pointer<Char>, Pointer<Void>)>>(
-            'Dart_ExecuteInternalCommand').asFunction<void Function(Pointer<Char>, Pointer<Void>)>();
+    return DynamicLibrary.process()
+        .lookup<NativeFunction<Void Function(Pointer<Char>, Pointer<Void>)>>(
+            'Dart_ExecuteInternalCommand')
+        .asFunction<void Function(Pointer<Char>, Pointer<Void>)>();
   } on ArgumentError {
     return null;
   }

--- a/pkgs/ffigen/test/native_objc_test/util.dart
+++ b/pkgs/ffigen/test/native_objc_test/util.dart
@@ -5,8 +5,8 @@
 import 'dart:ffi';
 import 'dart:io';
 
-import 'package:ffi/ffi.dart';
 import 'package:ffigen/ffigen.dart';
+import 'package:leak_tracker/leak_tracker.dart' show forceGC;
 import 'package:logging/logging.dart' show Level;
 import 'package:objective_c/objective_c.dart';
 import 'package:objective_c/src/internal.dart' as internal_for_testing
@@ -25,14 +25,9 @@ void generateBindingsForCoverage(String testName) {
   FfiGen(logLevel: Level.SEVERE).run(config);
 }
 
-@Native<Void Function(Pointer<Char>, Pointer<Void>)>(
-    symbol: 'Dart_ExecuteInternalCommand')
-external void _executeInternalCommand(Pointer<Char> cmd, Pointer<Void> arg);
-
-void doGC() {
-  final gcNow = "gc-now".toNativeUtf8();
-  _executeInternalCommand(gcNow.cast(), nullptr);
-  calloc.free(gcNow);
+Future<void> doGC() async {
+  forceGC();
+  await Future<void>.delayed(Duration(milliseconds: 50));
 }
 
 @Native<Bool Function(Pointer<Void>)>(isLeaf: true, symbol: 'isReadableMemory')

--- a/pkgs/ffigen/test/test_utils.dart
+++ b/pkgs/ffigen/test/test_utils.dart
@@ -171,3 +171,5 @@ T withChDir<T>(String path, T Function() inner) {
 
   return result;
 }
+
+bool isFlutterTester = Platform.resolvedExecutable.contains('flutter_tester');


### PR DESCRIPTION
#1570, #1571, and #1470 are only reproducible/testable in flutter, so we need to run the tests under `flutter test`. But the GC tests don't work reliably in flutter, so we still need to run the tests in `dart test` as well, and skip the GC tests on flutter.

The issue with the GC tests is that `Dart_ExecuteInternalCommand` doesn't exist in the flutter tester. I tried package:leak_tracker's `forceGC` function, but it broke the autorelease tests, had general flakiness issues.