### PR TITLE
[ffigen] Fix protocol inclusion rules

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -4,6 +4,12 @@
 - ObjC objects now include the methods from the protocols they implement. Both
   required and optional methods are included. Optional methods will throw an
   exception if the method isn't implemented.
+- __Breaking change__: Only generate ObjC protocol implementation bindings for
+  protocols that are included by the config filters. This is breaking because
+  previously super protocols would automatically get implementation bindings,
+  rather than just being incorporated into the child protocol. If you want those
+  implementation bindings, you may need to add the super protocol to your
+  `objc-protocols` filters.
 
 ## 14.0.1
 

--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -31,7 +31,8 @@ class ObjCProtocol extends NoLookUpBinding with ObjCMethods {
   @override
   BindingString toBindingString(Writer w) {
     if (!generateBindings) {
-      return BindingString(type: BindingStringType.objcProtocol, string: '');
+      return const BindingString(
+          type: BindingStringType.objcProtocol, string: '');
     }
 
     final protocolMethod = ObjCBuiltInFunctions.protocolMethod.gen(w);

--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -12,6 +12,7 @@ class ObjCProtocol extends NoLookUpBinding with ObjCMethods {
   final superProtocols = <ObjCProtocol>[];
   final String lookupName;
   late final ObjCInternalGlobal _protocolPointer;
+  final bool generateBindings;
 
   @override
   final ObjCBuiltInFunctions builtInFunctions;
@@ -23,11 +24,16 @@ class ObjCProtocol extends NoLookUpBinding with ObjCMethods {
     String? lookupName,
     super.dartDoc,
     required this.builtInFunctions,
+    required this.generateBindings,
   })  : lookupName = lookupName ?? originalName,
         super(name: name ?? originalName);
 
   @override
   BindingString toBindingString(Writer w) {
+    if (!generateBindings) {
+      return BindingString(type: BindingStringType.objcProtocol, string: '');
+    }
+
     final protocolMethod = ObjCBuiltInFunctions.protocolMethod.gen(w);
     final protocolListenableMethod =
         ObjCBuiltInFunctions.protocolListenableMethod.gen(w);
@@ -154,11 +160,13 @@ ${makeDartDoc(dartDoc ?? originalName)}abstract final class $name {
     if (dependencies.contains(this)) return;
     dependencies.add(this);
 
-    _protocolPointer = ObjCInternalGlobal(
-        '_protocol_$originalName',
-        (Writer w) =>
-            '${ObjCBuiltInFunctions.getProtocol.gen(w)}("$lookupName")')
-      ..addDependencies(dependencies);
+    if (generateBindings) {
+      _protocolPointer = ObjCInternalGlobal(
+          '_protocol_$originalName',
+          (Writer w) =>
+              '${ObjCBuiltInFunctions.getProtocol.gen(w)}("$lookupName")')
+        ..addDependencies(dependencies);
+    }
 
     for (final superProtocol in superProtocols) {
       superProtocol.addDependencies(dependencies);

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
@@ -118,7 +118,7 @@ void _parseSuperType(clang_types.CXCursor cursor, ObjCInterface itf) {
 
 void _parseProtocol(clang_types.CXCursor cursor, ObjCInterface itf) {
   final protoCursor = clang.clang_getCursorDefinition(cursor);
-  final proto = parseObjCProtocolDeclaration(protoCursor);
+  final proto = parseObjCProtocolDeclaration(protoCursor, ignoreFilter: true);
   if (proto != null) {
     itf.addProtocol(proto);
   }

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -381,7 +381,8 @@ void main() {
       // SuperProtocol and FilteredProtocol's methods are included in the
       // bindings, but there shouldn't actually be bindings for the protocols
       // themselves, because they're not included by the config.
-      final bindings = File('test/native_objc_test/protocol_bindings.dart').readAsStringSync();
+      final bindings = File('test/native_objc_test/protocol_bindings.dart')
+          .readAsStringSync();
 
       expect(bindings, contains('instanceMethod_withDouble_'));
       expect(bindings, contains('fooMethod'));

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -70,6 +70,9 @@ void main() {
         // Required instance method from secondary protocol.
         final otherIntResult = protocolImpl.otherMethod_b_c_d_(2, 4, 6, 8);
         expect(otherIntResult, 20);
+
+        // Method from a protocol that isn't included by the filters.
+        expect(protocolImpl.fooMethod(), 2468);
       });
 
       test('Unimplemented method', () {
@@ -372,6 +375,23 @@ void main() {
         expect(objectRetainCount(proxyPtr), 0);
         expect(blockRetainCount(blockPtr), 0);
       }, skip: !canDoGC);
+    });
+
+    test('Filters', () {
+      // SuperProtocol and FilteredProtocol's methods are included in the
+      // bindings, but there shouldn't actually be bindings for the protocols
+      // themselves, because they're not included by the config.
+      final bindings = File('test/native_objc_test/protocol_bindings.dart').readAsStringSync();
+
+      expect(bindings, contains('instanceMethod_withDouble_'));
+      expect(bindings, contains('fooMethod'));
+
+      expect(bindings, contains('EmptyProtocol'));
+      expect(bindings, contains('MyProtocol'));
+      expect(bindings, contains('SecondaryProtocol'));
+
+      expect(bindings, isNot(contains('SuperProtocol')));
+      expect(bindings, isNot(contains('FilteredProtocol')));
     });
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.h
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.h
@@ -43,6 +43,11 @@ typedef struct {
 @protocol EmptyProtocol
 @end
 
+@protocol FilteredProtocol
+@required
+- (int32_t)fooMethod;
+@end
+
 
 @interface ProtocolConsumer : NSObject
 - (NSString*)callInstanceMethod:(id<MyProtocol>)protocol;
@@ -52,7 +57,8 @@ typedef struct {
 @end
 
 
-@interface ObjCProtocolImpl : NSObject<MyProtocol, SecondaryProtocol>
+@interface ObjCProtocolImpl :
+    NSObject<MyProtocol, SecondaryProtocol, FilteredProtocol>
 @end
 
 

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.m
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.m
@@ -46,6 +46,10 @@
   return a + b + c + d;
 }
 
+- (int32_t)fooMethod {
+  return 2468;
+}
+
 @end
 
 


### PR DESCRIPTION
The current (buggy) behavior is that, when parsing an interface's conforming protocols to include their methods in the interface, the protocols are only parsed if they're included by the config filters. The typical approach in ffigen for this sort of thing is to bypass the filters when a entity is being included transitively (this is already the case for super protocols for example). But that would lead to the generation of a ton of protocol bindings (boilerplate for implementing those protocols from Dart) that the user probably doesn't want.

So I'm bypassing the filters when parsing transitively included protocols, but then only generating implementation bindings for the protocol if it is included by the config filters. This is technically a breaking change because it affects super protocols too, so users may need to add the super protocol to their filters if they still want those bindings (I don't expect this to actually affect anyone though).

Fixes #1487