### PR TITLE
[ffigen] More fixes for large integration test

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/objc_block.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_block.dart
@@ -21,7 +21,16 @@ class ObjCBlock extends BindingType {
     required bool returnsRetained,
     required ObjCBuiltInFunctions builtInFunctions,
   }) {
-    final usr = _getBlockUsr(returnType, params, returnsRetained);
+    final renamedParams = [
+      for (var i = 0; i < params.length; ++i)
+        Parameter(
+          name: 'arg$i',
+          type: params[i].type,
+          objCConsumed: params[i].objCConsumed,
+        ),
+    ];
+
+    final usr = _getBlockUsr(returnType, renamedParams, returnsRetained);
 
     final oldBlock = bindingsIndex.getSeenObjCBlock(usr);
     if (oldBlock != null) {
@@ -30,9 +39,9 @@ class ObjCBlock extends BindingType {
 
     final block = ObjCBlock._(
       usr: usr,
-      name: _getBlockName(returnType, params.map((a) => a.type)),
+      name: _getBlockName(returnType, renamedParams.map((a) => a.type)),
       returnType: returnType,
-      params: params,
+      params: renamedParams,
       returnsRetained: returnsRetained,
       builtInFunctions: builtInFunctions,
     );

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objc_block_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objc_block_parser.dart
@@ -18,7 +18,6 @@ ObjCBlock parseObjCBlock(clang_types.CXType cxtype) {
   for (var i = 0; i < numArgs; ++i) {
     final type = clang.clang_getArgType(blk, i);
     params.add(Parameter(
-      name: 'arg$i',
       type: type.toCodeGenType(),
       objCConsumed: false,
     ));

--- a/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
+++ b/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
@@ -48,6 +48,7 @@ void main() {
       'candidateListTouchBarItem',
       'hyphenationFactor',
       'tag',
+      'title',
     };
     final interfaceFilter = DeclarationFilters(
       shouldInclude: randInclude,


### PR DESCRIPTION
- Caught a real bug where synthetic blocks created by protocol bindings would use the protocol method's arg names, which could conflict with arg names used by the trampolines etc. Fix is to explicitly rename all the args to `arg0`, `arg1` etc.
- Added another disallowed method