### PR TITLE
[jnigen] Implement void interface methods as listeners

### DIFF
--- a/pkgs/jni/lib/_internal.dart
+++ b/pkgs/jni/lib/_internal.dart
@@ -12,6 +12,7 @@ import 'dart:ffi' as ffi show Int32;
 import 'dart:ffi' hide Int32;
 
 // Exporting all the necessary bits for the generated bindings.
+export 'dart:async' show FutureOr;
 export 'dart:ffi'
     show
         Double,

--- a/pkgs/jni/lib/_internal.dart
+++ b/pkgs/jni/lib/_internal.dart
@@ -12,7 +12,6 @@ import 'dart:ffi' as ffi show Int32;
 import 'dart:ffi' hide Int32;
 
 // Exporting all the necessary bits for the generated bindings.
-export 'dart:async' show FutureOr;
 export 'dart:ffi'
     show
         Double,

--- a/pkgs/jni/lib/src/jni.dart
+++ b/pkgs/jni/lib/src/jni.dart
@@ -273,7 +273,10 @@ extension ProtectedJniExtensions on Jni {
   /// Returns the result of a callback.
   static void returnResult(
       Pointer<CallbackResult> result, JObjectPtr object) async {
-    Jni._bindings.resultFor(result, object);
+    // The result is `nullptr` when the callback is a listener.
+    if (result != nullptr) {
+      Jni._bindings.resultFor(result, object);
+    }
   }
 
   static Dart_FinalizableHandle newJObjectFinalizableHandle(

--- a/pkgs/jni/src/dartjni.c
+++ b/pkgs/jni/src/dartjni.c
@@ -418,14 +418,20 @@ Java_com_github_dart_1lang_jni_PortProxyBuilder__1invoke(
     jlong functionPtr,
     jobject proxy,
     jstring methodDescriptor,
-    jobjectArray args) {
-  CallbackResult* result = (CallbackResult*)malloc(sizeof(CallbackResult));
-  if (isolateId != (jlong)Dart_CurrentIsolate_DL()) {
-    init_lock(&result->lock);
-    init_cond(&result->cond);
-    acquire_lock(&result->lock);
-    result->ready = 0;
-    result->object = NULL;
+    jobjectArray args,
+    jboolean isBlocking) {
+  CallbackResult* result = NULL;
+  if (isBlocking) {
+    result = (CallbackResult*)malloc(sizeof(CallbackResult));
+  }
+  if (isolateId != (jlong)Dart_CurrentIsolate_DL() || !isBlocking) {
+    if (isBlocking) {
+      init_lock(&result->lock);
+      init_cond(&result->cond);
+      acquire_lock(&result->lock);
+      result->ready = 0;
+      result->object = NULL;
+    }
 
     Dart_CObject c_result;
     c_result.type = Dart_CObject_kInt64;
@@ -448,17 +454,23 @@ Java_com_github_dart_1lang_jni_PortProxyBuilder__1invoke(
 
     Dart_PostCObject_DL(port, &c_post);
 
-    while (!result->ready) {
-      wait_for(&result->cond, &result->lock);
-    }
+    if (isBlocking) {
+      while (!result->ready) {
+        wait_for(&result->cond, &result->lock);
+      }
 
-    release_lock(&result->lock);
-    destroy_lock(&result->lock);
-    destroy_cond(&result->cond);
+      release_lock(&result->lock);
+      destroy_lock(&result->lock);
+      destroy_cond(&result->cond);
+    }
   } else {
     result->object = ((jobject(*)(uint64_t, jobject, jobject))functionPtr)(
         port, (*env)->NewGlobalRef(env, methodDescriptor),
         (*env)->NewGlobalRef(env, args));
+  }
+  if (!isBlocking) {
+    // No result is created in this case, there is nothing to clean up either.
+    return NULL;
   }
   // Returning an array of length 2.
   // [0]: The result pointer, used for cleaning up the global reference, and

--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Added `JImplementer` which enables building an object that implements multiple
   Java interfaces. Each interface now has a static `implementIn` method that
   takes a `JImplementer` and the implementation object.
+- Added the ability to implement void-returning interface methods as listeners.
 - Generating identifiers that start with an underscore (`_`) and making them
   public by prepending a dollar sign.
 - Fixed an issue where inheriting a generic class could generate incorrect code.

--- a/pkgs/jnigen/docs/interface_implementation.md
+++ b/pkgs/jnigen/docs/interface_implementation.md
@@ -151,10 +151,12 @@ class Printer with $Runnable {
   Printer(this.text);
 
   @override
-  Future<void> run() async {
+  void run() {
     print(text);
   }
-}
+
+  @override
+  bool get run$async => true; // This makes the run method non-blocking.
 ```
 
 

--- a/pkgs/jnigen/docs/interface_implementation.md
+++ b/pkgs/jnigen/docs/interface_implementation.md
@@ -38,20 +38,20 @@ class Runnable extends JObject {
 
 abstract interface class $Runnable {
   factory $Runnable({
-    required void Function() run,
+    required FutureOr<void> Function() run,
   }) = _$Runnable;
 
-  void run();
+  FutureOr<void> run();
 }
 
 class _$Runnable implements $Runnable {
   _$Runnable({
-    required void Function() run,
+    required FutureOr<void> Function() run,
   }) : _run = run;
 
-  final void Function() _run;
+  final FutureOr<void> Function() _run;
 
-  void run() {
+  FutureOr<void> run() {
     return _run();
   }
 }
@@ -119,6 +119,39 @@ class Printer implements $Runnable {
 And similarly write `Runnable.implement(Printer('hello'))` and
 `Runnable.implement(Printer('world'))`, to create multiple Runnables and share
 common logic.
+
+### Implement as a listener
+
+By default, when any of methods of the implemented interface gets called, the
+caller will block until the callee returns a result.
+
+Void-returning functions don't have to return a result, so we can choose to not
+block the caller when the method is just a listener. To signal this, make the
+return type of your method `Future<void>` instead of `void`.
+
+When implementing the interface inline, this is as simple as adding `async`:
+
+```dart
+// Dart
+final runnable = Runnable.implement($Runnable(run: () async => print('hello')));
+```
+
+Similarly, when subclassing make sure you use the correct return type:
+
+```dart
+// Dart
+class Printer implements $Runnable {
+  final String text;
+
+  Printer(this.text);
+
+  @override
+  Future<void> run() async {
+    print(text);
+  }
+}
+```
+
 
 ### Implement multiple interfaces
 

--- a/pkgs/jnigen/docs/interface_implementation.md
+++ b/pkgs/jnigen/docs/interface_implementation.md
@@ -36,20 +36,24 @@ class Runnable extends JObject {
   ) { /* ... */ }
 }
 
-abstract interface class $Runnable {
+abstract mixin class $Runnable {
   factory $Runnable({
     required void Function() run,
+    bool run$async,
   }) = _$Runnable;
 
+  bool get run$async => false;
   void run();
 }
 
 class _$Runnable implements $Runnable {
   _$Runnable({
     required void Function() run,
+    this.run$async = false;
   }) : _run = run;
 
   final void Function() _run;
+  final bool run$async;
 
   void run() {
     return _run();
@@ -83,7 +87,7 @@ implementing the interface in Java instead of using the lambdas:
 
 ```java
 // Java
-public class Printer implements Runnable {
+public class Printer with Runnable {
   private final String text;
 
   public Printer(String text) {
@@ -104,7 +108,7 @@ You can do the same in Dart by creating a subclass that implements `$Runnable`:
 
 ```dart
 // Dart
-class Printer implements $Runnable {
+class Printer with $Runnable {
   final String text;
 
   Printer(this.text);
@@ -126,21 +130,22 @@ By default, when any of methods of the implemented interface gets called, the
 caller will block until the callee returns a result.
 
 Void-returning functions don't have to return a result, so we can choose to not
-block the caller when the method is just a listener. To signal this, make the
-return type of your method `Future<void>` instead of `void`.
-
-When implementing the interface inline, this is as simple as adding `async`:
+block the caller when the method is just a listener. To signal this, pass `true`
+to `<method name>$async` argument when implementing the interface inline:
 
 ```dart
 // Dart
-final runnable = Runnable.implement($Runnable(run: () async => print('hello')));
+final runnable = Runnable.implement($Runnable(
+  run: () => print('hello'),
+  run$async: true, // This makes the run method non-blocking.
+));
 ```
 
-Similarly, when subclassing make sure you use the correct return type:
+Similarly, when subclassing 
 
 ```dart
 // Dart
-class Printer implements $Runnable {
+class Printer with $Runnable {
   final String text;
 
   Printer(this.text);
@@ -174,5 +179,5 @@ possible to make it a `Closable` by passing in `Closable.type` to
 
 ```dart
 // Dart
-final closable = object.castTo(Closable.type);
+final closable = object.as(Closable.type);
 ```

--- a/pkgs/jnigen/docs/interface_implementation.md
+++ b/pkgs/jnigen/docs/interface_implementation.md
@@ -38,20 +38,20 @@ class Runnable extends JObject {
 
 abstract interface class $Runnable {
   factory $Runnable({
-    required FutureOr<void> Function() run,
+    required void Function() run,
   }) = _$Runnable;
 
-  FutureOr<void> run();
+  void run();
 }
 
 class _$Runnable implements $Runnable {
   _$Runnable({
-    required FutureOr<void> Function() run,
+    required void Function() run,
   }) : _run = run;
 
-  final FutureOr<void> Function() _run;
+  final void Function() _run;
 
-  FutureOr<void> run() {
+  void run() {
     return _run();
   }
 }

--- a/pkgs/jnigen/lib/src/bindings/dart_generator.dart
+++ b/pkgs/jnigen/lib/src/bindings/dart_generator.dart
@@ -747,18 +747,6 @@ class _TypeGenerator extends TypeVisitor<String> {
   }
 }
 
-class _ImplReturnType extends _TypeGenerator {
-  _ImplReturnType(super.resolver);
-
-  @override
-  String visitPrimitiveType(PrimitiveType node) {
-    // Supporting both `Future<void>` for listener callbacks and `void` for
-    // blocking ones.
-    if (node.name == 'void') return '$_jni.FutureOr<void>';
-    return super.visitPrimitiveType(node);
-  }
-}
-
 class _TypeClass {
   final String name;
   final bool canBeConst;
@@ -1503,7 +1491,7 @@ class _AbstractImplMethod extends Visitor<Method, void> {
 
   @override
   void visit(Method node) {
-    final returnType = node.returnType.accept(_ImplReturnType(resolver));
+    final returnType = node.returnType.accept(_TypeGenerator(resolver));
     final name = node.finalName;
     final args = node.params.accept(_ParamDef(resolver)).join(', ');
     s.writeln('  $returnType $name($args);');
@@ -1519,7 +1507,7 @@ class _ConcreteImplClosureDef extends Visitor<Method, void> {
 
   @override
   void visit(Method node) {
-    final returnType = node.returnType.accept(_ImplReturnType(resolver));
+    final returnType = node.returnType.accept(_TypeGenerator(resolver));
     final name = node.finalName;
     final args = node.params.accept(_ParamDef(resolver)).join(', ');
     s.writeln('  final $returnType Function($args) _$name;');
@@ -1535,7 +1523,7 @@ class _ConcreteImplClosureCtorArg extends Visitor<Method, String> {
 
   @override
   String visit(Method node) {
-    final returnType = node.returnType.accept(_ImplReturnType(resolver));
+    final returnType = node.returnType.accept(_TypeGenerator(resolver));
     final name = node.finalName;
     final args = node.params.accept(_ParamDef(resolver)).join(', ');
     return 'required $returnType Function($args) $name,';
@@ -1588,7 +1576,7 @@ class _ConcreteImplMethod extends Visitor<Method, void> {
 
   @override
   void visit(Method node) {
-    final returnType = node.returnType.accept(_ImplReturnType(resolver));
+    final returnType = node.returnType.accept(_TypeGenerator(resolver));
     final name = node.finalName;
     final argsDef = node.params.accept(_ParamDef(resolver)).join(', ');
     final argsCall = node.params.map((param) => param.finalName).join(', ');
@@ -1647,7 +1635,7 @@ class _InterfaceIfAsyncMethod extends Visitor<Method, void> {
     final neverType = node.accept(_InterfaceNeverFunctionType(resolver));
     // If the implementation is using the callback passing style, look at the
     // actual passed callback instead of the wrapper function. The wrapper is
-    // always going to return `FutureOr<void>`.
+    // always going to return `void`.
     //
     // If the callback simply throws its return type will be `Never`. As any
     // function `R <F>` is a subtype of `Never <F>`, we should have a special

--- a/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
@@ -4866,15 +4866,7 @@ class MyInterface<$T extends _$jni.JObject> extends _$jni.JObject {
       $p,
       _$invokePointer,
       [
-        if (($impl is _$MyInterface &&
-                ($impl as _$MyInterface)._voidCallback is _$core.Future<void>
-                    Function(_$jni.JString) &&
-                ($impl as _$MyInterface)._voidCallback is! _$core.Never
-                    Function(_$jni.JString)) ||
-            ($impl.voidCallback is _$core.Future<void> Function(
-                    _$jni.JString) &&
-                $impl.voidCallback is! _$core.Never Function(_$jni.JString)))
-          r'voidCallback(Ljava/lang/String;)V',
+        if ($impl.voidCallback$async) r'voidCallback(Ljava/lang/String;)V',
       ],
     );
     final $a = $p.sendPort.nativePort;
@@ -4894,10 +4886,11 @@ class MyInterface<$T extends _$jni.JObject> extends _$jni.JObject {
   static _$core.Map<int, $MyInterface> get $impls => _$impls;
 }
 
-abstract interface class $MyInterface<$T extends _$jni.JObject> {
+abstract mixin class $MyInterface<$T extends _$jni.JObject> {
   factory $MyInterface({
     required _$jni.JObjType<$T> T,
     required void Function(_$jni.JString s) voidCallback,
+    bool voidCallback$async,
     required _$jni.JString Function(_$jni.JString s) stringCallback,
     required $T Function($T t) varCallback,
     required int Function(int a, bool b, int c, double d) manyPrimitives,
@@ -4906,6 +4899,7 @@ abstract interface class $MyInterface<$T extends _$jni.JObject> {
   _$jni.JObjType<$T> get T;
 
   void voidCallback(_$jni.JString s);
+  bool get voidCallback$async => false;
   _$jni.JString stringCallback(_$jni.JString s);
   $T varCallback($T t);
   int manyPrimitives(int a, bool b, int c, double d);
@@ -4915,6 +4909,7 @@ class _$MyInterface<$T extends _$jni.JObject> implements $MyInterface<$T> {
   _$MyInterface({
     required this.T,
     required void Function(_$jni.JString s) voidCallback,
+    this.voidCallback$async = false,
     required _$jni.JString Function(_$jni.JString s) stringCallback,
     required $T Function($T t) varCallback,
     required int Function(int a, bool b, int c, double d) manyPrimitives,
@@ -4927,6 +4922,7 @@ class _$MyInterface<$T extends _$jni.JObject> implements $MyInterface<$T> {
   final _$jni.JObjType<$T> T;
 
   final void Function(_$jni.JString s) _voidCallback;
+  final bool voidCallback$async;
   final _$jni.JString Function(_$jni.JString s) _stringCallback;
   final $T Function($T t) _varCallback;
   final int Function(int a, bool b, int c, double d) _manyPrimitives;
@@ -5281,13 +5277,7 @@ class MyRunnable extends _$jni.JObject {
       $p,
       _$invokePointer,
       [
-        if (($impl is _$MyRunnable &&
-                ($impl as _$MyRunnable)._run is _$core.Future<void>
-                    Function() &&
-                ($impl as _$MyRunnable)._run is! _$core.Never Function()) ||
-            ($impl.run is _$core.Future<void> Function() &&
-                $impl.run is! _$core.Never Function()))
-          r'run()V',
+        if ($impl.run$async) r'run()V',
       ],
     );
     final $a = $p.sendPort.nativePort;
@@ -5306,20 +5296,24 @@ class MyRunnable extends _$jni.JObject {
   static _$core.Map<int, $MyRunnable> get $impls => _$impls;
 }
 
-abstract interface class $MyRunnable {
+abstract mixin class $MyRunnable {
   factory $MyRunnable({
     required void Function() run,
+    bool run$async,
   }) = _$MyRunnable;
 
   void run();
+  bool get run$async => false;
 }
 
 class _$MyRunnable implements $MyRunnable {
   _$MyRunnable({
     required void Function() run,
+    this.run$async = false,
   }) : _run = run;
 
   final void Function() _run;
+  final bool run$async;
 
   void run() {
     return _run();
@@ -5716,7 +5710,7 @@ class StringConverter extends _$jni.JObject {
   }
 }
 
-abstract interface class $StringConverter {
+abstract mixin class $StringConverter {
   factory $StringConverter({
     required int Function(_$jni.JString s) parseToInt,
   }) = _$StringConverter;
@@ -6402,7 +6396,7 @@ class JsonSerializable extends _$jni.JObject {
   }
 }
 
-abstract interface class $JsonSerializable {
+abstract mixin class $JsonSerializable {
   factory $JsonSerializable({
     required JsonSerializable_Case Function() value,
   }) = _$JsonSerializable;

--- a/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
@@ -4897,7 +4897,7 @@ class MyInterface<$T extends _$jni.JObject> extends _$jni.JObject {
 abstract interface class $MyInterface<$T extends _$jni.JObject> {
   factory $MyInterface({
     required _$jni.JObjType<$T> T,
-    required _$jni.FutureOr<void> Function(_$jni.JString s) voidCallback,
+    required void Function(_$jni.JString s) voidCallback,
     required _$jni.JString Function(_$jni.JString s) stringCallback,
     required $T Function($T t) varCallback,
     required int Function(int a, bool b, int c, double d) manyPrimitives,
@@ -4905,7 +4905,7 @@ abstract interface class $MyInterface<$T extends _$jni.JObject> {
 
   _$jni.JObjType<$T> get T;
 
-  _$jni.FutureOr<void> voidCallback(_$jni.JString s);
+  void voidCallback(_$jni.JString s);
   _$jni.JString stringCallback(_$jni.JString s);
   $T varCallback($T t);
   int manyPrimitives(int a, bool b, int c, double d);
@@ -4914,7 +4914,7 @@ abstract interface class $MyInterface<$T extends _$jni.JObject> {
 class _$MyInterface<$T extends _$jni.JObject> implements $MyInterface<$T> {
   _$MyInterface({
     required this.T,
-    required _$jni.FutureOr<void> Function(_$jni.JString s) voidCallback,
+    required void Function(_$jni.JString s) voidCallback,
     required _$jni.JString Function(_$jni.JString s) stringCallback,
     required $T Function($T t) varCallback,
     required int Function(int a, bool b, int c, double d) manyPrimitives,
@@ -4926,12 +4926,12 @@ class _$MyInterface<$T extends _$jni.JObject> implements $MyInterface<$T> {
   @_$core.override
   final _$jni.JObjType<$T> T;
 
-  final _$jni.FutureOr<void> Function(_$jni.JString s) _voidCallback;
+  final void Function(_$jni.JString s) _voidCallback;
   final _$jni.JString Function(_$jni.JString s) _stringCallback;
   final $T Function($T t) _varCallback;
   final int Function(int a, bool b, int c, double d) _manyPrimitives;
 
-  _$jni.FutureOr<void> voidCallback(_$jni.JString s) {
+  void voidCallback(_$jni.JString s) {
     return _voidCallback(s);
   }
 
@@ -5308,20 +5308,20 @@ class MyRunnable extends _$jni.JObject {
 
 abstract interface class $MyRunnable {
   factory $MyRunnable({
-    required _$jni.FutureOr<void> Function() run,
+    required void Function() run,
   }) = _$MyRunnable;
 
-  _$jni.FutureOr<void> run();
+  void run();
 }
 
 class _$MyRunnable implements $MyRunnable {
   _$MyRunnable({
-    required _$jni.FutureOr<void> Function() run,
+    required void Function() run,
   }) : _run = run;
 
-  final _$jni.FutureOr<void> Function() _run;
+  final void Function() _run;
 
-  _$jni.FutureOr<void> run() {
+  void run() {
     return _run();
   }
 }

--- a/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
@@ -4865,6 +4865,17 @@ class MyInterface<$T extends _$jni.JObject> extends _$jni.JObject {
       r'com.github.dart_lang.jnigen.interfaces.MyInterface',
       $p,
       _$invokePointer,
+      [
+        if (($impl is _$MyInterface &&
+                ($impl as _$MyInterface)._voidCallback is _$core.Future<void>
+                    Function(_$jni.JString) &&
+                ($impl as _$MyInterface)._voidCallback is! _$core.Never
+                    Function(_$jni.JString)) ||
+            ($impl.voidCallback is _$core.Future<void> Function(
+                    _$jni.JString) &&
+                $impl.voidCallback is! _$core.Never Function(_$jni.JString)))
+          r'voidCallback(Ljava/lang/String;)V',
+      ],
     );
     final $a = $p.sendPort.nativePort;
     _$impls[$a] = $impl;
@@ -4886,7 +4897,7 @@ class MyInterface<$T extends _$jni.JObject> extends _$jni.JObject {
 abstract interface class $MyInterface<$T extends _$jni.JObject> {
   factory $MyInterface({
     required _$jni.JObjType<$T> T,
-    required void Function(_$jni.JString s) voidCallback,
+    required _$jni.FutureOr<void> Function(_$jni.JString s) voidCallback,
     required _$jni.JString Function(_$jni.JString s) stringCallback,
     required $T Function($T t) varCallback,
     required int Function(int a, bool b, int c, double d) manyPrimitives,
@@ -4894,7 +4905,7 @@ abstract interface class $MyInterface<$T extends _$jni.JObject> {
 
   _$jni.JObjType<$T> get T;
 
-  void voidCallback(_$jni.JString s);
+  _$jni.FutureOr<void> voidCallback(_$jni.JString s);
   _$jni.JString stringCallback(_$jni.JString s);
   $T varCallback($T t);
   int manyPrimitives(int a, bool b, int c, double d);
@@ -4903,7 +4914,7 @@ abstract interface class $MyInterface<$T extends _$jni.JObject> {
 class _$MyInterface<$T extends _$jni.JObject> implements $MyInterface<$T> {
   _$MyInterface({
     required this.T,
-    required void Function(_$jni.JString s) voidCallback,
+    required _$jni.FutureOr<void> Function(_$jni.JString s) voidCallback,
     required _$jni.JString Function(_$jni.JString s) stringCallback,
     required $T Function($T t) varCallback,
     required int Function(int a, bool b, int c, double d) manyPrimitives,
@@ -4915,12 +4926,12 @@ class _$MyInterface<$T extends _$jni.JObject> implements $MyInterface<$T> {
   @_$core.override
   final _$jni.JObjType<$T> T;
 
-  final void Function(_$jni.JString s) _voidCallback;
+  final _$jni.FutureOr<void> Function(_$jni.JString s) _voidCallback;
   final _$jni.JString Function(_$jni.JString s) _stringCallback;
   final $T Function($T t) _varCallback;
   final int Function(int a, bool b, int c, double d) _manyPrimitives;
 
-  void voidCallback(_$jni.JString s) {
+  _$jni.FutureOr<void> voidCallback(_$jni.JString s) {
     return _voidCallback(s);
   }
 
@@ -5269,6 +5280,15 @@ class MyRunnable extends _$jni.JObject {
       r'com.github.dart_lang.jnigen.interfaces.MyRunnable',
       $p,
       _$invokePointer,
+      [
+        if (($impl is _$MyRunnable &&
+                ($impl as _$MyRunnable)._run is _$core.Future<void>
+                    Function() &&
+                ($impl as _$MyRunnable)._run is! _$core.Never Function()) ||
+            ($impl.run is _$core.Future<void> Function() &&
+                $impl.run is! _$core.Never Function()))
+          r'run()V',
+      ],
     );
     final $a = $p.sendPort.nativePort;
     _$impls[$a] = $impl;
@@ -5288,20 +5308,20 @@ class MyRunnable extends _$jni.JObject {
 
 abstract interface class $MyRunnable {
   factory $MyRunnable({
-    required void Function() run,
+    required _$jni.FutureOr<void> Function() run,
   }) = _$MyRunnable;
 
-  void run();
+  _$jni.FutureOr<void> run();
 }
 
 class _$MyRunnable implements $MyRunnable {
   _$MyRunnable({
-    required void Function() run,
+    required _$jni.FutureOr<void> Function() run,
   }) : _run = run;
 
-  final void Function() _run;
+  final _$jni.FutureOr<void> Function() _run;
 
-  void run() {
+  _$jni.FutureOr<void> run() {
     return _run();
   }
 }
@@ -5438,6 +5458,30 @@ class MyRunnableRunner extends _$jni.JObject {
   void runOnAnotherThread() {
     _runOnAnotherThread(
             reference.pointer, _id_runOnAnotherThread as _$jni.JMethodIDPtr)
+        .check();
+  }
+
+  static final _id_runOnAnotherThreadAndJoin = _class.instanceMethodId(
+    r'runOnAnotherThreadAndJoin',
+    r'()V',
+  );
+
+  static final _runOnAnotherThreadAndJoin = _$jni.ProtectedJniExtensions.lookup<
+          _$jni.NativeFunction<
+              _$jni.JThrowablePtr Function(
+                _$jni.Pointer<_$jni.Void>,
+                _$jni.JMethodIDPtr,
+              )>>('globalEnv_CallVoidMethod')
+      .asFunction<
+          _$jni.JThrowablePtr Function(
+            _$jni.Pointer<_$jni.Void>,
+            _$jni.JMethodIDPtr,
+          )>();
+
+  /// from: `public void runOnAnotherThreadAndJoin()`
+  void runOnAnotherThreadAndJoin() {
+    _runOnAnotherThreadAndJoin(reference.pointer,
+            _id_runOnAnotherThreadAndJoin as _$jni.JMethodIDPtr)
         .check();
   }
 }
@@ -5655,6 +5699,7 @@ class StringConverter extends _$jni.JObject {
       r'com.github.dart_lang.jnigen.interfaces.StringConverter',
       $p,
       _$invokePointer,
+      [],
     );
     final $a = $p.sendPort.nativePort;
     _$impls[$a] = $impl;
@@ -6340,6 +6385,7 @@ class JsonSerializable extends _$jni.JObject {
       r'com.github.dart_lang.jnigen.annotations.JsonSerializable',
       $p,
       _$invokePointer,
+      [],
     );
     final $a = $p.sendPort.nativePort;
     _$impls[$a] = $impl;

--- a/pkgs/jnigen/test/simple_package_test/java/com/github/dart_lang/jnigen/interfaces/MyRunnableRunner.java
+++ b/pkgs/jnigen/test/simple_package_test/java/com/github/dart_lang/jnigen/interfaces/MyRunnableRunner.java
@@ -25,4 +25,10 @@ public class MyRunnableRunner {
     var thread = new Thread(this::runOnSameThread);
     thread.start();
   }
+
+  public void runOnAnotherThreadAndJoin() throws InterruptedException {
+    var thread = new Thread(this::runOnSameThread);
+    thread.start();
+    thread.join();
+  }
 }

--- a/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
+++ b/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
@@ -709,9 +709,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
           final MyRunnable runnable;
           if (style == 'callback') {
             runnable = MyRunnable.implement($MyRunnable(
-              run: () async /* <-- Having `async` makes this a listener. */ {
-                completer.complete();
-              },
+              run: completer.complete,
+              run$async: true,
             ));
           } else {
             runnable = MyRunnable.implement(AsyncRunnable(completer));
@@ -946,7 +945,7 @@ class DartStringToIntParser implements $StringConverter {
   }
 }
 
-class AsyncRunnable implements $MyRunnable {
+class AsyncRunnable with $MyRunnable {
   final Completer<void> completer;
 
   AsyncRunnable(this.completer);
@@ -955,4 +954,7 @@ class AsyncRunnable implements $MyRunnable {
   Future<void> run() async {
     completer.complete();
   }
+
+  @override
+  bool get run$async => true;
 }


### PR DESCRIPTION
Closes #1568.

Added a boolean `<method name>$async` for each given void method in an interface that defaults to `false`. If set to `true`, it will treat the method as a listener.