### PR TITLE
[native_toolchain_c] Enable Android RISC-V testing

### DIFF
--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
         with:
-          ndk-version: r26b
+          ndk-version: r27
         if: ${{ matrix.os != 'macos' }}
 
       - run: dart pub get

--- a/.github/workflows/native_toolchain_c.yaml
+++ b/.github/workflows/native_toolchain_c.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
         with:
-          ndk-version: r26b
+          ndk-version: r27
         if: ${{ matrix.sdk == 'stable' }}
 
       - run: dart pub get

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -17,8 +17,7 @@ void main() {
     Architecture.arm64,
     Architecture.ia32,
     Architecture.x64,
-    // TODO(rmacnak): Enable when stable NDK 27 is available.
-    // Architecture.riscv64,
+    Architecture.riscv64,
   ];
 
   const objdumpFileFormat = {


### PR DESCRIPTION
Android NDK r27 has been released, which means we can now test RISC-V on Android.