### PR TITLE
[hooks] Remove explicit adding of source dependency in `hook/link.dart` scripts

### DIFF
--- a/pkgs/native_assets_builder/test_data/drop_dylib_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/drop_dylib_link/hook/link.dart
@@ -14,6 +14,5 @@ Received ${config.codeAssets.all.length} encodedAssets: ${config.codeAssets.all.
     print('''
 Keeping only ${output.codeAssets.all.map((e) => e.id)}.
 ''');
-    output.addDependency(config.packageRoot.resolve('hook/link.dart'));
   });
 }

--- a/pkgs/native_assets_builder/test_data/no_asset_for_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/no_asset_for_link/hook/link.dart
@@ -7,6 +7,5 @@ import 'package:native_assets_cli/native_assets_cli.dart';
 void main(List<String> arguments) async {
   await link(arguments, (config, output) async {
     output.addEncodedAssets(config.encodedAssets);
-    output.addDependency(config.packageRoot.resolve('hook/link.dart'));
   });
 }


### PR DESCRIPTION
A hook author doesn't know the transitive dart files. The bundling tool should already take care of re-building & re-running hooks if their source changes.