### PR TITLE
Ensure the NativeAssetsBuildRunner.link() produces a BuildResult with all assets

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -14,6 +14,13 @@
 - **Breaking change**: Remove asset-type specific logic from `package:native_assets_builder`.
   Bundling tools have to now supply `supportedAssetTypes` and corresponding
   validation routines.
+- **Breaking change**: The `NativeAssetsBuildRunner.link()` command will now
+  produce a `LinkResult` containing all assets for the application (not just
+  those that happened to have a linker). This removes the need for a bundling
+  tool to combine parts of `BuildResult` and `LinkResult` and possibly checking
+  consistency of the sum of those parts. Effectively this means: Any asset that
+  doesn't have an explicit linker will get a NOP linker that emits as outputs
+  it's inputs.
 
 ## 0.8.3
 

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -234,6 +234,9 @@ class NativeAssetsBuildRunner {
     }
 
     var hookResult = HookResult();
+    if (hook == Hook.link) {
+      hookResult.encodedAssets.addAll(buildResult!.encodedAssets);
+    }
     final metadata = <String, Metadata>{};
     for (final package in buildPlan) {
       final DependencyMetadata? dependencyMetadata;

--- a/pkgs/native_assets_builder/lib/src/model/link_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/link_result.dart
@@ -9,7 +9,8 @@ import '../build_runner/build_runner.dart';
 /// The result of executing the link hooks in dry run mode from all packages in
 /// the dependency tree of the entry point application.
 abstract interface class LinkResult {
-  /// The native assets produced by the hooks, which should be bundled.
+  /// All assets (produced by the build & link hooks) that have to be bundled
+  /// with the app.
   List<EncodedAsset> get encodedAssets;
 
   /// The files used by the hooks.

--- a/pkgs/native_assets_builder/test/build_runner/conflicting_dylib_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/conflicting_dylib_test.dart
@@ -72,14 +72,8 @@ void main() async {
         linkValidator: validateCodeAssetLinkOutput,
         applicationAssetValidator: validateCodeAssetsInApplication,
       );
-      expect(linkResult.success, isTrue);
-
-      final allAssets = [
-        ...buildResult.encodedAssets,
-        ...linkResult.encodedAssets
-      ].where((e) => e.type == CodeAsset.type).toList();
-      final validateResult = await validateCodeAssetsInApplication(allAssets);
-      expect(validateResult, isNotEmpty);
+      // Application validation error due to conflicting dylib name.
+      expect(linkResult.success, isFalse);
     });
   });
 }

--- a/pkgs/native_assets_builder/test/build_runner/link_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/link_test.dart
@@ -121,8 +121,8 @@ void main() async {
         );
         expect(linkResult.success, true);
 
-        expect(
-            _getNames(linkResult.encodedAssets), unorderedEquals(linkedAssets));
+        expect(_getNames(linkResult.encodedAssets),
+            unorderedEquals([...builtHelperAssets, ...linkedAssets]));
       });
     },
   );


### PR DESCRIPTION
Before this change a bundling tool would

  * call `buildResult = nativeAssetsBuildRunner.build(...)`
  * call `linkResult = nativeAssetsBuildRunner.link(buildResult: buildResult, ...)
  * get all assets via `allAssets = [...buildResult.assets, ...linkResult.assets]`

=> This PR makes the `link()` command produce a `LinkResult` containing
   all assets of the final application.

=> One could view this as the assets from `build()` without a linker to go to
   a default linker that just emits all of it's inputs.

=> This allows the `link()` step to also perform the application-wide
   validation steps (not just over all linker outputs but across build &
   link outputs)

Bundling tools now only have to deal with
  * `buildResult` in JIT mode (where linking is not enabled)
  * `linkResult` in AOT mode (where linking is enabled)

Instead of dealing with both `buildResult` and `linkResult` in AOT mode.

(In some sense one actually would prefer a `NativeAssetsBuilder.build` and
`NativeAssetsBuilder.buildAndLink` instead of the current API that exposes the
intermediary result from `build(linkingEnabled: true)` just to be explicitly
passed on to `link` later on)