### PR TITLE
[ffigen] Fix the weekly bot

### DIFF
--- a/.github/workflows/ffigen_weekly.yml
+++ b/.github/workflows/ffigen_weekly.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Install dependencies
         run: flutter pub get && flutter pub get --directory="../objective_c"
       - name: Build test dylib and bindings
-        run: dart test/setup.dart
+        run: dart test/setup.dart --main-thread-dispatcher
       - name: Run VM tests
         run: flutter test

--- a/.github/workflows/ffigen_weekly.yml
+++ b/.github/workflows/ffigen_weekly.yml
@@ -5,6 +5,14 @@ name: ffigen_weekly
 
 on:
   # Run once a week.
+  push:
+    branches: [main, stable]
+    paths:
+      - '.github/workflows/ffigen_weekly.yml'
+  pull_request:
+    branches: [main, stable]
+    paths:
+      - '.github/workflows/ffigen_weekly.yml'
   schedule:
     - cron: "0 0 * * 0"
 
@@ -22,7 +30,6 @@ jobs:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
       - uses: subosito/flutter-action@44ac965b96f18d999802d4b807e3256d5a3f9fa1
         with:
-          flutter-version: 3.19.0
           channel: 'stable'
       - name: Install dependencies
         run: flutter pub get && flutter pub get --directory="../objective_c"


### PR DESCRIPTION
The weekly bot failed again https://github.com/dart-lang/native/actions/runs/11197253228/job/31126969184. Fixes:
- Updated the workflow so that it also runs on any PR that alters that file
- Updated the version of flutter
- Pass the new `--main-thread-dispatcher` flag to setup.dart

Fixes https://github.com/dart-lang/native/issues/1617