### PR TITLE
[jnigen] Exclude invalid Dart identifiers by default

### DIFF
--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.2-wip
+
+- Now excludes invalid identifiers by default.
+
 ## 0.12.1
 
 - Support implementing generic functions in interfaces.

--- a/pkgs/jnigen/lib/src/bindings/excluder.dart
+++ b/pkgs/jnigen/lib/src/bindings/excluder.dart
@@ -11,6 +11,21 @@ extension on ClassMember {
   bool get isPrivate => !isPublic;
 }
 
+// TODO(https://github.com/dart-lang/native/issues/1164): Kotlin compiler
+// appends the method name with a dash and a hash code when arguments contain
+// inline classes. This is because inline classes do not have any runtime type
+// and the typical operator overloading supported by JVM cannot work for them.
+//
+// Once we support inline classes, we can relax the following constraints.
+final _validDartIdentifier = RegExp(r'^[a-zA-Z_$][a-zA-Z0-9_$]*$');
+
+extension on String {
+  bool get isInvalidDartIdentifier =>
+      !_validDartIdentifier.hasMatch(this) &&
+      this != '<init>' &&
+      this != '<clinit>';
+}
+
 class Excluder extends Visitor<Classes, void> {
   final Config config;
 
@@ -23,6 +38,11 @@ class Excluder extends Visitor<Classes, void> {
           !(config.exclude?.classes?.included(classDecl) ?? true);
       if (excluded) {
         log.fine('Excluded class ${classDecl.binaryName}');
+      }
+      if (classDecl.name.isInvalidDartIdentifier) {
+        log.warning('Excluded class ${classDecl.binaryName}: the name is not a'
+            ' valid Dart identifer');
+        return true;
       }
       return excluded;
     });
@@ -51,6 +71,12 @@ class _ClassExcluder extends Visitor<ClassDecl, void> {
       if (excluded) {
         log.fine('Excluded method ${node.binaryName}#${method.name}');
       }
+      if (method.name.isInvalidDartIdentifier) {
+        log.warning(
+            'Excluded method ${node.binaryName}#${method.name}: the name is not'
+            ' a valid Dart identifer');
+        return false;
+      }
       return !excluded;
     }).toList();
     node.fields = node.fields.where((field) {
@@ -58,6 +84,12 @@ class _ClassExcluder extends Visitor<ClassDecl, void> {
           (config.exclude?.fields?.included(node, field) ?? true);
       if (excluded) {
         log.fine('Excluded field ${node.binaryName}#${field.name}');
+      }
+      if (field.name.isInvalidDartIdentifier) {
+        log.warning(
+            'Excluded field ${node.binaryName}#${field.name}: the name is not'
+            ' a valid Dart identifer');
+        return false;
       }
       return !excluded;
     }).toList();

--- a/pkgs/jnigen/pubspec.yaml
+++ b/pkgs/jnigen/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jnigen
 description: A Dart bindings generator for Java and Kotlin that uses JNI under the hood to interop with Java virtual machine.
-version: 0.12.1
+version: 0.12.2-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jnigen
 
 environment:


### PR DESCRIPTION
Show a warning and exclude all the identifiers that are currently malformed for whatever reason! Kotlin generates dashes in the names of the methods that have arguments with inline class types, until we correctly support them, let's exclude them so that because of one potentially unused method the entire generated bindings are not unusable. 