### PR TITLE
[jnigen] Add a helper for sending jobjects through method channels

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.12.1-wip
+
+- Add `JniUtils.fromReferenceAddress` which helps with sending `JObject`s
+  through method channels. You can send the address of the pointer as `long` and
+  reconstruct the class using the helper method.
+
 ## 0.12.0
 
 - **Breaking Change**: Renamed `castTo` to `as`.

--- a/pkgs/jni/java/src/main/java/com/github/dart_lang/jni/JniUtils.java
+++ b/pkgs/jni/java/src/main/java/com/github/dart_lang/jni/JniUtils.java
@@ -1,0 +1,13 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+package com.github.dart_lang.jni;
+
+public class JniUtils {
+  static {
+    System.loadLibrary("dartjni");
+  }
+
+  public static native Object fromReferenceAddress(long address);
+}

--- a/pkgs/jni/pubspec.yaml
+++ b/pkgs/jni/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jni
 description: A library to access JNI from Dart and Flutter that acts as a support library for package:jnigen.
-version: 0.12.0
+version: 0.12.1-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jni
 
 topics:


### PR DESCRIPTION
Somehow I did not add this even though the C code existed. This is useful when trying to reconstruct an object from the its pointer's address in Java after sending the address through method channels.