### PR TITLE
Fix a bug where toNSInputStream would leak if the stream is closed before being fully read

### DIFF
--- a/pkgs/objective_c/lib/src/ns_input_stream.dart
+++ b/pkgs/objective_c/lib/src/ns_input_stream.dart
@@ -41,10 +41,15 @@ extension NSInputStreamStreamExtension on Stream<List<int>> {
 
     dataSubscription.pause();
     port.listen((count) {
+      print('Got $count');
       // -1 indicates that the `NSInputStream` is closed. All other values
       // indicate that the `NSInputStream` needs more data.
+      //
+      // If [DartInputStreamAdapter.setError_] or
+      // [DartInputStreamAdapter.setDone] is called then the close message (-1)
+      // will not be sent when the input stream is closed.
       if (count == -1) {
-        dataSubscription.cancel();
+        port.close();
       } else {
         dataSubscription.resume();
       }

--- a/pkgs/objective_c/lib/src/ns_input_stream.dart
+++ b/pkgs/objective_c/lib/src/ns_input_stream.dart
@@ -41,7 +41,6 @@ extension NSInputStreamStreamExtension on Stream<List<int>> {
 
     dataSubscription.pause();
     port.listen((count) {
-      print('Got $count');
       // -1 indicates that the `NSInputStream` is closed. All other values
       // indicate that the `NSInputStream` needs more data.
       //


### PR DESCRIPTION
- [X ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
