### PR TITLE
[ffigen] Migrate method filtering to the visitor

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Ensure all protocols referenced in bindings are available at runtime.
 - Use package:objective_c 4.0.0
+- Fix various small bugs todo with config filters:
+  - https://github.com/dart-lang/native/issues/1582
+  - https://github.com/dart-lang/native/issues/1594
+  - https://github.com/dart-lang/native/issues/1595
 
 ## 15.0.0
 

--- a/pkgs/ffigen/lib/src/code_generator/imports.dart
+++ b/pkgs/ffigen/lib/src/code_generator/imports.dart
@@ -135,6 +135,6 @@ final wCharType = ImportedType(ffiImport, 'WChar', 'int', 'wchar_t', '0');
 final objCObjectType =
     ImportedType(objcPkgImport, 'ObjCObject', 'ObjCObject', 'void');
 final objCSelType = ImportedType(
-    objcPkgImport, 'ObjCSelector', 'ObjCSelector', 'objc_selector');
+    objcPkgImport, 'ObjCSelector', 'ObjCSelector', 'struct objc_selector');
 final objCBlockType =
     ImportedType(objcPkgImport, 'ObjCBlockImpl', 'ObjCBlockImpl', 'id');

--- a/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
@@ -154,18 +154,6 @@ class ObjCInterface extends BindingType with ObjCMethods {
       s.write(' {\n');
 
       // Implementation.
-      final sel = m.selObject.name;
-      if (m.isOptional) {
-        s.write('''
-    if (!${ObjCBuiltInFunctions.respondsToSelector.gen(w)}(ref.pointer, $sel)) {
-      throw ${ObjCBuiltInFunctions.unimplementedOptionalMethodException.gen(w)}(
-          '$originalName', '${m.originalName}');
-    }
-''');
-      }
-      final convertReturn = m.kind != ObjCMethodKind.propertySetter &&
-          !returnType.sameDartAndFfiDartType;
-
       final target = isStatic
           ? _classObject.name
           : convertDartTypeToFfiDartType(
@@ -174,6 +162,18 @@ class ObjCInterface extends BindingType with ObjCMethods {
               objCRetain: m.consumesSelf,
               objCAutorelease: false,
             );
+      final sel = m.selObject.name;
+      if (m.isOptional) {
+        s.write('''
+    if (!${ObjCBuiltInFunctions.respondsToSelector.gen(w)}($target, $sel)) {
+      throw ${ObjCBuiltInFunctions.unimplementedOptionalMethodException.gen(w)}(
+          '$originalName', '${m.originalName}');
+    }
+''');
+      }
+      final convertReturn = m.kind != ObjCMethodKind.propertySetter &&
+          !returnType.sameDartAndFfiDartType;
+
       final msgSendParams =
           m.params.map((p) => p.type.convertDartTypeToFfiDartType(
                 w,

--- a/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
@@ -98,7 +98,7 @@ mixin ObjCMethods {
 
   void sortMethods() => _order.sort();
 
-  void filterMethods(bool predicate(ObjCMethod method)) {
+  void filterMethods(bool Function(ObjCMethod method) predicate) {
     final newOrder = <String>[];
     final newMethods = <String, ObjCMethod>{};
     for (final name in _order) {

--- a/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
@@ -15,8 +15,8 @@ import 'writer.dart';
 final _logger = Logger('ffigen.code_generator.objc_methods');
 
 mixin ObjCMethods {
-  final _methods = <String, ObjCMethod>{};
-  final _order = <String>[];
+  Map<String, ObjCMethod> _methods = <String, ObjCMethod>{};
+  List<String> _order = <String>[];
 
   Iterable<ObjCMethod> get methods =>
       _order.map((name) => _methods[name]).nonNulls;
@@ -97,6 +97,20 @@ mixin ObjCMethods {
       parent: w.topLevelUniqueNamer);
 
   void sortMethods() => _order.sort();
+
+  void filterMethods(bool predicate(ObjCMethod method)) {
+    final newOrder = <String>[];
+    final newMethods = <String, ObjCMethod>{};
+    for (final name in _order) {
+      final method = _methods[name];
+      if (method != null && predicate(method)) {
+        newMethods[name] = method;
+        newOrder.add(name);
+      }
+    }
+    _order = newOrder;
+    _methods = newMethods;
+  }
 }
 
 enum ObjCMethodKind {

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
@@ -131,10 +131,6 @@ void _parseProperty(
     return;
   }
 
-  if (!config.objcInterfaces.shouldIncludeMember(itfDecl, fieldName)) {
-    return;
-  }
-
   final dartDoc = getCursorDocComment(cursor);
 
   final propertyAttributes =
@@ -218,10 +214,6 @@ ObjCMethod? parseObjCMethod(clang_types.CXCursor cursor, Declaration itfDecl,
   if (!isApiAvailable(cursor)) {
     _logger
         .info('Omitting deprecated method ${itfDecl.originalName}.$methodName');
-    return null;
-  }
-
-  if (!filters.shouldIncludeMember(itfDecl, methodName)) {
     return null;
   }
 

--- a/pkgs/ffigen/lib/src/visitor/apply_config_filters.dart
+++ b/pkgs/ffigen/lib/src/visitor/apply_config_filters.dart
@@ -37,15 +37,22 @@ class ApplyConfigFiltersVisitation extends Visitation {
 
   @override
   void visitObjCInterface(ObjCInterface node) {
-    node.filterMethods((method) =>
-        config.objcInterfaces.shouldIncludeMember(node, method.originalName));
+    node.filterMethods(
+        (m) => config.objcInterfaces.shouldIncludeMember(node, m.originalName));
     _visitImpl(node, config.objcInterfaces);
   }
 
   @override
   void visitObjCProtocol(ObjCProtocol node) {
-    node.filterMethods((method) =>
-        config.objcProtocols.shouldIncludeMember(node, method.originalName));
+    node.filterMethods((m) {
+      // TODO(https://github.com/dart-lang/native/issues/1149): Support class
+      // methods on protocols if there's a use case. For now filter them. We
+      // filter here instead of during parsing so that these methods are still
+      // copied to any interfaces that implement the protocol.
+      if (m.isClassMethod) return false;
+
+      return config.objcProtocols.shouldIncludeMember(node, m.originalName);
+    });
     _visitImpl(node, config.objcProtocols);
   }
 

--- a/pkgs/ffigen/lib/src/visitor/apply_config_filters.dart
+++ b/pkgs/ffigen/lib/src/visitor/apply_config_filters.dart
@@ -36,12 +36,18 @@ class ApplyConfigFiltersVisitation extends Visitation {
       _visitImpl(node, config.macroDecl);
 
   @override
-  void visitObjCInterface(ObjCInterface node) =>
-      _visitImpl(node, config.objcInterfaces);
+  void visitObjCInterface(ObjCInterface node) {
+    node.filterMethods((method) =>
+        config.objcInterfaces.shouldIncludeMember(node, method.originalName));
+    _visitImpl(node, config.objcInterfaces);
+  }
 
   @override
-  void visitObjCProtocol(ObjCProtocol node) =>
-      _visitImpl(node, config.objcProtocols);
+  void visitObjCProtocol(ObjCProtocol node) {
+    node.filterMethods((method) =>
+        config.objcProtocols.shouldIncludeMember(node, method.originalName));
+    _visitImpl(node, config.objcProtocols);
+  }
 
   @override
   void visitUnnamedEnumConstant(UnnamedEnumConstant node) =>

--- a/pkgs/ffigen/test/native_objc_test/block_config.yaml
+++ b/pkgs/ffigen/test/native_objc_test/block_config.yaml
@@ -14,6 +14,7 @@ typedefs:
     - FloatBlock
     - DoubleBlock
     - Vec4Block
+    - SelectorBlock
     - VoidBlock
     - ObjectBlock
     - NullableObjectBlock

--- a/pkgs/ffigen/test/native_objc_test/block_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test.dart
@@ -27,6 +27,7 @@ typedef ListenerBlock = ObjCBlock_ffiVoid_IntBlock;
 typedef FloatBlock = ObjCBlock_ffiFloat_ffiFloat;
 typedef DoubleBlock = ObjCBlock_ffiDouble_ffiDouble;
 typedef Vec4Block = ObjCBlock_Vec4_Vec4;
+typedef SelectorBlock = ObjCBlock_ffiVoid_objcObjCSelector;
 typedef ObjectBlock = ObjCBlock_DummyObject_DummyObject;
 typedef NullableObjectBlock = ObjCBlock_DummyObject_DummyObject1;
 typedef NullableStringBlock = ObjCBlock_NSString_NSString;
@@ -160,6 +161,19 @@ void main() {
         expect(result2.z, 7.8);
         expect(result2.w, 1.2);
       });
+    });
+
+    test('Selector block', () {
+      late String sel;
+      final block = SelectorBlock.fromFunction((Pointer<ObjCSelector> x) {
+        sel = x.toDartString();
+      });
+
+      block('Hello'.toSelector());
+      expect(sel, 'Hello');
+
+      BlockTester.callSelectorBlock_(block);
+      expect(sel, 'Select');
     });
 
     test('Object block', () {

--- a/pkgs/ffigen/test/native_objc_test/block_test.h
+++ b/pkgs/ffigen/test/native_objc_test/block_test.h
@@ -35,6 +35,7 @@ typedef float (^FloatBlock)(float);
 typedef double (^DoubleBlock)(double);
 typedef Vec4 (^Vec4Block)(Vec4);
 typedef void (^VoidBlock)();
+typedef void (^SelectorBlock)(SEL);
 typedef DummyObject* (^ObjectBlock)(DummyObject*);
 typedef DummyObject* _Nullable (^NullableObjectBlock)(DummyObject* _Nullable);
 typedef NSString* _Nullable (^NullableStringBlock)(NSString* _Nullable);
@@ -64,6 +65,7 @@ typedef void (^NoTrampolineListenerBlock)(int32_t, Vec4, const char*);
 + (float)callFloatBlock:(FloatBlock)block;
 + (double)callDoubleBlock:(DoubleBlock)block;
 + (Vec4)callVec4Block:(Vec4Block)block;
++ (void)callSelectorBlock:(SelectorBlock)block;
 + (DummyObject*)callObjectBlock:(ObjectBlock)block NS_RETURNS_RETAINED;
 + (nullable DummyObject*)callNullableObjectBlock:(NullableObjectBlock)block
     NS_RETURNS_RETAINED;

--- a/pkgs/ffigen/test/native_objc_test/block_test.m
+++ b/pkgs/ffigen/test/native_objc_test/block_test.m
@@ -153,6 +153,10 @@ void objc_release(id value);
   return block(vec4);
 }
 
++ (void)callSelectorBlock:(SelectorBlock)block {
+  block(sel_registerName("Select"));
+}
+
 + (DummyObject*)callObjectBlock:(ObjectBlock)block NS_RETURNS_RETAINED {
   return block([DummyObject new]);
 }

--- a/pkgs/ffigen/test/native_objc_test/method_filtering_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/method_filtering_test.dart
@@ -45,6 +45,11 @@ void main() {
         expect(bindings, contains('includedProtocolMethod'));
         expect(bindings, isNot(contains('excludedProtocolMethod')));
       });
+
+      test('transitive deps', () {
+        expect(bindings, isNot(contains('TransitiveInterface')));
+        expect(bindings, isNot(contains('someTransitiveMethod')));
+      });
     });
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/method_filtering_test.m
+++ b/pkgs/ffigen/test/native_objc_test/method_filtering_test.m
@@ -4,11 +4,16 @@
 
 #import <Foundation/NSObject.h>
 
+@interface TransitiveInterface : NSObject {}
++ (instancetype)someTransitiveMethod: (double)arg;
+@end
+
 @interface MethodFilteringTestInterface : NSObject {}
 + (instancetype)includedStaticMethod;
 + (instancetype)excludedStaticMethod;
 - (instancetype)includedInstanceMethod: (int32_t)arg with: (int32_t)otherArg;
-- (instancetype)excludedInstanceMethod: (int32_t)arg with: (int32_t)otherArg;
+- (instancetype)excludedInstanceMethod: (int32_t)arg
+    with: (TransitiveInterface*)otherArg;
 @property (assign) NSObject* includedProperty;
 @property (assign) NSObject* excludedProperty;
 @end

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -73,6 +73,10 @@ void main() {
 
         // Method from a protocol that isn't included by the filters.
         expect(protocolImpl.fooMethod(), 2468);
+
+        // Class methods.
+        expect(ObjCProtocolImpl.requiredClassMethod(), 9876);
+        expect(ObjCProtocolImpl.optionalClassMethod(), 5432);
       });
 
       test('Unimplemented method', () {
@@ -94,6 +98,9 @@ void main() {
         expect(() => protocolImpl.optionalMethod_(structPtr.ref),
             throwsA(isA<UnimplementedOptionalMethodException>()));
         calloc.free(structPtr);
+
+        expect(() => ObjCProtocolImpl.unimplementedOtionalClassMethod(),
+            throwsA(isA<UnimplementedOptionalMethodException>()));
       });
     });
 

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.h
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.h
@@ -25,6 +25,17 @@ typedef struct {
 @optional
 - (void)voidMethod:(int32_t)x;
 
+// Class methods aren't supported in protocol implementation from Dart, but they
+// are still codegenned for any native interfaces that implement this protocol.
+@required
++ (int32_t)requiredClassMethod;
+
+@optional
++ (int32_t)optionalClassMethod;
+
+@optional
++ (int32_t)unimplementedOtionalClassMethod;
+
 @end
 
 

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.m
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.m
@@ -49,6 +49,14 @@
   return 2468;
 }
 
++ (int32_t)requiredClassMethod {
+  return 9876;
+}
+
++ (int32_t)optionalClassMethod {
+  return 5432;
+}
+
 @end
 
 

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -197,7 +197,7 @@ class DartInputStreamAdapter extends NSInputStream {
 
   /// stream:handleEvent:
   void stream_handleEvent_(NSStream aStream, NSStreamEvent eventCode) {
-    if (!objc.respondsToSelector(ref.pointer, _sel_stream_handleEvent_)) {
+    if (!objc.respondsToSelector(this.ref.pointer, _sel_stream_handleEvent_)) {
       throw objc.UnimplementedOptionalMethodException(
           'DartInputStreamAdapter', 'stream:handleEvent:');
     }
@@ -255,7 +255,7 @@ class DartProxy extends NSProxy {
   /// methodSignatureForSelector:
   NSMethodSignature methodSignatureForSelector_(
       ffi.Pointer<objc.ObjCSelector> sel) {
-    final _ret = _objc_msgSend_12790oz(
+    final _ret = _objc_msgSend_xkbibe(
         this.ref.pointer, _sel_methodSignatureForSelector_, sel);
     return NSMethodSignature.castFromPointer(_ret, retain: true, release: true);
   }
@@ -269,7 +269,7 @@ class DartProxy extends NSProxy {
 
   /// respondsToSelector:
   bool respondsToSelector_(ffi.Pointer<objc.ObjCSelector> sel) {
-    return _objc_msgSend_8d7dvc(
+    return _objc_msgSend_pkqu83(
         this.ref.pointer, _sel_respondsToSelector_, sel);
   }
 
@@ -337,7 +337,7 @@ class DartProxyBuilder extends NSObject {
       ffi.Pointer<objc.ObjCSelector> sel,
       NSMethodSignature signature,
       ffi.Pointer<ffi.Void> block) {
-    _objc_msgSend_1ev9yls(
+    _objc_msgSend_6hd21t(
         this.ref.pointer,
         _sel_implementMethod_withSignature_andBlock_,
         sel,
@@ -753,14 +753,14 @@ class NSArray extends NSObject {
 
   /// makeObjectsPerformSelector:
   void makeObjectsPerformSelector_(ffi.Pointer<objc.ObjCSelector> aSelector) {
-    _objc_msgSend_5ns8s6(
+    _objc_msgSend_79o315(
         this.ref.pointer, _sel_makeObjectsPerformSelector_, aSelector);
   }
 
   /// makeObjectsPerformSelector:withObject:
   void makeObjectsPerformSelector_withObject_(
       ffi.Pointer<objc.ObjCSelector> aSelector, objc.ObjCObjectBase? argument) {
-    _objc_msgSend_1x7hfdx(
+    _objc_msgSend_fg1n2q(
         this.ref.pointer,
         _sel_makeObjectsPerformSelector_withObject_,
         aSelector,
@@ -889,7 +889,7 @@ class NSArray extends NSObject {
 
   /// sortedArrayUsingSelector:
   NSArray sortedArrayUsingSelector_(ffi.Pointer<objc.ObjCSelector> comparator) {
-    final _ret = _objc_msgSend_12790oz(
+    final _ret = _objc_msgSend_xkbibe(
         this.ref.pointer, _sel_sortedArrayUsingSelector_, comparator);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
@@ -2388,7 +2388,7 @@ class NSDictionary extends NSObject {
   /// keysSortedByValueUsingSelector:
   NSArray keysSortedByValueUsingSelector_(
       ffi.Pointer<objc.ObjCSelector> comparator) {
-    final _ret = _objc_msgSend_12790oz(
+    final _ret = _objc_msgSend_xkbibe(
         this.ref.pointer, _sel_keysSortedByValueUsingSelector_, comparator);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
@@ -3828,7 +3828,7 @@ class NSMutableArray extends NSArray {
 
   /// sortUsingSelector:
   void sortUsingSelector_(ffi.Pointer<objc.ObjCSelector> comparator) {
-    _objc_msgSend_5ns8s6(this.ref.pointer, _sel_sortUsingSelector_, comparator);
+    _objc_msgSend_79o315(this.ref.pointer, _sel_sortUsingSelector_, comparator);
   }
 
   /// supportsSecureCoding
@@ -6601,7 +6601,7 @@ class NSObject extends objc.ObjCObjectBase {
           objc.ObjCObjectBase? delegate,
           ffi.Pointer<objc.ObjCSelector> didRecoverSelector,
           ffi.Pointer<ffi.Void> contextInfo) {
-    _objc_msgSend_1xz4izt(
+    _objc_msgSend_y0nvhk(
         this.ref.pointer,
         _sel_attemptRecoveryFromError_optionIndex_delegate_didRecoverSelector_contextInfo_,
         error.ref.pointer,
@@ -6677,7 +6677,7 @@ class NSObject extends objc.ObjCObjectBase {
 
   /// debugDescription
   NSString debugDescription() {
-    if (!objc.respondsToSelector(ref.pointer, _sel_debugDescription)) {
+    if (!objc.respondsToSelector(this.ref.pointer, _sel_debugDescription)) {
       throw objc.UnimplementedOptionalMethodException(
           'NSObject', 'debugDescription');
     }
@@ -6721,7 +6721,7 @@ class NSObject extends objc.ObjCObjectBase {
 
   /// doesNotRecognizeSelector:
   void doesNotRecognizeSelector_(ffi.Pointer<objc.ObjCSelector> aSelector) {
-    _objc_msgSend_5ns8s6(
+    _objc_msgSend_79o315(
         this.ref.pointer, _sel_doesNotRecognizeSelector_, aSelector);
   }
 
@@ -6734,7 +6734,7 @@ class NSObject extends objc.ObjCObjectBase {
   /// forwardingTargetForSelector:
   objc.ObjCObjectBase forwardingTargetForSelector_(
       ffi.Pointer<objc.ObjCSelector> aSelector) {
-    final _ret = _objc_msgSend_12790oz(
+    final _ret = _objc_msgSend_xkbibe(
         this.ref.pointer, _sel_forwardingTargetForSelector_, aSelector);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
@@ -6759,14 +6759,14 @@ class NSObject extends objc.ObjCObjectBase {
   /// instanceMethodForSelector:
   static ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>
       instanceMethodForSelector_(ffi.Pointer<objc.ObjCSelector> aSelector) {
-    return _objc_msgSend_nbaahq(
+    return _objc_msgSend_1l0dfsh(
         _class_NSObject, _sel_instanceMethodForSelector_, aSelector);
   }
 
   /// instanceMethodSignatureForSelector:
   static NSMethodSignature instanceMethodSignatureForSelector_(
       ffi.Pointer<objc.ObjCSelector> aSelector) {
-    final _ret = _objc_msgSend_12790oz(
+    final _ret = _objc_msgSend_xkbibe(
         _class_NSObject, _sel_instanceMethodSignatureForSelector_, aSelector);
     return NSMethodSignature.castFromPointer(_ret, retain: true, release: true);
   }
@@ -6774,7 +6774,7 @@ class NSObject extends objc.ObjCObjectBase {
   /// instancesRespondToSelector:
   static bool instancesRespondToSelector_(
       ffi.Pointer<objc.ObjCSelector> aSelector) {
-    return _objc_msgSend_8d7dvc(
+    return _objc_msgSend_pkqu83(
         _class_NSObject, _sel_instancesRespondToSelector_, aSelector);
   }
 
@@ -6822,14 +6822,14 @@ class NSObject extends objc.ObjCObjectBase {
   /// methodForSelector:
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> methodForSelector_(
       ffi.Pointer<objc.ObjCSelector> aSelector) {
-    return _objc_msgSend_nbaahq(
+    return _objc_msgSend_1l0dfsh(
         this.ref.pointer, _sel_methodForSelector_, aSelector);
   }
 
   /// methodSignatureForSelector:
   NSMethodSignature methodSignatureForSelector_(
       ffi.Pointer<objc.ObjCSelector> aSelector) {
-    final _ret = _objc_msgSend_12790oz(
+    final _ret = _objc_msgSend_xkbibe(
         this.ref.pointer, _sel_methodSignatureForSelector_, aSelector);
     return NSMethodSignature.castFromPointer(_ret, retain: true, release: true);
   }
@@ -6876,7 +6876,7 @@ class NSObject extends objc.ObjCObjectBase {
   /// performSelector:
   objc.ObjCObjectBase performSelector_(
       ffi.Pointer<objc.ObjCSelector> aSelector) {
-    final _ret = _objc_msgSend_12790oz(
+    final _ret = _objc_msgSend_xkbibe(
         this.ref.pointer, _sel_performSelector_, aSelector);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
@@ -6884,7 +6884,7 @@ class NSObject extends objc.ObjCObjectBase {
   /// performSelector:withObject:
   objc.ObjCObjectBase performSelector_withObject_(
       ffi.Pointer<objc.ObjCSelector> aSelector, objc.ObjCObjectBase object) {
-    final _ret = _objc_msgSend_1g3ang8(this.ref.pointer,
+    final _ret = _objc_msgSend_1r6ru49(this.ref.pointer,
         _sel_performSelector_withObject_, aSelector, object.ref.pointer);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
@@ -6894,7 +6894,7 @@ class NSObject extends objc.ObjCObjectBase {
       ffi.Pointer<objc.ObjCSelector> aSelector,
       objc.ObjCObjectBase object1,
       objc.ObjCObjectBase object2) {
-    final _ret = _objc_msgSend_1f2tuqz(
+    final _ret = _objc_msgSend_nsvgz6(
         this.ref.pointer,
         _sel_performSelector_withObject_withObject_,
         aSelector,
@@ -6936,18 +6936,18 @@ class NSObject extends objc.ObjCObjectBase {
 
   /// resolveClassMethod:
   static bool resolveClassMethod_(ffi.Pointer<objc.ObjCSelector> sel) {
-    return _objc_msgSend_8d7dvc(_class_NSObject, _sel_resolveClassMethod_, sel);
+    return _objc_msgSend_pkqu83(_class_NSObject, _sel_resolveClassMethod_, sel);
   }
 
   /// resolveInstanceMethod:
   static bool resolveInstanceMethod_(ffi.Pointer<objc.ObjCSelector> sel) {
-    return _objc_msgSend_8d7dvc(
+    return _objc_msgSend_pkqu83(
         _class_NSObject, _sel_resolveInstanceMethod_, sel);
   }
 
   /// respondsToSelector:
   bool respondsToSelector_(ffi.Pointer<objc.ObjCSelector> aSelector) {
-    return _objc_msgSend_8d7dvc(
+    return _objc_msgSend_pkqu83(
         this.ref.pointer, _sel_respondsToSelector_, aSelector);
   }
 
@@ -7894,7 +7894,7 @@ class NSProxy extends objc.ObjCObjectBase {
   /// methodSignatureForSelector:
   NSMethodSignature? methodSignatureForSelector_(
       ffi.Pointer<objc.ObjCSelector> sel) {
-    final _ret = _objc_msgSend_12790oz(
+    final _ret = _objc_msgSend_xkbibe(
         this.ref.pointer, _sel_methodSignatureForSelector_, sel);
     return _ret.address == 0
         ? null
@@ -7904,7 +7904,7 @@ class NSProxy extends objc.ObjCObjectBase {
   /// performSelector:
   objc.ObjCObjectBase performSelector_(
       ffi.Pointer<objc.ObjCSelector> aSelector) {
-    final _ret = _objc_msgSend_12790oz(
+    final _ret = _objc_msgSend_xkbibe(
         this.ref.pointer, _sel_performSelector_, aSelector);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
@@ -7912,7 +7912,7 @@ class NSProxy extends objc.ObjCObjectBase {
   /// performSelector:withObject:
   objc.ObjCObjectBase performSelector_withObject_(
       ffi.Pointer<objc.ObjCSelector> aSelector, objc.ObjCObjectBase object) {
-    final _ret = _objc_msgSend_1g3ang8(this.ref.pointer,
+    final _ret = _objc_msgSend_1r6ru49(this.ref.pointer,
         _sel_performSelector_withObject_, aSelector, object.ref.pointer);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
@@ -7922,7 +7922,7 @@ class NSProxy extends objc.ObjCObjectBase {
       ffi.Pointer<objc.ObjCSelector> aSelector,
       objc.ObjCObjectBase object1,
       objc.ObjCObjectBase object2) {
-    final _ret = _objc_msgSend_1f2tuqz(
+    final _ret = _objc_msgSend_nsvgz6(
         this.ref.pointer,
         _sel_performSelector_withObject_withObject_,
         aSelector,
@@ -7938,7 +7938,7 @@ class NSProxy extends objc.ObjCObjectBase {
 
   /// respondsToSelector:
   static bool respondsToSelector_(ffi.Pointer<objc.ObjCSelector> aSelector) {
-    return _objc_msgSend_8d7dvc(
+    return _objc_msgSend_pkqu83(
         _class_NSProxy, _sel_respondsToSelector_, aSelector);
   }
 
@@ -8179,14 +8179,14 @@ class NSSet extends NSObject {
 
   /// makeObjectsPerformSelector:
   void makeObjectsPerformSelector_(ffi.Pointer<objc.ObjCSelector> aSelector) {
-    _objc_msgSend_5ns8s6(
+    _objc_msgSend_79o315(
         this.ref.pointer, _sel_makeObjectsPerformSelector_, aSelector);
   }
 
   /// makeObjectsPerformSelector:withObject:
   void makeObjectsPerformSelector_withObject_(
       ffi.Pointer<objc.ObjCSelector> aSelector, objc.ObjCObjectBase? argument) {
-    _objc_msgSend_1x7hfdx(
+    _objc_msgSend_fg1n2q(
         this.ref.pointer,
         _sel_makeObjectsPerformSelector_withObject_,
         aSelector,
@@ -9161,7 +9161,7 @@ class NSString extends NSObject {
   NSItemProviderRepresentationVisibility
       itemProviderVisibilityForRepresentationWithTypeIdentifier_(
           NSString typeIdentifier) {
-    if (!objc.respondsToSelector(ref.pointer,
+    if (!objc.respondsToSelector(this.ref.pointer,
         _sel_itemProviderVisibilityForRepresentationWithTypeIdentifier_)) {
       throw objc.UnimplementedOptionalMethodException('NSString',
           'itemProviderVisibilityForRepresentationWithTypeIdentifier:');
@@ -9769,7 +9769,7 @@ class NSString extends NSObject {
   /// writableTypeIdentifiersForItemProvider
   NSArray writableTypeIdentifiersForItemProvider() {
     if (!objc.respondsToSelector(
-        ref.pointer, _sel_writableTypeIdentifiersForItemProvider)) {
+        this.ref.pointer, _sel_writableTypeIdentifiersForItemProvider)) {
       throw objc.UnimplementedOptionalMethodException(
           'NSString', 'writableTypeIdentifiersForItemProvider');
     }
@@ -10448,7 +10448,7 @@ class NSURL extends NSObject {
   NSItemProviderRepresentationVisibility
       itemProviderVisibilityForRepresentationWithTypeIdentifier_(
           NSString typeIdentifier) {
-    if (!objc.respondsToSelector(ref.pointer,
+    if (!objc.respondsToSelector(this.ref.pointer,
         _sel_itemProviderVisibilityForRepresentationWithTypeIdentifier_)) {
       throw objc.UnimplementedOptionalMethodException('NSURL',
           'itemProviderVisibilityForRepresentationWithTypeIdentifier:');
@@ -10700,7 +10700,7 @@ class NSURL extends NSObject {
   /// writableTypeIdentifiersForItemProvider
   NSArray writableTypeIdentifiersForItemProvider() {
     if (!objc.respondsToSelector(
-        ref.pointer, _sel_writableTypeIdentifiersForItemProvider)) {
+        this.ref.pointer, _sel_writableTypeIdentifiersForItemProvider)) {
       throw objc.UnimplementedOptionalMethodException(
           'NSURL', 'writableTypeIdentifiersForItemProvider');
     }
@@ -13253,16 +13253,6 @@ final _objc_msgSend_122gbai = objc.msgSendPointer
     .asFunction<
         ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<objc.ObjCSelector>, int)>();
-final _objc_msgSend_12790oz = objc.msgSendPointer
-    .cast<
-        ffi.NativeFunction<
-            ffi.Pointer<objc.ObjCObject> Function(
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCSelector>)>>()
-    .asFunction<
-        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCSelector>)>();
 final _objc_msgSend_1294bp9 = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -13668,38 +13658,6 @@ final _objc_msgSend_1el0by7 = objc.msgSendPointer
             ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<ffi.Pointer<objc.ObjCObject>>,
             ffi.Pointer<ffi.Bool>)>();
-final _objc_msgSend_1ev9yls = objc.msgSendPointer
-    .cast<
-        ffi.NativeFunction<
-            ffi.Void Function(
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<ffi.Void>)>>()
-    .asFunction<
-        void Function(
-            ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>,
-            ffi.Pointer<objc.ObjCSelector>,
-            ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<ffi.Void>)>();
-final _objc_msgSend_1f2tuqz = objc.msgSendPointer
-    .cast<
-        ffi.NativeFunction<
-            ffi.Pointer<objc.ObjCObject> Function(
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCObject>)>>()
-    .asFunction<
-        ffi.Pointer<objc.ObjCObject> Function(
-            ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>,
-            ffi.Pointer<objc.ObjCSelector>,
-            ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCObject>)>();
 final _objc_msgSend_1g0atks = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -13713,20 +13671,6 @@ final _objc_msgSend_1g0atks = objc.msgSendPointer
             ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<objc.ObjCSelector>,
             NSRange,
-            ffi.Pointer<objc.ObjCObject>)>();
-final _objc_msgSend_1g3ang8 = objc.msgSendPointer
-    .cast<
-        ffi.NativeFunction<
-            ffi.Pointer<objc.ObjCObject> Function(
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCObject>)>>()
-    .asFunction<
-        ffi.Pointer<objc.ObjCObject> Function(
-            ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>,
-            ffi.Pointer<objc.ObjCSelector>,
             ffi.Pointer<objc.ObjCObject>)>();
 final _objc_msgSend_1h339ej = objc.msgSendPointer
     .cast<
@@ -13836,6 +13780,18 @@ final _objc_msgSend_1k4zaz5 = objc.msgSendPointer
     .asFunction<
         void Function(ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<objc.ObjCSelector>, int)>();
+final _objc_msgSend_1l0dfsh = objc.msgSendPointer
+    .cast<
+        ffi.NativeFunction<
+            ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> Function(
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCSelector>)>>()
+    .asFunction<
+        ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> Function(
+            ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>,
+            ffi.Pointer<objc.ObjCSelector>)>();
 final _objc_msgSend_1lpsn5w = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -14003,6 +13959,20 @@ final _objc_msgSend_1qje3rk = objc.msgSendPointer
             ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCObject>)>();
+final _objc_msgSend_1r6ru49 = objc.msgSendPointer
+    .cast<
+        ffi.NativeFunction<
+            ffi.Pointer<objc.ObjCObject> Function(
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCObject>)>>()
+    .asFunction<
+        ffi.Pointer<objc.ObjCObject> Function(
+            ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>,
+            ffi.Pointer<objc.ObjCSelector>,
             ffi.Pointer<objc.ObjCObject>)>();
 final _objc_msgSend_1rimh2f = objc.msgSendPointer
     .cast<
@@ -14186,40 +14156,6 @@ final _objc_msgSend_1wopcqf = objc.msgSendPointer
     .asFunction<
         int Function(ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<ffi.Uint8>, int)>();
-final _objc_msgSend_1x7hfdx = objc.msgSendPointer
-    .cast<
-        ffi.NativeFunction<
-            ffi.Void Function(
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCObject>)>>()
-    .asFunction<
-        void Function(
-            ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>,
-            ffi.Pointer<objc.ObjCSelector>,
-            ffi.Pointer<objc.ObjCObject>)>();
-final _objc_msgSend_1xz4izt = objc.msgSendPointer
-    .cast<
-        ffi.NativeFunction<
-            ffi.Void Function(
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.UnsignedLong,
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<ffi.Void>)>>()
-    .asFunction<
-        void Function(
-            ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>,
-            ffi.Pointer<objc.ObjCObject>,
-            int,
-            ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>,
-            ffi.Pointer<ffi.Void>)>();
 final _objc_msgSend_1y425zh = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -14316,16 +14252,6 @@ final _objc_msgSend_2x4dib = objc.msgSendPointer
                         ffi.Pointer<objc.ObjCObject>, ffi.Pointer<ffi.Void>)>>,
             ffi.Pointer<ffi.Void>,
             ffi.Pointer<objc.ObjCObject>)>();
-final _objc_msgSend_5ns8s6 = objc.msgSendPointer
-    .cast<
-        ffi.NativeFunction<
-            ffi.Void Function(
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCSelector>)>>()
-    .asFunction<
-        void Function(ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCSelector>)>();
 final _objc_msgSend_5r8xlx = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -14342,6 +14268,22 @@ final _objc_msgSend_5r8xlx = objc.msgSendPointer
             int,
             ffi.Pointer<ffi.Pointer<objc.ObjCObject>>,
             ffi.Pointer<ffi.Pointer<objc.ObjCObject>>)>();
+final _objc_msgSend_6hd21t = objc.msgSendPointer
+    .cast<
+        ffi.NativeFunction<
+            ffi.Void Function(
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<ffi.Void>)>>()
+    .asFunction<
+        void Function(
+            ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>,
+            ffi.Pointer<objc.ObjCSelector>,
+            ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<ffi.Void>)>();
 final _objc_msgSend_6ka9sp = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -14392,6 +14334,16 @@ final _objc_msgSend_6toz8x = objc.msgSendPointer
             ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<ffi.Pointer<objc.ObjCObject>>)>();
+final _objc_msgSend_79o315 = objc.msgSendPointer
+    .cast<
+        ffi.NativeFunction<
+            ffi.Void Function(
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCSelector>)>>()
+    .asFunction<
+        void Function(ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCSelector>)>();
 final _objc_msgSend_7zmbk4 = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -14438,16 +14390,6 @@ final _objc_msgSend_884p6v = objc.msgSendPointer
             int,
             NSRange,
             ffi.Pointer<objc.ObjCObject>)>();
-final _objc_msgSend_8d7dvc = objc.msgSendPointer
-    .cast<
-        ffi.NativeFunction<
-            ffi.Bool Function(
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCSelector>)>>()
-    .asFunction<
-        bool Function(ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCSelector>)>();
 final _objc_msgSend_91rfyn = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -14641,6 +14583,20 @@ final _objc_msgSend_fcilgxFpret = objc.msgSendFpretPointer
     .asFunction<
         double Function(
             ffi.Pointer<objc.ObjCObject>, ffi.Pointer<objc.ObjCSelector>)>();
+final _objc_msgSend_fg1n2q = objc.msgSendPointer
+    .cast<
+        ffi.NativeFunction<
+            ffi.Void Function(
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCObject>)>>()
+    .asFunction<
+        void Function(
+            ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>,
+            ffi.Pointer<objc.ObjCSelector>,
+            ffi.Pointer<objc.ObjCObject>)>();
 final _objc_msgSend_fnfvai = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -14997,18 +14953,6 @@ final _objc_msgSend_n9eq1n = objc.msgSendPointer
     .asFunction<
         instancetype Function(ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<objc.ObjCSelector>, int)>();
-final _objc_msgSend_nbaahq = objc.msgSendPointer
-    .cast<
-        ffi.NativeFunction<
-            ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> Function(
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCSelector>)>>()
-    .asFunction<
-        ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> Function(
-            ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>,
-            ffi.Pointer<objc.ObjCSelector>)>();
 final _objc_msgSend_nr96mn = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -15017,6 +14961,22 @@ final _objc_msgSend_nr96mn = objc.msgSendPointer
     .asFunction<
         bool Function(ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<objc.ObjCSelector>, int)>();
+final _objc_msgSend_nsvgz6 = objc.msgSendPointer
+    .cast<
+        ffi.NativeFunction<
+            ffi.Pointer<objc.ObjCObject> Function(
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCObject>)>>()
+    .asFunction<
+        ffi.Pointer<objc.ObjCObject> Function(
+            ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>,
+            ffi.Pointer<objc.ObjCSelector>,
+            ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCObject>)>();
 final _objc_msgSend_oihbep = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -15094,6 +15054,16 @@ final _objc_msgSend_pblopu = objc.msgSendPointer
     .asFunction<
         instancetype Function(ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<ffi.Uint8>, int)>();
+final _objc_msgSend_pkqu83 = objc.msgSendPointer
+    .cast<
+        ffi.NativeFunction<
+            ffi.Bool Function(
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCSelector>)>>()
+    .asFunction<
+        bool Function(ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCSelector>)>();
 final _objc_msgSend_pxgym4 = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -15355,6 +15325,16 @@ final _objc_msgSend_x1r7wm = objc.msgSendPointer
     .asFunction<
         ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<objc.ObjCSelector>, int)>();
+final _objc_msgSend_xkbibe = objc.msgSendPointer
+    .cast<
+        ffi.NativeFunction<
+            ffi.Pointer<objc.ObjCObject> Function(
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCSelector>)>>()
+    .asFunction<
+        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<objc.ObjCSelector>)>();
 final _objc_msgSend_xnpl2w = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -15379,6 +15359,26 @@ final _objc_msgSend_xwn22y = objc.msgSendPointer
             ffi.Pointer<objc.ObjCSelector>,
             ffi.Pointer<objc.ObjCObject>,
             NSRange)>();
+final _objc_msgSend_y0nvhk = objc.msgSendPointer
+    .cast<
+        ffi.NativeFunction<
+            ffi.Void Function(
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.UnsignedLong,
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<ffi.Void>)>>()
+    .asFunction<
+        void Function(
+            ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>,
+            ffi.Pointer<objc.ObjCObject>,
+            int,
+            ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>,
+            ffi.Pointer<ffi.Void>)>();
 final _objc_msgSend_y4z43q = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<


### PR DESCRIPTION
The [main change](https://github.com/dart-lang/native/pull/1684/commits/06d86a1f27f4c1a9f27a1be3572c1938513ce5f3) is simple enough. Fixes #1595. Fixes #1594.

But this change altered the order that methods are filtered in, which means the randomized large_objc_test.dart now selects different APIs. So a few new bugs were exposed:

- We don't support [class methods on protocols](https://github.com/dart-lang/native/issues/1149), but interfaces copy all the methods from the protocols they implement, including class methods. There was a bug in `@optional` class methods that were copied from a protocol to a class.
- Protocols were still codegenning these class methods, even though they're not supported. They were generating them as if they were instance methods.
- Listener blocks that take selectors as args generated ObjC trampolines that had a compile error.