### PR TITLE
[ffigen] Replace cli_util's `getSdkPath()` with `sdkPath`

### DIFF
--- a/pkgs/ffigen/example/shared_bindings/generate.dart
+++ b/pkgs/ffigen/example/shared_bindings/generate.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:cli_util/cli_util.dart';
 import 'package:path/path.dart' as p;
 
-ProcessResult runFfigenForConfig(String sdkPath, String configPath) {
+ProcessResult runFfigenForConfig(String configPath) {
   return Process.runSync(
     p.join(sdkPath, 'bin', 'dart'),
     [
@@ -16,14 +16,13 @@ ProcessResult runFfigenForConfig(String sdkPath, String configPath) {
 }
 
 void main() {
-  final sdkPath = getSdkPath();
   final configPaths = [
     'ffigen_configs/base.yaml',
     'ffigen_configs/a.yaml',
     'ffigen_configs/a_shared_base.yaml'
   ];
   for (final configPath in configPaths) {
-    final res = runFfigenForConfig(sdkPath, configPath);
+    final res = runFfigenForConfig(configPath);
     print(res.stdout.toString());
     if (res.exitCode != 0) {
       throw Exception('Some error occurred: ${res.stderr.toString()}');

--- a/pkgs/ffigen/example/shared_bindings/pubspec.yaml
+++ b/pkgs/ffigen/example/shared_bindings/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=3.2.0 <4.0.0'
 
 dependencies:
-  cli_util: ^0.4.0
+  cli_util: ^0.4.2
   ffi: ^2.0.1
   path: ^1.8.0
 

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
 
 dependencies:
   args: ^2.0.0
-  cli_util: ^0.4.0
+  cli_util: ^0.4.2
   collection: ^1.18.0
   ffi: ^2.0.1
   file: ^7.0.0

--- a/pkgs/ffigen/test/header_parser_tests/dart_handle_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/dart_handle_test.dart
@@ -22,7 +22,7 @@ void main() {
 ${strings.name}: 'NativeLibrary'
 ${strings.description}: 'Dart_Handle Test'
 ${strings.output}: 'unused'
-${strings.compilerOpts}: '-I${path.join(getSdkPath(), "include")}'
+${strings.compilerOpts}: '-I${path.join(sdkPath, "include")}'
 
 ${strings.headers}:
   ${strings.entryPoints}:


### PR DESCRIPTION
`getSdkPath()` is deprecated, which is causing CI failures: https://github.com/dart-lang/native/actions/runs/11583599790/job/32249077936