### PR TITLE
[objective_c] Handle missing protocol methods more gracefully

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -97,6 +97,7 @@ class ObjCProtocol extends NoLookUpBinding with ObjCMethods {
 
       methodFields.write(makeDartDoc(method.dartDoc ?? method.originalName));
       methodFields.write('''static final $fieldName = $methodClass<$funcType>(
+      ${_protocolPointer.name},
       ${method.selObject.name},
       $getSignature(
           ${_protocolPointer.name},

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -414,8 +414,9 @@ void main() {
       expect(MyProtocol.optionalMethod_.isAvailable, isTrue);
       expect(MyProtocol.disabledMethod.isAvailable, isFalse);
 
-      expect(() =>
-          MyProtocol.disabledMethod.implement(ObjCProtocolBuilder(), () => 123),
+      expect(
+          () => MyProtocol.disabledMethod
+              .implement(ObjCProtocolBuilder(), () => 123),
           throwsA(isA<FailedToLoadProtocolMethodException>()));
     });
   });

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -258,7 +258,7 @@ void main() {
 
         final sel = registerName('instanceMethod:withDouble:');
         final signature = getProtocolMethodSignature(protocol, sel,
-            isRequired: true, isInstanceMethod: true);
+            isRequired: true, isInstanceMethod: true)!;
         final block = InstanceMethodBlock.fromFunction(
             (Pointer<Void> p, NSString s, double x) {
           return 'DartProxy: $s: $x'.toNSString();
@@ -268,7 +268,7 @@ void main() {
 
         final optSel = registerName('optionalMethod:');
         final optSignature = getProtocolMethodSignature(protocol, optSel,
-            isRequired: false, isInstanceMethod: true);
+            isRequired: false, isInstanceMethod: true)!;
         final optBlock =
             OptionalMethodBlock.fromFunction((Pointer<Void> p, SomeStruct s) {
           return s.y - s.x;
@@ -279,7 +279,7 @@ void main() {
         final otherSel = registerName('otherMethod:b:c:d:');
         final otherSignature = getProtocolMethodSignature(
             secondProtocol, otherSel,
-            isRequired: true, isInstanceMethod: true);
+            isRequired: true, isInstanceMethod: true)!;
         final otherBlock = OtherMethodBlock.fromFunction(
             (Pointer<Void> p, int a, int b, int c, int d) {
           return a * b * c * d;
@@ -339,7 +339,7 @@ void main() {
 
         final sel = registerName('instanceMethod:withDouble:');
         final signature = getProtocolMethodSignature(protocol, sel,
-            isRequired: true, isInstanceMethod: true);
+            isRequired: true, isInstanceMethod: true)!;
         final block = InstanceMethodBlock.fromFunction(
             (Pointer<Void> p, NSString s, double x) => 'Hello'.toNSString());
         proxyBuilder.implementMethod_withSignature_andBlock_(
@@ -406,6 +406,17 @@ void main() {
       // Regression test for https://github.com/dart-lang/native/issues/1672.
       final proto = UnusedProtocol.implement(someMethod: () => 123);
       expect(proto, isNotNull);
+    });
+
+    test('Disabled method', () {
+      // Regression test for https://github.com/dart-lang/native/issues/1702.
+      expect(MyProtocol.instanceMethod_withDouble_.isAvailable, isTrue);
+      expect(MyProtocol.optionalMethod_.isAvailable, isTrue);
+      expect(MyProtocol.disabledMethod.isAvailable, isFalse);
+
+      expect(() =>
+          MyProtocol.disabledMethod.implement(ObjCProtocolBuilder(), () => 123),
+          throwsA(isA<FailedToLoadProtocolMethodException>()));
     });
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.h
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.h
@@ -36,6 +36,14 @@ typedef struct {
 @optional
 + (int32_t)unimplementedOtionalClassMethod;
 
+// For https://github.com/dart-lang/native/issues/1702 regression test, disable
+// a method (in practice this would be due to API versioning) and verify that
+// the protocol builder fails gracefully.
+#ifndef DISABLE_METHOD
+@optional
+- (int32_t)disabledMethod;
+#endif
+
 @end
 
 

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.m
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.m
@@ -4,6 +4,8 @@
 
 #import <dispatch/dispatch.h>
 
+#define DISABLE_METHOD 1
+
 #include "protocol_test.h"
 
 @implementation ProtocolConsumer : NSObject

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -17,6 +17,11 @@
        generate bindings for that category yourself in your own package.
     2. If the category is common/important enough that it should be included
        in package:objective_c, file a bug and we'll consider adding it back in.
+- Fixed [a bug](https://github.com/dart-lang/native/issues/1702) where missing
+  methods could cause runtime errors, even if they weren't being implemented.
+- Throw more useful errors in all internal failure cases.
+- Added `ObjCProtocolMethod.isAvailable` getter, to make it easier to implement
+  fallback logic if a method is missing at runtime.
 
 ## 3.0.0
 

--- a/pkgs/objective_c/ffigen_c.yaml
+++ b/pkgs/objective_c/ffigen_c.yaml
@@ -19,6 +19,7 @@ functions:
     - 'sel_registerName'
     - 'sel_getName'
     - 'protocol_getMethodDescription'
+    - 'protocol_getName'
     - 'disposeObjCBlockWithClosure'
     - 'isValidBlock'
     - 'isValidObject'
@@ -51,6 +52,7 @@ functions:
     'objc_copyClassList': 'copyClassList'
     'objc_getProtocol': 'getProtocol'
     'protocol_getMethodDescription': 'getMethodDescription'
+    'protocol_getName': 'getProtocolName'
 globals:
   include:
     - '_NSConcrete.*Block'

--- a/pkgs/objective_c/lib/src/c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/c_bindings_generated.dart
@@ -120,6 +120,12 @@ external ffi.Pointer<ObjCProtocol> getProtocol(
   ffi.Pointer<ffi.Char> name,
 );
 
+@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.Pointer<ObjCProtocol>)>(
+    symbol: "protocol_getName", isLeaf: true)
+external ffi.Pointer<ffi.Char> getProtocolName(
+  ffi.Pointer<ObjCProtocol> proto,
+);
+
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ObjCBlockImpl>)>(isLeaf: true)
 external bool isValidBlock(
   ffi.Pointer<ObjCBlockImpl> block,

--- a/pkgs/objective_c/lib/src/internal.dart
+++ b/pkgs/objective_c/lib/src/internal.dart
@@ -34,8 +34,7 @@ final class FailedToLoadClassException implements Exception {
   FailedToLoadClassException(this.clazz);
 
   @override
-  String toString() =>
-      '$runtimeType: Failed to load Objective-C class: $clazz';
+  String toString() => '$runtimeType: Failed to load Objective-C class: $clazz';
 }
 
 final class FailedToLoadProtocolException implements Exception {
@@ -78,8 +77,7 @@ final class ObjCRuntimeError extends Error {
 
 extension GetProtocolName on Pointer<c.ObjCProtocol> {
   /// Returns the name of the protocol.
-  String get name =>
-      c.getProtocolName(this).cast<Utf8>().toDartString();
+  String get name => c.getProtocolName(this).cast<Utf8>().toDartString();
 }
 
 /// Only for use by ffigen bindings.

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -6116,6 +6116,7 @@ abstract final class NSStreamDelegate {
   /// stream:handleEvent:
   static final stream_handleEvent_ =
       objc.ObjCProtocolListenableMethod<void Function(NSStream, NSStreamEvent)>(
+    _protocol_NSStreamDelegate,
     _sel_stream_handleEvent_,
     objc.getProtocolMethodSignature(
       _protocol_NSStreamDelegate,

--- a/pkgs/objective_c/lib/src/protocol_builder.dart
+++ b/pkgs/objective_c/lib/src/protocol_builder.dart
@@ -5,8 +5,8 @@
 import 'dart:ffi';
 
 import 'c_bindings_generated.dart' as c;
-import 'internal.dart' show
-    FailedToLoadProtocolMethodException, GetProtocolName, ObjCBlockBase;
+import 'internal.dart'
+    show FailedToLoadProtocolMethodException, GetProtocolName, ObjCBlockBase;
 import 'objective_c_bindings_generated.dart' as objc;
 import 'selector.dart';
 
@@ -43,7 +43,8 @@ class ObjCProtocolMethod<T extends Function> {
   final ObjCBlockBase Function(T) _createBlock;
 
   /// Only for use by ffigen bindings.
-  ObjCProtocolMethod(this._proto, this._sel, this._signature, this._createBlock);
+  ObjCProtocolMethod(
+      this._proto, this._sel, this._signature, this._createBlock);
 
   /// Implement this method on the protocol [builder] using a Dart [function].
   ///
@@ -76,8 +77,8 @@ class ObjCProtocolListenableMethod<T extends Function>
   final ObjCBlockBase Function(T) _createListenerBlock;
 
   /// Only for use by ffigen bindings.
-  ObjCProtocolListenableMethod(super._proto, super._sel, super._signature, super._createBlock,
-      this._createListenerBlock);
+  ObjCProtocolListenableMethod(super._proto, super._sel, super._signature,
+      super._createBlock, this._createListenerBlock);
 
   /// Implement this method on the protocol [builder] as a listener using a Dart
   /// [function].

--- a/pkgs/objective_c/lib/src/protocol_builder.dart
+++ b/pkgs/objective_c/lib/src/protocol_builder.dart
@@ -5,8 +5,10 @@
 import 'dart:ffi';
 
 import 'c_bindings_generated.dart' as c;
-import 'internal.dart' show ObjCBlockBase;
+import 'internal.dart' show
+    FailedToLoadProtocolMethodException, GetProtocolName, ObjCBlockBase;
 import 'objective_c_bindings_generated.dart' as objc;
+import 'selector.dart';
 
 /// Helper class for building Objective C objects that implement protocols.
 class ObjCProtocolBuilder {
@@ -35,12 +37,13 @@ class ObjCProtocolBuilder {
 /// want to implement. The generated bindings will include a
 /// [ObjCProtocolMethod] for each method of the protocol.
 class ObjCProtocolMethod<T extends Function> {
+  final Pointer<c.ObjCProtocol> _proto;
   final Pointer<c.ObjCSelector> _sel;
-  final objc.NSMethodSignature _signature;
+  final objc.NSMethodSignature? _signature;
   final ObjCBlockBase Function(T) _createBlock;
 
   /// Only for use by ffigen bindings.
-  ObjCProtocolMethod(this._sel, this._signature, this._createBlock);
+  ObjCProtocolMethod(this._proto, this._sel, this._signature, this._createBlock);
 
   /// Implement this method on the protocol [builder] using a Dart [function].
   ///
@@ -49,8 +52,16 @@ class ObjCProtocolMethod<T extends Function> {
   /// the wrong thread will result in a crash.
   void implement(ObjCProtocolBuilder builder, T? function) {
     if (function != null) {
-      builder.implementMethod(_sel, _signature, _createBlock(function));
+      builder.implementMethod(_sel, _sig, _createBlock(function));
     }
+  }
+
+  bool get isAvailable => _signature != null;
+
+  objc.NSMethodSignature get _sig {
+    final sig = _signature;
+    if (sig != null) return sig;
+    throw FailedToLoadProtocolMethodException(_proto.name, _sel.toDartString());
   }
 }
 
@@ -65,7 +76,7 @@ class ObjCProtocolListenableMethod<T extends Function>
   final ObjCBlockBase Function(T) _createListenerBlock;
 
   /// Only for use by ffigen bindings.
-  ObjCProtocolListenableMethod(super._sel, super._signature, super._createBlock,
+  ObjCProtocolListenableMethod(super._proto, super._sel, super._signature, super._createBlock,
       this._createListenerBlock);
 
   /// Implement this method on the protocol [builder] as a listener using a Dart
@@ -77,7 +88,7 @@ class ObjCProtocolListenableMethod<T extends Function>
   /// See NativeCallable.listener for more details.
   void implementAsListener(ObjCProtocolBuilder builder, T? function) {
     if (function != null) {
-      builder.implementMethod(_sel, _signature, _createListenerBlock(function));
+      builder.implementMethod(_sel, _sig, _createListenerBlock(function));
     }
   }
 }

--- a/pkgs/objective_c/src/objective_c_runtime.h
+++ b/pkgs/objective_c/src/objective_c_runtime.h
@@ -69,5 +69,6 @@ ObjCProtocol* objc_getProtocol(const char* name);
 ObjCMethodDesc protocol_getMethodDescription(
     ObjCProtocol* protocol, ObjCSelector* sel, bool isRequiredMethod,
     bool isInstanceMethod);
+const char *protocol_getName(ObjCProtocol *proto);
 
 #endif  // OBJECTIVE_C_SRC_OBJECTIVE_C_RUNTIME_H_


### PR DESCRIPTION
- Only throw an error if the user tries to *implement* a missing method.
- Make the thrown error more descriptive and useful
- Add `ObjCProtocolMethod.isAvailable`, to make it easier to implement fallback logic if a method is missing.

Fixes https://github.com/dart-lang/native/issues/1702