### PR TITLE
[ffigen] Fix method vs getter conflicts

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
@@ -19,6 +19,7 @@ class ObjCInterface extends BindingType with ObjCMethods {
   late final ObjCMsgSendFunc _isKindOfClassMsgSend;
   final protocols = <ObjCProtocol>[];
   final categories = <ObjCCategory>[];
+  final subtypes = <ObjCInterface>[];
 
   @override
   final ObjCBuiltInFunctions builtInFunctions;
@@ -194,5 +195,9 @@ ${generateAsStub ? '' : _generateMethods(w)}
     visitor.visitAll(protocols);
     visitor.visitAll(categories);
     visitMethods(visitor);
+
+    // Note: Don't visit subtypes here, because they shouldn't affect transitive
+    // inclusion. Including an interface shouldn't auto-include all its
+    // subtypes, even as stubs.
   }
 }

--- a/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
@@ -188,7 +188,7 @@ class ObjCMethod extends AstNode {
   final ObjCProperty? property;
   Type returnType;
   final List<Parameter> params;
-  final ObjCMethodKind kind;
+  ObjCMethodKind kind;
   final bool isClassMethod;
   final bool isOptional;
   ObjCMethodOwnership? ownershipAttribute;

--- a/pkgs/ffigen/lib/src/code_generator/type.dart
+++ b/pkgs/ffigen/lib/src/code_generator/type.dart
@@ -33,9 +33,6 @@ abstract class Type extends AstNode {
   /// Returns true if the type is a [Compound] and is incomplete.
   bool get isIncompleteCompound => false;
 
-  /// Returns true if [other] is a subtype of this type.
-  bool isSubtype(Type other) => this == other;
-
   /// Returns the C type of the Type. This is the FFI compatible type that is
   /// passed to native code.
   String getCType(Writer w) =>
@@ -154,9 +151,6 @@ abstract class BindingType extends NoLookUpBinding implements Type {
 
   @override
   bool get isIncompleteCompound => false;
-
-  @override
-  bool isSubtype(Type other) => this == other;
 
   @override
   String getFfiDartType(Writer w) => getCType(w);

--- a/pkgs/ffigen/lib/src/code_generator/type.dart
+++ b/pkgs/ffigen/lib/src/code_generator/type.dart
@@ -33,6 +33,9 @@ abstract class Type extends AstNode {
   /// Returns true if the type is a [Compound] and is incomplete.
   bool get isIncompleteCompound => false;
 
+  /// Returns true if [other] is a subtype of this type.
+  bool isSubtype(Type other) => this == other;
+
   /// Returns the C type of the Type. This is the FFI compatible type that is
   /// passed to native code.
   String getCType(Writer w) =>
@@ -151,6 +154,9 @@ abstract class BindingType extends NoLookUpBinding implements Type {
 
   @override
   bool get isIncompleteCompound => false;
+
+  @override
+  bool isSubtype(Type other) => this == other;
 
   @override
   String getFfiDartType(Writer w) => getCType(w);

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
@@ -101,6 +101,7 @@ void _parseSuperType(clang_types.CXCursor cursor, ObjCInterface itf) {
       '$superType ${cursor.completeStringRepr()}');
   if (superType is ObjCInterface) {
     itf.superType = superType;
+    superType.subtypes.add(itf);
   } else {
     _logger.severe(
         'Super type of $itf is $superType, which is not a valid interface.');

--- a/pkgs/ffigen/lib/src/visitor/fix_overridden_methods.dart
+++ b/pkgs/ffigen/lib/src/visitor/fix_overridden_methods.dart
@@ -60,7 +60,8 @@ class FixOverriddenMethodsVisitation extends Visitation {
     }
   }
 
-  (ObjCInterface, ObjCMethod) _findRootWithMethod(ObjCInterface node, ObjCMethod method) {
+  (ObjCInterface, ObjCMethod) _findRootWithMethod(
+      ObjCInterface node, ObjCMethod method) {
     ObjCInterface root = node;
     ObjCMethod rootMethod = method;
     for (ObjCInterface? t = node; t != null; t = t.superType) {
@@ -73,7 +74,8 @@ class FixOverriddenMethodsVisitation extends Visitation {
     return (root, rootMethod);
   }
 
-  void _convertAllSubtreeMethodsToProperties(ObjCInterface node, ObjCMethod rootMethod) {
+  void _convertAllSubtreeMethodsToProperties(
+      ObjCInterface node, ObjCMethod rootMethod) {
     ObjCMethod? method = node.getMethod(rootMethod.originalName);
     if (method != null && method.kind == ObjCMethodKind.method) {
       method.kind = ObjCMethodKind.propertyGetter;

--- a/pkgs/ffigen/lib/src/visitor/fix_overridden_methods.dart
+++ b/pkgs/ffigen/lib/src/visitor/fix_overridden_methods.dart
@@ -10,7 +10,11 @@ class FixOverriddenMethodsVisitation extends Visitation {
   @override
   void visitObjCInterface(ObjCInterface node) {
     node.visitChildren(visitor);
+    _fixNullability(node);
+    _fixMethodsVsProperties(node);
+  }
 
+  void _fixNullability(ObjCInterface node) {
     // ObjC ignores nullability when deciding if an override for an inherited
     // method is valid. But in Dart it's invalid to override a method and change
     // it's return type from non-null to nullable, or its arg type from nullable
@@ -39,6 +43,43 @@ class FixOverriddenMethodsVisitation extends Visitation {
           }
         }
       }
+    }
+  }
+
+  void _fixMethodsVsProperties(ObjCInterface node) {
+    // In ObjC, supertypes and subtypes can have a method that's an ordinary
+    // method in some classes of the heirarchy, and a property in others. This
+    // isn't allowed in Dart, so we change all such conflicts to properties.
+    // This change could cause more conflicts in the heirarchy, so first we walk
+    // up to find the root of the subtree that has this method, then we walk
+    // down the subtreee to change all conflicting methods to properties.
+    for (final method in node.methods) {
+      final (root, rootMethod) = _findRootWithMethod(node, method);
+      if (method.isProperty == rootMethod.isProperty) continue;
+      _convertAllSubtreeMethodsToProperties(root, rootMethod);
+    }
+  }
+
+  (ObjCInterface, ObjCMethod) _findRootWithMethod(ObjCInterface node, ObjCMethod method) {
+    ObjCInterface root = node;
+    ObjCMethod rootMethod = method;
+    for (ObjCInterface? t = node; t != null; t = t.superType) {
+      final tMethod = t.getMethod(method.originalName);
+      if (tMethod != null) {
+        root = t;
+        rootMethod = tMethod;
+      }
+    }
+    return (root, rootMethod);
+  }
+
+  void _convertAllSubtreeMethodsToProperties(ObjCInterface node, ObjCMethod rootMethod) {
+    ObjCMethod? method = node.getMethod(rootMethod.originalName);
+    if (method != null && method.kind == ObjCMethodKind.method) {
+      method.kind = ObjCMethodKind.propertyGetter;
+    }
+    for (final t in node.subtypes) {
+      _convertAllSubtreeMethodsToProperties(t, rootMethod);
     }
   }
 }

--- a/pkgs/ffigen/lib/src/visitor/fix_overridden_methods.dart
+++ b/pkgs/ffigen/lib/src/visitor/fix_overridden_methods.dart
@@ -62,8 +62,8 @@ class FixOverriddenMethodsVisitation extends Visitation {
 
   (ObjCInterface, ObjCMethod) _findRootWithMethod(
       ObjCInterface node, ObjCMethod method) {
-    ObjCInterface root = node;
-    ObjCMethod rootMethod = method;
+    var root = node;
+    var rootMethod = method;
     for (ObjCInterface? t = node; t != null; t = t.superType) {
       final tMethod = t.getMethod(method.originalName);
       if (tMethod != null) {
@@ -76,7 +76,7 @@ class FixOverriddenMethodsVisitation extends Visitation {
 
   void _convertAllSubtreeMethodsToProperties(
       ObjCInterface node, ObjCMethod rootMethod) {
-    ObjCMethod? method = node.getMethod(rootMethod.originalName);
+    final method = node.getMethod(rootMethod.originalName);
     if (method != null && method.kind == ObjCMethodKind.method) {
       method.kind = ObjCMethodKind.propertyGetter;
     }

--- a/pkgs/ffigen/test/native_objc_test/bad_override_config.yaml
+++ b/pkgs/ffigen/test/native_objc_test/bad_override_config.yaml
@@ -1,0 +1,18 @@
+name: BadOverrideTestObjCLibrary
+description: 'Tests various overrides that are valid in ObjC but invalid in Dart'
+language: objc
+output: 'bad_override_bindings.dart'
+exclude-all-by-default: true
+objc-interfaces:
+  include:
+    - Polygon
+    - Triangle
+    - Rectangle
+    - Square
+    - BadOverrideBase
+    - BadOverrideChild
+headers:
+  entry-points:
+    - 'bad_override_test.m'
+preamble: |
+  // ignore_for_file: camel_case_types, non_constant_identifier_names, unnecessary_non_null_assertion, unused_element, unused_field

--- a/pkgs/ffigen/test/native_objc_test/bad_override_config.yaml
+++ b/pkgs/ffigen/test/native_objc_test/bad_override_config.yaml
@@ -5,12 +5,13 @@ output: 'bad_override_bindings.dart'
 exclude-all-by-default: true
 objc-interfaces:
   include:
-    - Polygon
-    - Triangle
-    - Rectangle
-    - Square
-    - BadOverrideBase
+    - BadOverrideGrandparent
+    - BadOverrideParent
+    - BadOverrideUncle
+    - BadOverrideAunt
     - BadOverrideChild
+    - BadOverrideSibbling
+    - BadOverrideGrandchild
 headers:
   entry-points:
     - 'bad_override_test.m'

--- a/pkgs/ffigen/test/native_objc_test/bad_override_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/bad_override_test.dart
@@ -25,13 +25,27 @@ void main() {
       generateBindingsForCoverage('bad_override');
     });
 
-    test('Contravariant returns', () {
-      // Return types are supposed to be covariant, but ObjC allows them to be
-      // contravariant.
+    test('Method vs getter', () {
+      // In ObjC, supertypes and subtypes can have a method that's an ordinary
+      // method in some classes of the heirarchy, and a property in others. This
+      // isn't allowed in Dart, so we change all such conflicts to properties.
       // https://github.com/dart-lang/native/issues/1220
-    });
+      expect(BadOverrideParent.new1().methodVsGetter, 1);
+      expect(BadOverrideChild.new1().methodVsGetter, 11);
+      expect(BadOverrideSibbling.new1().methodVsGetter, 12);
+      expect(BadOverrideGrandchild.new1().methodVsGetter, 111);
 
-    test('Subtyped args', () {
+      var inst = BadOverrideParent.new1();
+      expect(inst.methodVsGetter, 1);
+      inst = BadOverrideChild.new1();
+      expect(inst.methodVsGetter, 11);
+      inst = BadOverrideSibbling.new1();
+      expect(inst.methodVsGetter, 12);
+      inst = BadOverrideGrandchild.new1();
+      expect(inst.methodVsGetter, 111);
+
+      // Uncle isn't affected by the transform, so has an ordinary method.
+      expect(BadOverrideUncle.new1().methodVsGetter(), 2);
     });
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/bad_override_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/bad_override_test.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Objective C support is only available on mac.
+@TestOn('mac-os')
+
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:ffi/ffi.dart';
+import 'package:test/test.dart';
+import '../test_utils.dart';
+import 'bad_override_bindings.dart';
+import 'util.dart';
+
+void main() {
+  group('bad overrides', () {
+    setUpAll(() {
+      // TODO(https://github.com/dart-lang/native/issues/1068): Remove this.
+      DynamicLibrary.open('../objective_c/test/objective_c.dylib');
+      final dylib = File('test/native_objc_test/objc_test.dylib');
+      verifySetupFile(dylib);
+      DynamicLibrary.open(dylib.absolute.path);
+      generateBindingsForCoverage('bad_override');
+    });
+
+    test('Contravariant returns', () {
+      // Return types are supposed to be covariant, but ObjC allows them to be
+      // contravariant.
+      // https://github.com/dart-lang/native/issues/1220
+    });
+
+    test('Subtyped args', () {
+    });
+  });
+}

--- a/pkgs/ffigen/test/native_objc_test/bad_override_test.m
+++ b/pkgs/ffigen/test/native_objc_test/bad_override_test.m
@@ -4,49 +4,48 @@
 
 #import <Foundation/NSObject.h>
 
-
-@interface Polygon : NSObject {}
--(NSString*)name;
+@interface BadOverrideGrandparent : NSObject {}
 @end
-@implementation Polygon
--(NSString*)name { return @"Polygon"; }
+@implementation BadOverrideGrandparent
 @end
 
-@interface Triangle : Polygon {}
--(NSString*)name;
+@interface BadOverrideParent : BadOverrideGrandparent {}
+-(int32_t)methodVsGetter;
+@property (readonly) int32_t methodVsGetter;
 @end
-@implementation Triangle
--(NSString*)name { return @"Triangle"; }
-@end
-
-@interface Rectangle : Polygon {}
--(NSString*)name;
-@end
-@implementation Rectangle
--(NSString*)name { return @"Rectangle"; }
+@implementation BadOverrideParent
+-(int32_t)methodVsGetter { return 1; }
 @end
 
-@interface Square : Rectangle {}
--(NSString*)name;
+@interface BadOverrideUncle : BadOverrideGrandparent {}
+-(int32_t)methodVsGetter;
 @end
-@implementation Square
--(NSString*)name { return @"Square"; }
-@end
-
-
-
-@interface BadOverrideBase : NSObject {}
--(Square*)contravariantReturn;
+@implementation BadOverrideUncle
+-(int32_t)methodVsGetter { return 2; }
 @end
 
-@implementation BadOverrideBase
--(Square*)contravariantReturn { return [Square new]; }
+@interface BadOverrideAunt : BadOverrideGrandparent {}
+@end
+@implementation BadOverrideAunt
 @end
 
-@interface BadOverrideChild : BadOverrideBase {}
--(Rectangle*)contravariantReturn;
+@interface BadOverrideChild : BadOverrideParent {}
+@property (readonly) int32_t methodVsGetter;
 @end
-
 @implementation BadOverrideChild
--(Rectangle*)contravariantReturn { return [Rectangle new]; }
+-(int32_t)methodVsGetter { return 11; }
+@end
+
+@interface BadOverrideSibbling : BadOverrideParent {}
+-(int32_t)methodVsGetter;
+@end
+@implementation BadOverrideSibbling
+-(int32_t)methodVsGetter { return 12; }
+@end
+
+@interface BadOverrideGrandchild : BadOverrideParent {}
+-(int32_t)methodVsGetter;
+@end
+@implementation BadOverrideGrandchild
+-(int32_t)methodVsGetter { return 111; }
 @end

--- a/pkgs/ffigen/test/native_objc_test/bad_override_test.m
+++ b/pkgs/ffigen/test/native_objc_test/bad_override_test.m
@@ -1,0 +1,52 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#import <Foundation/NSObject.h>
+
+
+@interface Polygon : NSObject {}
+-(NSString*)name;
+@end
+@implementation Polygon
+-(NSString*)name { return @"Polygon"; }
+@end
+
+@interface Triangle : Polygon {}
+-(NSString*)name;
+@end
+@implementation Triangle
+-(NSString*)name { return @"Triangle"; }
+@end
+
+@interface Rectangle : Polygon {}
+-(NSString*)name;
+@end
+@implementation Rectangle
+-(NSString*)name { return @"Rectangle"; }
+@end
+
+@interface Square : Rectangle {}
+-(NSString*)name;
+@end
+@implementation Square
+-(NSString*)name { return @"Square"; }
+@end
+
+
+
+@interface BadOverrideBase : NSObject {}
+-(Square*)contravariantReturn;
+@end
+
+@implementation BadOverrideBase
+-(Square*)contravariantReturn { return [Square new]; }
+@end
+
+@interface BadOverrideChild : BadOverrideBase {}
+-(Rectangle*)contravariantReturn;
+@end
+
+@implementation BadOverrideChild
+-(Rectangle*)contravariantReturn { return [Rectangle new]; }
+@end


### PR DESCRIPTION
Fix one of the bad override bugs: conflicts between methods and getters.

In ObjC, supertypes and subtypes can have a method that's an ordinary method in some classes of the heirarchy, and a property in others. This isn't allowed in Dart, so we change all such conflicts to properties. This change could cause more conflicts in the heirarchy, so first we walk up to find the root of the subtree that has this method, then we walk down the subtreee to change all conflicting methods to properties.

Why change them all to properties, not methods? If a method can sensibly be made into a getter, that's always preferable. And we know these methods are reasonable candidates to be made into getters, since some of them already are. Also, if we changed the getters into methods, we'd have to worry about conflicts with setters.

The remaining bad override issues are related to subtyping, and I'll tackle them next.

https://github.com/dart-lang/native/issues/1220