### PR TITLE
Fix the diagnostics where there is a JDK version mismatch

### DIFF
--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed a bug where if multiple jars have classes within the same package, only
   one of them gets generated.
 - Fixed a bug where it would be possible for a type class inference to fail.
+- Improve the diagnostics when gradle fails when `bin/jnigen` is run.
 
 ## 0.12.1
 

--- a/pkgs/jnigen/lib/src/generate_bindings.dart
+++ b/pkgs/jnigen/lib/src/generate_bindings.dart
@@ -33,8 +33,6 @@ Future<void> generateJniBindings(Config config) async {
       printError(e.stderr);
     }
     log.fatal(e.message);
-  } on GradleException catch (e) {
-    log.fatal(e.message);
   }
 
   classes.accept(Excluder(config));

--- a/pkgs/jnigen/lib/src/generate_bindings.dart
+++ b/pkgs/jnigen/lib/src/generate_bindings.dart
@@ -33,6 +33,8 @@ Future<void> generateJniBindings(Config config) async {
       printError(e.stderr);
     }
     log.fatal(e.message);
+  } on GradleException catch (e) {
+    log.fatal(e.message);
   }
 
   classes.accept(Excluder(config));

--- a/pkgs/jnigen/lib/src/tools/android_sdk_tools.dart
+++ b/pkgs/jnigen/lib/src/tools/android_sdk_tools.dart
@@ -203,11 +203,30 @@ task $_gradleGetSourcesTaskName(type: Copy) {
     }
     if (procRes.exitCode != 0) {
       final inAndroidProject =
-          (androidProject == '.') ? '' : ' in $androidProject';
-      throw GradleException('\n\ngradle exited with status '
-          '${procRes.exitCode}\n. This can be because the Android build is not '
-          'yet cached. Please run `flutter build apk`$inAndroidProject and try '
-          'again\n');
+          (androidProject == '') ? '' : ' in $androidProject';
+      throw GradleException('''\n\nGradle execution failed.
+
+1. The most likely cause is that the Android build is not yet cached.
+
+Run `flutter build apk`$inAndroidProject and try again.
+
+2. If the Gradle output includes text like this:
+
+* What went wrong:
+Execution failed for task ':gradle:compileGroovy'.
+> BUG! exception in phase 'semantic analysis' ...  Unsupported class file major version
+
+Then the JDK versions used by jnigen and flutter are not compatible. Try
+changing the default JDK version e.g. with `export JAVA_VERSION=11` on macOS and
+`sudo update-alternatives --config java` on Ubuntu.
+
+GRADLE OUTPUT:
+--------------------------------------------------------------------------------
+
+${procRes.stderr}
+
+--------------------------------------------------------------------------------
+''');
     }
     // Record both stdout and stderr of gradle.
     log.writeSectionToFile('Gradle logs ($stubName)', procRes.stderr);


### PR DESCRIPTION
The output looks like:

```
Gradle execution failed.

1. The most likely cause is that the Android build is not yet cached.

Run `flutter build apk` in example/ and try again.

2. If the Gradle output includes text like this:

* What went wrong:
Execution failed for task ':gradle:compileGroovy'.
> BUG! exception in phase 'semantic analysis' ...  Unsupported class file major version

Then the JDK versions used by jnigen and flutter are not compatible. Try
changing the default JDK version e.g. with `export JAVA_VERSION=11` on macOS and
`sudo update-alternatives --config java` on Ubuntu.

GRADLE OUTPUT:
--------------------------------------------------------------------------------

Gradle stub cannot find JAR libraries. This might be because no APK build has happened yet.
If you are seeing this error in `flutter build` output, it is likely that `jnigen` left some stubs in the build.gradle file. Please restore that file from your version control system or manually remove the stub functions named getReleaseCompileClasspath and / or getSources.

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/bquinlan/dart/http/pkgs/ok_http/example/android/build.gradle' line: 29

* What went wrong:
A problem occurred configuring root project 'android'.
> Could not resolve all files for configuration ':app:releaseCompileClasspath'.
   > Failed to transform libs.jar to match attributes {artifactType=android-classes-jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}.
      > Execution failed for JetifyTransform: /Users/bquinlan/dart/http/pkgs/ok_http/example/build/app/intermediates/flutter/release/libs.jar.
         > Transform's input file does not exist: /Users/bquinlan/dart/http/pkgs/ok_http/example/build/app/intermediates/flutter/release/libs.jar. (See https://issuetracker.google.com/issues/158753935)

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 3s


--------------------------------------------------------------------------------

#0      AndroidSdkTools._runGradleStub (package:jnigen/src/tools/android_sdk_tools.dart:207:7)
#1      AndroidSdkTools.getGradleClasspaths (package:jnigen/src/tools/android_sdk_tools.dart:144:7)
#2      getSummary (package:jnigen/src/summary/summary.dart:136:34)
#3      generateJniBindings (package:jnigen/src/generate_bindings.dart:30:21)
<asynchronous suspension>
#4      main (file:///Users/bquinlan/dart/native/pkgs/jnigen/bin/jnigen.dart:18:3)
<asynchronous suspension>
```

It would be worth cleaning up the traceback in a follow-up PR. That might be as easy as changing `generate_bindings.dart`:

```diff
  try {
    classes = await getSummary(config);
  } on SummaryParseException catch (e) {
    if (e.stderr != null) {
      printError(e.stderr);
    }
    log.fatal(e.message);
-  }
+  } on GradleException catch (e) {
+    log.fatal(e.message);
+  }
```
- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
