### PR TITLE
[ffigen] Improve enum warning

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/enum_class.dart
+++ b/pkgs/ffigen/lib/src/code_generator/enum_class.dart
@@ -269,7 +269,7 @@ class EnumClass extends BindingType {
 
   @override
   String getCType(Writer w) {
-    w.usedEnumCType = true;
+    w.usedEnumCTypes.add(this);
     return nativeType.getCType(w);
   }
 

--- a/pkgs/ffigen/lib/src/code_generator/writer.dart
+++ b/pkgs/ffigen/lib/src/code_generator/writer.dart
@@ -39,9 +39,9 @@ class Writer {
 
   final List<String> nativeEntryPoints;
 
-  /// Tracks where enumType.getCType is called. Reset everytime [generate] is
-  /// called.
-  bool usedEnumCType = false;
+  /// Tracks the enums for which enumType.getCType is called. Reset everytime
+  /// [generate] is called.
+  final usedEnumCTypes = <EnumClass>{};
 
   String? _ffiLibraryPrefix;
   String get ffiLibraryPrefix {
@@ -243,8 +243,8 @@ class Writer {
     // Reset unique namers to initial state.
     _resetUniqueNamersNamers();
 
-    // Reset [usedEnumCType].
-    usedEnumCType = false;
+    // Reset [usedEnumCTypes].
+    usedEnumCTypes.clear();
 
     // Write file header (if any).
     if (header != null) {
@@ -333,14 +333,15 @@ class Writer {
     result.write(s);
 
     // Warn about Enum usage in API surface.
-    if (!silenceEnumWarning && usedEnumCType) {
+    if (!silenceEnumWarning && !usedEnumCTypes.isEmpty) {
+      final names = usedEnumCTypes.map((e) => e.originalName).toList()..sort();
       _logger.severe('The integer type used for enums is '
           'implementation-defined. FFIgen tries to mimic the integer sizes '
           'chosen by the most common compilers for the various OS and '
           'architecture combinations. To prevent any crashes, remove the '
           'enums from your API surface. To rely on the (unsafe!) mimicking, '
           'you can silence this warning by adding silence-enum-warning: true '
-          'to the FFIgen config.');
+          'to the FFIgen config. Affected enums:\n\t${names.join('\n\t')}');
     }
 
     _canGenerateSymbolOutput = true;

--- a/pkgs/ffigen/lib/src/code_generator/writer.dart
+++ b/pkgs/ffigen/lib/src/code_generator/writer.dart
@@ -333,7 +333,7 @@ class Writer {
     result.write(s);
 
     // Warn about Enum usage in API surface.
-    if (!silenceEnumWarning && !usedEnumCTypes.isEmpty) {
+    if (!silenceEnumWarning && usedEnumCTypes.isNotEmpty) {
       final names = usedEnumCTypes.map((e) => e.originalName).toList()..sort();
       _logger.severe('The integer type used for enums is '
           'implementation-defined. FFIgen tries to mimic the integer sizes '


### PR DESCRIPTION
Example of the new warning:

```
[SEVERE] : The integer type used for enums is implementation-defined. FFIgen tries to mimic the integer sizes chosen by the most common compilers for the various OS and architecture combinations. To prevent any crashes, remove the enums from your API surface. To rely on the (unsafe!) mimicking, you can silence this warning by adding silence-enum-warning: true to the FFIgen config. Affected enums:
	NSComparisonResult
	NSDataBase64DecodingOptions
	NSDataCompressionAlgorithm
	NSDataReadingOptions
	NSItemProviderFileOptions
	NSItemProviderRepresentationVisibility
	NSStreamEvent
	NSStreamStatus
	NSStringCompareOptions
	NSStringEncodingConversionOptions
	NSURLBookmarkCreationOptions
	NSURLBookmarkResolutionOptions
```

Fixes #1715