### PR TITLE
[ffigen] Fix last bit of log spam

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
@@ -57,6 +57,14 @@ mixin ObjCMethods {
       return oldMethod;
     }
 
+    // If one of the methods is optional, and the other is required, keep the
+    // required one.
+    if (newMethod.isOptional && !oldMethod.isOptional) {
+      return oldMethod;
+    } else if (!newMethod.isOptional && oldMethod.isOptional) {
+      return newMethod;
+    }
+
     // Check the duplicate is the same method.
     if (!newMethod.sameAs(oldMethod)) {
       _logger.severe('Duplicate methods with different signatures: '


### PR DESCRIPTION
While investigating #1137, which was already fixed, I found that all the remaining "duplicate method" log spam is for methods like this:

```
[SEVERE] : Duplicate methods with different signatures: NSMenu.isAccessibilityFocused: @optional bool isAccessibilityFocused() vs bool isAccessibilityFocused()
[SEVERE] : Duplicate methods with different signatures: NSMenuItem.isAccessibilityFocused: @optional bool isAccessibilityFocused() vs bool isAccessibilityFocused()
[SEVERE] : Duplicate methods with different signatures: NSCell.isAccessibilityFocused: @optional bool isAccessibilityFocused() vs bool isAccessibilityFocused()
[SEVERE] : Duplicate methods with different signatures: NSWindow.isAccessibilityFocused: @optional bool isAccessibilityFocused() vs bool isAccessibilityFocused()
[SEVERE] : Duplicate methods with different signatures: NSView.isAccessibilityFocused: @optional bool isAccessibilityFocused() vs bool isAccessibilityFocused()
```

These are methods that are multiply declared, where one of the declarations is optional and the other is required. I think it makes sense that the required method should win the conflict, so I've done that.

With that fixed, all the log spam is gone.