### PR TITLE
[ffigen] Fix CI failure

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
@@ -259,8 +259,9 @@ class ObjCMethod extends AstNode {
     );
   }
 
-  String getDartMethodName(UniqueNamer uniqueNamer) {
-    if (property != null) {
+  String getDartMethodName(UniqueNamer uniqueNamer,
+      {bool usePropertyNaming = true}) {
+    if (property != null && usePropertyNaming) {
       // A getter and a setter are allowed to have the same name, so we can't
       // just run the name through uniqueNamer. Instead they need to share
       // the dartName, which is run through uniqueNamer.

--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -55,7 +55,8 @@ class ObjCProtocol extends NoLookUpBinding with ObjCMethods {
 
     var anyListeners = false;
     for (final method in methods) {
-      final methodName = method.getDartMethodName(methodNamer);
+      final methodName =
+          method.getDartMethodName(methodNamer, usePropertyNaming: false);
       final fieldName = methodName;
       final argName = methodName;
       final block = method.protocolBlock!;

--- a/pkgs/ffigen/lib/src/visitor/fix_overridden_methods.dart
+++ b/pkgs/ffigen/lib/src/visitor/fix_overridden_methods.dart
@@ -128,7 +128,8 @@ class FixOverriddenMethodsVisitation extends Visitation {
     for (final method in node.methods) {
       if (method.isClassMethod) continue;
       final (root, rootMethod) = _findRootWithMethod(node, method);
-      if (method.isProperty == rootMethod.isProperty) continue;
+      if ((method.kind == ObjCMethodKind.propertyGetter) ==
+          (rootMethod.kind == ObjCMethodKind.propertyGetter)) continue;
       _convertAllSubtreeMethodsToProperties(root, rootMethod);
     }
   }

--- a/pkgs/ffigen/lib/src/visitor/fix_overridden_methods.dart
+++ b/pkgs/ffigen/lib/src/visitor/fix_overridden_methods.dart
@@ -128,6 +128,7 @@ class FixOverriddenMethodsVisitation extends Visitation {
     for (final method in node.methods) {
       if (method.isClassMethod) continue;
       final (root, rootMethod) = _findRootWithMethod(node, method);
+      // If method and rootMethod are the same kind, then there's nothing to do.
       if ((method.kind == ObjCMethodKind.propertyGetter) ==
           (rootMethod.kind == ObjCMethodKind.propertyGetter)) continue;
       _convertAllSubtreeMethodsToProperties(root, rootMethod);

--- a/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
+++ b/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
@@ -11,7 +11,6 @@ library;
 
 import 'dart:async';
 import 'dart:io';
-import 'dart:math';
 
 import 'package:ffigen/ffigen.dart';
 import 'package:ffigen/src/code_generator/utils.dart';

--- a/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
+++ b/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
@@ -14,6 +14,7 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:ffigen/ffigen.dart';
+import 'package:ffigen/src/code_generator/utils.dart';
 import 'package:ffigen/src/config_provider/config.dart';
 import 'package:ffigen/src/config_provider/config_types.dart';
 import 'package:logging/logging.dart';
@@ -32,12 +33,15 @@ void main() {
     // reasonable amount of time.
     // TODO(https://github.com/dart-lang/sdk/issues/56247): Remove this.
     const inclusionRatio = 0.1;
-    final rand = Random(1234);
-    bool randInclude([_, __]) => rand.nextDouble() < inclusionRatio;
-    final randomFilter = DeclarationFilters(
-      shouldInclude: randInclude,
-      shouldIncludeMember: randInclude,
-    );
+    const seed = 1234;
+    bool randInclude(String kind, Declaration clazz, [String? method]) =>
+        fnvHash32('$seed.$kind.${clazz.usr}.$method') <
+        ((1 << 32) * inclusionRatio);
+    DeclarationFilters randomFilter(String kind) => DeclarationFilters(
+          shouldInclude: (Declaration clazz) => randInclude(kind, clazz),
+          shouldIncludeMember: (Declaration clazz, String method) =>
+              randInclude('$kind.memb', clazz, method),
+        );
 
     const outFile = 'test/large_integration_tests/large_objc_bindings.dart';
     const outObjCFile = 'test/large_integration_tests/large_objc_bindings.m';
@@ -51,16 +55,16 @@ void main() {
       includeTransitiveObjCInterfaces: false,
       includeTransitiveObjCProtocols: false,
       includeTransitiveObjCCategories: false,
-      functionDecl: randomFilter,
-      structDecl: randomFilter,
-      unionDecl: randomFilter,
-      enumClassDecl: randomFilter,
-      unnamedEnumConstants: randomFilter,
-      globals: randomFilter,
-      typedefs: randomFilter,
-      objcInterfaces: randomFilter,
-      objcProtocols: randomFilter,
-      objcCategories: randomFilter,
+      functionDecl: randomFilter('functionDecl'),
+      structDecl: randomFilter('structDecl'),
+      unionDecl: randomFilter('unionDecl'),
+      enumClassDecl: randomFilter('enumClassDecl'),
+      unnamedEnumConstants: randomFilter('unnamedEnumConstants'),
+      globals: randomFilter('globals'),
+      typedefs: randomFilter('typedefs'),
+      objcInterfaces: randomFilter('objcInterfaces'),
+      objcProtocols: randomFilter('objcProtocols'),
+      objcCategories: randomFilter('objcCategories'),
       externalVersions: ExternalVersions(
         ios: Versions(min: Version(12, 0, 0)),
         macos: Versions(min: Version(10, 14, 0)),


### PR DESCRIPTION
- Make large_objc_test.dart's random includer deterministic, regardless of AST iteration order
- Fix a bug where `_fixMethodsVsProperties` was affecting setters as well as getters
- Fix a bug where protocol properties were being renamed according to class-style getter/setter rules, even though they're not code-genned as getters/setters