### PR TITLE
[swift2objc] More little fixes

### DIFF
--- a/pkgs/swift2objc/lib/src/ast/_core/shared/parameter.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/shared/parameter.dart
@@ -15,4 +15,7 @@ class Parameter {
     this.internalName,
     required this.type,
   });
+
+  @override
+  String toString() => '$name $internalName: $type';
 }

--- a/pkgs/swift2objc/lib/src/ast/_core/shared/referred_type.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/shared/referred_type.dart
@@ -45,6 +45,9 @@ class DeclaredType<T extends Declaration> implements ReferredType {
     required this.declaration,
     this.typeParams = const [],
   });
+
+  @override
+  String toString() => name;
 }
 
 /// Describes a reference of a generic type

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/method_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/method_declaration.dart
@@ -38,6 +38,11 @@ class MethodDeclaration
 
   bool isStatic;
 
+  String get fullName => [
+        name,
+        for (final p in params) p.name,
+      ].join(':');
+
   MethodDeclaration({
     required this.id,
     required this.name,

--- a/pkgs/swift2objc/lib/src/config.dart
+++ b/pkgs/swift2objc/lib/src/config.dart
@@ -96,7 +96,7 @@ class ModuleInputConfig implements InputConfig {
 
   @override
   Command? get symbolgraphCommand => Command(
-        executable: 'swiftc',
+        executable: 'swift',
         args: [
           'symbolgraph-extract',
           '-module-name',

--- a/pkgs/swift2objc/lib/src/parser/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/parser/_core/utils.dart
@@ -88,3 +88,27 @@ ReferredType parseTypeFromId(String typeId, ParsedSymbolgraph symbolgraph) {
 
   return paramTypeDeclaration.asDeclaredType;
 }
+
+final class ObsoleteException implements Exception {
+  final String symbol;
+  ObsoleteException(this.symbol);
+
+  @override
+  String toString() => '$runtimeType: Symbol is obsolete: $symbol';
+}
+
+bool isObsoleted(Json symbolJson) {
+  final availability = symbolJson['availability'];
+  if (!availability.exists) return false;
+  for (final entry in availability) {
+    if (entry['domain'].get<String>() == 'Swift' && entry['obsoleted'].exists) {
+      return true;
+    }
+  }
+  return false;
+}
+
+extension Deduper<T> on Iterable<T> {
+  Iterable<T> dedupeBy<K>(K Function(T) id) =>
+      <K, T>{for (final t in this) id(t): t}.values;
+}

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_compound_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_compound_declaration.dart
@@ -65,7 +65,9 @@ T _parseCompoundDeclaration<T extends CompoundDeclaration>(
       .toList();
 
   compound.methods.addAll(
-    memberDeclarations.whereType<MethodDeclaration>(),
+    memberDeclarations
+        .whereType<MethodDeclaration>()
+        .dedupeBy((m) => m.fullName),
   );
   compound.properties.addAll(
     memberDeclarations.whereType<PropertyDeclaration>(),

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_compound_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_compound_declaration.dart
@@ -61,6 +61,7 @@ T _parseCompoundDeclaration<T extends CompoundDeclaration>(
         },
       )
       .nonNulls
+      .dedupeBy((decl) => decl.id)
       .toList();
 
   compound.methods.addAll(

--- a/pkgs/swift2objc/lib/src/parser/parsers/parse_declarations.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/parse_declarations.dart
@@ -35,6 +35,10 @@ Declaration parseDeclaration(
 
   final symbolJson = parsedSymbol.json;
 
+  if (isObsoleted(symbolJson)) {
+    throw ObsoleteException(parseSymbolId(symbolJson));
+  }
+
   final symbolType = symbolJson['kind']['identifier'].get<String>();
 
   parsedSymbol.declaration = switch (symbolType) {

--- a/pkgs/swift2objc/lib/src/transformer/transformers/const.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/const.dart
@@ -3,6 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Certain methods are not allowed to be overriden in swift.
-const disallowedMethods = const {
+const disallowedMethods = {
   'hashValue',
 };

--- a/pkgs/swift2objc/lib/src/transformer/transformers/const.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/const.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Certain methods are not allowed to be overriden in swift.
+const disallowedMethods = const {
+  'hashValue',
+};

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_compound.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_compound.dart
@@ -48,6 +48,7 @@ ClassDeclaration transformCompound(
             globalNamer,
             transformationMap,
           ))
+      .nonNulls
       .toList()
     ..sort((Declaration a, Declaration b) => a.id.compareTo(b.id));
 
@@ -68,6 +69,7 @@ ClassDeclaration transformCompound(
             globalNamer,
             transformationMap,
           ))
+      .nonNulls
       .toList()
     ..sort((Declaration a, Declaration b) => a.id.compareTo(b.id));
 

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_function.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_function.dart
@@ -11,6 +11,7 @@ import '../../ast/declarations/globals/globals.dart';
 import '../_core/unique_namer.dart';
 import '../_core/utils.dart';
 import '../transform.dart';
+import 'const.dart';
 import 'transform_referred_type.dart';
 
 // The main difference between generating a wrapper method for a global function
@@ -19,12 +20,16 @@ import 'transform_referred_type.dart';
 // wrapped class instance in the wrapper class. In global function case,
 // it can be referenced directly since it's not a member of any entity.
 
-MethodDeclaration transformMethod(
+MethodDeclaration? transformMethod(
   MethodDeclaration originalMethod,
   PropertyDeclaration wrappedClassInstance,
   UniqueNamer globalNamer,
   TransformationMap transformationMap,
 ) {
+  if (disallowedMethods.contains(originalMethod.name)) {
+    return null;
+  }
+
   return _transformFunction(
     originalMethod,
     globalNamer,

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_variable.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_variable.dart
@@ -5,6 +5,7 @@ import '../_core/unique_namer.dart';
 import '../_core/utils.dart';
 import '../transform.dart';
 import 'transform_referred_type.dart';
+import 'const.dart';
 
 // The main difference between generating a wrapper property for a global
 // variable and a compound property is the way the original variable/property
@@ -12,12 +13,16 @@ import 'transform_referred_type.dart';
 // through the wrapped class instance in the wrapper class. In global variable
 // case, it can be  referenced directly since it's not a member of any entity.
 
-PropertyDeclaration transformProperty(
+PropertyDeclaration? transformProperty(
   PropertyDeclaration originalProperty,
   PropertyDeclaration wrappedClassInstance,
   UniqueNamer globalNamer,
   TransformationMap transformationMap,
 ) {
+  if (disallowedMethods.contains(originalProperty.name)) {
+    return null;
+  }
+
   final propertySource = originalProperty.isStatic
       ? wrappedClassInstance.type.name
       : wrappedClassInstance.name;

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_variable.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_variable.dart
@@ -4,8 +4,8 @@ import '../../ast/declarations/globals/globals.dart';
 import '../_core/unique_namer.dart';
 import '../_core/utils.dart';
 import '../transform.dart';
-import 'transform_referred_type.dart';
 import 'const.dart';
+import 'transform_referred_type.dart';
 
 // The main difference between generating a wrapper property for a global
 // variable and a compound property is the way the original variable/property


### PR DESCRIPTION
- The `ModuleInputConfig` symbolgraph command should use `swift`, not `swiftc`
- Dedupe class methods by ID, to fix multiple definition issues
- Also dedupe methods by their full name (name + arg names), to work around [this buggy API](https://developer.apple.com/documentation/avfaudio/avaudioengine/3012856-disconnectmidi) conflicting with [this other API](https://developer.apple.com/documentation/avfaudio/avaudioengine/3012855-disconnectmidi)
- Hard code a list of methods that we don't try to wrap, such as `hashValue`, because these are special cased in Swift, and we're not allowed to override them

I don't really have a way of testing these changes, since they're mostly dealing with bugs in the apple APIs that I'm not sure how to replicate in Swift source without compile errors. Once I get the end-to-end demo working I'll add an integration test that wraps a real Apple API.