### PR TITLE
[swift2objc] Support globals with explicit getters/setters

### DIFF
--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_variable_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_variable_declaration.dart
@@ -29,11 +29,13 @@ GlobalVariableDeclaration parseGlobalVariableDeclaration(
   ParsedSymbolgraph symbolgraph, {
   bool isStatic = false,
 }) {
+  final isConstant = _parseVariableIsConstant(variableSymbolJson);
+  final hasSetter = _parsePropertyHasSetter(variableSymbolJson);
   return GlobalVariableDeclaration(
     id: parseSymbolId(variableSymbolJson),
     name: parseSymbolName(variableSymbolJson),
     type: _parseVariableType(variableSymbolJson, symbolgraph),
-    isConstant: _parseVariableIsConstant(variableSymbolJson),
+    isConstant: isConstant || !hasSetter,
   );
 }
 

--- a/pkgs/swift2objc/test/integration/global_variables_and_functions_input.swift
+++ b/pkgs/swift2objc/test/integration/global_variables_and_functions_input.swift
@@ -6,6 +6,9 @@ public let globalRepresentableConstant = 1
 public var globalCustomVariable = MyOtherClass()
 public let globalCustomConstant = MyOtherClass()
 
+public var globalGetterVariable: Double { get { 123 } }
+public var globalSetterVariable: Double { get { 123 } set {} }
+
 public func globalCustomFunction(label1 param1: Int, param2: MyOtherClass) -> MyOtherClass {
     return MyOtherClass()
 }

--- a/pkgs/swift2objc/test/integration/global_variables_and_functions_output.swift
+++ b/pkgs/swift2objc/test/integration/global_variables_and_functions_output.swift
@@ -18,6 +18,21 @@ import Foundation
     }
   }
   
+  @objc static public var globalGetterVariableWrapper: Double {
+    get {
+      globalGetterVariable
+    }
+  }
+  
+  @objc static public var globalSetterVariableWrapper: Double {
+    get {
+      globalSetterVariable
+    }
+    set {
+      globalSetterVariable = newValue
+    }
+  }
+  
   @objc static public var globalRepresentableConstantWrapper: Int {
     get {
       globalRepresentableConstant


### PR DESCRIPTION
Before this change, variables with an explicit getter but no setter would be wrapped by a getter/setter pair, and the setter was causing compile errors.