### PR TITLE
[swift2objc] Support failable initializers

### DIFF
--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/initializer_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/initializer_declaration.dart
@@ -29,7 +29,6 @@ class InitializerDeclaration
   @override
   bool isOverriding;
 
-  @override
   bool isFailable;
 
   @override

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/initializer_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/initializer_declaration.dart
@@ -30,6 +30,9 @@ class InitializerDeclaration
   bool isOverriding;
 
   @override
+  bool isFailable;
+
+  @override
   List<Parameter> params;
 
   @override
@@ -41,5 +44,6 @@ class InitializerDeclaration
     this.statements = const [],
     required this.hasObjCAnnotation,
     required this.isOverriding,
+    required this.isFailable,
   });
 }

--- a/pkgs/swift2objc/lib/src/generator/generators/class_generator.dart
+++ b/pkgs/swift2objc/lib/src/generator/generators/class_generator.dart
@@ -68,7 +68,13 @@ List<String> _generateInitializers(ClassDeclaration declaration) {
         header.write('override ');
       }
 
-      header.write('init(${generateParameters(initializer.params)})');
+      header.write('init');
+
+      if (initializer.isFailable) {
+        header.write('?');
+      }
+
+      header.write('(${generateParameters(initializer.params)})');
 
       return ['$header {', initializer.statements.join('\n').indent(), '}']
           .join('\n');

--- a/pkgs/swift2objc/lib/src/parser/_core/json.dart
+++ b/pkgs/swift2objc/lib/src/parser/_core/json.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:collection';
+import 'dart:convert';
 
 /// This is a helper class that helps with parsing Json values. It supports
 /// accessing the json content using the subscript syntax similar to `List`
@@ -101,6 +102,9 @@ class Json extends IterableBase<Json> {
       ),
     );
   }
+
+  @override
+  String toString() => jsonEncode(_json);
 }
 
 class _JsonIterator implements Iterator<Json> {

--- a/pkgs/swift2objc/lib/src/parser/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/parser/_core/utils.dart
@@ -61,13 +61,13 @@ String parseSymbolName(Json symbolJson) {
 }
 
 bool parseSymbolHasObjcAnnotation(Json symbolJson) {
-  return symbolJson['declarationFragments'].any(
-    (json) => matchFragment(json, 'attribute', '@objc'));
+  return symbolJson['declarationFragments']
+      .any((json) => matchFragment(json, 'attribute', '@objc'));
 }
 
 bool parseIsOverriding(Json symbolJson) {
-  return symbolJson['declarationFragments'].any(
-    (json) => matchFragment(json, 'keyword', 'override'));
+  return symbolJson['declarationFragments']
+      .any((json) => matchFragment(json, 'keyword', 'override'));
 }
 
 ReferredType parseTypeFromId(String typeId, ParsedSymbolgraph symbolgraph) {

--- a/pkgs/swift2objc/lib/src/parser/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/parser/_core/utils.dart
@@ -38,6 +38,11 @@ extension TopLevelOnly<T extends Declaration> on List<T> {
       ).toList();
 }
 
+/// Matches fragments, which look like {"kind": "foo", "spelling": "bar"}.
+bool matchFragment(Json fragment, String kind, String spelling) =>
+    fragment['kind'].get<String?>() == kind &&
+    fragment['spelling'].get<String?>() == spelling;
+
 String parseSymbolId(Json symbolJson) {
   final idJson = symbolJson['identifier']['precise'];
   final id = idJson.get<String>();
@@ -57,22 +62,12 @@ String parseSymbolName(Json symbolJson) {
 
 bool parseSymbolHasObjcAnnotation(Json symbolJson) {
   return symbolJson['declarationFragments'].any(
-    (json) =>
-        json['kind'].exists &&
-        json['kind'].get<String>() == 'attribute' &&
-        json['spelling'].exists &&
-        json['spelling'].get<String>() == '@objc',
-  );
+    (json) => matchFragment(json, 'attribute', '@objc'));
 }
 
 bool parseIsOverriding(Json symbolJson) {
   return symbolJson['declarationFragments'].any(
-    (json) =>
-        json['kind'].exists &&
-        json['kind'].get<String>() == 'keyword' &&
-        json['spelling'].exists &&
-        json['spelling'].get<String>() == 'override',
-  );
+    (json) => matchFragment(json, 'keyword', 'override'));
 }
 
 ReferredType parseTypeFromId(String typeId, ParsedSymbolgraph symbolgraph) {

--- a/pkgs/swift2objc/lib/src/transformer/_core/unique_namer.dart
+++ b/pkgs/swift2objc/lib/src/transformer/_core/unique_namer.dart
@@ -7,8 +7,8 @@ import '../../ast/_core/interfaces/compound_declaration.dart';
 class UniqueNamer {
   final Set<String> _usedNames;
 
-  UniqueNamer([Iterable<String> usedNames = const <String>[]]) :
-      _usedNames = usedNames.toSet();
+  UniqueNamer([Iterable<String> usedNames = const <String>[]])
+      : _usedNames = usedNames.toSet();
 
   UniqueNamer.inCompound(CompoundDeclaration compoundDeclaration)
       : _usedNames = {

--- a/pkgs/swift2objc/lib/src/transformer/_core/unique_namer.dart
+++ b/pkgs/swift2objc/lib/src/transformer/_core/unique_namer.dart
@@ -1,9 +1,14 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import '../../ast/_core/interfaces/compound_declaration.dart';
 
 class UniqueNamer {
   final Set<String> _usedNames;
 
-  UniqueNamer(Iterable<String> usedNames) : _usedNames = usedNames.toSet();
+  UniqueNamer([Iterable<String> usedNames = const <String>[]]) :
+      _usedNames = usedNames.toSet();
 
   UniqueNamer.inCompound(CompoundDeclaration compoundDeclaration)
       : _usedNames = {

--- a/pkgs/swift2objc/lib/src/transformer/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/transformer/_core/utils.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import '../../ast/_core/interfaces/declaration.dart';
 import '../../ast/_core/shared/referred_type.dart';
 import '../../ast/declarations/compounds/class_declaration.dart';

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_compound.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_compound.dart
@@ -89,6 +89,7 @@ InitializerDeclaration _buildWrapperInitializer(
       )
     ],
     isOverriding: false,
+    isFailable: false,
     statements: ['self.${wrappedClassInstance.name} = wrappedInstance'],
     hasObjCAnnotation: wrappedClassInstance.hasObjCAnnotation,
   );

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_initializer.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_initializer.dart
@@ -34,6 +34,7 @@ InitializerDeclaration transformInitializer(
       id: originalInitializer.id,
       params: transformedParams,
       hasObjCAnnotation: true,
+      isFailable: originalInitializer.isFailable,
       // Because the wrapper class extends NSObject that has an initializer with
       // no parameters. If we make a similar parameterless initializer we need
       // to add `override` keyword.
@@ -54,13 +55,14 @@ List<String> _generateInitializerStatements(
   InitializerDeclaration transformedInitializer,
 ) {
   final argumentsList = <String>[];
+  final localNamer = UniqueNamer();
 
   for (var i = 0; i < originalInitializer.params.length; i++) {
     final originalParam = originalInitializer.params[i];
     final transformedParam = transformedInitializer.params[i];
 
     final transformedParamName =
-        transformedParam.internalName ?? transformedParam.name;
+        localNamer.makeUnique(transformedParam.internalName ?? transformedParam.name);
 
     final (unwrappedParamValue, unwrappedType) = maybeUnwrapValue(
       transformedParam.type,
@@ -77,5 +79,16 @@ List<String> _generateInitializerStatements(
   final arguments = argumentsList.join(', ');
 
   final instanceConstruction = '${wrappedClassInstance.type.name}($arguments)';
-  return ['${wrappedClassInstance.name} = $instanceConstruction'];
+  if (originalInitializer.isFailable) {
+    final instance = localNamer.makeUnique('instance');
+    return [
+      'if let $instance = $instanceConstruction {',
+      '  ${wrappedClassInstance.name} = $instance',
+      '} else {',
+      '  return nil',
+      '}',
+    ];
+  } else {
+    return ['${wrappedClassInstance.name} = $instanceConstruction'];
+  }
 }

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_initializer.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_initializer.dart
@@ -61,8 +61,8 @@ List<String> _generateInitializerStatements(
     final originalParam = originalInitializer.params[i];
     final transformedParam = transformedInitializer.params[i];
 
-    final transformedParamName =
-        localNamer.makeUnique(transformedParam.internalName ?? transformedParam.name);
+    final transformedParamName = localNamer
+        .makeUnique(transformedParam.internalName ?? transformedParam.name);
 
     final (unwrappedParamValue, unwrappedType) = maybeUnwrapValue(
       transformedParam.type,

--- a/pkgs/swift2objc/test/integration/classes_and_initializers_input.swift
+++ b/pkgs/swift2objc/test/integration/classes_and_initializers_input.swift
@@ -8,6 +8,15 @@ public class MyClass {
         self.representableProperty = representableProperty
         self.customProperty = customProperty
     }
+
+    public init?(outerLabel x: Int) {
+        if x == 0 {
+            return nil
+        } else {
+            self.representableProperty = x
+            self.customProperty = MyOtherClass()
+        }
+    }
 }
 
 public class MyOtherClass {}

--- a/pkgs/swift2objc/test/integration/classes_and_initializers_output.swift
+++ b/pkgs/swift2objc/test/integration/classes_and_initializers_output.swift
@@ -32,4 +32,12 @@ import Foundation
   @objc init(outerLabel representableProperty: Int, customProperty: MyOtherClassWrapper) {
     wrappedInstance = MyClass(outerLabel: representableProperty, customProperty: customProperty.wrappedInstance)
   }
+  
+  @objc init?(outerLabel x: Int) {
+    if let instance = MyClass(outerLabel: x) {
+      wrappedInstance = instance
+    } else {
+      return nil
+    }
+  }
 }

--- a/pkgs/swift2objc/test/integration/integration_test.dart
+++ b/pkgs/swift2objc/test/integration/integration_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 import 'package:swift2objc/swift2objc.dart';
 import 'package:test/test.dart';
@@ -11,6 +12,10 @@ import 'package:test/test.dart';
 const regenerateExpectedOutputs = false;
 
 void main() {
+  Logger.root.onRecord.listen((record) {
+    stderr.writeln('${record.level.name}: ${record.message}');
+  });
+
   group('Integration tests', () {
     const inputSuffix = '_input.swift';
     const outputSuffix = '_output.swift';

--- a/pkgs/swift2objc/test/integration/structs_and_initializers_input.swift
+++ b/pkgs/swift2objc/test/integration/structs_and_initializers_input.swift
@@ -8,6 +8,15 @@ public class MyStruct {
         self.representableProperty = representableProperty
         self.customProperty = customProperty
     }
+
+    public init?(outerLabel x: Int) {
+        if x == 0 {
+            return nil
+        } else {
+            self.representableProperty = x
+            self.customProperty = MyOtherStruct()
+        }
+    }
 }
 
 public struct MyOtherStruct {}

--- a/pkgs/swift2objc/test/integration/structs_and_initializers_output.swift
+++ b/pkgs/swift2objc/test/integration/structs_and_initializers_output.swift
@@ -20,4 +20,12 @@ import Foundation
   @objc init(outerLabel representableProperty: Int, customProperty: MyOtherStructWrapper) {
     wrappedInstance = MyStruct(outerLabel: representableProperty, customProperty: customProperty.wrappedInstance)
   }
+  
+  @objc init?(outerLabel x: Int) {
+    if let instance = MyStruct(outerLabel: x) {
+      wrappedInstance = instance
+    } else {
+      return nil
+    }
+  }
 }

--- a/pkgs/swift2objc/test/unit/parse_initializer_param_test.dart
+++ b/pkgs/swift2objc/test/unit/parse_initializer_param_test.dart
@@ -34,30 +34,28 @@ void main() {
     test('Two params with one internal name', () {
       final json = Json(jsonDecode(
         '''
-        {
-          "declarationFragments": [
-            { "kind": "keyword", "spelling": "init" },
-            { "kind": "text", "spelling": "(" },
-            { "kind": "externalParam", "spelling": "outerLabel" },
-            { "kind": "text", "spelling": " " },
-            { "kind": "internalParam", "spelling": "internalLabel" },
-            { "kind": "text", "spelling": ": " },
-            {
-              "kind": "typeIdentifier",
-              "spelling": "Int",
-              "preciseIdentifier": "s:Si"
-            },
-            { "kind": "text", "spelling": ", " },
-            { "kind": "externalParam", "spelling": "singleLabel" },
-            { "kind": "text", "spelling": ": " },
-            {
-              "kind": "typeIdentifier",
-              "spelling": "Int",
-              "preciseIdentifier": "s:Si"
-            },
-            { "kind": "text", "spelling": ")" }
-          ]
-        }
+        [
+          { "kind": "keyword", "spelling": "init" },
+          { "kind": "text", "spelling": "(" },
+          { "kind": "externalParam", "spelling": "outerLabel" },
+          { "kind": "text", "spelling": " " },
+          { "kind": "internalParam", "spelling": "internalLabel" },
+          { "kind": "text", "spelling": ": " },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          { "kind": "text", "spelling": ", " },
+          { "kind": "externalParam", "spelling": "singleLabel" },
+          { "kind": "text", "spelling": ": " },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          { "kind": "text", "spelling": ")" }
+        ]
         ''',
       ));
 
@@ -80,20 +78,18 @@ void main() {
     test('One param', () {
       final json = Json(jsonDecode(
         '''
-        {
-          "declarationFragments": [
-            { "kind": "keyword", "spelling": "init" },
-            { "kind": "text", "spelling": "(" },
-            { "kind": "externalParam", "spelling": "parameter" },
-            { "kind": "text", "spelling": ": " },
-            {
-              "kind": "typeIdentifier",
-              "spelling": "Int",
-              "preciseIdentifier": "s:Si"
-            },
-            { "kind": "text", "spelling": ")" }
-          ]
-        }
+        [
+          { "kind": "keyword", "spelling": "init" },
+          { "kind": "text", "spelling": "(" },
+          { "kind": "externalParam", "spelling": "parameter" },
+          { "kind": "text", "spelling": ": " },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          { "kind": "text", "spelling": ")" }
+        ]
         ''',
       ));
 
@@ -112,12 +108,10 @@ void main() {
     test('No params', () {
       final json = Json(jsonDecode(
         '''
-        {
-          "declarationFragments": [
-            { "kind": "keyword", "spelling": "init" },
-            { "kind": "text", "spelling": "()" }
-          ]
-        }
+        [
+          { "kind": "keyword", "spelling": "init" },
+          { "kind": "text", "spelling": "()" }
+        ]
         ''',
       ));
 
@@ -131,20 +125,18 @@ void main() {
     test('Parameter with no outer label', () {
       final json = Json(jsonDecode(
         '''
-        {
-          "declarationFragments": [
-            { "kind": "keyword", "spelling": "init" },
-            { "kind": "text", "spelling": "(" },
-            { "kind": "internalParam", "spelling": "internalLabel" },
-            { "kind": "text", "spelling": ": " },
-            {
-              "kind": "typeIdentifier",
-              "spelling": "Int",
-              "preciseIdentifier": "s:Si"
-            },
-            { "kind": "text", "spelling": ")" }
-          ]
-        }
+        [
+          { "kind": "keyword", "spelling": "init" },
+          { "kind": "text", "spelling": "(" },
+          { "kind": "internalParam", "spelling": "internalLabel" },
+          { "kind": "text", "spelling": ": " },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          { "kind": "text", "spelling": ")" }
+        ]
         ''',
       ));
 
@@ -157,16 +149,14 @@ void main() {
     test('Parameter with no type', () {
       final json = Json(jsonDecode(
         '''
-        {
-          "declarationFragments": [
-            { "kind": "keyword", "spelling": "init" },
-            { "kind": "text", "spelling": "(" },
-            { "kind": "externalParam", "spelling": "outerLabel" },
-            { "kind": "text", "spelling": " " },
-            { "kind": "internalParam", "spelling": "internalLabel" },
-            { "kind": "text", "spelling": ")" }
-          ]
-        }
+        [
+          { "kind": "keyword", "spelling": "init" },
+          { "kind": "text", "spelling": "(" },
+          { "kind": "externalParam", "spelling": "outerLabel" },
+          { "kind": "text", "spelling": " " },
+          { "kind": "internalParam", "spelling": "internalLabel" },
+          { "kind": "text", "spelling": ")" }
+        ]
         ''',
       ));
 
@@ -179,19 +169,17 @@ void main() {
     test('Parameter with just a type (no label)', () {
       final json = Json(jsonDecode(
         '''
-        {
-          "declarationFragments": [
-            { "kind": "keyword", "spelling": "init" },
-            { "kind": "text", "spelling": "(" },
-            { "kind": "text", "spelling": ": " },
-            {
-              "kind": "typeIdentifier",
-              "spelling": "Int",
-              "preciseIdentifier": "s:Si"
-            },
-            { "kind": "text", "spelling": ")" }
-          ]
-        }
+        [
+          { "kind": "keyword", "spelling": "init" },
+          { "kind": "text", "spelling": "(" },
+          { "kind": "text", "spelling": ": " },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          { "kind": "text", "spelling": ")" }
+        ]
         ''',
       ));
 


### PR DESCRIPTION
A failable initializer in Swift is an initializer that can return nil:

```Swift
public class MyClass {
    public let someInt: Int

    public init?(outerLabel x: Int) {
        if x == 0 {
            return nil
        } else {
            self.someInt = x
        }
    }
}
```

They show up in the symbolgraph with a `?(` token in their second fragment instead of a `(`:

```json
"declarationFragments": [
    {
        "kind": "keyword",
        "spelling": "init"
    },
    {
        "kind": "text",
        "spelling": "?("
    },
```

When wrapping these constructors, we have to declare the wrapper initializer as failable, and check if the wrapped initializer returned `nil`.

```Swift
@objc public class MyClassWrapper: NSObject {
  var wrappedInstance: MyClass

  @objc init?(outerLabel x: Int) {
    if let instance = MyClass(outerLabel: x) {
      wrappedInstance = instance
    } else {
      return nil
    }
  }
}
```