### PR TITLE
[native_assets_builder] Keep `outputDirectory` if `LinkConfig.assets` changes

### DIFF
--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -232,12 +232,14 @@ class NativeAssetsBuildRunner {
           buildMode: buildMode,
           packageName: package.name,
           packageRoot: packageLayout.packageRoot(package.name),
-        )
-        ..setupLinkConfig(
-            assets: buildResult.encodedAssetsForLinking[package.name] ?? []);
+        );
 
       final (buildDirUri, outDirUri, outDirSharedUri) = await _setupDirectories(
           Hook.link, packageLayout, configBuilder, package);
+
+      configBuilder.setupLinkConfig(
+        assets: buildResult.encodedAssetsForLinking[package.name] ?? [],
+      );
 
       File? resourcesFile;
       if (resourceIdentifiers != null) {

--- a/pkgs/native_assets_cli/lib/src/config.dart
+++ b/pkgs/native_assets_cli/lib/src/config.dart
@@ -135,10 +135,13 @@ sealed class HookConfigBuilder {
   /// assumed the output directory has not been set yet.
   String computeChecksum() {
     if (json.containsKey(_outDirConfigKey) ||
-        json.containsKey(_outDirSharedConfigKey)) {
+        json.containsKey(_outDirSharedConfigKey) ||
+        json.containsKey(_assetsKey)) {
       // The bundling tools would first calculate the checksum, create an output
       // directory and then call [BuildConfigBuilder.setupBuildRunConfig] &
       // [LinkConfigBuilder.setupLinkRunConfig].
+      // The output directory should not depend on the assets passed in for
+      // linking.
       throw StateError('The checksum should be generated before setting '
           'up the run configuration');
     }


### PR DESCRIPTION
https://github.com/dart-lang/native/pull/1643 accidentally made the output directory of link hooks change when different assets are passed in for linking.