### PR TITLE
[native_toolchain_c] Compile with `-O3` by default

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - For Android, produce dylibs with page-size set to 16kb by default.
   https://github.com/dart-lang/native/issues/1611
-- Make optimization level configurable. Defaults to `-Os` and `/Os`.
+- Make optimization level configurable. Defaults to `-3s` and `/O3`.
   https://github.com/dart-lang/native/issues/1267
 
 ## 0.6.0

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -68,7 +68,7 @@ class CBuilder extends CTool implements Builder {
     super.language = Language.c,
     super.cppLinkStdLib,
     super.linkModePreference,
-    super.optimizationLevel = OptimizationLevel.oS,
+    super.optimizationLevel = OptimizationLevel.o3,
   }) : super(type: OutputType.library);
 
   CBuilder.executable({
@@ -89,7 +89,7 @@ class CBuilder extends CTool implements Builder {
     super.std,
     super.language = Language.c,
     super.cppLinkStdLib,
-    super.optimizationLevel = OptimizationLevel.oS,
+    super.optimizationLevel = OptimizationLevel.o3,
   }) : super(
           type: OutputType.executable,
           assetName: null,

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
@@ -37,7 +37,7 @@ class CLinker extends CTool implements Linker {
     super.language = Language.c,
     super.cppLinkStdLib,
     super.linkModePreference,
-    super.optimizationLevel = OptimizationLevel.oS,
+    super.optimizationLevel = OptimizationLevel.o3,
   }) : super(type: OutputType.library);
 
   /// Runs the C Linker with on this C build spec.


### PR DESCRIPTION
[Not all linkers support `-Os`](https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8730301908709004769/+/u/test_results/new_test_failures__logs_), so defaulting to `-O3` is more portable.

Issue:

* https://github.com/dart-lang/native/issues/1267