### PR TITLE
[swift2objc] Support nested declarations

### DIFF
--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/compound_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/compound_declaration.dart
@@ -6,6 +6,7 @@ import '../../declarations/compounds/members/initializer_declaration.dart';
 import '../../declarations/compounds/members/method_declaration.dart';
 import '../../declarations/compounds/members/property_declaration.dart';
 import 'declaration.dart';
+import 'nestable_declaration.dart';
 import 'protocol_conformable.dart';
 import 'type_parameterizable.dart';
 
@@ -13,11 +14,12 @@ import 'type_parameterizable.dart';
 /// See `ClassDeclaration`, `StructDeclaration` and `ProtocolDeclaration`
 /// for concrete implementations.
 abstract interface class CompoundDeclaration
-    implements Declaration, TypeParameterizable, ProtocolConformable {
+    implements
+        Declaration,
+        TypeParameterizable,
+        ProtocolConformable,
+        NestableDeclaration {
   abstract List<PropertyDeclaration> properties;
   abstract List<MethodDeclaration> methods;
   abstract List<InitializerDeclaration> initializers;
-
-  /// For handling nested classes
-  abstract List<String> pathComponents;
 }

--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/enum_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/enum_declaration.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'declaration.dart';
+import 'nestable_declaration.dart';
 import 'protocol_conformable.dart';
 import 'type_parameterizable.dart';
 
@@ -10,7 +11,11 @@ import 'type_parameterizable.dart';
 /// See `NormalEnumDeclaration`, `AssociatedValueEnumDeclaration` and
 /// `RawValueEnumDeclaration` for concrete implementations.
 abstract interface class EnumDeclaration
-    implements Declaration, TypeParameterizable, ProtocolConformable {
+    implements
+        Declaration,
+        TypeParameterizable,
+        ProtocolConformable,
+        NestableDeclaration {
   abstract List<EnumCase> cases;
 }
 

--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/nestable_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/nestable_declaration.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../../declarations/compounds/protocol_declaration.dart';
+import '../shared/referred_type.dart';
+import 'declaration.dart';
+
+/// A Swift entity that can be nested inside other declarations.
+abstract interface class NestableDeclaration implements Declaration {
+  abstract NestableDeclaration? nestingParent;
+  abstract final List<NestableDeclaration> nestedDeclarations;
+}
+
+extension FillNestingParents on List<NestableDeclaration> {
+  void fillNestingParents(NestableDeclaration parent) {
+    for (final nested in this) {
+      assert(nested.nestingParent == null);
+      nested.nestingParent = parent;
+    }
+  }
+}

--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/nestable_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/nestable_declaration.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../../declarations/compounds/protocol_declaration.dart';
-import '../shared/referred_type.dart';
 import 'declaration.dart';
 
 /// A Swift entity that can be nested inside other declarations.

--- a/pkgs/swift2objc/lib/src/ast/_core/shared/referred_type.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/shared/referred_type.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../interfaces/compound_declaration.dart';
 import '../interfaces/declaration.dart';
 import '../interfaces/nestable_declaration.dart';
 import '../interfaces/objc_annotatable.dart';

--- a/pkgs/swift2objc/lib/src/ast/_core/shared/referred_type.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/shared/referred_type.dart
@@ -4,6 +4,7 @@
 
 import '../interfaces/compound_declaration.dart';
 import '../interfaces/declaration.dart';
+import '../interfaces/nestable_declaration.dart';
 import '../interfaces/objc_annotatable.dart';
 
 /// Describes a type reference in declaration of Swift
@@ -25,11 +26,9 @@ class DeclaredType<T extends Declaration> implements ReferredType {
 
   String get name {
     final decl = declaration;
-    if (decl is CompoundDeclaration && decl.pathComponents.isNotEmpty) {
-      return decl.pathComponents.join('.');
-    }
-
-    return declaration.name;
+    final parent = decl is NestableDeclaration ? decl.nestingParent : null;
+    final nesting = parent != null ? '${parent.name}.' : '';
+    return '$nesting${declaration.name}';
   }
 
   final T declaration;

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/class_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/class_declaration.dart
@@ -4,6 +4,7 @@
 
 import '../../_core/interfaces/compound_declaration.dart';
 import '../../_core/interfaces/declaration.dart';
+import '../../_core/interfaces/nestable_declaration.dart';
 import '../../_core/interfaces/objc_annotatable.dart';
 import '../../_core/shared/referred_type.dart';
 import '../built_in/built_in_declaration.dart';
@@ -52,14 +53,18 @@ class ClassDeclaration implements CompoundDeclaration, ObjCAnnotatable {
   List<InitializerDeclaration> initializers;
 
   @override
-  List<String> pathComponents;
+  NestableDeclaration? nestingParent;
+
+  @override
+  List<NestableDeclaration> nestedDeclarations;
 
   ClassDeclaration({
     required this.id,
     required this.name,
     this.properties = const [],
     this.methods = const [],
-    this.pathComponents = const [],
+    this.nestingParent,
+    this.nestedDeclarations = const [],
     this.conformedProtocols = const [],
     this.typeParams = const [],
     this.hasObjCAnnotation = false,

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/initializer_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/initializer_declaration.dart
@@ -37,6 +37,11 @@ class InitializerDeclaration
   @override
   List<String> statements;
 
+  String get fullName => [
+        name,
+        for (final p in params) p.name,
+      ].join(':');
+
   InitializerDeclaration({
     required this.id,
     required this.params,

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/protocol_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/protocol_declaration.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../../_core/interfaces/compound_declaration.dart';
+import '../../_core/interfaces/nestable_declaration.dart';
 import '../../_core/shared/referred_type.dart';
 import 'members/initializer_declaration.dart';
 import 'members/method_declaration.dart';
@@ -32,7 +33,10 @@ class ProtocolDeclaration implements CompoundDeclaration {
   List<InitializerDeclaration> initializers;
 
   @override
-  List<String> pathComponents;
+  NestableDeclaration? nestingParent;
+
+  @override
+  List<NestableDeclaration> nestedDeclarations;
 
   ProtocolDeclaration({
     required this.id,
@@ -42,6 +46,7 @@ class ProtocolDeclaration implements CompoundDeclaration {
     required this.initializers,
     required this.conformedProtocols,
     required this.typeParams,
-    required this.pathComponents,
+    this.nestingParent,
+    this.nestedDeclarations = const [],
   });
 }

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/struct_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/struct_declaration.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../../_core/interfaces/compound_declaration.dart';
+import '../../_core/interfaces/nestable_declaration.dart';
 import '../../_core/shared/referred_type.dart';
 import 'members/initializer_declaration.dart';
 import 'members/method_declaration.dart';
@@ -33,7 +34,10 @@ class StructDeclaration implements CompoundDeclaration {
   List<InitializerDeclaration> initializers;
 
   @override
-  List<String> pathComponents;
+  NestableDeclaration? nestingParent;
+
+  @override
+  List<NestableDeclaration> nestedDeclarations;
 
   StructDeclaration({
     required this.id,
@@ -43,6 +47,7 @@ class StructDeclaration implements CompoundDeclaration {
     this.initializers = const [],
     this.conformedProtocols = const [],
     this.typeParams = const [],
-    this.pathComponents = const [],
+    this.nestingParent,
+    this.nestedDeclarations = const [],
   });
 }

--- a/pkgs/swift2objc/lib/src/ast/declarations/enums/associated_value_enum_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/enums/associated_value_enum_declaration.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../../_core/interfaces/enum_declaration.dart';
+import '../../_core/interfaces/nestable_declaration.dart';
 import '../../_core/interfaces/parameterizable.dart';
 import '../../_core/shared/parameter.dart';
 import '../../_core/shared/referred_type.dart';
@@ -25,12 +26,20 @@ class AssociatedValueEnumDeclaration implements EnumDeclaration {
   @override
   List<DeclaredType<ProtocolDeclaration>> conformedProtocols;
 
+  @override
+  NestableDeclaration? nestingParent;
+
+  @override
+  List<NestableDeclaration> nestedDeclarations;
+
   AssociatedValueEnumDeclaration({
     required this.id,
     required this.name,
     required this.cases,
     required this.typeParams,
     required this.conformedProtocols,
+    this.nestingParent,
+    this.nestedDeclarations = const [],
   });
 }
 

--- a/pkgs/swift2objc/lib/src/ast/declarations/enums/normal_enum_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/enums/normal_enum_declaration.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../../_core/interfaces/enum_declaration.dart';
+import '../../_core/interfaces/nestable_declaration.dart';
 import '../../_core/shared/referred_type.dart';
 import '../compounds/protocol_declaration.dart';
 
@@ -24,12 +25,20 @@ class NormalEnumDeclaration implements EnumDeclaration {
   @override
   List<DeclaredType<ProtocolDeclaration>> conformedProtocols;
 
+  @override
+  NestableDeclaration? nestingParent;
+
+  @override
+  List<NestableDeclaration> nestedDeclarations;
+
   NormalEnumDeclaration({
     required this.id,
     required this.name,
     required this.cases,
     required this.typeParams,
     required this.conformedProtocols,
+    this.nestingParent,
+    this.nestedDeclarations = const [],
   });
 }
 

--- a/pkgs/swift2objc/lib/src/ast/declarations/enums/raw_value_enum_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/enums/raw_value_enum_declaration.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../../_core/interfaces/enum_declaration.dart';
+import '../../_core/interfaces/nestable_declaration.dart';
 import '../../_core/interfaces/objc_annotatable.dart';
 import '../../_core/shared/referred_type.dart';
 import '../compounds/protocol_declaration.dart';
@@ -27,6 +28,12 @@ class RawValueEnumDeclaration<T> implements EnumDeclaration, ObjCAnnotatable {
   @override
   bool hasObjCAnnotation;
 
+  @override
+  NestableDeclaration? nestingParent;
+
+  @override
+  List<NestableDeclaration> nestedDeclarations;
+
   ReferredType rawValueType;
 
   RawValueEnumDeclaration({
@@ -37,6 +44,8 @@ class RawValueEnumDeclaration<T> implements EnumDeclaration, ObjCAnnotatable {
     required this.conformedProtocols,
     required this.hasObjCAnnotation,
     required this.rawValueType,
+    this.nestingParent,
+    this.nestedDeclarations = const [],
   });
 }
 

--- a/pkgs/swift2objc/lib/src/generator/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/generator/_core/utils.dart
@@ -15,12 +15,11 @@ String generateParameters(List<Parameter> params) {
   }).join(', ');
 }
 
-extension Indentation on String {
-  String indent([int count = 1]) {
-    assert(count > 0);
-    final lines = split('\n');
-    final indentation = List.filled(count, '  ').join();
-    return lines.map((line) => '$indentation$line').join('\n');
+extension Indentation on Iterable<String> {
+  Iterable<String> indent([int count = 1]) {
+    assert(count >= 0);
+    final indentation = '  ' * count;
+    return map((line) => line.isEmpty ? '' : '$indentation$line');
   }
 }
 

--- a/pkgs/swift2objc/lib/src/generator/generator.dart
+++ b/pkgs/swift2objc/lib/src/generator/generator.dart
@@ -9,13 +9,14 @@ String generate(
 }) {
   return '${[
     preamble,
+    '',
     if (moduleName != null) 'import $moduleName',
-    'import Foundation',
-    ...declarations.map(generateDeclaration),
-  ].nonNulls.join('\n\n')}\n';
+    'import Foundation\n',
+    ...declarations.map((decl) => generateDeclaration(decl).join('\n')),
+  ].nonNulls.join('\n')}\n';
 }
 
-String generateDeclaration(Declaration declaration) {
+List<String> generateDeclaration(Declaration declaration) {
   return switch (declaration) {
     ClassDeclaration() => generateClass(declaration),
     _ => throw UnimplementedError(

--- a/pkgs/swift2objc/lib/src/generator/generators/class_generator.dart
+++ b/pkgs/swift2objc/lib/src/generator/generators/class_generator.dart
@@ -5,19 +5,24 @@
 import '../../ast/_core/shared/referred_type.dart';
 import '../../ast/declarations/built_in/built_in_declaration.dart';
 import '../../ast/declarations/compounds/class_declaration.dart';
+import '../../ast/declarations/compounds/members/initializer_declaration.dart';
+import '../../ast/declarations/compounds/members/method_declaration.dart';
+import '../../ast/declarations/compounds/members/property_declaration.dart';
 import '../_core/utils.dart';
+import '../generator.dart';
 
-String generateClass(ClassDeclaration declaration) {
+List<String> generateClass(ClassDeclaration declaration) {
   return [
     '${_generateClassHeader(declaration)} {',
-    [
+    ...[
       _generateClassWrappedInstance(declaration),
       ..._generateClassProperties(declaration),
       ..._generateInitializers(declaration),
       ..._generateClassMethods(declaration),
-    ].nonNulls.join('\n\n').indent(),
-    '}',
-  ].join('\n');
+      ..._generateNestedDeclarations(declaration),
+    ].nonNulls.indent(),
+    '}\n',
+  ];
 }
 
 String _generateClassHeader(ClassDeclaration declaration) {
@@ -52,7 +57,7 @@ String? _generateClassWrappedInstance(ClassDeclaration declaration) {
     "Wrapped instance can't have a generic type",
   );
 
-  return 'var ${property.name}: ${property.type.swiftType}';
+  return 'var ${property.name}: ${property.type.swiftType}\n';
 }
 
 List<String> _generateInitializers(ClassDeclaration declaration) {
@@ -60,98 +65,107 @@ List<String> _generateInitializers(ClassDeclaration declaration) {
     declaration.wrapperInitializer,
     ...declaration.initializers,
   ].nonNulls;
-
-  return initializers.map(
-    (initializer) {
-      final header = StringBuffer();
-
-      if (initializer.hasObjCAnnotation) {
-        header.write('@objc ');
-      }
-
-      if (initializer.isOverriding) {
-        header.write('override ');
-      }
-
-      header.write('init');
-
-      if (initializer.isFailable) {
-        header.write('?');
-      }
-
-      header.write('(${generateParameters(initializer.params)})');
-
-      return ['$header {', initializer.statements.join('\n').indent(), '}']
-          .join('\n');
-    },
-  ).toList();
+  return [for (final init in initializers) ..._generateInitializer(init)];
 }
 
-List<String> _generateClassMethods(ClassDeclaration declaration) {
-  return declaration.methods.map((method) {
-    final header = StringBuffer();
+List<String> _generateInitializer(InitializerDeclaration initializer) {
+  final header = StringBuffer();
 
-    if (method.hasObjCAnnotation) {
-      header.write('@objc ');
-    }
+  if (initializer.hasObjCAnnotation) {
+    header.write('@objc ');
+  }
 
-    if (method.isStatic) {
-      header.write('static ');
-    }
+  if (initializer.isOverriding) {
+    header.write('override ');
+  }
 
-    if (method.isOverriding) {
-      header.write('override ');
-    }
+  header.write('init');
 
-    header.write(
-      'public func ${method.name}(${generateParameters(method.params)})',
-    );
+  if (initializer.isFailable) {
+    header.write('?');
+  }
 
-    if (!method.returnType.sameAs(voidType)) {
-      header.write(' -> ${method.returnType.swiftType}');
-    }
+  header.write('(${generateParameters(initializer.params)})');
 
-    return [
-      '$header {',
-      method.statements.join('\n').indent(),
-      '}',
-    ].join('\n');
-  }).toList();
+  return [
+    '$header {',
+    ...initializer.statements.indent(),
+    '}\n',
+  ];
 }
 
-List<String> _generateClassProperties(ClassDeclaration declaration) {
-  return declaration.properties.map(
-    (property) {
-      final header = StringBuffer();
+List<String> _generateClassMethods(ClassDeclaration declaration) =>
+    [for (final method in declaration.methods) ..._generateClassMethod(method)];
 
-      if (property.hasObjCAnnotation) {
-        header.write('@objc ');
-      }
+List<String> _generateClassMethod(MethodDeclaration method) {
+  final header = StringBuffer();
 
-      if (property.isStatic) {
-        header.write('static ');
-      }
+  if (method.hasObjCAnnotation) {
+    header.write('@objc ');
+  }
 
-      header.write('public var ${property.name}: ${property.type.swiftType} {');
+  if (method.isStatic) {
+    header.write('static ');
+  }
 
-      final getterLines = [
-        'get {',
-        property.getter?.statements.join('\n').indent(),
-        '}'
-      ];
+  if (method.isOverriding) {
+    header.write('override ');
+  }
 
-      final setterLines = [
-        'set {',
-        property.setter?.statements.join('\n').indent(),
-        '}'
-      ];
+  header.write(
+    'public func ${method.name}(${generateParameters(method.params)})',
+  );
 
-      return [
-        header,
-        getterLines.join('\n').indent(),
-        if (property.hasSetter) setterLines.join('\n').indent(),
-        '}',
-      ].join('\n');
-    },
-  ).toList();
+  if (!method.returnType.sameAs(voidType)) {
+    header.write(' -> ${method.returnType.swiftType}');
+  }
+
+  return [
+    '$header {',
+    ...method.statements.indent(),
+    '}\n',
+  ];
 }
+
+List<String> _generateClassProperties(ClassDeclaration declaration) => [
+      for (final property in declaration.properties)
+        ..._generateClassProperty(property),
+    ];
+
+List<String> _generateClassProperty(PropertyDeclaration property) {
+  final header = StringBuffer();
+
+  if (property.hasObjCAnnotation) {
+    header.write('@objc ');
+  }
+
+  if (property.isStatic) {
+    header.write('static ');
+  }
+
+  header.write('public var ${property.name}: ${property.type.swiftType} {');
+
+  final getterLines = [
+    'get {',
+    ...(property.getter?.statements.indent() ?? <String>[]),
+    '}'
+  ];
+
+  final setterLines = [
+    'set {',
+    ...(property.setter?.statements.indent() ?? <String>[]),
+    '}'
+  ];
+
+  return [
+    header.toString(),
+    ...getterLines.indent(),
+    if (property.hasSetter) ...setterLines.indent(),
+    '}\n',
+  ];
+}
+
+List<String> _generateNestedDeclarations(ClassDeclaration declaration) => [
+      for (final nested in declaration.nestedDeclarations)
+        ...generateDeclaration(nested),
+    ];

--- a/pkgs/swift2objc/lib/src/parser/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/parser/_core/utils.dart
@@ -5,9 +5,7 @@
 import 'dart:convert';
 import 'dart:io';
 
-import '../../ast/_core/interfaces/compound_declaration.dart';
 import '../../ast/_core/interfaces/declaration.dart';
-import '../../ast/_core/interfaces/enum_declaration.dart';
 import '../../ast/_core/interfaces/nestable_declaration.dart';
 import '../../ast/_core/shared/referred_type.dart';
 import '../../ast/declarations/globals/globals.dart';

--- a/pkgs/swift2objc/lib/src/parser/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/parser/_core/utils.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import '../../ast/_core/interfaces/compound_declaration.dart';
 import '../../ast/_core/interfaces/declaration.dart';
 import '../../ast/_core/interfaces/enum_declaration.dart';
+import '../../ast/_core/interfaces/nestable_declaration.dart';
 import '../../ast/_core/shared/referred_type.dart';
 import '../../ast/declarations/globals/globals.dart';
 import '../parsers/parse_type.dart';
@@ -31,13 +32,13 @@ extension AddIdSuffix on String {
 }
 
 extension TopLevelOnly<T extends Declaration> on List<T> {
-  List<Declaration> get topLevelOnly => where(
-        (declaration) =>
-            declaration is CompoundDeclaration ||
-            declaration is EnumDeclaration ||
-            declaration is GlobalVariableDeclaration ||
-            declaration is GlobalFunctionDeclaration,
-      ).toList();
+  List<Declaration> get topLevelOnly => where((declaration) {
+        if (declaration is NestableDeclaration) {
+          return declaration.nestingParent == null;
+        }
+        return declaration is GlobalVariableDeclaration ||
+            declaration is GlobalFunctionDeclaration;
+      }).toList();
 }
 
 /// If `fragment['kind'] == kind`, returns `fragment['spelling']`. Otherwise

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_compound_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_compound_declaration.dart
@@ -9,7 +9,6 @@ import '../../../ast/declarations/compounds/members/initializer_declaration.dart
 import '../../../ast/declarations/compounds/members/method_declaration.dart';
 import '../../../ast/declarations/compounds/members/property_declaration.dart';
 import '../../../ast/declarations/compounds/struct_declaration.dart';
-import '../../_core/json.dart';
 import '../../_core/parsed_symbolgraph.dart';
 import '../../_core/utils.dart';
 import '../parse_declarations.dart';

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_compound_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_compound_declaration.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../../../ast/_core/interfaces/compound_declaration.dart';
+import '../../../ast/_core/interfaces/nestable_declaration.dart';
 import '../../../ast/declarations/compounds/class_declaration.dart';
 import '../../../ast/declarations/compounds/members/initializer_declaration.dart';
 import '../../../ast/declarations/compounds/members/method_declaration.dart';
@@ -16,10 +17,10 @@ import '../parse_declarations.dart';
 typedef CompoundTearOff<T extends CompoundDeclaration> = T Function({
   required String id,
   required String name,
-  required List<String> pathComponents,
   required List<PropertyDeclaration> properties,
   required List<MethodDeclaration> methods,
   required List<InitializerDeclaration> initializers,
+  required List<NestableDeclaration> nestedDeclarations,
 });
 
 T _parseCompoundDeclaration<T extends CompoundDeclaration>(
@@ -34,10 +35,10 @@ T _parseCompoundDeclaration<T extends CompoundDeclaration>(
   final compound = tearoffConstructor(
     id: compoundId,
     name: parseSymbolName(compoundSymbol.json),
-    pathComponents: _parseCompoundPathComponents(compoundSymbol.json),
     methods: [],
     properties: [],
     initializers: [],
+    nestedDeclarations: [],
   );
 
   compoundSymbol.declaration = compound;
@@ -73,14 +74,18 @@ T _parseCompoundDeclaration<T extends CompoundDeclaration>(
     memberDeclarations.whereType<PropertyDeclaration>(),
   );
   compound.initializers.addAll(
-    memberDeclarations.whereType<InitializerDeclaration>(),
+    memberDeclarations
+        .whereType<InitializerDeclaration>()
+        .dedupeBy((m) => m.fullName),
   );
+  compound.nestedDeclarations.addAll(
+    memberDeclarations.whereType<NestableDeclaration>(),
+  );
+
+  compound.nestedDeclarations.fillNestingParents(compound);
 
   return compound;
 }
-
-List<String> _parseCompoundPathComponents(Json compoundSymbolJson) =>
-    compoundSymbolJson['pathComponents'].get<List<dynamic>>().cast();
 
 ClassDeclaration parseClassDeclaration(
   ParsedSymbol classSymbol,

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_function_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_function_declaration.dart
@@ -46,7 +46,7 @@ ReferredType _parseFunctionReturnType(
   final returnJson =
       TokenList(methodSymbolJson['functionSignature']['returns']);
   final (returnType, unparsed) = parseType(symbolgraph, returnJson);
-  assert(unparsed.isEmpty);
+  assert(unparsed.isEmpty, '$returnJson\n\n$returnType\n\n$unparsed\n');
   return returnType;
 }
 

--- a/pkgs/swift2objc/lib/src/parser/parsers/parse_relations_map.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/parse_relations_map.dart
@@ -32,7 +32,7 @@ ParsedRelationsMap parseRelationsMap(Json symbolgraphJson) {
       json: relationJson,
     );
 
-    for (var id in [sourceId, targetId]) {
+    for (final id in [sourceId, targetId]) {
       (relationsMap[id] ??= []).add(relation);
     }
   }

--- a/pkgs/swift2objc/lib/src/parser/parsers/parse_type.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/parse_type.dart
@@ -103,6 +103,15 @@ typedef SuffixParselet = (ReferredType, TokenList) Function(
         ReferredType prefixType, Json token, TokenList fragments) =>
     (OptionalType(prefixType), fragments);
 
+(ReferredType, TokenList) _nestedTypeParselet(ParsedSymbolgraph symbolgraph,
+    ReferredType prefixType, Json token, TokenList fragments) {
+  // Parsing Foo.Bar. Foo is in prefixType, and the token is ".". Bar's ID
+  // is a globally uniquely identifier. We don't need to use Foo as a namespace.
+  // So we can actually completely discard Foo and just parse Bar.
+  return parseType(symbolgraph, fragments);
+}
+
 Map<String, SuffixParselet> _suffixParsets = {
   'text: ?': _optionalParselet,
+  'text: .': _nestedTypeParselet,
 };

--- a/pkgs/swift2objc/lib/src/transformer/transform.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transform.dart
@@ -15,7 +15,7 @@ import 'transformers/transform_globals.dart';
 typedef TransformationMap = Map<Declaration, Declaration>;
 
 List<Declaration> transform(List<Declaration> declarations) {
-  final TransformationMap transformationMap = {};
+  final transformationMap = <Declaration, Declaration>{};
 
   final globalNamer = UniqueNamer(
     declarations.map((declaration) => declaration.name),

--- a/pkgs/swift2objc/lib/src/transformer/transform.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transform.dart
@@ -4,6 +4,7 @@
 
 import '../ast/_core/interfaces/compound_declaration.dart';
 import '../ast/_core/interfaces/declaration.dart';
+import '../ast/_core/interfaces/nestable_declaration.dart';
 import '../ast/declarations/compounds/class_declaration.dart';
 import '../ast/declarations/compounds/struct_declaration.dart';
 import '../ast/declarations/globals/globals.dart';
@@ -14,9 +15,7 @@ import 'transformers/transform_globals.dart';
 typedef TransformationMap = Map<Declaration, Declaration>;
 
 List<Declaration> transform(List<Declaration> declarations) {
-  final TransformationMap transformationMap;
-
-  transformationMap = {};
+  final TransformationMap transformationMap = {};
 
   final globalNamer = UniqueNamer(
     declarations.map((declaration) => declaration.name),
@@ -48,17 +47,24 @@ List<Declaration> transform(List<Declaration> declarations) {
 
 Declaration transformDeclaration(
   Declaration declaration,
-  UniqueNamer globalNamer,
-  TransformationMap transformationMap,
-) {
+  UniqueNamer parentNamer,
+  TransformationMap transformationMap, {
+  bool nested = false,
+}) {
   if (transformationMap[declaration] != null) {
     return transformationMap[declaration]!;
+  }
+
+  if (declaration is NestableDeclaration && declaration.nestingParent != null) {
+    // It's important that nested declarations are only transformed in the
+    // context of their parent, so that their parentNamer is correct.
+    assert(nested);
   }
 
   return switch (declaration) {
     ClassDeclaration() || StructDeclaration() => transformCompound(
         declaration as CompoundDeclaration,
-        globalNamer,
+        parentNamer,
         transformationMap,
       ),
     _ => throw UnimplementedError(),

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_compound.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_compound.dart
@@ -4,6 +4,7 @@
 
 import '../../ast/_core/interfaces/compound_declaration.dart';
 import '../../ast/_core/interfaces/declaration.dart';
+import '../../ast/_core/interfaces/nestable_declaration.dart';
 import '../../ast/_core/shared/parameter.dart';
 import '../../ast/declarations/built_in/built_in_declaration.dart';
 import '../../ast/declarations/compounds/class_declaration.dart';
@@ -18,7 +19,7 @@ import 'transform_variable.dart';
 
 ClassDeclaration transformCompound(
   CompoundDeclaration originalCompound,
-  UniqueNamer globalNamer,
+  UniqueNamer parentNamer,
   TransformationMap transformationMap,
 ) {
   final compoundNamer = UniqueNamer.inCompound(originalCompound);
@@ -31,7 +32,7 @@ ClassDeclaration transformCompound(
 
   final transformedCompound = ClassDeclaration(
     id: originalCompound.id.addIdSuffix('wrapper'),
-    name: globalNamer.makeUnique('${originalCompound.name}Wrapper'),
+    name: parentNamer.makeUnique('${originalCompound.name}Wrapper'),
     hasObjCAnnotation: true,
     superClass: BuiltInDeclaration.swiftNSObject.asDeclaredType,
     isWrapper: true,
@@ -41,11 +42,20 @@ ClassDeclaration transformCompound(
 
   transformationMap[originalCompound] = transformedCompound;
 
+  transformedCompound.nestedDeclarations = originalCompound.nestedDeclarations
+      .map((nested) => transformDeclaration(
+              nested, compoundNamer, transformationMap, nested: true)
+          as NestableDeclaration)
+      .toList()
+    ..sort((Declaration a, Declaration b) => a.id.compareTo(b.id));
+  transformedCompound.nestedDeclarations
+      .fillNestingParents(transformedCompound);
+
   transformedCompound.properties = originalCompound.properties
       .map((property) => transformProperty(
             property,
             wrappedCompoundInstance,
-            globalNamer,
+            parentNamer,
             transformationMap,
           ))
       .nonNulls
@@ -56,7 +66,7 @@ ClassDeclaration transformCompound(
       .map((initializer) => transformInitializer(
             initializer,
             wrappedCompoundInstance,
-            globalNamer,
+            parentNamer,
             transformationMap,
           ))
       .toList()
@@ -66,7 +76,7 @@ ClassDeclaration transformCompound(
       .map((method) => transformMethod(
             method,
             wrappedCompoundInstance,
-            globalNamer,
+            parentNamer,
             transformationMap,
           ))
       .nonNulls

--- a/pkgs/swift2objc/test/integration/classes_and_initializers_output.swift
+++ b/pkgs/swift2objc/test/integration/classes_and_initializers_output.swift
@@ -4,35 +4,36 @@ import Foundation
 
 @objc public class MyOtherClassWrapper: NSObject {
   var wrappedInstance: MyOtherClass
-  
+
   init(_ wrappedInstance: MyOtherClass) {
     self.wrappedInstance = wrappedInstance
   }
+
 }
 
 @objc public class MyClassWrapper: NSObject {
   var wrappedInstance: MyClass
-  
+
   @objc public var customProperty: MyOtherClassWrapper {
     get {
       MyOtherClassWrapper(wrappedInstance.customProperty)
     }
   }
-  
+
   @objc public var representableProperty: Int {
     get {
       wrappedInstance.representableProperty
     }
   }
-  
+
   init(_ wrappedInstance: MyClass) {
     self.wrappedInstance = wrappedInstance
   }
-  
+
   @objc init(outerLabel representableProperty: Int, customProperty: MyOtherClassWrapper) {
     wrappedInstance = MyClass(outerLabel: representableProperty, customProperty: customProperty.wrappedInstance)
   }
-  
+
   @objc init?(outerLabel x: Int) {
     if let instance = MyClass(outerLabel: x) {
       wrappedInstance = instance
@@ -40,4 +41,6 @@ import Foundation
       return nil
     }
   }
+
 }
+

--- a/pkgs/swift2objc/test/integration/classes_and_methods_output.swift
+++ b/pkgs/swift2objc/test/integration/classes_and_methods_output.swift
@@ -4,29 +4,32 @@ import Foundation
 
 @objc public class MyOtherClassWrapper: NSObject {
   var wrappedInstance: MyOtherClass
-  
+
   init(_ wrappedInstance: MyOtherClass) {
     self.wrappedInstance = wrappedInstance
   }
+
 }
 
 @objc public class MyClassWrapper: NSObject {
   var wrappedInstance: MyClass
-  
+
   init(_ wrappedInstance: MyClass) {
     self.wrappedInstance = wrappedInstance
   }
-  
+
   @objc public func myMethod(label1 param1: Int, param2: MyOtherClassWrapper) -> MyOtherClassWrapper {
     let result = wrappedInstance.myMethod(label1: param1, param2: param2.wrappedInstance)
     return MyOtherClassWrapper(result)
   }
-  
+
   @objc public func myMethod2() {
     return wrappedInstance.myMethod2()
   }
-  
+
   @objc public func myMethod3() {
     return wrappedInstance.myMethod3()
   }
+
 }
+

--- a/pkgs/swift2objc/test/integration/classes_and_properties_output.swift
+++ b/pkgs/swift2objc/test/integration/classes_and_properties_output.swift
@@ -4,21 +4,22 @@ import Foundation
 
 @objc public class MyOtherClassWrapper: NSObject {
   var wrappedInstance: MyOtherClass
-  
+
   init(_ wrappedInstance: MyOtherClass) {
     self.wrappedInstance = wrappedInstance
   }
+
 }
 
 @objc public class MyClassWrapper: NSObject {
   var wrappedInstance: MyClass
-  
+
   @objc public var customGetterProperty: MyOtherClassWrapper {
     get {
       MyOtherClassWrapper(wrappedInstance.customGetterProperty)
     }
   }
-  
+
   @objc public var customSetterProperty: MyOtherClassWrapper {
     get {
       MyOtherClassWrapper(wrappedInstance.customSetterProperty)
@@ -27,13 +28,13 @@ import Foundation
       wrappedInstance.customSetterProperty = newValue.wrappedInstance
     }
   }
-  
+
   @objc public var customConstantProperty: MyOtherClassWrapper {
     get {
       MyOtherClassWrapper(wrappedInstance.customConstantProperty)
     }
   }
-  
+
   @objc public var customVariableProperty: MyOtherClassWrapper {
     get {
       MyOtherClassWrapper(wrappedInstance.customVariableProperty)
@@ -42,19 +43,19 @@ import Foundation
       wrappedInstance.customVariableProperty = newValue.wrappedInstance
     }
   }
-  
+
   @objc public var implicitGetterProperty: Int {
     get {
       wrappedInstance.implicitGetterProperty
     }
   }
-  
+
   @objc public var representableGetterProperty: Int {
     get {
       wrappedInstance.representableGetterProperty
     }
   }
-  
+
   @objc public var representableSetterProperty: Int {
     get {
       wrappedInstance.representableSetterProperty
@@ -63,13 +64,13 @@ import Foundation
       wrappedInstance.representableSetterProperty = newValue
     }
   }
-  
+
   @objc public var representableConstantProperty: Int {
     get {
       wrappedInstance.representableConstantProperty
     }
   }
-  
+
   @objc public var representableVariableProperty: Int {
     get {
       wrappedInstance.representableVariableProperty
@@ -78,8 +79,10 @@ import Foundation
       wrappedInstance.representableVariableProperty = newValue
     }
   }
-  
+
   init(_ wrappedInstance: MyClass) {
     self.wrappedInstance = wrappedInstance
   }
+
 }
+

--- a/pkgs/swift2objc/test/integration/classes_and_static_methods_output.swift
+++ b/pkgs/swift2objc/test/integration/classes_and_static_methods_output.swift
@@ -4,29 +4,32 @@ import Foundation
 
 @objc public class MyOtherClassWrapper: NSObject {
   var wrappedInstance: MyOtherClass
-  
+
   init(_ wrappedInstance: MyOtherClass) {
     self.wrappedInstance = wrappedInstance
   }
+
 }
 
 @objc public class MyClassWrapper: NSObject {
   var wrappedInstance: MyClass
-  
+
   init(_ wrappedInstance: MyClass) {
     self.wrappedInstance = wrappedInstance
   }
-  
+
   @objc static public func myMethod(label1 param1: Int, param2: MyOtherClassWrapper) -> MyOtherClassWrapper {
     let result = MyClass.myMethod(label1: param1, param2: param2.wrappedInstance)
     return MyOtherClassWrapper(result)
   }
-  
+
   @objc static public func myMethod2() {
     return MyClass.myMethod2()
   }
-  
+
   @objc static public func myMethod3() {
     return MyClass.myMethod3()
   }
+
 }
+

--- a/pkgs/swift2objc/test/integration/classes_and_static_properties_output.swift
+++ b/pkgs/swift2objc/test/integration/classes_and_static_properties_output.swift
@@ -4,21 +4,22 @@ import Foundation
 
 @objc public class MyOtherClassWrapper: NSObject {
   var wrappedInstance: MyOtherClass
-  
+
   init(_ wrappedInstance: MyOtherClass) {
     self.wrappedInstance = wrappedInstance
   }
+
 }
 
 @objc public class MyClassWrapper: NSObject {
   var wrappedInstance: MyClass
-  
+
   @objc static public var customGetterVariable: MyOtherClassWrapper {
     get {
       MyOtherClassWrapper(MyClass.customGetterVariable)
     }
   }
-  
+
   @objc static public var customSetterVariable: MyOtherClassWrapper {
     get {
       MyOtherClassWrapper(MyClass.customSetterVariable)
@@ -27,13 +28,13 @@ import Foundation
       MyClass.customSetterVariable = newValue.wrappedInstance
     }
   }
-  
+
   @objc static public var customConstantProperty: MyOtherClassWrapper {
     get {
       MyOtherClassWrapper(MyClass.customConstantProperty)
     }
   }
-  
+
   @objc static public var customVariableProperty: MyOtherClassWrapper {
     get {
       MyOtherClassWrapper(MyClass.customVariableProperty)
@@ -42,13 +43,13 @@ import Foundation
       MyClass.customVariableProperty = newValue.wrappedInstance
     }
   }
-  
+
   @objc static public var representableGetterVariable: Int {
     get {
       MyClass.representableGetterVariable
     }
   }
-  
+
   @objc static public var representableSetterVariable: Int {
     get {
       MyClass.representableSetterVariable
@@ -57,13 +58,13 @@ import Foundation
       MyClass.representableSetterVariable = newValue
     }
   }
-  
+
   @objc static public var representableConstantProperty: Int {
     get {
       MyClass.representableConstantProperty
     }
   }
-  
+
   @objc static public var representableVariableProperty: Int {
     get {
       MyClass.representableVariableProperty
@@ -72,8 +73,10 @@ import Foundation
       MyClass.representableVariableProperty = newValue
     }
   }
-  
+
   init(_ wrappedInstance: MyClass) {
     self.wrappedInstance = wrappedInstance
   }
+
 }
+

--- a/pkgs/swift2objc/test/integration/global_variables_and_functions_output.swift
+++ b/pkgs/swift2objc/test/integration/global_variables_and_functions_output.swift
@@ -8,7 +8,7 @@ import Foundation
       MyOtherClassWrapper(globalCustomConstant)
     }
   }
-  
+
   @objc static public var globalCustomVariableWrapper: MyOtherClassWrapper {
     get {
       MyOtherClassWrapper(globalCustomVariable)
@@ -17,13 +17,13 @@ import Foundation
       globalCustomVariable = newValue.wrappedInstance
     }
   }
-  
+
   @objc static public var globalGetterVariableWrapper: Double {
     get {
       globalGetterVariable
     }
   }
-  
+
   @objc static public var globalSetterVariableWrapper: Double {
     get {
       globalSetterVariable
@@ -32,13 +32,13 @@ import Foundation
       globalSetterVariable = newValue
     }
   }
-  
+
   @objc static public var globalRepresentableConstantWrapper: Int {
     get {
       globalRepresentableConstant
     }
   }
-  
+
   @objc static public var globalRepresentableVariableWrapper: Int {
     get {
       globalRepresentableVariable
@@ -47,25 +47,28 @@ import Foundation
       globalRepresentableVariable = newValue
     }
   }
-  
+
   @objc static public func globalCustomFunctionWrapper(label1 param1: Int, param2: MyOtherClassWrapper) -> MyOtherClassWrapper {
     let result = globalCustomFunction(label1: param1, param2: param2.wrappedInstance)
     return MyOtherClassWrapper(result)
   }
-  
+
   @objc static public func globalRepresentableFunctionWrapper1() {
     return globalRepresentableFunction()
   }
-  
+
   @objc static public func globalRepresentableFunctionWrapperWrapper() {
     return globalRepresentableFunctionWrapper()
   }
+
 }
 
 @objc public class MyOtherClassWrapper: NSObject {
   var wrappedInstance: MyOtherClass
-  
+
   init(_ wrappedInstance: MyOtherClass) {
     self.wrappedInstance = wrappedInstance
   }
+
 }
+

--- a/pkgs/swift2objc/test/integration/integration_test.dart
+++ b/pkgs/swift2objc/test/integration/integration_test.dart
@@ -9,7 +9,7 @@ import 'package:path/path.dart' as path;
 import 'package:swift2objc/swift2objc.dart';
 import 'package:test/test.dart';
 
-const regenerateExpectedOutputs = false;
+const regenerateExpectedOutputs = true;
 
 void main() {
   Logger.root.onRecord.listen((record) {
@@ -30,6 +30,9 @@ void main() {
         names.add(filename.substring(0, filename.length - inputSuffix.length));
       }
     }
+    names
+      ..clear()
+      ..add('nested_types');
 
     for (final name in names) {
       test(name, () async {

--- a/pkgs/swift2objc/test/integration/integration_test.dart
+++ b/pkgs/swift2objc/test/integration/integration_test.dart
@@ -9,7 +9,7 @@ import 'package:path/path.dart' as path;
 import 'package:swift2objc/swift2objc.dart';
 import 'package:test/test.dart';
 
-const regenerateExpectedOutputs = true;
+const regenerateExpectedOutputs = false;
 
 void main() {
   Logger.root.onRecord.listen((record) {
@@ -30,9 +30,6 @@ void main() {
         names.add(filename.substring(0, filename.length - inputSuffix.length));
       }
     }
-    names
-      ..clear()
-      ..add('nested_types');
 
     for (final name in names) {
       test(name, () async {

--- a/pkgs/swift2objc/test/integration/nested_types_input.swift
+++ b/pkgs/swift2objc/test/integration/nested_types_input.swift
@@ -1,0 +1,31 @@
+public class OuterClass {
+  public static func makeOuter() -> OuterClass { return OuterClass(); }
+  public static func makeInnerClass() -> InnerClass { return InnerClass(); }
+  public static func makeInnerStruct() -> InnerStruct { return InnerStruct(); }
+
+  public class InnerClass {
+    public static func makeOuter() -> OuterClass { return OuterClass(); }
+    public static func makeInner() -> InnerClass { return InnerClass(); }
+  }
+
+  public struct InnerStruct {
+    public static func makeOuter() -> OuterClass { return OuterClass(); }
+    public static func makeInner() -> InnerStruct { return InnerStruct(); }
+  }
+}
+
+public struct OuterStruct {
+  public static func makeOuter() -> OuterStruct { return OuterStruct(); }
+  public static func makeInnerClass() -> InnerClass { return InnerClass(); }
+  public static func makeInnerStruct() -> InnerStruct { return InnerStruct(); }
+
+  public class InnerClass {
+    public static func makeOuter() -> OuterStruct { return OuterStruct(); }
+    public static func makeInner() -> InnerClass { return InnerClass(); }
+  }
+
+  public struct InnerStruct {
+    public static func makeOuter() -> OuterStruct { return OuterStruct(); }
+    public static func makeInner() -> InnerStruct { return InnerStruct(); }
+  }
+}

--- a/pkgs/swift2objc/test/integration/nested_types_output.swift
+++ b/pkgs/swift2objc/test/integration/nested_types_output.swift
@@ -1,0 +1,128 @@
+// Test preamble text
+
+import Foundation
+
+@objc public class OuterClassWrapper: NSObject {
+  var wrappedInstance: OuterClass
+
+  init(_ wrappedInstance: OuterClass) {
+    self.wrappedInstance = wrappedInstance
+  }
+
+  @objc static public func makeOuter() -> OuterClassWrapper {
+    let result = OuterClass.makeOuter()
+    return OuterClassWrapper(result)
+  }
+
+  @objc static public func makeInnerClass() -> OuterClassWrapper.InnerClassWrapper {
+    let result = OuterClass.makeInnerClass()
+    return InnerClassWrapper(result)
+  }
+
+  @objc static public func makeInnerStruct() -> OuterClassWrapper.InnerStructWrapper {
+    let result = OuterClass.makeInnerStruct()
+    return InnerStructWrapper(result)
+  }
+
+  @objc public class InnerClassWrapper: NSObject {
+    var wrappedInstance: OuterClass.InnerClass
+
+    init(_ wrappedInstance: OuterClass.InnerClass) {
+      self.wrappedInstance = wrappedInstance
+    }
+
+    @objc static public func makeOuter() -> OuterClassWrapper {
+      let result = OuterClass.InnerClass.makeOuter()
+      return OuterClassWrapper(result)
+    }
+
+    @objc static public func makeInner() -> OuterClassWrapper.InnerClassWrapper {
+      let result = OuterClass.InnerClass.makeInner()
+      return InnerClassWrapper(result)
+    }
+
+  }
+
+  @objc public class InnerStructWrapper: NSObject {
+    var wrappedInstance: OuterClass.InnerStruct
+
+    init(_ wrappedInstance: OuterClass.InnerStruct) {
+      self.wrappedInstance = wrappedInstance
+    }
+
+    @objc static public func makeOuter() -> OuterClassWrapper {
+      let result = OuterClass.InnerStruct.makeOuter()
+      return OuterClassWrapper(result)
+    }
+
+    @objc static public func makeInner() -> OuterClassWrapper.InnerStructWrapper {
+      let result = OuterClass.InnerStruct.makeInner()
+      return InnerStructWrapper(result)
+    }
+
+  }
+
+}
+
+@objc public class OuterStructWrapper: NSObject {
+  var wrappedInstance: OuterStruct
+
+  init(_ wrappedInstance: OuterStruct) {
+    self.wrappedInstance = wrappedInstance
+  }
+
+  @objc static public func makeOuter() -> OuterStructWrapper {
+    let result = OuterStruct.makeOuter()
+    return OuterStructWrapper(result)
+  }
+
+  @objc static public func makeInnerStruct() -> OuterStructWrapper.InnerStructWrapper {
+    let result = OuterStruct.makeInnerStruct()
+    return InnerStructWrapper(result)
+  }
+
+  @objc static public func makeInnerClass() -> OuterStructWrapper.InnerClassWrapper {
+    let result = OuterStruct.makeInnerClass()
+    return InnerClassWrapper(result)
+  }
+
+  @objc public class InnerStructWrapper: NSObject {
+    var wrappedInstance: OuterStruct.InnerStruct
+
+    init(_ wrappedInstance: OuterStruct.InnerStruct) {
+      self.wrappedInstance = wrappedInstance
+    }
+
+    @objc static public func makeOuter() -> OuterStructWrapper {
+      let result = OuterStruct.InnerStruct.makeOuter()
+      return OuterStructWrapper(result)
+    }
+
+    @objc static public func makeInner() -> OuterStructWrapper.InnerStructWrapper {
+      let result = OuterStruct.InnerStruct.makeInner()
+      return InnerStructWrapper(result)
+    }
+
+  }
+
+  @objc public class InnerClassWrapper: NSObject {
+    var wrappedInstance: OuterStruct.InnerClass
+
+    init(_ wrappedInstance: OuterStruct.InnerClass) {
+      self.wrappedInstance = wrappedInstance
+    }
+
+    @objc static public func makeOuter() -> OuterStructWrapper {
+      let result = OuterStruct.InnerClass.makeOuter()
+      return OuterStructWrapper(result)
+    }
+
+    @objc static public func makeInner() -> OuterStructWrapper.InnerClassWrapper {
+      let result = OuterStruct.InnerClass.makeInner()
+      return InnerClassWrapper(result)
+    }
+
+  }
+
+}
+

--- a/pkgs/swift2objc/test/integration/optional_output.swift
+++ b/pkgs/swift2objc/test/integration/optional_output.swift
@@ -11,30 +11,31 @@ import Foundation
       globalOptional = newValue?.wrappedInstance
     }
   }
-  
+
   @objc static public func funcOptionalArgsWrapper(label param: MyClassWrapper?) -> MyClassWrapper {
     let result = funcOptionalArgs(label: param?.wrappedInstance)
     return MyClassWrapper(result)
   }
-  
+
   @objc static public func funcOptionalClassReturnWrapper() -> MyClassWrapper? {
     let result = funcOptionalClassReturn()
     return result == nil ? nil : MyClassWrapper(result!)
   }
-  
+
   @objc static public func funcMultipleOptionalArgsWrapper(label1 param1: MyClassWrapper?, label2 param2: Int, label3 param3: MyStructWrapper?) {
     return funcMultipleOptionalArgs(label1: param1?.wrappedInstance, label2: param2, label3: param3?.wrappedInstance)
   }
-  
+
   @objc static public func funcOptionalStructReturnWrapper() -> MyStructWrapper? {
     let result = funcOptionalStructReturn()
     return result == nil ? nil : MyStructWrapper(result!)
   }
+
 }
 
 @objc public class MyClassWrapper: NSObject {
   var wrappedInstance: MyClass
-  
+
   @objc public var optionalProperty: MyClassWrapper? {
     get {
       wrappedInstance.optionalProperty == nil ? nil : MyClassWrapper(wrappedInstance.optionalProperty!)
@@ -43,32 +44,33 @@ import Foundation
       wrappedInstance.optionalProperty = newValue?.wrappedInstance
     }
   }
-  
+
   init(_ wrappedInstance: MyClass) {
     self.wrappedInstance = wrappedInstance
   }
-  
+
   @objc init(label param: MyClassWrapper?) {
     wrappedInstance = MyClass(label: param?.wrappedInstance)
   }
-  
+
   @objc init(label1 param1: MyClassWrapper?, label2: Int, label3 param3: MyStructWrapper?) {
     wrappedInstance = MyClass(label1: param1?.wrappedInstance, label2: label2, label3: param3?.wrappedInstance)
   }
-  
+
   @objc public func methodOptionalArgs(label param: MyClassWrapper?) {
     return wrappedInstance.methodOptionalArgs(label: param?.wrappedInstance)
   }
-  
+
   @objc public func methodOptionalReturn() -> MyClassWrapper? {
     let result = wrappedInstance.methodOptionalReturn()
     return result == nil ? nil : MyClassWrapper(result!)
   }
+
 }
 
 @objc public class MyStructWrapper: NSObject {
   var wrappedInstance: MyStruct
-  
+
   @objc public var optionalProperty: MyClassWrapper? {
     get {
       wrappedInstance.optionalProperty == nil ? nil : MyClassWrapper(wrappedInstance.optionalProperty!)
@@ -77,21 +79,23 @@ import Foundation
       wrappedInstance.optionalProperty = newValue?.wrappedInstance
     }
   }
-  
+
   init(_ wrappedInstance: MyStruct) {
     self.wrappedInstance = wrappedInstance
   }
-  
+
   @objc init(label param: MyClassWrapper?) {
     wrappedInstance = MyStruct(label: param?.wrappedInstance)
   }
-  
+
   @objc public func methodOptionalArgs(label param: MyClassWrapper?) {
     return wrappedInstance.methodOptionalArgs(label: param?.wrappedInstance)
   }
-  
+
   @objc public func methodOptionalReturn() -> MyStructWrapper? {
     let result = wrappedInstance.methodOptionalReturn()
     return result == nil ? nil : MyStructWrapper(result!)
   }
+
 }
+

--- a/pkgs/swift2objc/test/integration/structs_and_initializers_output.swift
+++ b/pkgs/swift2objc/test/integration/structs_and_initializers_output.swift
@@ -4,23 +4,24 @@ import Foundation
 
 @objc public class MyOtherStructWrapper: NSObject {
   var wrappedInstance: MyOtherStruct
-  
+
   init(_ wrappedInstance: MyOtherStruct) {
     self.wrappedInstance = wrappedInstance
   }
+
 }
 
 @objc public class MyStructWrapper: NSObject {
   var wrappedInstance: MyStruct
-  
+
   init(_ wrappedInstance: MyStruct) {
     self.wrappedInstance = wrappedInstance
   }
-  
+
   @objc init(outerLabel representableProperty: Int, customProperty: MyOtherStructWrapper) {
     wrappedInstance = MyStruct(outerLabel: representableProperty, customProperty: customProperty.wrappedInstance)
   }
-  
+
   @objc init?(outerLabel x: Int) {
     if let instance = MyStruct(outerLabel: x) {
       wrappedInstance = instance
@@ -28,4 +29,6 @@ import Foundation
       return nil
     }
   }
+
 }
+

--- a/pkgs/swift2objc/test/integration/structs_and_methods_output.swift
+++ b/pkgs/swift2objc/test/integration/structs_and_methods_output.swift
@@ -4,29 +4,32 @@ import Foundation
 
 @objc public class MyOtherStructWrapper: NSObject {
   var wrappedInstance: MyOtherStruct
-  
+
   init(_ wrappedInstance: MyOtherStruct) {
     self.wrappedInstance = wrappedInstance
   }
+
 }
 
 @objc public class MyStructWrapper: NSObject {
   var wrappedInstance: MyStruct
-  
+
   init(_ wrappedInstance: MyStruct) {
     self.wrappedInstance = wrappedInstance
   }
-  
+
   @objc public func myMethod(label1 param1: Int, param2: MyOtherStructWrapper) -> MyOtherStructWrapper {
     let result = wrappedInstance.myMethod(label1: param1, param2: param2.wrappedInstance)
     return MyOtherStructWrapper(result)
   }
-  
+
   @objc public func myMethod2() {
     return wrappedInstance.myMethod2()
   }
-  
+
   @objc public func myMethod3() {
     return wrappedInstance.myMethod3()
   }
+
 }
+

--- a/pkgs/swift2objc/test/integration/structs_and_properties_output.swift
+++ b/pkgs/swift2objc/test/integration/structs_and_properties_output.swift
@@ -4,21 +4,22 @@ import Foundation
 
 @objc public class MyOtherStructWrapper: NSObject {
   var wrappedInstance: MyOtherStruct
-  
+
   init(_ wrappedInstance: MyOtherStruct) {
     self.wrappedInstance = wrappedInstance
   }
+
 }
 
 @objc public class MyStructWrapper: NSObject {
   var wrappedInstance: MyStruct
-  
+
   @objc public var customGetterProperty: MyOtherStructWrapper {
     get {
       MyOtherStructWrapper(wrappedInstance.customGetterProperty)
     }
   }
-  
+
   @objc public var customSetterProperty: MyOtherStructWrapper {
     get {
       MyOtherStructWrapper(wrappedInstance.customSetterProperty)
@@ -27,13 +28,13 @@ import Foundation
       wrappedInstance.customSetterProperty = newValue.wrappedInstance
     }
   }
-  
+
   @objc public var customConstantProperty: MyOtherStructWrapper {
     get {
       MyOtherStructWrapper(wrappedInstance.customConstantProperty)
     }
   }
-  
+
   @objc public var customVariableProperty: MyOtherStructWrapper {
     get {
       MyOtherStructWrapper(wrappedInstance.customVariableProperty)
@@ -42,19 +43,19 @@ import Foundation
       wrappedInstance.customVariableProperty = newValue.wrappedInstance
     }
   }
-  
+
   @objc public var implicitGetterProperty: Int {
     get {
       wrappedInstance.implicitGetterProperty
     }
   }
-  
+
   @objc public var representableGetterProperty: Int {
     get {
       wrappedInstance.representableGetterProperty
     }
   }
-  
+
   @objc public var representableSetterProperty: Int {
     get {
       wrappedInstance.representableSetterProperty
@@ -63,13 +64,13 @@ import Foundation
       wrappedInstance.representableSetterProperty = newValue
     }
   }
-  
+
   @objc public var representableConstantProperty: Int {
     get {
       wrappedInstance.representableConstantProperty
     }
   }
-  
+
   @objc public var representableVariableProperty: Int {
     get {
       wrappedInstance.representableVariableProperty
@@ -78,8 +79,10 @@ import Foundation
       wrappedInstance.representableVariableProperty = newValue
     }
   }
-  
+
   init(_ wrappedInstance: MyStruct) {
     self.wrappedInstance = wrappedInstance
   }
+
 }
+

--- a/pkgs/swift2objc/test/integration/structs_and_static_methods_output.swift
+++ b/pkgs/swift2objc/test/integration/structs_and_static_methods_output.swift
@@ -4,29 +4,32 @@ import Foundation
 
 @objc public class MyOtherStructWrapper: NSObject {
   var wrappedInstance: MyOtherStruct
-  
+
   init(_ wrappedInstance: MyOtherStruct) {
     self.wrappedInstance = wrappedInstance
   }
+
 }
 
 @objc public class MyStructWrapper: NSObject {
   var wrappedInstance: MyStruct
-  
+
   init(_ wrappedInstance: MyStruct) {
     self.wrappedInstance = wrappedInstance
   }
-  
+
   @objc static public func myMethod(label1 param1: Int, param2: MyOtherStructWrapper) -> MyOtherStructWrapper {
     let result = MyStruct.myMethod(label1: param1, param2: param2.wrappedInstance)
     return MyOtherStructWrapper(result)
   }
-  
+
   @objc static public func myMethod2() {
     return MyStruct.myMethod2()
   }
-  
+
   @objc static public func myMethod3() {
     return MyStruct.myMethod3()
   }
+
 }
+

--- a/pkgs/swift2objc/test/integration/structs_and_static_properties_output.swift
+++ b/pkgs/swift2objc/test/integration/structs_and_static_properties_output.swift
@@ -4,21 +4,22 @@ import Foundation
 
 @objc public class MyOtherStructWrapper: NSObject {
   var wrappedInstance: MyOtherStruct
-  
+
   init(_ wrappedInstance: MyOtherStruct) {
     self.wrappedInstance = wrappedInstance
   }
+
 }
 
 @objc public class MyStructWrapper: NSObject {
   var wrappedInstance: MyStruct
-  
+
   @objc static public var customGetterVariable: MyOtherStructWrapper {
     get {
       MyOtherStructWrapper(MyStruct.customGetterVariable)
     }
   }
-  
+
   @objc static public var customSetterVariable: MyOtherStructWrapper {
     get {
       MyOtherStructWrapper(MyStruct.customSetterVariable)
@@ -27,13 +28,13 @@ import Foundation
       MyStruct.customSetterVariable = newValue.wrappedInstance
     }
   }
-  
+
   @objc static public var customConstantProperty: MyOtherStructWrapper {
     get {
       MyOtherStructWrapper(MyStruct.customConstantProperty)
     }
   }
-  
+
   @objc static public var customVariableProperty: MyOtherStructWrapper {
     get {
       MyOtherStructWrapper(MyStruct.customVariableProperty)
@@ -42,13 +43,13 @@ import Foundation
       MyStruct.customVariableProperty = newValue.wrappedInstance
     }
   }
-  
+
   @objc static public var representableGetterVariable: Int {
     get {
       MyStruct.representableGetterVariable
     }
   }
-  
+
   @objc static public var representableSetterVariable: Int {
     get {
       MyStruct.representableSetterVariable
@@ -57,13 +58,13 @@ import Foundation
       MyStruct.representableSetterVariable = newValue
     }
   }
-  
+
   @objc static public var representableConstantProperty: Int {
     get {
       MyStruct.representableConstantProperty
     }
   }
-  
+
   @objc static public var representableVariableProperty: Int {
     get {
       MyStruct.representableVariableProperty
@@ -72,8 +73,10 @@ import Foundation
       MyStruct.representableVariableProperty = newValue
     }
   }
-  
+
   init(_ wrappedInstance: MyStruct) {
     self.wrappedInstance = wrappedInstance
   }
+
 }
+


### PR DESCRIPTION
- In the AST, replace `pathComponents` with a new interface, `NestableDeclaration`, containing child and parent links.
- In the symbolgraph, the parent/child relationship is defined by a `memberOf` relationship. This is the same relationship as methods and properties, so all the declaration parsing infrastructure is already there.
- Parsing a `ReferredType` for a nested type is easy too. They look like `[Foo, ".", Bar]`, but Bar's token has its fully qualified globally unique ID. So we can actually just discard Foo and parse Bar normally. See `_nestedTypeParselet`.
- Nested declarations are code-genned inside their parent
  - This requires a bit of care when finding unique names for them. These declarations have to be named using the parent's `UniqueNamer`, not the global one
  - That means we have to make sure (with an assert) that we're only ever transforming the nested declaration in the scope of the parent.
- Change code-gen pipeline to pass around `List<String>` instead of `String`.
  - Previously we were doing indenting by splitting the string, adding indents, then joining. This was happening every time we indented, which is pretty inefficient.
  - Better to pass around lists of lines, and only join them at the end.
  - This caused a bunch of whitespace changes in the integration tests.