### PR TITLE
[native_x] Deprecate `dryRun`

### DIFF
--- a/pkgs/native_assets_builder/test_data/transformer/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/transformer/hook/build.dart
@@ -28,6 +28,7 @@ void main(List<String> arguments) async {
       final targetFile = File.fromUri(config.outputDirectoryShared
           .resolve(sourceName.replaceFirst('data', 'data_transformed')));
 
+      // ignore: deprecated_member_use
       if (!config.dryRun) {
         // TODO(dacoharkes): Timestamps are not enough for correct caching.
         if (!await targetFile.exists() ||
@@ -52,6 +53,7 @@ void main(List<String> arguments) async {
       );
     }
 
+    // ignore: deprecated_member_use
     if (!config.dryRun) {
       print('Transformed $transformedFiles files.');
       print('Reused $cachedFiles cached files.');

--- a/pkgs/native_assets_builder/test_data/wrong_linker/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/wrong_linker/hook/build.dart
@@ -11,6 +11,7 @@ void main(List<String> arguments) async {
     final assetUri = config.outputDirectory.resolve(
       OS.current.dylibFileName('foo'),
     );
+    // ignore: deprecated_member_use
     if (!config.dryRun) {
       await File.fromUri(assetUri).writeAsBytes([1, 2, 3]);
     }

--- a/pkgs/native_assets_builder/test_data/wrong_namespace_asset/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/wrong_namespace_asset/hook/build.dart
@@ -11,6 +11,7 @@ void main(List<String> arguments) async {
     final assetUri = config.outputDirectory.resolve(
       OS.current.dylibFileName('foo'),
     );
+    // ignore: deprecated_member_use
     if (!config.dryRun) {
       await File.fromUri(assetUri).writeAsBytes([1, 2, 3]);
     }

--- a/pkgs/native_assets_cli/example/build/local_asset/hook/build.dart
+++ b/pkgs/native_assets_cli/example/build/local_asset/hook/build.dart
@@ -21,6 +21,7 @@ Future<void> main(List<String> args) async {
     final packageName = config.packageName;
     final assetPath = config.outputDirectory.resolve(assetName);
     final assetSourcePath = config.packageRoot.resolveUri(packageAssetPath);
+    // ignore: deprecated_member_use
     if (!config.dryRun) {
       // Insert code that downloads or builds the asset to `assetPath`.
       await File.fromUri(assetSourcePath).copy(assetPath.toFilePath());
@@ -39,6 +40,7 @@ Future<void> main(List<String> args) async {
         linkMode: DynamicLoadingBundled(),
         os: config.targetOS,
         architecture:
+            // ignore: deprecated_member_use
             config.dryRun ? null : config.codeConfig.targetArchitecture,
       ),
     );

--- a/pkgs/native_assets_cli/lib/src/code_assets/code_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/code_asset.dart
@@ -61,8 +61,6 @@ final class CodeAsset {
   final OS os;
 
   /// The architecture this asset can run on.
-  ///
-  /// Not available during a [BuildConfig.dryRun].
   final Architecture? architecture;
 
   /// The link mode for this native code.
@@ -72,14 +70,14 @@ final class CodeAsset {
 
   /// The file to be bundled with the Dart or Flutter application.
   ///
-  /// If the [linkMode] is [DynamicLoadingBundled], the file name must be
-  /// provided in the [BuildOutput] for [BuildConfig.dryRun]. Supplying a file
-  /// name instead of an absolute path is enough for [BuildConfig.dryRun]. The
-  /// file does not have to exist on disk during a dry run.
+  /// If the [linkMode] is [DynamicLoadingBundled], the file must be provided
+  /// and exist.
   ///
-  /// If the [linkMode] is [DynamicLoadingSystem], [LookupInProcess], or
-  /// [LookupInExecutable] the file must be omitted in the [BuildOutput] for
-  /// [BuildConfig.dryRun].
+  /// If the [linkMode] is [DynamicLoadingSystem], the file must be provided,
+  /// and not exist.
+  ///
+  /// If the [linkMode] is [LookupInProcess], or [LookupInExecutable] the file
+  /// must be omitted in the [BuildOutput].
   final Uri? file;
 
   /// Constructs a native code asset.

--- a/pkgs/native_assets_cli/lib/src/code_assets/config.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/config.dart
@@ -51,6 +51,7 @@ class CodeConfig {
   CodeConfig(HookConfig config)
       : linkModePreference = LinkModePreference.fromString(
             config.json.string(_linkModePreferenceKey)),
+        // ignore: deprecated_member_use_from_same_package
         _targetArchitecture = (config is BuildConfig && config.dryRun)
             ? null
             : Architecture.fromString(config.json.string(_targetArchitectureKey,

--- a/pkgs/native_assets_cli/lib/src/code_assets/link_mode.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/link_mode.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../config.dart';
-
 import 'code_asset.dart';
 
 /// The link mode for a [CodeAsset].
@@ -75,10 +73,6 @@ abstract final class DynamicLoading extends LinkMode {
 /// An asset with this dynamic loading method must provide a
 /// [CodeAsset.file]. The Dart and Flutter SDK will bundle this code in
 /// the final application.
-///
-/// During a [BuildConfig.dryRun], the [CodeAsset.file] can be a file name
-/// instead of a the full path. The file does not have to exist during a dry
-/// run.
 final class DynamicLoadingBundled extends DynamicLoading {
   DynamicLoadingBundled._() : super._();
 

--- a/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
@@ -11,7 +11,12 @@ import 'link_mode.dart';
 Future<ValidationErrors> validateCodeAssetBuildConfig(
         BuildConfig config) async =>
     _validateCodeConfig(
-        'BuildConfig', config.targetOS, config.dryRun, config.codeConfig);
+      'BuildConfig',
+      config.targetOS,
+      // ignore: deprecated_member_use_from_same_package
+      config.dryRun,
+      config.codeConfig,
+    );
 
 Future<ValidationErrors> validateCodeAssetLinkConfig(LinkConfig config) async =>
     _validateCodeConfig(
@@ -71,8 +76,15 @@ Future<ValidationErrors> validateCodeAssetBuildOutput(
   BuildConfig config,
   BuildOutput output,
 ) =>
-    _validateCodeAssetBuildOrLinkOutput(config, config.codeConfig,
-        output.encodedAssets, config.dryRun, output, true);
+    _validateCodeAssetBuildOrLinkOutput(
+      config,
+      config.codeConfig,
+      output.encodedAssets,
+      // ignore: deprecated_member_use_from_same_package
+      config.dryRun,
+      output,
+      true,
+    );
 
 Future<ValidationErrors> validateCodeAssetLinkOutput(
   LinkConfig config,

--- a/pkgs/native_assets_cli/lib/src/config.dart
+++ b/pkgs/native_assets_cli/lib/src/config.dart
@@ -166,10 +166,13 @@ const _packageRootConfigKey = 'package_root';
 const _supportedAssetTypesKey = 'supported_asset_types';
 
 final class BuildConfig extends HookConfig {
+  // TODO(dcharkes): Remove after 3.7.0 stable is released and bump the SDK
+  // constraint in the pubspec. Ditto for all uses in related packages.
   /// Whether this run is a dry-run, which doesn't build anything.
   ///
   /// A dry-run only reports information about which assets a build would
   /// create, but doesn't actually create files.
+  @Deprecated('Flutter will no longer invoke dry run as of 3.27.')
   final bool dryRun;
 
   final bool linkingEnabled;
@@ -177,6 +180,7 @@ final class BuildConfig extends HookConfig {
   final Map<String, Metadata> metadata;
 
   BuildConfig(super.json)
+      // ignore: deprecated_member_use_from_same_package
       : dryRun = json.getOptional<bool>(_dryRunConfigKey) ?? false,
         linkingEnabled = json.get<bool>(_linkingEnabledKey),
         metadata = {

--- a/pkgs/native_assets_cli/lib/src/data_assets/data_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/data_asset.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../config.dart';
 import '../encoded_asset.dart';
 import '../json_utils.dart';
 import '../utils/map.dart';
@@ -17,8 +16,6 @@ import '../utils/map.dart';
 /// bundle this code in the final application.
 final class DataAsset {
   /// The file to be bundled with the Dart or Flutter application.
-  ///
-  /// The file can be omitted in the [BuildOutput] for [BuildConfig.dryRun].
   ///
   /// The file can also be omitted for asset types which refer to an asset
   /// already present on the target system or an asset already present in Dart

--- a/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
@@ -26,7 +26,12 @@ Future<ValidationErrors> validateDataAssetBuildOutput(
   BuildOutput output,
 ) =>
     _validateDataAssetBuildOrLinkOutput(
-        config, output.encodedAssets, config.dryRun, true);
+      config,
+      output.encodedAssets,
+      // ignore: deprecated_member_use_from_same_package
+      config.dryRun,
+      true,
+    );
 
 Future<ValidationErrors> validateDataAssetLinkOutput(
   LinkConfig config,

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -132,6 +132,7 @@ class CBuilder extends CTool implements Builder {
       // ignore: deprecated_member_use_from_same_package
       for (final source in this.dartBuildFiles) packageRoot.resolve(source),
     ];
+    // ignore: deprecated_member_use
     if (!config.dryRun) {
       final task = RunCBuilder(
         config: config,
@@ -175,11 +176,13 @@ class CBuilder extends CTool implements Builder {
           linkMode: linkMode,
           os: config.targetOS,
           architecture:
+              // ignore: deprecated_member_use
               config.dryRun ? null : config.codeConfig.targetArchitecture,
         ),
         linkInPackage: linkInPackage,
       );
     }
+    // ignore: deprecated_member_use
     if (!config.dryRun) {
       final includeFiles = await Stream.fromIterable(includes)
           .asyncExpand(


### PR DESCRIPTION
This deprecates `BuildConfig.dryRun`.

We will be able to remove it after Dart 3.7 is released and we can increase the SDK bound in `native_assets_cli` to that version.

For now, add some ignores to suppress to suppress the deprecation lints.

Bug:

* https://github.com/dart-lang/native/issues/1485