### PR TITLE
[native_assets_builder] Recompile hook kernel if Dart changes

### DIFF
--- a/pkgs/native_assets_builder/lib/src/dependencies_hash_file/dependencies_hash_file.dart
+++ b/pkgs/native_assets_builder/lib/src/dependencies_hash_file/dependencies_hash_file.dart
@@ -26,7 +26,7 @@ class DependenciesHashFile {
     }
     final jsonObject =
         (json.decode(utf8.decode(await _file.readAsBytes())) as Map)
-            .cast<String, dynamic>();
+            .cast<String, Object>();
     _hashes = FileSystemHashes.fromJson(jsonObject);
   }
 
@@ -38,7 +38,7 @@ class DependenciesHashFile {
   /// If [validBeforeLastModified] is provided, any entities that were modified
   /// after [validBeforeLastModified] will get a dummy hash so that they will
   /// show up as outdated. If any such entity exists, its uri will be returned.
-  Future<Uri?> hashFiles(
+  Future<Uri?> hashFilesAndDirectories(
     List<Uri> fileSystemEntities, {
     DateTime? validBeforeLastModified,
   }) async {
@@ -134,32 +134,25 @@ class DependenciesHashFile {
 /// [Directory] hashes are a hash of the names of the direct children.
 class FileSystemHashes {
   FileSystemHashes({
-    this.version = 1,
     List<FilesystemEntityHash>? files,
   }) : files = files ?? [];
 
-  factory FileSystemHashes.fromJson(Map<String, dynamic> json) {
-    final version = json[_versionKey] as int;
-    final rawEntries =
-        (json[_entitiesKey] as List<dynamic>).cast<Map<String, dynamic>>();
+  factory FileSystemHashes.fromJson(Map<String, Object> json) {
+    final rawEntries = (json[_entitiesKey] as List).cast<Object>();
     final files = <FilesystemEntityHash>[
-      for (final Map<String, dynamic> rawEntry in rawEntries)
-        FilesystemEntityHash._fromJson(rawEntry),
+      for (final rawEntry in rawEntries)
+        FilesystemEntityHash._fromJson((rawEntry as Map).cast()),
     ];
     return FileSystemHashes(
-      version: version,
       files: files,
     );
   }
 
-  final int version;
   final List<FilesystemEntityHash> files;
 
-  static const _versionKey = 'version';
   static const _entitiesKey = 'entities';
 
   Map<String, Object> toJson() => <String, Object>{
-        _versionKey: version,
         _entitiesKey: <Object>[
           for (final FilesystemEntityHash file in files) file.toJson(),
         ],
@@ -177,7 +170,7 @@ class FilesystemEntityHash {
     this.hash,
   );
 
-  factory FilesystemEntityHash._fromJson(Map<String, dynamic> json) =>
+  factory FilesystemEntityHash._fromJson(Map<String, Object> json) =>
       FilesystemEntityHash(
         _fileSystemPathToUri(json[_pathKey] as String),
         json[_hashKey] as int,

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_caching_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_caching_test.dart
@@ -61,6 +61,12 @@ void main() async {
           buildValidator: validateCodeAssetBuildOutput,
           applicationAssetValidator: validateCodeAssetInApplication,
         ))!;
+        final hookUri = packageUri.resolve('hook/build.dart');
+        print(logMessages.join('\n'));
+        expect(
+          logMessages.join('\n'),
+          isNot(contains('Recompiling ${hookUri.toFilePath()}')),
+        );
         expect(
           logMessages.join('\n'),
           contains('Skipping build for native_add'),
@@ -199,7 +205,7 @@ void main() async {
             applicationAssetValidator: validateCodeAssetInApplication,
           ))!;
 
-          final hookUri = packageUri.resolve('hook/').resolve('build.dart');
+          final hookUri = packageUri.resolve('hook/build.dart');
           expect(
             logMessages.join('\n'),
             contains('Recompiling ${hookUri.toFilePath()}'),

--- a/pkgs/native_assets_builder/test/dependencies_hash_file/dependencies_hash_file_test.dart
+++ b/pkgs/native_assets_builder/test/dependencies_hash_file/dependencies_hash_file_test.dart
@@ -43,7 +43,7 @@ void main() async {
         await tempFile.writeAsString('hello');
         await subFile.writeAsString('world');
 
-        await hashes.hashFiles([
+        await hashes.hashFilesAndDirectories([
           tempFile.uri,
           tempSubDir.uri,
         ]);
@@ -95,7 +95,7 @@ void main() async {
 
       // If a file is modified after the valid timestamp, it should be marked
       // as changed.
-      await hashes.hashFiles(
+      await hashes.hashFilesAndDirectories(
         [
           tempFile.uri,
         ],


### PR DESCRIPTION
Addresses the remaining comments on https://github.com/dart-lang/native/pull/1750.

I'm unsure how to test the recompiling of the kernel file if Dart changes without writing a test that downloads a different Dart SDK.