### PR TITLE
[swift2objc] Support `throws` annotation

### DIFF
--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/can_throw.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/can_throw.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// An interface to describe a Swift entity's ability to be annotated
-/// with `override`.
-abstract interface class Overridable {
-  abstract final bool isOverriding;
+/// with `throws`.
+abstract interface class CanThrow {
+  abstract final bool throws;
 }

--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/function_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/function_declaration.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../shared/referred_type.dart';
+import 'can_throw.dart';
 import 'declaration.dart';
 import 'executable.dart';
 import 'parameterizable.dart';
@@ -10,6 +11,11 @@ import 'type_parameterizable.dart';
 
 /// Describes a function-like entity.
 abstract interface class FunctionDeclaration
-    implements Declaration, Parameterizable, Executable, TypeParameterizable {
+    implements
+        Declaration,
+        Parameterizable,
+        Executable,
+        TypeParameterizable,
+        CanThrow {
   abstract final ReferredType returnType;
 }

--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/variable_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/variable_declaration.dart
@@ -3,10 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../shared/referred_type.dart';
+import 'can_throw.dart';
 import 'declaration.dart';
 
 /// Describes a variable-like entity.
-abstract interface class VariableDeclaration implements Declaration {
+///
+/// This declaration [CanThrow] because Swift variables can have explicit
+/// getters, which can be marked with `throws`. Such variables may not have a
+/// setter.
+abstract interface class VariableDeclaration implements Declaration, CanThrow {
   abstract final bool isConstant;
   abstract final ReferredType type;
 }

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/initializer_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/initializer_declaration.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../../_core/interfaces/can_throw.dart';
 import '../../../_core/interfaces/declaration.dart';
 import '../../../_core/interfaces/executable.dart';
 import '../../../_core/interfaces/objc_annotatable.dart';
@@ -16,7 +17,8 @@ class InitializerDeclaration
         Executable,
         Parameterizable,
         ObjCAnnotatable,
-        Overridable {
+        Overridable,
+        CanThrow {
   @override
   String id;
 
@@ -28,6 +30,9 @@ class InitializerDeclaration
 
   @override
   bool isOverriding;
+
+  @override
+  bool throws;
 
   bool isFailable;
 
@@ -48,6 +53,7 @@ class InitializerDeclaration
     this.statements = const [],
     required this.hasObjCAnnotation,
     required this.isOverriding,
+    required this.throws,
     required this.isFailable,
   });
 }

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/method_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/method_declaration.dart
@@ -31,6 +31,9 @@ class MethodDeclaration
   bool isOverriding;
 
   @override
+  bool throws;
+
+  @override
   List<String> statements;
 
   @override
@@ -53,5 +56,6 @@ class MethodDeclaration
     this.statements = const [],
     this.isStatic = false,
     this.isOverriding = false,
+    this.throws = false,
   }) : assert(!isStatic || !isOverriding);
 }

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/property_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/property_declaration.dart
@@ -25,6 +25,9 @@ class PropertyDeclaration implements VariableDeclaration, ObjCAnnotatable {
   @override
   bool isConstant;
 
+  @override
+  bool throws;
+
   bool hasSetter;
 
   PropertyStatements? getter;
@@ -42,7 +45,9 @@ class PropertyDeclaration implements VariableDeclaration, ObjCAnnotatable {
     this.getter,
     this.setter,
     this.isStatic = false,
-  }) : assert(!isConstant || !hasSetter);
+    this.throws = false,
+  })  : assert(!(isConstant && hasSetter)),
+        assert(!(hasSetter && throws));
 }
 
 class PropertyStatements implements Executable {

--- a/pkgs/swift2objc/lib/src/ast/declarations/globals/globals.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/globals/globals.dart
@@ -34,6 +34,9 @@ class GlobalFunctionDeclaration implements FunctionDeclaration {
   List<GenericType> typeParams;
 
   @override
+  bool throws;
+
+  @override
   ReferredType returnType;
 
   @override
@@ -46,6 +49,7 @@ class GlobalFunctionDeclaration implements FunctionDeclaration {
     required this.returnType,
     this.typeParams = const [],
     this.statements = const [],
+    this.throws = false,
   });
 }
 
@@ -63,10 +67,14 @@ class GlobalVariableDeclaration implements VariableDeclaration {
   @override
   bool isConstant;
 
+  @override
+  bool throws;
+
   GlobalVariableDeclaration({
     required this.id,
     required this.name,
     required this.type,
     required this.isConstant,
-  });
+    required this.throws,
+  }) : assert(!(throws && !isConstant));
 }

--- a/pkgs/swift2objc/lib/src/generator/generators/class_generator.dart
+++ b/pkgs/swift2objc/lib/src/generator/generators/class_generator.dart
@@ -87,6 +87,10 @@ List<String> _generateInitializer(InitializerDeclaration initializer) {
 
   header.write('(${generateParameters(initializer.params)})');
 
+  if (initializer.throws) {
+    header.write(' throws');
+  }
+
   return [
     '$header {',
     ...initializer.statements.indent(),
@@ -115,6 +119,10 @@ List<String> _generateClassMethod(MethodDeclaration method) {
   header.write(
     'public func ${method.name}(${generateParameters(method.params)})',
   );
+
+  if (method.throws) {
+    header.write(' throws');
+  }
 
   if (!method.returnType.sameAs(voidType)) {
     header.write(' -> ${method.returnType.swiftType}');

--- a/pkgs/swift2objc/lib/src/parser/_core/json.dart
+++ b/pkgs/swift2objc/lib/src/parser/_core/json.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:collection';
 import 'dart:convert';
 
 /// This is a helper class that helps with parsing Json values. It supports
@@ -18,13 +17,13 @@ import 'dart:convert';
 /// The class is also an `Iterable` so if the json is an array, you can directly
 /// iterate over it with a `for` loop. If the json isn't an array, attempting to
 /// iterate over it will throw an error.
-class Json extends IterableBase<Json> {
-  final List<String> _pathSegments;
+class Json extends Iterable<Json> {
+  final List<String> pathSegments;
   final dynamic _json;
 
-  String get path => _pathSegments.join('/');
+  String get path => pathSegments.join('/');
 
-  Json(this._json, [this._pathSegments = const []]);
+  Json(this._json, [this.pathSegments = const []]);
 
   /// The subscript syntax is intended to access a value at a field of a map or
   /// at an index if an array, and thus, the `index` parameter here can either
@@ -37,7 +36,7 @@ class Json extends IterableBase<Json> {
           'Expected a map at "$path", found a ${_json.runtimeType}',
         );
       }
-      return Json(_json[index], [..._pathSegments, index]);
+      return Json(_json[index], [...pathSegments, index]);
     }
 
     if (index is int) {
@@ -57,7 +56,7 @@ class Json extends IterableBase<Json> {
           'Invalid negative index at "$path" (supplied index: $index)',
         );
       }
-      return Json(_json[index], [..._pathSegments, '$index']);
+      return Json(_json[index], [...pathSegments, '$index']);
     }
 
     throw Exception(
@@ -115,7 +114,7 @@ class _JsonIterator implements Iterator<Json> {
   _JsonIterator(this._json) : _list = _json.get();
 
   @override
-  Json get current => Json(_list[_index], [..._json._pathSegments, '$_index']);
+  Json get current => Json(_list[_index], [..._json.pathSegments, '$_index']);
 
   @override
   bool moveNext() {

--- a/pkgs/swift2objc/lib/src/parser/_core/token_list.dart
+++ b/pkgs/swift2objc/lib/src/parser/_core/token_list.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:meta/meta.dart';
+
 import 'json.dart';
 import 'utils.dart';
 
@@ -15,7 +17,7 @@ import 'utils.dart';
 /// can pass it to parseType, because certain tokens get concatenated by the
 /// swift compiler. This class performs that preprocessing, as well as providing
 /// convenience methods for parsing, like slicing.
-class TokenList {
+class TokenList extends Iterable<Json> {
   final List<Json> _list;
   final int _start;
   final int _end;
@@ -24,30 +26,55 @@ class TokenList {
       : assert(0 <= _start && _start <= _end && _end <= _list.length);
 
   factory TokenList(Json fragments) {
-    const splits = {
-      '?(': ['?', '('],
-      '?)': ['?', ')'],
-      '?, ': ['?', ', '],
-      ') -> ': [')', '->'],
-      '?) -> ': ['?', ')', '->'],
-    };
-
-    final list = <Json>[];
-    for (final token in fragments) {
-      final split = splits[getSpellingForKind(token, 'text')];
-      if (split != null) {
-        for (final sub in split) {
-          list.add(Json({'kind': 'text', 'spelling': sub}));
-        }
-      } else {
-        list.add(token);
-      }
-    }
+    final list = [for (final token in fragments) ...splitToken(token)];
     return TokenList._(list, 0, list.length);
   }
 
+  @visibleForTesting
+  static Iterable<Json> splitToken(Json token) sync* {
+    const splittables = ['(', ')', '?', ',', '->'];
+    Json textToken(String text) =>
+        Json({'kind': 'text', 'spelling': text}, token.pathSegments);
+
+    final text = getSpellingForKind(token, 'text')?.trim();
+    if (text == null) {
+      // Not a text token. Pass it though unchanged.
+      yield token;
+      return;
+    }
+
+    if (text.isEmpty) {
+      // Input text token was nothing but whitespace. The loop below would yield
+      // nothing, but we still need it as a separator.
+      yield textToken(text);
+      return;
+    }
+
+    var suffix = text;
+    while (true) {
+      var any = false;
+      for (final prefix in splittables) {
+        if (suffix.startsWith(prefix)) {
+          yield textToken(prefix);
+          suffix = suffix.substring(prefix.length).trim();
+          any = true;
+          break;
+        }
+      }
+      if (!any) {
+        // Remaining text isn't splittable.
+        if (suffix.isNotEmpty) yield textToken(suffix);
+        break;
+      }
+    }
+  }
+
+  @override
   int get length => _end - _start;
-  bool get isEmpty => length == 0;
+
+  @override
+  Iterator<Json> get iterator => _TokenListIterator(this);
+
   Json operator [](int index) => _list[index + _start];
 
   int indexWhere(bool Function(Json element) test) {
@@ -62,4 +89,20 @@ class TokenList {
 
   @override
   String toString() => _list.getRange(_start, _end).toString();
+}
+
+class _TokenListIterator implements Iterator<Json> {
+  final TokenList _list;
+  var _index = -1;
+
+  _TokenListIterator(this._list);
+
+  @override
+  Json get current => _list[_index];
+
+  @override
+  bool moveNext() {
+    _index++;
+    return _index < _list.length;
+  }
 }

--- a/pkgs/swift2objc/lib/src/parser/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/parser/_core/utils.dart
@@ -107,7 +107,7 @@ ReferredType parseTypeAfterSeparator(
 ) {
   // fragments = [..., ': ', type tokens...]
   final separatorIndex =
-      fragments.indexWhere((token) => matchFragment(token, 'text', ': '));
+      fragments.indexWhere((token) => matchFragment(token, 'text', ':'));
   final (type, suffix) =
       parseType(symbolgraph, fragments.slice(separatorIndex + 1));
   assert(suffix.isEmpty, '$suffix');

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_function_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_function_declaration.dart
@@ -16,12 +16,14 @@ GlobalFunctionDeclaration parseGlobalFunctionDeclaration(
   Json globalFunctionSymbolJson,
   ParsedSymbolgraph symbolgraph,
 ) {
+  final info = parseFunctionInfo(
+      globalFunctionSymbolJson['declarationFragments'], symbolgraph);
   return GlobalFunctionDeclaration(
     id: parseSymbolId(globalFunctionSymbolJson),
     name: parseSymbolName(globalFunctionSymbolJson),
     returnType: _parseFunctionReturnType(globalFunctionSymbolJson, symbolgraph),
-    params: parseFunctionParams(
-        globalFunctionSymbolJson['declarationFragments'], symbolgraph),
+    params: info.params,
+    throws: info.throws,
   );
 }
 
@@ -30,29 +32,38 @@ MethodDeclaration parseMethodDeclaration(
   ParsedSymbolgraph symbolgraph, {
   bool isStatic = false,
 }) {
+  final info =
+      parseFunctionInfo(methodSymbolJson['declarationFragments'], symbolgraph);
   return MethodDeclaration(
     id: parseSymbolId(methodSymbolJson),
     name: parseSymbolName(methodSymbolJson),
     returnType: _parseFunctionReturnType(methodSymbolJson, symbolgraph),
-    params: parseFunctionParams(
-        methodSymbolJson['declarationFragments'], symbolgraph),
+    params: info.params,
     hasObjCAnnotation: parseSymbolHasObjcAnnotation(methodSymbolJson),
     isStatic: isStatic,
+    throws: info.throws,
   );
 }
 
-List<Parameter> parseFunctionParams(
+typedef ParsedFunctionInfo = ({
+  List<Parameter> params,
+  bool throws,
+});
+
+ParsedFunctionInfo parseFunctionInfo(
   Json declarationFragments,
   ParsedSymbolgraph symbolgraph,
 ) {
-  // `declarationFragments` describes each part of the initializer declaration,
+  // `declarationFragments` describes each part of the function declaration,
   // things like the `func` keyword, brackets, spaces, etc. We only care about
-  // the parameter fragments here, and they always appear in this order:
+  // the parameter fragments and annotations here, and they always appear in
+  // this order:
   // [
   //   ..., '(',
   //   externalParam, ' ', internalParam, ': ', type..., ', '
   //   externalParam, ': ', type..., ', '
   //   externalParam, ' ', internalParam, ': ', type..., ')'
+  //   annotations..., '->', returnType...
   // ]
   // Note: `internalParam` may or may not exist.
   //
@@ -60,34 +71,40 @@ List<Parameter> parseFunctionParams(
   // while making sure the parameter fragments have the expected order.
 
   final parameters = <Parameter>[];
+  final malformedInitializerException = Exception(
+    'Malformed parameter list at ${declarationFragments.path}: '
+    '$declarationFragments',
+  );
 
   var tokens = TokenList(declarationFragments);
-  final openParen = tokens.indexWhere((tok) => matchFragment(tok, 'text', '('));
-  if (openParen != -1) {
-    tokens = tokens.slice(openParen + 1);
-    String? consume(String kind) {
-      if (tokens.isEmpty) return null;
-      final token = tokens[0];
-      tokens = tokens.slice(1);
-      return getSpellingForKind(token, kind);
-    }
+  String? maybeConsume(String kind) {
+    if (tokens.isEmpty) return null;
+    final spelling = getSpellingForKind(tokens[0], kind);
+    if (spelling != null) tokens = tokens.slice(1);
+    return spelling;
+  }
 
-    final malformedInitializerException = Exception(
-      'Malformed initializer at ${declarationFragments.path}',
-    );
+  final openParen = tokens.indexWhere((tok) => matchFragment(tok, 'text', '('));
+  if (openParen == -1) throw malformedInitializerException;
+  tokens = tokens.slice(openParen + 1);
+
+  // Parse parameters until we find a ')'.
+  if (maybeConsume('text') == ')') {
+    // Empty param list.
+  } else {
     while (true) {
-      final externalParam = consume('externalParam');
+      final externalParam = maybeConsume('externalParam');
       if (externalParam == null) throw malformedInitializerException;
 
-      var sep = consume('text');
+      var sep = maybeConsume('text');
       String? internalParam;
-      if (sep == ' ') {
-        internalParam = consume('internalParam');
+      if (sep == '') {
+        internalParam = maybeConsume('internalParam');
         if (internalParam == null) throw malformedInitializerException;
-        sep = consume('text');
+        sep = maybeConsume('text');
       }
 
-      if (sep != ': ') throw malformedInitializerException;
+      if (sep != ':') throw malformedInitializerException;
       final (type, remainingTokens) = parseType(symbolgraph, tokens);
       tokens = remainingTokens;
 
@@ -97,16 +114,24 @@ List<Parameter> parseFunctionParams(
         type: type,
       ));
 
-      final end = consume('text');
+      final end = maybeConsume('text');
       if (end == ')') break;
-      if (end != ', ') throw malformedInitializerException;
-    }
-    if (!(tokens.isEmpty || consume('text') == '->')) {
-      throw malformedInitializerException;
+      if (end != ',') throw malformedInitializerException;
     }
   }
 
-  return parameters;
+  // Parse annotations until we run out.
+  final annotations = <String>{};
+  while (true) {
+    final keyword = maybeConsume('keyword');
+    if (keyword == null) break;
+    annotations.add(keyword);
+  }
+
+  return (
+    params: parameters,
+    throws: annotations.contains('throws'),
+  );
 }
 
 ReferredType _parseFunctionReturnType(

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_initializer_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_initializer_declaration.dart
@@ -19,12 +19,14 @@ InitializerDeclaration parseInitializerDeclaration(
     throw Exception('Invalid initializer at ${declarationFragments.path}: $id');
   }
 
+  final info = parseFunctionInfo(declarationFragments, symbolgraph);
   return InitializerDeclaration(
     id: id,
-    params: parseFunctionParams(declarationFragments, symbolgraph),
+    params: info.params,
     hasObjCAnnotation: parseSymbolHasObjcAnnotation(initializerSymbolJson),
     isOverriding: parseIsOverriding(initializerSymbolJson),
     isFailable: parseIsFailableInit(id, declarationFragments),
+    throws: info.throws,
   );
 }
 

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_variable_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_variable_declaration.dart
@@ -24,6 +24,7 @@ PropertyDeclaration parsePropertyDeclaration(
     isConstant: isConstant,
     hasSetter: isConstant ? false : _parsePropertyHasSetter(propertySymbolJson),
     isStatic: isStatic,
+    throws: _parseVariableThrows(propertySymbolJson),
   );
 }
 
@@ -39,6 +40,7 @@ GlobalVariableDeclaration parseGlobalVariableDeclaration(
     name: parseSymbolName(variableSymbolJson),
     type: _parseVariableType(variableSymbolJson, symbolgraph),
     isConstant: isConstant || !hasSetter,
+    throws: _parseVariableThrows(variableSymbolJson),
   );
 }
 
@@ -52,36 +54,37 @@ ReferredType _parseVariableType(
 bool _parseVariableIsConstant(Json variableSymbolJson) {
   final fragmentsJson = variableSymbolJson['declarationFragments'];
 
-  final declarationKeywordJson = fragmentsJson.firstWhere(
-    (json) {
-      if (json['kind'].get<String>() != 'keyword') return false;
-
-      final keyword = json['spelling'].get<String>();
-      if (keyword != 'var' && keyword != 'let') return false;
-
-      return true;
-    },
+  final declarationKeyword = fragmentsJson.firstWhere(
+    (json) =>
+        matchFragment(json, 'keyword', 'var') ||
+        matchFragment(json, 'keyword', 'let'),
     orElse: () => throw ArgumentError(
       'Invalid property declaration fragments at path: ${fragmentsJson.path}. '
       'Expected to find "var" or "let" as a keyword, found none',
     ),
   );
 
-  final declarationKeyword = declarationKeywordJson['spelling'].get<String>();
+  return matchFragment(declarationKeyword, 'keyword', 'let');
+}
 
-  return declarationKeyword == 'let';
+bool _parseVariableThrows(Json json) {
+  final throws = json['declarationFragments']
+      .any((frag) => matchFragment(frag, 'keyword', 'throws'));
+  if (throws) {
+    // TODO(https://github.com/dart-lang/native/issues/1765): Support throwing
+    // getters.
+    throw Exception("Throwing getters aren't supported yet, at ${json.path}");
+  }
+  return throws;
 }
 
 bool _parsePropertyHasSetter(Json propertySymbolJson) {
   final fragmentsJson = propertySymbolJson['declarationFragments'];
 
-  final hasExplicitSetter = fragmentsJson.any(
-    (json) => json['spelling'].get<String>() == 'set',
-  );
-
-  final hasExplicitGetter = fragmentsJson.any(
-    (json) => json['spelling'].get<String>() == 'get',
-  );
+  final hasExplicitSetter =
+      fragmentsJson.any((frag) => matchFragment(frag, 'keyword', 'set'));
+  final hasExplicitGetter =
+      fragmentsJson.any((frag) => matchFragment(frag, 'keyword', 'get'));
 
   if (hasExplicitGetter) {
     if (hasExplicitSetter) {

--- a/pkgs/swift2objc/lib/src/parser/parsers/parse_type.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/parse_type.dart
@@ -80,13 +80,18 @@ typedef PrefixParselet = (ReferredType, TokenList) Function(
   return (type, fragments);
 }
 
-(ReferredType, TokenList) _emptyTupleParselet(
-        ParsedSymbolgraph symbolgraph, Json token, TokenList fragments) =>
-    (voidType, fragments);
+(ReferredType, TokenList) _tupleParselet(
+    ParsedSymbolgraph symbolgraph, Json token, TokenList fragments) {
+  final nextToken = fragments[0];
+  if (_tokenId(nextToken) != 'text: )') {
+    throw Exception('Tuples not supported yet, at ${token.path}');
+  }
+  return (voidType, fragments.slice(1));
+}
 
 Map<String, PrefixParselet> _prefixParsets = {
   'typeIdentifier': _typeIdentifierParselet,
-  'text: ()': _emptyTupleParselet,
+  'text: (': _tupleParselet,
 };
 
 // ========================

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_compound.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_compound.dart
@@ -100,6 +100,7 @@ InitializerDeclaration _buildWrapperInitializer(
     ],
     isOverriding: false,
     isFailable: false,
+    throws: false,
     statements: ['self.${wrappedClassInstance.name} = wrappedInstance'],
     hasObjCAnnotation: wrappedClassInstance.hasObjCAnnotation,
   );

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_function.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_function.dart
@@ -99,6 +99,7 @@ MethodDeclaration _transformFunction(
     isStatic: originalFunction is MethodDeclaration
         ? originalFunction.isStatic
         : true,
+    throws: originalFunction.throws,
   );
 
   transformedMethod.statements = _generateStatements(
@@ -148,7 +149,10 @@ List<String> _generateStatements(
   final localNamer = UniqueNamer();
   final arguments = generateInvocationParams(
       localNamer, originalFunction.params, transformedMethod.params);
-  final originalMethodCall = originalCallGenerator(arguments);
+  var originalMethodCall = originalCallGenerator(arguments);
+  if (transformedMethod.throws) {
+    originalMethodCall = 'try $originalMethodCall';
+  }
 
   if (originalFunction.returnType.sameAs(transformedMethod.returnType)) {
     return ['return $originalMethodCall'];

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_initializer.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_initializer.dart
@@ -35,6 +35,7 @@ InitializerDeclaration transformInitializer(
       params: transformedParams,
       hasObjCAnnotation: true,
       isFailable: originalInitializer.isFailable,
+      throws: originalInitializer.throws,
       // Because the wrapper class extends NSObject that has an initializer with
       // no parameters. If we make a similar parameterless initializer we need
       // to add `override` keyword.
@@ -57,8 +58,11 @@ List<String> _generateInitializerStatements(
   final localNamer = UniqueNamer();
   final arguments = generateInvocationParams(
       localNamer, originalInitializer.params, transformedInitializer.params);
-  final instanceConstruction =
+  var instanceConstruction =
       '${wrappedClassInstance.type.swiftType}($arguments)';
+  if (transformedInitializer.throws) {
+    instanceConstruction = 'try $instanceConstruction';
+  }
   if (originalInitializer.isFailable) {
     final instance = localNamer.makeUnique('instance');
     return [

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_variable.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_variable.dart
@@ -81,6 +81,7 @@ PropertyDeclaration _transformVariable(
         ? originalVariable.isStatic
         : true,
     isConstant: originalVariable.isConstant,
+    throws: originalVariable.throws,
   );
 
   final getterStatements = _generateGetterStatements(

--- a/pkgs/swift2objc/pubspec.yaml
+++ b/pkgs/swift2objc/pubspec.yaml
@@ -16,6 +16,7 @@ topics:
 
 dependencies:
   logging: ^1.3.0
+  meta: ^1.16.0
   path: ^1.9.0
 
 environment:

--- a/pkgs/swift2objc/test/integration/integration_test.dart
+++ b/pkgs/swift2objc/test/integration/integration_test.dart
@@ -43,13 +43,16 @@ void main([List<String>? args]) {
     }
   }
 
+  var loggedErrors = 0;
   Logger.root.onRecord.listen((record) {
     stderr.writeln('${record.level.name}: ${record.message}');
+    if (record.level >= Level.WARNING) ++loggedErrors;
   });
 
   group('Integration tests', () {
     for (final name in testNames) {
       test(name, () async {
+        loggedErrors = 0;
         final inputFile = path.join(thisDir, '$name$inputSuffix');
         final expectedOutputFile = path.join(thisDir, '$name$outputSuffix');
         final actualOutputFile = regen
@@ -69,6 +72,7 @@ void main([List<String>? args]) {
         final expectedOutput = File(expectedOutputFile).readAsStringSync();
 
         expect(actualOutput, expectedOutput);
+        expect(loggedErrors, 0);
 
         // Try generating symbolgraph for input & output files
         // to make sure the result compiles. Input file must be included cause

--- a/pkgs/swift2objc/test/integration/throws_input.swift
+++ b/pkgs/swift2objc/test/integration/throws_input.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public class MyClass {
+  public init(y: Int) throws {}
+
+  public func voidMethod() throws {}
+  public func intMethod(y: Int) throws -> MyClass { return try MyClass(y: 123) }
+}
+
+public func voidFunc(x: Int, y: Int) throws {}
+public func intFunc() throws -> MyClass { return try MyClass(y: 123) }

--- a/pkgs/swift2objc/test/integration/throws_output.swift
+++ b/pkgs/swift2objc/test/integration/throws_output.swift
@@ -1,0 +1,38 @@
+// Test preamble text
+
+import Foundation
+
+@objc public class GlobalsWrapper: NSObject {
+  @objc static public func intFuncWrapper() throws -> MyClassWrapper {
+    let result = try intFunc()
+    return MyClassWrapper(result)
+  }
+
+  @objc static public func voidFuncWrapper(x: Int, y: Int) throws {
+    return try voidFunc(x: x, y: y)
+  }
+
+}
+
+@objc public class MyClassWrapper: NSObject {
+  var wrappedInstance: MyClass
+
+  init(_ wrappedInstance: MyClass) {
+    self.wrappedInstance = wrappedInstance
+  }
+
+  @objc init(y: Int) throws {
+    wrappedInstance = try MyClass(y: y)
+  }
+
+  @objc public func voidMethod() throws {
+    return try wrappedInstance.voidMethod()
+  }
+
+  @objc public func intMethod(y: Int) throws -> MyClassWrapper {
+    let result = try wrappedInstance.intMethod(y: y)
+    return MyClassWrapper(result)
+  }
+
+}
+

--- a/pkgs/swift2objc/test/unit/parse_function_info_test.dart
+++ b/pkgs/swift2objc/test/unit/parse_function_info_test.dart
@@ -63,7 +63,8 @@ void main() {
         ''',
       ));
 
-      final outputParams = parseFunctionParams(json, emptySymbolgraph);
+      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final outputParams = info.params;
 
       final expectedParams = [
         Parameter(
@@ -78,6 +79,7 @@ void main() {
       ];
 
       expectEqualParams(outputParams, expectedParams);
+      expect(info.throws, isFalse);
     });
 
     test('Three params with some optional', () {
@@ -118,7 +120,8 @@ void main() {
         ''',
       ));
 
-      final outputParams = parseFunctionParams(json, emptySymbolgraph);
+      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final outputParams = info.params;
 
       final expectedParams = [
         Parameter(
@@ -138,6 +141,7 @@ void main() {
       ];
 
       expectEqualParams(outputParams, expectedParams);
+      expect(info.throws, isFalse);
     });
 
     test('One param', () {
@@ -158,7 +162,8 @@ void main() {
         ''',
       ));
 
-      final outputParams = parseFunctionParams(json, emptySymbolgraph);
+      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final outputParams = info.params;
 
       final expectedParams = [
         Parameter(
@@ -168,6 +173,7 @@ void main() {
       ];
 
       expectEqualParams(outputParams, expectedParams);
+      expect(info.throws, isFalse);
     });
 
     test('No params', () {
@@ -180,9 +186,11 @@ void main() {
         ''',
       ));
 
-      final outputParams = parseFunctionParams(json, emptySymbolgraph);
+      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final outputParams = info.params;
 
       expectEqualParams(outputParams, []);
+      expect(info.throws, isFalse);
     });
   });
 
@@ -206,7 +214,7 @@ void main() {
       ));
 
       expect(
-        () => parseFunctionParams(json, emptySymbolgraph),
+        () => parseFunctionInfo(json, emptySymbolgraph),
         throwsA(isA<Exception>()),
       );
     });
@@ -226,7 +234,7 @@ void main() {
       ));
 
       expect(
-        () => parseFunctionParams(json, emptySymbolgraph),
+        () => parseFunctionInfo(json, emptySymbolgraph),
         throwsA(isA<Exception>()),
       );
     });
@@ -249,7 +257,7 @@ void main() {
       ));
 
       expect(
-        () => parseFunctionParams(json, emptySymbolgraph),
+        () => parseFunctionInfo(json, emptySymbolgraph),
         throwsA(isA<Exception>()),
       );
     });

--- a/pkgs/swift2objc/test/unit/parse_function_info_test.dart
+++ b/pkgs/swift2objc/test/unit/parse_function_info_test.dart
@@ -64,7 +64,6 @@ void main() {
       ));
 
       final info = parseFunctionInfo(json, emptySymbolgraph);
-      final outputParams = info.params;
 
       final expectedParams = [
         Parameter(
@@ -78,7 +77,7 @@ void main() {
         ),
       ];
 
-      expectEqualParams(outputParams, expectedParams);
+      expectEqualParams(info.params, expectedParams);
       expect(info.throws, isFalse);
     });
 
@@ -121,7 +120,6 @@ void main() {
       ));
 
       final info = parseFunctionInfo(json, emptySymbolgraph);
-      final outputParams = info.params;
 
       final expectedParams = [
         Parameter(
@@ -140,7 +138,7 @@ void main() {
         ),
       ];
 
-      expectEqualParams(outputParams, expectedParams);
+      expectEqualParams(info.params, expectedParams);
       expect(info.throws, isFalse);
     });
 
@@ -163,7 +161,6 @@ void main() {
       ));
 
       final info = parseFunctionInfo(json, emptySymbolgraph);
-      final outputParams = info.params;
 
       final expectedParams = [
         Parameter(
@@ -172,7 +169,7 @@ void main() {
         ),
       ];
 
-      expectEqualParams(outputParams, expectedParams);
+      expectEqualParams(info.params, expectedParams);
       expect(info.throws, isFalse);
     });
 
@@ -187,10 +184,183 @@ void main() {
       ));
 
       final info = parseFunctionInfo(json, emptySymbolgraph);
-      final outputParams = info.params;
 
-      expectEqualParams(outputParams, []);
+      expectEqualParams(info.params, []);
       expect(info.throws, isFalse);
+    });
+
+    test('Function with return type', () {
+      // parseFunctionInfo doesn't parse the return type, but it should be able
+      // to cope with one.
+      final json = Json(jsonDecode(
+        '''
+        [
+          { "kind": "keyword", "spelling": "func" },
+          { "kind": "text", "spelling": " " },
+          { "kind": "identifier", "spelling": "foo" },
+          { "kind": "text", "spelling": "(" },
+          { "kind": "externalParam", "spelling": "parameter" },
+          { "kind": "text", "spelling": ": " },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          { "kind": "text", "spelling": ") -> " },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          }
+        ]
+        ''',
+      ));
+
+      final info = parseFunctionInfo(json, emptySymbolgraph);
+
+      final expectedParams = [
+        Parameter(
+          name: 'parameter',
+          type: intType,
+        ),
+      ];
+
+      expectEqualParams(info.params, expectedParams);
+      expect(info.throws, isFalse);
+    });
+
+    test('Function with no params with return type', () {
+      final json = Json(jsonDecode(
+        '''
+        [
+          { "kind": "keyword", "spelling": "func" },
+          { "kind": "text", "spelling": " " },
+          { "kind": "identifier", "spelling": "foo" },
+          { "kind": "text", "spelling": "() -> " },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          }
+        ]
+        ''',
+      ));
+
+      final info = parseFunctionInfo(json, emptySymbolgraph);
+
+      expectEqualParams(info.params, []);
+      expect(info.throws, isFalse);
+    });
+
+    test('Function with no params and no return type', () {
+      final json = Json(jsonDecode(
+        '''
+        [
+          { "kind": "keyword", "spelling": "func" },
+          { "kind": "text", "spelling": " " },
+          { "kind": "identifier", "spelling": "foo" },
+          { "kind": "text", "spelling": "()" }
+        ]
+        ''',
+      ));
+
+      final info = parseFunctionInfo(json, emptySymbolgraph);
+
+      expectEqualParams(info.params, []);
+      expect(info.throws, isFalse);
+    });
+
+    test('Function with return type that throws', () {
+      final json = Json(jsonDecode(
+        '''
+        [
+          { "kind": "keyword", "spelling": "func" },
+          { "kind": "text", "spelling": " " },
+          { "kind": "identifier", "spelling": "foo" },
+          { "kind": "text", "spelling": "(" },
+          { "kind": "externalParam", "spelling": "parameter" },
+          { "kind": "text", "spelling": ": " },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          { "kind": "text", "spelling": ") " },
+          { "kind": "keyword", "spelling": "throws" },
+          { "kind": "text", "spelling": " -> " },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          }
+        ]
+        ''',
+      ));
+
+      final info = parseFunctionInfo(json, emptySymbolgraph);
+
+      final expectedParams = [
+        Parameter(
+          name: 'parameter',
+          type: intType,
+        ),
+      ];
+
+      expectEqualParams(info.params, expectedParams);
+      expect(info.throws, isTrue);
+    });
+
+    test('Function with no return type that throws', () {
+      final json = Json(jsonDecode(
+        '''
+        [
+          { "kind": "keyword", "spelling": "func" },
+          { "kind": "text", "spelling": " " },
+          { "kind": "identifier", "spelling": "foo" },
+          { "kind": "text", "spelling": "(" },
+          { "kind": "externalParam", "spelling": "parameter" },
+          { "kind": "text", "spelling": ": " },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          { "kind": "text", "spelling": ") " },
+          { "kind": "keyword", "spelling": "throws" }
+        ]
+        ''',
+      ));
+
+      final info = parseFunctionInfo(json, emptySymbolgraph);
+
+      final expectedParams = [
+        Parameter(
+          name: 'parameter',
+          type: intType,
+        ),
+      ];
+
+      expectEqualParams(info.params, expectedParams);
+      expect(info.throws, isTrue);
+    });
+
+    test('Function with no params that throws', () {
+      final json = Json(jsonDecode(
+        '''
+        [
+          { "kind": "keyword", "spelling": "func" },
+          { "kind": "text", "spelling": " " },
+          { "kind": "identifier", "spelling": "foo" },
+          { "kind": "text", "spelling": "() " },
+          { "kind": "keyword", "spelling": "throws" }
+        ]
+        ''',
+      ));
+
+      final info = parseFunctionInfo(json, emptySymbolgraph);
+
+      expectEqualParams(info.params, []);
+      expect(info.throws, isTrue);
     });
   });
 

--- a/pkgs/swiftgen/pubspec.yaml
+++ b/pkgs/swiftgen/pubspec.yaml
@@ -19,6 +19,7 @@ environment:
 
 dependencies:
   ffi: ^2.1.0
+  meta: ^1.16.0
 
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0

--- a/pkgs/swiftgen/pubspec.yaml
+++ b/pkgs/swiftgen/pubspec.yaml
@@ -19,7 +19,6 @@ environment:
 
 dependencies:
   ffi: ^2.1.0
-  meta: ^1.16.0
 
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0


### PR DESCRIPTION
Methods and functions in Swift that can throw an exception must be annotated with `throws`. When you call one of these functions, you have to either handle the exception, or forward it by prefixing the call with `try` (in which case your function must also be marked `throws`).

So when we're wrapping one of these methods we need to add `try` and `throws` keywords, like this:

```Swift
@objc public class MyClassWrapper: NSObject {
  var wrappedInstance: MyClass

  @objc public func voidMethod() throws {
    return try wrappedInstance.voidMethod()
  }
}
```

`throws` shows up in the `declarationFragments` of the function, after the `)` but before the `->`. Getters can also throw, but supporting them is a [little more complicated](https://github.com/dart-lang/native/issues/1765).

### Details

- I didn't realize about the issues with throwing getters until I'd already implemented their AST and parsing changes. So I'm leaving those changes in and just logging an error if we hit that case. It makes the error a bit nicer for users anyway.
- In the AST, added a `CanThrow` interface. Added this to all functions, methods, initializers, properties, and variables.
- Code-gen is trivial. Just add `throws` to the method signature, and `try` when invoking the wrapped method.
- Parsing is more complicated
  - The old way I was doing token splitting was getting a bit combinatorial, so I changed it to just split text tokens whenever it finds a splittable string. To avoid writing a full tokenizer, it gives up as soon as it finds an unknown prefix, but I've never seen this in real symbolgraphs.
  - I'm also trimming all the whitespace from these tokens now.
  - Now that `()` is split into `(` and `)`, in parse_type.dart I had to change the `_emptyTupleParselet` to be a `_tupleParselet`, though we haven't added support for tuples yet.
  - Changed `parseFunctionParams` to `parseFunctionInfo`, which now also checks for annotations. Essentially it just reads all the keywords after the `)`. Had to refactor a bit to handle all the new token splitting.
  - Cleaned up parse_variable_declaration.dart, using `matchFragment`.