### PR TITLE
[swift2objc] Fix bug with optional string params

### DIFF
--- a/pkgs/swift2objc/lib/src/transformer/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/transformer/_core/utils.dart
@@ -66,7 +66,12 @@ import 'unique_namer.dart';
       return (value, type);
     }
   } else if (type is OptionalType) {
-    final (newValue, newType) = maybeUnwrapValue(type.child, '$value?');
+    final optValue = '$value?';
+    var (newValue, newType) = maybeUnwrapValue(type.child, optValue);
+    if (newValue == optValue) {
+      // newValue is value?, so the ? isn't necessary and causes compile errors.
+      newValue = value;
+    }
     return (newValue, OptionalType(newType));
   } else {
     throw UnimplementedError('Unknown type: $type');

--- a/pkgs/swift2objc/test/integration/optional_input.swift
+++ b/pkgs/swift2objc/test/integration/optional_input.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-// public func funcOptionalPrimitiveReturn() -> Int? { return 123 }
 public func funcOptionalClassReturn() -> MyClass? { return MyClass(label: nil) }
 public func funcOptionalStructReturn() -> MyStruct? { return nil }
 public func funcOptionalArgs(label param: MyClass?) -> MyClass { return param! }
 public func funcMultipleOptionalArgs(
     label1 param1: MyClass?,label2 param2: Int, label3 param3: MyStruct?){}
+public func funcOptionalStrings(str: String?) -> String? { return str; }
 
 public var globalOptional: MyStruct?
 

--- a/pkgs/swift2objc/test/integration/optional_output.swift
+++ b/pkgs/swift2objc/test/integration/optional_output.swift
@@ -17,6 +17,10 @@ import Foundation
     return MyClassWrapper(result)
   }
 
+  @objc static public func funcOptionalStringsWrapper(str: String?) -> String? {
+    return funcOptionalStrings(str: str)
+  }
+
   @objc static public func funcOptionalClassReturnWrapper() -> MyClassWrapper? {
     let result = funcOptionalClassReturn()
     return result == nil ? nil : MyClassWrapper(result!)


### PR DESCRIPTION
The wrapper for

```Swift
public func funcOptionalStrings(str: String?) -> String? { return str; }
```

was being generated as

```Swift
@objc static public func funcOptionalStringsWrapper(str: String?) -> String? {
  return funcOptionalStrings(str: str?)
}
```

The `str?` is generated by `maybeUnwrapValue`, which was inserting `?` because in most cases it's expecting to unwrap a wrapper type, which would add a `.wrappedInstance` to get `str?.wrappedInstance`. But strings don't need to be wrapped, because they bridge directly to `NSString`. So we end up with `str?`, with this unnecessary `?` at the end, which causes compile errors.

The fix is just to drop the `?` if the nested `maybeUnwrapValue` call didn't do anything.