### PR TITLE
Update build output test to use .compareTo()/.isSameMomentAs() as operators don't exist on DateTime

### DIFF
--- a/pkgs/native_assets_cli/test/build_output_test.dart
+++ b/pkgs/native_assets_cli/test/build_output_test.dart
@@ -40,10 +40,12 @@ void main() {
         linkInPackage: 'package:linker2');
 
     final config = BuildOutput(builder.json);
-    expect(config.timestamp, greaterThanOrEqualTo(before));
-    expect(config.timestamp, lessThanOrEqualTo(after));
-    expect(config.timestamp,
-        lessThanOrEqualTo(config.timestamp.roundDownToSeconds()));
+    expect(config.timestamp.compareTo(before), greaterThanOrEqualTo(0));
+    expect(config.timestamp.compareTo(after), lessThanOrEqualTo(0));
+    expect(
+        config.timestamp
+            .isAtSameMomentAs(config.timestamp.roundDownToSeconds()),
+        true);
 
     // The JSON format of the build output.
     <String, Object?>{

--- a/pkgs/native_assets_cli/test/link_output_test.dart
+++ b/pkgs/native_assets_cli/test/link_output_test.dart
@@ -26,10 +26,12 @@ void main() {
     builder.addEncodedAssets(assets.skip(1).take(2).toList());
 
     final config = BuildOutput(builder.json);
-    expect(config.timestamp, greaterThanOrEqualTo(before));
-    expect(config.timestamp, lessThanOrEqualTo(after));
-    expect(config.timestamp,
-        lessThanOrEqualTo(config.timestamp.roundDownToSeconds()));
+    expect(config.timestamp.compareTo(before), greaterThanOrEqualTo(0));
+    expect(config.timestamp.compareTo(after), lessThanOrEqualTo(0));
+    expect(
+        config.timestamp
+            .isAtSameMomentAs(config.timestamp.roundDownToSeconds()),
+        true);
 
     // The JSON format of the link output.
     <String, Object?>{


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/1745