### PR TITLE
[swift2objc] Support the `async` annotation

### DIFF
--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/can_async.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/can_async.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// An interface to describe a Swift entity's ability to be annotated
+/// with `async`.
+abstract interface class CanAsync {
+  abstract final bool async;
+}

--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/function_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/function_declaration.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../shared/referred_type.dart';
+import 'can_async.dart';
 import 'can_throw.dart';
 import 'declaration.dart';
 import 'executable.dart';
@@ -16,6 +17,7 @@ abstract interface class FunctionDeclaration
         Parameterizable,
         Executable,
         TypeParameterizable,
-        CanThrow {
+        CanThrow,
+        CanAsync {
   abstract final ReferredType returnType;
 }

--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/variable_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/variable_declaration.dart
@@ -3,15 +3,17 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../shared/referred_type.dart';
+import 'can_async.dart';
 import 'can_throw.dart';
 import 'declaration.dart';
 
 /// Describes a variable-like entity.
 ///
-/// This declaration [CanThrow] because Swift variables can have explicit
-/// getters, which can be marked with `throws`. Such variables may not have a
-/// setter.
-abstract interface class VariableDeclaration implements Declaration, CanThrow {
+/// This declaration implements [CanThrow] and [CanAsync] because Swift
+/// variables can have explicit getters, which can be marked with `throws` and
+/// `async`. Such variables may not have a setter.
+abstract interface class VariableDeclaration
+    implements Declaration, CanThrow, CanAsync {
   abstract final bool isConstant;
   abstract final ReferredType type;
 }

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/initializer_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/initializer_declaration.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../../_core/interfaces/can_async.dart';
 import '../../../_core/interfaces/can_throw.dart';
 import '../../../_core/interfaces/declaration.dart';
 import '../../../_core/interfaces/executable.dart';
@@ -18,7 +19,8 @@ class InitializerDeclaration
         Parameterizable,
         ObjCAnnotatable,
         Overridable,
-        CanThrow {
+        CanThrow,
+        CanAsync {
   @override
   String id;
 
@@ -33,6 +35,9 @@ class InitializerDeclaration
 
   @override
   bool throws;
+
+  @override
+  bool async;
 
   bool isFailable;
 
@@ -54,6 +59,7 @@ class InitializerDeclaration
     required this.hasObjCAnnotation,
     required this.isOverriding,
     required this.throws,
+    required this.async,
     required this.isFailable,
   });
 }

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/method_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/method_declaration.dart
@@ -34,6 +34,9 @@ class MethodDeclaration
   bool throws;
 
   @override
+  bool async;
+
+  @override
   List<String> statements;
 
   @override
@@ -57,5 +60,6 @@ class MethodDeclaration
     this.isStatic = false,
     this.isOverriding = false,
     this.throws = false,
+    this.async = false,
   }) : assert(!isStatic || !isOverriding);
 }

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/property_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/property_declaration.dart
@@ -28,6 +28,9 @@ class PropertyDeclaration implements VariableDeclaration, ObjCAnnotatable {
   @override
   bool throws;
 
+  @override
+  bool async;
+
   bool hasSetter;
 
   PropertyStatements? getter;
@@ -46,6 +49,7 @@ class PropertyDeclaration implements VariableDeclaration, ObjCAnnotatable {
     this.setter,
     this.isStatic = false,
     this.throws = false,
+    this.async = false,
   })  : assert(!(isConstant && hasSetter)),
         assert(!(hasSetter && throws));
 }

--- a/pkgs/swift2objc/lib/src/ast/declarations/globals/globals.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/globals/globals.dart
@@ -37,6 +37,9 @@ class GlobalFunctionDeclaration implements FunctionDeclaration {
   bool throws;
 
   @override
+  bool async;
+
+  @override
   ReferredType returnType;
 
   @override
@@ -50,6 +53,7 @@ class GlobalFunctionDeclaration implements FunctionDeclaration {
     this.typeParams = const [],
     this.statements = const [],
     this.throws = false,
+    this.async = false,
   });
 }
 
@@ -70,11 +74,15 @@ class GlobalVariableDeclaration implements VariableDeclaration {
   @override
   bool throws;
 
+  @override
+  bool async;
+
   GlobalVariableDeclaration({
     required this.id,
     required this.name,
     required this.type,
     required this.isConstant,
     required this.throws,
+    required this.async,
   }) : assert(!(throws && !isConstant));
 }

--- a/pkgs/swift2objc/lib/src/generator/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/generator/_core/utils.dart
@@ -1,5 +1,8 @@
 import 'dart:io';
 import 'package:path/path.dart' as path;
+import '../../ast/_core/interfaces/can_async.dart';
+import '../../ast/_core/interfaces/can_throw.dart';
+import '../../ast/_core/interfaces/declaration.dart';
 import '../../ast/_core/shared/parameter.dart';
 
 String generateParameters(List<Parameter> params) {
@@ -33,4 +36,15 @@ void outputNextToFile({
   final outputPath = path.joinAll(segments);
 
   File(outputPath).writeAsStringSync(content);
+}
+
+String generateAnnotations(Declaration decl) {
+  final annotations = StringBuffer();
+  if (decl is CanAsync && (decl as CanAsync).async) {
+    annotations.write(' async');
+  }
+  if (decl is CanThrow && (decl as CanThrow).throws) {
+    annotations.write(' throws');
+  }
+  return annotations.toString();
 }

--- a/pkgs/swift2objc/lib/src/generator/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/generator/_core/utils.dart
@@ -41,10 +41,10 @@ void outputNextToFile({
 String generateAnnotations(Declaration decl) {
   final annotations = StringBuffer();
   if (decl is CanAsync && (decl as CanAsync).async) {
-    annotations.write(' async');
+    annotations.write('async ');
   }
   if (decl is CanThrow && (decl as CanThrow).throws) {
-    annotations.write(' throws');
+    annotations.write('throws ');
   }
   return annotations.toString();
 }

--- a/pkgs/swift2objc/lib/src/generator/generators/class_generator.dart
+++ b/pkgs/swift2objc/lib/src/generator/generators/class_generator.dart
@@ -113,17 +113,17 @@ List<String> _generateClassMethod(MethodDeclaration method) {
   }
 
   header.write(
-    'public func ${method.name}(${generateParameters(method.params)})',
+    'public func ${method.name}(${generateParameters(method.params)}) ',
   );
 
   header.write(generateAnnotations(method));
 
   if (!method.returnType.sameAs(voidType)) {
-    header.write(' -> ${method.returnType.swiftType}');
+    header.write('-> ${method.returnType.swiftType} ');
   }
 
   return [
-    '$header {',
+    '$header{',
     ...method.statements.indent(),
     '}\n',
   ];

--- a/pkgs/swift2objc/lib/src/generator/generators/class_generator.dart
+++ b/pkgs/swift2objc/lib/src/generator/generators/class_generator.dart
@@ -87,12 +87,8 @@ List<String> _generateInitializer(InitializerDeclaration initializer) {
 
   header.write('(${generateParameters(initializer.params)})');
 
-  if (initializer.throws) {
-    header.write(' throws');
-  }
-
   return [
-    '$header {',
+    '$header ${generateAnnotations(initializer)}{',
     ...initializer.statements.indent(),
     '}\n',
   ];
@@ -120,9 +116,7 @@ List<String> _generateClassMethod(MethodDeclaration method) {
     'public func ${method.name}(${generateParameters(method.params)})',
   );
 
-  if (method.throws) {
-    header.write(' throws');
-  }
+  header.write(generateAnnotations(method));
 
   if (!method.returnType.sameAs(voidType)) {
     header.write(' -> ${method.returnType.swiftType}');
@@ -154,7 +148,7 @@ List<String> _generateClassProperty(PropertyDeclaration property) {
   header.write('public var ${property.name}: ${property.type.swiftType} {');
 
   final getterLines = [
-    'get {',
+    'get ${generateAnnotations(property)}{',
     ...(property.getter?.statements.indent() ?? <String>[]),
     '}'
   ];

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_function_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_function_declaration.dart
@@ -34,7 +34,7 @@ MethodDeclaration parseMethodDeclaration(
   bool isStatic = false,
 }) {
   final info =
-      parseFunctionInfo(methodSymbolJson['declarationFragments'], symbolgraph, parseSymbolName(methodSymbolJson));
+      parseFunctionInfo(methodSymbolJson['declarationFragments'], symbolgraph);
   return MethodDeclaration(
     id: parseSymbolId(methodSymbolJson),
     name: parseSymbolName(methodSymbolJson),
@@ -56,7 +56,6 @@ typedef ParsedFunctionInfo = ({
 ParsedFunctionInfo parseFunctionInfo(
   Json declarationFragments,
   ParsedSymbolgraph symbolgraph,
-  [String? name]
 ) {
   // `declarationFragments` describes each part of the function declaration,
   // things like the `func` keyword, brackets, spaces, etc. We only care about

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_initializer_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_initializer_declaration.dart
@@ -20,6 +20,15 @@ InitializerDeclaration parseInitializerDeclaration(
   }
 
   final info = parseFunctionInfo(declarationFragments, symbolgraph);
+
+  if (info.async) {
+    // TODO(https://github.com/dart-lang/native/issues/1778): Support async
+    // initializerse.
+    throw Exception(
+        "Async initializers aren't supported yet, at "
+        '${initializerSymbolJson.path}');
+  }
+
   return InitializerDeclaration(
     id: id,
     params: info.params,
@@ -27,6 +36,7 @@ InitializerDeclaration parseInitializerDeclaration(
     isOverriding: parseIsOverriding(initializerSymbolJson),
     isFailable: parseIsFailableInit(id, declarationFragments),
     throws: info.throws,
+    async: info.async,
   );
 }
 

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_initializer_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_initializer_declaration.dart
@@ -24,8 +24,7 @@ InitializerDeclaration parseInitializerDeclaration(
   if (info.async) {
     // TODO(https://github.com/dart-lang/native/issues/1778): Support async
     // initializerse.
-    throw Exception(
-        "Async initializers aren't supported yet, at "
+    throw Exception("Async initializers aren't supported yet, at "
         '${initializerSymbolJson.path}');
   }
 

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_variable_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_variable_declaration.dart
@@ -91,7 +91,6 @@ bool _parseVariableAsync(Json json) {
   return async;
 }
 
-
 bool _parsePropertyHasSetter(Json propertySymbolJson) {
   final fragmentsJson = propertySymbolJson['declarationFragments'];
 

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_variable_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_variable_declaration.dart
@@ -25,6 +25,7 @@ PropertyDeclaration parsePropertyDeclaration(
     hasSetter: isConstant ? false : _parsePropertyHasSetter(propertySymbolJson),
     isStatic: isStatic,
     throws: _parseVariableThrows(propertySymbolJson),
+    async: _parseVariableAsync(propertySymbolJson),
   );
 }
 
@@ -41,6 +42,7 @@ GlobalVariableDeclaration parseGlobalVariableDeclaration(
     type: _parseVariableType(variableSymbolJson, symbolgraph),
     isConstant: isConstant || !hasSetter,
     throws: _parseVariableThrows(variableSymbolJson),
+    async: _parseVariableAsync(variableSymbolJson),
   );
 }
 
@@ -77,6 +79,18 @@ bool _parseVariableThrows(Json json) {
   }
   return throws;
 }
+
+bool _parseVariableAsync(Json json) {
+  final async = json['declarationFragments']
+      .any((frag) => matchFragment(frag, 'keyword', 'async'));
+  if (async) {
+    // TODO(https://github.com/dart-lang/native/issues/1778): Support async
+    // getters.
+    throw Exception("Async getters aren't supported yet, at ${json.path}");
+  }
+  return async;
+}
+
 
 bool _parsePropertyHasSetter(Json propertySymbolJson) {
   final fragmentsJson = propertySymbolJson['declarationFragments'];

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_compound.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_compound.dart
@@ -101,6 +101,7 @@ InitializerDeclaration _buildWrapperInitializer(
     isOverriding: false,
     isFailable: false,
     throws: false,
+    async: false,
     statements: ['self.${wrappedClassInstance.name} = wrappedInstance'],
     hasObjCAnnotation: wrappedClassInstance.hasObjCAnnotation,
   );

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_function.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_function.dart
@@ -100,6 +100,7 @@ MethodDeclaration _transformFunction(
         ? originalFunction.isStatic
         : true,
     throws: originalFunction.throws,
+    async: originalFunction.async,
   );
 
   transformedMethod.statements = _generateStatements(
@@ -150,6 +151,9 @@ List<String> _generateStatements(
   final arguments = generateInvocationParams(
       localNamer, originalFunction.params, transformedMethod.params);
   var originalMethodCall = originalCallGenerator(arguments);
+  if (transformedMethod.async) {
+    originalMethodCall = 'await $originalMethodCall';
+  }
   if (transformedMethod.throws) {
     originalMethodCall = 'try $originalMethodCall';
   }

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_initializer.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_initializer.dart
@@ -36,6 +36,7 @@ InitializerDeclaration transformInitializer(
       hasObjCAnnotation: true,
       isFailable: originalInitializer.isFailable,
       throws: originalInitializer.throws,
+      async: originalInitializer.async,
       // Because the wrapper class extends NSObject that has an initializer with
       // no parameters. If we make a similar parameterless initializer we need
       // to add `override` keyword.
@@ -60,6 +61,9 @@ List<String> _generateInitializerStatements(
       localNamer, originalInitializer.params, transformedInitializer.params);
   var instanceConstruction =
       '${wrappedClassInstance.type.swiftType}($arguments)';
+  if (transformedInitializer.async) {
+    instanceConstruction = 'await $instanceConstruction';
+  }
   if (transformedInitializer.throws) {
     instanceConstruction = 'try $instanceConstruction';
   }

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_variable.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_variable.dart
@@ -82,6 +82,7 @@ PropertyDeclaration _transformVariable(
         : true,
     isConstant: originalVariable.isConstant,
     throws: originalVariable.throws,
+    async: originalVariable.async,
   );
 
   final getterStatements = _generateGetterStatements(

--- a/pkgs/swift2objc/test/integration/async_input.swift
+++ b/pkgs/swift2objc/test/integration/async_input.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public class MyClass {
+  public func voidMethod() async {}
+  public func intMethod(y: Int) async -> MyClass { return MyClass() }
+  public func asyncThrowsMethod(y: Int) async throws -> MyClass {
+    return MyClass()
+  }
+}
+
+public func voidFunc(x: Int, y: Int) async {}
+public func intFunc() async -> MyClass { return MyClass() }

--- a/pkgs/swift2objc/test/integration/async_output.swift
+++ b/pkgs/swift2objc/test/integration/async_output.swift
@@ -1,0 +1,39 @@
+// Test preamble text
+
+import Foundation
+
+@objc public class GlobalsWrapper: NSObject {
+  @objc static public func intFuncWrapper() async -> MyClassWrapper {
+    let result = await intFunc()
+    return MyClassWrapper(result)
+  }
+
+  @objc static public func voidFuncWrapper(x: Int, y: Int) async {
+    return await voidFunc(x: x, y: y)
+  }
+
+}
+
+@objc public class MyClassWrapper: NSObject {
+  var wrappedInstance: MyClass
+
+  init(_ wrappedInstance: MyClass) {
+    self.wrappedInstance = wrappedInstance
+  }
+
+  @objc public func voidMethod() async {
+    return await wrappedInstance.voidMethod()
+  }
+
+  @objc public func asyncThrowsMethod(y: Int) async throws -> MyClassWrapper {
+    let result = try await wrappedInstance.asyncThrowsMethod(y: y)
+    return MyClassWrapper(result)
+  }
+
+  @objc public func intMethod(y: Int) async -> MyClassWrapper {
+    let result = await wrappedInstance.intMethod(y: y)
+    return MyClassWrapper(result)
+  }
+
+}
+

--- a/pkgs/swift2objc/test/unit/parse_function_info_test.dart
+++ b/pkgs/swift2objc/test/unit/parse_function_info_test.dart
@@ -79,6 +79,7 @@ void main() {
 
       expectEqualParams(info.params, expectedParams);
       expect(info.throws, isFalse);
+      expect(info.async, isFalse);
     });
 
     test('Three params with some optional', () {
@@ -140,6 +141,7 @@ void main() {
 
       expectEqualParams(info.params, expectedParams);
       expect(info.throws, isFalse);
+      expect(info.async, isFalse);
     });
 
     test('One param', () {
@@ -171,6 +173,7 @@ void main() {
 
       expectEqualParams(info.params, expectedParams);
       expect(info.throws, isFalse);
+      expect(info.async, isFalse);
     });
 
     test('No params', () {
@@ -187,6 +190,7 @@ void main() {
 
       expectEqualParams(info.params, []);
       expect(info.throws, isFalse);
+      expect(info.async, isFalse);
     });
 
     test('Function with return type', () {
@@ -227,6 +231,7 @@ void main() {
 
       expectEqualParams(info.params, expectedParams);
       expect(info.throws, isFalse);
+      expect(info.async, isFalse);
     });
 
     test('Function with no params with return type', () {
@@ -250,6 +255,7 @@ void main() {
 
       expectEqualParams(info.params, []);
       expect(info.throws, isFalse);
+      expect(info.async, isFalse);
     });
 
     test('Function with no params and no return type', () {
@@ -268,6 +274,7 @@ void main() {
 
       expectEqualParams(info.params, []);
       expect(info.throws, isFalse);
+      expect(info.async, isFalse);
     });
 
     test('Function with return type that throws', () {
@@ -308,6 +315,7 @@ void main() {
 
       expectEqualParams(info.params, expectedParams);
       expect(info.throws, isTrue);
+      expect(info.async, isFalse);
     });
 
     test('Function with no return type that throws', () {
@@ -342,6 +350,7 @@ void main() {
 
       expectEqualParams(info.params, expectedParams);
       expect(info.throws, isTrue);
+      expect(info.async, isFalse);
     });
 
     test('Function with no params that throws', () {
@@ -361,6 +370,91 @@ void main() {
 
       expectEqualParams(info.params, []);
       expect(info.throws, isTrue);
+      expect(info.async, isFalse);
+    });
+
+    test('Function with async annotation', () {
+      final json = Json(jsonDecode(
+        '''
+        [
+          { "kind": "keyword", "spelling": "func" },
+          { "kind": "text", "spelling": " " },
+          { "kind": "identifier", "spelling": "foo" },
+          { "kind": "text", "spelling": "(" },
+          { "kind": "externalParam", "spelling": "parameter" },
+          { "kind": "text", "spelling": ": " },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          { "kind": "text", "spelling": ") " },
+          { "kind": "keyword", "spelling": "async" },
+          { "kind": "text", "spelling": " -> " },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          }
+        ]
+        ''',
+      ));
+
+      final info = parseFunctionInfo(json, emptySymbolgraph);
+
+      final expectedParams = [
+        Parameter(
+          name: 'parameter',
+          type: intType,
+        ),
+      ];
+
+      expectEqualParams(info.params, expectedParams);
+      expect(info.throws, isFalse);
+      expect(info.async, isTrue);
+    });
+
+    test('Function with async and throws annotations', () {
+      final json = Json(jsonDecode(
+        '''
+        [
+          { "kind": "keyword", "spelling": "func" },
+          { "kind": "text", "spelling": " " },
+          { "kind": "identifier", "spelling": "foo" },
+          { "kind": "text", "spelling": "(" },
+          { "kind": "externalParam", "spelling": "parameter" },
+          { "kind": "text", "spelling": ": " },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          },
+          { "kind": "text", "spelling": ") " },
+          { "kind": "keyword", "spelling": "async" },
+          { "kind": "text", "spelling": " " },
+          { "kind": "keyword", "spelling": "throws" },
+          { "kind": "text", "spelling": " -> " },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          }
+        ]
+        ''',
+      ));
+
+      final info = parseFunctionInfo(json, emptySymbolgraph);
+
+      final expectedParams = [
+        Parameter(
+          name: 'parameter',
+          type: intType,
+        ),
+      ];
+
+      expectEqualParams(info.params, expectedParams);
+      expect(info.throws, isTrue);
+      expect(info.async, isTrue);
     });
   });
 


### PR DESCRIPTION
This is implemented in pretty much exactly the same way as `throws`. Added a `CanAsync` interface, started parsing the annotation in `parseFunctionInfo`, and added the annotation to the generated code. The wrapper method gets an `async` annotation, and when invoking the wrapped method it must `await` the result.

Also like `throws`, there are edge cases where `async` APIs can't be marked with `@objc`. Support for these edge cases will be implemented later. See https://github.com/dart-lang/native/issues/1778

Fixes https://github.com/dart-lang/native/issues/1773