### PR TITLE
[native_assets_builder] Report dart sources as dependencies of hooks

### DIFF
--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -7,7 +7,7 @@ permissions: read-all
 
 on:
   pull_request:
-    branches: [main]
+    # No `branches:` to enable stacked PRs on GitHub.
     paths:
       - ".github/workflows/native.yaml"
       - "pkgs/native_assets_builder/**"

--- a/pkgs/native_assets_builder/lib/src/dependencies_hash_file/dependencies_hash_file.dart
+++ b/pkgs/native_assets_builder/lib/src/dependencies_hash_file/dependencies_hash_file.dart
@@ -13,19 +13,21 @@ import '../utils/uri.dart';
 
 class DependenciesHashFile {
   DependenciesHashFile({
-    required File file,
-  }) : _file = file;
+    required this.file,
+  });
 
-  final File _file;
+  final File file;
   FileSystemHashes _hashes = FileSystemHashes();
 
+  List<Uri> get fileSystemEntities => _hashes.files.map((e) => e.path).toList();
+
   Future<void> _readFile() async {
-    if (!await _file.exists()) {
+    if (!await file.exists()) {
       _hashes = FileSystemHashes();
       return;
     }
     final jsonObject =
-        (json.decode(utf8.decode(await _file.readAsBytes())) as Map)
+        (json.decode(utf8.decode(await file.readAsBytes())) as Map)
             .cast<String, Object>();
     _hashes = FileSystemHashes.fromJson(jsonObject);
   }
@@ -70,7 +72,7 @@ class DependenciesHashFile {
     return modifiedAfterTimeStamp;
   }
 
-  Future<void> _persist() => _file.writeAsString(json.encode(_hashes.toJson()));
+  Future<void> _persist() => file.writeAsString(json.encode(_hashes.toJson()));
 
   /// Reads the file with hashes and reports if there is an outdated file,
   /// directory or environment variable.

--- a/pkgs/native_assets_builder/lib/src/model/hook_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/hook_result.dart
@@ -39,7 +39,7 @@ final class HookResult implements BuildResult, BuildDryRunResult, LinkResult {
         dependencies: dependencies ?? [],
       );
 
-  HookResult copyAdd(HookOutput hookOutput, List<Uri> dependencies) {
+  HookResult copyAdd(HookOutput hookOutput, List<Uri> hookDependencies) {
     final mergedMaps = mergeMaps(
         encodedAssetsForLinking,
         hookOutput is BuildOutput
@@ -59,9 +59,9 @@ final class HookResult implements BuildResult, BuildDryRunResult, LinkResult {
       ],
       encodedAssetsForLinking: mergedMaps,
       dependencies: [
-        ...this.dependencies,
-        ...hookOutput.dependencies,
         ...dependencies,
+        ...hookOutput.dependencies,
+        ...hookDependencies,
       ]..sort(_uriCompare),
     );
   }

--- a/pkgs/native_assets_builder/lib/src/model/hook_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/hook_result.dart
@@ -39,7 +39,7 @@ final class HookResult implements BuildResult, BuildDryRunResult, LinkResult {
         dependencies: dependencies ?? [],
       );
 
-  HookResult copyAdd(HookOutput hookOutput) {
+  HookResult copyAdd(HookOutput hookOutput, List<Uri> dependencies) {
     final mergedMaps = mergeMaps(
         encodedAssetsForLinking,
         hookOutput is BuildOutput
@@ -59,8 +59,9 @@ final class HookResult implements BuildResult, BuildDryRunResult, LinkResult {
       ],
       encodedAssetsForLinking: mergedMaps,
       dependencies: [
-        ...dependencies,
+        ...this.dependencies,
         ...hookOutput.dependencies,
+        ...dependencies,
       ]..sort(_uriCompare),
     );
   }

--- a/pkgs/native_assets_builder/test/build_runner/build_dependencies_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_dependencies_test.dart
@@ -50,13 +50,28 @@ void main() async {
         expect(result.encodedAssets.length, 2);
         expect(
           result.dependencies,
-          [
-            tempUri.resolve('native_add/').resolve('src/native_add.c'),
-            tempUri
-                .resolve('native_subtract/')
-                .resolve('src/native_subtract.c'),
-          ],
+          containsAll([
+            tempUri.resolve('native_add/src/native_add.c'),
+            tempUri.resolve('native_subtract/src/native_subtract.c'),
+            if (!Platform.isWindows) ...[
+              tempUri.resolve('native_add/hook/build.dart'),
+              tempUri.resolve('native_subtract/hook/build.dart'),
+            ],
+          ]),
         );
+        if (Platform.isWindows) {
+          expect(
+            // https://github.com/dart-lang/sdk/issues/59657
+            // Deps file on windows sometimes have lowercase drive letters.
+            // File.exists will work, but Uri equality doesn't.
+            result.dependencies
+                .map((e) => Uri.file(e.toFilePath().toLowerCase())),
+            containsAll([
+              tempUri.resolve('native_add/hook/build.dart'),
+              tempUri.resolve('native_subtract/hook/build.dart'),
+            ].map((e) => Uri.file(e.toFilePath().toLowerCase()))),
+          );
+        }
       }
     });
   });

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_caching_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_caching_test.dart
@@ -44,9 +44,9 @@ void main() async {
         );
         expect(
           result.dependencies,
-          [
+          contains(
             packageUri.resolve('src/native_add.c'),
-          ],
+          ),
         );
       }
 
@@ -80,9 +80,9 @@ void main() async {
         );
         expect(
           result.dependencies,
-          [
+          contains(
             packageUri.resolve('src/native_add.c'),
-          ],
+          ),
         );
       }
     });

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_failure_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_failure_test.dart
@@ -39,9 +39,9 @@ void main() async {
             symbols: ['add']);
         expect(
           result.dependencies,
-          [
+          contains(
             packageUri.resolve('src/native_add.c'),
-          ],
+          ),
         );
       }
 
@@ -95,9 +95,9 @@ void main() async {
             symbols: ['add']);
         expect(
           result.dependencies,
-          [
+          contains(
             packageUri.resolve('src/native_add.c'),
-          ],
+          ),
         );
       }
     });

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_non_root_package_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_non_root_package_test.dart
@@ -55,9 +55,9 @@ void main() async {
         expect(result.encodedAssets, isNotEmpty);
         expect(
           result.dependencies,
-          [
+          contains(
             packageUri.resolve('src/native_add.c'),
-          ],
+          ),
         );
         expect(
           logMessages.join('\n'),

--- a/pkgs/native_assets_builder/test/build_runner/parse_dep_file_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/parse_dep_file_test.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:native_assets_builder/src/build_runner/build_runner.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('parseDepFileInputs', () {
+    expect(
+      parseDepFileInputs(
+        r'C:\\Program\ Files\\foo.dill: C:\\Program\ Files\\foo.dart C:\\Program\ Files\\bar.dart',
+      ),
+      [
+        r'C:\Program Files\foo.dart',
+        r'C:\Program Files\bar.dart',
+      ],
+    );
+  });
+}


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/1770

This PR adds the Dart sources to the dependencies in `HookResult`.

It also fixes the dep-file parsing w.r.t. to escapes.

### Implementation details

We're passing around `HookOutput`s which is the deserialized `output.json`. We could add the Dart sources as dependencies to it _after_ deserializing, but then the correspondence to the json is lost. So instead I've added an extra return value to the places where we pass `HookOutput` around.