### PR TITLE
Handle dart typedefs in import/export of symbol files.

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Ensure that required symbols are available to FFI even when the final binary
   is linked with `-dead_strip`.
+- Handle dart typedefs in import/export of symbol files.
 
 ## 16.0.0
 

--- a/pkgs/ffigen/example/shared_bindings/headers/a.h
+++ b/pkgs/ffigen/example/shared_bindings/headers/a.h
@@ -20,4 +20,9 @@ void a_func1();
 
 void a_func2(struct BaseStruct2 s, union BaseUnion2 u, BaseTypedef2 t);
 
-void a_func3(TestInt i);
+void a_func3(BaseNativeTypedef1 i);
+
+void a_func4(BaseNativeTypedef2 i);
+
+void a_func5(BaseNativeTypedef3 i);
+

--- a/pkgs/ffigen/example/shared_bindings/headers/a.h
+++ b/pkgs/ffigen/example/shared_bindings/headers/a.h
@@ -19,3 +19,5 @@ enum A_Enum{
 void a_func1();
 
 void a_func2(struct BaseStruct2 s, union BaseUnion2 u, BaseTypedef2 t);
+
+void a_func3(TestInt i);

--- a/pkgs/ffigen/example/shared_bindings/headers/base.h
+++ b/pkgs/ffigen/example/shared_bindings/headers/base.h
@@ -20,6 +20,9 @@ union BaseUnion2{
 
 typedef struct BaseStruct1 BaseTypedef1;
 typedef struct BaseStruct2 BaseTypedef2;
+typedef int BaseNativeTypedef1;
+typedef BaseNativeTypedef1 BaseNativeTypedef2;
+typedef BaseNativeTypedef2 BaseNativeTypedef3;
 
 enum BaseEnum{
     BASE_ENUM_1,
@@ -30,4 +33,3 @@ enum BaseEnum{
 
 void base_func1(BaseTypedef1 t1, BaseTypedef2 t2);
 
-typedef int TestInt;

--- a/pkgs/ffigen/example/shared_bindings/headers/base.h
+++ b/pkgs/ffigen/example/shared_bindings/headers/base.h
@@ -29,3 +29,5 @@ enum BaseEnum{
 #define BASE_MACRO_1 1;
 
 void base_func1(BaseTypedef1 t1, BaseTypedef2 t2);
+
+typedef int TestInt;

--- a/pkgs/ffigen/example/shared_bindings/lib/generated/a_gen.dart
+++ b/pkgs/ffigen/example/shared_bindings/lib/generated/a_gen.dart
@@ -63,6 +63,18 @@ class NativeLibraryA {
           ffi.Void Function(BaseStruct2, BaseUnion2, BaseTypedef2)>>('a_func2');
   late final _a_func2 = _a_func2Ptr
       .asFunction<void Function(BaseStruct2, BaseUnion2, BaseTypedef2)>();
+
+  void a_func3(
+    int i,
+  ) {
+    return _a_func3(
+      i,
+    );
+  }
+
+  late final _a_func3Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(TestInt)>>('a_func3');
+  late final _a_func3 = _a_func3Ptr.asFunction<void Function(int)>();
 }
 
 final class BaseStruct1 extends ffi.Struct {
@@ -85,16 +97,25 @@ final class BaseUnion2 extends ffi.Union {
   external int a;
 }
 
+typedef BaseTypedef1 = BaseStruct1;
+typedef BaseTypedef2 = BaseStruct2;
+
 enum BaseEnum {
   BASE_ENUM_1(0),
   BASE_ENUM_2(1);
 
   final int value;
   const BaseEnum(this.value);
+
+  static BaseEnum fromValue(int value) => switch (value) {
+        0 => BASE_ENUM_1,
+        1 => BASE_ENUM_2,
+        _ => throw ArgumentError("Unknown value for BaseEnum: $value"),
+      };
 }
 
-typedef BaseTypedef1 = BaseStruct1;
-typedef BaseTypedef2 = BaseStruct2;
+typedef TestInt = ffi.Int;
+typedef DartTestInt = int;
 
 final class A_Struct1 extends ffi.Struct {
   @ffi.Int()

--- a/pkgs/ffigen/example/shared_bindings/lib/generated/a_gen.dart
+++ b/pkgs/ffigen/example/shared_bindings/lib/generated/a_gen.dart
@@ -73,8 +73,35 @@ class NativeLibraryA {
   }
 
   late final _a_func3Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(TestInt)>>('a_func3');
+      _lookup<ffi.NativeFunction<ffi.Void Function(BaseNativeTypedef1)>>(
+          'a_func3');
   late final _a_func3 = _a_func3Ptr.asFunction<void Function(int)>();
+
+  void a_func4(
+    int i,
+  ) {
+    return _a_func4(
+      i,
+    );
+  }
+
+  late final _a_func4Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(BaseNativeTypedef2)>>(
+          'a_func4');
+  late final _a_func4 = _a_func4Ptr.asFunction<void Function(int)>();
+
+  void a_func5(
+    int i,
+  ) {
+    return _a_func5(
+      i,
+    );
+  }
+
+  late final _a_func5Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(BaseNativeTypedef3)>>(
+          'a_func5');
+  late final _a_func5 = _a_func5Ptr.asFunction<void Function(int)>();
 }
 
 final class BaseStruct1 extends ffi.Struct {
@@ -99,6 +126,10 @@ final class BaseUnion2 extends ffi.Union {
 
 typedef BaseTypedef1 = BaseStruct1;
 typedef BaseTypedef2 = BaseStruct2;
+typedef BaseNativeTypedef1 = ffi.Int;
+typedef DartBaseNativeTypedef1 = int;
+typedef BaseNativeTypedef2 = BaseNativeTypedef1;
+typedef BaseNativeTypedef3 = BaseNativeTypedef2;
 
 enum BaseEnum {
   BASE_ENUM_1(0),
@@ -113,9 +144,6 @@ enum BaseEnum {
         _ => throw ArgumentError("Unknown value for BaseEnum: $value"),
       };
 }
-
-typedef TestInt = ffi.Int;
-typedef DartTestInt = int;
 
 final class A_Struct1 extends ffi.Struct {
   @ffi.Int()

--- a/pkgs/ffigen/example/shared_bindings/lib/generated/a_shared_b_gen.dart
+++ b/pkgs/ffigen/example/shared_bindings/lib/generated/a_shared_b_gen.dart
@@ -49,6 +49,19 @@ class NativeLibraryASharedB {
               imp1.BaseTypedef2)>>('a_func2');
   late final _a_func2 = _a_func2Ptr.asFunction<
       void Function(imp1.BaseStruct2, imp1.BaseUnion2, imp1.BaseTypedef2)>();
+
+  void a_func3(
+    imp1.DartTestInt i,
+  ) {
+    return _a_func3(
+      i,
+    );
+  }
+
+  late final _a_func3Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(imp1.TestInt)>>('a_func3');
+  late final _a_func3 =
+      _a_func3Ptr.asFunction<void Function(imp1.DartTestInt)>();
 }
 
 final class A_Struct1 extends ffi.Struct {

--- a/pkgs/ffigen/example/shared_bindings/lib/generated/a_shared_b_gen.dart
+++ b/pkgs/ffigen/example/shared_bindings/lib/generated/a_shared_b_gen.dart
@@ -51,7 +51,7 @@ class NativeLibraryASharedB {
       void Function(imp1.BaseStruct2, imp1.BaseUnion2, imp1.BaseTypedef2)>();
 
   void a_func3(
-    imp1.DartTestInt i,
+    imp1.DartBaseNativeTypedef1 i,
   ) {
     return _a_func3(
       i,
@@ -59,9 +59,38 @@ class NativeLibraryASharedB {
   }
 
   late final _a_func3Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(imp1.TestInt)>>('a_func3');
+      _lookup<ffi.NativeFunction<ffi.Void Function(imp1.BaseNativeTypedef1)>>(
+          'a_func3');
   late final _a_func3 =
-      _a_func3Ptr.asFunction<void Function(imp1.DartTestInt)>();
+      _a_func3Ptr.asFunction<void Function(imp1.DartBaseNativeTypedef1)>();
+
+  void a_func4(
+    imp1.DartBaseNativeTypedef1 i,
+  ) {
+    return _a_func4(
+      i,
+    );
+  }
+
+  late final _a_func4Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(imp1.BaseNativeTypedef2)>>(
+          'a_func4');
+  late final _a_func4 =
+      _a_func4Ptr.asFunction<void Function(imp1.DartBaseNativeTypedef1)>();
+
+  void a_func5(
+    imp1.DartBaseNativeTypedef1 i,
+  ) {
+    return _a_func5(
+      i,
+    );
+  }
+
+  late final _a_func5Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(imp1.BaseNativeTypedef3)>>(
+          'a_func5');
+  late final _a_func5 =
+      _a_func5Ptr.asFunction<void Function(imp1.DartBaseNativeTypedef1)>();
 }
 
 final class A_Struct1 extends ffi.Struct {

--- a/pkgs/ffigen/example/shared_bindings/lib/generated/base_gen.dart
+++ b/pkgs/ffigen/example/shared_bindings/lib/generated/base_gen.dart
@@ -61,6 +61,10 @@ final class BaseUnion2 extends ffi.Union {
 
 typedef BaseTypedef1 = BaseStruct1;
 typedef BaseTypedef2 = BaseStruct2;
+typedef BaseNativeTypedef1 = ffi.Int;
+typedef DartBaseNativeTypedef1 = int;
+typedef BaseNativeTypedef2 = BaseNativeTypedef1;
+typedef BaseNativeTypedef3 = BaseNativeTypedef2;
 
 enum BaseEnum {
   BASE_ENUM_1(0),
@@ -75,8 +79,5 @@ enum BaseEnum {
         _ => throw ArgumentError("Unknown value for BaseEnum: $value"),
       };
 }
-
-typedef TestInt = ffi.Int;
-typedef DartTestInt = int;
 
 const int BASE_MACRO_1 = 1;

--- a/pkgs/ffigen/example/shared_bindings/lib/generated/base_gen.dart
+++ b/pkgs/ffigen/example/shared_bindings/lib/generated/base_gen.dart
@@ -59,15 +59,24 @@ final class BaseUnion2 extends ffi.Union {
   external int a;
 }
 
+typedef BaseTypedef1 = BaseStruct1;
+typedef BaseTypedef2 = BaseStruct2;
+
 enum BaseEnum {
   BASE_ENUM_1(0),
   BASE_ENUM_2(1);
 
   final int value;
   const BaseEnum(this.value);
+
+  static BaseEnum fromValue(int value) => switch (value) {
+        0 => BASE_ENUM_1,
+        1 => BASE_ENUM_2,
+        _ => throw ArgumentError("Unknown value for BaseEnum: $value"),
+      };
 }
 
-typedef BaseTypedef1 = BaseStruct1;
-typedef BaseTypedef2 = BaseStruct2;
+typedef TestInt = ffi.Int;
+typedef DartTestInt = int;
 
 const int BASE_MACRO_1 = 1;

--- a/pkgs/ffigen/example/shared_bindings/lib/generated/base_symbols.yaml
+++ b/pkgs/ffigen/example/shared_bindings/lib/generated/base_symbols.yaml
@@ -18,13 +18,13 @@ files:
         name: BaseUnion2
       c:base.h@T@BaseNativeTypedef1:
         name: BaseNativeTypedef1
-        dartName: DartBaseNativeTypedef1
+        dart-name: DartBaseNativeTypedef1
       c:base.h@T@BaseNativeTypedef2:
         name: BaseNativeTypedef2
-        dartName: DartBaseNativeTypedef1
+        dart-name: DartBaseNativeTypedef1
       c:base.h@T@BaseNativeTypedef3:
         name: BaseNativeTypedef3
-        dartName: DartBaseNativeTypedef1
+        dart-name: DartBaseNativeTypedef1
       c:base.h@T@BaseTypedef1:
         name: BaseTypedef1
       c:base.h@T@BaseTypedef2:

--- a/pkgs/ffigen/example/shared_bindings/lib/generated/base_symbols.yaml
+++ b/pkgs/ffigen/example/shared_bindings/lib/generated/base_symbols.yaml
@@ -16,10 +16,16 @@ files:
         name: BaseUnion1
       c:@U@BaseUnion2:
         name: BaseUnion2
+      c:base.h@T@BaseNativeTypedef1:
+        name: BaseNativeTypedef1
+        dartName: DartBaseNativeTypedef1
+      c:base.h@T@BaseNativeTypedef2:
+        name: BaseNativeTypedef2
+        dartName: DartBaseNativeTypedef1
+      c:base.h@T@BaseNativeTypedef3:
+        name: BaseNativeTypedef3
+        dartName: DartBaseNativeTypedef1
       c:base.h@T@BaseTypedef1:
         name: BaseTypedef1
       c:base.h@T@BaseTypedef2:
         name: BaseTypedef2
-      c:base.h@T@TestInt:
-        name: TestInt
-        dartName: DartTestInt

--- a/pkgs/ffigen/example/shared_bindings/lib/generated/base_symbols.yaml
+++ b/pkgs/ffigen/example/shared_bindings/lib/generated/base_symbols.yaml
@@ -20,3 +20,6 @@ files:
         name: BaseTypedef1
       c:base.h@T@BaseTypedef2:
         name: BaseTypedef2
+      c:base.h@T@TestInt:
+        name: TestInt
+        dartName: DartTestInt

--- a/pkgs/ffigen/lib/src/code_generator/imports.dart
+++ b/pkgs/ffigen/lib/src/code_generator/imports.dart
@@ -45,8 +45,17 @@ class ImportedType extends Type {
   final String nativeType;
   final String? defaultValue;
 
-  ImportedType(this.libraryImport, this.cType, this.dartType, this.nativeType,
-      [this.defaultValue]);
+  /// Whether the [dartType] is an import from the [libraryImport].
+  final bool importedDartType;
+
+  ImportedType(
+    this.libraryImport,
+    this.cType,
+    this.dartType,
+    this.nativeType, {
+    this.defaultValue,
+    this.importedDartType = false,
+  });
 
   @override
   String getCType(Writer w) {
@@ -55,7 +64,14 @@ class ImportedType extends Type {
   }
 
   @override
-  String getFfiDartType(Writer w) => cType == dartType ? getCType(w) : dartType;
+  String getFfiDartType(Writer w) {
+    if (importedDartType) {
+      w.markImportUsed(libraryImport);
+      return '${libraryImport.prefix}.$dartType';
+    } else {
+      return cType == dartType ? getCType(w) : dartType;
+    }
+  }
 
   @override
   String getNativeType({String varName = ''}) => '$nativeType $varName';
@@ -107,30 +123,42 @@ final self = LibraryImport('self', '');
 
 final voidType = ImportedType(ffiImport, 'Void', 'void', 'void');
 
-final unsignedCharType =
-    ImportedType(ffiImport, 'UnsignedChar', 'int', 'unsigned char', '0');
+final unsignedCharType = ImportedType(
+    ffiImport, 'UnsignedChar', 'int', 'unsigned char',
+    defaultValue: '0');
 final signedCharType =
-    ImportedType(ffiImport, 'SignedChar', 'int', 'char', '0');
-final charType = ImportedType(ffiImport, 'Char', 'int', 'char', '0');
-final unsignedShortType =
-    ImportedType(ffiImport, 'UnsignedShort', 'int', 'unsigned short', '0');
-final shortType = ImportedType(ffiImport, 'Short', 'int', 'short', '0');
-final unsignedIntType =
-    ImportedType(ffiImport, 'UnsignedInt', 'int', 'unsigned', '0');
-final intType = ImportedType(ffiImport, 'Int', 'int', 'int', '0');
-final unsignedLongType =
-    ImportedType(ffiImport, 'UnsignedLong', 'int', 'unsigned long', '0');
-final longType = ImportedType(ffiImport, 'Long', 'int', 'long', '0');
+    ImportedType(ffiImport, 'SignedChar', 'int', 'char', defaultValue: '0');
+final charType =
+    ImportedType(ffiImport, 'Char', 'int', 'char', defaultValue: '0');
+final unsignedShortType = ImportedType(
+    ffiImport, 'UnsignedShort', 'int', 'unsigned short',
+    defaultValue: '0');
+final shortType =
+    ImportedType(ffiImport, 'Short', 'int', 'short', defaultValue: '0');
+final unsignedIntType = ImportedType(
+    ffiImport, 'UnsignedInt', 'int', 'unsigned',
+    defaultValue: '0');
+final intType = ImportedType(ffiImport, 'Int', 'int', 'int', defaultValue: '0');
+final unsignedLongType = ImportedType(
+    ffiImport, 'UnsignedLong', 'int', 'unsigned long',
+    defaultValue: '0');
+final longType =
+    ImportedType(ffiImport, 'Long', 'int', 'long', defaultValue: '0');
 final unsignedLongLongType = ImportedType(
-    ffiImport, 'UnsignedLongLong', 'int', 'unsigned long long', '0');
+    ffiImport, 'UnsignedLongLong', 'int', 'unsigned long long',
+    defaultValue: '0');
 final longLongType =
-    ImportedType(ffiImport, 'LongLong', 'int', 'long long', '0');
+    ImportedType(ffiImport, 'LongLong', 'int', 'long long', defaultValue: '0');
 
-final floatType = ImportedType(ffiImport, 'Float', 'double', 'float', '0.0');
-final doubleType = ImportedType(ffiImport, 'Double', 'double', 'double', '0.0');
+final floatType =
+    ImportedType(ffiImport, 'Float', 'double', 'float', defaultValue: '0.0');
+final doubleType =
+    ImportedType(ffiImport, 'Double', 'double', 'double', defaultValue: '0.0');
 
-final sizeType = ImportedType(ffiImport, 'Size', 'int', 'size_t', '0');
-final wCharType = ImportedType(ffiImport, 'WChar', 'int', 'wchar_t', '0');
+final sizeType =
+    ImportedType(ffiImport, 'Size', 'int', 'size_t', defaultValue: '0');
+final wCharType =
+    ImportedType(ffiImport, 'WChar', 'int', 'wchar_t', defaultValue: '0');
 
 final objCObjectType =
     ImportedType(objcPkgImport, 'ObjCObject', 'ObjCObject', 'void');

--- a/pkgs/ffigen/lib/src/code_generator/typealias.dart
+++ b/pkgs/ffigen/lib/src/code_generator/typealias.dart
@@ -19,7 +19,7 @@ import 'writer.dart';
 class Typealias extends BindingType {
   final Type type;
   String? _ffiDartAliasName;
-  String? _dartAliasName;
+  String? dartAliasName;
 
   /// Creates a Typealias.
   ///
@@ -75,7 +75,7 @@ class Typealias extends BindingType {
     bool genFfiDartType = false,
     super.isInternal,
   })  : _ffiDartAliasName = genFfiDartType ? 'Dart$name' : null,
-        _dartAliasName =
+        dartAliasName =
             (!genFfiDartType && type is! Typealias && !type.sameDartAndCType)
                 ? 'Dart$name'
                 : null,
@@ -95,8 +95,8 @@ class Typealias extends BindingType {
     if (_ffiDartAliasName != null) {
       _ffiDartAliasName = w.topLevelUniqueNamer.makeUnique(_ffiDartAliasName!);
     }
-    if (_dartAliasName != null) {
-      _dartAliasName = w.topLevelUniqueNamer.makeUnique(_dartAliasName!);
+    if (dartAliasName != null) {
+      dartAliasName = w.topLevelUniqueNamer.makeUnique(dartAliasName!);
     }
 
     final sb = StringBuffer();
@@ -107,8 +107,8 @@ class Typealias extends BindingType {
     if (_ffiDartAliasName != null) {
       sb.write('typedef $_ffiDartAliasName = ${type.getFfiDartType(w)};\n');
     }
-    if (_dartAliasName != null) {
-      sb.write('typedef $_dartAliasName = ${type.getDartType(w)};\n');
+    if (dartAliasName != null) {
+      sb.write('typedef $dartAliasName = ${type.getDartType(w)};\n');
     }
     return BindingString(
         type: BindingStringType.typeDef, string: sb.toString());
@@ -142,8 +142,8 @@ class Typealias extends BindingType {
   @override
   String getDartType(Writer w) {
     if (generateBindings) {
-      if (_dartAliasName != null) {
-        return _dartAliasName!;
+      if (dartAliasName != null) {
+        return dartAliasName!;
       } else if (type.sameDartAndCType) {
         return getFfiDartType(w);
       }

--- a/pkgs/ffigen/lib/src/code_generator/writer.dart
+++ b/pkgs/ffigen/lib/src/code_generator/writer.dart
@@ -390,10 +390,18 @@ class Writer {
             strings.ffiNative: usesFfiNative,
           },
           strings.symbols: {
-            for (final b in bindings) b.usr: {strings.name: b.name},
+            for (final b in bindings) b.usr: makeSymbolMapValue(b),
           },
         },
       },
+    };
+  }
+
+  Map<String, String> makeSymbolMapValue(Binding b) {
+    return {
+      strings.name: b.name,
+      if (b is Typealias && b.dartAliasName != null)
+        strings.dartName: b.dartAliasName!,
     };
   }
 

--- a/pkgs/ffigen/lib/src/code_generator/writer.dart
+++ b/pkgs/ffigen/lib/src/code_generator/writer.dart
@@ -390,19 +390,24 @@ class Writer {
             strings.ffiNative: usesFfiNative,
           },
           strings.symbols: {
-            for (final b in bindings) b.usr: makeSymbolMapValue(b),
+            for (final b in bindings) b.usr: _makeSymbolMapValue(b),
           },
         },
       },
     };
   }
 
-  Map<String, String> makeSymbolMapValue(Binding b) {
+  Map<String, String> _makeSymbolMapValue(Binding b) {
+    final dartName = b is Typealias ? getTypedefDartAliasName(b) : null;
     return {
       strings.name: b.name,
-      if (b is Typealias && b.dartAliasName != null)
-        strings.dartName: b.dartAliasName!,
+      if (dartName != null) strings.dartName: dartName,
     };
+  }
+
+  String? getTypedefDartAliasName(Type b) {
+    if (b is! Typealias) return null;
+    return b.dartAliasName ?? getTypedefDartAliasName(b.type);
   }
 
   static String _objcImport(String entryPoint, String outDir) {

--- a/pkgs/ffigen/lib/src/config_provider/spec_utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/spec_utils.dart
@@ -59,7 +59,9 @@ void loadImportedTypes(YamlMap fileConfig,
     final usr = key as String;
     final value = symbols[usr]! as YamlMap;
     final name = value['name'] as String;
-    usrTypeMappings[usr] = ImportedType(libraryImport, name, name, name);
+    final dartName = (value['dartName'] as String?) ?? name;
+    usrTypeMappings[usr] = ImportedType(libraryImport, name, dartName, name,
+        importedDartType: true);
   }
 }
 

--- a/pkgs/ffigen/lib/src/config_provider/spec_utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/spec_utils.dart
@@ -58,8 +58,8 @@ void loadImportedTypes(YamlMap fileConfig,
   for (final key in symbols.keys) {
     final usr = key as String;
     final value = symbols[usr]! as YamlMap;
-    final name = value['name'] as String;
-    final dartName = (value['dartName'] as String?) ?? name;
+    final name = value[strings.name] as String;
+    final dartName = (value[strings.dartName] as String?) ?? name;
     usrTypeMappings[usr] = ImportedType(libraryImport, name, dartName, name,
         importedDartType: true);
   }

--- a/pkgs/ffigen/lib/src/strings.dart
+++ b/pkgs/ffigen/lib/src/strings.dart
@@ -170,6 +170,7 @@ const formatVersion = 'format_version';
 const symbolFileFormatVersion = '1.0.0';
 const files = 'files';
 const usedConfig = 'used-config';
+const dartName = 'dartName';
 
 const import = 'import';
 const defaultSymbolFileImportPrefix = 'imp';

--- a/pkgs/ffigen/lib/src/strings.dart
+++ b/pkgs/ffigen/lib/src/strings.dart
@@ -170,7 +170,7 @@ const formatVersion = 'format_version';
 const symbolFileFormatVersion = '1.0.0';
 const files = 'files';
 const usedConfig = 'used-config';
-const dartName = 'dartName';
+const dartName = 'dart-name';
 
 const import = 'import';
 const defaultSymbolFileImportPrefix = 'imp';


### PR DESCRIPTION
Closes #1776

- Adds a `dart-name` field to the symbol map if required (currently only for typedefs)
- Nested typedefs have been handled by using the dart name for the root one.
- Updated changelog and shared_bindings test.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
