### PR TITLE
[jnigen] Use dollar signs for nested class name separator

### DIFF
--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.13.0-wip
 
+- **Breaking Change**([#1516](https://github.com/dart-lang/native/issues/1516)):
+  Inner classes are now generated as `OuterClass$InnerClass`.
 - **Breaking Change**([#1644](https://github.com/dart-lang/native/issues/1644)):
   Generate null-safe Dart bindings for Java and Kotlin.
 - Fixed a potential name collision when generating in multi-file mode.

--- a/pkgs/jnigen/doc/java_differences.md
+++ b/pkgs/jnigen/doc/java_differences.md
@@ -217,8 +217,8 @@ class $_Example extends JObject {
 ### Inner classes
 
 Java has the concept of inner classes, while Dart does not. Therefore, inner
-classes are generated as separate classes named by the name of their outer class
-followed by a dollar sign (`$`) followed by their original name.
+classes are generated as separate classes named using the name of their
+outer-class followed by a dollar sign (`$`) followed by their original name.
 
 For example:
 

--- a/pkgs/jnigen/doc/java_differences.md
+++ b/pkgs/jnigen/doc/java_differences.md
@@ -213,3 +213,27 @@ class $_Example extends JObject {
   void $_printMessage() { /* ... */ }
 }
 ```
+
+### Inner classes
+
+Java has the concept of inner classes, while Dart does not. Therefore, inner
+classes are generated as separate classes named by the name of their outer class
+followed by a dollar sign (`$`) followed by their original name.
+
+For example:
+
+```java
+// Java
+public class Outer {
+  public class Inner {}
+}
+```
+
+will be turned into:
+
+```dart
+// Dart Bindings - Boilerplate omitted for clarity.
+class Outer extends JObject {}
+
+class Outer$Inner extends JObject {}
+```

--- a/pkgs/jnigen/example/in_app_java/lib/android_utils.dart
+++ b/pkgs/jnigen/example/in_app_java/lib/android_utils.dart
@@ -36,13 +36,13 @@ import 'package:jni/_internal.dart' as jni$_;
 import 'package:jni/jni.dart' as jni$_;
 
 /// from: `com.example.in_app_java.R$drawable`
-class R_drawable extends jni$_.JObject {
+class R$drawable extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<R_drawable> $type;
+  final jni$_.JObjType<R$drawable> $type;
 
   @jni$_.internal
-  R_drawable.fromReference(
+  R$drawable.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -51,8 +51,8 @@ class R_drawable extends jni$_.JObject {
       jni$_.JClass.forName(r'com/example/in_app_java/R$drawable');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $R_drawable$NullableType();
-  static const type = $R_drawable$Type();
+  static const nullableType = $R$drawable$NullableType();
+  static const type = $R$drawable$Type();
   static final _id_launch_background = _class.staticFieldId(
     r'launch_background',
     r'I',
@@ -67,9 +67,9 @@ class R_drawable extends jni$_.JObject {
       _id_launch_background.set(_class, const jni$_.jintType(), value);
 }
 
-final class $R_drawable$NullableType extends jni$_.JObjType<R_drawable?> {
+final class $R$drawable$NullableType extends jni$_.JObjType<R$drawable?> {
   @jni$_.internal
-  const $R_drawable$NullableType();
+  const $R$drawable$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -77,9 +77,9 @@ final class $R_drawable$NullableType extends jni$_.JObjType<R_drawable?> {
 
   @jni$_.internal
   @core$_.override
-  R_drawable? fromReference(jni$_.JReference reference) => reference.isNull
+  R$drawable? fromReference(jni$_.JReference reference) => reference.isNull
       ? null
-      : R_drawable.fromReference(
+      : R$drawable.fromReference(
           reference,
         );
   @jni$_.internal
@@ -88,25 +88,25 @@ final class $R_drawable$NullableType extends jni$_.JObjType<R_drawable?> {
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R_drawable?> get nullableType => this;
+  jni$_.JObjType<R$drawable?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($R_drawable$NullableType).hashCode;
+  int get hashCode => ($R$drawable$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R_drawable$NullableType) &&
-        other is $R_drawable$NullableType;
+    return other.runtimeType == ($R$drawable$NullableType) &&
+        other is $R$drawable$NullableType;
   }
 }
 
-final class $R_drawable$Type extends jni$_.JObjType<R_drawable> {
+final class $R$drawable$Type extends jni$_.JObjType<R$drawable> {
   @jni$_.internal
-  const $R_drawable$Type();
+  const $R$drawable$Type();
 
   @jni$_.internal
   @core$_.override
@@ -114,8 +114,8 @@ final class $R_drawable$Type extends jni$_.JObjType<R_drawable> {
 
   @jni$_.internal
   @core$_.override
-  R_drawable fromReference(jni$_.JReference reference) =>
-      R_drawable.fromReference(
+  R$drawable fromReference(jni$_.JReference reference) =>
+      R$drawable.fromReference(
         reference,
       );
   @jni$_.internal
@@ -124,30 +124,30 @@ final class $R_drawable$Type extends jni$_.JObjType<R_drawable> {
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R_drawable?> get nullableType =>
-      const $R_drawable$NullableType();
+  jni$_.JObjType<R$drawable?> get nullableType =>
+      const $R$drawable$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($R_drawable$Type).hashCode;
+  int get hashCode => ($R$drawable$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R_drawable$Type) && other is $R_drawable$Type;
+    return other.runtimeType == ($R$drawable$Type) && other is $R$drawable$Type;
   }
 }
 
 /// from: `com.example.in_app_java.R$mipmap`
-class R_mipmap extends jni$_.JObject {
+class R$mipmap extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<R_mipmap> $type;
+  final jni$_.JObjType<R$mipmap> $type;
 
   @jni$_.internal
-  R_mipmap.fromReference(
+  R$mipmap.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -156,8 +156,8 @@ class R_mipmap extends jni$_.JObject {
       jni$_.JClass.forName(r'com/example/in_app_java/R$mipmap');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $R_mipmap$NullableType();
-  static const type = $R_mipmap$Type();
+  static const nullableType = $R$mipmap$NullableType();
+  static const type = $R$mipmap$Type();
   static final _id_ic_launcher = _class.staticFieldId(
     r'ic_launcher',
     r'I',
@@ -172,9 +172,9 @@ class R_mipmap extends jni$_.JObject {
       _id_ic_launcher.set(_class, const jni$_.jintType(), value);
 }
 
-final class $R_mipmap$NullableType extends jni$_.JObjType<R_mipmap?> {
+final class $R$mipmap$NullableType extends jni$_.JObjType<R$mipmap?> {
   @jni$_.internal
-  const $R_mipmap$NullableType();
+  const $R$mipmap$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -182,9 +182,9 @@ final class $R_mipmap$NullableType extends jni$_.JObjType<R_mipmap?> {
 
   @jni$_.internal
   @core$_.override
-  R_mipmap? fromReference(jni$_.JReference reference) => reference.isNull
+  R$mipmap? fromReference(jni$_.JReference reference) => reference.isNull
       ? null
-      : R_mipmap.fromReference(
+      : R$mipmap.fromReference(
           reference,
         );
   @jni$_.internal
@@ -193,25 +193,25 @@ final class $R_mipmap$NullableType extends jni$_.JObjType<R_mipmap?> {
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R_mipmap?> get nullableType => this;
+  jni$_.JObjType<R$mipmap?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($R_mipmap$NullableType).hashCode;
+  int get hashCode => ($R$mipmap$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R_mipmap$NullableType) &&
-        other is $R_mipmap$NullableType;
+    return other.runtimeType == ($R$mipmap$NullableType) &&
+        other is $R$mipmap$NullableType;
   }
 }
 
-final class $R_mipmap$Type extends jni$_.JObjType<R_mipmap> {
+final class $R$mipmap$Type extends jni$_.JObjType<R$mipmap> {
   @jni$_.internal
-  const $R_mipmap$Type();
+  const $R$mipmap$Type();
 
   @jni$_.internal
   @core$_.override
@@ -219,7 +219,7 @@ final class $R_mipmap$Type extends jni$_.JObjType<R_mipmap> {
 
   @jni$_.internal
   @core$_.override
-  R_mipmap fromReference(jni$_.JReference reference) => R_mipmap.fromReference(
+  R$mipmap fromReference(jni$_.JReference reference) => R$mipmap.fromReference(
         reference,
       );
   @jni$_.internal
@@ -228,29 +228,29 @@ final class $R_mipmap$Type extends jni$_.JObjType<R_mipmap> {
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R_mipmap?> get nullableType => const $R_mipmap$NullableType();
+  jni$_.JObjType<R$mipmap?> get nullableType => const $R$mipmap$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($R_mipmap$Type).hashCode;
+  int get hashCode => ($R$mipmap$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R_mipmap$Type) && other is $R_mipmap$Type;
+    return other.runtimeType == ($R$mipmap$Type) && other is $R$mipmap$Type;
   }
 }
 
 /// from: `com.example.in_app_java.R$style`
-class R_style extends jni$_.JObject {
+class R$style extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<R_style> $type;
+  final jni$_.JObjType<R$style> $type;
 
   @jni$_.internal
-  R_style.fromReference(
+  R$style.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -259,8 +259,8 @@ class R_style extends jni$_.JObject {
       jni$_.JClass.forName(r'com/example/in_app_java/R$style');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $R_style$NullableType();
-  static const type = $R_style$Type();
+  static const nullableType = $R$style$NullableType();
+  static const type = $R$style$Type();
   static final _id_LaunchTheme = _class.staticFieldId(
     r'LaunchTheme',
     r'I',
@@ -288,9 +288,9 @@ class R_style extends jni$_.JObject {
       _id_NormalTheme.set(_class, const jni$_.jintType(), value);
 }
 
-final class $R_style$NullableType extends jni$_.JObjType<R_style?> {
+final class $R$style$NullableType extends jni$_.JObjType<R$style?> {
   @jni$_.internal
-  const $R_style$NullableType();
+  const $R$style$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -298,9 +298,9 @@ final class $R_style$NullableType extends jni$_.JObjType<R_style?> {
 
   @jni$_.internal
   @core$_.override
-  R_style? fromReference(jni$_.JReference reference) => reference.isNull
+  R$style? fromReference(jni$_.JReference reference) => reference.isNull
       ? null
-      : R_style.fromReference(
+      : R$style.fromReference(
           reference,
         );
   @jni$_.internal
@@ -309,25 +309,25 @@ final class $R_style$NullableType extends jni$_.JObjType<R_style?> {
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R_style?> get nullableType => this;
+  jni$_.JObjType<R$style?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($R_style$NullableType).hashCode;
+  int get hashCode => ($R$style$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R_style$NullableType) &&
-        other is $R_style$NullableType;
+    return other.runtimeType == ($R$style$NullableType) &&
+        other is $R$style$NullableType;
   }
 }
 
-final class $R_style$Type extends jni$_.JObjType<R_style> {
+final class $R$style$Type extends jni$_.JObjType<R$style> {
   @jni$_.internal
-  const $R_style$Type();
+  const $R$style$Type();
 
   @jni$_.internal
   @core$_.override
@@ -335,7 +335,7 @@ final class $R_style$Type extends jni$_.JObjType<R_style> {
 
   @jni$_.internal
   @core$_.override
-  R_style fromReference(jni$_.JReference reference) => R_style.fromReference(
+  R$style fromReference(jni$_.JReference reference) => R$style.fromReference(
         reference,
       );
   @jni$_.internal
@@ -344,18 +344,18 @@ final class $R_style$Type extends jni$_.JObjType<R_style> {
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R_style?> get nullableType => const $R_style$NullableType();
+  jni$_.JObjType<R$style?> get nullableType => const $R$style$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($R_style$Type).hashCode;
+  int get hashCode => ($R$style$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R_style$Type) && other is $R_style$Type;
+    return other.runtimeType == ($R$style$Type) && other is $R$style$Type;
   }
 }
 
@@ -449,13 +449,13 @@ final class $R$Type extends jni$_.JObjType<R> {
 }
 
 /// from: `androidx.emoji2.text.EmojiCompat$CodepointSequenceMatchResult`
-class EmojiCompat_CodepointSequenceMatchResult extends jni$_.JObject {
+class EmojiCompat$CodepointSequenceMatchResult extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat_CodepointSequenceMatchResult> $type;
+  final jni$_.JObjType<EmojiCompat$CodepointSequenceMatchResult> $type;
 
   @jni$_.internal
-  EmojiCompat_CodepointSequenceMatchResult.fromReference(
+  EmojiCompat$CodepointSequenceMatchResult.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -465,11 +465,11 @@ class EmojiCompat_CodepointSequenceMatchResult extends jni$_.JObject {
 
   /// The type which includes information such as the signature of this class.
   static const nullableType =
-      $EmojiCompat_CodepointSequenceMatchResult$NullableType();
-  static const type = $EmojiCompat_CodepointSequenceMatchResult$Type();
+      $EmojiCompat$CodepointSequenceMatchResult$NullableType();
+  static const type = $EmojiCompat$CodepointSequenceMatchResult$Type();
 
   /// Maps a specific port to the implemented interface.
-  static final core$_.Map<int, $EmojiCompat_CodepointSequenceMatchResult>
+  static final core$_.Map<int, $EmojiCompat$CodepointSequenceMatchResult>
       _$impls = {};
   static jni$_.JObjectPtr _$invoke(
     int port,
@@ -507,7 +507,7 @@ class EmojiCompat_CodepointSequenceMatchResult extends jni$_.JObject {
 
   static void implementIn(
     jni$_.JImplementer implementer,
-    $EmojiCompat_CodepointSequenceMatchResult $impl,
+    $EmojiCompat$CodepointSequenceMatchResult $impl,
   ) {
     late final jni$_.RawReceivePort $p;
     $p = jni$_.RawReceivePort(($m) {
@@ -530,31 +530,31 @@ class EmojiCompat_CodepointSequenceMatchResult extends jni$_.JObject {
     _$impls[$a] = $impl;
   }
 
-  factory EmojiCompat_CodepointSequenceMatchResult.implement(
-    $EmojiCompat_CodepointSequenceMatchResult $impl,
+  factory EmojiCompat$CodepointSequenceMatchResult.implement(
+    $EmojiCompat$CodepointSequenceMatchResult $impl,
   ) {
     final $i = jni$_.JImplementer();
     implementIn($i, $impl);
-    return EmojiCompat_CodepointSequenceMatchResult.fromReference(
+    return EmojiCompat$CodepointSequenceMatchResult.fromReference(
       $i.implementReference(),
     );
   }
 }
 
-abstract base mixin class $EmojiCompat_CodepointSequenceMatchResult {
-  factory $EmojiCompat_CodepointSequenceMatchResult() =
-      _$EmojiCompat_CodepointSequenceMatchResult;
+abstract base mixin class $EmojiCompat$CodepointSequenceMatchResult {
+  factory $EmojiCompat$CodepointSequenceMatchResult() =
+      _$EmojiCompat$CodepointSequenceMatchResult;
 }
 
-final class _$EmojiCompat_CodepointSequenceMatchResult
-    with $EmojiCompat_CodepointSequenceMatchResult {
-  _$EmojiCompat_CodepointSequenceMatchResult();
+final class _$EmojiCompat$CodepointSequenceMatchResult
+    with $EmojiCompat$CodepointSequenceMatchResult {
+  _$EmojiCompat$CodepointSequenceMatchResult();
 }
 
-final class $EmojiCompat_CodepointSequenceMatchResult$NullableType
-    extends jni$_.JObjType<EmojiCompat_CodepointSequenceMatchResult?> {
+final class $EmojiCompat$CodepointSequenceMatchResult$NullableType
+    extends jni$_.JObjType<EmojiCompat$CodepointSequenceMatchResult?> {
   @jni$_.internal
-  const $EmojiCompat_CodepointSequenceMatchResult$NullableType();
+  const $EmojiCompat$CodepointSequenceMatchResult$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -563,11 +563,11 @@ final class $EmojiCompat_CodepointSequenceMatchResult$NullableType
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_CodepointSequenceMatchResult? fromReference(
+  EmojiCompat$CodepointSequenceMatchResult? fromReference(
           jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : EmojiCompat_CodepointSequenceMatchResult.fromReference(
+          : EmojiCompat$CodepointSequenceMatchResult.fromReference(
               reference,
             );
   @jni$_.internal
@@ -576,7 +576,7 @@ final class $EmojiCompat_CodepointSequenceMatchResult$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_CodepointSequenceMatchResult?> get nullableType =>
+  jni$_.JObjType<EmojiCompat$CodepointSequenceMatchResult?> get nullableType =>
       this;
 
   @jni$_.internal
@@ -585,20 +585,20 @@ final class $EmojiCompat_CodepointSequenceMatchResult$NullableType
 
   @core$_.override
   int get hashCode =>
-      ($EmojiCompat_CodepointSequenceMatchResult$NullableType).hashCode;
+      ($EmojiCompat$CodepointSequenceMatchResult$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($EmojiCompat_CodepointSequenceMatchResult$NullableType) &&
-        other is $EmojiCompat_CodepointSequenceMatchResult$NullableType;
+            ($EmojiCompat$CodepointSequenceMatchResult$NullableType) &&
+        other is $EmojiCompat$CodepointSequenceMatchResult$NullableType;
   }
 }
 
-final class $EmojiCompat_CodepointSequenceMatchResult$Type
-    extends jni$_.JObjType<EmojiCompat_CodepointSequenceMatchResult> {
+final class $EmojiCompat$CodepointSequenceMatchResult$Type
+    extends jni$_.JObjType<EmojiCompat$CodepointSequenceMatchResult> {
   @jni$_.internal
-  const $EmojiCompat_CodepointSequenceMatchResult$Type();
+  const $EmojiCompat$CodepointSequenceMatchResult$Type();
 
   @jni$_.internal
   @core$_.override
@@ -607,9 +607,9 @@ final class $EmojiCompat_CodepointSequenceMatchResult$Type
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_CodepointSequenceMatchResult fromReference(
+  EmojiCompat$CodepointSequenceMatchResult fromReference(
           jni$_.JReference reference) =>
-      EmojiCompat_CodepointSequenceMatchResult.fromReference(
+      EmojiCompat$CodepointSequenceMatchResult.fromReference(
         reference,
       );
   @jni$_.internal
@@ -618,32 +618,32 @@ final class $EmojiCompat_CodepointSequenceMatchResult$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_CodepointSequenceMatchResult?> get nullableType =>
-      const $EmojiCompat_CodepointSequenceMatchResult$NullableType();
+  jni$_.JObjType<EmojiCompat$CodepointSequenceMatchResult?> get nullableType =>
+      const $EmojiCompat$CodepointSequenceMatchResult$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_CodepointSequenceMatchResult$Type).hashCode;
+  int get hashCode => ($EmojiCompat$CodepointSequenceMatchResult$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($EmojiCompat_CodepointSequenceMatchResult$Type) &&
-        other is $EmojiCompat_CodepointSequenceMatchResult$Type;
+            ($EmojiCompat$CodepointSequenceMatchResult$Type) &&
+        other is $EmojiCompat$CodepointSequenceMatchResult$Type;
   }
 }
 
 /// from: `androidx.emoji2.text.EmojiCompat$Config`
-class EmojiCompat_Config extends jni$_.JObject {
+class EmojiCompat$Config extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat_Config> $type;
+  final jni$_.JObjType<EmojiCompat$Config> $type;
 
   @jni$_.internal
-  EmojiCompat_Config.fromReference(
+  EmojiCompat$Config.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -652,8 +652,8 @@ class EmojiCompat_Config extends jni$_.JObject {
       jni$_.JClass.forName(r'androidx/emoji2/text/EmojiCompat$Config');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat_Config$NullableType();
-  static const type = $EmojiCompat_Config$Type();
+  static const nullableType = $EmojiCompat$Config$NullableType();
+  static const type = $EmojiCompat$Config$Type();
   static final _id_registerInitCallback = _class.instanceMethodId(
     r'registerInitCallback',
     r'(Landroidx/emoji2/text/EmojiCompat$InitCallback;)Landroidx/emoji2/text/EmojiCompat$Config;',
@@ -672,15 +672,15 @@ class EmojiCompat_Config extends jni$_.JObject {
 
   /// from: `public androidx.emoji2.text.EmojiCompat$Config registerInitCallback(androidx.emoji2.text.EmojiCompat$InitCallback initCallback)`
   /// The returned object must be released after use, by calling the [release] method.
-  EmojiCompat_Config? registerInitCallback(
-    EmojiCompat_InitCallback? initCallback,
+  EmojiCompat$Config? registerInitCallback(
+    EmojiCompat$InitCallback? initCallback,
   ) {
     final _$initCallback = initCallback?.reference ?? jni$_.jNullReference;
     return _registerInitCallback(
             reference.pointer,
             _id_registerInitCallback as jni$_.JMethodIDPtr,
             _$initCallback.pointer)
-        .object<EmojiCompat_Config?>(const $EmojiCompat_Config$NullableType());
+        .object<EmojiCompat$Config?>(const $EmojiCompat$Config$NullableType());
   }
 
   static final _id_unregisterInitCallback = _class.instanceMethodId(
@@ -701,15 +701,15 @@ class EmojiCompat_Config extends jni$_.JObject {
 
   /// from: `public androidx.emoji2.text.EmojiCompat$Config unregisterInitCallback(androidx.emoji2.text.EmojiCompat$InitCallback initCallback)`
   /// The returned object must be released after use, by calling the [release] method.
-  EmojiCompat_Config? unregisterInitCallback(
-    EmojiCompat_InitCallback? initCallback,
+  EmojiCompat$Config? unregisterInitCallback(
+    EmojiCompat$InitCallback? initCallback,
   ) {
     final _$initCallback = initCallback?.reference ?? jni$_.jNullReference;
     return _unregisterInitCallback(
             reference.pointer,
             _id_unregisterInitCallback as jni$_.JMethodIDPtr,
             _$initCallback.pointer)
-        .object<EmojiCompat_Config?>(const $EmojiCompat_Config$NullableType());
+        .object<EmojiCompat$Config?>(const $EmojiCompat$Config$NullableType());
   }
 
   static final _id_setReplaceAll = _class.instanceMethodId(
@@ -729,12 +729,12 @@ class EmojiCompat_Config extends jni$_.JObject {
 
   /// from: `public androidx.emoji2.text.EmojiCompat$Config setReplaceAll(boolean z)`
   /// The returned object must be released after use, by calling the [release] method.
-  EmojiCompat_Config? setReplaceAll(
+  EmojiCompat$Config? setReplaceAll(
     bool z,
   ) {
     return _setReplaceAll(reference.pointer,
             _id_setReplaceAll as jni$_.JMethodIDPtr, z ? 1 : 0)
-        .object<EmojiCompat_Config?>(const $EmojiCompat_Config$NullableType());
+        .object<EmojiCompat$Config?>(const $EmojiCompat$Config$NullableType());
   }
 
   static final _id_setUseEmojiAsDefaultStyle = _class.instanceMethodId(
@@ -754,12 +754,12 @@ class EmojiCompat_Config extends jni$_.JObject {
 
   /// from: `public androidx.emoji2.text.EmojiCompat$Config setUseEmojiAsDefaultStyle(boolean z)`
   /// The returned object must be released after use, by calling the [release] method.
-  EmojiCompat_Config? setUseEmojiAsDefaultStyle(
+  EmojiCompat$Config? setUseEmojiAsDefaultStyle(
     bool z,
   ) {
     return _setUseEmojiAsDefaultStyle(reference.pointer,
             _id_setUseEmojiAsDefaultStyle as jni$_.JMethodIDPtr, z ? 1 : 0)
-        .object<EmojiCompat_Config?>(const $EmojiCompat_Config$NullableType());
+        .object<EmojiCompat$Config?>(const $EmojiCompat$Config$NullableType());
   }
 
   static final _id_setUseEmojiAsDefaultStyle$1 = _class.instanceMethodId(
@@ -784,7 +784,7 @@ class EmojiCompat_Config extends jni$_.JObject {
 
   /// from: `public androidx.emoji2.text.EmojiCompat$Config setUseEmojiAsDefaultStyle(boolean z, java.util.List list)`
   /// The returned object must be released after use, by calling the [release] method.
-  EmojiCompat_Config? setUseEmojiAsDefaultStyle$1(
+  EmojiCompat$Config? setUseEmojiAsDefaultStyle$1(
     bool z,
     jni$_.JList<jni$_.JInteger?>? list,
   ) {
@@ -794,7 +794,7 @@ class EmojiCompat_Config extends jni$_.JObject {
             _id_setUseEmojiAsDefaultStyle$1 as jni$_.JMethodIDPtr,
             z ? 1 : 0,
             _$list.pointer)
-        .object<EmojiCompat_Config?>(const $EmojiCompat_Config$NullableType());
+        .object<EmojiCompat$Config?>(const $EmojiCompat$Config$NullableType());
   }
 
   static final _id_setEmojiSpanIndicatorEnabled = _class.instanceMethodId(
@@ -814,12 +814,12 @@ class EmojiCompat_Config extends jni$_.JObject {
 
   /// from: `public androidx.emoji2.text.EmojiCompat$Config setEmojiSpanIndicatorEnabled(boolean z)`
   /// The returned object must be released after use, by calling the [release] method.
-  EmojiCompat_Config? setEmojiSpanIndicatorEnabled(
+  EmojiCompat$Config? setEmojiSpanIndicatorEnabled(
     bool z,
   ) {
     return _setEmojiSpanIndicatorEnabled(reference.pointer,
             _id_setEmojiSpanIndicatorEnabled as jni$_.JMethodIDPtr, z ? 1 : 0)
-        .object<EmojiCompat_Config?>(const $EmojiCompat_Config$NullableType());
+        .object<EmojiCompat$Config?>(const $EmojiCompat$Config$NullableType());
   }
 
   static final _id_setEmojiSpanIndicatorColor = _class.instanceMethodId(
@@ -839,12 +839,12 @@ class EmojiCompat_Config extends jni$_.JObject {
 
   /// from: `public androidx.emoji2.text.EmojiCompat$Config setEmojiSpanIndicatorColor(int i)`
   /// The returned object must be released after use, by calling the [release] method.
-  EmojiCompat_Config? setEmojiSpanIndicatorColor(
+  EmojiCompat$Config? setEmojiSpanIndicatorColor(
     int i,
   ) {
     return _setEmojiSpanIndicatorColor(reference.pointer,
             _id_setEmojiSpanIndicatorColor as jni$_.JMethodIDPtr, i)
-        .object<EmojiCompat_Config?>(const $EmojiCompat_Config$NullableType());
+        .object<EmojiCompat$Config?>(const $EmojiCompat$Config$NullableType());
   }
 
   static final _id_setMetadataLoadStrategy = _class.instanceMethodId(
@@ -864,12 +864,12 @@ class EmojiCompat_Config extends jni$_.JObject {
 
   /// from: `public androidx.emoji2.text.EmojiCompat$Config setMetadataLoadStrategy(int i)`
   /// The returned object must be released after use, by calling the [release] method.
-  EmojiCompat_Config? setMetadataLoadStrategy(
+  EmojiCompat$Config? setMetadataLoadStrategy(
     int i,
   ) {
     return _setMetadataLoadStrategy(reference.pointer,
             _id_setMetadataLoadStrategy as jni$_.JMethodIDPtr, i)
-        .object<EmojiCompat_Config?>(const $EmojiCompat_Config$NullableType());
+        .object<EmojiCompat$Config?>(const $EmojiCompat$Config$NullableType());
   }
 
   static final _id_setSpanFactory = _class.instanceMethodId(
@@ -890,13 +890,13 @@ class EmojiCompat_Config extends jni$_.JObject {
 
   /// from: `public androidx.emoji2.text.EmojiCompat$Config setSpanFactory(androidx.emoji2.text.EmojiCompat$SpanFactory spanFactory)`
   /// The returned object must be released after use, by calling the [release] method.
-  EmojiCompat_Config? setSpanFactory(
-    EmojiCompat_SpanFactory? spanFactory,
+  EmojiCompat$Config? setSpanFactory(
+    EmojiCompat$SpanFactory? spanFactory,
   ) {
     final _$spanFactory = spanFactory?.reference ?? jni$_.jNullReference;
     return _setSpanFactory(reference.pointer,
             _id_setSpanFactory as jni$_.JMethodIDPtr, _$spanFactory.pointer)
-        .object<EmojiCompat_Config?>(const $EmojiCompat_Config$NullableType());
+        .object<EmojiCompat$Config?>(const $EmojiCompat$Config$NullableType());
   }
 
   static final _id_setGlyphChecker = _class.instanceMethodId(
@@ -917,20 +917,20 @@ class EmojiCompat_Config extends jni$_.JObject {
 
   /// from: `public androidx.emoji2.text.EmojiCompat$Config setGlyphChecker(androidx.emoji2.text.EmojiCompat$GlyphChecker glyphChecker)`
   /// The returned object must be released after use, by calling the [release] method.
-  EmojiCompat_Config? setGlyphChecker(
-    EmojiCompat_GlyphChecker? glyphChecker,
+  EmojiCompat$Config? setGlyphChecker(
+    EmojiCompat$GlyphChecker? glyphChecker,
   ) {
     final _$glyphChecker = glyphChecker?.reference ?? jni$_.jNullReference;
     return _setGlyphChecker(reference.pointer,
             _id_setGlyphChecker as jni$_.JMethodIDPtr, _$glyphChecker.pointer)
-        .object<EmojiCompat_Config?>(const $EmojiCompat_Config$NullableType());
+        .object<EmojiCompat$Config?>(const $EmojiCompat$Config$NullableType());
   }
 }
 
-final class $EmojiCompat_Config$NullableType
-    extends jni$_.JObjType<EmojiCompat_Config?> {
+final class $EmojiCompat$Config$NullableType
+    extends jni$_.JObjType<EmojiCompat$Config?> {
   @jni$_.internal
-  const $EmojiCompat_Config$NullableType();
+  const $EmojiCompat$Config$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -938,10 +938,10 @@ final class $EmojiCompat_Config$NullableType
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_Config? fromReference(jni$_.JReference reference) =>
+  EmojiCompat$Config? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : EmojiCompat_Config.fromReference(
+          : EmojiCompat$Config.fromReference(
               reference,
             );
   @jni$_.internal
@@ -950,26 +950,26 @@ final class $EmojiCompat_Config$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_Config?> get nullableType => this;
+  jni$_.JObjType<EmojiCompat$Config?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_Config$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$Config$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat_Config$NullableType) &&
-        other is $EmojiCompat_Config$NullableType;
+    return other.runtimeType == ($EmojiCompat$Config$NullableType) &&
+        other is $EmojiCompat$Config$NullableType;
   }
 }
 
-final class $EmojiCompat_Config$Type
-    extends jni$_.JObjType<EmojiCompat_Config> {
+final class $EmojiCompat$Config$Type
+    extends jni$_.JObjType<EmojiCompat$Config> {
   @jni$_.internal
-  const $EmojiCompat_Config$Type();
+  const $EmojiCompat$Config$Type();
 
   @jni$_.internal
   @core$_.override
@@ -977,8 +977,8 @@ final class $EmojiCompat_Config$Type
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_Config fromReference(jni$_.JReference reference) =>
-      EmojiCompat_Config.fromReference(
+  EmojiCompat$Config fromReference(jni$_.JReference reference) =>
+      EmojiCompat$Config.fromReference(
         reference,
       );
   @jni$_.internal
@@ -987,31 +987,31 @@ final class $EmojiCompat_Config$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_Config?> get nullableType =>
-      const $EmojiCompat_Config$NullableType();
+  jni$_.JObjType<EmojiCompat$Config?> get nullableType =>
+      const $EmojiCompat$Config$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_Config$Type).hashCode;
+  int get hashCode => ($EmojiCompat$Config$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat_Config$Type) &&
-        other is $EmojiCompat_Config$Type;
+    return other.runtimeType == ($EmojiCompat$Config$Type) &&
+        other is $EmojiCompat$Config$Type;
   }
 }
 
 /// from: `androidx.emoji2.text.EmojiCompat$DefaultSpanFactory`
-class EmojiCompat_DefaultSpanFactory extends jni$_.JObject {
+class EmojiCompat$DefaultSpanFactory extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat_DefaultSpanFactory> $type;
+  final jni$_.JObjType<EmojiCompat$DefaultSpanFactory> $type;
 
   @jni$_.internal
-  EmojiCompat_DefaultSpanFactory.fromReference(
+  EmojiCompat$DefaultSpanFactory.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -1020,8 +1020,8 @@ class EmojiCompat_DefaultSpanFactory extends jni$_.JObject {
       r'androidx/emoji2/text/EmojiCompat$DefaultSpanFactory');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat_DefaultSpanFactory$NullableType();
-  static const type = $EmojiCompat_DefaultSpanFactory$Type();
+  static const nullableType = $EmojiCompat$DefaultSpanFactory$NullableType();
+  static const type = $EmojiCompat$DefaultSpanFactory$Type();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -1040,8 +1040,8 @@ class EmojiCompat_DefaultSpanFactory extends jni$_.JObject {
 
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
-  factory EmojiCompat_DefaultSpanFactory() {
-    return EmojiCompat_DefaultSpanFactory.fromReference(
+  factory EmojiCompat$DefaultSpanFactory() {
+    return EmojiCompat$DefaultSpanFactory.fromReference(
         _new$(_class.reference.pointer, _id_new$ as jni$_.JMethodIDPtr)
             .reference);
   }
@@ -1075,10 +1075,10 @@ class EmojiCompat_DefaultSpanFactory extends jni$_.JObject {
   }
 }
 
-final class $EmojiCompat_DefaultSpanFactory$NullableType
-    extends jni$_.JObjType<EmojiCompat_DefaultSpanFactory?> {
+final class $EmojiCompat$DefaultSpanFactory$NullableType
+    extends jni$_.JObjType<EmojiCompat$DefaultSpanFactory?> {
   @jni$_.internal
-  const $EmojiCompat_DefaultSpanFactory$NullableType();
+  const $EmojiCompat$DefaultSpanFactory$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -1087,10 +1087,10 @@ final class $EmojiCompat_DefaultSpanFactory$NullableType
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_DefaultSpanFactory? fromReference(jni$_.JReference reference) =>
+  EmojiCompat$DefaultSpanFactory? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : EmojiCompat_DefaultSpanFactory.fromReference(
+          : EmojiCompat$DefaultSpanFactory.fromReference(
               reference,
             );
   @jni$_.internal
@@ -1099,27 +1099,27 @@ final class $EmojiCompat_DefaultSpanFactory$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_DefaultSpanFactory?> get nullableType => this;
+  jni$_.JObjType<EmojiCompat$DefaultSpanFactory?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_DefaultSpanFactory$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$DefaultSpanFactory$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($EmojiCompat_DefaultSpanFactory$NullableType) &&
-        other is $EmojiCompat_DefaultSpanFactory$NullableType;
+            ($EmojiCompat$DefaultSpanFactory$NullableType) &&
+        other is $EmojiCompat$DefaultSpanFactory$NullableType;
   }
 }
 
-final class $EmojiCompat_DefaultSpanFactory$Type
-    extends jni$_.JObjType<EmojiCompat_DefaultSpanFactory> {
+final class $EmojiCompat$DefaultSpanFactory$Type
+    extends jni$_.JObjType<EmojiCompat$DefaultSpanFactory> {
   @jni$_.internal
-  const $EmojiCompat_DefaultSpanFactory$Type();
+  const $EmojiCompat$DefaultSpanFactory$Type();
 
   @jni$_.internal
   @core$_.override
@@ -1128,8 +1128,8 @@ final class $EmojiCompat_DefaultSpanFactory$Type
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_DefaultSpanFactory fromReference(jni$_.JReference reference) =>
-      EmojiCompat_DefaultSpanFactory.fromReference(
+  EmojiCompat$DefaultSpanFactory fromReference(jni$_.JReference reference) =>
+      EmojiCompat$DefaultSpanFactory.fromReference(
         reference,
       );
   @jni$_.internal
@@ -1138,31 +1138,31 @@ final class $EmojiCompat_DefaultSpanFactory$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_DefaultSpanFactory?> get nullableType =>
-      const $EmojiCompat_DefaultSpanFactory$NullableType();
+  jni$_.JObjType<EmojiCompat$DefaultSpanFactory?> get nullableType =>
+      const $EmojiCompat$DefaultSpanFactory$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_DefaultSpanFactory$Type).hashCode;
+  int get hashCode => ($EmojiCompat$DefaultSpanFactory$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat_DefaultSpanFactory$Type) &&
-        other is $EmojiCompat_DefaultSpanFactory$Type;
+    return other.runtimeType == ($EmojiCompat$DefaultSpanFactory$Type) &&
+        other is $EmojiCompat$DefaultSpanFactory$Type;
   }
 }
 
 /// from: `androidx.emoji2.text.EmojiCompat$GlyphChecker`
-class EmojiCompat_GlyphChecker extends jni$_.JObject {
+class EmojiCompat$GlyphChecker extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat_GlyphChecker> $type;
+  final jni$_.JObjType<EmojiCompat$GlyphChecker> $type;
 
   @jni$_.internal
-  EmojiCompat_GlyphChecker.fromReference(
+  EmojiCompat$GlyphChecker.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -1171,8 +1171,8 @@ class EmojiCompat_GlyphChecker extends jni$_.JObject {
       jni$_.JClass.forName(r'androidx/emoji2/text/EmojiCompat$GlyphChecker');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat_GlyphChecker$NullableType();
-  static const type = $EmojiCompat_GlyphChecker$Type();
+  static const nullableType = $EmojiCompat$GlyphChecker$NullableType();
+  static const type = $EmojiCompat$GlyphChecker$Type();
   static final _id_hasGlyph = _class.instanceMethodId(
     r'hasGlyph',
     r'(Ljava/lang/CharSequence;III)Z',
@@ -1208,7 +1208,7 @@ class EmojiCompat_GlyphChecker extends jni$_.JObject {
   }
 
   /// Maps a specific port to the implemented interface.
-  static final core$_.Map<int, $EmojiCompat_GlyphChecker> _$impls = {};
+  static final core$_.Map<int, $EmojiCompat$GlyphChecker> _$impls = {};
   static jni$_.JObjectPtr _$invoke(
     int port,
     jni$_.JObjectPtr descriptor,
@@ -1260,7 +1260,7 @@ class EmojiCompat_GlyphChecker extends jni$_.JObject {
 
   static void implementIn(
     jni$_.JImplementer implementer,
-    $EmojiCompat_GlyphChecker $impl,
+    $EmojiCompat$GlyphChecker $impl,
   ) {
     late final jni$_.RawReceivePort $p;
     $p = jni$_.RawReceivePort(($m) {
@@ -1283,28 +1283,28 @@ class EmojiCompat_GlyphChecker extends jni$_.JObject {
     _$impls[$a] = $impl;
   }
 
-  factory EmojiCompat_GlyphChecker.implement(
-    $EmojiCompat_GlyphChecker $impl,
+  factory EmojiCompat$GlyphChecker.implement(
+    $EmojiCompat$GlyphChecker $impl,
   ) {
     final $i = jni$_.JImplementer();
     implementIn($i, $impl);
-    return EmojiCompat_GlyphChecker.fromReference(
+    return EmojiCompat$GlyphChecker.fromReference(
       $i.implementReference(),
     );
   }
 }
 
-abstract base mixin class $EmojiCompat_GlyphChecker {
-  factory $EmojiCompat_GlyphChecker({
+abstract base mixin class $EmojiCompat$GlyphChecker {
+  factory $EmojiCompat$GlyphChecker({
     required bool Function(jni$_.JObject? charSequence, int i, int i1, int i2)
         hasGlyph,
-  }) = _$EmojiCompat_GlyphChecker;
+  }) = _$EmojiCompat$GlyphChecker;
 
   bool hasGlyph(jni$_.JObject? charSequence, int i, int i1, int i2);
 }
 
-final class _$EmojiCompat_GlyphChecker with $EmojiCompat_GlyphChecker {
-  _$EmojiCompat_GlyphChecker({
+final class _$EmojiCompat$GlyphChecker with $EmojiCompat$GlyphChecker {
+  _$EmojiCompat$GlyphChecker({
     required bool Function(jni$_.JObject? charSequence, int i, int i1, int i2)
         hasGlyph,
   }) : _hasGlyph = hasGlyph;
@@ -1317,10 +1317,10 @@ final class _$EmojiCompat_GlyphChecker with $EmojiCompat_GlyphChecker {
   }
 }
 
-final class $EmojiCompat_GlyphChecker$NullableType
-    extends jni$_.JObjType<EmojiCompat_GlyphChecker?> {
+final class $EmojiCompat$GlyphChecker$NullableType
+    extends jni$_.JObjType<EmojiCompat$GlyphChecker?> {
   @jni$_.internal
-  const $EmojiCompat_GlyphChecker$NullableType();
+  const $EmojiCompat$GlyphChecker$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -1328,10 +1328,10 @@ final class $EmojiCompat_GlyphChecker$NullableType
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_GlyphChecker? fromReference(jni$_.JReference reference) =>
+  EmojiCompat$GlyphChecker? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : EmojiCompat_GlyphChecker.fromReference(
+          : EmojiCompat$GlyphChecker.fromReference(
               reference,
             );
   @jni$_.internal
@@ -1340,26 +1340,26 @@ final class $EmojiCompat_GlyphChecker$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_GlyphChecker?> get nullableType => this;
+  jni$_.JObjType<EmojiCompat$GlyphChecker?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_GlyphChecker$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$GlyphChecker$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat_GlyphChecker$NullableType) &&
-        other is $EmojiCompat_GlyphChecker$NullableType;
+    return other.runtimeType == ($EmojiCompat$GlyphChecker$NullableType) &&
+        other is $EmojiCompat$GlyphChecker$NullableType;
   }
 }
 
-final class $EmojiCompat_GlyphChecker$Type
-    extends jni$_.JObjType<EmojiCompat_GlyphChecker> {
+final class $EmojiCompat$GlyphChecker$Type
+    extends jni$_.JObjType<EmojiCompat$GlyphChecker> {
   @jni$_.internal
-  const $EmojiCompat_GlyphChecker$Type();
+  const $EmojiCompat$GlyphChecker$Type();
 
   @jni$_.internal
   @core$_.override
@@ -1367,8 +1367,8 @@ final class $EmojiCompat_GlyphChecker$Type
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_GlyphChecker fromReference(jni$_.JReference reference) =>
-      EmojiCompat_GlyphChecker.fromReference(
+  EmojiCompat$GlyphChecker fromReference(jni$_.JReference reference) =>
+      EmojiCompat$GlyphChecker.fromReference(
         reference,
       );
   @jni$_.internal
@@ -1377,31 +1377,31 @@ final class $EmojiCompat_GlyphChecker$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_GlyphChecker?> get nullableType =>
-      const $EmojiCompat_GlyphChecker$NullableType();
+  jni$_.JObjType<EmojiCompat$GlyphChecker?> get nullableType =>
+      const $EmojiCompat$GlyphChecker$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_GlyphChecker$Type).hashCode;
+  int get hashCode => ($EmojiCompat$GlyphChecker$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat_GlyphChecker$Type) &&
-        other is $EmojiCompat_GlyphChecker$Type;
+    return other.runtimeType == ($EmojiCompat$GlyphChecker$Type) &&
+        other is $EmojiCompat$GlyphChecker$Type;
   }
 }
 
 /// from: `androidx.emoji2.text.EmojiCompat$InitCallback`
-class EmojiCompat_InitCallback extends jni$_.JObject {
+class EmojiCompat$InitCallback extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat_InitCallback> $type;
+  final jni$_.JObjType<EmojiCompat$InitCallback> $type;
 
   @jni$_.internal
-  EmojiCompat_InitCallback.fromReference(
+  EmojiCompat$InitCallback.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -1410,8 +1410,8 @@ class EmojiCompat_InitCallback extends jni$_.JObject {
       jni$_.JClass.forName(r'androidx/emoji2/text/EmojiCompat$InitCallback');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat_InitCallback$NullableType();
-  static const type = $EmojiCompat_InitCallback$Type();
+  static const nullableType = $EmojiCompat$InitCallback$NullableType();
+  static const type = $EmojiCompat$InitCallback$Type();
   static final _id_onInitialized = _class.instanceMethodId(
     r'onInitialized',
     r'()V',
@@ -1462,10 +1462,10 @@ class EmojiCompat_InitCallback extends jni$_.JObject {
   }
 }
 
-final class $EmojiCompat_InitCallback$NullableType
-    extends jni$_.JObjType<EmojiCompat_InitCallback?> {
+final class $EmojiCompat$InitCallback$NullableType
+    extends jni$_.JObjType<EmojiCompat$InitCallback?> {
   @jni$_.internal
-  const $EmojiCompat_InitCallback$NullableType();
+  const $EmojiCompat$InitCallback$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -1473,10 +1473,10 @@ final class $EmojiCompat_InitCallback$NullableType
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_InitCallback? fromReference(jni$_.JReference reference) =>
+  EmojiCompat$InitCallback? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : EmojiCompat_InitCallback.fromReference(
+          : EmojiCompat$InitCallback.fromReference(
               reference,
             );
   @jni$_.internal
@@ -1485,26 +1485,26 @@ final class $EmojiCompat_InitCallback$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_InitCallback?> get nullableType => this;
+  jni$_.JObjType<EmojiCompat$InitCallback?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_InitCallback$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$InitCallback$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat_InitCallback$NullableType) &&
-        other is $EmojiCompat_InitCallback$NullableType;
+    return other.runtimeType == ($EmojiCompat$InitCallback$NullableType) &&
+        other is $EmojiCompat$InitCallback$NullableType;
   }
 }
 
-final class $EmojiCompat_InitCallback$Type
-    extends jni$_.JObjType<EmojiCompat_InitCallback> {
+final class $EmojiCompat$InitCallback$Type
+    extends jni$_.JObjType<EmojiCompat$InitCallback> {
   @jni$_.internal
-  const $EmojiCompat_InitCallback$Type();
+  const $EmojiCompat$InitCallback$Type();
 
   @jni$_.internal
   @core$_.override
@@ -1512,8 +1512,8 @@ final class $EmojiCompat_InitCallback$Type
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_InitCallback fromReference(jni$_.JReference reference) =>
-      EmojiCompat_InitCallback.fromReference(
+  EmojiCompat$InitCallback fromReference(jni$_.JReference reference) =>
+      EmojiCompat$InitCallback.fromReference(
         reference,
       );
   @jni$_.internal
@@ -1522,31 +1522,31 @@ final class $EmojiCompat_InitCallback$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_InitCallback?> get nullableType =>
-      const $EmojiCompat_InitCallback$NullableType();
+  jni$_.JObjType<EmojiCompat$InitCallback?> get nullableType =>
+      const $EmojiCompat$InitCallback$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_InitCallback$Type).hashCode;
+  int get hashCode => ($EmojiCompat$InitCallback$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat_InitCallback$Type) &&
-        other is $EmojiCompat_InitCallback$Type;
+    return other.runtimeType == ($EmojiCompat$InitCallback$Type) &&
+        other is $EmojiCompat$InitCallback$Type;
   }
 }
 
 /// from: `androidx.emoji2.text.EmojiCompat$LoadStrategy`
-class EmojiCompat_LoadStrategy extends jni$_.JObject {
+class EmojiCompat$LoadStrategy extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat_LoadStrategy> $type;
+  final jni$_.JObjType<EmojiCompat$LoadStrategy> $type;
 
   @jni$_.internal
-  EmojiCompat_LoadStrategy.fromReference(
+  EmojiCompat$LoadStrategy.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -1555,11 +1555,11 @@ class EmojiCompat_LoadStrategy extends jni$_.JObject {
       jni$_.JClass.forName(r'androidx/emoji2/text/EmojiCompat$LoadStrategy');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat_LoadStrategy$NullableType();
-  static const type = $EmojiCompat_LoadStrategy$Type();
+  static const nullableType = $EmojiCompat$LoadStrategy$NullableType();
+  static const type = $EmojiCompat$LoadStrategy$Type();
 
   /// Maps a specific port to the implemented interface.
-  static final core$_.Map<int, $EmojiCompat_LoadStrategy> _$impls = {};
+  static final core$_.Map<int, $EmojiCompat$LoadStrategy> _$impls = {};
   static jni$_.JObjectPtr _$invoke(
     int port,
     jni$_.JObjectPtr descriptor,
@@ -1596,7 +1596,7 @@ class EmojiCompat_LoadStrategy extends jni$_.JObject {
 
   static void implementIn(
     jni$_.JImplementer implementer,
-    $EmojiCompat_LoadStrategy $impl,
+    $EmojiCompat$LoadStrategy $impl,
   ) {
     late final jni$_.RawReceivePort $p;
     $p = jni$_.RawReceivePort(($m) {
@@ -1619,29 +1619,29 @@ class EmojiCompat_LoadStrategy extends jni$_.JObject {
     _$impls[$a] = $impl;
   }
 
-  factory EmojiCompat_LoadStrategy.implement(
-    $EmojiCompat_LoadStrategy $impl,
+  factory EmojiCompat$LoadStrategy.implement(
+    $EmojiCompat$LoadStrategy $impl,
   ) {
     final $i = jni$_.JImplementer();
     implementIn($i, $impl);
-    return EmojiCompat_LoadStrategy.fromReference(
+    return EmojiCompat$LoadStrategy.fromReference(
       $i.implementReference(),
     );
   }
 }
 
-abstract base mixin class $EmojiCompat_LoadStrategy {
-  factory $EmojiCompat_LoadStrategy() = _$EmojiCompat_LoadStrategy;
+abstract base mixin class $EmojiCompat$LoadStrategy {
+  factory $EmojiCompat$LoadStrategy() = _$EmojiCompat$LoadStrategy;
 }
 
-final class _$EmojiCompat_LoadStrategy with $EmojiCompat_LoadStrategy {
-  _$EmojiCompat_LoadStrategy();
+final class _$EmojiCompat$LoadStrategy with $EmojiCompat$LoadStrategy {
+  _$EmojiCompat$LoadStrategy();
 }
 
-final class $EmojiCompat_LoadStrategy$NullableType
-    extends jni$_.JObjType<EmojiCompat_LoadStrategy?> {
+final class $EmojiCompat$LoadStrategy$NullableType
+    extends jni$_.JObjType<EmojiCompat$LoadStrategy?> {
   @jni$_.internal
-  const $EmojiCompat_LoadStrategy$NullableType();
+  const $EmojiCompat$LoadStrategy$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -1649,10 +1649,10 @@ final class $EmojiCompat_LoadStrategy$NullableType
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_LoadStrategy? fromReference(jni$_.JReference reference) =>
+  EmojiCompat$LoadStrategy? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : EmojiCompat_LoadStrategy.fromReference(
+          : EmojiCompat$LoadStrategy.fromReference(
               reference,
             );
   @jni$_.internal
@@ -1661,26 +1661,26 @@ final class $EmojiCompat_LoadStrategy$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_LoadStrategy?> get nullableType => this;
+  jni$_.JObjType<EmojiCompat$LoadStrategy?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_LoadStrategy$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$LoadStrategy$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat_LoadStrategy$NullableType) &&
-        other is $EmojiCompat_LoadStrategy$NullableType;
+    return other.runtimeType == ($EmojiCompat$LoadStrategy$NullableType) &&
+        other is $EmojiCompat$LoadStrategy$NullableType;
   }
 }
 
-final class $EmojiCompat_LoadStrategy$Type
-    extends jni$_.JObjType<EmojiCompat_LoadStrategy> {
+final class $EmojiCompat$LoadStrategy$Type
+    extends jni$_.JObjType<EmojiCompat$LoadStrategy> {
   @jni$_.internal
-  const $EmojiCompat_LoadStrategy$Type();
+  const $EmojiCompat$LoadStrategy$Type();
 
   @jni$_.internal
   @core$_.override
@@ -1688,8 +1688,8 @@ final class $EmojiCompat_LoadStrategy$Type
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_LoadStrategy fromReference(jni$_.JReference reference) =>
-      EmojiCompat_LoadStrategy.fromReference(
+  EmojiCompat$LoadStrategy fromReference(jni$_.JReference reference) =>
+      EmojiCompat$LoadStrategy.fromReference(
         reference,
       );
   @jni$_.internal
@@ -1698,31 +1698,31 @@ final class $EmojiCompat_LoadStrategy$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_LoadStrategy?> get nullableType =>
-      const $EmojiCompat_LoadStrategy$NullableType();
+  jni$_.JObjType<EmojiCompat$LoadStrategy?> get nullableType =>
+      const $EmojiCompat$LoadStrategy$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_LoadStrategy$Type).hashCode;
+  int get hashCode => ($EmojiCompat$LoadStrategy$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat_LoadStrategy$Type) &&
-        other is $EmojiCompat_LoadStrategy$Type;
+    return other.runtimeType == ($EmojiCompat$LoadStrategy$Type) &&
+        other is $EmojiCompat$LoadStrategy$Type;
   }
 }
 
 /// from: `androidx.emoji2.text.EmojiCompat$MetadataRepoLoader`
-class EmojiCompat_MetadataRepoLoader extends jni$_.JObject {
+class EmojiCompat$MetadataRepoLoader extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat_MetadataRepoLoader> $type;
+  final jni$_.JObjType<EmojiCompat$MetadataRepoLoader> $type;
 
   @jni$_.internal
-  EmojiCompat_MetadataRepoLoader.fromReference(
+  EmojiCompat$MetadataRepoLoader.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -1731,8 +1731,8 @@ class EmojiCompat_MetadataRepoLoader extends jni$_.JObject {
       r'androidx/emoji2/text/EmojiCompat$MetadataRepoLoader');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat_MetadataRepoLoader$NullableType();
-  static const type = $EmojiCompat_MetadataRepoLoader$Type();
+  static const nullableType = $EmojiCompat$MetadataRepoLoader$NullableType();
+  static const type = $EmojiCompat$MetadataRepoLoader$Type();
   static final _id_load = _class.instanceMethodId(
     r'load',
     r'(Landroidx/emoji2/text/EmojiCompat$MetadataRepoLoaderCallback;)V',
@@ -1751,7 +1751,7 @@ class EmojiCompat_MetadataRepoLoader extends jni$_.JObject {
 
   /// from: `public abstract void load(androidx.emoji2.text.EmojiCompat$MetadataRepoLoaderCallback metadataRepoLoaderCallback)`
   void load(
-    EmojiCompat_MetadataRepoLoaderCallback? metadataRepoLoaderCallback,
+    EmojiCompat$MetadataRepoLoaderCallback? metadataRepoLoaderCallback,
   ) {
     final _$metadataRepoLoaderCallback =
         metadataRepoLoaderCallback?.reference ?? jni$_.jNullReference;
@@ -1761,7 +1761,7 @@ class EmojiCompat_MetadataRepoLoader extends jni$_.JObject {
   }
 
   /// Maps a specific port to the implemented interface.
-  static final core$_.Map<int, $EmojiCompat_MetadataRepoLoader> _$impls = {};
+  static final core$_.Map<int, $EmojiCompat$MetadataRepoLoader> _$impls = {};
   static jni$_.JObjectPtr _$invoke(
     int port,
     jni$_.JObjectPtr descriptor,
@@ -1793,7 +1793,7 @@ class EmojiCompat_MetadataRepoLoader extends jni$_.JObject {
       if ($d ==
           r'load(Landroidx/emoji2/text/EmojiCompat$MetadataRepoLoaderCallback;)V') {
         _$impls[$p]!.load(
-          $a![0]?.as(const $EmojiCompat_MetadataRepoLoaderCallback$Type(),
+          $a![0]?.as(const $EmojiCompat$MetadataRepoLoaderCallback$Type(),
               releaseOriginal: true),
         );
         return jni$_.nullptr;
@@ -1806,7 +1806,7 @@ class EmojiCompat_MetadataRepoLoader extends jni$_.JObject {
 
   static void implementIn(
     jni$_.JImplementer implementer,
-    $EmojiCompat_MetadataRepoLoader $impl,
+    $EmojiCompat$MetadataRepoLoader $impl,
   ) {
     late final jni$_.RawReceivePort $p;
     $p = jni$_.RawReceivePort(($m) {
@@ -1832,52 +1832,52 @@ class EmojiCompat_MetadataRepoLoader extends jni$_.JObject {
     _$impls[$a] = $impl;
   }
 
-  factory EmojiCompat_MetadataRepoLoader.implement(
-    $EmojiCompat_MetadataRepoLoader $impl,
+  factory EmojiCompat$MetadataRepoLoader.implement(
+    $EmojiCompat$MetadataRepoLoader $impl,
   ) {
     final $i = jni$_.JImplementer();
     implementIn($i, $impl);
-    return EmojiCompat_MetadataRepoLoader.fromReference(
+    return EmojiCompat$MetadataRepoLoader.fromReference(
       $i.implementReference(),
     );
   }
 }
 
-abstract base mixin class $EmojiCompat_MetadataRepoLoader {
-  factory $EmojiCompat_MetadataRepoLoader({
+abstract base mixin class $EmojiCompat$MetadataRepoLoader {
+  factory $EmojiCompat$MetadataRepoLoader({
     required void Function(
-            EmojiCompat_MetadataRepoLoaderCallback? metadataRepoLoaderCallback)
+            EmojiCompat$MetadataRepoLoaderCallback? metadataRepoLoaderCallback)
         load,
     bool load$async,
-  }) = _$EmojiCompat_MetadataRepoLoader;
+  }) = _$EmojiCompat$MetadataRepoLoader;
 
-  void load(EmojiCompat_MetadataRepoLoaderCallback? metadataRepoLoaderCallback);
+  void load(EmojiCompat$MetadataRepoLoaderCallback? metadataRepoLoaderCallback);
   bool get load$async => false;
 }
 
-final class _$EmojiCompat_MetadataRepoLoader
-    with $EmojiCompat_MetadataRepoLoader {
-  _$EmojiCompat_MetadataRepoLoader({
+final class _$EmojiCompat$MetadataRepoLoader
+    with $EmojiCompat$MetadataRepoLoader {
+  _$EmojiCompat$MetadataRepoLoader({
     required void Function(
-            EmojiCompat_MetadataRepoLoaderCallback? metadataRepoLoaderCallback)
+            EmojiCompat$MetadataRepoLoaderCallback? metadataRepoLoaderCallback)
         load,
     this.load$async = false,
   }) : _load = load;
 
   final void Function(
-      EmojiCompat_MetadataRepoLoaderCallback? metadataRepoLoaderCallback) _load;
+      EmojiCompat$MetadataRepoLoaderCallback? metadataRepoLoaderCallback) _load;
   final bool load$async;
 
   void load(
-      EmojiCompat_MetadataRepoLoaderCallback? metadataRepoLoaderCallback) {
+      EmojiCompat$MetadataRepoLoaderCallback? metadataRepoLoaderCallback) {
     return _load(metadataRepoLoaderCallback);
   }
 }
 
-final class $EmojiCompat_MetadataRepoLoader$NullableType
-    extends jni$_.JObjType<EmojiCompat_MetadataRepoLoader?> {
+final class $EmojiCompat$MetadataRepoLoader$NullableType
+    extends jni$_.JObjType<EmojiCompat$MetadataRepoLoader?> {
   @jni$_.internal
-  const $EmojiCompat_MetadataRepoLoader$NullableType();
+  const $EmojiCompat$MetadataRepoLoader$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -1886,10 +1886,10 @@ final class $EmojiCompat_MetadataRepoLoader$NullableType
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_MetadataRepoLoader? fromReference(jni$_.JReference reference) =>
+  EmojiCompat$MetadataRepoLoader? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : EmojiCompat_MetadataRepoLoader.fromReference(
+          : EmojiCompat$MetadataRepoLoader.fromReference(
               reference,
             );
   @jni$_.internal
@@ -1898,27 +1898,27 @@ final class $EmojiCompat_MetadataRepoLoader$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_MetadataRepoLoader?> get nullableType => this;
+  jni$_.JObjType<EmojiCompat$MetadataRepoLoader?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_MetadataRepoLoader$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$MetadataRepoLoader$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($EmojiCompat_MetadataRepoLoader$NullableType) &&
-        other is $EmojiCompat_MetadataRepoLoader$NullableType;
+            ($EmojiCompat$MetadataRepoLoader$NullableType) &&
+        other is $EmojiCompat$MetadataRepoLoader$NullableType;
   }
 }
 
-final class $EmojiCompat_MetadataRepoLoader$Type
-    extends jni$_.JObjType<EmojiCompat_MetadataRepoLoader> {
+final class $EmojiCompat$MetadataRepoLoader$Type
+    extends jni$_.JObjType<EmojiCompat$MetadataRepoLoader> {
   @jni$_.internal
-  const $EmojiCompat_MetadataRepoLoader$Type();
+  const $EmojiCompat$MetadataRepoLoader$Type();
 
   @jni$_.internal
   @core$_.override
@@ -1927,8 +1927,8 @@ final class $EmojiCompat_MetadataRepoLoader$Type
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_MetadataRepoLoader fromReference(jni$_.JReference reference) =>
-      EmojiCompat_MetadataRepoLoader.fromReference(
+  EmojiCompat$MetadataRepoLoader fromReference(jni$_.JReference reference) =>
+      EmojiCompat$MetadataRepoLoader.fromReference(
         reference,
       );
   @jni$_.internal
@@ -1937,31 +1937,31 @@ final class $EmojiCompat_MetadataRepoLoader$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_MetadataRepoLoader?> get nullableType =>
-      const $EmojiCompat_MetadataRepoLoader$NullableType();
+  jni$_.JObjType<EmojiCompat$MetadataRepoLoader?> get nullableType =>
+      const $EmojiCompat$MetadataRepoLoader$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_MetadataRepoLoader$Type).hashCode;
+  int get hashCode => ($EmojiCompat$MetadataRepoLoader$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat_MetadataRepoLoader$Type) &&
-        other is $EmojiCompat_MetadataRepoLoader$Type;
+    return other.runtimeType == ($EmojiCompat$MetadataRepoLoader$Type) &&
+        other is $EmojiCompat$MetadataRepoLoader$Type;
   }
 }
 
 /// from: `androidx.emoji2.text.EmojiCompat$MetadataRepoLoaderCallback`
-class EmojiCompat_MetadataRepoLoaderCallback extends jni$_.JObject {
+class EmojiCompat$MetadataRepoLoaderCallback extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat_MetadataRepoLoaderCallback> $type;
+  final jni$_.JObjType<EmojiCompat$MetadataRepoLoaderCallback> $type;
 
   @jni$_.internal
-  EmojiCompat_MetadataRepoLoaderCallback.fromReference(
+  EmojiCompat$MetadataRepoLoaderCallback.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -1971,8 +1971,8 @@ class EmojiCompat_MetadataRepoLoaderCallback extends jni$_.JObject {
 
   /// The type which includes information such as the signature of this class.
   static const nullableType =
-      $EmojiCompat_MetadataRepoLoaderCallback$NullableType();
-  static const type = $EmojiCompat_MetadataRepoLoaderCallback$Type();
+      $EmojiCompat$MetadataRepoLoaderCallback$NullableType();
+  static const type = $EmojiCompat$MetadataRepoLoaderCallback$Type();
   static final _id_onLoaded = _class.instanceMethodId(
     r'onLoaded',
     r'(Landroidx/emoji2/text/MetadataRepo;)V',
@@ -2026,10 +2026,10 @@ class EmojiCompat_MetadataRepoLoaderCallback extends jni$_.JObject {
   }
 }
 
-final class $EmojiCompat_MetadataRepoLoaderCallback$NullableType
-    extends jni$_.JObjType<EmojiCompat_MetadataRepoLoaderCallback?> {
+final class $EmojiCompat$MetadataRepoLoaderCallback$NullableType
+    extends jni$_.JObjType<EmojiCompat$MetadataRepoLoaderCallback?> {
   @jni$_.internal
-  const $EmojiCompat_MetadataRepoLoaderCallback$NullableType();
+  const $EmojiCompat$MetadataRepoLoaderCallback$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -2038,11 +2038,11 @@ final class $EmojiCompat_MetadataRepoLoaderCallback$NullableType
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_MetadataRepoLoaderCallback? fromReference(
+  EmojiCompat$MetadataRepoLoaderCallback? fromReference(
           jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : EmojiCompat_MetadataRepoLoaderCallback.fromReference(
+          : EmojiCompat$MetadataRepoLoaderCallback.fromReference(
               reference,
             );
   @jni$_.internal
@@ -2051,7 +2051,7 @@ final class $EmojiCompat_MetadataRepoLoaderCallback$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_MetadataRepoLoaderCallback?> get nullableType =>
+  jni$_.JObjType<EmojiCompat$MetadataRepoLoaderCallback?> get nullableType =>
       this;
 
   @jni$_.internal
@@ -2060,20 +2060,20 @@ final class $EmojiCompat_MetadataRepoLoaderCallback$NullableType
 
   @core$_.override
   int get hashCode =>
-      ($EmojiCompat_MetadataRepoLoaderCallback$NullableType).hashCode;
+      ($EmojiCompat$MetadataRepoLoaderCallback$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($EmojiCompat_MetadataRepoLoaderCallback$NullableType) &&
-        other is $EmojiCompat_MetadataRepoLoaderCallback$NullableType;
+            ($EmojiCompat$MetadataRepoLoaderCallback$NullableType) &&
+        other is $EmojiCompat$MetadataRepoLoaderCallback$NullableType;
   }
 }
 
-final class $EmojiCompat_MetadataRepoLoaderCallback$Type
-    extends jni$_.JObjType<EmojiCompat_MetadataRepoLoaderCallback> {
+final class $EmojiCompat$MetadataRepoLoaderCallback$Type
+    extends jni$_.JObjType<EmojiCompat$MetadataRepoLoaderCallback> {
   @jni$_.internal
-  const $EmojiCompat_MetadataRepoLoaderCallback$Type();
+  const $EmojiCompat$MetadataRepoLoaderCallback$Type();
 
   @jni$_.internal
   @core$_.override
@@ -2082,9 +2082,9 @@ final class $EmojiCompat_MetadataRepoLoaderCallback$Type
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_MetadataRepoLoaderCallback fromReference(
+  EmojiCompat$MetadataRepoLoaderCallback fromReference(
           jni$_.JReference reference) =>
-      EmojiCompat_MetadataRepoLoaderCallback.fromReference(
+      EmojiCompat$MetadataRepoLoaderCallback.fromReference(
         reference,
       );
   @jni$_.internal
@@ -2093,32 +2093,32 @@ final class $EmojiCompat_MetadataRepoLoaderCallback$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_MetadataRepoLoaderCallback?> get nullableType =>
-      const $EmojiCompat_MetadataRepoLoaderCallback$NullableType();
+  jni$_.JObjType<EmojiCompat$MetadataRepoLoaderCallback?> get nullableType =>
+      const $EmojiCompat$MetadataRepoLoaderCallback$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_MetadataRepoLoaderCallback$Type).hashCode;
+  int get hashCode => ($EmojiCompat$MetadataRepoLoaderCallback$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($EmojiCompat_MetadataRepoLoaderCallback$Type) &&
-        other is $EmojiCompat_MetadataRepoLoaderCallback$Type;
+            ($EmojiCompat$MetadataRepoLoaderCallback$Type) &&
+        other is $EmojiCompat$MetadataRepoLoaderCallback$Type;
   }
 }
 
 /// from: `androidx.emoji2.text.EmojiCompat$ReplaceStrategy`
-class EmojiCompat_ReplaceStrategy extends jni$_.JObject {
+class EmojiCompat$ReplaceStrategy extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat_ReplaceStrategy> $type;
+  final jni$_.JObjType<EmojiCompat$ReplaceStrategy> $type;
 
   @jni$_.internal
-  EmojiCompat_ReplaceStrategy.fromReference(
+  EmojiCompat$ReplaceStrategy.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -2127,11 +2127,11 @@ class EmojiCompat_ReplaceStrategy extends jni$_.JObject {
       jni$_.JClass.forName(r'androidx/emoji2/text/EmojiCompat$ReplaceStrategy');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat_ReplaceStrategy$NullableType();
-  static const type = $EmojiCompat_ReplaceStrategy$Type();
+  static const nullableType = $EmojiCompat$ReplaceStrategy$NullableType();
+  static const type = $EmojiCompat$ReplaceStrategy$Type();
 
   /// Maps a specific port to the implemented interface.
-  static final core$_.Map<int, $EmojiCompat_ReplaceStrategy> _$impls = {};
+  static final core$_.Map<int, $EmojiCompat$ReplaceStrategy> _$impls = {};
   static jni$_.JObjectPtr _$invoke(
     int port,
     jni$_.JObjectPtr descriptor,
@@ -2168,7 +2168,7 @@ class EmojiCompat_ReplaceStrategy extends jni$_.JObject {
 
   static void implementIn(
     jni$_.JImplementer implementer,
-    $EmojiCompat_ReplaceStrategy $impl,
+    $EmojiCompat$ReplaceStrategy $impl,
   ) {
     late final jni$_.RawReceivePort $p;
     $p = jni$_.RawReceivePort(($m) {
@@ -2191,29 +2191,29 @@ class EmojiCompat_ReplaceStrategy extends jni$_.JObject {
     _$impls[$a] = $impl;
   }
 
-  factory EmojiCompat_ReplaceStrategy.implement(
-    $EmojiCompat_ReplaceStrategy $impl,
+  factory EmojiCompat$ReplaceStrategy.implement(
+    $EmojiCompat$ReplaceStrategy $impl,
   ) {
     final $i = jni$_.JImplementer();
     implementIn($i, $impl);
-    return EmojiCompat_ReplaceStrategy.fromReference(
+    return EmojiCompat$ReplaceStrategy.fromReference(
       $i.implementReference(),
     );
   }
 }
 
-abstract base mixin class $EmojiCompat_ReplaceStrategy {
-  factory $EmojiCompat_ReplaceStrategy() = _$EmojiCompat_ReplaceStrategy;
+abstract base mixin class $EmojiCompat$ReplaceStrategy {
+  factory $EmojiCompat$ReplaceStrategy() = _$EmojiCompat$ReplaceStrategy;
 }
 
-final class _$EmojiCompat_ReplaceStrategy with $EmojiCompat_ReplaceStrategy {
-  _$EmojiCompat_ReplaceStrategy();
+final class _$EmojiCompat$ReplaceStrategy with $EmojiCompat$ReplaceStrategy {
+  _$EmojiCompat$ReplaceStrategy();
 }
 
-final class $EmojiCompat_ReplaceStrategy$NullableType
-    extends jni$_.JObjType<EmojiCompat_ReplaceStrategy?> {
+final class $EmojiCompat$ReplaceStrategy$NullableType
+    extends jni$_.JObjType<EmojiCompat$ReplaceStrategy?> {
   @jni$_.internal
-  const $EmojiCompat_ReplaceStrategy$NullableType();
+  const $EmojiCompat$ReplaceStrategy$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -2221,10 +2221,10 @@ final class $EmojiCompat_ReplaceStrategy$NullableType
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_ReplaceStrategy? fromReference(jni$_.JReference reference) =>
+  EmojiCompat$ReplaceStrategy? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : EmojiCompat_ReplaceStrategy.fromReference(
+          : EmojiCompat$ReplaceStrategy.fromReference(
               reference,
             );
   @jni$_.internal
@@ -2233,26 +2233,26 @@ final class $EmojiCompat_ReplaceStrategy$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_ReplaceStrategy?> get nullableType => this;
+  jni$_.JObjType<EmojiCompat$ReplaceStrategy?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_ReplaceStrategy$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$ReplaceStrategy$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat_ReplaceStrategy$NullableType) &&
-        other is $EmojiCompat_ReplaceStrategy$NullableType;
+    return other.runtimeType == ($EmojiCompat$ReplaceStrategy$NullableType) &&
+        other is $EmojiCompat$ReplaceStrategy$NullableType;
   }
 }
 
-final class $EmojiCompat_ReplaceStrategy$Type
-    extends jni$_.JObjType<EmojiCompat_ReplaceStrategy> {
+final class $EmojiCompat$ReplaceStrategy$Type
+    extends jni$_.JObjType<EmojiCompat$ReplaceStrategy> {
   @jni$_.internal
-  const $EmojiCompat_ReplaceStrategy$Type();
+  const $EmojiCompat$ReplaceStrategy$Type();
 
   @jni$_.internal
   @core$_.override
@@ -2260,8 +2260,8 @@ final class $EmojiCompat_ReplaceStrategy$Type
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_ReplaceStrategy fromReference(jni$_.JReference reference) =>
-      EmojiCompat_ReplaceStrategy.fromReference(
+  EmojiCompat$ReplaceStrategy fromReference(jni$_.JReference reference) =>
+      EmojiCompat$ReplaceStrategy.fromReference(
         reference,
       );
   @jni$_.internal
@@ -2270,31 +2270,31 @@ final class $EmojiCompat_ReplaceStrategy$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_ReplaceStrategy?> get nullableType =>
-      const $EmojiCompat_ReplaceStrategy$NullableType();
+  jni$_.JObjType<EmojiCompat$ReplaceStrategy?> get nullableType =>
+      const $EmojiCompat$ReplaceStrategy$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_ReplaceStrategy$Type).hashCode;
+  int get hashCode => ($EmojiCompat$ReplaceStrategy$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat_ReplaceStrategy$Type) &&
-        other is $EmojiCompat_ReplaceStrategy$Type;
+    return other.runtimeType == ($EmojiCompat$ReplaceStrategy$Type) &&
+        other is $EmojiCompat$ReplaceStrategy$Type;
   }
 }
 
 /// from: `androidx.emoji2.text.EmojiCompat$SpanFactory`
-class EmojiCompat_SpanFactory extends jni$_.JObject {
+class EmojiCompat$SpanFactory extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat_SpanFactory> $type;
+  final jni$_.JObjType<EmojiCompat$SpanFactory> $type;
 
   @jni$_.internal
-  EmojiCompat_SpanFactory.fromReference(
+  EmojiCompat$SpanFactory.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -2303,8 +2303,8 @@ class EmojiCompat_SpanFactory extends jni$_.JObject {
       jni$_.JClass.forName(r'androidx/emoji2/text/EmojiCompat$SpanFactory');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat_SpanFactory$NullableType();
-  static const type = $EmojiCompat_SpanFactory$Type();
+  static const nullableType = $EmojiCompat$SpanFactory$NullableType();
+  static const type = $EmojiCompat$SpanFactory$Type();
   static final _id_createSpan = _class.instanceMethodId(
     r'createSpan',
     r'(Landroidx/emoji2/text/TypefaceEmojiRasterizer;)Landroidx/emoji2/text/EmojiSpan;',
@@ -2334,7 +2334,7 @@ class EmojiCompat_SpanFactory extends jni$_.JObject {
   }
 
   /// Maps a specific port to the implemented interface.
-  static final core$_.Map<int, $EmojiCompat_SpanFactory> _$impls = {};
+  static final core$_.Map<int, $EmojiCompat$SpanFactory> _$impls = {};
   static jni$_.JObjectPtr _$invoke(
     int port,
     jni$_.JObjectPtr descriptor,
@@ -2382,7 +2382,7 @@ class EmojiCompat_SpanFactory extends jni$_.JObject {
 
   static void implementIn(
     jni$_.JImplementer implementer,
-    $EmojiCompat_SpanFactory $impl,
+    $EmojiCompat$SpanFactory $impl,
   ) {
     late final jni$_.RawReceivePort $p;
     $p = jni$_.RawReceivePort(($m) {
@@ -2405,28 +2405,28 @@ class EmojiCompat_SpanFactory extends jni$_.JObject {
     _$impls[$a] = $impl;
   }
 
-  factory EmojiCompat_SpanFactory.implement(
-    $EmojiCompat_SpanFactory $impl,
+  factory EmojiCompat$SpanFactory.implement(
+    $EmojiCompat$SpanFactory $impl,
   ) {
     final $i = jni$_.JImplementer();
     implementIn($i, $impl);
-    return EmojiCompat_SpanFactory.fromReference(
+    return EmojiCompat$SpanFactory.fromReference(
       $i.implementReference(),
     );
   }
 }
 
-abstract base mixin class $EmojiCompat_SpanFactory {
-  factory $EmojiCompat_SpanFactory({
+abstract base mixin class $EmojiCompat$SpanFactory {
+  factory $EmojiCompat$SpanFactory({
     required jni$_.JObject? Function(jni$_.JObject? typefaceEmojiRasterizer)
         createSpan,
-  }) = _$EmojiCompat_SpanFactory;
+  }) = _$EmojiCompat$SpanFactory;
 
   jni$_.JObject? createSpan(jni$_.JObject? typefaceEmojiRasterizer);
 }
 
-final class _$EmojiCompat_SpanFactory with $EmojiCompat_SpanFactory {
-  _$EmojiCompat_SpanFactory({
+final class _$EmojiCompat$SpanFactory with $EmojiCompat$SpanFactory {
+  _$EmojiCompat$SpanFactory({
     required jni$_.JObject? Function(jni$_.JObject? typefaceEmojiRasterizer)
         createSpan,
   }) : _createSpan = createSpan;
@@ -2439,10 +2439,10 @@ final class _$EmojiCompat_SpanFactory with $EmojiCompat_SpanFactory {
   }
 }
 
-final class $EmojiCompat_SpanFactory$NullableType
-    extends jni$_.JObjType<EmojiCompat_SpanFactory?> {
+final class $EmojiCompat$SpanFactory$NullableType
+    extends jni$_.JObjType<EmojiCompat$SpanFactory?> {
   @jni$_.internal
-  const $EmojiCompat_SpanFactory$NullableType();
+  const $EmojiCompat$SpanFactory$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -2450,10 +2450,10 @@ final class $EmojiCompat_SpanFactory$NullableType
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_SpanFactory? fromReference(jni$_.JReference reference) =>
+  EmojiCompat$SpanFactory? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : EmojiCompat_SpanFactory.fromReference(
+          : EmojiCompat$SpanFactory.fromReference(
               reference,
             );
   @jni$_.internal
@@ -2462,26 +2462,26 @@ final class $EmojiCompat_SpanFactory$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_SpanFactory?> get nullableType => this;
+  jni$_.JObjType<EmojiCompat$SpanFactory?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_SpanFactory$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$SpanFactory$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat_SpanFactory$NullableType) &&
-        other is $EmojiCompat_SpanFactory$NullableType;
+    return other.runtimeType == ($EmojiCompat$SpanFactory$NullableType) &&
+        other is $EmojiCompat$SpanFactory$NullableType;
   }
 }
 
-final class $EmojiCompat_SpanFactory$Type
-    extends jni$_.JObjType<EmojiCompat_SpanFactory> {
+final class $EmojiCompat$SpanFactory$Type
+    extends jni$_.JObjType<EmojiCompat$SpanFactory> {
   @jni$_.internal
-  const $EmojiCompat_SpanFactory$Type();
+  const $EmojiCompat$SpanFactory$Type();
 
   @jni$_.internal
   @core$_.override
@@ -2489,8 +2489,8 @@ final class $EmojiCompat_SpanFactory$Type
 
   @jni$_.internal
   @core$_.override
-  EmojiCompat_SpanFactory fromReference(jni$_.JReference reference) =>
-      EmojiCompat_SpanFactory.fromReference(
+  EmojiCompat$SpanFactory fromReference(jni$_.JReference reference) =>
+      EmojiCompat$SpanFactory.fromReference(
         reference,
       );
   @jni$_.internal
@@ -2499,20 +2499,20 @@ final class $EmojiCompat_SpanFactory$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat_SpanFactory?> get nullableType =>
-      const $EmojiCompat_SpanFactory$NullableType();
+  jni$_.JObjType<EmojiCompat$SpanFactory?> get nullableType =>
+      const $EmojiCompat$SpanFactory$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat_SpanFactory$Type).hashCode;
+  int get hashCode => ($EmojiCompat$SpanFactory$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat_SpanFactory$Type) &&
-        other is $EmojiCompat_SpanFactory$Type;
+    return other.runtimeType == ($EmojiCompat$SpanFactory$Type) &&
+        other is $EmojiCompat$SpanFactory$Type;
   }
 }
 
@@ -2644,7 +2644,7 @@ class EmojiCompat extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   static EmojiCompat? init$1(
     jni$_.JObject? context,
-    DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory?
+    DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory?
         defaultEmojiCompatConfigFactory,
   ) {
     final _$context = context?.reference ?? jni$_.jNullReference;
@@ -2674,7 +2674,7 @@ class EmojiCompat extends jni$_.JObject {
   /// from: `static public androidx.emoji2.text.EmojiCompat init(androidx.emoji2.text.EmojiCompat$Config config)`
   /// The returned object must be released after use, by calling the [release] method.
   static EmojiCompat? init$2(
-    EmojiCompat_Config? config,
+    EmojiCompat$Config? config,
   ) {
     final _$config = config?.reference ?? jni$_.jNullReference;
     return _init$2(_class.reference.pointer, _id_init$2 as jni$_.JMethodIDPtr,
@@ -2725,7 +2725,7 @@ class EmojiCompat extends jni$_.JObject {
   /// from: `static public androidx.emoji2.text.EmojiCompat reset(androidx.emoji2.text.EmojiCompat$Config config)`
   /// The returned object must be released after use, by calling the [release] method.
   static EmojiCompat? reset(
-    EmojiCompat_Config? config,
+    EmojiCompat$Config? config,
   ) {
     final _$config = config?.reference ?? jni$_.jNullReference;
     return _reset(_class.reference.pointer, _id_reset as jni$_.JMethodIDPtr,
@@ -2848,7 +2848,7 @@ class EmojiCompat extends jni$_.JObject {
 
   /// from: `public void registerInitCallback(androidx.emoji2.text.EmojiCompat$InitCallback initCallback)`
   void registerInitCallback(
-    EmojiCompat_InitCallback? initCallback,
+    EmojiCompat$InitCallback? initCallback,
   ) {
     final _$initCallback = initCallback?.reference ?? jni$_.jNullReference;
     _registerInitCallback(
@@ -2876,7 +2876,7 @@ class EmojiCompat extends jni$_.JObject {
 
   /// from: `public void unregisterInitCallback(androidx.emoji2.text.EmojiCompat$InitCallback initCallback)`
   void unregisterInitCallback(
-    EmojiCompat_InitCallback? initCallback,
+    EmojiCompat$InitCallback? initCallback,
   ) {
     final _$initCallback = initCallback?.reference ?? jni$_.jNullReference;
     _unregisterInitCallback(
@@ -3458,15 +3458,15 @@ final class $EmojiCompat$Type extends jni$_.JObjType<EmojiCompat> {
 }
 
 /// from: `androidx.emoji2.text.DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory`
-class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory
+class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory
     extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory>
+  final jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory>
       $type;
 
   @jni$_.internal
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory.fromReference(
+  DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -3476,9 +3476,9 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory
 
   /// The type which includes information such as the signature of this class.
   static const nullableType =
-      $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$NullableType();
+      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType();
   static const type =
-      $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$Type();
+      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type();
   static final _id_new$ = _class.constructorId(
     r'(Landroidx/emoji2/text/DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper;)V',
   );
@@ -3496,13 +3496,13 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory
 
   /// from: `public void <init>(androidx.emoji2.text.DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper defaultEmojiCompatConfigHelper)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory(
-    DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper?
+  factory DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory(
+    DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper?
         defaultEmojiCompatConfigHelper,
   ) {
     final _$defaultEmojiCompatConfigHelper =
         defaultEmojiCompatConfigHelper?.reference ?? jni$_.jNullReference;
-    return DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory
+    return DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory
         .fromReference(_new$(
                 _class.reference.pointer,
                 _id_new$ as jni$_.JMethodIDPtr,
@@ -3528,21 +3528,21 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory
 
   /// from: `public androidx.emoji2.text.EmojiCompat$Config create(android.content.Context context)`
   /// The returned object must be released after use, by calling the [release] method.
-  EmojiCompat_Config? create(
+  EmojiCompat$Config? create(
     jni$_.JObject? context,
   ) {
     final _$context = context?.reference ?? jni$_.jNullReference;
     return _create(reference.pointer, _id_create as jni$_.JMethodIDPtr,
             _$context.pointer)
-        .object<EmojiCompat_Config?>(const $EmojiCompat_Config$NullableType());
+        .object<EmojiCompat$Config?>(const $EmojiCompat$Config$NullableType());
   }
 }
 
-final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$NullableType
+final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType
     extends jni$_
-    .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory?> {
+    .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory?> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$NullableType();
+  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -3551,11 +3551,11 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$NullableTy
 
   @jni$_.internal
   @core$_.override
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory? fromReference(
+  DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory? fromReference(
           jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory
+          : DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory
               .fromReference(
               reference,
             );
@@ -3565,7 +3565,7 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$NullableTy
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory?>
+  jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory?>
       get nullableType => this;
 
   @jni$_.internal
@@ -3574,23 +3574,23 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$NullableTy
 
   @core$_.override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$NullableType)
+      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType)
           .hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$NullableType) &&
+            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType) &&
         other
-            is $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$NullableType;
+            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType;
   }
 }
 
-final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$Type
+final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type
     extends jni$_
-    .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory> {
+    .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$Type();
+  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type();
 
   @jni$_.internal
   @core$_.override
@@ -3599,9 +3599,9 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$Type
 
   @jni$_.internal
   @core$_.override
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory fromReference(
+  DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory fromReference(
           jni$_.JReference reference) =>
-      DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory.fromReference(
+      DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory.fromReference(
         reference,
       );
   @jni$_.internal
@@ -3610,9 +3610,9 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory?>
+  jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory?>
       get nullableType =>
-          const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$NullableType();
+          const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -3620,26 +3620,26 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$Type
 
   @core$_.override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$Type).hashCode;
+      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$Type) &&
-        other is $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory$Type;
+            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type) &&
+        other is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type;
   }
 }
 
 /// from: `androidx.emoji2.text.DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper`
-class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper
+class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper
     extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper>
+  final jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper>
       $type;
 
   @jni$_.internal
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper.fromReference(
+  DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -3649,9 +3649,9 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper
 
   /// The type which includes information such as the signature of this class.
   static const nullableType =
-      $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$NullableType();
+      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType();
   static const type =
-      $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$Type();
+      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -3670,8 +3670,8 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper
 
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
-  factory DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper() {
-    return DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper
+  factory DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper() {
+    return DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper
         .fromReference(
             _new$(_class.reference.pointer, _id_new$ as jni$_.JMethodIDPtr)
                 .reference);
@@ -3790,11 +3790,11 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper
   }
 }
 
-final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$NullableType
+final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType
     extends jni$_
-    .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper?> {
+    .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper?> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$NullableType();
+  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -3803,11 +3803,11 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$NullableTyp
 
   @jni$_.internal
   @core$_.override
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper? fromReference(
+  DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper? fromReference(
           jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper
+          : DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper
               .fromReference(
               reference,
             );
@@ -3817,7 +3817,7 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$NullableTyp
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper?>
+  jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper?>
       get nullableType => this;
 
   @jni$_.internal
@@ -3826,23 +3826,23 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$NullableTyp
 
   @core$_.override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$NullableType)
+      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType)
           .hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$NullableType) &&
+            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType) &&
         other
-            is $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$NullableType;
+            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType;
   }
 }
 
-final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$Type
+final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type
     extends jni$_
-    .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper> {
+    .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$Type();
+  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type();
 
   @jni$_.internal
   @core$_.override
@@ -3851,9 +3851,9 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$Type
 
   @jni$_.internal
   @core$_.override
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper fromReference(
+  DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper fromReference(
           jni$_.JReference reference) =>
-      DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper.fromReference(
+      DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper.fromReference(
         reference,
       );
   @jni$_.internal
@@ -3862,9 +3862,9 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper?>
+  jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper?>
       get nullableType =>
-          const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$NullableType();
+          const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -3872,27 +3872,27 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$Type
 
   @core$_.override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$Type).hashCode;
+      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$Type) &&
-        other is $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$Type;
+            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type) &&
+        other is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type;
   }
 }
 
 /// from: `androidx.emoji2.text.DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19`
-class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
-    extends DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper {
+class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19
+    extends DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper {
   @jni$_.internal
   @core$_.override
   final jni$_
-      .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19>
+      .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19>
       $type;
 
   @jni$_.internal
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19.fromReference(
+  DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -3902,9 +3902,9 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
 
   /// The type which includes information such as the signature of this class.
   static const nullableType =
-      $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$NullableType();
+      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType();
   static const type =
-      $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type();
+      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -3923,8 +3923,8 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
 
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
-  factory DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19() {
-    return DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
+  factory DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19() {
+    return DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19
         .fromReference(
             _new$(_class.reference.pointer, _id_new$ as jni$_.JMethodIDPtr)
                 .reference);
@@ -4003,11 +4003,11 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
   }
 }
 
-final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$NullableType
+final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType
     extends jni$_
-    .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19?> {
+    .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19?> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$NullableType();
+  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -4016,22 +4016,22 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Nulla
 
   @jni$_.internal
   @core$_.override
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19? fromReference(
+  DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19? fromReference(
           jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
+          : DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19
               .fromReference(
               reference,
             );
   @jni$_.internal
   @core$_.override
   jni$_.JObjType get superType =>
-      const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$NullableType();
+      const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19?>
+  jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19?>
       get nullableType => this;
 
   @jni$_.internal
@@ -4040,23 +4040,23 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Nulla
 
   @core$_.override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$NullableType)
+      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType)
           .hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$NullableType) &&
+            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType) &&
         other
-            is $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$NullableType;
+            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType;
   }
 }
 
-final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type
+final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type
     extends jni$_
-    .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19> {
+    .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type();
+  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type();
 
   @jni$_.internal
   @core$_.override
@@ -4065,22 +4065,22 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type
 
   @jni$_.internal
   @core$_.override
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19 fromReference(
+  DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19 fromReference(
           jni$_.JReference reference) =>
-      DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
+      DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19
           .fromReference(
         reference,
       );
   @jni$_.internal
   @core$_.override
   jni$_.JObjType get superType =>
-      const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper$NullableType();
+      const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19?>
+  jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19?>
       get nullableType =>
-          const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$NullableType();
+          const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -4088,29 +4088,29 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type
 
   @core$_.override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type)
+      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type)
           .hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type) &&
+            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type) &&
         other
-            is $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$Type;
+            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type;
   }
 }
 
 /// from: `androidx.emoji2.text.DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28`
-class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
-    extends DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19 {
+class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28
+    extends DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19 {
   @jni$_.internal
   @core$_.override
   final jni$_
-      .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28>
+      .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28>
       $type;
 
   @jni$_.internal
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28.fromReference(
+  DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -4120,9 +4120,9 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
 
   /// The type which includes information such as the signature of this class.
   static const nullableType =
-      $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$NullableType();
+      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType();
   static const type =
-      $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type();
+      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -4141,8 +4141,8 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
 
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
-  factory DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28() {
-    return DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
+  factory DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28() {
+    return DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28
         .fromReference(
             _new$(_class.reference.pointer, _id_new$ as jni$_.JMethodIDPtr)
                 .reference);
@@ -4189,11 +4189,11 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
   }
 }
 
-final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$NullableType
+final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType
     extends jni$_
-    .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28?> {
+    .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28?> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$NullableType();
+  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -4202,22 +4202,22 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Nulla
 
   @jni$_.internal
   @core$_.override
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28? fromReference(
+  DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28? fromReference(
           jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
+          : DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28
               .fromReference(
               reference,
             );
   @jni$_.internal
   @core$_.override
   jni$_.JObjType get superType =>
-      const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$NullableType();
+      const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28?>
+  jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28?>
       get nullableType => this;
 
   @jni$_.internal
@@ -4226,23 +4226,23 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Nulla
 
   @core$_.override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$NullableType)
+      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType)
           .hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$NullableType) &&
+            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType) &&
         other
-            is $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$NullableType;
+            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType;
   }
 }
 
-final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type
+final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type
     extends jni$_
-    .JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28> {
+    .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type();
+  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type();
 
   @jni$_.internal
   @core$_.override
@@ -4251,22 +4251,22 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type
 
   @jni$_.internal
   @core$_.override
-  DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28 fromReference(
+  DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28 fromReference(
           jni$_.JReference reference) =>
-      DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
+      DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28
           .fromReference(
         reference,
       );
   @jni$_.internal
   @core$_.override
   jni$_.JObjType get superType =>
-      const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19$NullableType();
+      const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28?>
+  jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28?>
       get nullableType =>
-          const $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$NullableType();
+          const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -4274,15 +4274,15 @@ final class $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type
 
   @core$_.override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type)
+      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type)
           .hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type) &&
+            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type) &&
         other
-            is $DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28$Type;
+            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type;
   }
 }
 
@@ -4410,13 +4410,13 @@ final class $DefaultEmojiCompatConfig$Type
 }
 
 /// from: `android.os.Build$Partition`
-class Build_Partition extends jni$_.JObject {
+class Build$Partition extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Build_Partition> $type;
+  final jni$_.JObjType<Build$Partition> $type;
 
   @jni$_.internal
-  Build_Partition.fromReference(
+  Build$Partition.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -4424,8 +4424,8 @@ class Build_Partition extends jni$_.JObject {
   static final _class = jni$_.JClass.forName(r'android/os/Build$Partition');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Build_Partition$NullableType();
-  static const type = $Build_Partition$Type();
+  static const nullableType = $Build$Partition$NullableType();
+  static const type = $Build$Partition$Type();
   static final _id_PARTITION_NAME_SYSTEM = _class.staticFieldId(
     r'PARTITION_NAME_SYSTEM',
     r'Ljava/lang/String;',
@@ -4559,10 +4559,10 @@ class Build_Partition extends jni$_.JObject {
   }
 }
 
-final class $Build_Partition$NullableType
-    extends jni$_.JObjType<Build_Partition?> {
+final class $Build$Partition$NullableType
+    extends jni$_.JObjType<Build$Partition?> {
   @jni$_.internal
-  const $Build_Partition$NullableType();
+  const $Build$Partition$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -4570,9 +4570,9 @@ final class $Build_Partition$NullableType
 
   @jni$_.internal
   @core$_.override
-  Build_Partition? fromReference(jni$_.JReference reference) => reference.isNull
+  Build$Partition? fromReference(jni$_.JReference reference) => reference.isNull
       ? null
-      : Build_Partition.fromReference(
+      : Build$Partition.fromReference(
           reference,
         );
   @jni$_.internal
@@ -4581,25 +4581,25 @@ final class $Build_Partition$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Build_Partition?> get nullableType => this;
+  jni$_.JObjType<Build$Partition?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Build_Partition$NullableType).hashCode;
+  int get hashCode => ($Build$Partition$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Build_Partition$NullableType) &&
-        other is $Build_Partition$NullableType;
+    return other.runtimeType == ($Build$Partition$NullableType) &&
+        other is $Build$Partition$NullableType;
   }
 }
 
-final class $Build_Partition$Type extends jni$_.JObjType<Build_Partition> {
+final class $Build$Partition$Type extends jni$_.JObjType<Build$Partition> {
   @jni$_.internal
-  const $Build_Partition$Type();
+  const $Build$Partition$Type();
 
   @jni$_.internal
   @core$_.override
@@ -4607,8 +4607,8 @@ final class $Build_Partition$Type extends jni$_.JObjType<Build_Partition> {
 
   @jni$_.internal
   @core$_.override
-  Build_Partition fromReference(jni$_.JReference reference) =>
-      Build_Partition.fromReference(
+  Build$Partition fromReference(jni$_.JReference reference) =>
+      Build$Partition.fromReference(
         reference,
       );
   @jni$_.internal
@@ -4617,31 +4617,31 @@ final class $Build_Partition$Type extends jni$_.JObjType<Build_Partition> {
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Build_Partition?> get nullableType =>
-      const $Build_Partition$NullableType();
+  jni$_.JObjType<Build$Partition?> get nullableType =>
+      const $Build$Partition$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Build_Partition$Type).hashCode;
+  int get hashCode => ($Build$Partition$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Build_Partition$Type) &&
-        other is $Build_Partition$Type;
+    return other.runtimeType == ($Build$Partition$Type) &&
+        other is $Build$Partition$Type;
   }
 }
 
 /// from: `android.os.Build$VERSION`
-class Build_VERSION extends jni$_.JObject {
+class Build$VERSION extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Build_VERSION> $type;
+  final jni$_.JObjType<Build$VERSION> $type;
 
   @jni$_.internal
-  Build_VERSION.fromReference(
+  Build$VERSION.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -4649,8 +4649,8 @@ class Build_VERSION extends jni$_.JObject {
   static final _class = jni$_.JClass.forName(r'android/os/Build$VERSION');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Build_VERSION$NullableType();
-  static const type = $Build_VERSION$Type();
+  static const nullableType = $Build$VERSION$NullableType();
+  static const type = $Build$VERSION$Type();
   static final _id_BASE_OS = _class.staticFieldId(
     r'BASE_OS',
     r'Ljava/lang/String;',
@@ -4776,16 +4776,16 @@ class Build_VERSION extends jni$_.JObject {
 
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
-  factory Build_VERSION() {
-    return Build_VERSION.fromReference(
+  factory Build$VERSION() {
+    return Build$VERSION.fromReference(
         _new$(_class.reference.pointer, _id_new$ as jni$_.JMethodIDPtr)
             .reference);
   }
 }
 
-final class $Build_VERSION$NullableType extends jni$_.JObjType<Build_VERSION?> {
+final class $Build$VERSION$NullableType extends jni$_.JObjType<Build$VERSION?> {
   @jni$_.internal
-  const $Build_VERSION$NullableType();
+  const $Build$VERSION$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -4793,9 +4793,9 @@ final class $Build_VERSION$NullableType extends jni$_.JObjType<Build_VERSION?> {
 
   @jni$_.internal
   @core$_.override
-  Build_VERSION? fromReference(jni$_.JReference reference) => reference.isNull
+  Build$VERSION? fromReference(jni$_.JReference reference) => reference.isNull
       ? null
-      : Build_VERSION.fromReference(
+      : Build$VERSION.fromReference(
           reference,
         );
   @jni$_.internal
@@ -4804,25 +4804,25 @@ final class $Build_VERSION$NullableType extends jni$_.JObjType<Build_VERSION?> {
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Build_VERSION?> get nullableType => this;
+  jni$_.JObjType<Build$VERSION?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Build_VERSION$NullableType).hashCode;
+  int get hashCode => ($Build$VERSION$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Build_VERSION$NullableType) &&
-        other is $Build_VERSION$NullableType;
+    return other.runtimeType == ($Build$VERSION$NullableType) &&
+        other is $Build$VERSION$NullableType;
   }
 }
 
-final class $Build_VERSION$Type extends jni$_.JObjType<Build_VERSION> {
+final class $Build$VERSION$Type extends jni$_.JObjType<Build$VERSION> {
   @jni$_.internal
-  const $Build_VERSION$Type();
+  const $Build$VERSION$Type();
 
   @jni$_.internal
   @core$_.override
@@ -4830,8 +4830,8 @@ final class $Build_VERSION$Type extends jni$_.JObjType<Build_VERSION> {
 
   @jni$_.internal
   @core$_.override
-  Build_VERSION fromReference(jni$_.JReference reference) =>
-      Build_VERSION.fromReference(
+  Build$VERSION fromReference(jni$_.JReference reference) =>
+      Build$VERSION.fromReference(
         reference,
       );
   @jni$_.internal
@@ -4840,31 +4840,31 @@ final class $Build_VERSION$Type extends jni$_.JObjType<Build_VERSION> {
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Build_VERSION?> get nullableType =>
-      const $Build_VERSION$NullableType();
+  jni$_.JObjType<Build$VERSION?> get nullableType =>
+      const $Build$VERSION$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Build_VERSION$Type).hashCode;
+  int get hashCode => ($Build$VERSION$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Build_VERSION$Type) &&
-        other is $Build_VERSION$Type;
+    return other.runtimeType == ($Build$VERSION$Type) &&
+        other is $Build$VERSION$Type;
   }
 }
 
 /// from: `android.os.Build$VERSION_CODES`
-class Build_VERSION_CODES extends jni$_.JObject {
+class Build$VERSION_CODES extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Build_VERSION_CODES> $type;
+  final jni$_.JObjType<Build$VERSION_CODES> $type;
 
   @jni$_.internal
-  Build_VERSION_CODES.fromReference(
+  Build$VERSION_CODES.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -4872,8 +4872,8 @@ class Build_VERSION_CODES extends jni$_.JObject {
   static final _class = jni$_.JClass.forName(r'android/os/Build$VERSION_CODES');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Build_VERSION_CODES$NullableType();
-  static const type = $Build_VERSION_CODES$Type();
+  static const nullableType = $Build$VERSION_CODES$NullableType();
+  static const type = $Build$VERSION_CODES$Type();
 
   /// from: `static public final int BASE`
   static const BASE = 1;
@@ -5000,17 +5000,17 @@ class Build_VERSION_CODES extends jni$_.JObject {
 
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
-  factory Build_VERSION_CODES() {
-    return Build_VERSION_CODES.fromReference(
+  factory Build$VERSION_CODES() {
+    return Build$VERSION_CODES.fromReference(
         _new$(_class.reference.pointer, _id_new$ as jni$_.JMethodIDPtr)
             .reference);
   }
 }
 
-final class $Build_VERSION_CODES$NullableType
-    extends jni$_.JObjType<Build_VERSION_CODES?> {
+final class $Build$VERSION_CODES$NullableType
+    extends jni$_.JObjType<Build$VERSION_CODES?> {
   @jni$_.internal
-  const $Build_VERSION_CODES$NullableType();
+  const $Build$VERSION_CODES$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -5018,10 +5018,10 @@ final class $Build_VERSION_CODES$NullableType
 
   @jni$_.internal
   @core$_.override
-  Build_VERSION_CODES? fromReference(jni$_.JReference reference) =>
+  Build$VERSION_CODES? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : Build_VERSION_CODES.fromReference(
+          : Build$VERSION_CODES.fromReference(
               reference,
             );
   @jni$_.internal
@@ -5030,26 +5030,26 @@ final class $Build_VERSION_CODES$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Build_VERSION_CODES?> get nullableType => this;
+  jni$_.JObjType<Build$VERSION_CODES?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Build_VERSION_CODES$NullableType).hashCode;
+  int get hashCode => ($Build$VERSION_CODES$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Build_VERSION_CODES$NullableType) &&
-        other is $Build_VERSION_CODES$NullableType;
+    return other.runtimeType == ($Build$VERSION_CODES$NullableType) &&
+        other is $Build$VERSION_CODES$NullableType;
   }
 }
 
-final class $Build_VERSION_CODES$Type
-    extends jni$_.JObjType<Build_VERSION_CODES> {
+final class $Build$VERSION_CODES$Type
+    extends jni$_.JObjType<Build$VERSION_CODES> {
   @jni$_.internal
-  const $Build_VERSION_CODES$Type();
+  const $Build$VERSION_CODES$Type();
 
   @jni$_.internal
   @core$_.override
@@ -5057,8 +5057,8 @@ final class $Build_VERSION_CODES$Type
 
   @jni$_.internal
   @core$_.override
-  Build_VERSION_CODES fromReference(jni$_.JReference reference) =>
-      Build_VERSION_CODES.fromReference(
+  Build$VERSION_CODES fromReference(jni$_.JReference reference) =>
+      Build$VERSION_CODES.fromReference(
         reference,
       );
   @jni$_.internal
@@ -5067,20 +5067,20 @@ final class $Build_VERSION_CODES$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Build_VERSION_CODES?> get nullableType =>
-      const $Build_VERSION_CODES$NullableType();
+  jni$_.JObjType<Build$VERSION_CODES?> get nullableType =>
+      const $Build$VERSION_CODES$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Build_VERSION_CODES$Type).hashCode;
+  int get hashCode => ($Build$VERSION_CODES$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Build_VERSION_CODES$Type) &&
-        other is $Build_VERSION_CODES$Type;
+    return other.runtimeType == ($Build$VERSION_CODES$Type) &&
+        other is $Build$VERSION_CODES$Type;
   }
 }
 
@@ -5457,12 +5457,12 @@ class Build extends jni$_.JObject {
 
   /// from: `static public java.util.List getFingerprintedPartitions()`
   /// The returned object must be released after use, by calling the [release] method.
-  static jni$_.JList<Build_Partition?>? getFingerprintedPartitions() {
+  static jni$_.JList<Build$Partition?>? getFingerprintedPartitions() {
     return _getFingerprintedPartitions(_class.reference.pointer,
             _id_getFingerprintedPartitions as jni$_.JMethodIDPtr)
-        .object<jni$_.JList<Build_Partition?>?>(
-            const jni$_.JListNullableType<Build_Partition?>(
-                $Build_Partition$NullableType()));
+        .object<jni$_.JList<Build$Partition?>?>(
+            const jni$_.JListNullableType<Build$Partition?>(
+                $Build$Partition$NullableType()));
   }
 
   static final _id_getRadioVersion = _class.staticMethodId(

--- a/pkgs/jnigen/lib/src/elements/elements.dart
+++ b/pkgs/jnigen/lib/src/elements/elements.dart
@@ -179,8 +179,17 @@ class ClassDecl with ClassMember, Annotated implements Element<ClassDecl> {
   @override
   ClassDecl get classDecl => this;
 
+  /// Simple name of this class without the outerclasses.
+  ///
+  /// This is not uniquely identifiable from the [binaryName]. For instance,
+  /// `com.xyz.Foo$Bar` could represent a class named `Bar` that is nested in a
+  /// class name `Foo` in which case its name is `Bar`. But it can also
+  /// represent a class named `Foo$Bar`.
   @override
-  String get name => binaryName.split('.').last;
+  String get name => binaryName
+      .substring((outerClassBinaryName?.length ?? -1) + 1)
+      .split('.')
+      .last;
 
   bool get isObject => superCount == 0;
 

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
@@ -58,13 +58,13 @@ import 'JsonParser.dart' as jsonparser$_;
 ///
 /// Enumeration that defines all on/off features that can only be
 /// changed for JsonFactory.
-class JsonFactory_Feature extends jni$_.JObject {
+class JsonFactory$Feature extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<JsonFactory_Feature> $type;
+  final jni$_.JObjType<JsonFactory$Feature> $type;
 
   @jni$_.internal
-  JsonFactory_Feature.fromReference(
+  JsonFactory$Feature.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -73,8 +73,8 @@ class JsonFactory_Feature extends jni$_.JObject {
       jni$_.JClass.forName(r'com/fasterxml/jackson/core/JsonFactory$Feature');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $JsonFactory_Feature$NullableType();
-  static const type = $JsonFactory_Feature$Type();
+  static const nullableType = $JsonFactory$Feature$NullableType();
+  static const type = $JsonFactory$Feature$Type();
   static final _id_values = _class.staticMethodId(
     r'values',
     r'()[Lcom/fasterxml/jackson/core/JsonFactory$Feature;',
@@ -94,11 +94,11 @@ class JsonFactory_Feature extends jni$_.JObject {
 
   /// from: `static public com.fasterxml.jackson.core.JsonFactory.Feature[] values()`
   /// The returned object must be released after use, by calling the [release] method.
-  static jni$_.JArray<JsonFactory_Feature?>? values() {
+  static jni$_.JArray<JsonFactory$Feature?>? values() {
     return _values(_class.reference.pointer, _id_values as jni$_.JMethodIDPtr)
-        .object<jni$_.JArray<JsonFactory_Feature?>?>(
-            const jni$_.JArrayNullableType<JsonFactory_Feature?>(
-                $JsonFactory_Feature$NullableType()));
+        .object<jni$_.JArray<JsonFactory$Feature?>?>(
+            const jni$_.JArrayNullableType<JsonFactory$Feature?>(
+                $JsonFactory$Feature$NullableType()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -119,14 +119,14 @@ class JsonFactory_Feature extends jni$_.JObject {
 
   /// from: `static public com.fasterxml.jackson.core.JsonFactory.Feature valueOf(java.lang.String name)`
   /// The returned object must be released after use, by calling the [release] method.
-  static JsonFactory_Feature? valueOf(
+  static JsonFactory$Feature? valueOf(
     jni$_.JString? name,
   ) {
     final _$name = name?.reference ?? jni$_.jNullReference;
     return _valueOf(_class.reference.pointer, _id_valueOf as jni$_.JMethodIDPtr,
             _$name.pointer)
-        .object<JsonFactory_Feature?>(
-            const $JsonFactory_Feature$NullableType());
+        .object<JsonFactory$Feature?>(
+            const $JsonFactory$Feature$NullableType());
   }
 
   static final _id_collectDefaults = _class.staticMethodId(
@@ -230,10 +230,10 @@ class JsonFactory_Feature extends jni$_.JObject {
   }
 }
 
-final class $JsonFactory_Feature$NullableType
-    extends jni$_.JObjType<JsonFactory_Feature?> {
+final class $JsonFactory$Feature$NullableType
+    extends jni$_.JObjType<JsonFactory$Feature?> {
   @jni$_.internal
-  const $JsonFactory_Feature$NullableType();
+  const $JsonFactory$Feature$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -241,10 +241,10 @@ final class $JsonFactory_Feature$NullableType
 
   @jni$_.internal
   @core$_.override
-  JsonFactory_Feature? fromReference(jni$_.JReference reference) =>
+  JsonFactory$Feature? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : JsonFactory_Feature.fromReference(
+          : JsonFactory$Feature.fromReference(
               reference,
             );
   @jni$_.internal
@@ -253,26 +253,26 @@ final class $JsonFactory_Feature$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonFactory_Feature?> get nullableType => this;
+  jni$_.JObjType<JsonFactory$Feature?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonFactory_Feature$NullableType).hashCode;
+  int get hashCode => ($JsonFactory$Feature$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonFactory_Feature$NullableType) &&
-        other is $JsonFactory_Feature$NullableType;
+    return other.runtimeType == ($JsonFactory$Feature$NullableType) &&
+        other is $JsonFactory$Feature$NullableType;
   }
 }
 
-final class $JsonFactory_Feature$Type
-    extends jni$_.JObjType<JsonFactory_Feature> {
+final class $JsonFactory$Feature$Type
+    extends jni$_.JObjType<JsonFactory$Feature> {
   @jni$_.internal
-  const $JsonFactory_Feature$Type();
+  const $JsonFactory$Feature$Type();
 
   @jni$_.internal
   @core$_.override
@@ -280,8 +280,8 @@ final class $JsonFactory_Feature$Type
 
   @jni$_.internal
   @core$_.override
-  JsonFactory_Feature fromReference(jni$_.JReference reference) =>
-      JsonFactory_Feature.fromReference(
+  JsonFactory$Feature fromReference(jni$_.JReference reference) =>
+      JsonFactory$Feature.fromReference(
         reference,
       );
   @jni$_.internal
@@ -290,20 +290,20 @@ final class $JsonFactory_Feature$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonFactory_Feature?> get nullableType =>
-      const $JsonFactory_Feature$NullableType();
+  jni$_.JObjType<JsonFactory$Feature?> get nullableType =>
+      const $JsonFactory$Feature$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonFactory_Feature$Type).hashCode;
+  int get hashCode => ($JsonFactory$Feature$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonFactory_Feature$Type) &&
-        other is $JsonFactory_Feature$Type;
+    return other.runtimeType == ($JsonFactory$Feature$Type) &&
+        other is $JsonFactory$Feature$Type;
   }
 }
 
@@ -932,7 +932,7 @@ class JsonFactory extends jni$_.JObject {
   ///@return This factory instance (to allow call chaining)
   ///@deprecated since 2.10 use JsonFactoryBuilder\#configure(JsonFactory.Feature, boolean) instead
   JsonFactory? configure(
-    JsonFactory_Feature? f,
+    JsonFactory$Feature? f,
     bool state,
   ) {
     final _$f = f?.reference ?? jni$_.jNullReference;
@@ -966,7 +966,7 @@ class JsonFactory extends jni$_.JObject {
   ///@return This factory instance (to allow call chaining)
   ///@deprecated since 2.10 use JsonFactoryBuilder\#configure(JsonFactory.Feature, boolean) instead
   JsonFactory? enable(
-    JsonFactory_Feature? f,
+    JsonFactory$Feature? f,
   ) {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _enable(
@@ -999,7 +999,7 @@ class JsonFactory extends jni$_.JObject {
   ///@return This factory instance (to allow call chaining)
   ///@deprecated since 2.10 use JsonFactoryBuilder\#configure(JsonFactory.Feature, boolean) instead
   JsonFactory? disable(
-    JsonFactory_Feature? f,
+    JsonFactory$Feature? f,
   ) {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _disable(
@@ -1029,7 +1029,7 @@ class JsonFactory extends jni$_.JObject {
   ///@param f Feature to check
   ///@return True if the specified feature is enabled
   bool isEnabled(
-    JsonFactory_Feature? f,
+    JsonFactory$Feature? f,
   ) {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _isEnabled(
@@ -1160,7 +1160,7 @@ class JsonFactory extends jni$_.JObject {
   ///@param state Whether to enable or disable the feature
   ///@return This factory instance (to allow call chaining)
   JsonFactory? configure$1(
-    jsonparser$_.JsonParser_Feature? f,
+    jsonparser$_.JsonParser$Feature? f,
     bool state,
   ) {
     final _$f = f?.reference ?? jni$_.jNullReference;
@@ -1193,7 +1193,7 @@ class JsonFactory extends jni$_.JObject {
   ///@param f Feature to enable
   ///@return This factory instance (to allow call chaining)
   JsonFactory? enable$1(
-    jsonparser$_.JsonParser_Feature? f,
+    jsonparser$_.JsonParser$Feature? f,
   ) {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _enable$1(
@@ -1225,7 +1225,7 @@ class JsonFactory extends jni$_.JObject {
   ///@param f Feature to disable
   ///@return This factory instance (to allow call chaining)
   JsonFactory? disable$1(
-    jsonparser$_.JsonParser_Feature? f,
+    jsonparser$_.JsonParser$Feature? f,
   ) {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _disable$1(
@@ -1255,7 +1255,7 @@ class JsonFactory extends jni$_.JObject {
   ///@param f Feature to check
   ///@return True if specified feature is enabled
   bool isEnabled$1(
-    jsonparser$_.JsonParser_Feature? f,
+    jsonparser$_.JsonParser$Feature? f,
   ) {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _isEnabled$1(reference.pointer,

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonParser.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonParser.dart
@@ -57,13 +57,13 @@ import 'JsonToken.dart' as jsontoken$_;
 /// from: `com.fasterxml.jackson.core.JsonParser$Feature`
 ///
 /// Enumeration that defines all on/off features for parsers.
-class JsonParser_Feature extends jni$_.JObject {
+class JsonParser$Feature extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<JsonParser_Feature> $type;
+  final jni$_.JObjType<JsonParser$Feature> $type;
 
   @jni$_.internal
-  JsonParser_Feature.fromReference(
+  JsonParser$Feature.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -72,8 +72,8 @@ class JsonParser_Feature extends jni$_.JObject {
       jni$_.JClass.forName(r'com/fasterxml/jackson/core/JsonParser$Feature');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $JsonParser_Feature$NullableType();
-  static const type = $JsonParser_Feature$Type();
+  static const nullableType = $JsonParser$Feature$NullableType();
+  static const type = $JsonParser$Feature$Type();
   static final _id_values = _class.staticMethodId(
     r'values',
     r'()[Lcom/fasterxml/jackson/core/JsonParser$Feature;',
@@ -93,11 +93,11 @@ class JsonParser_Feature extends jni$_.JObject {
 
   /// from: `static public com.fasterxml.jackson.core.JsonParser.Feature[] values()`
   /// The returned object must be released after use, by calling the [release] method.
-  static jni$_.JArray<JsonParser_Feature?>? values() {
+  static jni$_.JArray<JsonParser$Feature?>? values() {
     return _values(_class.reference.pointer, _id_values as jni$_.JMethodIDPtr)
-        .object<jni$_.JArray<JsonParser_Feature?>?>(
-            const jni$_.JArrayNullableType<JsonParser_Feature?>(
-                $JsonParser_Feature$NullableType()));
+        .object<jni$_.JArray<JsonParser$Feature?>?>(
+            const jni$_.JArrayNullableType<JsonParser$Feature?>(
+                $JsonParser$Feature$NullableType()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -118,13 +118,13 @@ class JsonParser_Feature extends jni$_.JObject {
 
   /// from: `static public com.fasterxml.jackson.core.JsonParser.Feature valueOf(java.lang.String name)`
   /// The returned object must be released after use, by calling the [release] method.
-  static JsonParser_Feature? valueOf(
+  static JsonParser$Feature? valueOf(
     jni$_.JString? name,
   ) {
     final _$name = name?.reference ?? jni$_.jNullReference;
     return _valueOf(_class.reference.pointer, _id_valueOf as jni$_.JMethodIDPtr,
             _$name.pointer)
-        .object<JsonParser_Feature?>(const $JsonParser_Feature$NullableType());
+        .object<JsonParser$Feature?>(const $JsonParser$Feature$NullableType());
   }
 
   static final _id_collectDefaults = _class.staticMethodId(
@@ -228,10 +228,10 @@ class JsonParser_Feature extends jni$_.JObject {
   }
 }
 
-final class $JsonParser_Feature$NullableType
-    extends jni$_.JObjType<JsonParser_Feature?> {
+final class $JsonParser$Feature$NullableType
+    extends jni$_.JObjType<JsonParser$Feature?> {
   @jni$_.internal
-  const $JsonParser_Feature$NullableType();
+  const $JsonParser$Feature$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -239,10 +239,10 @@ final class $JsonParser_Feature$NullableType
 
   @jni$_.internal
   @core$_.override
-  JsonParser_Feature? fromReference(jni$_.JReference reference) =>
+  JsonParser$Feature? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : JsonParser_Feature.fromReference(
+          : JsonParser$Feature.fromReference(
               reference,
             );
   @jni$_.internal
@@ -251,26 +251,26 @@ final class $JsonParser_Feature$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonParser_Feature?> get nullableType => this;
+  jni$_.JObjType<JsonParser$Feature?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonParser_Feature$NullableType).hashCode;
+  int get hashCode => ($JsonParser$Feature$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonParser_Feature$NullableType) &&
-        other is $JsonParser_Feature$NullableType;
+    return other.runtimeType == ($JsonParser$Feature$NullableType) &&
+        other is $JsonParser$Feature$NullableType;
   }
 }
 
-final class $JsonParser_Feature$Type
-    extends jni$_.JObjType<JsonParser_Feature> {
+final class $JsonParser$Feature$Type
+    extends jni$_.JObjType<JsonParser$Feature> {
   @jni$_.internal
-  const $JsonParser_Feature$Type();
+  const $JsonParser$Feature$Type();
 
   @jni$_.internal
   @core$_.override
@@ -278,8 +278,8 @@ final class $JsonParser_Feature$Type
 
   @jni$_.internal
   @core$_.override
-  JsonParser_Feature fromReference(jni$_.JReference reference) =>
-      JsonParser_Feature.fromReference(
+  JsonParser$Feature fromReference(jni$_.JReference reference) =>
+      JsonParser$Feature.fromReference(
         reference,
       );
   @jni$_.internal
@@ -288,20 +288,20 @@ final class $JsonParser_Feature$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonParser_Feature?> get nullableType =>
-      const $JsonParser_Feature$NullableType();
+  jni$_.JObjType<JsonParser$Feature?> get nullableType =>
+      const $JsonParser$Feature$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonParser_Feature$Type).hashCode;
+  int get hashCode => ($JsonParser$Feature$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonParser_Feature$Type) &&
-        other is $JsonParser_Feature$Type;
+    return other.runtimeType == ($JsonParser$Feature$Type) &&
+        other is $JsonParser$Feature$Type;
   }
 }
 
@@ -309,13 +309,13 @@ final class $JsonParser_Feature$Type
 ///
 /// Enumeration of possible "native" (optimal) types that can be
 /// used for numbers.
-class JsonParser_NumberType extends jni$_.JObject {
+class JsonParser$NumberType extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<JsonParser_NumberType> $type;
+  final jni$_.JObjType<JsonParser$NumberType> $type;
 
   @jni$_.internal
-  JsonParser_NumberType.fromReference(
+  JsonParser$NumberType.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -324,8 +324,8 @@ class JsonParser_NumberType extends jni$_.JObject {
       jni$_.JClass.forName(r'com/fasterxml/jackson/core/JsonParser$NumberType');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $JsonParser_NumberType$NullableType();
-  static const type = $JsonParser_NumberType$Type();
+  static const nullableType = $JsonParser$NumberType$NullableType();
+  static const type = $JsonParser$NumberType$Type();
   static final _id_values = _class.staticMethodId(
     r'values',
     r'()[Lcom/fasterxml/jackson/core/JsonParser$NumberType;',
@@ -345,11 +345,11 @@ class JsonParser_NumberType extends jni$_.JObject {
 
   /// from: `static public com.fasterxml.jackson.core.JsonParser.NumberType[] values()`
   /// The returned object must be released after use, by calling the [release] method.
-  static jni$_.JArray<JsonParser_NumberType?>? values() {
+  static jni$_.JArray<JsonParser$NumberType?>? values() {
     return _values(_class.reference.pointer, _id_values as jni$_.JMethodIDPtr)
-        .object<jni$_.JArray<JsonParser_NumberType?>?>(
-            const jni$_.JArrayNullableType<JsonParser_NumberType?>(
-                $JsonParser_NumberType$NullableType()));
+        .object<jni$_.JArray<JsonParser$NumberType?>?>(
+            const jni$_.JArrayNullableType<JsonParser$NumberType?>(
+                $JsonParser$NumberType$NullableType()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -370,21 +370,21 @@ class JsonParser_NumberType extends jni$_.JObject {
 
   /// from: `static public com.fasterxml.jackson.core.JsonParser.NumberType valueOf(java.lang.String name)`
   /// The returned object must be released after use, by calling the [release] method.
-  static JsonParser_NumberType? valueOf(
+  static JsonParser$NumberType? valueOf(
     jni$_.JString? name,
   ) {
     final _$name = name?.reference ?? jni$_.jNullReference;
     return _valueOf(_class.reference.pointer, _id_valueOf as jni$_.JMethodIDPtr,
             _$name.pointer)
-        .object<JsonParser_NumberType?>(
-            const $JsonParser_NumberType$NullableType());
+        .object<JsonParser$NumberType?>(
+            const $JsonParser$NumberType$NullableType());
   }
 }
 
-final class $JsonParser_NumberType$NullableType
-    extends jni$_.JObjType<JsonParser_NumberType?> {
+final class $JsonParser$NumberType$NullableType
+    extends jni$_.JObjType<JsonParser$NumberType?> {
   @jni$_.internal
-  const $JsonParser_NumberType$NullableType();
+  const $JsonParser$NumberType$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -392,10 +392,10 @@ final class $JsonParser_NumberType$NullableType
 
   @jni$_.internal
   @core$_.override
-  JsonParser_NumberType? fromReference(jni$_.JReference reference) =>
+  JsonParser$NumberType? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : JsonParser_NumberType.fromReference(
+          : JsonParser$NumberType.fromReference(
               reference,
             );
   @jni$_.internal
@@ -404,26 +404,26 @@ final class $JsonParser_NumberType$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonParser_NumberType?> get nullableType => this;
+  jni$_.JObjType<JsonParser$NumberType?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonParser_NumberType$NullableType).hashCode;
+  int get hashCode => ($JsonParser$NumberType$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonParser_NumberType$NullableType) &&
-        other is $JsonParser_NumberType$NullableType;
+    return other.runtimeType == ($JsonParser$NumberType$NullableType) &&
+        other is $JsonParser$NumberType$NullableType;
   }
 }
 
-final class $JsonParser_NumberType$Type
-    extends jni$_.JObjType<JsonParser_NumberType> {
+final class $JsonParser$NumberType$Type
+    extends jni$_.JObjType<JsonParser$NumberType> {
   @jni$_.internal
-  const $JsonParser_NumberType$Type();
+  const $JsonParser$NumberType$Type();
 
   @jni$_.internal
   @core$_.override
@@ -431,8 +431,8 @@ final class $JsonParser_NumberType$Type
 
   @jni$_.internal
   @core$_.override
-  JsonParser_NumberType fromReference(jni$_.JReference reference) =>
-      JsonParser_NumberType.fromReference(
+  JsonParser$NumberType fromReference(jni$_.JReference reference) =>
+      JsonParser$NumberType.fromReference(
         reference,
       );
   @jni$_.internal
@@ -441,20 +441,20 @@ final class $JsonParser_NumberType$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonParser_NumberType?> get nullableType =>
-      const $JsonParser_NumberType$NullableType();
+  jni$_.JObjType<JsonParser$NumberType?> get nullableType =>
+      const $JsonParser$NumberType$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonParser_NumberType$Type).hashCode;
+  int get hashCode => ($JsonParser$NumberType$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonParser_NumberType$Type) &&
-        other is $JsonParser_NumberType$Type;
+    return other.runtimeType == ($JsonParser$NumberType$Type) &&
+        other is $JsonParser$NumberType$Type;
   }
 }
 
@@ -1412,7 +1412,7 @@ class JsonParser extends jni$_.JObject {
   ///@param f Feature to enable
   ///@return This parser, to allow call chaining
   JsonParser? enable(
-    JsonParser_Feature? f,
+    JsonParser$Feature? f,
   ) {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _enable(
@@ -1444,7 +1444,7 @@ class JsonParser extends jni$_.JObject {
   ///@param f Feature to disable
   ///@return This parser, to allow call chaining
   JsonParser? disable(
-    JsonParser_Feature? f,
+    JsonParser$Feature? f,
   ) {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _disable(
@@ -1478,7 +1478,7 @@ class JsonParser extends jni$_.JObject {
   ///@param state Whether to enable feature ({@code true}) or disable ({@code false})
   ///@return This parser, to allow call chaining
   JsonParser? configure(
-    JsonParser_Feature? f,
+    JsonParser$Feature? f,
     bool state,
   ) {
     final _$f = f?.reference ?? jni$_.jNullReference;
@@ -1509,7 +1509,7 @@ class JsonParser extends jni$_.JObject {
   ///@param f Feature to check
   ///@return {@code True} if feature is enabled; {@code false} otherwise
   bool isEnabled(
-    JsonParser_Feature? f,
+    JsonParser$Feature? f,
   ) {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _isEnabled(
@@ -2993,11 +2993,11 @@ class JsonParser extends jni$_.JObject {
   ///@return Type of current number, if parser points to numeric token; {@code null} otherwise
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
-  JsonParser_NumberType? getNumberType() {
+  JsonParser$NumberType? getNumberType() {
     return _getNumberType(
             reference.pointer, _id_getNumberType as jni$_.JMethodIDPtr)
-        .object<JsonParser_NumberType?>(
-            const $JsonParser_NumberType$NullableType());
+        .object<JsonParser$NumberType?>(
+            const $JsonParser$NumberType$NullableType());
   }
 
   static final _id_getByteValue = _class.instanceMethodId(

--- a/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
+++ b/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
@@ -492,11 +492,11 @@ final class $MeasureUnit$Type extends jni$_.JObjType<MeasureUnit> {
 }
 
 /// from: `com.github.dart_lang.jnigen.Nullability$InnerClass`
-class Nullability_InnerClass<$T extends jni$_.JObject?,
+class Nullability$InnerClass<$T extends jni$_.JObject?,
     $U extends jni$_.JObject, $V extends jni$_.JObject?> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Nullability_InnerClass<$T, $U, $V>> $type;
+  final jni$_.JObjType<Nullability$InnerClass<$T, $U, $V>> $type;
 
   @jni$_.internal
   final jni$_.JObjType<$T> T;
@@ -508,7 +508,7 @@ class Nullability_InnerClass<$T extends jni$_.JObject?,
   final jni$_.JObjType<$V> V;
 
   @jni$_.internal
-  Nullability_InnerClass.fromReference(
+  Nullability$InnerClass.fromReference(
     this.T,
     this.U,
     this.V,
@@ -520,7 +520,7 @@ class Nullability_InnerClass<$T extends jni$_.JObject?,
       r'com/github/dart_lang/jnigen/Nullability$InnerClass');
 
   /// The type which includes information such as the signature of this class.
-  static $Nullability_InnerClass$NullableType<$T, $U, $V> nullableType<
+  static $Nullability$InnerClass$NullableType<$T, $U, $V> nullableType<
       $T extends jni$_.JObject?,
       $U extends jni$_.JObject,
       $V extends jni$_.JObject?>(
@@ -528,14 +528,14 @@ class Nullability_InnerClass<$T extends jni$_.JObject?,
     jni$_.JObjType<$U> U,
     jni$_.JObjType<$V> V,
   ) {
-    return $Nullability_InnerClass$NullableType<$T, $U, $V>(
+    return $Nullability$InnerClass$NullableType<$T, $U, $V>(
       T,
       U,
       V,
     );
   }
 
-  static $Nullability_InnerClass$Type<$T, $U, $V> type<
+  static $Nullability$InnerClass$Type<$T, $U, $V> type<
       $T extends jni$_.JObject?,
       $U extends jni$_.JObject,
       $V extends jni$_.JObject?>(
@@ -543,7 +543,7 @@ class Nullability_InnerClass<$T extends jni$_.JObject?,
     jni$_.JObjType<$U> U,
     jni$_.JObjType<$V> V,
   ) {
-    return $Nullability_InnerClass$Type<$T, $U, $V>(
+    return $Nullability$InnerClass$Type<$T, $U, $V>(
       T,
       U,
       V,
@@ -567,7 +567,7 @@ class Nullability_InnerClass<$T extends jni$_.JObject?,
 
   /// from: `public void <init>(com.github.dart_lang.jnigen.Nullability $outerClass)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory Nullability_InnerClass(
+  factory Nullability$InnerClass(
     Nullability<$T?, $U> $outerClass, {
     jni$_.JObjType<$T>? T,
     jni$_.JObjType<$U>? U,
@@ -582,7 +582,7 @@ class Nullability_InnerClass<$T extends jni$_.JObject?,
           .U,
     ]) as jni$_.JObjType<$U>;
     final _$$outerClass = $outerClass.reference;
-    return Nullability_InnerClass<$T, $U, $V>.fromReference(
+    return Nullability$InnerClass<$T, $U, $V>.fromReference(
         T,
         U,
         V,
@@ -630,9 +630,9 @@ class Nullability_InnerClass<$T extends jni$_.JObject?,
   }
 }
 
-final class $Nullability_InnerClass$NullableType<$T extends jni$_.JObject?,
+final class $Nullability$InnerClass$NullableType<$T extends jni$_.JObject?,
         $U extends jni$_.JObject, $V extends jni$_.JObject?>
-    extends jni$_.JObjType<Nullability_InnerClass<$T, $U, $V>?> {
+    extends jni$_.JObjType<Nullability$InnerClass<$T, $U, $V>?> {
   @jni$_.internal
   final jni$_.JObjType<$T> T;
 
@@ -643,7 +643,7 @@ final class $Nullability_InnerClass$NullableType<$T extends jni$_.JObject?,
   final jni$_.JObjType<$V> V;
 
   @jni$_.internal
-  const $Nullability_InnerClass$NullableType(
+  const $Nullability$InnerClass$NullableType(
     this.T,
     this.U,
     this.V,
@@ -656,11 +656,11 @@ final class $Nullability_InnerClass$NullableType<$T extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  Nullability_InnerClass<$T, $U, $V>? fromReference(
+  Nullability$InnerClass<$T, $U, $V>? fromReference(
           jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : Nullability_InnerClass<$T, $U, $V>.fromReference(
+          : Nullability$InnerClass<$T, $U, $V>.fromReference(
               T,
               U,
               V,
@@ -672,7 +672,7 @@ final class $Nullability_InnerClass$NullableType<$T extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Nullability_InnerClass<$T, $U, $V>?> get nullableType => this;
+  jni$_.JObjType<Nullability$InnerClass<$T, $U, $V>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
@@ -680,22 +680,22 @@ final class $Nullability_InnerClass$NullableType<$T extends jni$_.JObject?,
 
   @core$_.override
   int get hashCode =>
-      Object.hash($Nullability_InnerClass$NullableType, T, U, V);
+      Object.hash($Nullability$InnerClass$NullableType, T, U, V);
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($Nullability_InnerClass$NullableType<$T, $U, $V>) &&
-        other is $Nullability_InnerClass$NullableType<$T, $U, $V> &&
+            ($Nullability$InnerClass$NullableType<$T, $U, $V>) &&
+        other is $Nullability$InnerClass$NullableType<$T, $U, $V> &&
         T == other.T &&
         U == other.U &&
         V == other.V;
   }
 }
 
-final class $Nullability_InnerClass$Type<$T extends jni$_.JObject?,
+final class $Nullability$InnerClass$Type<$T extends jni$_.JObject?,
         $U extends jni$_.JObject, $V extends jni$_.JObject?>
-    extends jni$_.JObjType<Nullability_InnerClass<$T, $U, $V>> {
+    extends jni$_.JObjType<Nullability$InnerClass<$T, $U, $V>> {
   @jni$_.internal
   final jni$_.JObjType<$T> T;
 
@@ -706,7 +706,7 @@ final class $Nullability_InnerClass$Type<$T extends jni$_.JObject?,
   final jni$_.JObjType<$V> V;
 
   @jni$_.internal
-  const $Nullability_InnerClass$Type(
+  const $Nullability$InnerClass$Type(
     this.T,
     this.U,
     this.V,
@@ -719,9 +719,9 @@ final class $Nullability_InnerClass$Type<$T extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  Nullability_InnerClass<$T, $U, $V> fromReference(
+  Nullability$InnerClass<$T, $U, $V> fromReference(
           jni$_.JReference reference) =>
-      Nullability_InnerClass<$T, $U, $V>.fromReference(
+      Nullability$InnerClass<$T, $U, $V>.fromReference(
         T,
         U,
         V,
@@ -733,20 +733,20 @@ final class $Nullability_InnerClass$Type<$T extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Nullability_InnerClass<$T, $U, $V>?> get nullableType =>
-      $Nullability_InnerClass$NullableType<$T, $U, $V>(T, U, V);
+  jni$_.JObjType<Nullability$InnerClass<$T, $U, $V>?> get nullableType =>
+      $Nullability$InnerClass$NullableType<$T, $U, $V>(T, U, V);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($Nullability_InnerClass$Type, T, U, V);
+  int get hashCode => Object.hash($Nullability$InnerClass$Type, T, U, V);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Nullability_InnerClass$Type<$T, $U, $V>) &&
-        other is $Nullability_InnerClass$Type<$T, $U, $V> &&
+    return other.runtimeType == ($Nullability$InnerClass$Type<$T, $U, $V>) &&
+        other is $Nullability$InnerClass$Type<$T, $U, $V> &&
         T == other.T &&
         U == other.U &&
         V == other.V;

--- a/pkgs/jnigen/test/kotlin_test/runtime_test_registrant.dart
+++ b/pkgs/jnigen/test/kotlin_test/runtime_test_registrant.dart
@@ -235,7 +235,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
       test('Inner class', () {
         using((arena) {
           final obj = testObject(arena);
-          final innerObj = Nullability_InnerClass<JString?, JString, JInteger>(
+          final innerObj = Nullability$InnerClass<JString?, JString, JInteger>(
               obj,
               V: JInteger.type);
           expect(

--- a/pkgs/jnigen/test/renamer_test.dart
+++ b/pkgs/jnigen/test/renamer_test.dart
@@ -177,8 +177,6 @@ void main() {
   });
 
   test('Names with existing dollar signs', () async {
-    // TODO(https://github.com/dart-lang/native/issues/1544): Test class names
-    // containing dollar signs.
     final classes = Classes({
       'Foo': ClassDecl(
         binaryName: 'Foo',
@@ -294,5 +292,43 @@ void main() {
     expect(interfaceRenamedMethods, [r'implement$1', r'implementIn$1']);
     final classRenamedMethods = classes.decls['MyClass']!.methods.finalNames;
     expect(classRenamedMethods, [r'implement', r'implementIn']);
+  });
+
+  test('Inner classes vs classes with dollar signs', () async {
+    final classes = Classes({
+      'Outer': ClassDecl(
+        binaryName: 'Outer',
+        declKind: DeclKind.classKind,
+        superclass: TypeUsage.object,
+        methods: [],
+      ),
+      r'Outer$Inner': ClassDecl(
+        binaryName: r'Outer$Inner',
+        declKind: DeclKind.classKind,
+        superclass: TypeUsage.object,
+        methods: [],
+        outerClassBinaryName: 'Outer',
+      ),
+      r'Outer$Inner$Innermost': ClassDecl(
+        binaryName: r'Outer$Inner$Innermost',
+        declKind: DeclKind.classKind,
+        superclass: TypeUsage.object,
+        methods: [],
+        outerClassBinaryName: r'Outer$Inner',
+      ),
+      r'Outer$With$Many$Dollarsigns': ClassDecl(
+        binaryName: r'Outer$With$Many$Dollarsigns',
+        declKind: DeclKind.classKind,
+        superclass: TypeUsage.object,
+        methods: [],
+      ),
+    });
+    await rename(classes);
+    expect(classes.decls['Outer']!.finalName, 'Outer');
+    expect(classes.decls[r'Outer$Inner']!.finalName, r'Outer$Inner');
+    expect(classes.decls[r'Outer$Inner$Innermost']!.finalName,
+        r'Outer$Inner$Innermost');
+    expect(classes.decls[r'Outer$With$Many$Dollarsigns']!.finalName,
+        r'Outer$$With$$Many$$Dollarsigns');
   });
 }

--- a/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
@@ -237,13 +237,13 @@ final class $Color$Type extends jni$_.JObjType<Color> {
 }
 
 /// from: `com.github.dart_lang.jnigen.simple_package.Example$Nested$NestedTwice`
-class Example_Nested_NestedTwice extends jni$_.JObject {
+class Example$Nested$NestedTwice extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Example_Nested_NestedTwice> $type;
+  final jni$_.JObjType<Example$Nested$NestedTwice> $type;
 
   @jni$_.internal
-  Example_Nested_NestedTwice.fromReference(
+  Example$Nested$NestedTwice.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -252,8 +252,8 @@ class Example_Nested_NestedTwice extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/simple_package/Example$Nested$NestedTwice');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Example_Nested_NestedTwice$NullableType();
-  static const type = $Example_Nested_NestedTwice$Type();
+  static const nullableType = $Example$Nested$NestedTwice$NullableType();
+  static const type = $Example$Nested$NestedTwice$Type();
   static final _id_ZERO = _class.staticFieldId(
     r'ZERO',
     r'I',
@@ -284,17 +284,17 @@ class Example_Nested_NestedTwice extends jni$_.JObject {
 
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
-  factory Example_Nested_NestedTwice() {
-    return Example_Nested_NestedTwice.fromReference(
+  factory Example$Nested$NestedTwice() {
+    return Example$Nested$NestedTwice.fromReference(
         _new$(_class.reference.pointer, _id_new$ as jni$_.JMethodIDPtr)
             .reference);
   }
 }
 
-final class $Example_Nested_NestedTwice$NullableType
-    extends jni$_.JObjType<Example_Nested_NestedTwice?> {
+final class $Example$Nested$NestedTwice$NullableType
+    extends jni$_.JObjType<Example$Nested$NestedTwice?> {
   @jni$_.internal
-  const $Example_Nested_NestedTwice$NullableType();
+  const $Example$Nested$NestedTwice$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -303,10 +303,10 @@ final class $Example_Nested_NestedTwice$NullableType
 
   @jni$_.internal
   @core$_.override
-  Example_Nested_NestedTwice? fromReference(jni$_.JReference reference) =>
+  Example$Nested$NestedTwice? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : Example_Nested_NestedTwice.fromReference(
+          : Example$Nested$NestedTwice.fromReference(
               reference,
             );
   @jni$_.internal
@@ -315,26 +315,26 @@ final class $Example_Nested_NestedTwice$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example_Nested_NestedTwice?> get nullableType => this;
+  jni$_.JObjType<Example$Nested$NestedTwice?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example_Nested_NestedTwice$NullableType).hashCode;
+  int get hashCode => ($Example$Nested$NestedTwice$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example_Nested_NestedTwice$NullableType) &&
-        other is $Example_Nested_NestedTwice$NullableType;
+    return other.runtimeType == ($Example$Nested$NestedTwice$NullableType) &&
+        other is $Example$Nested$NestedTwice$NullableType;
   }
 }
 
-final class $Example_Nested_NestedTwice$Type
-    extends jni$_.JObjType<Example_Nested_NestedTwice> {
+final class $Example$Nested$NestedTwice$Type
+    extends jni$_.JObjType<Example$Nested$NestedTwice> {
   @jni$_.internal
-  const $Example_Nested_NestedTwice$Type();
+  const $Example$Nested$NestedTwice$Type();
 
   @jni$_.internal
   @core$_.override
@@ -343,8 +343,8 @@ final class $Example_Nested_NestedTwice$Type
 
   @jni$_.internal
   @core$_.override
-  Example_Nested_NestedTwice fromReference(jni$_.JReference reference) =>
-      Example_Nested_NestedTwice.fromReference(
+  Example$Nested$NestedTwice fromReference(jni$_.JReference reference) =>
+      Example$Nested$NestedTwice.fromReference(
         reference,
       );
   @jni$_.internal
@@ -353,31 +353,31 @@ final class $Example_Nested_NestedTwice$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example_Nested_NestedTwice?> get nullableType =>
-      const $Example_Nested_NestedTwice$NullableType();
+  jni$_.JObjType<Example$Nested$NestedTwice?> get nullableType =>
+      const $Example$Nested$NestedTwice$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example_Nested_NestedTwice$Type).hashCode;
+  int get hashCode => ($Example$Nested$NestedTwice$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example_Nested_NestedTwice$Type) &&
-        other is $Example_Nested_NestedTwice$Type;
+    return other.runtimeType == ($Example$Nested$NestedTwice$Type) &&
+        other is $Example$Nested$NestedTwice$Type;
   }
 }
 
 /// from: `com.github.dart_lang.jnigen.simple_package.Example$Nested`
-class Example_Nested extends jni$_.JObject {
+class Example$Nested extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Example_Nested> $type;
+  final jni$_.JObjType<Example$Nested> $type;
 
   @jni$_.internal
-  Example_Nested.fromReference(
+  Example$Nested.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -386,8 +386,8 @@ class Example_Nested extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/simple_package/Example$Nested');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Example_Nested$NullableType();
-  static const type = $Example_Nested$Type();
+  static const nullableType = $Example$Nested$NullableType();
+  static const type = $Example$Nested$Type();
   static final _id_new$ = _class.constructorId(
     r'(Z)V',
   );
@@ -404,10 +404,10 @@ class Example_Nested extends jni$_.JObject {
 
   /// from: `public void <init>(boolean z)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory Example_Nested(
+  factory Example$Nested(
     bool z,
   ) {
-    return Example_Nested.fromReference(_new$(
+    return Example$Nested.fromReference(_new$(
             _class.reference.pointer, _id_new$ as jni$_.JMethodIDPtr, z ? 1 : 0)
         .reference);
   }
@@ -483,10 +483,10 @@ class Example_Nested extends jni$_.JObject {
   }
 }
 
-final class $Example_Nested$NullableType
-    extends jni$_.JObjType<Example_Nested?> {
+final class $Example$Nested$NullableType
+    extends jni$_.JObjType<Example$Nested?> {
   @jni$_.internal
-  const $Example_Nested$NullableType();
+  const $Example$Nested$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -495,9 +495,9 @@ final class $Example_Nested$NullableType
 
   @jni$_.internal
   @core$_.override
-  Example_Nested? fromReference(jni$_.JReference reference) => reference.isNull
+  Example$Nested? fromReference(jni$_.JReference reference) => reference.isNull
       ? null
-      : Example_Nested.fromReference(
+      : Example$Nested.fromReference(
           reference,
         );
   @jni$_.internal
@@ -506,25 +506,25 @@ final class $Example_Nested$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example_Nested?> get nullableType => this;
+  jni$_.JObjType<Example$Nested?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example_Nested$NullableType).hashCode;
+  int get hashCode => ($Example$Nested$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example_Nested$NullableType) &&
-        other is $Example_Nested$NullableType;
+    return other.runtimeType == ($Example$Nested$NullableType) &&
+        other is $Example$Nested$NullableType;
   }
 }
 
-final class $Example_Nested$Type extends jni$_.JObjType<Example_Nested> {
+final class $Example$Nested$Type extends jni$_.JObjType<Example$Nested> {
   @jni$_.internal
-  const $Example_Nested$Type();
+  const $Example$Nested$Type();
 
   @jni$_.internal
   @core$_.override
@@ -533,8 +533,8 @@ final class $Example_Nested$Type extends jni$_.JObjType<Example_Nested> {
 
   @jni$_.internal
   @core$_.override
-  Example_Nested fromReference(jni$_.JReference reference) =>
-      Example_Nested.fromReference(
+  Example$Nested fromReference(jni$_.JReference reference) =>
+      Example$Nested.fromReference(
         reference,
       );
   @jni$_.internal
@@ -543,31 +543,31 @@ final class $Example_Nested$Type extends jni$_.JObjType<Example_Nested> {
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example_Nested?> get nullableType =>
-      const $Example_Nested$NullableType();
+  jni$_.JObjType<Example$Nested?> get nullableType =>
+      const $Example$Nested$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example_Nested$Type).hashCode;
+  int get hashCode => ($Example$Nested$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example_Nested$Type) &&
-        other is $Example_Nested$Type;
+    return other.runtimeType == ($Example$Nested$Type) &&
+        other is $Example$Nested$Type;
   }
 }
 
 /// from: `com.github.dart_lang.jnigen.simple_package.Example$NonStaticNested`
-class Example_NonStaticNested extends jni$_.JObject {
+class Example$NonStaticNested extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Example_NonStaticNested> $type;
+  final jni$_.JObjType<Example$NonStaticNested> $type;
 
   @jni$_.internal
-  Example_NonStaticNested.fromReference(
+  Example$NonStaticNested.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -576,8 +576,8 @@ class Example_NonStaticNested extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/simple_package/Example$NonStaticNested');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Example_NonStaticNested$NullableType();
-  static const type = $Example_NonStaticNested$Type();
+  static const nullableType = $Example$NonStaticNested$NullableType();
+  static const type = $Example$NonStaticNested$Type();
   static final _id_ok = _class.instanceFieldId(
     r'ok',
     r'Z',
@@ -606,20 +606,20 @@ class Example_NonStaticNested extends jni$_.JObject {
 
   /// from: `public void <init>(com.github.dart_lang.jnigen.simple_package.Example $outerClass)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory Example_NonStaticNested(
+  factory Example$NonStaticNested(
     Example $outerClass,
   ) {
     final _$$outerClass = $outerClass.reference;
-    return Example_NonStaticNested.fromReference(_new$(_class.reference.pointer,
+    return Example$NonStaticNested.fromReference(_new$(_class.reference.pointer,
             _id_new$ as jni$_.JMethodIDPtr, _$$outerClass.pointer)
         .reference);
   }
 }
 
-final class $Example_NonStaticNested$NullableType
-    extends jni$_.JObjType<Example_NonStaticNested?> {
+final class $Example$NonStaticNested$NullableType
+    extends jni$_.JObjType<Example$NonStaticNested?> {
   @jni$_.internal
-  const $Example_NonStaticNested$NullableType();
+  const $Example$NonStaticNested$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -628,10 +628,10 @@ final class $Example_NonStaticNested$NullableType
 
   @jni$_.internal
   @core$_.override
-  Example_NonStaticNested? fromReference(jni$_.JReference reference) =>
+  Example$NonStaticNested? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : Example_NonStaticNested.fromReference(
+          : Example$NonStaticNested.fromReference(
               reference,
             );
   @jni$_.internal
@@ -640,26 +640,26 @@ final class $Example_NonStaticNested$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example_NonStaticNested?> get nullableType => this;
+  jni$_.JObjType<Example$NonStaticNested?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example_NonStaticNested$NullableType).hashCode;
+  int get hashCode => ($Example$NonStaticNested$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example_NonStaticNested$NullableType) &&
-        other is $Example_NonStaticNested$NullableType;
+    return other.runtimeType == ($Example$NonStaticNested$NullableType) &&
+        other is $Example$NonStaticNested$NullableType;
   }
 }
 
-final class $Example_NonStaticNested$Type
-    extends jni$_.JObjType<Example_NonStaticNested> {
+final class $Example$NonStaticNested$Type
+    extends jni$_.JObjType<Example$NonStaticNested> {
   @jni$_.internal
-  const $Example_NonStaticNested$Type();
+  const $Example$NonStaticNested$Type();
 
   @jni$_.internal
   @core$_.override
@@ -668,8 +668,8 @@ final class $Example_NonStaticNested$Type
 
   @jni$_.internal
   @core$_.override
-  Example_NonStaticNested fromReference(jni$_.JReference reference) =>
-      Example_NonStaticNested.fromReference(
+  Example$NonStaticNested fromReference(jni$_.JReference reference) =>
+      Example$NonStaticNested.fromReference(
         reference,
       );
   @jni$_.internal
@@ -678,20 +678,20 @@ final class $Example_NonStaticNested$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example_NonStaticNested?> get nullableType =>
-      const $Example_NonStaticNested$NullableType();
+  jni$_.JObjType<Example$NonStaticNested?> get nullableType =>
+      const $Example$NonStaticNested$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example_NonStaticNested$Type).hashCode;
+  int get hashCode => ($Example$NonStaticNested$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example_NonStaticNested$Type) &&
-        other is $Example_NonStaticNested$Type;
+    return other.runtimeType == ($Example$NonStaticNested$Type) &&
+        other is $Example$NonStaticNested$Type;
   }
 }
 
@@ -859,10 +859,10 @@ class Example extends jni$_.JObject {
 
   /// from: `static public com.github.dart_lang.jnigen.simple_package.Example$Nested getNestedInstance()`
   /// The returned object must be released after use, by calling the [release] method.
-  static Example_Nested? getNestedInstance() {
+  static Example$Nested? getNestedInstance() {
     return _getNestedInstance(_class.reference.pointer,
             _id_getNestedInstance as jni$_.JMethodIDPtr)
-        .object<Example_Nested?>(const $Example_Nested$NullableType());
+        .object<Example$Nested?>(const $Example$Nested$NullableType());
   }
 
   static final _id_setAmount = _class.staticMethodId(
@@ -931,7 +931,7 @@ class Example extends jni$_.JObject {
 
   /// from: `static public void setNestedInstance(com.github.dart_lang.jnigen.simple_package.Example$Nested nested)`
   static void setNestedInstance(
-    Example_Nested? nested,
+    Example$Nested? nested,
   ) {
     final _$nested = nested?.reference ?? jni$_.jNullReference;
     _setNestedInstance(_class.reference.pointer,
@@ -2509,13 +2509,13 @@ final class $Exceptions$Type extends jni$_.JObjType<Exceptions> {
 }
 
 /// from: `com.github.dart_lang.jnigen.simple_package.Fields$Nested`
-class Fields_Nested extends jni$_.JObject {
+class Fields$Nested extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Fields_Nested> $type;
+  final jni$_.JObjType<Fields$Nested> $type;
 
   @jni$_.internal
-  Fields_Nested.fromReference(
+  Fields$Nested.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -2524,8 +2524,8 @@ class Fields_Nested extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/simple_package/Fields$Nested');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Fields_Nested$NullableType();
-  static const type = $Fields_Nested$Type();
+  static const nullableType = $Fields$Nested$NullableType();
+  static const type = $Fields$Nested$Type();
   static final _id_hundred = _class.instanceFieldId(
     r'hundred',
     r'J',
@@ -2571,16 +2571,16 @@ class Fields_Nested extends jni$_.JObject {
 
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
-  factory Fields_Nested() {
-    return Fields_Nested.fromReference(
+  factory Fields$Nested() {
+    return Fields$Nested.fromReference(
         _new$(_class.reference.pointer, _id_new$ as jni$_.JMethodIDPtr)
             .reference);
   }
 }
 
-final class $Fields_Nested$NullableType extends jni$_.JObjType<Fields_Nested?> {
+final class $Fields$Nested$NullableType extends jni$_.JObjType<Fields$Nested?> {
   @jni$_.internal
-  const $Fields_Nested$NullableType();
+  const $Fields$Nested$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -2589,9 +2589,9 @@ final class $Fields_Nested$NullableType extends jni$_.JObjType<Fields_Nested?> {
 
   @jni$_.internal
   @core$_.override
-  Fields_Nested? fromReference(jni$_.JReference reference) => reference.isNull
+  Fields$Nested? fromReference(jni$_.JReference reference) => reference.isNull
       ? null
-      : Fields_Nested.fromReference(
+      : Fields$Nested.fromReference(
           reference,
         );
   @jni$_.internal
@@ -2600,25 +2600,25 @@ final class $Fields_Nested$NullableType extends jni$_.JObjType<Fields_Nested?> {
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Fields_Nested?> get nullableType => this;
+  jni$_.JObjType<Fields$Nested?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Fields_Nested$NullableType).hashCode;
+  int get hashCode => ($Fields$Nested$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Fields_Nested$NullableType) &&
-        other is $Fields_Nested$NullableType;
+    return other.runtimeType == ($Fields$Nested$NullableType) &&
+        other is $Fields$Nested$NullableType;
   }
 }
 
-final class $Fields_Nested$Type extends jni$_.JObjType<Fields_Nested> {
+final class $Fields$Nested$Type extends jni$_.JObjType<Fields$Nested> {
   @jni$_.internal
-  const $Fields_Nested$Type();
+  const $Fields$Nested$Type();
 
   @jni$_.internal
   @core$_.override
@@ -2627,8 +2627,8 @@ final class $Fields_Nested$Type extends jni$_.JObjType<Fields_Nested> {
 
   @jni$_.internal
   @core$_.override
-  Fields_Nested fromReference(jni$_.JReference reference) =>
-      Fields_Nested.fromReference(
+  Fields$Nested fromReference(jni$_.JReference reference) =>
+      Fields$Nested.fromReference(
         reference,
       );
   @jni$_.internal
@@ -2637,20 +2637,20 @@ final class $Fields_Nested$Type extends jni$_.JObjType<Fields_Nested> {
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Fields_Nested?> get nullableType =>
-      const $Fields_Nested$NullableType();
+  jni$_.JObjType<Fields$Nested?> get nullableType =>
+      const $Fields$Nested$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Fields_Nested$Type).hashCode;
+  int get hashCode => ($Fields$Nested$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Fields_Nested$Type) &&
-        other is $Fields_Nested$Type;
+    return other.runtimeType == ($Fields$Nested$Type) &&
+        other is $Fields$Nested$Type;
   }
 }
 
@@ -3353,13 +3353,13 @@ final class $GenericTypeParams$Type<$S extends jni$_.JObject?,
 }
 
 /// from: `com.github.dart_lang.jnigen.generics.GrandParent$Parent$Child`
-class GrandParent_Parent_Child<
+class GrandParent$Parent$Child<
     $T extends jni$_.JObject?,
     $S extends jni$_.JObject?,
     $U extends jni$_.JObject?> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<GrandParent_Parent_Child<$T, $S, $U>> $type;
+  final jni$_.JObjType<GrandParent$Parent$Child<$T, $S, $U>> $type;
 
   @jni$_.internal
   final jni$_.JObjType<$T> T;
@@ -3371,7 +3371,7 @@ class GrandParent_Parent_Child<
   final jni$_.JObjType<$U> U;
 
   @jni$_.internal
-  GrandParent_Parent_Child.fromReference(
+  GrandParent$Parent$Child.fromReference(
     this.T,
     this.S,
     this.U,
@@ -3383,7 +3383,7 @@ class GrandParent_Parent_Child<
       r'com/github/dart_lang/jnigen/generics/GrandParent$Parent$Child');
 
   /// The type which includes information such as the signature of this class.
-  static $GrandParent_Parent_Child$NullableType<$T, $S, $U> nullableType<
+  static $GrandParent$Parent$Child$NullableType<$T, $S, $U> nullableType<
       $T extends jni$_.JObject?,
       $S extends jni$_.JObject?,
       $U extends jni$_.JObject?>(
@@ -3391,14 +3391,14 @@ class GrandParent_Parent_Child<
     jni$_.JObjType<$S> S,
     jni$_.JObjType<$U> U,
   ) {
-    return $GrandParent_Parent_Child$NullableType<$T, $S, $U>(
+    return $GrandParent$Parent$Child$NullableType<$T, $S, $U>(
       T,
       S,
       U,
     );
   }
 
-  static $GrandParent_Parent_Child$Type<$T, $S, $U> type<
+  static $GrandParent$Parent$Child$Type<$T, $S, $U> type<
       $T extends jni$_.JObject?,
       $S extends jni$_.JObject?,
       $U extends jni$_.JObject?>(
@@ -3406,7 +3406,7 @@ class GrandParent_Parent_Child<
     jni$_.JObjType<$S> S,
     jni$_.JObjType<$U> U,
   ) {
-    return $GrandParent_Parent_Child$Type<$T, $S, $U>(
+    return $GrandParent$Parent$Child$Type<$T, $S, $U>(
       T,
       S,
       U,
@@ -3477,8 +3477,8 @@ class GrandParent_Parent_Child<
 
   /// from: `public void <init>(com.github.dart_lang.jnigen.generics.GrandParent$Parent $outerClass, U object)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory GrandParent_Parent_Child(
-    GrandParent_Parent<$T?, $S?> $outerClass,
+  factory GrandParent$Parent$Child(
+    GrandParent$Parent<$T?, $S?> $outerClass,
     $U? object, {
     jni$_.JObjType<$T>? T,
     jni$_.JObjType<$S>? S,
@@ -3486,17 +3486,17 @@ class GrandParent_Parent_Child<
   }) {
     T ??= jni$_.lowestCommonSuperType([
       ($outerClass.$type
-              as $GrandParent_Parent$Type<core$_.dynamic, core$_.dynamic>)
+              as $GrandParent$Parent$Type<core$_.dynamic, core$_.dynamic>)
           .T,
     ]) as jni$_.JObjType<$T>;
     S ??= jni$_.lowestCommonSuperType([
       ($outerClass.$type
-              as $GrandParent_Parent$Type<core$_.dynamic, core$_.dynamic>)
+              as $GrandParent$Parent$Type<core$_.dynamic, core$_.dynamic>)
           .S,
     ]) as jni$_.JObjType<$S>;
     final _$$outerClass = $outerClass.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return GrandParent_Parent_Child<$T, $S, $U>.fromReference(
+    return GrandParent$Parent$Child<$T, $S, $U>.fromReference(
         T,
         S,
         U,
@@ -3506,9 +3506,9 @@ class GrandParent_Parent_Child<
   }
 }
 
-final class $GrandParent_Parent_Child$NullableType<$T extends jni$_.JObject?,
+final class $GrandParent$Parent$Child$NullableType<$T extends jni$_.JObject?,
         $S extends jni$_.JObject?, $U extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent_Parent_Child<$T, $S, $U>?> {
+    extends jni$_.JObjType<GrandParent$Parent$Child<$T, $S, $U>?> {
   @jni$_.internal
   final jni$_.JObjType<$T> T;
 
@@ -3519,7 +3519,7 @@ final class $GrandParent_Parent_Child$NullableType<$T extends jni$_.JObject?,
   final jni$_.JObjType<$U> U;
 
   @jni$_.internal
-  const $GrandParent_Parent_Child$NullableType(
+  const $GrandParent$Parent$Child$NullableType(
     this.T,
     this.S,
     this.U,
@@ -3532,11 +3532,11 @@ final class $GrandParent_Parent_Child$NullableType<$T extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  GrandParent_Parent_Child<$T, $S, $U>? fromReference(
+  GrandParent$Parent$Child<$T, $S, $U>? fromReference(
           jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : GrandParent_Parent_Child<$T, $S, $U>.fromReference(
+          : GrandParent$Parent$Child<$T, $S, $U>.fromReference(
               T,
               S,
               U,
@@ -3548,7 +3548,7 @@ final class $GrandParent_Parent_Child$NullableType<$T extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent_Parent_Child<$T, $S, $U>?> get nullableType =>
+  jni$_.JObjType<GrandParent$Parent$Child<$T, $S, $U>?> get nullableType =>
       this;
 
   @jni$_.internal
@@ -3557,22 +3557,22 @@ final class $GrandParent_Parent_Child$NullableType<$T extends jni$_.JObject?,
 
   @core$_.override
   int get hashCode =>
-      Object.hash($GrandParent_Parent_Child$NullableType, T, S, U);
+      Object.hash($GrandParent$Parent$Child$NullableType, T, S, U);
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($GrandParent_Parent_Child$NullableType<$T, $S, $U>) &&
-        other is $GrandParent_Parent_Child$NullableType<$T, $S, $U> &&
+            ($GrandParent$Parent$Child$NullableType<$T, $S, $U>) &&
+        other is $GrandParent$Parent$Child$NullableType<$T, $S, $U> &&
         T == other.T &&
         S == other.S &&
         U == other.U;
   }
 }
 
-final class $GrandParent_Parent_Child$Type<$T extends jni$_.JObject?,
+final class $GrandParent$Parent$Child$Type<$T extends jni$_.JObject?,
         $S extends jni$_.JObject?, $U extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent_Parent_Child<$T, $S, $U>> {
+    extends jni$_.JObjType<GrandParent$Parent$Child<$T, $S, $U>> {
   @jni$_.internal
   final jni$_.JObjType<$T> T;
 
@@ -3583,7 +3583,7 @@ final class $GrandParent_Parent_Child$Type<$T extends jni$_.JObject?,
   final jni$_.JObjType<$U> U;
 
   @jni$_.internal
-  const $GrandParent_Parent_Child$Type(
+  const $GrandParent$Parent$Child$Type(
     this.T,
     this.S,
     this.U,
@@ -3596,9 +3596,9 @@ final class $GrandParent_Parent_Child$Type<$T extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  GrandParent_Parent_Child<$T, $S, $U> fromReference(
+  GrandParent$Parent$Child<$T, $S, $U> fromReference(
           jni$_.JReference reference) =>
-      GrandParent_Parent_Child<$T, $S, $U>.fromReference(
+      GrandParent$Parent$Child<$T, $S, $U>.fromReference(
         T,
         S,
         U,
@@ -3610,20 +3610,20 @@ final class $GrandParent_Parent_Child$Type<$T extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent_Parent_Child<$T, $S, $U>?> get nullableType =>
-      $GrandParent_Parent_Child$NullableType<$T, $S, $U>(T, S, U);
+  jni$_.JObjType<GrandParent$Parent$Child<$T, $S, $U>?> get nullableType =>
+      $GrandParent$Parent$Child$NullableType<$T, $S, $U>(T, S, U);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GrandParent_Parent_Child$Type, T, S, U);
+  int get hashCode => Object.hash($GrandParent$Parent$Child$Type, T, S, U);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent_Parent_Child$Type<$T, $S, $U>) &&
-        other is $GrandParent_Parent_Child$Type<$T, $S, $U> &&
+    return other.runtimeType == ($GrandParent$Parent$Child$Type<$T, $S, $U>) &&
+        other is $GrandParent$Parent$Child$Type<$T, $S, $U> &&
         T == other.T &&
         S == other.S &&
         U == other.U;
@@ -3631,11 +3631,11 @@ final class $GrandParent_Parent_Child$Type<$T extends jni$_.JObject?,
 }
 
 /// from: `com.github.dart_lang.jnigen.generics.GrandParent$Parent`
-class GrandParent_Parent<$T extends jni$_.JObject?, $S extends jni$_.JObject?>
+class GrandParent$Parent<$T extends jni$_.JObject?, $S extends jni$_.JObject?>
     extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<GrandParent_Parent<$T, $S>> $type;
+  final jni$_.JObjType<GrandParent$Parent<$T, $S>> $type;
 
   @jni$_.internal
   final jni$_.JObjType<$T> T;
@@ -3644,7 +3644,7 @@ class GrandParent_Parent<$T extends jni$_.JObject?, $S extends jni$_.JObject?>
   final jni$_.JObjType<$S> S;
 
   @jni$_.internal
-  GrandParent_Parent.fromReference(
+  GrandParent$Parent.fromReference(
     this.T,
     this.S,
     jni$_.JReference reference,
@@ -3655,23 +3655,23 @@ class GrandParent_Parent<$T extends jni$_.JObject?, $S extends jni$_.JObject?>
       r'com/github/dart_lang/jnigen/generics/GrandParent$Parent');
 
   /// The type which includes information such as the signature of this class.
-  static $GrandParent_Parent$NullableType<$T, $S>
+  static $GrandParent$Parent$NullableType<$T, $S>
       nullableType<$T extends jni$_.JObject?, $S extends jni$_.JObject?>(
     jni$_.JObjType<$T> T,
     jni$_.JObjType<$S> S,
   ) {
-    return $GrandParent_Parent$NullableType<$T, $S>(
+    return $GrandParent$Parent$NullableType<$T, $S>(
       T,
       S,
     );
   }
 
-  static $GrandParent_Parent$Type<$T, $S>
+  static $GrandParent$Parent$Type<$T, $S>
       type<$T extends jni$_.JObject?, $S extends jni$_.JObject?>(
     jni$_.JObjType<$T> T,
     jni$_.JObjType<$S> S,
   ) {
-    return $GrandParent_Parent$Type<$T, $S>(
+    return $GrandParent$Parent$Type<$T, $S>(
       T,
       S,
     );
@@ -3727,7 +3727,7 @@ class GrandParent_Parent<$T extends jni$_.JObject?, $S extends jni$_.JObject?>
 
   /// from: `public void <init>(com.github.dart_lang.jnigen.generics.GrandParent $outerClass, S object)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory GrandParent_Parent(
+  factory GrandParent$Parent(
     GrandParent<$T?> $outerClass,
     $S? object, {
     jni$_.JObjType<$T>? T,
@@ -3738,7 +3738,7 @@ class GrandParent_Parent<$T extends jni$_.JObject?, $S extends jni$_.JObject?>
     ]) as jni$_.JObjType<$T>;
     final _$$outerClass = $outerClass.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return GrandParent_Parent<$T, $S>.fromReference(
+    return GrandParent$Parent<$T, $S>.fromReference(
         T,
         S,
         _new$(_class.reference.pointer, _id_new$ as jni$_.JMethodIDPtr,
@@ -3747,9 +3747,9 @@ class GrandParent_Parent<$T extends jni$_.JObject?, $S extends jni$_.JObject?>
   }
 }
 
-final class $GrandParent_Parent$NullableType<$T extends jni$_.JObject?,
+final class $GrandParent$Parent$NullableType<$T extends jni$_.JObject?,
         $S extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent_Parent<$T, $S>?> {
+    extends jni$_.JObjType<GrandParent$Parent<$T, $S>?> {
   @jni$_.internal
   final jni$_.JObjType<$T> T;
 
@@ -3757,7 +3757,7 @@ final class $GrandParent_Parent$NullableType<$T extends jni$_.JObject?,
   final jni$_.JObjType<$S> S;
 
   @jni$_.internal
-  const $GrandParent_Parent$NullableType(
+  const $GrandParent$Parent$NullableType(
     this.T,
     this.S,
   );
@@ -3769,10 +3769,10 @@ final class $GrandParent_Parent$NullableType<$T extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  GrandParent_Parent<$T, $S>? fromReference(jni$_.JReference reference) =>
+  GrandParent$Parent<$T, $S>? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : GrandParent_Parent<$T, $S>.fromReference(
+          : GrandParent$Parent<$T, $S>.fromReference(
               T,
               S,
               reference,
@@ -3783,27 +3783,27 @@ final class $GrandParent_Parent$NullableType<$T extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent_Parent<$T, $S>?> get nullableType => this;
+  jni$_.JObjType<GrandParent$Parent<$T, $S>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GrandParent_Parent$NullableType, T, S);
+  int get hashCode => Object.hash($GrandParent$Parent$NullableType, T, S);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent_Parent$NullableType<$T, $S>) &&
-        other is $GrandParent_Parent$NullableType<$T, $S> &&
+    return other.runtimeType == ($GrandParent$Parent$NullableType<$T, $S>) &&
+        other is $GrandParent$Parent$NullableType<$T, $S> &&
         T == other.T &&
         S == other.S;
   }
 }
 
-final class $GrandParent_Parent$Type<$T extends jni$_.JObject?,
+final class $GrandParent$Parent$Type<$T extends jni$_.JObject?,
         $S extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent_Parent<$T, $S>> {
+    extends jni$_.JObjType<GrandParent$Parent<$T, $S>> {
   @jni$_.internal
   final jni$_.JObjType<$T> T;
 
@@ -3811,7 +3811,7 @@ final class $GrandParent_Parent$Type<$T extends jni$_.JObject?,
   final jni$_.JObjType<$S> S;
 
   @jni$_.internal
-  const $GrandParent_Parent$Type(
+  const $GrandParent$Parent$Type(
     this.T,
     this.S,
   );
@@ -3823,8 +3823,8 @@ final class $GrandParent_Parent$Type<$T extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  GrandParent_Parent<$T, $S> fromReference(jni$_.JReference reference) =>
-      GrandParent_Parent<$T, $S>.fromReference(
+  GrandParent$Parent<$T, $S> fromReference(jni$_.JReference reference) =>
+      GrandParent$Parent<$T, $S>.fromReference(
         T,
         S,
         reference,
@@ -3835,31 +3835,31 @@ final class $GrandParent_Parent$Type<$T extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent_Parent<$T, $S>?> get nullableType =>
-      $GrandParent_Parent$NullableType<$T, $S>(T, S);
+  jni$_.JObjType<GrandParent$Parent<$T, $S>?> get nullableType =>
+      $GrandParent$Parent$NullableType<$T, $S>(T, S);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GrandParent_Parent$Type, T, S);
+  int get hashCode => Object.hash($GrandParent$Parent$Type, T, S);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent_Parent$Type<$T, $S>) &&
-        other is $GrandParent_Parent$Type<$T, $S> &&
+    return other.runtimeType == ($GrandParent$Parent$Type<$T, $S>) &&
+        other is $GrandParent$Parent$Type<$T, $S> &&
         T == other.T &&
         S == other.S;
   }
 }
 
 /// from: `com.github.dart_lang.jnigen.generics.GrandParent$StaticParent$Child`
-class GrandParent_StaticParent_Child<$S extends jni$_.JObject?,
+class GrandParent$StaticParent$Child<$S extends jni$_.JObject?,
     $U extends jni$_.JObject?> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<GrandParent_StaticParent_Child<$S, $U>> $type;
+  final jni$_.JObjType<GrandParent$StaticParent$Child<$S, $U>> $type;
 
   @jni$_.internal
   final jni$_.JObjType<$S> S;
@@ -3868,7 +3868,7 @@ class GrandParent_StaticParent_Child<$S extends jni$_.JObject?,
   final jni$_.JObjType<$U> U;
 
   @jni$_.internal
-  GrandParent_StaticParent_Child.fromReference(
+  GrandParent$StaticParent$Child.fromReference(
     this.S,
     this.U,
     jni$_.JReference reference,
@@ -3879,23 +3879,23 @@ class GrandParent_StaticParent_Child<$S extends jni$_.JObject?,
       r'com/github/dart_lang/jnigen/generics/GrandParent$StaticParent$Child');
 
   /// The type which includes information such as the signature of this class.
-  static $GrandParent_StaticParent_Child$NullableType<$S, $U>
+  static $GrandParent$StaticParent$Child$NullableType<$S, $U>
       nullableType<$S extends jni$_.JObject?, $U extends jni$_.JObject?>(
     jni$_.JObjType<$S> S,
     jni$_.JObjType<$U> U,
   ) {
-    return $GrandParent_StaticParent_Child$NullableType<$S, $U>(
+    return $GrandParent$StaticParent$Child$NullableType<$S, $U>(
       S,
       U,
     );
   }
 
-  static $GrandParent_StaticParent_Child$Type<$S, $U>
+  static $GrandParent$StaticParent$Child$Type<$S, $U>
       type<$S extends jni$_.JObject?, $U extends jni$_.JObject?>(
     jni$_.JObjType<$S> S,
     jni$_.JObjType<$U> U,
   ) {
-    return $GrandParent_StaticParent_Child$Type<$S, $U>(
+    return $GrandParent$StaticParent$Child$Type<$S, $U>(
       S,
       U,
     );
@@ -3953,20 +3953,20 @@ class GrandParent_StaticParent_Child<$S extends jni$_.JObject?,
 
   /// from: `public void <init>(com.github.dart_lang.jnigen.generics.GrandParent$StaticParent $outerClass, S object, U object1)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory GrandParent_StaticParent_Child(
-    GrandParent_StaticParent<$S?> $outerClass,
+  factory GrandParent$StaticParent$Child(
+    GrandParent$StaticParent<$S?> $outerClass,
     $S? object,
     $U? object1, {
     jni$_.JObjType<$S>? S,
     required jni$_.JObjType<$U> U,
   }) {
     S ??= jni$_.lowestCommonSuperType([
-      ($outerClass.$type as $GrandParent_StaticParent$Type<core$_.dynamic>).S,
+      ($outerClass.$type as $GrandParent$StaticParent$Type<core$_.dynamic>).S,
     ]) as jni$_.JObjType<$S>;
     final _$$outerClass = $outerClass.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return GrandParent_StaticParent_Child<$S, $U>.fromReference(
+    return GrandParent$StaticParent$Child<$S, $U>.fromReference(
         S,
         U,
         _new$(_class.reference.pointer, _id_new$ as jni$_.JMethodIDPtr,
@@ -3975,9 +3975,9 @@ class GrandParent_StaticParent_Child<$S extends jni$_.JObject?,
   }
 }
 
-final class $GrandParent_StaticParent_Child$NullableType<
+final class $GrandParent$StaticParent$Child$NullableType<
         $S extends jni$_.JObject?, $U extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent_StaticParent_Child<$S, $U>?> {
+    extends jni$_.JObjType<GrandParent$StaticParent$Child<$S, $U>?> {
   @jni$_.internal
   final jni$_.JObjType<$S> S;
 
@@ -3985,7 +3985,7 @@ final class $GrandParent_StaticParent_Child$NullableType<
   final jni$_.JObjType<$U> U;
 
   @jni$_.internal
-  const $GrandParent_StaticParent_Child$NullableType(
+  const $GrandParent$StaticParent$Child$NullableType(
     this.S,
     this.U,
   );
@@ -3997,11 +3997,11 @@ final class $GrandParent_StaticParent_Child$NullableType<
 
   @jni$_.internal
   @core$_.override
-  GrandParent_StaticParent_Child<$S, $U>? fromReference(
+  GrandParent$StaticParent$Child<$S, $U>? fromReference(
           jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : GrandParent_StaticParent_Child<$S, $U>.fromReference(
+          : GrandParent$StaticParent$Child<$S, $U>.fromReference(
               S,
               U,
               reference,
@@ -4012,7 +4012,7 @@ final class $GrandParent_StaticParent_Child$NullableType<
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent_StaticParent_Child<$S, $U>?> get nullableType =>
+  jni$_.JObjType<GrandParent$StaticParent$Child<$S, $U>?> get nullableType =>
       this;
 
   @jni$_.internal
@@ -4021,21 +4021,21 @@ final class $GrandParent_StaticParent_Child$NullableType<
 
   @core$_.override
   int get hashCode =>
-      Object.hash($GrandParent_StaticParent_Child$NullableType, S, U);
+      Object.hash($GrandParent$StaticParent$Child$NullableType, S, U);
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($GrandParent_StaticParent_Child$NullableType<$S, $U>) &&
-        other is $GrandParent_StaticParent_Child$NullableType<$S, $U> &&
+            ($GrandParent$StaticParent$Child$NullableType<$S, $U>) &&
+        other is $GrandParent$StaticParent$Child$NullableType<$S, $U> &&
         S == other.S &&
         U == other.U;
   }
 }
 
-final class $GrandParent_StaticParent_Child$Type<$S extends jni$_.JObject?,
+final class $GrandParent$StaticParent$Child$Type<$S extends jni$_.JObject?,
         $U extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent_StaticParent_Child<$S, $U>> {
+    extends jni$_.JObjType<GrandParent$StaticParent$Child<$S, $U>> {
   @jni$_.internal
   final jni$_.JObjType<$S> S;
 
@@ -4043,7 +4043,7 @@ final class $GrandParent_StaticParent_Child$Type<$S extends jni$_.JObject?,
   final jni$_.JObjType<$U> U;
 
   @jni$_.internal
-  const $GrandParent_StaticParent_Child$Type(
+  const $GrandParent$StaticParent$Child$Type(
     this.S,
     this.U,
   );
@@ -4055,9 +4055,9 @@ final class $GrandParent_StaticParent_Child$Type<$S extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  GrandParent_StaticParent_Child<$S, $U> fromReference(
+  GrandParent$StaticParent$Child<$S, $U> fromReference(
           jni$_.JReference reference) =>
-      GrandParent_StaticParent_Child<$S, $U>.fromReference(
+      GrandParent$StaticParent$Child<$S, $U>.fromReference(
         S,
         U,
         reference,
@@ -4068,38 +4068,38 @@ final class $GrandParent_StaticParent_Child$Type<$S extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent_StaticParent_Child<$S, $U>?> get nullableType =>
-      $GrandParent_StaticParent_Child$NullableType<$S, $U>(S, U);
+  jni$_.JObjType<GrandParent$StaticParent$Child<$S, $U>?> get nullableType =>
+      $GrandParent$StaticParent$Child$NullableType<$S, $U>(S, U);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GrandParent_StaticParent_Child$Type, S, U);
+  int get hashCode => Object.hash($GrandParent$StaticParent$Child$Type, S, U);
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($GrandParent_StaticParent_Child$Type<$S, $U>) &&
-        other is $GrandParent_StaticParent_Child$Type<$S, $U> &&
+            ($GrandParent$StaticParent$Child$Type<$S, $U>) &&
+        other is $GrandParent$StaticParent$Child$Type<$S, $U> &&
         S == other.S &&
         U == other.U;
   }
 }
 
 /// from: `com.github.dart_lang.jnigen.generics.GrandParent$StaticParent`
-class GrandParent_StaticParent<$S extends jni$_.JObject?>
+class GrandParent$StaticParent<$S extends jni$_.JObject?>
     extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<GrandParent_StaticParent<$S>> $type;
+  final jni$_.JObjType<GrandParent$StaticParent<$S>> $type;
 
   @jni$_.internal
   final jni$_.JObjType<$S> S;
 
   @jni$_.internal
-  GrandParent_StaticParent.fromReference(
+  GrandParent$StaticParent.fromReference(
     this.S,
     jni$_.JReference reference,
   )   : $type = type<$S>(S),
@@ -4109,19 +4109,19 @@ class GrandParent_StaticParent<$S extends jni$_.JObject?>
       r'com/github/dart_lang/jnigen/generics/GrandParent$StaticParent');
 
   /// The type which includes information such as the signature of this class.
-  static $GrandParent_StaticParent$NullableType<$S>
+  static $GrandParent$StaticParent$NullableType<$S>
       nullableType<$S extends jni$_.JObject?>(
     jni$_.JObjType<$S> S,
   ) {
-    return $GrandParent_StaticParent$NullableType<$S>(
+    return $GrandParent$StaticParent$NullableType<$S>(
       S,
     );
   }
 
-  static $GrandParent_StaticParent$Type<$S> type<$S extends jni$_.JObject?>(
+  static $GrandParent$StaticParent$Type<$S> type<$S extends jni$_.JObject?>(
     jni$_.JObjType<$S> S,
   ) {
-    return $GrandParent_StaticParent$Type<$S>(
+    return $GrandParent$StaticParent$Type<$S>(
       S,
     );
   }
@@ -4156,12 +4156,12 @@ class GrandParent_StaticParent<$S extends jni$_.JObject?>
 
   /// from: `public void <init>(S object)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory GrandParent_StaticParent(
+  factory GrandParent$StaticParent(
     $S? object, {
     required jni$_.JObjType<$S> S,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return GrandParent_StaticParent<$S>.fromReference(
+    return GrandParent$StaticParent<$S>.fromReference(
         S,
         _new$(_class.reference.pointer, _id_new$ as jni$_.JMethodIDPtr,
                 _$object.pointer)
@@ -4169,13 +4169,13 @@ class GrandParent_StaticParent<$S extends jni$_.JObject?>
   }
 }
 
-final class $GrandParent_StaticParent$NullableType<$S extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent_StaticParent<$S>?> {
+final class $GrandParent$StaticParent$NullableType<$S extends jni$_.JObject?>
+    extends jni$_.JObjType<GrandParent$StaticParent<$S>?> {
   @jni$_.internal
   final jni$_.JObjType<$S> S;
 
   @jni$_.internal
-  const $GrandParent_StaticParent$NullableType(
+  const $GrandParent$StaticParent$NullableType(
     this.S,
   );
 
@@ -4186,10 +4186,10 @@ final class $GrandParent_StaticParent$NullableType<$S extends jni$_.JObject?>
 
   @jni$_.internal
   @core$_.override
-  GrandParent_StaticParent<$S>? fromReference(jni$_.JReference reference) =>
+  GrandParent$StaticParent<$S>? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : GrandParent_StaticParent<$S>.fromReference(
+          : GrandParent$StaticParent<$S>.fromReference(
               S,
               reference,
             );
@@ -4199,30 +4199,30 @@ final class $GrandParent_StaticParent$NullableType<$S extends jni$_.JObject?>
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent_StaticParent<$S>?> get nullableType => this;
+  jni$_.JObjType<GrandParent$StaticParent<$S>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GrandParent_StaticParent$NullableType, S);
+  int get hashCode => Object.hash($GrandParent$StaticParent$NullableType, S);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent_StaticParent$NullableType<$S>) &&
-        other is $GrandParent_StaticParent$NullableType<$S> &&
+    return other.runtimeType == ($GrandParent$StaticParent$NullableType<$S>) &&
+        other is $GrandParent$StaticParent$NullableType<$S> &&
         S == other.S;
   }
 }
 
-final class $GrandParent_StaticParent$Type<$S extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent_StaticParent<$S>> {
+final class $GrandParent$StaticParent$Type<$S extends jni$_.JObject?>
+    extends jni$_.JObjType<GrandParent$StaticParent<$S>> {
   @jni$_.internal
   final jni$_.JObjType<$S> S;
 
   @jni$_.internal
-  const $GrandParent_StaticParent$Type(
+  const $GrandParent$StaticParent$Type(
     this.S,
   );
 
@@ -4233,8 +4233,8 @@ final class $GrandParent_StaticParent$Type<$S extends jni$_.JObject?>
 
   @jni$_.internal
   @core$_.override
-  GrandParent_StaticParent<$S> fromReference(jni$_.JReference reference) =>
-      GrandParent_StaticParent<$S>.fromReference(
+  GrandParent$StaticParent<$S> fromReference(jni$_.JReference reference) =>
+      GrandParent$StaticParent<$S>.fromReference(
         S,
         reference,
       );
@@ -4244,20 +4244,20 @@ final class $GrandParent_StaticParent$Type<$S extends jni$_.JObject?>
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent_StaticParent<$S>?> get nullableType =>
-      $GrandParent_StaticParent$NullableType<$S>(S);
+  jni$_.JObjType<GrandParent$StaticParent<$S>?> get nullableType =>
+      $GrandParent$StaticParent$NullableType<$S>(S);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GrandParent_StaticParent$Type, S);
+  int get hashCode => Object.hash($GrandParent$StaticParent$Type, S);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent_StaticParent$Type<$S>) &&
-        other is $GrandParent_StaticParent$Type<$S> &&
+    return other.runtimeType == ($GrandParent$StaticParent$Type<$S>) &&
+        other is $GrandParent$StaticParent$Type<$S> &&
         S == other.S;
   }
 }
@@ -4359,11 +4359,11 @@ class GrandParent<$T extends jni$_.JObject?> extends jni$_.JObject {
 
   /// from: `public com.github.dart_lang.jnigen.generics.GrandParent.Parent stringParent()`
   /// The returned object must be released after use, by calling the [release] method.
-  GrandParent_Parent<$T?, jni$_.JString?>? stringParent() {
+  GrandParent$Parent<$T?, jni$_.JString?>? stringParent() {
     return _stringParent(
             reference.pointer, _id_stringParent as jni$_.JMethodIDPtr)
-        .object<GrandParent_Parent<$T?, jni$_.JString?>?>(
-            $GrandParent_Parent$NullableType<$T?, jni$_.JString?>(
+        .object<GrandParent$Parent<$T?, jni$_.JString?>?>(
+            $GrandParent$Parent$NullableType<$T?, jni$_.JString?>(
                 T.nullableType, const jni$_.JStringNullableType()));
   }
 
@@ -4385,15 +4385,15 @@ class GrandParent<$T extends jni$_.JObject?> extends jni$_.JObject {
 
   /// from: `public com.github.dart_lang.jnigen.generics.GrandParent.Parent varParent(S object)`
   /// The returned object must be released after use, by calling the [release] method.
-  GrandParent_Parent<$T?, $S?>? varParent<$S extends jni$_.JObject?>(
+  GrandParent$Parent<$T?, $S?>? varParent<$S extends jni$_.JObject?>(
     $S? object, {
     required jni$_.JObjType<$S> S,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _varParent(reference.pointer, _id_varParent as jni$_.JMethodIDPtr,
             _$object.pointer)
-        .object<GrandParent_Parent<$T?, $S?>?>(
-            $GrandParent_Parent$NullableType<$T?, $S?>(
+        .object<GrandParent$Parent<$T?, $S?>?>(
+            $GrandParent$Parent$NullableType<$T?, $S?>(
                 T.nullableType, S.nullableType));
   }
 
@@ -4416,11 +4416,11 @@ class GrandParent<$T extends jni$_.JObject?> extends jni$_.JObject {
 
   /// from: `static public com.github.dart_lang.jnigen.generics.GrandParent$StaticParent stringStaticParent()`
   /// The returned object must be released after use, by calling the [release] method.
-  static GrandParent_StaticParent<jni$_.JString?>? stringStaticParent() {
+  static GrandParent$StaticParent<jni$_.JString?>? stringStaticParent() {
     return _stringStaticParent(_class.reference.pointer,
             _id_stringStaticParent as jni$_.JMethodIDPtr)
-        .object<GrandParent_StaticParent<jni$_.JString?>?>(
-            const $GrandParent_StaticParent$NullableType<jni$_.JString?>(
+        .object<GrandParent$StaticParent<jni$_.JString?>?>(
+            const $GrandParent$StaticParent$NullableType<jni$_.JString?>(
                 jni$_.JStringNullableType()));
   }
 
@@ -4442,7 +4442,7 @@ class GrandParent<$T extends jni$_.JObject?> extends jni$_.JObject {
 
   /// from: `static public com.github.dart_lang.jnigen.generics.GrandParent$StaticParent varStaticParent(S object)`
   /// The returned object must be released after use, by calling the [release] method.
-  static GrandParent_StaticParent<$S?>?
+  static GrandParent$StaticParent<$S?>?
       varStaticParent<$S extends jni$_.JObject?>(
     $S? object, {
     required jni$_.JObjType<$S> S,
@@ -4450,8 +4450,8 @@ class GrandParent<$T extends jni$_.JObject?> extends jni$_.JObject {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _varStaticParent(_class.reference.pointer,
             _id_varStaticParent as jni$_.JMethodIDPtr, _$object.pointer)
-        .object<GrandParent_StaticParent<$S?>?>(
-            $GrandParent_StaticParent$NullableType<$S?>(S.nullableType));
+        .object<GrandParent$StaticParent<$S?>?>(
+            $GrandParent$StaticParent$NullableType<$S?>(S.nullableType));
   }
 
   static final _id_staticParentWithSameType = _class.instanceMethodId(
@@ -4473,11 +4473,11 @@ class GrandParent<$T extends jni$_.JObject?> extends jni$_.JObject {
 
   /// from: `public com.github.dart_lang.jnigen.generics.GrandParent$StaticParent staticParentWithSameType()`
   /// The returned object must be released after use, by calling the [release] method.
-  GrandParent_StaticParent<$T?>? staticParentWithSameType() {
+  GrandParent$StaticParent<$T?>? staticParentWithSameType() {
     return _staticParentWithSameType(reference.pointer,
             _id_staticParentWithSameType as jni$_.JMethodIDPtr)
-        .object<GrandParent_StaticParent<$T?>?>(
-            $GrandParent_StaticParent$NullableType<$T?>(T.nullableType));
+        .object<GrandParent$StaticParent<$T?>?>(
+            $GrandParent$StaticParent$NullableType<$T?>(T.nullableType));
   }
 }
 
@@ -4572,11 +4572,11 @@ final class $GrandParent$Type<$T extends jni$_.JObject?>
 }
 
 /// from: `com.github.dart_lang.jnigen.generics.MyMap$MyEntry`
-class MyMap_MyEntry<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
+class MyMap$MyEntry<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<MyMap_MyEntry<$K, $V>> $type;
+  final jni$_.JObjType<MyMap$MyEntry<$K, $V>> $type;
 
   @jni$_.internal
   final jni$_.JObjType<$K> K;
@@ -4585,7 +4585,7 @@ class MyMap_MyEntry<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   final jni$_.JObjType<$V> V;
 
   @jni$_.internal
-  MyMap_MyEntry.fromReference(
+  MyMap$MyEntry.fromReference(
     this.K,
     this.V,
     jni$_.JReference reference,
@@ -4596,23 +4596,23 @@ class MyMap_MyEntry<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
       r'com/github/dart_lang/jnigen/generics/MyMap$MyEntry');
 
   /// The type which includes information such as the signature of this class.
-  static $MyMap_MyEntry$NullableType<$K, $V>
+  static $MyMap$MyEntry$NullableType<$K, $V>
       nullableType<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
     jni$_.JObjType<$K> K,
     jni$_.JObjType<$V> V,
   ) {
-    return $MyMap_MyEntry$NullableType<$K, $V>(
+    return $MyMap$MyEntry$NullableType<$K, $V>(
       K,
       V,
     );
   }
 
-  static $MyMap_MyEntry$Type<$K, $V>
+  static $MyMap$MyEntry$Type<$K, $V>
       type<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
     jni$_.JObjType<$K> K,
     jni$_.JObjType<$V> V,
   ) {
-    return $MyMap_MyEntry$Type<$K, $V>(
+    return $MyMap$MyEntry$Type<$K, $V>(
       K,
       V,
     );
@@ -4669,7 +4669,7 @@ class MyMap_MyEntry<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
 
   /// from: `public void <init>(com.github.dart_lang.jnigen.generics.MyMap $outerClass, K object, V object1)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory MyMap_MyEntry(
+  factory MyMap$MyEntry(
     MyMap<$K?, $V?> $outerClass,
     $K? object,
     $V? object1, {
@@ -4685,7 +4685,7 @@ class MyMap_MyEntry<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     final _$$outerClass = $outerClass.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return MyMap_MyEntry<$K, $V>.fromReference(
+    return MyMap$MyEntry<$K, $V>.fromReference(
         K,
         V,
         _new$(_class.reference.pointer, _id_new$ as jni$_.JMethodIDPtr,
@@ -4694,8 +4694,8 @@ class MyMap_MyEntry<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   }
 }
 
-final class $MyMap_MyEntry$NullableType<$K extends jni$_.JObject?,
-    $V extends jni$_.JObject?> extends jni$_.JObjType<MyMap_MyEntry<$K, $V>?> {
+final class $MyMap$MyEntry$NullableType<$K extends jni$_.JObject?,
+    $V extends jni$_.JObject?> extends jni$_.JObjType<MyMap$MyEntry<$K, $V>?> {
   @jni$_.internal
   final jni$_.JObjType<$K> K;
 
@@ -4703,7 +4703,7 @@ final class $MyMap_MyEntry$NullableType<$K extends jni$_.JObject?,
   final jni$_.JObjType<$V> V;
 
   @jni$_.internal
-  const $MyMap_MyEntry$NullableType(
+  const $MyMap$MyEntry$NullableType(
     this.K,
     this.V,
   );
@@ -4715,10 +4715,10 @@ final class $MyMap_MyEntry$NullableType<$K extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  MyMap_MyEntry<$K, $V>? fromReference(jni$_.JReference reference) =>
+  MyMap$MyEntry<$K, $V>? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : MyMap_MyEntry<$K, $V>.fromReference(
+          : MyMap$MyEntry<$K, $V>.fromReference(
               K,
               V,
               reference,
@@ -4729,26 +4729,26 @@ final class $MyMap_MyEntry$NullableType<$K extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyMap_MyEntry<$K, $V>?> get nullableType => this;
+  jni$_.JObjType<MyMap$MyEntry<$K, $V>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($MyMap_MyEntry$NullableType, K, V);
+  int get hashCode => Object.hash($MyMap$MyEntry$NullableType, K, V);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyMap_MyEntry$NullableType<$K, $V>) &&
-        other is $MyMap_MyEntry$NullableType<$K, $V> &&
+    return other.runtimeType == ($MyMap$MyEntry$NullableType<$K, $V>) &&
+        other is $MyMap$MyEntry$NullableType<$K, $V> &&
         K == other.K &&
         V == other.V;
   }
 }
 
-final class $MyMap_MyEntry$Type<$K extends jni$_.JObject?,
-    $V extends jni$_.JObject?> extends jni$_.JObjType<MyMap_MyEntry<$K, $V>> {
+final class $MyMap$MyEntry$Type<$K extends jni$_.JObject?,
+    $V extends jni$_.JObject?> extends jni$_.JObjType<MyMap$MyEntry<$K, $V>> {
   @jni$_.internal
   final jni$_.JObjType<$K> K;
 
@@ -4756,7 +4756,7 @@ final class $MyMap_MyEntry$Type<$K extends jni$_.JObject?,
   final jni$_.JObjType<$V> V;
 
   @jni$_.internal
-  const $MyMap_MyEntry$Type(
+  const $MyMap$MyEntry$Type(
     this.K,
     this.V,
   );
@@ -4768,8 +4768,8 @@ final class $MyMap_MyEntry$Type<$K extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  MyMap_MyEntry<$K, $V> fromReference(jni$_.JReference reference) =>
-      MyMap_MyEntry<$K, $V>.fromReference(
+  MyMap$MyEntry<$K, $V> fromReference(jni$_.JReference reference) =>
+      MyMap$MyEntry<$K, $V>.fromReference(
         K,
         V,
         reference,
@@ -4780,20 +4780,20 @@ final class $MyMap_MyEntry$Type<$K extends jni$_.JObject?,
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyMap_MyEntry<$K, $V>?> get nullableType =>
-      $MyMap_MyEntry$NullableType<$K, $V>(K, V);
+  jni$_.JObjType<MyMap$MyEntry<$K, $V>?> get nullableType =>
+      $MyMap$MyEntry$NullableType<$K, $V>(K, V);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($MyMap_MyEntry$Type, K, V);
+  int get hashCode => Object.hash($MyMap$MyEntry$Type, K, V);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyMap_MyEntry$Type<$K, $V>) &&
-        other is $MyMap_MyEntry$Type<$K, $V> &&
+    return other.runtimeType == ($MyMap$MyEntry$Type<$K, $V>) &&
+        other is $MyMap$MyEntry$Type<$K, $V> &&
         K == other.K &&
         V == other.V;
   }
@@ -4956,11 +4956,11 @@ class MyMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
 
   /// from: `public com.github.dart_lang.jnigen.generics.MyStack entryStack()`
   /// The returned object must be released after use, by calling the [release] method.
-  MyStack<MyMap_MyEntry<$K?, $V?>?>? entryStack() {
+  MyStack<MyMap$MyEntry<$K?, $V?>?>? entryStack() {
     return _entryStack(reference.pointer, _id_entryStack as jni$_.JMethodIDPtr)
-        .object<MyStack<MyMap_MyEntry<$K?, $V?>?>?>(
-            $MyStack$NullableType<MyMap_MyEntry<$K?, $V?>?>(
-                $MyMap_MyEntry$NullableType<$K?, $V?>(
+        .object<MyStack<MyMap$MyEntry<$K?, $V?>?>?>(
+            $MyStack$NullableType<MyMap$MyEntry<$K?, $V?>?>(
+                $MyMap$MyEntry$NullableType<$K?, $V?>(
                     K.nullableType, V.nullableType)));
   }
 }
@@ -8668,11 +8668,11 @@ final class $SpecificDerivedClass$Type
 }
 
 /// from: `com.github.dart_lang.jnigen.annotations.Annotated$Nested`
-class Annotated_Nested<$T extends jni$_.JObject?, $U extends jni$_.JObject,
+class Annotated$Nested<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     $W extends jni$_.JObject, $V extends jni$_.JObject?> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Annotated_Nested<$T, $U, $W, $V>> $type;
+  final jni$_.JObjType<Annotated$Nested<$T, $U, $W, $V>> $type;
 
   @jni$_.internal
   final jni$_.JObjType<$T> T;
@@ -8687,7 +8687,7 @@ class Annotated_Nested<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   final jni$_.JObjType<$V> V;
 
   @jni$_.internal
-  Annotated_Nested.fromReference(
+  Annotated$Nested.fromReference(
     this.T,
     this.U,
     this.W,
@@ -8700,7 +8700,7 @@ class Annotated_Nested<$T extends jni$_.JObject?, $U extends jni$_.JObject,
       r'com/github/dart_lang/jnigen/annotations/Annotated$Nested');
 
   /// The type which includes information such as the signature of this class.
-  static $Annotated_Nested$NullableType<$T, $U, $W, $V> nullableType<
+  static $Annotated$Nested$NullableType<$T, $U, $W, $V> nullableType<
       $T extends jni$_.JObject?,
       $U extends jni$_.JObject,
       $W extends jni$_.JObject,
@@ -8710,7 +8710,7 @@ class Annotated_Nested<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     jni$_.JObjType<$W> W,
     jni$_.JObjType<$V> V,
   ) {
-    return $Annotated_Nested$NullableType<$T, $U, $W, $V>(
+    return $Annotated$Nested$NullableType<$T, $U, $W, $V>(
       T,
       U,
       W,
@@ -8718,7 +8718,7 @@ class Annotated_Nested<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     );
   }
 
-  static $Annotated_Nested$Type<$T, $U, $W, $V> type<
+  static $Annotated$Nested$Type<$T, $U, $W, $V> type<
       $T extends jni$_.JObject?,
       $U extends jni$_.JObject,
       $W extends jni$_.JObject,
@@ -8728,7 +8728,7 @@ class Annotated_Nested<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     jni$_.JObjType<$W> W,
     jni$_.JObjType<$V> V,
   ) {
-    return $Annotated_Nested$Type<$T, $U, $W, $V>(
+    return $Annotated$Nested$Type<$T, $U, $W, $V>(
       T,
       U,
       W,
@@ -8785,7 +8785,7 @@ class Annotated_Nested<$T extends jni$_.JObject?, $U extends jni$_.JObject,
 
   /// from: `public void <init>(com.github.dart_lang.jnigen.annotations.Annotated $outerClass, V object)`
   /// The returned object must be released after use, by calling the [release] method.
-  factory Annotated_Nested(
+  factory Annotated$Nested(
     Annotated<$T?, $U, $W> $outerClass,
     $V? object, {
     jni$_.JObjType<$T>? T,
@@ -8810,7 +8810,7 @@ class Annotated_Nested<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     ]) as jni$_.JObjType<$W>;
     final _$$outerClass = $outerClass.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return Annotated_Nested<$T, $U, $W, $V>.fromReference(
+    return Annotated$Nested<$T, $U, $W, $V>.fromReference(
         T,
         U,
         W,
@@ -8821,12 +8821,12 @@ class Annotated_Nested<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   }
 }
 
-final class $Annotated_Nested$NullableType<
+final class $Annotated$Nested$NullableType<
         $T extends jni$_.JObject?,
         $U extends jni$_.JObject,
         $W extends jni$_.JObject,
         $V extends jni$_.JObject?>
-    extends jni$_.JObjType<Annotated_Nested<$T, $U, $W, $V>?> {
+    extends jni$_.JObjType<Annotated$Nested<$T, $U, $W, $V>?> {
   @jni$_.internal
   final jni$_.JObjType<$T> T;
 
@@ -8840,7 +8840,7 @@ final class $Annotated_Nested$NullableType<
   final jni$_.JObjType<$V> V;
 
   @jni$_.internal
-  const $Annotated_Nested$NullableType(
+  const $Annotated$Nested$NullableType(
     this.T,
     this.U,
     this.W,
@@ -8854,10 +8854,10 @@ final class $Annotated_Nested$NullableType<
 
   @jni$_.internal
   @core$_.override
-  Annotated_Nested<$T, $U, $W, $V>? fromReference(jni$_.JReference reference) =>
+  Annotated$Nested<$T, $U, $W, $V>? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : Annotated_Nested<$T, $U, $W, $V>.fromReference(
+          : Annotated$Nested<$T, $U, $W, $V>.fromReference(
               T,
               U,
               W,
@@ -8870,20 +8870,20 @@ final class $Annotated_Nested$NullableType<
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Annotated_Nested<$T, $U, $W, $V>?> get nullableType => this;
+  jni$_.JObjType<Annotated$Nested<$T, $U, $W, $V>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($Annotated_Nested$NullableType, T, U, W, V);
+  int get hashCode => Object.hash($Annotated$Nested$NullableType, T, U, W, V);
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($Annotated_Nested$NullableType<$T, $U, $W, $V>) &&
-        other is $Annotated_Nested$NullableType<$T, $U, $W, $V> &&
+            ($Annotated$Nested$NullableType<$T, $U, $W, $V>) &&
+        other is $Annotated$Nested$NullableType<$T, $U, $W, $V> &&
         T == other.T &&
         U == other.U &&
         W == other.W &&
@@ -8891,12 +8891,12 @@ final class $Annotated_Nested$NullableType<
   }
 }
 
-final class $Annotated_Nested$Type<
+final class $Annotated$Nested$Type<
         $T extends jni$_.JObject?,
         $U extends jni$_.JObject,
         $W extends jni$_.JObject,
         $V extends jni$_.JObject?>
-    extends jni$_.JObjType<Annotated_Nested<$T, $U, $W, $V>> {
+    extends jni$_.JObjType<Annotated$Nested<$T, $U, $W, $V>> {
   @jni$_.internal
   final jni$_.JObjType<$T> T;
 
@@ -8910,7 +8910,7 @@ final class $Annotated_Nested$Type<
   final jni$_.JObjType<$V> V;
 
   @jni$_.internal
-  const $Annotated_Nested$Type(
+  const $Annotated$Nested$Type(
     this.T,
     this.U,
     this.W,
@@ -8924,8 +8924,8 @@ final class $Annotated_Nested$Type<
 
   @jni$_.internal
   @core$_.override
-  Annotated_Nested<$T, $U, $W, $V> fromReference(jni$_.JReference reference) =>
-      Annotated_Nested<$T, $U, $W, $V>.fromReference(
+  Annotated$Nested<$T, $U, $W, $V> fromReference(jni$_.JReference reference) =>
+      Annotated$Nested<$T, $U, $W, $V>.fromReference(
         T,
         U,
         W,
@@ -8938,20 +8938,20 @@ final class $Annotated_Nested$Type<
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Annotated_Nested<$T, $U, $W, $V>?> get nullableType =>
-      $Annotated_Nested$NullableType<$T, $U, $W, $V>(T, U, W, V);
+  jni$_.JObjType<Annotated$Nested<$T, $U, $W, $V>?> get nullableType =>
+      $Annotated$Nested$NullableType<$T, $U, $W, $V>(T, U, W, V);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($Annotated_Nested$Type, T, U, W, V);
+  int get hashCode => Object.hash($Annotated$Nested$Type, T, U, W, V);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Annotated_Nested$Type<$T, $U, $W, $V>) &&
-        other is $Annotated_Nested$Type<$T, $U, $W, $V> &&
+    return other.runtimeType == ($Annotated$Nested$Type<$T, $U, $W, $V>) &&
+        other is $Annotated$Nested$Type<$T, $U, $W, $V> &&
         T == other.T &&
         U == other.U &&
         W == other.W &&
@@ -10704,10 +10704,10 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
 
   /// from: `public com.github.dart_lang.jnigen.annotations.Annotated.Nested nested()`
   /// The returned object must be released after use, by calling the [release] method.
-  Annotated_Nested<$T?, $U, $W, jni$_.JInteger>? nested() {
+  Annotated$Nested<$T?, $U, $W, jni$_.JInteger>? nested() {
     return _nested(reference.pointer, _id_nested as jni$_.JMethodIDPtr)
-        .object<Annotated_Nested<$T?, $U, $W, jni$_.JInteger>?>(
-            $Annotated_Nested$NullableType<$T?, $U, $W, jni$_.JInteger>(
+        .object<Annotated$Nested<$T?, $U, $W, jni$_.JInteger>?>(
+            $Annotated$Nested$NullableType<$T?, $U, $W, jni$_.JInteger>(
                 T.nullableType, U, W, const jni$_.JIntegerType()));
   }
 
@@ -10857,13 +10857,13 @@ final class $Annotated$Type<$T extends jni$_.JObject?, $U extends jni$_.JObject,
 }
 
 /// from: `com.github.dart_lang.jnigen.annotations.JsonSerializable$Case`
-class JsonSerializable_Case extends jni$_.JObject {
+class JsonSerializable$Case extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<JsonSerializable_Case> $type;
+  final jni$_.JObjType<JsonSerializable$Case> $type;
 
   @jni$_.internal
-  JsonSerializable_Case.fromReference(
+  JsonSerializable$Case.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
         super.fromReference(reference);
@@ -10872,8 +10872,8 @@ class JsonSerializable_Case extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/annotations/JsonSerializable$Case');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $JsonSerializable_Case$NullableType();
-  static const type = $JsonSerializable_Case$Type();
+  static const nullableType = $JsonSerializable$Case$NullableType();
+  static const type = $JsonSerializable$Case$Type();
   static final _id_SNAKE_CASE = _class.staticFieldId(
     r'SNAKE_CASE',
     r'Lcom/github/dart_lang/jnigen/annotations/JsonSerializable$Case;',
@@ -10881,8 +10881,8 @@ class JsonSerializable_Case extends jni$_.JObject {
 
   /// from: `static public final com.github.dart_lang.jnigen.annotations.JsonSerializable$Case SNAKE_CASE`
   /// The returned object must be released after use, by calling the [release] method.
-  static JsonSerializable_Case? get SNAKE_CASE =>
-      _id_SNAKE_CASE.get(_class, const $JsonSerializable_Case$NullableType());
+  static JsonSerializable$Case? get SNAKE_CASE =>
+      _id_SNAKE_CASE.get(_class, const $JsonSerializable$Case$NullableType());
 
   static final _id_KEBAB_CASE = _class.staticFieldId(
     r'KEBAB_CASE',
@@ -10891,8 +10891,8 @@ class JsonSerializable_Case extends jni$_.JObject {
 
   /// from: `static public final com.github.dart_lang.jnigen.annotations.JsonSerializable$Case KEBAB_CASE`
   /// The returned object must be released after use, by calling the [release] method.
-  static JsonSerializable_Case? get KEBAB_CASE =>
-      _id_KEBAB_CASE.get(_class, const $JsonSerializable_Case$NullableType());
+  static JsonSerializable$Case? get KEBAB_CASE =>
+      _id_KEBAB_CASE.get(_class, const $JsonSerializable$Case$NullableType());
 
   static final _id_CAMEL_CASE = _class.staticFieldId(
     r'CAMEL_CASE',
@@ -10901,8 +10901,8 @@ class JsonSerializable_Case extends jni$_.JObject {
 
   /// from: `static public final com.github.dart_lang.jnigen.annotations.JsonSerializable$Case CAMEL_CASE`
   /// The returned object must be released after use, by calling the [release] method.
-  static JsonSerializable_Case? get CAMEL_CASE =>
-      _id_CAMEL_CASE.get(_class, const $JsonSerializable_Case$NullableType());
+  static JsonSerializable$Case? get CAMEL_CASE =>
+      _id_CAMEL_CASE.get(_class, const $JsonSerializable$Case$NullableType());
 
   static final _id_values = _class.staticMethodId(
     r'values',
@@ -10923,11 +10923,11 @@ class JsonSerializable_Case extends jni$_.JObject {
 
   /// from: `static public com.github.dart_lang.jnigen.annotations.JsonSerializable$Case[] values()`
   /// The returned object must be released after use, by calling the [release] method.
-  static jni$_.JArray<JsonSerializable_Case?>? values() {
+  static jni$_.JArray<JsonSerializable$Case?>? values() {
     return _values(_class.reference.pointer, _id_values as jni$_.JMethodIDPtr)
-        .object<jni$_.JArray<JsonSerializable_Case?>?>(
-            const jni$_.JArrayNullableType<JsonSerializable_Case?>(
-                $JsonSerializable_Case$NullableType()));
+        .object<jni$_.JArray<JsonSerializable$Case?>?>(
+            const jni$_.JArrayNullableType<JsonSerializable$Case?>(
+                $JsonSerializable$Case$NullableType()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -10948,21 +10948,21 @@ class JsonSerializable_Case extends jni$_.JObject {
 
   /// from: `static public com.github.dart_lang.jnigen.annotations.JsonSerializable$Case valueOf(java.lang.String string)`
   /// The returned object must be released after use, by calling the [release] method.
-  static JsonSerializable_Case? valueOf(
+  static JsonSerializable$Case? valueOf(
     jni$_.JString? string,
   ) {
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _valueOf(_class.reference.pointer, _id_valueOf as jni$_.JMethodIDPtr,
             _$string.pointer)
-        .object<JsonSerializable_Case?>(
-            const $JsonSerializable_Case$NullableType());
+        .object<JsonSerializable$Case?>(
+            const $JsonSerializable$Case$NullableType());
   }
 }
 
-final class $JsonSerializable_Case$NullableType
-    extends jni$_.JObjType<JsonSerializable_Case?> {
+final class $JsonSerializable$Case$NullableType
+    extends jni$_.JObjType<JsonSerializable$Case?> {
   @jni$_.internal
-  const $JsonSerializable_Case$NullableType();
+  const $JsonSerializable$Case$NullableType();
 
   @jni$_.internal
   @core$_.override
@@ -10971,10 +10971,10 @@ final class $JsonSerializable_Case$NullableType
 
   @jni$_.internal
   @core$_.override
-  JsonSerializable_Case? fromReference(jni$_.JReference reference) =>
+  JsonSerializable$Case? fromReference(jni$_.JReference reference) =>
       reference.isNull
           ? null
-          : JsonSerializable_Case.fromReference(
+          : JsonSerializable$Case.fromReference(
               reference,
             );
   @jni$_.internal
@@ -10983,26 +10983,26 @@ final class $JsonSerializable_Case$NullableType
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonSerializable_Case?> get nullableType => this;
+  jni$_.JObjType<JsonSerializable$Case?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonSerializable_Case$NullableType).hashCode;
+  int get hashCode => ($JsonSerializable$Case$NullableType).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonSerializable_Case$NullableType) &&
-        other is $JsonSerializable_Case$NullableType;
+    return other.runtimeType == ($JsonSerializable$Case$NullableType) &&
+        other is $JsonSerializable$Case$NullableType;
   }
 }
 
-final class $JsonSerializable_Case$Type
-    extends jni$_.JObjType<JsonSerializable_Case> {
+final class $JsonSerializable$Case$Type
+    extends jni$_.JObjType<JsonSerializable$Case> {
   @jni$_.internal
-  const $JsonSerializable_Case$Type();
+  const $JsonSerializable$Case$Type();
 
   @jni$_.internal
   @core$_.override
@@ -11011,8 +11011,8 @@ final class $JsonSerializable_Case$Type
 
   @jni$_.internal
   @core$_.override
-  JsonSerializable_Case fromReference(jni$_.JReference reference) =>
-      JsonSerializable_Case.fromReference(
+  JsonSerializable$Case fromReference(jni$_.JReference reference) =>
+      JsonSerializable$Case.fromReference(
         reference,
       );
   @jni$_.internal
@@ -11021,20 +11021,20 @@ final class $JsonSerializable_Case$Type
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonSerializable_Case?> get nullableType =>
-      const $JsonSerializable_Case$NullableType();
+  jni$_.JObjType<JsonSerializable$Case?> get nullableType =>
+      const $JsonSerializable$Case$NullableType();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonSerializable_Case$Type).hashCode;
+  int get hashCode => ($JsonSerializable$Case$Type).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonSerializable_Case$Type) &&
-        other is $JsonSerializable_Case$Type;
+    return other.runtimeType == ($JsonSerializable$Case$Type) &&
+        other is $JsonSerializable$Case$Type;
   }
 }
 
@@ -11075,10 +11075,10 @@ class JsonSerializable extends jni$_.JObject {
 
   /// from: `public abstract com.github.dart_lang.jnigen.annotations.JsonSerializable$Case value()`
   /// The returned object must be released after use, by calling the [release] method.
-  JsonSerializable_Case? value() {
+  JsonSerializable$Case? value() {
     return _value(reference.pointer, _id_value as jni$_.JMethodIDPtr)
-        .object<JsonSerializable_Case?>(
-            const $JsonSerializable_Case$NullableType());
+        .object<JsonSerializable$Case?>(
+            const $JsonSerializable$Case$NullableType());
   }
 
   /// Maps a specific port to the implemented interface.
@@ -11164,20 +11164,20 @@ class JsonSerializable extends jni$_.JObject {
 
 abstract base mixin class $JsonSerializable {
   factory $JsonSerializable({
-    required JsonSerializable_Case? Function() value,
+    required JsonSerializable$Case? Function() value,
   }) = _$JsonSerializable;
 
-  JsonSerializable_Case? value();
+  JsonSerializable$Case? value();
 }
 
 final class _$JsonSerializable with $JsonSerializable {
   _$JsonSerializable({
-    required JsonSerializable_Case? Function() value,
+    required JsonSerializable$Case? Function() value,
   }) : _value = value;
 
-  final JsonSerializable_Case? Function() _value;
+  final JsonSerializable$Case? Function() _value;
 
-  JsonSerializable_Case? value() {
+  JsonSerializable$Case? value() {
     return _value();
   }
 }

--- a/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
+++ b/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
@@ -180,9 +180,9 @@ void registerTests(String groupName, TestRunnerCallback test) {
     });
 
     test('Fields from nested class', () {
-      expect(Fields_Nested().hundred, equals(100));
+      expect(Fields$Nested().hundred, equals(100));
       // Hector of Troy may disagree.
-      expect(Fields_Nested.BEST_GOD!.toDartString(), equals('Pallas Athena'));
+      expect(Fields$Nested.BEST_GOD!.toDartString(), equals('Pallas Athena'));
     });
 
     test('static methods arrays', () {
@@ -448,10 +448,10 @@ void registerTests(String groupName, TestRunnerCallback test) {
         final grandParent = GrandParent(1.toJInteger(), T: JInteger.type)
           ..releasedBy(arena);
         final parent =
-            GrandParent_Parent(grandParent, 2.toJInteger(), S: JInteger.type)
+            GrandParent$Parent(grandParent, 2.toJInteger(), S: JInteger.type)
               ..releasedBy(arena);
         final child =
-            GrandParent_Parent_Child(parent, 3.toJInteger(), U: JInteger.type)
+            GrandParent$Parent$Child(parent, 3.toJInteger(), U: JInteger.type)
               ..releasedBy(arena);
         expect(grandParent.value!.intValue(releaseOriginal: true), 1);
         expect(parent.parentValue!.intValue(releaseOriginal: true), 1);

--- a/pkgs/jnigen/test/summary_test.dart
+++ b/pkgs/jnigen/test/summary_test.dart
@@ -45,10 +45,9 @@ void registerCommonTests(Classes classes) {
     expect(example.getMethod('getCodename').modifiers, notContainsStatic);
     expect(example.getField('ON').modifiers, containsStatic);
     expect(example.getField('codename').modifiers, notContainsStatic);
-    final nested = classes.getClassBySimpleName('Example\$Nested');
+    final nested = classes.getClassBySimpleName('Nested');
     expect(nested.modifiers, containsStatic);
-    final nonStaticNested =
-        classes.getClassBySimpleName('Example\$NonStaticNested');
+    final nonStaticNested = classes.getClassBySimpleName('NonStaticNested');
     expect(nonStaticNested.modifiers, notContainsStatic);
   });
 

--- a/pkgs/jnigen/test/summary_test.dart
+++ b/pkgs/jnigen/test/summary_test.dart
@@ -19,7 +19,7 @@ const simplePackage = '$jnigenPackage.simple_package';
 
 extension on Classes {
   ClassDecl getClassBySimpleName(String simpleName) {
-    return decls.values.firstWhere((c) => c.name == simpleName);
+    return decls.values.firstWhere((c) => c.binaryName.endsWith(simpleName));
   }
 
   ClassDecl getClass(String dirName, String className) {
@@ -45,9 +45,10 @@ void registerCommonTests(Classes classes) {
     expect(example.getMethod('getCodename').modifiers, notContainsStatic);
     expect(example.getField('ON').modifiers, containsStatic);
     expect(example.getField('codename').modifiers, notContainsStatic);
-    final nested = classes.getClassBySimpleName('Nested');
+    final nested = classes.getClassBySimpleName('Example\$Nested');
     expect(nested.modifiers, containsStatic);
-    final nonStaticNested = classes.getClassBySimpleName('NonStaticNested');
+    final nonStaticNested =
+        classes.getClassBySimpleName('Example\$NonStaticNested');
     expect(nonStaticNested.modifiers, notContainsStatic);
   });
 


### PR DESCRIPTION
The `Bar` class defined inside the `Foo` class in Java like `class Foo { class Bar {} }` used to be generated as `Foo_Bar`, but we can have a class named `Foo_Bar`, now we generate it as `Foo$Bar`.

We can (although very rare – rarer than using underscores) have a class named `Foo$Bar` that is not nested, this will be generated as `Foo$$Bar` as all dollar signs that are pre-existing in Java code will be replaced by 2 dollar signs. So we continue not to have any collisions.

I should mention that it's impossible to have both a nested `Bar` inside `Foo` and a class named `Foo$Bar` in the same package in Java because they will share the same binary name of `com.package.Foo$Bar`, so choosing `$` is better than `_` because of this as well.

Closes #1516.