### PR TITLE
Separate java primitive arrays and implement Iterable

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## 0.13.0-wip
 
+- **Breaking Change**: Separated primitive arrays from object arrays.
+  Previously, a primitive array like an array of bytes was typed
+  `JArray<jbyte>`. Now `JArray<T>` only accepts `JObject`s as types and
+  primitive arrays like arrays of bytes have their own types such as
+  `JByteArray`.
+
+  This allows all arrays to implement `Iterable` which makes it possible to use
+  them in a for-loop or use methods such as `map` on them.
+
 - Added nullable type classes for all Java objects.
 
 ## 0.12.2

--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -6,7 +6,7 @@
   primitive arrays like arrays of bytes have their own types such as
   `JByteArray`.
 
-  This allows all arrays to implement `Iterable` which makes it possible to use
+  This enables all arrays to implement `Iterable` which makes it possible to use
   them in a for-loop or use methods such as `map` on them.
 
 - Added nullable type classes for all Java objects.

--- a/pkgs/jni/lib/_internal.dart
+++ b/pkgs/jni/lib/_internal.dart
@@ -34,7 +34,6 @@ export 'src/method_invocation.dart';
 export 'src/types.dart'
     show
         JAccessible,
-        JArrayElementType,
         JCallable,
         JConstructable,
         JObjType,

--- a/pkgs/jni/lib/jni.dart
+++ b/pkgs/jni/lib/jni.dart
@@ -63,6 +63,7 @@ library;
 export 'package:ffi/ffi.dart' show Arena, using;
 
 export 'src/errors.dart';
+export 'src/jarray.dart';
 export 'src/jimplementer.dart';
 export 'src/jni.dart' hide ProtectedJniExtensions, StringMethodsForJni;
 export 'src/jobject.dart';
@@ -75,7 +76,6 @@ export 'src/third_party/generated_bindings.dart'
 export 'src/types.dart'
     hide
         JAccessible,
-        JArrayElementType,
         JCallable,
         JConstructable,
         JObjType,

--- a/pkgs/jni/lib/src/jarray.dart
+++ b/pkgs/jni/lib/src/jarray.dart
@@ -4,11 +4,22 @@
 
 // ignore_for_file: unnecessary_cast, overridden_fields
 
-part of 'types.dart';
+import 'dart:ffi';
+import 'dart:typed_data';
 
-final class JArrayNullableType<E> extends JObjType<JArray<E>?> {
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+
+import 'jni.dart';
+import 'jobject.dart';
+import 'jreference.dart';
+import 'third_party/generated_bindings.dart';
+import 'types.dart';
+
+final class JArrayNullableType<E extends JObject?>
+    extends JObjType<JArray<E>?> {
   @internal
-  final JArrayElementType<E> elementType;
+  final JObjType<E> elementType;
 
   @internal
   const JArrayNullableType(this.elementType);
@@ -20,7 +31,7 @@ final class JArrayNullableType<E> extends JObjType<JArray<E>?> {
   @internal
   @override
   JArray<E>? fromReference(JReference reference) =>
-      reference.isNull ? null : JArray.fromReference(elementType, reference);
+      reference.isNull ? null : JArray<E>.fromReference(elementType, reference);
 
   @internal
   @override
@@ -45,9 +56,9 @@ final class JArrayNullableType<E> extends JObjType<JArray<E>?> {
   }
 }
 
-final class JArrayType<E> extends JObjType<JArray<E>> {
+final class JArrayType<E extends JObject?> extends JObjType<JArray<E>> {
   @internal
-  final JArrayElementType<E> elementType;
+  final JObjType<E> elementType;
 
   @internal
   const JArrayType(this.elementType);
@@ -59,7 +70,7 @@ final class JArrayType<E> extends JObjType<JArray<E>> {
   @internal
   @override
   JArray<E> fromReference(JReference reference) =>
-      JArray.fromReference(elementType, reference);
+      JArray<E>.fromReference(elementType, reference);
 
   @internal
   @override
@@ -84,26 +95,26 @@ final class JArrayType<E> extends JObjType<JArray<E>> {
   }
 }
 
-class JArray<E> extends JObject {
+class JArray<E extends JObject?> extends JObject with Iterable<E> {
   @internal
-  final JArrayElementType<E> elementType;
+  final JObjType<E> elementType;
 
   @internal
   @override
   final JArrayType<E> $type;
 
   /// The type which includes information such as the signature of this class.
-  static JArrayType<E> type<E>(JArrayElementType<E> innerType) =>
-      JArrayType(innerType);
+  static JArrayType<E> type<E extends JObject?>(JObjType<E> innerType) =>
+      JArrayType<E>(innerType);
 
   /// The type which includes information such as the signature of this class.
-  static JArrayNullableType<E> nullableType<E>(
-          JArrayElementType<E> innerType) =>
-      JArrayNullableType(innerType);
+  static JArrayNullableType<E> nullableType<E extends JObject?>(
+          JObjType<E> innerType) =>
+      JArrayNullableType<E>(innerType);
 
   /// Construct a new [JArray] with [reference] as its underlying reference.
   JArray.fromReference(this.elementType, JReference reference)
-      : $type = type(elementType),
+      : $type = type<E>(elementType),
         super.fromReference(reference);
 
   /// Creates a [JArray] of the given length from the given [elementType].
@@ -111,15 +122,31 @@ class JArray<E> extends JObject {
   /// The [length] must be a non-negative integer.
   /// For objects, [elementType] must be a nullable type as this constructor
   /// initializes all elements with `null`.
-  factory JArray(JArrayElementType<E> elementType, int length) {
+  factory JArray(JObjType<E> elementType, int length) {
     RangeError.checkNotNegative(length);
-    if (elementType is JObjType<JObject?> &&
-        !(elementType as JObjType<JObject?>).isNullable) {
+    if (!elementType.isNullable) {
       throw StateError('Element type of JArray must be nullable when '
           'all elements with null\n\n'
           'Try using .nullableType instead');
     }
-    return elementType._newArray(length);
+    return _newArray<E>(elementType, length);
+  }
+
+  static JArray<$E> _newArray<$E extends JObject?>(
+      JObjType<$E> elementType, int length,
+      [$E? fill]) {
+    final classRef = elementType.jClass.reference;
+    final fillRef = fill?.reference ?? jNullReference;
+    final array = JArray<$E>.fromReference(
+      elementType,
+      JGlobalReference(Jni.env.NewObjectArray(
+        length,
+        classRef.pointer,
+        fillRef.pointer,
+      )),
+    );
+    classRef.release();
+    return array;
   }
 
   /// Creates a [JArray] of the given length with [fill] at each position.
@@ -129,27 +156,86 @@ class JArray<E> extends JObject {
       {JObjType<$E>? E}) {
     RangeError.checkNotNegative(length);
     E ??= fill.$type as JObjType<$E>;
-    return E._newArray(length, fill);
+    return _newArray<$E>(E, length, fill);
   }
 
-  int? _length;
-
   /// The number of elements in this array.
-  int get length {
-    return _length ??= Jni.env.GetArrayLength(reference.pointer);
+  @override
+  late final length = Jni.env.GetArrayLength(reference.pointer);
+
+  @override
+  E elementAt(int index) {
+    RangeError.checkValidIndex(index, this);
+    final pointer = Jni.env.GetObjectArrayElement(reference.pointer, index);
+    if (pointer == nullptr) {
+      return null as E;
+    }
+    return (elementType as JObjType<E>)
+        .fromReference(JGlobalReference(pointer));
+  }
+
+  E operator [](int index) {
+    return elementAt(index);
+  }
+
+  void operator []=(int index, E value) {
+    RangeError.checkValidIndex(index, this);
+    final valueRef = value?.reference ?? jNullReference;
+    Jni.env.SetObjectArrayElement(reference.pointer, index, valueRef.pointer);
+  }
+
+  void setRange(int start, int end, Iterable<E> iterable, [int skipCount = 0]) {
+    RangeError.checkValidRange(start, end, length);
+    final rangeLength = end - start;
+    final it = iterable.skip(skipCount).take(rangeLength);
+    for (final (index, element) in it.indexed) {
+      this[index] = element;
+    }
+  }
+
+  @override
+  Iterator<E> get iterator => _JArrayIterator(this);
+}
+
+class _JArrayIterator<E> implements Iterator<E> {
+  final Iterable<E> _iterable;
+  final int _length;
+  int _index;
+  E? _current;
+
+  _JArrayIterator(Iterable<E> iterable)
+      : _iterable = iterable,
+        _length = iterable.length,
+        _index = 0;
+
+  @override
+  E get current => _current as E;
+
+  @override
+  @pragma('vm:prefer-inline')
+  bool moveNext() {
+    final length = _iterable.length;
+    if (_length != length) {
+      throw ConcurrentModificationError(_iterable);
+    }
+    if (_index >= length) {
+      _current = null;
+      return false;
+    }
+    _current = _iterable.elementAt(_index);
+    _index++;
+    return true;
   }
 }
 
-extension NativeArray<E extends JPrimitive> on JArray<E> {
-  void _allocate<T extends NativeType>(
-    int byteCount,
-    void Function(Pointer<T> ptr) use,
-  ) {
-    using((arena) {
-      final ptr = arena.allocate<T>(byteCount);
-      use(ptr);
-    }, malloc);
-  }
+void _allocate<T extends NativeType>(
+  int byteCount,
+  void Function(Pointer<T> ptr) use,
+) {
+  using((arena) {
+    final ptr = arena.allocate<T>(byteCount);
+    use(ptr);
+  }, malloc);
 }
 
 extension on Allocator {
@@ -162,10 +248,115 @@ extension on Allocator {
   }
 }
 
-extension BoolArray on JArray<jboolean> {
-  bool operator [](int index) {
+final class JBooleanArrayNullableType extends JObjType<JBooleanArray?> {
+  @internal
+  const JBooleanArrayNullableType();
+
+  @internal
+  @override
+  String get signature => '[Z';
+
+  @internal
+  @override
+  JBooleanArray? fromReference(JReference reference) =>
+      reference.isNull ? null : JBooleanArray.fromReference(reference);
+
+  @internal
+  @override
+  JObjType get superType => const JObjectNullableType();
+
+  @internal
+  @override
+  JObjType<JBooleanArray?> get nullableType => this;
+
+  @internal
+  @override
+  final int superCount = 1;
+
+  @override
+  int get hashCode => (JBooleanArrayNullableType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == JBooleanArrayNullableType &&
+        other is JBooleanArrayNullableType;
+  }
+}
+
+final class JBooleanArrayType extends JObjType<JBooleanArray> {
+  @internal
+  const JBooleanArrayType();
+
+  @internal
+  @override
+  String get signature => '[Z';
+
+  @internal
+  @override
+  JBooleanArray fromReference(JReference reference) =>
+      JBooleanArray.fromReference(reference);
+
+  @internal
+  @override
+  JObjType get superType => const JObjectType();
+
+  @internal
+  @override
+  JObjType<JBooleanArray?> get nullableType =>
+      const JBooleanArrayNullableType();
+
+  @internal
+  @override
+  final int superCount = 1;
+
+  @override
+  int get hashCode => (JBooleanArrayType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == JBooleanArrayType && other is JBooleanArrayType;
+  }
+}
+
+class JBooleanArray extends JObject with Iterable<bool> {
+  @internal
+  @override
+  final JBooleanArrayType $type;
+
+  /// The type which includes information such as the signature of this class.
+  static const type = JBooleanArrayType();
+
+  /// The type which includes information such as the signature of this class.
+  static const nullableType = JBooleanArrayNullableType();
+
+  /// Construct a new [JBooleanArray] with [reference] as its underlying
+  /// reference.
+  JBooleanArray.fromReference(super.reference)
+      : $type = type,
+        super.fromReference();
+
+  /// Creates a [JBooleanArray] of the given [length].
+  ///
+  /// The [length] must be a non-negative integer.
+  factory JBooleanArray(int length) {
+    RangeError.checkNotNegative(length);
+    return JBooleanArray.fromReference(
+      JGlobalReference(Jni.env.NewBooleanArray(length)),
+    );
+  }
+
+  /// The number of elements in this array.
+  @override
+  late final length = Jni.env.GetArrayLength(reference.pointer);
+
+  @override
+  bool elementAt(int index) {
     RangeError.checkValidIndex(index, this);
     return Jni.env.GetBooleanArrayElement(reference.pointer, index);
+  }
+
+  bool operator [](int index) {
+    return elementAt(index);
   }
 
   void operator []=(int index, bool value) {
@@ -193,12 +384,118 @@ extension BoolArray on JArray<jboolean> {
       Jni.env.SetBooleanArrayRegion(reference.pointer, start, rangeLength, ptr);
     });
   }
+
+  @override
+  Iterator<bool> get iterator => _JArrayIterator(this);
 }
 
-extension ByteArray on JArray<jbyte> {
-  int operator [](int index) {
+final class JByteArrayNullableType extends JObjType<JByteArray?> {
+  @internal
+  const JByteArrayNullableType();
+
+  @internal
+  @override
+  String get signature => '[B';
+
+  @internal
+  @override
+  JByteArray? fromReference(JReference reference) =>
+      reference.isNull ? null : JByteArray.fromReference(reference);
+
+  @internal
+  @override
+  JObjType get superType => const JObjectNullableType();
+
+  @internal
+  @override
+  JObjType<JByteArray?> get nullableType => this;
+
+  @internal
+  @override
+  final int superCount = 1;
+
+  @override
+  int get hashCode => (JByteArrayNullableType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == JByteArrayNullableType &&
+        other is JByteArrayNullableType;
+  }
+}
+
+final class JByteArrayType extends JObjType<JByteArray> {
+  @internal
+  const JByteArrayType();
+
+  @internal
+  @override
+  String get signature => '[B';
+
+  @internal
+  @override
+  JByteArray fromReference(JReference reference) =>
+      JByteArray.fromReference(reference);
+
+  @internal
+  @override
+  JObjType get superType => const JObjectType();
+
+  @internal
+  @override
+  JObjType<JByteArray?> get nullableType => const JByteArrayNullableType();
+
+  @internal
+  @override
+  final int superCount = 1;
+
+  @override
+  int get hashCode => (JByteArrayType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == JByteArrayType && other is JByteArrayType;
+  }
+}
+
+class JByteArray extends JObject with Iterable<int> {
+  @internal
+  @override
+  final JByteArrayType $type;
+
+  /// The type which includes information such as the signature of this class.
+  static const type = JByteArrayType();
+
+  /// The type which includes information such as the signature of this class.
+  static const nullableType = JByteArrayNullableType();
+
+  /// Construct a new [JByteArray] with [reference] as its underlying
+  /// reference.
+  JByteArray.fromReference(super.reference)
+      : $type = type,
+        super.fromReference();
+
+  /// Creates a [JByteArray] of the given [length].
+  ///
+  /// The [length] must be a non-negative integer.
+  factory JByteArray(int length) {
+    RangeError.checkNotNegative(length);
+    return JByteArray.fromReference(
+        JGlobalReference(Jni.env.NewByteArray(length)));
+  }
+
+  /// The number of elements in this array.
+  @override
+  late final length = Jni.env.GetArrayLength(reference.pointer);
+
+  @override
+  int elementAt(int index) {
     RangeError.checkValidIndex(index, this);
     return Jni.env.GetByteArrayElement(reference.pointer, index);
+  }
+
+  int operator [](int index) {
+    return elementAt(index);
   }
 
   void operator []=(int index, int value) {
@@ -225,16 +522,122 @@ extension ByteArray on JArray<jbyte> {
       Jni.env.SetByteArrayRegion(reference.pointer, start, rangeLength, ptr);
     });
   }
+
+  @override
+  Iterator<int> get iterator => _JArrayIterator(this);
 }
 
-/// `JArray<jchar>` is a 16-bit integer array.
+final class JCharArrayNullableType extends JObjType<JCharArray?> {
+  @internal
+  const JCharArrayNullableType();
+
+  @internal
+  @override
+  String get signature => '[C';
+
+  @internal
+  @override
+  JCharArray? fromReference(JReference reference) =>
+      reference.isNull ? null : JCharArray.fromReference(reference);
+
+  @internal
+  @override
+  JObjType get superType => const JObjectNullableType();
+
+  @internal
+  @override
+  JObjType<JCharArray?> get nullableType => this;
+
+  @internal
+  @override
+  final int superCount = 1;
+
+  @override
+  int get hashCode => (JCharArrayNullableType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == JCharArrayNullableType &&
+        other is JCharArrayNullableType;
+  }
+}
+
+final class JCharArrayType extends JObjType<JCharArray> {
+  @internal
+  const JCharArrayType();
+
+  @internal
+  @override
+  String get signature => '[C';
+
+  @internal
+  @override
+  JCharArray fromReference(JReference reference) =>
+      JCharArray.fromReference(reference);
+
+  @internal
+  @override
+  JObjType get superType => const JObjectType();
+
+  @internal
+  @override
+  JObjType<JCharArray?> get nullableType => const JCharArrayNullableType();
+
+  @internal
+  @override
+  final int superCount = 1;
+
+  @override
+  int get hashCode => (JCharArrayType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == JCharArrayType && other is JCharArrayType;
+  }
+}
+
+/// `JCharArray` is a 16-bit integer array.
 ///
 /// Due to variable length encoding, the  number of code units is not equal to
 /// the number of characters.
-extension CharArray on JArray<jchar> {
-  int operator [](int index) {
+class JCharArray extends JObject with Iterable<int> {
+  @internal
+  @override
+  final JCharArrayType $type;
+
+  /// The type which includes information such as the signature of this class.
+  static const type = JCharArrayType();
+
+  /// The type which includes information such as the signature of this class.
+  static const nullableType = JCharArrayNullableType();
+
+  /// Construct a new [JCharArray] with [reference] as its underlying
+  /// reference.
+  JCharArray.fromReference(super.reference)
+      : $type = type,
+        super.fromReference();
+
+  /// Creates a [JCharArray] of the given [length].
+  ///
+  /// The [length] must be a non-negative integer.
+  factory JCharArray(int length) {
+    RangeError.checkNotNegative(length);
+    return JCharArray.fromReference(
+        JGlobalReference(Jni.env.NewCharArray(length)));
+  }
+
+  /// The number of elements in this array.
+  @override
+  late final length = Jni.env.GetArrayLength(reference.pointer);
+
+  @override
+  int elementAt(int index) {
     RangeError.checkValidIndex(index, this);
     return Jni.env.GetCharArrayElement(reference.pointer, index);
+  }
+
+  int operator [](int index) {
+    return elementAt(index);
   }
 
   void operator []=(int index, int value) {
@@ -261,12 +664,118 @@ extension CharArray on JArray<jchar> {
       Jni.env.SetCharArrayRegion(reference.pointer, start, rangeLength, ptr);
     });
   }
+
+  @override
+  Iterator<int> get iterator => _JArrayIterator(this);
 }
 
-extension ShortArray on JArray<jshort> {
-  int operator [](int index) {
+final class JShortArrayNullableType extends JObjType<JShortArray?> {
+  @internal
+  const JShortArrayNullableType();
+
+  @internal
+  @override
+  String get signature => '[S';
+
+  @internal
+  @override
+  JShortArray? fromReference(JReference reference) =>
+      reference.isNull ? null : JShortArray.fromReference(reference);
+
+  @internal
+  @override
+  JObjType get superType => const JObjectNullableType();
+
+  @internal
+  @override
+  JObjType<JShortArray?> get nullableType => this;
+
+  @internal
+  @override
+  final int superCount = 1;
+
+  @override
+  int get hashCode => (JShortArrayNullableType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == JShortArrayNullableType &&
+        other is JShortArrayNullableType;
+  }
+}
+
+final class JShortArrayType extends JObjType<JShortArray> {
+  @internal
+  const JShortArrayType();
+
+  @internal
+  @override
+  String get signature => '[S';
+
+  @internal
+  @override
+  JShortArray fromReference(JReference reference) =>
+      JShortArray.fromReference(reference);
+
+  @internal
+  @override
+  JObjType get superType => const JObjectType();
+
+  @internal
+  @override
+  JObjType<JShortArray?> get nullableType => const JShortArrayNullableType();
+
+  @internal
+  @override
+  final int superCount = 1;
+
+  @override
+  int get hashCode => (JShortArrayType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == JShortArrayType && other is JShortArrayType;
+  }
+}
+
+class JShortArray extends JObject with Iterable<int> {
+  @internal
+  @override
+  final JShortArrayType $type;
+
+  /// The type which includes information such as the signature of this class.
+  static const type = JShortArrayType();
+
+  /// The type which includes information such as the signature of this class.
+  static const nullableType = JShortArrayNullableType();
+
+  /// Construct a new [JShortArray] with [reference] as its underlying
+  /// reference.
+  JShortArray.fromReference(super.reference)
+      : $type = type,
+        super.fromReference();
+
+  /// Creates a [JShortArray] of the given [length].
+  ///
+  /// The [length] must be a non-negative integer.
+  factory JShortArray(int length) {
+    RangeError.checkNotNegative(length);
+    return JShortArray.fromReference(
+        JGlobalReference(Jni.env.NewShortArray(length)));
+  }
+
+  /// The number of elements in this array.
+  @override
+  late final length = Jni.env.GetArrayLength(reference.pointer);
+
+  @override
+  int elementAt(int index) {
     RangeError.checkValidIndex(index, this);
     return Jni.env.GetShortArrayElement(reference.pointer, index);
+  }
+
+  int operator [](int index) {
+    return elementAt(index);
   }
 
   void operator []=(int index, int value) {
@@ -293,12 +802,118 @@ extension ShortArray on JArray<jshort> {
       Jni.env.SetShortArrayRegion(reference.pointer, start, rangeLength, ptr);
     });
   }
+
+  @override
+  Iterator<int> get iterator => _JArrayIterator(this);
 }
 
-extension IntArray on JArray<jint> {
-  int operator [](int index) {
+final class JIntArrayNullableType extends JObjType<JIntArray?> {
+  @internal
+  const JIntArrayNullableType();
+
+  @internal
+  @override
+  String get signature => '[I';
+
+  @internal
+  @override
+  JIntArray? fromReference(JReference reference) =>
+      reference.isNull ? null : JIntArray.fromReference(reference);
+
+  @internal
+  @override
+  JObjType get superType => const JObjectNullableType();
+
+  @internal
+  @override
+  JObjType<JIntArray?> get nullableType => this;
+
+  @internal
+  @override
+  final int superCount = 1;
+
+  @override
+  int get hashCode => (JIntArrayNullableType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == JIntArrayNullableType &&
+        other is JIntArrayNullableType;
+  }
+}
+
+final class JIntArrayType extends JObjType<JIntArray> {
+  @internal
+  const JIntArrayType();
+
+  @internal
+  @override
+  String get signature => '[I';
+
+  @internal
+  @override
+  JIntArray fromReference(JReference reference) =>
+      JIntArray.fromReference(reference);
+
+  @internal
+  @override
+  JObjType get superType => const JObjectType();
+
+  @internal
+  @override
+  JObjType<JIntArray?> get nullableType => const JIntArrayNullableType();
+
+  @internal
+  @override
+  final int superCount = 1;
+
+  @override
+  int get hashCode => (JIntArrayType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == JIntArrayType && other is JIntArrayType;
+  }
+}
+
+class JIntArray extends JObject with Iterable<int> {
+  @internal
+  @override
+  final JIntArrayType $type;
+
+  /// The type which includes information such as the signature of this class.
+  static const type = JIntArrayType();
+
+  /// The type which includes information such as the signature of this class.
+  static const nullableType = JIntArrayNullableType();
+
+  /// Construct a new [JIntArray] with [reference] as its underlying
+  /// reference.
+  JIntArray.fromReference(super.reference)
+      : $type = type,
+        super.fromReference();
+
+  /// Creates a [JIntArray] of the given [length].
+  ///
+  /// The [length] must be a non-negative integer.
+  factory JIntArray(int length) {
+    RangeError.checkNotNegative(length);
+    return JIntArray.fromReference(
+        JGlobalReference(Jni.env.NewIntArray(length)));
+  }
+
+  /// The number of elements in this array.
+  @override
+  late final length = Jni.env.GetArrayLength(reference.pointer);
+
+  @override
+  int elementAt(int index) {
     RangeError.checkValidIndex(index, this);
     return Jni.env.GetIntArrayElement(reference.pointer, index);
+  }
+
+  int operator [](int index) {
+    return elementAt(index);
   }
 
   void operator []=(int index, int value) {
@@ -325,12 +940,118 @@ extension IntArray on JArray<jint> {
       Jni.env.SetIntArrayRegion(reference.pointer, start, rangeLength, ptr);
     });
   }
+
+  @override
+  Iterator<int> get iterator => _JArrayIterator(this);
 }
 
-extension LongArray on JArray<jlong> {
-  int operator [](int index) {
+final class JLongArrayNullableType extends JObjType<JLongArray?> {
+  @internal
+  const JLongArrayNullableType();
+
+  @internal
+  @override
+  String get signature => '[J';
+
+  @internal
+  @override
+  JLongArray? fromReference(JReference reference) =>
+      reference.isNull ? null : JLongArray.fromReference(reference);
+
+  @internal
+  @override
+  JObjType get superType => const JObjectNullableType();
+
+  @internal
+  @override
+  JObjType<JLongArray?> get nullableType => this;
+
+  @internal
+  @override
+  final int superCount = 1;
+
+  @override
+  int get hashCode => (JLongArrayNullableType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == JLongArrayNullableType &&
+        other is JLongArrayNullableType;
+  }
+}
+
+final class JLongArrayType extends JObjType<JLongArray> {
+  @internal
+  const JLongArrayType();
+
+  @internal
+  @override
+  String get signature => '[J';
+
+  @internal
+  @override
+  JLongArray fromReference(JReference reference) =>
+      JLongArray.fromReference(reference);
+
+  @internal
+  @override
+  JObjType get superType => const JObjectType();
+
+  @internal
+  @override
+  JObjType<JLongArray?> get nullableType => const JLongArrayNullableType();
+
+  @internal
+  @override
+  final int superCount = 1;
+
+  @override
+  int get hashCode => (JLongArrayType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == JLongArrayType && other is JLongArrayType;
+  }
+}
+
+class JLongArray extends JObject with Iterable<int> {
+  @internal
+  @override
+  final JLongArrayType $type;
+
+  /// The type which includes information such as the signature of this class.
+  static const type = JLongArrayType();
+
+  /// The type which includes information such as the signature of this class.
+  static const nullableType = JLongArrayNullableType();
+
+  /// Construct a new [JLongArray] with [reference] as its underlying
+  /// reference.
+  JLongArray.fromReference(super.reference)
+      : $type = type,
+        super.fromReference();
+
+  /// Creates a [JLongArray] of the given [length].
+  ///
+  /// The [length] must be a non-negative integer.
+  factory JLongArray(int length) {
+    RangeError.checkNotNegative(length);
+    return JLongArray.fromReference(
+        JGlobalReference(Jni.env.NewLongArray(length)));
+  }
+
+  /// The number of elements in this array.
+  @override
+  late final length = Jni.env.GetArrayLength(reference.pointer);
+
+  @override
+  int elementAt(int index) {
     RangeError.checkValidIndex(index, this);
     return Jni.env.GetLongArrayElement(reference.pointer, index);
+  }
+
+  int operator [](int index) {
+    return elementAt(index);
   }
 
   void operator []=(int index, int value) {
@@ -357,12 +1078,118 @@ extension LongArray on JArray<jlong> {
       Jni.env.SetLongArrayRegion(reference.pointer, start, rangeLength, ptr);
     });
   }
+
+  @override
+  Iterator<int> get iterator => _JArrayIterator(this);
 }
 
-extension FloatArray on JArray<jfloat> {
-  double operator [](int index) {
+final class JFloatArrayNullableType extends JObjType<JFloatArray?> {
+  @internal
+  const JFloatArrayNullableType();
+
+  @internal
+  @override
+  String get signature => '[F';
+
+  @internal
+  @override
+  JFloatArray? fromReference(JReference reference) =>
+      reference.isNull ? null : JFloatArray.fromReference(reference);
+
+  @internal
+  @override
+  JObjType get superType => const JObjectNullableType();
+
+  @internal
+  @override
+  JObjType<JFloatArray?> get nullableType => this;
+
+  @internal
+  @override
+  final int superCount = 1;
+
+  @override
+  int get hashCode => (JFloatArrayNullableType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == JFloatArrayNullableType &&
+        other is JFloatArrayNullableType;
+  }
+}
+
+final class JFloatArrayType extends JObjType<JFloatArray> {
+  @internal
+  const JFloatArrayType();
+
+  @internal
+  @override
+  String get signature => '[F';
+
+  @internal
+  @override
+  JFloatArray fromReference(JReference reference) =>
+      JFloatArray.fromReference(reference);
+
+  @internal
+  @override
+  JObjType get superType => const JObjectType();
+
+  @internal
+  @override
+  JObjType<JFloatArray?> get nullableType => const JFloatArrayNullableType();
+
+  @internal
+  @override
+  final int superCount = 1;
+
+  @override
+  int get hashCode => (JFloatArrayType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == JFloatArrayType && other is JFloatArrayType;
+  }
+}
+
+class JFloatArray extends JObject with Iterable<double> {
+  @internal
+  @override
+  final JFloatArrayType $type;
+
+  /// The type which includes information such as the signature of this class.
+  static const type = JFloatArrayType();
+
+  /// The type which includes information such as the signature of this class.
+  static const nullableType = JFloatArrayNullableType();
+
+  /// Construct a new [JFloatArray] with [reference] as its underlying
+  /// reference.
+  JFloatArray.fromReference(super.reference)
+      : $type = type,
+        super.fromReference();
+
+  /// Creates a [JFloatArray] of the given [length].
+  ///
+  /// The [length] must be a non-negative integer.
+  factory JFloatArray(int length) {
+    RangeError.checkNotNegative(length);
+    return JFloatArray.fromReference(
+        JGlobalReference(Jni.env.NewFloatArray(length)));
+  }
+
+  /// The number of elements in this array.
+  @override
+  late final length = Jni.env.GetArrayLength(reference.pointer);
+
+  @override
+  double elementAt(int index) {
     RangeError.checkValidIndex(index, this);
     return Jni.env.GetFloatArrayElement(reference.pointer, index);
+  }
+
+  double operator [](int index) {
+    return elementAt(index);
   }
 
   void operator []=(int index, double value) {
@@ -389,12 +1216,118 @@ extension FloatArray on JArray<jfloat> {
       Jni.env.SetFloatArrayRegion(reference.pointer, start, rangeLength, ptr);
     });
   }
+
+  @override
+  Iterator<double> get iterator => _JArrayIterator(this);
 }
 
-extension DoubleArray on JArray<jdouble> {
-  double operator [](int index) {
+final class JDoubleArrayNullableType extends JObjType<JDoubleArray?> {
+  @internal
+  const JDoubleArrayNullableType();
+
+  @internal
+  @override
+  String get signature => '[D';
+
+  @internal
+  @override
+  JDoubleArray? fromReference(JReference reference) =>
+      reference.isNull ? null : JDoubleArray.fromReference(reference);
+
+  @internal
+  @override
+  JObjType get superType => const JObjectNullableType();
+
+  @internal
+  @override
+  JObjType<JDoubleArray?> get nullableType => this;
+
+  @internal
+  @override
+  final int superCount = 1;
+
+  @override
+  int get hashCode => (JDoubleArrayNullableType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == JDoubleArrayNullableType &&
+        other is JDoubleArrayNullableType;
+  }
+}
+
+final class JDoubleArrayType extends JObjType<JDoubleArray> {
+  @internal
+  const JDoubleArrayType();
+
+  @internal
+  @override
+  String get signature => '[D';
+
+  @internal
+  @override
+  JDoubleArray fromReference(JReference reference) =>
+      JDoubleArray.fromReference(reference);
+
+  @internal
+  @override
+  JObjType get superType => const JObjectType();
+
+  @internal
+  @override
+  JObjType<JDoubleArray?> get nullableType => const JDoubleArrayNullableType();
+
+  @internal
+  @override
+  final int superCount = 1;
+
+  @override
+  int get hashCode => (JDoubleArrayType).hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other.runtimeType == JDoubleArrayType && other is JDoubleArrayType;
+  }
+}
+
+class JDoubleArray extends JObject with Iterable<double> {
+  @internal
+  @override
+  final JDoubleArrayType $type;
+
+  /// The type which includes information such as the signature of this class.
+  static const type = JDoubleArrayType();
+
+  /// The type which includes information such as the signature of this class.
+  static const nullableType = JDoubleArrayNullableType();
+
+  /// Construct a new [JDoubleArray] with [reference] as its underlying
+  /// reference.
+  JDoubleArray.fromReference(super.reference)
+      : $type = type,
+        super.fromReference();
+
+  /// Creates a [JDoubleArray] of the given [length].
+  ///
+  /// The [length] must be a non-negative integer.
+  factory JDoubleArray(int length) {
+    RangeError.checkNotNegative(length);
+    return JDoubleArray.fromReference(
+        JGlobalReference(Jni.env.NewDoubleArray(length)));
+  }
+
+  /// The number of elements in this array.
+  @override
+  late final length = Jni.env.GetArrayLength(reference.pointer);
+
+  @override
+  double elementAt(int index) {
     RangeError.checkValidIndex(index, this);
     return Jni.env.GetDoubleArrayElement(reference.pointer, index);
+  }
+
+  double operator [](int index) {
+    return elementAt(index);
   }
 
   void operator []=(int index, double value) {
@@ -421,31 +1354,7 @@ extension DoubleArray on JArray<jdouble> {
       Jni.env.SetDoubleArrayRegion(reference.pointer, start, rangeLength, ptr);
     });
   }
-}
 
-extension ObjectArray<T extends JObject?> on JArray<T> {
-  T operator [](int index) {
-    RangeError.checkValidIndex(index, this);
-    final pointer = Jni.env.GetObjectArrayElement(reference.pointer, index);
-    if (pointer == nullptr) {
-      return null as T;
-    }
-    return (elementType as JObjType<T>)
-        .fromReference(JGlobalReference(pointer));
-  }
-
-  void operator []=(int index, T value) {
-    RangeError.checkValidIndex(index, this);
-    final valueRef = value?.reference ?? jNullReference;
-    Jni.env.SetObjectArrayElement(reference.pointer, index, valueRef.pointer);
-  }
-
-  void setRange(int start, int end, Iterable<T> iterable, [int skipCount = 0]) {
-    RangeError.checkValidRange(start, end, length);
-    final rangeLength = end - start;
-    final it = iterable.skip(skipCount).take(rangeLength);
-    for (final (index, element) in it.indexed) {
-      this[index] = element;
-    }
-  }
+  @override
+  Iterator<double> get iterator => _JArrayIterator(this);
 }

--- a/pkgs/jni/lib/src/jprimitives.dart
+++ b/pkgs/jni/lib/src/jprimitives.dart
@@ -15,10 +15,7 @@ abstract final class jbyte extends JPrimitive {
 }
 
 final class jbyteType extends JType<jbyte>
-    with
-        JCallable<jbyte, int>,
-        JAccessible<jbyte, int>,
-        JArrayElementType<jbyte> {
+    with JCallable<jbyte, int>, JAccessible<jbyte, int> {
   @internal
   const jbyteType();
 
@@ -57,14 +54,6 @@ final class jbyteType extends JType<jbyte>
   void _staticSet(JClassPtr clazz, JFieldIDPtr fieldID, int val) {
     return Jni.env.SetStaticByteField(clazz, fieldID, val);
   }
-
-  @override
-  JArray<jbyte> _newArray(int length) {
-    return JArray.fromReference(
-      this,
-      JGlobalReference(Jni.env.NewByteArray(length)),
-    );
-  }
 }
 
 abstract final class jboolean extends JPrimitive {
@@ -72,10 +61,7 @@ abstract final class jboolean extends JPrimitive {
 }
 
 final class jbooleanType extends JType<jboolean>
-    with
-        JCallable<jboolean, bool>,
-        JAccessible<jboolean, bool>,
-        JArrayElementType<jboolean> {
+    with JCallable<jboolean, bool>, JAccessible<jboolean, bool> {
   @internal
   const jbooleanType();
 
@@ -114,14 +100,6 @@ final class jbooleanType extends JType<jboolean>
   void _staticSet(JClassPtr clazz, JFieldIDPtr fieldID, bool val) {
     return Jni.env.SetStaticBooleanField(clazz, fieldID, val ? 1 : 0);
   }
-
-  @override
-  JArray<jboolean> _newArray(int length) {
-    return JArray.fromReference(
-      this,
-      JGlobalReference(Jni.env.NewBooleanArray(length)),
-    );
-  }
 }
 
 abstract final class jchar extends JPrimitive {
@@ -129,10 +107,7 @@ abstract final class jchar extends JPrimitive {
 }
 
 final class jcharType extends JType<jchar>
-    with
-        JCallable<jchar, int>,
-        JAccessible<jchar, int>,
-        JArrayElementType<jchar> {
+    with JCallable<jchar, int>, JAccessible<jchar, int> {
   @internal
   const jcharType();
 
@@ -171,14 +146,6 @@ final class jcharType extends JType<jchar>
   void _staticSet(JClassPtr clazz, JFieldIDPtr fieldID, int val) {
     return Jni.env.SetStaticCharField(clazz, fieldID, val);
   }
-
-  @override
-  JArray<jchar> _newArray(int length) {
-    return JArray.fromReference(
-      this,
-      JGlobalReference(Jni.env.NewCharArray(length)),
-    );
-  }
 }
 
 abstract final class jshort extends JPrimitive {
@@ -186,10 +153,7 @@ abstract final class jshort extends JPrimitive {
 }
 
 final class jshortType extends JType<jshort>
-    with
-        JCallable<jshort, int>,
-        JAccessible<jshort, int>,
-        JArrayElementType<jshort> {
+    with JCallable<jshort, int>, JAccessible<jshort, int> {
   @internal
   const jshortType();
 
@@ -228,14 +192,6 @@ final class jshortType extends JType<jshort>
   void _staticSet(JClassPtr clazz, JFieldIDPtr fieldID, int val) {
     return Jni.env.SetStaticShortField(clazz, fieldID, val);
   }
-
-  @override
-  JArray<jshort> _newArray(int length) {
-    return JArray.fromReference(
-      this,
-      JGlobalReference(Jni.env.NewShortArray(length)),
-    );
-  }
 }
 
 abstract final class jint extends JPrimitive {
@@ -243,7 +199,7 @@ abstract final class jint extends JPrimitive {
 }
 
 final class jintType extends JType<jint>
-    with JCallable<jint, int>, JAccessible<jint, int>, JArrayElementType<jint> {
+    with JCallable<jint, int>, JAccessible<jint, int> {
   @internal
   const jintType();
 
@@ -281,14 +237,6 @@ final class jintType extends JType<jint>
   void _staticSet(JClassPtr clazz, JFieldIDPtr fieldID, int val) {
     return Jni.env.SetStaticIntField(clazz, fieldID, val);
   }
-
-  @override
-  JArray<jint> _newArray(int length) {
-    return JArray.fromReference(
-      this,
-      JGlobalReference(Jni.env.NewIntArray(length)),
-    );
-  }
 }
 
 abstract final class jlong extends JPrimitive {
@@ -296,10 +244,7 @@ abstract final class jlong extends JPrimitive {
 }
 
 final class jlongType extends JType<jlong>
-    with
-        JCallable<jlong, int>,
-        JAccessible<jlong, int>,
-        JArrayElementType<jlong> {
+    with JCallable<jlong, int>, JAccessible<jlong, int> {
   @internal
   const jlongType();
 
@@ -337,14 +282,6 @@ final class jlongType extends JType<jlong>
   void _staticSet(JClassPtr clazz, JFieldIDPtr fieldID, int val) {
     return Jni.env.SetStaticLongField(clazz, fieldID, val);
   }
-
-  @override
-  JArray<jlong> _newArray(int length) {
-    return JArray.fromReference(
-      this,
-      JGlobalReference(Jni.env.NewLongArray(length)),
-    );
-  }
 }
 
 abstract final class jfloat extends JPrimitive {
@@ -352,10 +289,7 @@ abstract final class jfloat extends JPrimitive {
 }
 
 final class jfloatType extends JType<jfloat>
-    with
-        JCallable<jfloat, double>,
-        JAccessible<jfloat, double>,
-        JArrayElementType<jfloat> {
+    with JCallable<jfloat, double>, JAccessible<jfloat, double> {
   @internal
   const jfloatType();
 
@@ -394,14 +328,6 @@ final class jfloatType extends JType<jfloat>
   void _staticSet(JClassPtr clazz, JFieldIDPtr fieldID, double val) {
     return Jni.env.SetStaticFloatField(clazz, fieldID, val);
   }
-
-  @override
-  JArray<jfloat> _newArray(int length) {
-    return JArray.fromReference(
-      this,
-      JGlobalReference(Jni.env.NewFloatArray(length)),
-    );
-  }
 }
 
 abstract final class jdouble extends JPrimitive {
@@ -409,10 +335,7 @@ abstract final class jdouble extends JPrimitive {
 }
 
 final class jdoubleType extends JType<jdouble>
-    with
-        JCallable<jdouble, double>,
-        JAccessible<jdouble, double>,
-        JArrayElementType<jdouble> {
+    with JCallable<jdouble, double>, JAccessible<jdouble, double> {
   @internal
   const jdoubleType();
 
@@ -450,14 +373,6 @@ final class jdoubleType extends JType<jdouble>
   @override
   void _staticSet(JClassPtr clazz, JFieldIDPtr fieldID, double val) {
     return Jni.env.SetStaticDoubleField(clazz, fieldID, val);
-  }
-
-  @override
-  JArray<jdouble> _newArray(int length) {
-    return JArray.fromReference(
-      this,
-      JGlobalReference(Jni.env.NewDoubleArray(length)),
-    );
   }
 }
 

--- a/pkgs/jni/lib/src/method_invocation.dart
+++ b/pkgs/jni/lib/src/method_invocation.dart
@@ -6,11 +6,11 @@ import 'dart:ffi';
 
 import 'package:meta/meta.dart' show internal;
 
+import 'jarray.dart';
 import 'jobject.dart';
 import 'jreference.dart';
 import 'lang/jstring.dart';
 import 'third_party/generated_bindings.dart';
-import 'types.dart';
 
 @internal
 class MethodInvocation {

--- a/pkgs/jni/lib/src/nio/jbyte_buffer.dart
+++ b/pkgs/jni/lib/src/nio/jbyte_buffer.dart
@@ -7,6 +7,7 @@ import 'dart:typed_data';
 
 import 'package:meta/meta.dart' show internal;
 
+import '../jarray.dart';
 import '../jni.dart';
 import '../jobject.dart';
 import '../jreference.dart';
@@ -184,7 +185,7 @@ class JByteBuffer extends JBuffer {
   /// modifications to the buffer will cause the array to be modified
   /// and vice versa.
   static JByteBuffer wrap(
-    JArray<jbyte> array, [
+    JByteArray array, [
     int? offset,
     int? length,
   ]) {
@@ -268,8 +269,8 @@ class JByteBuffer extends JBuffer {
   static final _arrayId = _class.instanceMethodId(r'array', r'()[B');
 
   @override
-  JArray<jbyte> get array {
-    return _arrayId(this, const JArrayType(jbyteType()), [])!;
+  JByteArray get array {
+    return _arrayId(this, JByteArray.type, [])!;
   }
 
   void _ensureIsDirect() {

--- a/pkgs/jni/lib/src/types.dart
+++ b/pkgs/jni/lib/src/types.dart
@@ -2,9 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:ffi';
-import 'dart:typed_data';
-
 import 'package:ffi/ffi.dart';
 
 import '../_internal.dart';
@@ -13,7 +10,6 @@ import 'jobject.dart';
 import 'jvalues.dart';
 import 'third_party/generated_bindings.dart';
 
-part 'jarray.dart';
 part 'jclass.dart';
 part 'jprimitives.dart';
 
@@ -49,12 +45,6 @@ mixin JAccessible<JavaT, DartT> on JType<JavaT> {
   void _instanceSet(JObjectPtr obj, JFieldIDPtr fieldID, DartT val);
 }
 
-/// Able to be the type of array elements.
-@internal
-mixin JArrayElementType<JavaT> on JType<JavaT> {
-  JArray<JavaT> _newArray(int length);
-}
-
 /// Only used for jnigen.
 ///
 /// Makes constructing objects easier inside the generated bindings by allowing
@@ -80,11 +70,7 @@ final class _ReferenceType extends JType<JReference>
 
 @internal
 abstract class JObjType<T extends JObject?> extends JType<T>
-    with
-        JCallable<T, T>,
-        JConstructable<T, T>,
-        JAccessible<T, T>,
-        JArrayElementType<T> {
+    with JCallable<T, T>, JConstructable<T, T>, JAccessible<T, T> {
   /// Number of super types. Distance to the root type.
   int get superCount;
 
@@ -146,22 +132,6 @@ abstract class JObjType<T extends JObject?> extends JType<T>
   void _staticSet(JClassPtr clazz, JFieldIDPtr fieldID, T? val) {
     final valRef = val?.reference ?? jNullReference;
     Jni.env.SetStaticObjectField(clazz, fieldID, valRef.pointer);
-  }
-
-  @override
-  JArray<T> _newArray(int length, [T? fill]) {
-    final classRef = jClass.reference;
-    final fillRef = fill?.reference ?? jNullReference;
-    final array = JArray<T>.fromReference(
-      this,
-      JGlobalReference(Jni.env.NewObjectArray(
-        length,
-        classRef.pointer,
-        fillRef.pointer,
-      )),
-    );
-    classRef.release();
-    return array;
   }
 }
 

--- a/pkgs/jni/test/jarray_test.dart
+++ b/pkgs/jni/test/jarray_test.dart
@@ -22,7 +22,13 @@ void main() {
 void run({required TestRunnerCallback testRunner}) {
   testRunner('Java boolean array', () {
     using((arena) {
-      final array = JArray(jboolean.type, 3)..releasedBy(arena);
+      final array = JBooleanArray(3)..releasedBy(arena);
+      var counter = 0;
+      for (final element in array) {
+        expect(element, array[counter]);
+        ++counter;
+      }
+      expect(counter, array.length);
       expect(array.length, 3);
       array[0] = true;
       array[1] = false;
@@ -58,7 +64,13 @@ void run({required TestRunnerCallback testRunner}) {
   });
   testRunner('Java char array', () {
     using((arena) {
-      final array = JArray(jchar.type, 3)..releasedBy(arena);
+      final array = JCharArray(3)..releasedBy(arena);
+      var counter = 0;
+      for (final element in array) {
+        expect(element, array[counter]);
+        ++counter;
+      }
+      expect(counter, array.length);
       expect(array.length, 3);
       array[0] = 1;
       array[1] = 2;
@@ -94,7 +106,13 @@ void run({required TestRunnerCallback testRunner}) {
   });
   testRunner('Java byte array', () {
     using((arena) {
-      final array = JArray(jbyte.type, 3)..releasedBy(arena);
+      final array = JByteArray(3)..releasedBy(arena);
+      var counter = 0;
+      for (final element in array) {
+        expect(element, array[counter]);
+        ++counter;
+      }
+      expect(counter, array.length);
       expect(array.length, 3);
       array[0] = 1;
       array[1] = 2;
@@ -130,7 +148,13 @@ void run({required TestRunnerCallback testRunner}) {
   });
   testRunner('Java short array', () {
     using((arena) {
-      final array = JArray(jshort.type, 3)..releasedBy(arena);
+      final array = JShortArray(3)..releasedBy(arena);
+      var counter = 0;
+      for (final element in array) {
+        expect(element, array[counter]);
+        ++counter;
+      }
+      expect(counter, array.length);
       expect(array.length, 3);
       array[0] = 1;
       array[1] = 2;
@@ -166,7 +190,13 @@ void run({required TestRunnerCallback testRunner}) {
   });
   testRunner('Java int array', () {
     using((arena) {
-      final array = JArray(jint.type, 3)..releasedBy(arena);
+      final array = JIntArray(3)..releasedBy(arena);
+      var counter = 0;
+      for (final element in array) {
+        expect(element, array[counter]);
+        ++counter;
+      }
+      expect(counter, array.length);
       expect(array.length, 3);
       array[0] = 1;
       array[1] = 2;
@@ -202,7 +232,13 @@ void run({required TestRunnerCallback testRunner}) {
   });
   testRunner('Java long array', () {
     using((arena) {
-      final array = JArray(jlong.type, 3)..releasedBy(arena);
+      final array = JLongArray(3)..releasedBy(arena);
+      var counter = 0;
+      for (final element in array) {
+        expect(element, array[counter]);
+        ++counter;
+      }
+      expect(counter, array.length);
       expect(array.length, 3);
       array[0] = 1;
       array[1] = 2;
@@ -239,7 +275,13 @@ void run({required TestRunnerCallback testRunner}) {
   const epsilon = 1e-6;
   testRunner('Java float array', () {
     using((arena) {
-      final array = JArray(jfloat.type, 3)..releasedBy(arena);
+      final array = JFloatArray(3)..releasedBy(arena);
+      var counter = 0;
+      for (final element in array) {
+        expect(element, array[counter]);
+        ++counter;
+      }
+      expect(counter, array.length);
       expect(array.length, 3);
       array[0] = 0.5;
       array[1] = 2;
@@ -275,7 +317,13 @@ void run({required TestRunnerCallback testRunner}) {
   });
   testRunner('Java double array', () {
     using((arena) {
-      final array = JArray(jdouble.type, 3)..releasedBy(arena);
+      final array = JDoubleArray(3)..releasedBy(arena);
+      var counter = 0;
+      for (final element in array) {
+        expect(element, array[counter]);
+        ++counter;
+      }
+      expect(counter, array.length);
       expect(array.length, 3);
       array[0] = 0.5;
       array[1] = 2;
@@ -312,6 +360,12 @@ void run({required TestRunnerCallback testRunner}) {
   testRunner('Java string array', () {
     using((arena) {
       final array = JArray(JString.nullableType, 3)..releasedBy(arena);
+      var counter = 0;
+      for (final element in array) {
+        expect(element, array[counter]);
+        ++counter;
+      }
+      expect(counter, array.length);
       expect(array.length, 3);
       array[0] = 'حس'.toJString()..releasedBy(arena);
       array[1] = '\$'.toJString()..releasedBy(arena);
@@ -347,6 +401,12 @@ void run({required TestRunnerCallback testRunner}) {
   testRunner('Java object array', () {
     using((arena) {
       final array = JArray(JObject.nullableType, 3)..releasedBy(arena);
+      var counter = 0;
+      for (final element in array) {
+        expect(element, array[counter]);
+        ++counter;
+      }
+      expect(counter, array.length);
       expect(array.length, 3);
       expect(array[0], isNull);
       expect(array[1], isNull);
@@ -355,12 +415,11 @@ void run({required TestRunnerCallback testRunner}) {
   });
   testRunner('Java 2d array', () {
     using((arena) {
-      final array = JArray(jint.type, 3)..releasedBy(arena);
+      final array = JIntArray(3)..releasedBy(arena);
       array[0] = 1;
       array[1] = 2;
       array[2] = 3;
-      final twoDimArray = JArray(JArray.nullableType(jint.type), 3)
-        ..releasedBy(arena);
+      final twoDimArray = JArray(JIntArray.nullableType, 3)..releasedBy(arena);
       expect(twoDimArray.length, 3);
       twoDimArray[0] = array;
       twoDimArray[1] = array;

--- a/pkgs/jni/test/jbyte_buffer_test.dart
+++ b/pkgs/jni/test/jbyte_buffer_test.dart
@@ -32,7 +32,7 @@ void run({required TestRunnerCallback testRunner}) {
 
   testRunner('wrap whole array', () {
     using((arena) {
-      final array = JArray(jbyte.type, 3)..releasedBy(arena);
+      final array = JByteArray(3)..releasedBy(arena);
       array[0] = 1;
       array[1] = 2;
       array[2] = 3;
@@ -43,7 +43,7 @@ void run({required TestRunnerCallback testRunner}) {
 
   testRunner('wrap partial array', () {
     using((arena) {
-      final array = JArray(jbyte.type, 3)..releasedBy(arena);
+      final array = JByteArray(3)..releasedBy(arena);
       array[0] = 1;
       array[1] = 2;
       array[2] = 3;

--- a/pkgs/jni/test/type_test.dart
+++ b/pkgs/jni/test/type_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:jni/_internal.dart';
 import 'package:jni/jni.dart';
-import 'package:jni/src/types.dart';
 import 'package:test/test.dart';
 
 import 'test_util/test_util.dart';
@@ -452,7 +451,7 @@ void run({required TestRunnerCallback testRunner}) {
     expect(lowestCommonSuperType([JString.type]), JString.type);
     expect(lowestCommonSuperType([JObject.type, JObject.type]), JObject.type);
     expect(lowestCommonSuperType([JString.type, JString.type]), JString.type);
-    expect(lowestCommonSuperType([JString.type, JArray.type(jlong.type)]),
+    expect(lowestCommonSuperType([JString.type, JArray.type(JString.type)]),
         JObject.type);
   });
 
@@ -490,10 +489,10 @@ void run({required TestRunnerCallback testRunner}) {
     using((arena) {
       expect(
         lowestCommonSuperType([
-          JArray.type(jint.type),
-          JArray.type(jint.type),
+          JIntArray.type,
+          JIntArray.type,
         ]),
-        JArray.type(jint.type),
+        JIntArray.type,
       );
       expect(
         lowestCommonSuperType([
@@ -505,7 +504,7 @@ void run({required TestRunnerCallback testRunner}) {
       expect(
         lowestCommonSuperType([
           JArray.type(JObject.type),
-          JArray.type(jint.type),
+          JIntArray.type,
         ]),
         JObject.type,
       );

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
@@ -1565,7 +1565,7 @@ class PDDocument extends jni$_.JObject {
   ///@throws InvalidPasswordException If the PDF required a non-empty password.
   ///@throws IOException In case of a reading or parsing error.
   static PDDocument? load$12(
-    jni$_.JArray<jni$_.jbyte>? input,
+    jni$_.JByteArray? input,
   ) {
     final _$input = input?.reference ?? jni$_.jNullReference;
     return _load$12(_class.reference.pointer, _id_load$12 as jni$_.JMethodIDPtr,
@@ -1605,7 +1605,7 @@ class PDDocument extends jni$_.JObject {
   ///@throws InvalidPasswordException If the password is incorrect.
   ///@throws IOException In case of a reading or parsing error.
   static PDDocument? load$13(
-    jni$_.JArray<jni$_.jbyte>? input,
+    jni$_.JByteArray? input,
     jni$_.JString? password,
   ) {
     final _$input = input?.reference ?? jni$_.jNullReference;
@@ -1653,7 +1653,7 @@ class PDDocument extends jni$_.JObject {
   ///@throws InvalidPasswordException If the password is incorrect.
   ///@throws IOException In case of a reading or parsing error.
   static PDDocument? load$14(
-    jni$_.JArray<jni$_.jbyte>? input,
+    jni$_.JByteArray? input,
     jni$_.JString? password,
     jni$_.JObject? keyStore,
     jni$_.JString? alias,
@@ -1713,7 +1713,7 @@ class PDDocument extends jni$_.JObject {
   ///@throws InvalidPasswordException If the password is incorrect.
   ///@throws IOException In case of a reading or parsing error.
   static PDDocument? load$15(
-    jni$_.JArray<jni$_.jbyte>? input,
+    jni$_.JByteArray? input,
     jni$_.JString? password,
     jni$_.JObject? keyStore,
     jni$_.JString? alias,

--- a/pkgs/jnigen/lib/src/bindings/dart_generator.dart
+++ b/pkgs/jnigen/lib/src/bindings/dart_generator.dart
@@ -733,6 +733,9 @@ class _TypeGenerator extends TypeVisitor<String> {
       includeNullability: true,
       arrayType: true,
     );
+    if (innerType.kind == Kind.primitive) {
+      return '$_jni.J${innerType.accept(typeGenerator)}Array$nullable';
+    }
     return '$_jArray<${innerType.accept(typeGenerator)}>$nullable';
   }
 
@@ -785,7 +788,7 @@ class _TypeGenerator extends TypeVisitor<String> {
   @override
   String visitPrimitiveType(PrimitiveType node) {
     if (arrayType) {
-      return '$_jni.j${node.name}';
+      return node.name.capitalize();
     }
     return node.dartType;
   }
@@ -886,6 +889,12 @@ class _TypeClassGenerator extends TypeVisitor<_TypeClass> {
     final ifConst = innerTypeClass.canBeConst && isConst ? 'const ' : '';
     final type =
         includeNullability && node.isNullable ? 'NullableType' : 'Type';
+    if (node.elementType.kind == Kind.primitive) {
+      return _TypeClass(
+        '$ifConst$_jni.J${innerType}Array$type()',
+        innerTypeClass.canBeConst,
+      );
+    }
     return _TypeClass(
       '$ifConst$_jArray$type<$innerType>(${innerTypeClass.name})',
       innerTypeClass.canBeConst,

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
@@ -1953,7 +1953,7 @@ class JsonFactory extends jni$_.JObject {
   /// the contents of given byte array.
   ///@since 2.1
   jsonparser$_.JsonParser? createParser$4(
-    jni$_.JArray<jni$_.jbyte>? data,
+    jni$_.JByteArray? data,
   ) {
     final _$data = data?.reference ?? jni$_.jNullReference;
     return _createParser$4(reference.pointer,
@@ -1992,7 +1992,7 @@ class JsonFactory extends jni$_.JObject {
   ///@param len Length of contents to parse within buffer
   ///@since 2.1
   jsonparser$_.JsonParser? createParser$5(
-    jni$_.JArray<jni$_.jbyte>? data,
+    jni$_.JByteArray? data,
     int offset,
     int len,
   ) {
@@ -2062,7 +2062,7 @@ class JsonFactory extends jni$_.JObject {
   /// contents of given char array.
   ///@since 2.4
   jsonparser$_.JsonParser? createParser$7(
-    jni$_.JArray<jni$_.jchar>? content,
+    jni$_.JCharArray? content,
   ) {
     final _$content = content?.reference ?? jni$_.jNullReference;
     return _createParser$7(reference.pointer,
@@ -2097,7 +2097,7 @@ class JsonFactory extends jni$_.JObject {
   /// Method for constructing parser for parsing contents of given char array.
   ///@since 2.4
   jsonparser$_.JsonParser? createParser$8(
-    jni$_.JArray<jni$_.jchar>? content,
+    jni$_.JCharArray? content,
     int offset,
     int len,
   ) {
@@ -2653,7 +2653,7 @@ class JsonFactory extends jni$_.JObject {
   ///@throws JsonParseException if parser initialization fails due to content decoding problem
   ///@deprecated Since 2.2, use \#createParser(byte[]) instead.
   jsonparser$_.JsonParser? createJsonParser$4(
-    jni$_.JArray<jni$_.jbyte>? data,
+    jni$_.JByteArray? data,
   ) {
     final _$data = data?.reference ?? jni$_.jNullReference;
     return _createJsonParser$4(reference.pointer,
@@ -2695,7 +2695,7 @@ class JsonFactory extends jni$_.JObject {
   ///@throws JsonParseException if parser initialization fails due to content decoding problem
   ///@deprecated Since 2.2, use \#createParser(byte[],int,int) instead.
   jsonparser$_.JsonParser? createJsonParser$5(
-    jni$_.JArray<jni$_.jbyte>? data,
+    jni$_.JByteArray? data,
     int offset,
     int len,
   ) {

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonParser.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonParser.dart
@@ -643,7 +643,7 @@ class JsonParser extends jni$_.JObject {
   ///@param charset Character encoding for (lazily) decoding payload
   ///@since 2.8
   void setRequestPayloadOnError$1(
-    jni$_.JArray<jni$_.jbyte>? payload,
+    jni$_.JByteArray? payload,
     jni$_.JString? charset,
   ) {
     final _$payload = payload?.reference ?? jni$_.jNullReference;
@@ -2780,11 +2780,10 @@ class JsonParser extends jni$_.JObject {
   ///    at offset 0, and not necessarily until the end of buffer)
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
-  jni$_.JArray<jni$_.jchar>? getTextCharacters() {
+  jni$_.JCharArray? getTextCharacters() {
     return _getTextCharacters(
             reference.pointer, _id_getTextCharacters as jni$_.JMethodIDPtr)
-        .object<jni$_.JArray<jni$_.jchar>?>(
-            const jni$_.JArrayNullableType<jni$_.jchar>(jni$_.jcharType()));
+        .object<jni$_.JCharArray?>(const jni$_.JCharArrayNullableType());
   }
 
   static final _id_getTextLength = _class.instanceMethodId(
@@ -3432,14 +3431,13 @@ class JsonParser extends jni$_.JObject {
   ///@return Decoded binary data
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
-  jni$_.JArray<jni$_.jbyte>? getBinaryValue(
+  jni$_.JByteArray? getBinaryValue(
     jni$_.JObject? bv,
   ) {
     final _$bv = bv?.reference ?? jni$_.jNullReference;
     return _getBinaryValue(reference.pointer,
             _id_getBinaryValue as jni$_.JMethodIDPtr, _$bv.pointer)
-        .object<jni$_.JArray<jni$_.jbyte>?>(
-            const jni$_.JArrayNullableType<jni$_.jbyte>(jni$_.jbyteType()));
+        .object<jni$_.JByteArray?>(const jni$_.JByteArrayNullableType());
   }
 
   static final _id_getBinaryValue$1 = _class.instanceMethodId(
@@ -3468,11 +3466,10 @@ class JsonParser extends jni$_.JObject {
   ///@return Decoded binary data
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
-  jni$_.JArray<jni$_.jbyte>? getBinaryValue$1() {
+  jni$_.JByteArray? getBinaryValue$1() {
     return _getBinaryValue$1(
             reference.pointer, _id_getBinaryValue$1 as jni$_.JMethodIDPtr)
-        .object<jni$_.JArray<jni$_.jbyte>?>(
-            const jni$_.JArrayNullableType<jni$_.jbyte>(jni$_.jbyteType()));
+        .object<jni$_.JByteArray?>(const jni$_.JByteArrayNullableType());
   }
 
   static final _id_readBinaryValue = _class.instanceMethodId(

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonToken.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonToken.dart
@@ -191,11 +191,10 @@ class JsonToken extends jni$_.JObject {
 
   /// from: `public final char[] asCharArray()`
   /// The returned object must be released after use, by calling the [release] method.
-  jni$_.JArray<jni$_.jchar>? asCharArray() {
+  jni$_.JCharArray? asCharArray() {
     return _asCharArray(
             reference.pointer, _id_asCharArray as jni$_.JMethodIDPtr)
-        .object<jni$_.JArray<jni$_.jchar>?>(
-            const jni$_.JArrayNullableType<jni$_.jchar>(jni$_.jcharType()));
+        .object<jni$_.JCharArray?>(const jni$_.JCharArrayNullableType());
   }
 
   static final _id_asByteArray = _class.instanceMethodId(
@@ -217,11 +216,10 @@ class JsonToken extends jni$_.JObject {
 
   /// from: `public final byte[] asByteArray()`
   /// The returned object must be released after use, by calling the [release] method.
-  jni$_.JArray<jni$_.jbyte>? asByteArray() {
+  jni$_.JByteArray? asByteArray() {
     return _asByteArray(
             reference.pointer, _id_asByteArray as jni$_.JMethodIDPtr)
-        .object<jni$_.JArray<jni$_.jbyte>?>(
-            const jni$_.JArrayNullableType<jni$_.jbyte>(jni$_.jbyteType()));
+        .object<jni$_.JByteArray?>(const jni$_.JByteArrayNullableType());
   }
 
   static final _id_isNumeric = _class.instanceMethodId(

--- a/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
@@ -1452,7 +1452,7 @@ class Example extends jni$_.JObject {
   void methodWithSeveralParams<$T extends jni$_.JObject?>(
     int c,
     jni$_.JString? string,
-    jni$_.JArray<jni$_.jint>? is$,
+    jni$_.JIntArray? is$,
     $T? charSequence,
     jni$_.JList<$T?>? list,
     jni$_.JMap<jni$_.JString?, jni$_.JObject?>? map, {
@@ -1691,10 +1691,9 @@ class Example extends jni$_.JObject {
 
   /// from: `static public int[] getArr()`
   /// The returned object must be released after use, by calling the [release] method.
-  static jni$_.JArray<jni$_.jint>? getArr() {
+  static jni$_.JIntArray? getArr() {
     return _getArr(_class.reference.pointer, _id_getArr as jni$_.JMethodIDPtr)
-        .object<jni$_.JArray<jni$_.jint>?>(
-            const jni$_.JArrayNullableType<jni$_.jint>(jni$_.jintType()));
+        .object<jni$_.JIntArray?>(const jni$_.JIntArrayNullableType());
   }
 
   static final _id_addAll = _class.staticMethodId(
@@ -1715,7 +1714,7 @@ class Example extends jni$_.JObject {
 
   /// from: `static public int addAll(int[] is)`
   static int addAll(
-    jni$_.JArray<jni$_.jint>? is$,
+    jni$_.JIntArray? is$,
   ) {
     final _$is$ = is$?.reference ?? jni$_.jNullReference;
     return _addAll(_class.reference.pointer, _id_addAll as jni$_.JMethodIDPtr,
@@ -2177,11 +2176,10 @@ class Exceptions extends jni$_.JObject {
 
   /// from: `static public int[] staticIntArrayMethod()`
   /// The returned object must be released after use, by calling the [release] method.
-  static jni$_.JArray<jni$_.jint>? staticIntArrayMethod() {
+  static jni$_.JIntArray? staticIntArrayMethod() {
     return _staticIntArrayMethod(_class.reference.pointer,
             _id_staticIntArrayMethod as jni$_.JMethodIDPtr)
-        .object<jni$_.JArray<jni$_.jint>?>(
-            const jni$_.JArrayNullableType<jni$_.jint>(jni$_.jintType()));
+        .object<jni$_.JIntArray?>(const jni$_.JIntArrayNullableType());
   }
 
   static final _id_objectMethod = _class.instanceMethodId(
@@ -2278,11 +2276,10 @@ class Exceptions extends jni$_.JObject {
 
   /// from: `public int[] intArrayMethod()`
   /// The returned object must be released after use, by calling the [release] method.
-  jni$_.JArray<jni$_.jint>? intArrayMethod() {
+  jni$_.JIntArray? intArrayMethod() {
     return _intArrayMethod(
             reference.pointer, _id_intArrayMethod as jni$_.JMethodIDPtr)
-        .object<jni$_.JArray<jni$_.jint>?>(
-            const jni$_.JArrayNullableType<jni$_.jint>(jni$_.jintType()));
+        .object<jni$_.JIntArray?>(const jni$_.JIntArrayNullableType());
   }
 
   static final _id_throwNullPointerException = _class.instanceMethodId(


### PR DESCRIPTION
Closes #1792.

As mentioned in https://github.com/dart-lang/native/issues/1792#issuecomment-2531316325 it was not possible to implement Dart's `Iterable` in a generic way for both primitive arrays and object arrays. This led me to separate them like how it's done in Kotlin.
