### PR TITLE
[jnigen] Run object default methods for interfaces

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -10,6 +10,8 @@
   them in a for-loop or use methods such as `map` on them.
 
 - Added nullable type classes for all Java objects.
+- Fixed a problem where interfaces implemented in Dart would crash when calling
+  the default object methods: `equals`, `hashCode`, and `toString`.
 
 ## 0.12.2
 

--- a/pkgs/jni/java/src/main/java/com/github/dart_lang/jni/PortProxyBuilder.java
+++ b/pkgs/jni/java/src/main/java/com/github/dart_lang/jni/PortProxyBuilder.java
@@ -85,7 +85,7 @@ public class PortProxyBuilder implements InvocationHandler {
   }
 
   public void addImplementation(
-    String binaryName, long port, long functionPointer, List<String> asyncMethods) {
+      String binaryName, long port, long functionPointer, List<String> asyncMethods) {
     implementations.put(binaryName, new DartImplementation(port, functionPointer));
     this.asyncMethods.addAll(asyncMethods);
   }
@@ -103,8 +103,8 @@ public class PortProxyBuilder implements InvocationHandler {
       classes.add(Class.forName(binaryName));
     }
     Object obj =
-      Proxy.newProxyInstance(
-        classes.get(0).getClassLoader(), classes.toArray(new Class<?>[0]), this);
+        Proxy.newProxyInstance(
+            classes.get(0).getClassLoader(), classes.toArray(new Class<?>[0]), this);
     for (DartImplementation implementation : implementations.values()) {
       cleaner.register(obj, implementation.port);
     }
@@ -115,13 +115,13 @@ public class PortProxyBuilder implements InvocationHandler {
   /// [0]: The address of the result pointer used for the clean-up.
   /// [1]: The result of the invocation.
   private static native Object[] _invoke(
-    long port,
-    long isolateId,
-    long functionPtr,
-    Object proxy,
-    String methodDescriptor,
-    Object[] args,
-    boolean isBlocking);
+      long port,
+      long isolateId,
+      long functionPtr,
+      Object proxy,
+      String methodDescriptor,
+      Object[] args,
+      boolean isBlocking);
 
   private static native void _cleanUp(long resultPtr);
 
@@ -140,14 +140,14 @@ public class PortProxyBuilder implements InvocationHandler {
     String descriptor = getDescriptor(method);
     boolean isBlocking = !asyncMethods.contains(descriptor);
     Object[] result =
-      _invoke(
-        implementation.port,
-        isolateId,
-        implementation.pointer,
-        proxy,
-        descriptor,
-        args,
-        isBlocking);
+        _invoke(
+            implementation.port,
+            isolateId,
+            implementation.pointer,
+            proxy,
+            descriptor,
+            args,
+            isBlocking);
     if (!isBlocking) {
       return null;
     }

--- a/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
+++ b/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
@@ -762,7 +762,6 @@ void registerTests(String groupName, TestRunnerCallback test) {
           await _waitUntil(() => MyInterface.$impls.isEmpty);
           expect(MyRunnable.$impls, isEmpty);
         }
-        runnable.release();
       });
     }
     group('Dart exceptions are handled', () {

--- a/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
+++ b/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
@@ -754,6 +754,16 @@ void registerTests(String groupName, TestRunnerCallback test) {
           }
         });
       }
+      test('Object methods work', () {
+        final runnable = MyRunnable.implement($MyRunnable(
+          run: () {},
+        ));
+        expect(runnable == runnable, true);
+        expect(runnable != runnable, false);
+        expect(runnable.hashCode, runnable.hashCode);
+        expect(runnable.toString(), runnable.toString());
+        runnable.release();
+      });
     }
     group('Dart exceptions are handled', () {
       for (final exception in [UnimplementedError(), 'Hello!']) {


### PR DESCRIPTION
Closes #1801.

`toString`, `equals`, and `hashCode` of interfaces now just call their default object implementation when implementing them in Dart.