### PR TITLE
[native_assets_cli] Nest `CodeConfig` OS-specific config

### DIFF
--- a/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
@@ -27,10 +27,15 @@ void main() async {
         dartExecutable: dartExecutable,
       );
 
+      final targetOS = OS.current;
+      const defaultMacOSVersion = 13;
       BuildConfigBuilder configCreator() => BuildConfigBuilder()
         ..setupCodeConfig(
           targetArchitecture: Architecture.current,
           targetOS: OS.current,
+          macOSConfig: targetOS == OS.macOS
+              ? MacOSConfig(targetVersion: defaultMacOSVersion)
+              : null,
           linkModePreference: LinkModePreference.dynamic,
         );
 

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test_helper.dart
@@ -16,6 +16,7 @@ void main(List<String> args) async {
     ..level = Level.ALL
     ..onRecord.listen((event) => print(event.message));
 
+  final targetOS = target.os;
   final result = await NativeAssetsBuildRunner(
     logger: logger,
     dartExecutable: dartExecutable,
@@ -25,7 +26,10 @@ void main(List<String> args) async {
     configCreator: () => BuildConfigBuilder()
       ..setupCodeConfig(
         targetArchitecture: target.architecture,
-        targetOS: target.os,
+        targetOS: targetOS,
+        macOSConfig: targetOS == OS.macOS
+            ? MacOSConfig(targetVersion: defaultMacOSVersion)
+            : null,
         linkModePreference: LinkModePreference.dynamic,
       ),
     workingDirectory: packageUri,
@@ -41,3 +45,5 @@ void main(List<String> args) async {
   }
   print('done');
 }
+
+int defaultMacOSVersion = 13;

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
@@ -20,6 +20,7 @@ void main(List<String> args) async {
     ..level = Level.ALL
     ..onRecord.listen((event) => print(event.message));
 
+  final targetOS = OS.current;
   final result = await NativeAssetsBuildRunner(
     logger: logger,
     dartExecutable: dartExecutable,
@@ -28,10 +29,12 @@ void main(List<String> args) async {
     configCreator: () => BuildConfigBuilder()
       ..setupCodeConfig(
         targetArchitecture: Architecture.current,
-        targetOS: OS.current,
+        targetOS: targetOS,
         linkModePreference: LinkModePreference.dynamic,
         cCompilerConfig: dartCICompilerConfig,
-        targetMacOSVersion: OS.current == OS.macOS ? defaultMacOSVersion : null,
+        macOSConfig: targetOS == OS.macOS
+            ? MacOSConfig(targetVersion: defaultMacOSVersion)
+            : null,
       ),
     workingDirectory: packageUri,
     linkingEnabled: false,

--- a/pkgs/native_assets_builder/test/build_runner/helpers.dart
+++ b/pkgs/native_assets_builder/test/build_runner/helpers.dart
@@ -62,11 +62,19 @@ Future<BuildResult?> build(
             targetOS: targetOS,
             linkModePreference: linkModePreference,
             cCompilerConfig: cCompilerConfig ?? dartCICompilerConfig,
-            targetIOSSdk: targetIOSSdk,
-            targetIOSVersion: targetIOSVersion,
-            targetMacOSVersion: targetMacOSVersion ??
-                (targetOS == OS.macOS ? defaultMacOSVersion : null),
-            targetAndroidNdkApi: targetAndroidNdkApi,
+            iOSConfig: targetOS == OS.iOS
+                ? IOSConfig(
+                    targetSdk: targetIOSSdk!,
+                    targetVersion: targetIOSVersion!,
+                  )
+                : null,
+            macOSConfig: targetOS == OS.macOS
+                ? MacOSConfig(
+                    targetVersion: targetMacOSVersion ?? defaultMacOSVersion)
+                : null,
+            androidConfig: targetOS == OS.android
+                ? AndroidConfig(targetNdkApi: targetAndroidNdkApi!)
+                : null,
           );
         }
         return configBuilder;
@@ -127,11 +135,19 @@ Future<LinkResult?> link(
             targetOS: target?.os ?? OS.current,
             linkModePreference: linkModePreference,
             cCompilerConfig: cCompilerConfig ?? dartCICompilerConfig,
-            targetIOSSdk: targetIOSSdk,
-            targetIOSVersion: targetIOSVersion,
-            targetMacOSVersion: targetMacOSVersion ??
-                (targetOS == OS.macOS ? defaultMacOSVersion : null),
-            targetAndroidNdkApi: targetAndroidNdkApi,
+            iOSConfig: targetOS == OS.iOS
+                ? IOSConfig(
+                    targetSdk: targetIOSSdk!,
+                    targetVersion: targetIOSVersion!,
+                  )
+                : null,
+            macOSConfig: targetOS == OS.macOS
+                ? MacOSConfig(
+                    targetVersion: targetMacOSVersion ?? defaultMacOSVersion)
+                : null,
+            androidConfig: targetOS == OS.android
+                ? AndroidConfig(targetNdkApi: targetAndroidNdkApi!)
+                : null,
           );
         }
         return configBuilder;
@@ -181,17 +197,27 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
         logger: logger,
         dartExecutable: dartExecutable,
       );
+      final targetOS = target?.os ?? OS.current;
       final buildResult = await buildRunner.build(
         configCreator: () => BuildConfigBuilder()
           ..setupCodeConfig(
             targetArchitecture: target?.architecture ?? Architecture.current,
-            targetOS: target?.os ?? OS.current,
+            targetOS: targetOS,
             linkModePreference: linkModePreference,
             cCompilerConfig: cCompilerConfig ?? dartCICompilerConfig,
-            targetIOSSdk: targetIOSSdk,
-            targetIOSVersion: targetIOSVersion,
-            targetMacOSVersion: targetMacOSVersion,
-            targetAndroidNdkApi: targetAndroidNdkApi,
+            iOSConfig: targetOS == OS.iOS
+                ? IOSConfig(
+                    targetSdk: targetIOSSdk!,
+                    targetVersion: targetIOSVersion!,
+                  )
+                : null,
+            macOSConfig: targetOS == OS.macOS
+                ? MacOSConfig(
+                    targetVersion: targetMacOSVersion ?? defaultMacOSVersion)
+                : null,
+            androidConfig: targetOS == OS.android
+                ? AndroidConfig(targetNdkApi: targetAndroidNdkApi!)
+                : null,
           ),
         configValidator: buildConfigValidator,
         workingDirectory: packageUri,
@@ -217,13 +243,22 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
         configCreator: () => LinkConfigBuilder()
           ..setupCodeConfig(
             targetArchitecture: target?.architecture ?? Architecture.current,
-            targetOS: target?.os ?? OS.current,
+            targetOS: targetOS,
             linkModePreference: linkModePreference,
             cCompilerConfig: cCompilerConfig,
-            targetIOSSdk: targetIOSSdk,
-            targetIOSVersion: targetIOSVersion,
-            targetMacOSVersion: targetMacOSVersion,
-            targetAndroidNdkApi: targetAndroidNdkApi,
+            iOSConfig: targetOS == OS.iOS
+                ? IOSConfig(
+                    targetSdk: targetIOSSdk!,
+                    targetVersion: targetIOSVersion!,
+                  )
+                : null,
+            macOSConfig: targetOS == OS.macOS
+                ? MacOSConfig(
+                    targetVersion: targetMacOSVersion ?? defaultMacOSVersion)
+                : null,
+            androidConfig: targetOS == OS.android
+                ? AndroidConfig(targetNdkApi: targetAndroidNdkApi!)
+                : null,
           ),
         configValidator: linkConfigValidator,
         workingDirectory: packageUri,

--- a/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
@@ -30,6 +30,7 @@ void main() async {
       final testPackageUri = testDataUri.resolve('$name/');
       final dartUri = Uri.file(Platform.resolvedExecutable);
 
+      final targetOS = OS.current;
       final configBuilder = BuildConfigBuilder()
         ..setupHookConfig(
           packageName: name,
@@ -43,7 +44,10 @@ void main() async {
         )
         ..setupCodeConfig(
           targetArchitecture: Architecture.current,
-          targetOS: OS.current,
+          targetOS: targetOS,
+          macOSConfig: targetOS == OS.macOS
+              ? MacOSConfig(targetVersion: defaultMacOSVersion)
+              : null,
           linkModePreference: LinkModePreference.dynamic,
           cCompilerConfig: cCompiler,
         );
@@ -125,3 +129,5 @@ void main() async {
     }),
   );
 }
+
+int defaultMacOSVersion = 13;

--- a/pkgs/native_assets_builder/test/test_data/transformer_test.dart
+++ b/pkgs/native_assets_builder/test/test_data/transformer_test.dart
@@ -44,6 +44,7 @@ void main() async {
       late String stdout;
       late BuildOutput output;
 
+      final targetOS = OS.current;
       Future<void> runBuild(Architecture architecture) async {
         final configBuilder = BuildConfigBuilder()
           ..setupHookConfig(
@@ -58,7 +59,10 @@ void main() async {
           )
           ..setupCodeConfig(
             targetArchitecture: architecture,
-            targetOS: OS.current,
+            targetOS: targetOS,
+            macOSConfig: targetOS == OS.macOS
+                ? MacOSConfig(targetVersion: defaultMacOSVersion)
+                : null,
             linkModePreference: LinkModePreference.dynamic,
           );
 

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/hook/build.dart
@@ -15,7 +15,7 @@ const minMacOSVersionForThisPackage = 13;
 void main(List<String> arguments) async {
   await build(arguments, (config, output) async {
     if (config.codeConfig.targetOS == OS.android) {
-      if (config.codeConfig.targetAndroidNdkApi! <
+      if (config.codeConfig.androidConfig.targetNdkApi <
           minNdkApiVersionForThisPackage) {
         throw UnsupportedError(
           'The native assets for this package require at '
@@ -23,19 +23,18 @@ void main(List<String> arguments) async {
         );
       }
     } else if (config.codeConfig.targetOS == OS.iOS) {
-      final iosVersion = config.codeConfig.targetIOSVersion;
+      final iosVersion = config.codeConfig.iOSConfig.targetVersion;
       // iosVersion is nullable to deal with version skew.
-      if (iosVersion != null && iosVersion < minIosVersionForThisPackage) {
+      if (iosVersion < minIosVersionForThisPackage) {
         throw UnsupportedError(
           'The native assets for this package require at '
           'least iOS version $minIosVersionForThisPackage.',
         );
       }
     } else if (config.codeConfig.targetOS == OS.macOS) {
-      final macosVersion = config.codeConfig.targetMacOSVersion;
+      final macosVersion = config.codeConfig.macOSConfig.targetVersion;
       // macosVersion is nullable to deal with version skew.
-      if (macosVersion != null &&
-          macosVersion < minMacOSVersionForThisPackage) {
+      if (macosVersion < minMacOSVersionForThisPackage) {
         throw UnsupportedError(
           'The native assets for this package require at '
           'least MacOS version $minMacOSVersionForThisPackage.',

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/hook/link.dart
@@ -15,7 +15,7 @@ const minMacOSVersionForThisPackage = 13;
 void main(List<String> arguments) async {
   await link(arguments, (config, output) async {
     if (config.codeConfig.targetOS == OS.android) {
-      if (config.codeConfig.targetAndroidNdkApi! <
+      if (config.codeConfig.androidConfig.targetNdkApi <
           minNdkApiVersionForThisPackage) {
         throw UnsupportedError(
           'The native assets for this package require at '
@@ -23,19 +23,18 @@ void main(List<String> arguments) async {
         );
       }
     } else if (config.codeConfig.targetOS == OS.iOS) {
-      final iosVersion = config.codeConfig.targetIOSVersion;
+      final iosVersion = config.codeConfig.iOSConfig.targetVersion;
       // iosVersion is nullable to deal with version skew.
-      if (iosVersion != null && iosVersion < minIosVersionForThisPackage) {
+      if (iosVersion < minIosVersionForThisPackage) {
         throw UnsupportedError(
           'The native assets for this package require at '
           'least iOS version $minIosVersionForThisPackage.',
         );
       }
     } else if (config.codeConfig.targetOS == OS.macOS) {
-      final macosVersion = config.codeConfig.targetMacOSVersion;
+      final macosVersion = config.codeConfig.macOSConfig.targetVersion;
       // macosVersion is nullable to deal with version skew.
-      if (macosVersion != null &&
-          macosVersion < minMacOSVersionForThisPackage) {
+      if (macosVersion < minMacOSVersionForThisPackage) {
         throw UnsupportedError(
           'The native assets for this package require at '
           'least MacOS version $minMacOSVersionForThisPackage.',

--- a/pkgs/native_assets_cli/lib/code_assets.dart
+++ b/pkgs/native_assets_cli/lib/code_assets.dart
@@ -15,13 +15,16 @@ export 'src/code_assets/c_compiler_config.dart' show CCompilerConfig;
 export 'src/code_assets/code_asset.dart' show CodeAsset, OSLibraryNaming;
 export 'src/code_assets/config.dart'
     show
+        AndroidConfig,
         CodeAssetBuildConfig,
         CodeAssetBuildOutputBuilder,
         CodeAssetBuildOutputBuilderAdd,
         CodeAssetLinkConfig,
         CodeAssetLinkOutputBuilder,
         CodeAssetLinkOutputBuilderAdd,
-        CodeConfig;
+        CodeConfig,
+        IOSConfig,
+        MacOSConfig;
 export 'src/code_assets/ios_sdk.dart' show IOSSdk;
 export 'src/code_assets/link_mode.dart'
     show

--- a/pkgs/native_assets_cli/lib/src/code_assets/config.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/config.dart
@@ -43,41 +43,124 @@ class CodeConfig {
 
   final LinkModePreference linkModePreference;
   final CCompilerConfig? cCompiler;
-  final int? targetIOSVersion;
-  final int? targetMacOSVersion;
-  final int? targetAndroidNdkApi;
-  final IOSSdk? targetIOSSdk;
 
   /// The operating system being compiled for.
   final OS targetOS;
 
+  late final IOSConfig? _iOSConfig;
+  late final AndroidConfig? _androidConfig;
+  late final MacOSConfig? _macOSConfig;
+
   CodeConfig(HookConfig config)
       : linkModePreference = LinkModePreference.fromString(
-            config.json.string(_linkModePreferenceKey)),
+            config.json.string(linkModePreferenceKey)),
         // ignore: deprecated_member_use_from_same_package
         _targetArchitecture = (config is BuildConfig && config.dryRun)
             ? null
-            : Architecture.fromString(config.json.string(_targetArchitectureKey,
+            : Architecture.fromString(config.json.string(targetArchitectureKey,
                 validValues: Architecture.values.map((a) => a.name))),
-        targetOS = OS.fromString(config.json.string(_targetOSConfigKey)),
-        cCompiler = switch (config.json.optionalMap(_compilerKey)) {
+        targetOS = OS.fromString(config.json.string(targetOSConfigKey)),
+        cCompiler = switch (config.json.optionalMap(compilerKey)) {
           final Map<String, Object?> map => CCompilerConfig.fromJson(map),
           null => null,
-        },
-        targetIOSVersion = config.json.optionalInt(_targetIOSVersionKey),
-        targetMacOSVersion = config.json.optionalInt(_targetMacOSVersionKey),
-        targetAndroidNdkApi = config.json.optionalInt(_targetAndroidNdkApiKey),
-        targetIOSSdk = switch (config.json.optionalString(_targetIOSSdkKey)) {
-          final String value => IOSSdk.fromString(value),
-          null => null,
-        };
+        } {
+    // ignore: deprecated_member_use_from_same_package
+    _iOSConfig = (config is BuildConfig && config.dryRun)
+        ? null
+        : targetOS == OS.iOS
+            ? IOSConfig.fromHookConfig(config)
+            : null;
+    // ignore: deprecated_member_use_from_same_package
+    _androidConfig = (config is BuildConfig && config.dryRun)
+        ? null
+        : targetOS == OS.android
+            ? AndroidConfig.fromHookConfig(config)
+            : null;
+    // ignore: deprecated_member_use_from_same_package
+    _macOSConfig = (config is BuildConfig && config.dryRun)
+        ? null
+        : targetOS == OS.macOS
+            ? MacOSConfig.fromHookConfig(config)
+            : null;
+  }
 
   Architecture get targetArchitecture {
+    // TODO: Remove once Dart 3.7 stable is out and we bump the minimum SDK to
+    // 3.7.
     if (_targetArchitecture == null) {
-      throw StateError('Cannot access target architecture in dry runs');
+      throw StateError('Cannot access target architecture in dry runs.');
     }
     return _targetArchitecture;
   }
+
+  /// Configuration provided when [CodeConfig.targetOS] is [OS.macOS].
+  IOSConfig get iOSConfig => switch (_iOSConfig) {
+        null =>
+          throw StateError('Cannot access iOSConfig if targetOS is not iOS'
+              ' or in dry runs.'),
+        final c => c,
+      };
+
+  /// Configuration provided when [CodeConfig.targetOS] is [OS.android].
+  AndroidConfig get androidConfig => switch (_androidConfig) {
+        null => throw StateError(
+            'Cannot access androidConfig if targetOS is not android'
+            ' or in dry runs.'),
+        final c => c,
+      };
+
+  /// Configuration provided when [CodeConfig.targetOS] is [OS.macOS].
+  MacOSConfig get macOSConfig => switch (_macOSConfig) {
+        null =>
+          throw StateError('Cannot access macOSConfig if targetOS is not MacOS'
+              ' or in dry runs.'),
+        final c => c,
+      };
+}
+
+/// Configuration provided when [CodeConfig.targetOS] is [OS.iOS].
+class IOSConfig {
+  /// Whether to target device or simulator.
+  final IOSSdk targetSdk;
+
+  /// The lowest iOS version that the compiled code will be compatible with.
+  final int targetVersion;
+
+  IOSConfig({
+    required this.targetSdk,
+    required this.targetVersion,
+  });
+
+  IOSConfig.fromHookConfig(HookConfig config)
+      : targetVersion = config.json.int(targetIOSVersionKey),
+        targetSdk = IOSSdk.fromString(config.json.string(targetIOSSdkKey));
+}
+
+/// Configuration provided when [CodeConfig.targetOS] is [OS.macOS].
+class AndroidConfig {
+  /// The minimum Android SDK API version to that the compiled code will be
+  /// compatible with.
+  final int targetNdkApi;
+
+  AndroidConfig({
+    required this.targetNdkApi,
+  });
+
+  AndroidConfig.fromHookConfig(HookConfig config)
+      : targetNdkApi = config.json.int(targetAndroidNdkApiKey);
+}
+
+//// Configuration provided when [CodeConfig.targetOS] is [OS.macOS].
+class MacOSConfig {
+  /// The lowest MacOS version that the compiled code will be compatible with.
+  final int targetVersion;
+
+  MacOSConfig({
+    required this.targetVersion,
+  });
+
+  MacOSConfig.fromHookConfig(HookConfig config)
+      : targetVersion = config.json.int(targetMacOSVersionKey);
 }
 
 /// Extension to the [BuildOutputBuilder] providing access to emitting code
@@ -128,31 +211,37 @@ extension CodeAssetBuildConfigBuilder on HookConfigBuilder {
     required OS targetOS,
     required LinkModePreference linkModePreference,
     CCompilerConfig? cCompilerConfig,
-    int? targetIOSVersion,
-    int? targetMacOSVersion,
-    int? targetAndroidNdkApi,
-    IOSSdk? targetIOSSdk,
+    AndroidConfig? androidConfig,
+    IOSConfig? iOSConfig,
+    MacOSConfig? macOSConfig,
   }) {
     if (targetArchitecture != null) {
-      json[_targetArchitectureKey] = targetArchitecture.toString();
+      json[targetArchitectureKey] = targetArchitecture.toString();
     }
-    json[_targetOSConfigKey] = targetOS.toString();
-    json[_linkModePreferenceKey] = linkModePreference.toString();
+    json[targetOSConfigKey] = targetOS.toString();
+    json[linkModePreferenceKey] = linkModePreference.toString();
     if (cCompilerConfig != null) {
-      json[_compilerKey] = cCompilerConfig.toJson();
+      json[compilerKey] = cCompilerConfig.toJson();
     }
 
-    if (targetIOSVersion != null) {
-      json[_targetIOSVersionKey] = targetIOSVersion;
-    }
-    if (targetMacOSVersion != null) {
-      json[_targetMacOSVersionKey] = targetMacOSVersion;
-    }
-    if (targetAndroidNdkApi != null) {
-      json[_targetAndroidNdkApiKey] = targetAndroidNdkApi;
-    }
-    if (targetIOSSdk != null) {
-      json[_targetIOSSdkKey] = targetIOSSdk.toString();
+    // Note, using ?. instead of !. enables using this in tests to write wrong
+    // invalid configs. Is this a good idea? The setup methods only create the
+    // JSON now, but don't enable creating all forms of wrong JSON. For example
+    // `IOSConfig` either has both fields or none.
+    // Maybe the builders should be more construct by construction, and the
+    // validator tests should be on the JSON. This requires duplicating JSON
+    // serialization logic in the tests though.
+    // This PR already duplicates deserialization logic in the validator and
+    // `Config`s. The configs classes need to provide non-nullable accessors, so
+    // they cannot be used inside the validators to check for invalid null
+    // values.
+    if (targetOS == OS.android) {
+      json[targetAndroidNdkApiKey] = androidConfig?.targetNdkApi;
+    } else if (targetOS == OS.iOS) {
+      json[targetIOSSdkKey] = iOSConfig?.targetSdk.toString();
+      json[targetIOSVersionKey] = iOSConfig?.targetVersion;
+    } else if (targetOS == OS.macOS) {
+      json[targetMacOSVersionKey] = macOSConfig?.targetVersion;
     }
   }
 }
@@ -175,11 +264,11 @@ extension CodeAssetLinkOutput on LinkOutput {
       .toList();
 }
 
-const String _compilerKey = 'c_compiler';
-const String _linkModePreferenceKey = 'link_mode_preference';
-const String _targetAndroidNdkApiKey = 'target_android_ndk_api';
-const String _targetArchitectureKey = 'target_architecture';
-const String _targetIOSSdkKey = 'target_ios_sdk';
-const String _targetIOSVersionKey = 'target_ios_version';
-const String _targetMacOSVersionKey = 'target_macos_version';
-const String _targetOSConfigKey = 'target_os';
+const String compilerKey = 'c_compiler';
+const String linkModePreferenceKey = 'link_mode_preference';
+const String targetAndroidNdkApiKey = 'target_android_ndk_api';
+const String targetArchitectureKey = 'target_architecture';
+const String targetIOSSdkKey = 'target_ios_sdk';
+const String targetIOSVersionKey = 'target_ios_version';
+const String targetMacOSVersionKey = 'target_macos_version';
+const String targetOSConfigKey = 'target_os';

--- a/pkgs/native_assets_cli/lib/src/code_assets/testing.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/testing.dart
@@ -43,10 +43,18 @@ Future<void> testCodeBuildHook({
         cCompilerConfig: cCompiler,
         targetArchitecture: targetArchitecture ?? Architecture.current,
         targetOS: targetOS ?? OS.current,
-        targetIOSSdk: targetIOSSdk,
-        targetIOSVersion: targetIOSVersion,
-        targetMacOSVersion: targetMacOSVersion,
-        targetAndroidNdkApi: targetAndroidNdkApi,
+        iOSConfig: targetOS == OS.iOS
+            ? IOSConfig(
+                targetSdk: targetIOSSdk!,
+                targetVersion: targetIOSVersion!,
+              )
+            : null,
+        macOSConfig: targetOS == OS.macOS
+            ? MacOSConfig(targetVersion: targetMacOSVersion!)
+            : null,
+        androidConfig: targetOS == OS.android
+            ? AndroidConfig(targetNdkApi: targetAndroidNdkApi!)
+            : null,
       );
     },
     check: (config, output) async {

--- a/pkgs/native_assets_cli/test/checksum_test.dart
+++ b/pkgs/native_assets_cli/test/checksum_test.dart
@@ -8,6 +8,8 @@ import 'package:native_assets_cli/code_assets_builder.dart';
 import 'package:native_assets_cli/data_assets_builder.dart';
 import 'package:test/test.dart';
 
+import 'helpers.dart';
+
 void main() {
   test('checksum', () async {
     // metadata, cc, link vs build, metadata, haslink
@@ -32,6 +34,9 @@ void main() {
                   ..setupCodeConfig(
                     targetArchitecture: architecture,
                     targetOS: os,
+                    macOSConfig: os == OS.macOS
+                        ? MacOSConfig(targetVersion: defaultMacOSVersion)
+                        : null,
                     linkModePreference: LinkModePreference.dynamic,
                   );
                 configs.add(
@@ -84,38 +89,38 @@ void main() {
       '5f2c169a71039d3d6b2ae74e3c2723d7',
       '67759625e5a0908dabcaeeb2b1264f84',
       '921b2b7012548949e9b465addccc2e71',
-      '94bc85e935634df06e208ac8ab9643d3',
-      'ee4cd19fc3ac5d4a85ceaf2e80e44682',
-      '661bf4e49dff3c104784a0d75cf45204',
-      '0b3529f1337b3759e97733095a868d29',
-      '1522580f1e96c5ea5dc68ca7a720adee',
-      '5c08a30f498edf9962c8ff20a1ab4fba',
-      '69f4f6640eba043f4df2e6f109f07b90',
-      '62db9da306210856e44bb7f8a75a15fd',
-      '125f6fa99282a3b7e8937030a3aa2c6d',
-      '1cf817dd1a1710bfacb82ef71da94e4f',
-      '1eccd6e8e62985cb9955db4fd8c22d2f',
-      '4becc04d3263f2b362dd76c0e0eb6d7b',
-      '74ecd3c74beb88f2f7f02921a8de1143',
-      'ad6bf3865f8addf4233e3a83192f5464',
-      'edf54995d97ad818449f09d9b2fc86e2',
-      '89014c91ebb4075bdea2d52f2d35b4ae',
-      'cb59b4041a0a7bbf636ed4e3b30d06be',
-      '3dd69a72235c9b45e1f85c143e8f97bc',
-      'b08bec82fca775aeec2e4f400b20a4a0',
-      '79381e4fd8c1191f2fceb7ad30b3fd64',
-      'b8e5434a62d4b0a381363dca1152a0d5',
-      'f70e0798fa96df0b6e1d14d69fd0deaa',
-      '3d807e9c6306c16f2ee61a32e8081e2f',
-      '0646eefc0cfd913506051f0c8a900983',
-      'b5adb85aeaf88a23e7bafd29e63c03ac',
-      '7b269c3e21fe9e29285daba8c370073f',
-      '1a47af48f1e3158000d44ef59ab597da',
-      '2665c64ac2a9d919fff7420c0e770db3',
-      '27c0acf56ef48f3855fc20ea8810ff8d',
-      '2a9a03940008cdd6f9231f1f54dd94bf',
-      '86d87e3cb682646e5d1158898ed7913f',
-      '6a7b30ccd5a35694c515d22f165be589',
+      'b1bddc0ed6904d52d8455779ea22ca7e',
+      'ddc148493501a29584b859bbad703dc8',
+      'f61b611c5cdf32c1251547c63773be4b',
+      '754258bb3497d76670f306c3bdcfb72e',
+      '9d7f0c3ea090c5c9a50bc68970b691de',
+      '2fb6a652e863e63b877bcf4d0f9c18ee',
+      'e6c27bf9b26cd1b9e093d8df3eb701f1',
+      '21b14473b8f4513afc07b10fc49b3a42',
+      '755e4a51021d2f06f81800d06005d3e8',
+      '18739efa01630bfb69b359f3471813e3',
+      '6532e84b2020034445983b4aaca63cf6',
+      '400486e5b7fd7bcee2cca005d9e365ef',
+      'ca9415247d3caf7469f7ef256dbfec7d',
+      '5f7e1b8477f41b8676d076375edc4160',
+      '79440103b796d05d7f2e3fe6a7eaaa3c',
+      '291e0f37d19c0b59abeeb96577f98295',
+      '266de1a05af22f800e9018dcacf5f9d5',
+      '899d2db19759e703b5093f4919db72b4',
+      'ba8fa2cfec652f80588ce5080cb8e0d7',
+      'aa946213d19406fa2db5ba89be7037ba',
+      '7e29bcee52269e094cf7645dba7b2257',
+      'c423ef2466bd1370d04ef82a7676e82c',
+      '7b258ea5c87c103e12968ea979339e13',
+      '344189c289fceff30a21681b28be98fb',
+      '1bfafa1611cef338271a338500a49d13',
+      'e59b31a6d8a958f1b894b6e536043b18',
+      '39c6bf2b59d2e335b444638352967969',
+      '672fe8c89974fbc794bf992da475b264',
+      '0690975592703ed47f236c8815d115f0',
+      '51d7e1b0c5b4a855d070f409150d2bcf',
+      '3299a12d5041c50fbe81167bf0aca0ff',
+      '46007e911efe370c1774c3a1d6c35ddd',
     ];
     printOnFailure('final expectedChecksums = <String>[');
     printOnFailure(checksums.map((e) => "  '$e',").join('\n'));

--- a/pkgs/native_assets_cli/test/code_assets/config_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/config_test.dart
@@ -53,7 +53,7 @@ void main() async {
     });
 
     expect(() => codeConfig.targetArchitecture, throwsStateError);
-    expect(codeConfig.targetAndroidNdkApi, null);
+    expect(() => codeConfig.androidConfig.targetNdkApi, throwsStateError);
     expect(codeConfig.linkModePreference, LinkModePreference.preferStatic);
     expect(codeConfig.cCompiler, null);
   }
@@ -77,7 +77,7 @@ void main() async {
     });
 
     expect(codeConfig.targetArchitecture, Architecture.arm64);
-    expect(codeConfig.targetAndroidNdkApi, 30);
+    expect(codeConfig.androidConfig.targetNdkApi, 30);
     expect(codeConfig.linkModePreference, LinkModePreference.preferStatic);
     expect(codeConfig.cCompiler?.compiler, fakeClang);
     expect(codeConfig.cCompiler?.linker, fakeLd);
@@ -101,6 +101,7 @@ void main() async {
       )
       ..setupCodeConfig(
         targetOS: OS.android,
+        androidConfig: null, // not available in dry run
         targetArchitecture: null, // not available in dry run
         cCompilerConfig: null, // not available in dry run
         linkModePreference: LinkModePreference.preferStatic,
@@ -127,7 +128,7 @@ void main() async {
       ..setupCodeConfig(
         targetOS: OS.android,
         targetArchitecture: Architecture.arm64,
-        targetAndroidNdkApi: 30,
+        androidConfig: AndroidConfig(targetNdkApi: 30),
         linkModePreference: LinkModePreference.preferStatic,
         cCompilerConfig: CCompilerConfig(
           compiler: fakeClang,
@@ -157,7 +158,7 @@ void main() async {
       ..setupCodeConfig(
         targetOS: OS.android,
         targetArchitecture: Architecture.arm64,
-        targetAndroidNdkApi: 30,
+        androidConfig: AndroidConfig(targetNdkApi: 30),
         linkModePreference: LinkModePreference.preferStatic,
         cCompilerConfig: CCompilerConfig(
           compiler: fakeClang,

--- a/pkgs/native_assets_cli/test/code_assets/validation_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/validation_test.dart
@@ -49,11 +49,10 @@ void main() {
 
   BuildConfig makeCodeBuildConfig({
     LinkModePreference linkModePreference = LinkModePreference.dynamic,
-    OS os = OS.iOS,
   }) {
     final builder = makeBuildConfigBuilder()
       ..setupCodeConfig(
-        targetOS: os,
+        targetOS: OS.linux,
         targetArchitecture: Architecture.arm64,
         linkModePreference: linkModePreference,
       );
@@ -227,8 +226,8 @@ void main() {
           await validateCodeAssetBuildConfig(BuildConfig(builder.json));
       expect(
           errors,
-          contains(
-              contains('BuildConfig.codeConfig.targetIOSVersion was missing')));
+          contains(contains(
+              'BuildConfig.codeConfig.iOSConfig.targetVersion was missing')));
       expect(
           errors,
           contains(
@@ -242,9 +241,10 @@ void main() {
           linkModePreference: LinkModePreference.dynamic,
         );
       expect(
-          await validateCodeAssetBuildConfig(BuildConfig(builder.json)),
-          contains(contains(
-              'BuildConfig.codeConfig.targetAndroidNdkApi was missing')));
+        await validateCodeAssetBuildConfig(BuildConfig(builder.json)),
+        contains(contains(
+            'BuildConfig.codeConfig.androidConfig.targetNdkApi was missing')),
+      );
     });
     test('Missing targetMacOSVersion', () async {
       final builder = makeBuildConfigBuilder()
@@ -256,7 +256,7 @@ void main() {
       expect(
           await validateCodeAssetBuildConfig(BuildConfig(builder.json)),
           contains(contains(
-              'BuildConfig.codeConfig.targetMacOSVersion was missing')));
+              'BuildConfig.codeConfig.macOSConfig.targetVersion was missing')));
     });
     test('Nonexisting compiler/archiver/linker/envScript', () async {
       final nonExistent = outDirUri.resolve('foo baz');

--- a/pkgs/native_assets_cli/test/example/local_asset_test.dart
+++ b/pkgs/native_assets_cli/test/example/local_asset_test.dart
@@ -40,6 +40,7 @@ void main() async {
       final testPackageUri = packageUri.resolve('example/build/$name/');
       final dartUri = Uri.file(Platform.resolvedExecutable);
 
+      final targetOS = OS.current;
       final configBuilder = BuildConfigBuilder()
         ..setupHookConfig(
           packageRoot: testPackageUri,
@@ -51,7 +52,10 @@ void main() async {
             outputDirectoryShared: outputDirectoryShared)
         ..setupBuildConfig(linkingEnabled: false, dryRun: dryRun)
         ..setupCodeConfig(
-          targetOS: OS.current,
+          targetOS: targetOS,
+          macOSConfig: targetOS == OS.macOS
+              ? MacOSConfig(targetVersion: defaultMacOSVersion)
+              : null,
           targetArchitecture: dryRun ? null : Architecture.current,
           linkModePreference: LinkModePreference.dynamic,
           cCompilerConfig: dryRun ? null : cCompiler,

--- a/pkgs/native_assets_cli/test/example/native_add_library_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_library_test.dart
@@ -40,6 +40,7 @@ void main() async {
       final testPackageUri = packageUri.resolve('example/build/$name/');
       final dartUri = Uri.file(Platform.resolvedExecutable);
 
+      final targetOS = OS.current;
       final configBuilder = BuildConfigBuilder()
         ..setupHookConfig(
           packageRoot: testPackageUri,
@@ -52,6 +53,9 @@ void main() async {
         ..setupBuildConfig(linkingEnabled: false, dryRun: dryRun)
         ..setupCodeConfig(
           targetOS: OS.current,
+          macOSConfig: targetOS == OS.macOS
+              ? MacOSConfig(targetVersion: defaultMacOSVersion)
+              : null,
           targetArchitecture: dryRun ? null : Architecture.current,
           linkModePreference: LinkModePreference.dynamic,
           cCompilerConfig: dryRun ? null : cCompiler,

--- a/pkgs/native_assets_cli/test/example/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_dynamic_linking_test.dart
@@ -44,6 +44,7 @@ void main() async {
       final testPackageUri = packageUri.resolve('example/build/$name/');
       final dartUri = Uri.file(Platform.resolvedExecutable);
 
+      final targetOS = OS.current;
       final configBuilder = BuildConfigBuilder()
         ..setupHookConfig(
           packageRoot: testPackageUri,
@@ -56,7 +57,10 @@ void main() async {
         )
         ..setupBuildConfig(linkingEnabled: false, dryRun: dryRun)
         ..setupCodeConfig(
-          targetOS: OS.current,
+          targetOS: targetOS,
+          macOSConfig: targetOS == OS.macOS
+              ? MacOSConfig(targetVersion: defaultMacOSVersion)
+              : null,
           targetArchitecture: dryRun ? null : Architecture.current,
           linkModePreference: LinkModePreference.dynamic,
           cCompilerConfig: dryRun ? null : cCompiler,

--- a/pkgs/native_assets_cli/test/helpers.dart
+++ b/pkgs/native_assets_cli/test/helpers.dart
@@ -187,3 +187,5 @@ Logger _createTestLogger({
       });
 
 final dartExecutable = File(Platform.resolvedExecutable).uri;
+
+int defaultMacOSVersion = 13;

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -140,7 +140,7 @@ class RunCBuilder {
 
     final IOSSdk? targetIosSdk;
     if (codeConfig.targetOS == OS.iOS) {
-      targetIosSdk = codeConfig.targetIOSSdk;
+      targetIosSdk = codeConfig.iOSConfig.targetSdk;
     } else {
       targetIosSdk = null;
     }
@@ -152,15 +152,18 @@ class RunCBuilder {
     if (codeConfig.targetOS == OS.android) {
       final minimumApi =
           codeConfig.targetArchitecture == Architecture.riscv64 ? 35 : 21;
-      targetAndroidNdkApi = max(codeConfig.targetAndroidNdkApi!, minimumApi);
+      targetAndroidNdkApi =
+          max(codeConfig.androidConfig.targetNdkApi, minimumApi);
     } else {
       targetAndroidNdkApi = null;
     }
 
-    final targetIOSVersion =
-        codeConfig.targetOS == OS.iOS ? codeConfig.targetIOSVersion : null;
-    final targetMacOSVersion =
-        codeConfig.targetOS == OS.macOS ? codeConfig.targetMacOSVersion : null;
+    final targetIOSVersion = codeConfig.targetOS == OS.iOS
+        ? codeConfig.iOSConfig.targetVersion
+        : null;
+    final targetMacOSVersion = codeConfig.targetOS == OS.macOS
+        ? codeConfig.macOSConfig.targetVersion
+        : null;
 
     final architecture = codeConfig.targetArchitecture;
     final sourceFiles = sources.map((e) => e.toFilePath()).toList();

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
@@ -29,6 +29,7 @@ void main() {
     await File.fromUri(addCUri).writeAsString(addCBrokenContents);
     const name = 'add';
 
+    final targetOS = OS.current;
     final buildConfigBuilder = BuildConfigBuilder()
       ..setupHookConfig(
         buildAssetTypes: [CodeAsset.type],
@@ -40,7 +41,10 @@ void main() {
         dryRun: false,
       )
       ..setupCodeConfig(
-        targetOS: OS.current,
+        targetOS: targetOS,
+        macOSConfig: targetOS == OS.macOS
+            ? MacOSConfig(targetVersion: defaultMacOSVersion)
+            : null,
         targetArchitecture: Architecture.current,
         linkModePreference: LinkModePreference.dynamic,
         cCompilerConfig: cCompiler,

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -158,7 +158,7 @@ Future<Uri> buildLib(
       targetOS: OS.android,
       targetArchitecture: targetArchitecture,
       cCompilerConfig: cCompiler,
-      targetAndroidNdkApi: androidNdkApi,
+      androidConfig: AndroidConfig(targetNdkApi: androidNdkApi),
       linkModePreference: linkMode == DynamicLoadingBundled()
           ? LinkModePreference.dynamic
           : LinkModePreference.static,

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -74,6 +74,7 @@ void main() {
                   ? LinkModePreference.dynamic
                   : LinkModePreference.static,
               cCompilerConfig: cCompiler,
+              macOSConfig: MacOSConfig(targetVersion: defaultMacOSVersion),
             );
           buildConfigBuilder.setupBuildRunConfig(
             outputDirectory: tempUri,
@@ -174,7 +175,7 @@ Future<Uri> buildLib(
       linkModePreference: linkMode == DynamicLoadingBundled()
           ? LinkModePreference.dynamic
           : LinkModePreference.static,
-      targetMacOSVersion: targetMacOSVersion,
+      macOSConfig: MacOSConfig(targetVersion: targetMacOSVersion),
       cCompilerConfig: cCompiler,
     );
   buildConfigBuilder.setupBuildRunConfig(

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -23,6 +23,10 @@ void main() {
     expect(Language.cpp.toString(), 'c++');
   });
 
+  final targetOS = OS.current;
+  final macOSConfig = targetOS == OS.macOS
+      ? MacOSConfig(targetVersion: defaultMacOSVersion)
+      : null;
   for (final pic in [null, true, false]) {
     final picTag =
         switch (pic) { null => 'auto_pic', true => 'pic', false => 'no_pic' };
@@ -54,7 +58,8 @@ void main() {
             dryRun: false,
           )
           ..setupCodeConfig(
-            targetOS: OS.current,
+            targetOS: targetOS,
+            macOSConfig: macOSConfig,
             targetArchitecture: Architecture.current,
             // Ignored by executables.
             linkModePreference: LinkModePreference.dynamic,
@@ -136,7 +141,8 @@ void main() {
             dryRun: dryRun,
           )
           ..setupCodeConfig(
-            targetOS: OS.current,
+            targetOS: targetOS,
+            macOSConfig: macOSConfig,
             targetArchitecture: Architecture.current,
             linkModePreference: LinkModePreference.dynamic,
             cCompilerConfig: dryRun ? null : cCompiler,
@@ -237,7 +243,8 @@ void main() {
         dryRun: false,
       )
       ..setupCodeConfig(
-        targetOS: OS.current,
+        targetOS: targetOS,
+        macOSConfig: macOSConfig,
         targetArchitecture: Architecture.current,
         // Ignored by executables.
         linkModePreference: LinkModePreference.dynamic,
@@ -304,7 +311,8 @@ void main() {
         dryRun: false,
       )
       ..setupCodeConfig(
-        targetOS: OS.current,
+        targetOS: targetOS,
+        macOSConfig: macOSConfig,
         targetArchitecture: Architecture.current,
         // Ignored by executables.
         linkModePreference: LinkModePreference.dynamic,
@@ -349,6 +357,7 @@ void main() {
     final logMessages = <String>[];
     final logger = createCapturingLogger(logMessages);
 
+    final targetOS = OS.current;
     final buildConfigBuilder = BuildConfigBuilder()
       ..setupHookConfig(
         buildAssetTypes: [CodeAsset.type],
@@ -360,7 +369,8 @@ void main() {
         dryRun: false,
       )
       ..setupCodeConfig(
-        targetOS: OS.current,
+        targetOS: targetOS,
+        macOSConfig: macOSConfig,
         targetArchitecture: Architecture.current,
         // Ignored by executables.
         linkModePreference: LinkModePreference.dynamic,
@@ -417,6 +427,7 @@ void main() {
     final logMessages = <String>[];
     final logger = createCapturingLogger(logMessages);
 
+    final targetOS = OS.current;
     final buildConfigBuilder = BuildConfigBuilder()
       ..setupHookConfig(
         buildAssetTypes: [CodeAsset.type],
@@ -428,7 +439,8 @@ void main() {
         dryRun: false,
       )
       ..setupCodeConfig(
-        targetOS: OS.current,
+        targetOS: targetOS,
+        macOSConfig: macOSConfig,
         targetArchitecture: Architecture.current,
         // Ignored by executables.
         linkModePreference: LinkModePreference.dynamic,
@@ -490,6 +502,7 @@ void main() {
     final logMessages = <String>[];
     final logger = createCapturingLogger(logMessages);
 
+    final targetOS = OS.current;
     final buildConfigBuilder = BuildConfigBuilder()
       ..setupHookConfig(
         buildAssetTypes: [CodeAsset.type],
@@ -501,7 +514,8 @@ void main() {
         dryRun: false,
       )
       ..setupCodeConfig(
-        targetOS: OS.current,
+        targetOS: targetOS,
+        macOSConfig: macOSConfig,
         targetArchitecture: Architecture.current,
         // Ignored by executables.
         linkModePreference: LinkModePreference.dynamic,
@@ -574,6 +588,7 @@ void main() {
     final logMessages = <String>[];
     final logger = createCapturingLogger(logMessages);
 
+    final targetOS = OS.current;
     final buildConfigBuilder = BuildConfigBuilder()
       ..setupHookConfig(
         buildAssetTypes: [CodeAsset.type],
@@ -585,7 +600,8 @@ void main() {
         dryRun: false,
       )
       ..setupCodeConfig(
-        targetOS: OS.current,
+        targetOS: targetOS,
+        macOSConfig: macOSConfig,
         targetArchitecture: Architecture.current,
         // Ignored by executables.
         linkModePreference: LinkModePreference.dynamic,
@@ -675,6 +691,7 @@ Future<void> testDefines({
   }
   const name = 'defines';
 
+  final targetOS = OS.current;
   final buildConfigBuilder = BuildConfigBuilder()
     ..setupHookConfig(
       buildAssetTypes: [CodeAsset.type],
@@ -686,7 +703,10 @@ Future<void> testDefines({
       dryRun: false,
     )
     ..setupCodeConfig(
-      targetOS: OS.current,
+      targetOS: targetOS,
+      macOSConfig: targetOS == OS.macOS
+          ? MacOSConfig(targetVersion: defaultMacOSVersion)
+          : null,
       targetArchitecture: Architecture.current,
       // Ignored by executables.
       linkModePreference: LinkModePreference.dynamic,

--- a/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
@@ -41,6 +41,7 @@ void main() {
       ...await msvc.vcvars64.defaultResolver!.resolve(logger: logger)
     ].firstOrNull?.uri;
 
+    final targetOS = OS.current;
     final buildConfigBuilder = BuildConfigBuilder()
       ..setupHookConfig(
         buildAssetTypes: [CodeAsset.type],
@@ -52,7 +53,10 @@ void main() {
         dryRun: false,
       )
       ..setupCodeConfig(
-        targetOS: OS.current,
+        targetOS: targetOS,
+        macOSConfig: targetOS == OS.macOS
+            ? MacOSConfig(targetVersion: defaultMacOSVersion)
+            : null,
         targetArchitecture: Architecture.current,
         linkModePreference: LinkModePreference.dynamic,
         cCompilerConfig: CCompilerConfig(

--- a/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
@@ -35,6 +35,7 @@ void main() {
     final logMessages = <String>[];
     final logger = createCapturingLogger(logMessages);
 
+    final targetOS = OS.current;
     final buildConfigBuilder = BuildConfigBuilder()
       ..setupHookConfig(
         buildAssetTypes: [CodeAsset.type],
@@ -46,7 +47,10 @@ void main() {
         dryRun: false,
       )
       ..setupCodeConfig(
-        targetOS: OS.current,
+        targetOS: targetOS,
+        macOSConfig: targetOS == OS.macOS
+            ? MacOSConfig(targetVersion: defaultMacOSVersion)
+            : null,
         targetArchitecture: Architecture.current,
         linkModePreference: LinkModePreference.dynamic,
         cCompilerConfig: cCompiler,

--- a/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
+++ b/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
@@ -25,6 +25,7 @@ Future<Uri> buildTestArchive(
   final logMessages = <String>[];
   final logger = createCapturingLogger(logMessages);
 
+  assert(os == OS.linux); // Setup code config for other OSes.
   final buildConfigBuilder = BuildConfigBuilder()
     ..setupHookConfig(
       buildAssetTypes: [CodeAsset.type],

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -302,3 +302,5 @@ Future<void> expectPageSize(
     expect(vma, greaterThanOrEqualTo(pageSize));
   }
 }
+
+int defaultMacOSVersion = 13;


### PR DESCRIPTION
Dart and Flutter have been passing the minimum OS SDK versions for a while (in non-dry-run), which means we can mark these fields non-optional if the target OS is used.

This PR changes the `CodeConfig` to nest the OS versions (and iOS target SDK: device or simulator) to be nested under the OS and required.

Side effects of this PR:

* Many unit tests where missing these (now) mandatory fields
* `native_toolchain_c` can no longer test without the minimum OS versions, which changed the iOS test `otool` output.

Addressing:

* https://github.com/dart-lang/native/issues/1738#issuecomment-2535921222