### PR TITLE
[native_assets_builder] Use ` package:file`s `FileSystem` abstraction

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Various fixes to caching.
 - **Breaking change** `BuildConfig.targetOS` is now only provided if
   `buildAssetTypes` contains the code asset.
+- **Breaking change** `NativeAssetsBuildRunner` and `PackageLayout` now take a
+  `FileSystem` from `package:file/file.dart`s.
 
 ## 0.9.0
 

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_planner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_planner.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' show Process;
 
 import 'package:graphs/graphs.dart' as graphs;
 import 'package:logging/logging.dart';

--- a/pkgs/native_assets_builder/lib/src/dependencies_hash_file/dependencies_hash_file.dart
+++ b/pkgs/native_assets_builder/lib/src/dependencies_hash_file/dependencies_hash_file.dart
@@ -3,19 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' show Platform;
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
+import 'package:file/file.dart';
 
 import '../utils/file.dart';
 import '../utils/uri.dart';
 
 class DependenciesHashFile {
-  DependenciesHashFile({
+  DependenciesHashFile(
+    this._fileSystem, {
     required this.file,
   });
 
+  final FileSystem _fileSystem;
   final File file;
   FileSystemHashes _hashes = FileSystemHashes();
 
@@ -51,7 +54,7 @@ class DependenciesHashFile {
     Uri? modifiedAfterTimeStamp;
     for (final uri in fileSystemEntities) {
       int hash;
-      if ((await uri.fileSystemEntity.lastModified())
+      if ((await _fileSystem.fileSystemEntity(uri).lastModified(_fileSystem))
           .isAfter(fileSystemValidBeforeLastModified)) {
         hash = _hashLastModifiedAfterCutoff;
         modifiedAfterTimeStamp = uri;
@@ -124,7 +127,7 @@ class DependenciesHashFile {
   }
 
   Future<int> _hashFile(Uri uri) async {
-    final file = File.fromUri(uri);
+    final file = _fileSystem.file(uri);
     if (!await file.exists()) {
       return _hashNotExists;
     }
@@ -132,7 +135,7 @@ class DependenciesHashFile {
   }
 
   Future<int> _hashDirectory(Uri uri) async {
-    final directory = Directory.fromUri(uri);
+    final directory = _fileSystem.directory(uri);
     if (!await directory.exists()) {
       return _hashNotExists;
     }

--- a/pkgs/native_assets_builder/lib/src/dependencies_hash_file/dependencies_hash_file.dart
+++ b/pkgs/native_assets_builder/lib/src/dependencies_hash_file/dependencies_hash_file.dart
@@ -15,16 +15,20 @@ import '../utils/uri.dart';
 class DependenciesHashFile {
   DependenciesHashFile(
     this._fileSystem, {
-    required this.file,
+    required this.fileUri,
   });
 
   final FileSystem _fileSystem;
-  final File file;
+  final Uri fileUri;
   FileSystemHashes _hashes = FileSystemHashes();
 
   List<Uri> get fileSystemEntities => _hashes.files.map((e) => e.path).toList();
 
+  Future<bool> exists() async => await _fileSystem.file(fileUri).exists();
+  Future<void> delete() async => await _fileSystem.file(fileUri).delete();
+
   Future<void> _readFile() async {
+    final file = _fileSystem.file(fileUri);
     if (!await file.exists()) {
       _hashes = FileSystemHashes();
       return;
@@ -75,7 +79,8 @@ class DependenciesHashFile {
     return modifiedAfterTimeStamp;
   }
 
-  Future<void> _persist() => file.writeAsString(json.encode(_hashes.toJson()));
+  Future<void> _persist() =>
+      _fileSystem.file(fileUri).writeAsString(json.encode(_hashes.toJson()));
 
   /// Reads the file with hashes and reports if there is an outdated file,
   /// directory or environment variable.

--- a/pkgs/native_assets_builder/lib/src/locking/locking.dart
+++ b/pkgs/native_assets_builder/lib/src/locking/locking.dart
@@ -10,7 +10,7 @@ import 'package:logging/logging.dart';
 
 Future<T> runUnderDirectoriesLock<T>(
   FileSystem fileSystem,
-  List<Directory> directories,
+  List<Uri> directories,
   Future<T> Function() callback, {
   Duration? timeout,
   Logger? logger,
@@ -46,13 +46,13 @@ Future<T> runUnderDirectoriesLock<T>(
 /// also streams error messages.
 Future<T> runUnderDirectoryLock<T>(
   FileSystem fileSystem,
-  Directory directory,
+  Uri directory,
   Future<T> Function() callback, {
   Duration? timeout,
   Logger? logger,
 }) async {
   const lockFileName = '.lock';
-  final lockFile = _fileInDir(fileSystem, directory, lockFileName);
+  final lockFile = _fileInDir(fileSystem.directory(directory), lockFileName);
   return _runUnderFileLock(
     lockFile,
     callback,
@@ -61,11 +61,11 @@ Future<T> runUnderDirectoryLock<T>(
   );
 }
 
-File _fileInDir(FileSystem fileSystem, Directory path, String filename) {
+File _fileInDir(Directory path, String filename) {
   final dirPath = path.path;
   var separator = Platform.pathSeparator;
   if (dirPath.endsWith(separator)) separator = '';
-  return fileSystem.file('$dirPath$separator$filename');
+  return path.fileSystem.file('$dirPath$separator$filename');
 }
 
 /// Run [callback] with this Dart process having exclusive access to [file].

--- a/pkgs/native_assets_builder/lib/src/package_layout/package_layout.dart
+++ b/pkgs/native_assets_builder/lib/src/package_layout/package_layout.dart
@@ -42,11 +42,17 @@ class PackageLayout {
     packageConfigUri = packageConfigUri.normalizePath();
     final rootPackageRoot = packageConfigUri.resolve('../');
     return PackageLayout._(
-        fileSystem, rootPackageRoot, packageConfig, packageConfigUri);
+      fileSystem,
+      rootPackageRoot,
+      packageConfig,
+      packageConfigUri,
+    );
   }
 
   static Future<PackageLayout> fromRootPackageRoot(
-      FileSystem fileSystem, Uri rootPackageRoot) async {
+    FileSystem fileSystem,
+    Uri rootPackageRoot,
+  ) async {
     rootPackageRoot = rootPackageRoot.normalizePath();
     final packageConfigUri =
         rootPackageRoot.resolve('.dart_tool/package_config.json');

--- a/pkgs/native_assets_builder/lib/src/utils/file.dart
+++ b/pkgs/native_assets_builder/lib/src/utils/file.dart
@@ -2,12 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
+import 'package:file/file.dart';
 
 extension FileSystemEntityExtension on FileSystemEntity {
-  Future<DateTime> lastModified() async {
+  Future<DateTime> lastModified(FileSystem fileSystem) async {
     final this_ = this;
-    if (this_ is Link || await FileSystemEntity.isLink(this_.path)) {
+
+    if (this_ is Link || await fileSystem.isLink(this_.path)) {
       // Don't follow links.
       return DateTime.fromMicrosecondsSinceEpoch(0);
     }
@@ -18,17 +19,15 @@ extension FileSystemEntityExtension on FileSystemEntity {
       }
       return await this_.lastModified();
     }
-    assert(this_ is Directory);
-    this_ as Directory;
-    return await this_.lastModified();
+    return await (this_ as Directory).lastModified(fileSystem);
   }
 }
 
 extension FileSystemEntityIterable on Iterable<FileSystemEntity> {
-  Future<DateTime> lastModified() async {
+  Future<DateTime> lastModified(FileSystem fileSystem) async {
     var last = DateTime.fromMillisecondsSinceEpoch(0);
     for (final entity in this) {
-      final entityTimestamp = await entity.lastModified();
+      final entityTimestamp = await entity.lastModified(fileSystem);
       if (entityTimestamp.isAfter(last)) {
         last = entityTimestamp;
       }
@@ -38,10 +37,10 @@ extension FileSystemEntityIterable on Iterable<FileSystemEntity> {
 }
 
 extension DirectoryExtension on Directory {
-  Future<DateTime> lastModified() async {
+  Future<DateTime> lastModified(FileSystem fileSystem) async {
     var last = DateTime.fromMillisecondsSinceEpoch(0);
     await for (final entity in list()) {
-      final entityTimestamp = await entity.lastModified();
+      final entityTimestamp = await entity.lastModified(fileSystem);
       if (entityTimestamp.isAfter(last)) {
         last = entityTimestamp;
       }

--- a/pkgs/native_assets_builder/lib/src/utils/run_process.dart
+++ b/pkgs/native_assets_builder/lib/src/utils/run_process.dart
@@ -4,8 +4,9 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' show Platform, Process, ProcessException, ProcessResult;
 
+import 'package:file/file.dart';
 import 'package:logging/logging.dart';
 
 /// Runs a [Process].
@@ -15,6 +16,7 @@ import 'package:logging/logging.dart';
 /// If [captureOutput], captures stdout and stderr.
 // TODO(dacoharkes): Share between package:native_toolchain_c and here.
 Future<RunProcessResult> runProcess({
+  required FileSystem filesystem,
   required Uri executable,
   List<String> arguments = const [],
   Uri? workingDirectory,
@@ -25,8 +27,8 @@ Future<RunProcessResult> runProcess({
   int expectedExitCode = 0,
   bool throwOnUnexpectedExitCode = false,
 }) async {
-  final printWorkingDir =
-      workingDirectory != null && workingDirectory != Directory.current.uri;
+  final printWorkingDir = workingDirectory != null &&
+      workingDirectory != filesystem.currentDirectory.uri;
   final commandString = [
     if (printWorkingDir) '(cd ${workingDirectory.toFilePath()};',
     ...?environment?.entries.map((entry) => '${entry.key}=${entry.value}'),

--- a/pkgs/native_assets_builder/lib/src/utils/uri.dart
+++ b/pkgs/native_assets_builder/lib/src/utils/uri.dart
@@ -2,13 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' show Platform;
 
-extension UriExtension on Uri {
-  FileSystemEntity get fileSystemEntity {
-    if (path.endsWith(Platform.pathSeparator) || path.endsWith('/')) {
-      return Directory.fromUri(this);
+import 'package:file/file.dart';
+
+extension UriExtension on FileSystem {
+  FileSystemEntity fileSystemEntity(Uri uri) {
+    if (uri.path.endsWith(Platform.pathSeparator) || uri.path.endsWith('/')) {
+      return directory(uri);
     }
-    return File.fromUri(this);
+    return file(uri);
   }
 }

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 dependencies:
   collection: ^1.18.0
   crypto: ^3.0.6
+  file: ^7.0.1
   graphs: ^2.3.1
   logging: ^1.2.0
   # native_assets_cli: ^0.9.0

--- a/pkgs/native_assets_builder/test/build_runner/build_planner_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_planner_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:file/local.dart';
 import 'package:native_assets_builder/native_assets_builder.dart';
 import 'package:native_assets_builder/src/build_runner/build_planner.dart';
 import 'package:test/test.dart';
@@ -34,8 +35,8 @@ void main() async {
 
       final graph = PackageGraph.fromPubDepsJsonString(result.stdout);
 
-      final packageLayout =
-          await PackageLayout.fromRootPackageRoot(nativeAddUri);
+      final packageLayout = await PackageLayout.fromRootPackageRoot(
+          const LocalFileSystem(), nativeAddUri);
       final packagesWithNativeAssets =
           await packageLayout.packagesWithAssets(Hook.build);
 
@@ -59,8 +60,8 @@ void main() async {
       // First, run `pub get`, we need pub to resolve our dependencies.
       await runPubGet(workingDirectory: nativeAddUri, logger: logger);
 
-      final packageLayout =
-          await PackageLayout.fromRootPackageRoot(nativeAddUri);
+      final packageLayout = await PackageLayout.fromRootPackageRoot(
+          const LocalFileSystem(), nativeAddUri);
       final packagesWithNativeAssets =
           await packageLayout.packagesWithAssets(Hook.build);
       final nativeAssetsBuildPlanner =
@@ -86,8 +87,8 @@ void main() async {
         // First, run `pub get`, we need pub to resolve our dependencies.
         await runPubGet(workingDirectory: nativeAddUri, logger: logger);
 
-        final packageLayout =
-            await PackageLayout.fromRootPackageRoot(nativeAddUri);
+        final packageLayout = await PackageLayout.fromRootPackageRoot(
+            const LocalFileSystem(), nativeAddUri);
         final packagesWithNativeAssets =
             await packageLayout.packagesWithAssets(Hook.build);
         final nativeAssetsBuildPlanner =

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:file/local.dart';
 import 'package:native_assets_builder/src/build_runner/build_runner.dart';
 import 'package:test/test.dart';
 
@@ -25,6 +26,7 @@ void main() async {
       final buildRunner = NativeAssetsBuildRunner(
         logger: logger,
         dartExecutable: dartExecutable,
+        fileSystem: const LocalFileSystem(),
       );
 
       BuildConfigBuilder configCreator() => BuildConfigBuilder()

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:file/local.dart';
 import 'package:native_assets_builder/native_assets_builder.dart';
 import 'package:test/test.dart';
 
@@ -50,7 +51,8 @@ void main() async {
       for (final passPackageLayout in [true, false]) {
         PackageLayout? packageLayout;
         if (passPackageLayout) {
-          packageLayout = await PackageLayout.fromRootPackageRoot(packageUri);
+          packageLayout = await PackageLayout.fromRootPackageRoot(
+              const LocalFileSystem(), packageUri);
         }
         final logMessages = <String>[];
         final result = (await build(

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test_helper.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:file/local.dart';
 import 'package:logging/logging.dart';
 import 'package:native_assets_builder/native_assets_builder.dart';
 
@@ -19,6 +20,7 @@ void main(List<String> args) async {
   final result = await NativeAssetsBuildRunner(
     logger: logger,
     dartExecutable: dartExecutable,
+    fileSystem: const LocalFileSystem(),
   ).build(
     // Set up the code config, so that the builds for different targets are
     // in different directories.

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:file/local.dart';
 import 'package:logging/logging.dart';
 import 'package:native_assets_builder/native_assets_builder.dart';
 
@@ -24,6 +25,7 @@ void main(List<String> args) async {
     logger: logger,
     dartExecutable: dartExecutable,
     singleHookTimeout: timeout,
+    fileSystem: const LocalFileSystem(),
   ).build(
     configCreator: () => BuildConfigBuilder()
       ..setupCodeConfig(

--- a/pkgs/native_assets_builder/test/build_runner/helpers.dart
+++ b/pkgs/native_assets_builder/test/build_runner/helpers.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:file/local.dart';
 import 'package:logging/logging.dart';
 import 'package:native_assets_builder/native_assets_builder.dart';
 import 'package:test/test.dart';
@@ -53,6 +54,7 @@ Future<BuildResult?> build(
     final result = await NativeAssetsBuildRunner(
       logger: logger,
       dartExecutable: dartExecutable,
+      fileSystem: const LocalFileSystem(),
     ).build(
       configCreator: () {
         final configBuilder = BuildConfigBuilder();
@@ -118,6 +120,7 @@ Future<LinkResult?> link(
     final result = await NativeAssetsBuildRunner(
       logger: logger,
       dartExecutable: dartExecutable,
+      fileSystem: const LocalFileSystem(),
     ).link(
       configCreator: () {
         final configBuilder = LinkConfigBuilder();
@@ -180,6 +183,7 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
       final buildRunner = NativeAssetsBuildRunner(
         logger: logger,
         dartExecutable: dartExecutable,
+        fileSystem: const LocalFileSystem(),
       );
       final buildResult = await buildRunner.build(
         configCreator: () => BuildConfigBuilder()

--- a/pkgs/native_assets_builder/test/build_runner/package_layout_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/package_layout_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:file/local.dart';
 import 'package:native_assets_builder/native_assets_builder.dart';
 import 'package:test/test.dart';
 
@@ -17,9 +18,11 @@ void main() async {
       // First, run `pub get`, we need pub to resolve our dependencies.
       await runPubGet(workingDirectory: nativeAddUri, logger: logger);
 
+      const fileSystem = LocalFileSystem();
       final packageLayout =
-          await PackageLayout.fromRootPackageRoot(nativeAddUri);
+          await PackageLayout.fromRootPackageRoot(fileSystem, nativeAddUri);
       final packageLayout2 = PackageLayout.fromPackageConfig(
+        fileSystem,
         packageLayout.packageConfig,
         packageLayout.packageConfigUri,
       );

--- a/pkgs/native_assets_builder/test/dependencies_hash_file/dependencies_hash_file_test.dart
+++ b/pkgs/native_assets_builder/test/dependencies_hash_file/dependencies_hash_file_test.dart
@@ -37,8 +37,8 @@ void main() async {
       final tempSubDir = fileSystem.directory(tempUri.resolve('subdir/'));
       final subFile = fileSystem.file(tempSubDir.uri.resolve('bar.txt'));
 
-      final hashesFile = fileSystem.file(tempUri.resolve('hashes.json'));
-      final hashes = DependenciesHashFile(fileSystem, file: hashesFile);
+      final hashesFileUri = tempUri.resolve('hashes.json');
+      final hashes = DependenciesHashFile(fileSystem, fileUri: hashesFileUri);
 
       Future<void> reset() async {
         await tempFile.create(recursive: true);

--- a/pkgs/native_assets_builder/test/dependencies_hash_file/dependencies_hash_file_test.dart
+++ b/pkgs/native_assets_builder/test/dependencies_hash_file/dependencies_hash_file_test.dart
@@ -3,8 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' show Platform;
 
+import 'package:file/local.dart';
 import 'package:native_assets_builder/src/dependencies_hash_file/dependencies_hash_file.dart';
 import 'package:test/test.dart';
 
@@ -12,6 +13,7 @@ import '../helpers.dart';
 
 void main() async {
   final environment = Platform.environment;
+  const fileSystem = LocalFileSystem();
 
   test('json format', () async {
     await inTempDir((tempUri) async {
@@ -31,12 +33,12 @@ void main() async {
 
   test('dependencies hash file', () async {
     await inTempDir((tempUri) async {
-      final tempFile = File.fromUri(tempUri.resolve('foo.txt'));
-      final tempSubDir = Directory.fromUri(tempUri.resolve('subdir/'));
-      final subFile = File.fromUri(tempSubDir.uri.resolve('bar.txt'));
+      final tempFile = fileSystem.file(tempUri.resolve('foo.txt'));
+      final tempSubDir = fileSystem.directory(tempUri.resolve('subdir/'));
+      final subFile = fileSystem.file(tempSubDir.uri.resolve('bar.txt'));
 
-      final hashesFile = File.fromUri(tempUri.resolve('hashes.json'));
-      final hashes = DependenciesHashFile(file: hashesFile);
+      final hashesFile = fileSystem.file(tempUri.resolve('hashes.json'));
+      final hashes = DependenciesHashFile(fileSystem, file: hashesFile);
 
       Future<void> reset() async {
         await tempFile.create(recursive: true);
@@ -77,7 +79,7 @@ void main() async {
       await reset();
 
       // Add file to tracked directory.
-      final subFile2 = File.fromUri(tempSubDir.uri.resolve('baz.txt'));
+      final subFile2 = fileSystem.file(tempSubDir.uri.resolve('baz.txt'));
       await subFile2.create(recursive: true);
       await subFile2.writeAsString('hello');
       expect(
@@ -103,7 +105,7 @@ void main() async {
       await reset();
 
       // Add directory to tracked directory.
-      final subDir2 = Directory.fromUri(tempSubDir.uri.resolve('baz/'));
+      final subDir2 = fileSystem.directory(tempSubDir.uri.resolve('baz/'));
       await subDir2.create(recursive: true);
       expect(
         await hashes.findOutdatedDependency(environment),

--- a/pkgs/native_assets_builder/test/helpers.dart
+++ b/pkgs/native_assets_builder/test/helpers.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:file/local.dart' show LocalFileSystem;
 import 'package:logging/logging.dart';
 import 'package:native_assets_builder/src/utils/run_process.dart'
     as run_process;
@@ -75,6 +76,7 @@ Future<run_process.RunProcessResult> runProcess({
   bool throwOnUnexpectedExitCode = false,
 }) =>
     run_process.runProcess(
+      filesystem: const LocalFileSystem(),
       executable: executable,
       arguments: arguments,
       workingDirectory: workingDirectory,

--- a/pkgs/native_assets_builder/test/locking/locking_test_helper.dart
+++ b/pkgs/native_assets_builder/test/locking/locking_test_helper.dart
@@ -16,7 +16,7 @@ void main(List<String> args) async {
   print('locking directory');
   await runUnderDirectoryLock<void>(
     fileSystem,
-    directory,
+    directory.uri,
     timeout: timeout,
     () async {
       print('directory locked');

--- a/pkgs/native_assets_builder/test/locking/locking_test_helper.dart
+++ b/pkgs/native_assets_builder/test/locking/locking_test_helper.dart
@@ -2,12 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
+import 'package:file/local.dart';
 import 'package:native_assets_builder/src/locking/locking.dart';
 
 void main(List<String> args) async {
-  final directory = Directory.fromUri(Uri.directory(args[0]));
+  const fileSystem = LocalFileSystem();
+  final directory = fileSystem.directory(Uri.directory(args[0]));
   Duration? timeout;
   if (args.length >= 2) {
     timeout = Duration(milliseconds: int.parse(args[1]));
@@ -15,6 +15,7 @@ void main(List<String> args) async {
 
   print('locking directory');
   await runUnderDirectoryLock<void>(
+    fileSystem,
     directory,
     timeout: timeout,
     () async {


### PR DESCRIPTION
The main motivation for this change is to make `package:native_assets_builder` cleanly usable in flutter tools. Right now flutter tools operates on a `FileSystem` and checks whether `.dart_tool/package_config.json` exists using that `FileSystem` but then reads the file with this packagag's code which uses `dart:io`.

This inconsistency causes issues in flutter tools. Using `package:file` should solve this and would also
allow injecting mocks. To be fully mockable the implementation would also need to make process invocations
mockable via `package:process`. That's a future task.

See also https://github.com/dart-lang/native/issues/90