### PR TITLE
[native_assets_cli] Drop `Config` suffixes v2

### DIFF
--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -119,12 +119,12 @@ class NativeAssetsBuildRunner {
       )?.forEach((key, value) => metadata[key] = value);
 
       final configBuilder = configCreator()
-        ..setupHookConfig(
+        ..setupHook(
           buildAssetTypes: buildAssetTypes,
           packageName: package.name,
           packageRoot: packageLayout.packageRoot(package.name),
         )
-        ..setupBuildConfig(
+        ..setupBuild(
           dryRun: false,
           linkingEnabled: linkingEnabled,
           metadata: metadata,
@@ -137,7 +137,7 @@ class NativeAssetsBuildRunner {
         package,
       );
 
-      configBuilder.setupBuildRunConfig(
+      configBuilder.setupBuildAfterChecksum(
         outputDirectory: outDirUri,
         outputDirectoryShared: outDirSharedUri,
       );
@@ -216,7 +216,7 @@ class NativeAssetsBuildRunner {
     var hookResult = HookResult(encodedAssets: buildResult.encodedAssets);
     for (final package in buildPlan) {
       final configBuilder = configCreator()
-        ..setupHookConfig(
+        ..setupHook(
           buildAssetTypes: buildAssetTypes,
           packageName: package.name,
           packageRoot: packageLayout.packageRoot(package.name),
@@ -235,7 +235,7 @@ class NativeAssetsBuildRunner {
         await resourcesFile.create();
         await File.fromUri(resourceIdentifiers).copy(resourcesFile.path);
       }
-      configBuilder.setupLinkRunConfig(
+      configBuilder.setupLinkAfterChecksum(
         outputDirectory: outDirUri,
         outputDirectoryShared: outDirSharedUri,
         recordedUsesFile: resourcesFile?.uri,

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
@@ -30,10 +30,10 @@ void main() async {
       final targetOS = OS.current;
       const defaultMacOSVersion = 13;
       BuildConfigBuilder configCreator() => BuildConfigBuilder()
-        ..setupCodeConfig(
+        ..setupCode(
           targetArchitecture: Architecture.current,
           targetOS: OS.current,
-          macOSConfig: targetOS == OS.macOS
+          macOS: targetOS == OS.macOS
               ? MacOSConfig(targetVersion: defaultMacOSVersion)
               : null,
           linkModePreference: LinkModePreference.dynamic,

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test_helper.dart
@@ -24,10 +24,10 @@ void main(List<String> args) async {
     // Set up the code config, so that the builds for different targets are
     // in different directories.
     configCreator: () => BuildConfigBuilder()
-      ..setupCodeConfig(
+      ..setupCode(
         targetArchitecture: target.architecture,
         targetOS: targetOS,
-        macOSConfig: targetOS == OS.macOS
+        macOS: targetOS == OS.macOS
             ? MacOSConfig(targetVersion: defaultMacOSVersion)
             : null,
         linkModePreference: LinkModePreference.dynamic,

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
@@ -27,12 +27,12 @@ void main(List<String> args) async {
     singleHookTimeout: timeout,
   ).build(
     configCreator: () => BuildConfigBuilder()
-      ..setupCodeConfig(
+      ..setupCode(
         targetArchitecture: Architecture.current,
         targetOS: targetOS,
         linkModePreference: LinkModePreference.dynamic,
-        cCompilerConfig: dartCICompilerConfig,
-        macOSConfig: targetOS == OS.macOS
+        cCompiler: dartCICompilerConfig,
+        macOS: targetOS == OS.macOS
             ? MacOSConfig(targetVersion: defaultMacOSVersion)
             : null,
       ),

--- a/pkgs/native_assets_builder/test/build_runner/helpers.dart
+++ b/pkgs/native_assets_builder/test/build_runner/helpers.dart
@@ -57,22 +57,22 @@ Future<BuildResult?> build(
       configCreator: () {
         final configBuilder = BuildConfigBuilder();
         if (buildAssetTypes.contains(CodeAsset.type)) {
-          configBuilder.setupCodeConfig(
+          configBuilder.setupCode(
             targetArchitecture: target?.architecture ?? Architecture.current,
             targetOS: targetOS,
             linkModePreference: linkModePreference,
-            cCompilerConfig: cCompilerConfig ?? dartCICompilerConfig,
-            iOSConfig: targetOS == OS.iOS
+            cCompiler: cCompilerConfig ?? dartCICompilerConfig,
+            iOS: targetOS == OS.iOS
                 ? IOSConfig(
                     targetSdk: targetIOSSdk!,
                     targetVersion: targetIOSVersion!,
                   )
                 : null,
-            macOSConfig: targetOS == OS.macOS
+            macOS: targetOS == OS.macOS
                 ? MacOSConfig(
                     targetVersion: targetMacOSVersion ?? defaultMacOSVersion)
                 : null,
-            androidConfig: targetOS == OS.android
+            android: targetOS == OS.android
                 ? AndroidConfig(targetNdkApi: targetAndroidNdkApi!)
                 : null,
           );
@@ -130,22 +130,22 @@ Future<LinkResult?> link(
       configCreator: () {
         final configBuilder = LinkConfigBuilder();
         if (buildAssetTypes.contains(CodeAsset.type)) {
-          configBuilder.setupCodeConfig(
+          configBuilder.setupCode(
             targetArchitecture: target?.architecture ?? Architecture.current,
             targetOS: target?.os ?? OS.current,
             linkModePreference: linkModePreference,
-            cCompilerConfig: cCompilerConfig ?? dartCICompilerConfig,
-            iOSConfig: targetOS == OS.iOS
+            cCompiler: cCompilerConfig ?? dartCICompilerConfig,
+            iOS: targetOS == OS.iOS
                 ? IOSConfig(
                     targetSdk: targetIOSSdk!,
                     targetVersion: targetIOSVersion!,
                   )
                 : null,
-            macOSConfig: targetOS == OS.macOS
+            macOS: targetOS == OS.macOS
                 ? MacOSConfig(
                     targetVersion: targetMacOSVersion ?? defaultMacOSVersion)
                 : null,
-            androidConfig: targetOS == OS.android
+            android: targetOS == OS.android
                 ? AndroidConfig(targetNdkApi: targetAndroidNdkApi!)
                 : null,
           );
@@ -200,22 +200,22 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
       final targetOS = target?.os ?? OS.current;
       final buildResult = await buildRunner.build(
         configCreator: () => BuildConfigBuilder()
-          ..setupCodeConfig(
+          ..setupCode(
             targetArchitecture: target?.architecture ?? Architecture.current,
             targetOS: targetOS,
             linkModePreference: linkModePreference,
-            cCompilerConfig: cCompilerConfig ?? dartCICompilerConfig,
-            iOSConfig: targetOS == OS.iOS
+            cCompiler: cCompilerConfig ?? dartCICompilerConfig,
+            iOS: targetOS == OS.iOS
                 ? IOSConfig(
                     targetSdk: targetIOSSdk!,
                     targetVersion: targetIOSVersion!,
                   )
                 : null,
-            macOSConfig: targetOS == OS.macOS
+            macOS: targetOS == OS.macOS
                 ? MacOSConfig(
                     targetVersion: targetMacOSVersion ?? defaultMacOSVersion)
                 : null,
-            androidConfig: targetOS == OS.android
+            android: targetOS == OS.android
                 ? AndroidConfig(targetNdkApi: targetAndroidNdkApi!)
                 : null,
           ),
@@ -241,22 +241,22 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
 
       final linkResult = await buildRunner.link(
         configCreator: () => LinkConfigBuilder()
-          ..setupCodeConfig(
+          ..setupCode(
             targetArchitecture: target?.architecture ?? Architecture.current,
             targetOS: targetOS,
             linkModePreference: linkModePreference,
-            cCompilerConfig: cCompilerConfig,
-            iOSConfig: targetOS == OS.iOS
+            cCompiler: cCompilerConfig,
+            iOS: targetOS == OS.iOS
                 ? IOSConfig(
                     targetSdk: targetIOSSdk!,
                     targetVersion: targetIOSVersion!,
                   )
                 : null,
-            macOSConfig: targetOS == OS.macOS
+            macOS: targetOS == OS.macOS
                 ? MacOSConfig(
                     targetVersion: targetMacOSVersion ?? defaultMacOSVersion)
                 : null,
-            androidConfig: targetOS == OS.android
+            android: targetOS == OS.android
                 ? AndroidConfig(targetNdkApi: targetAndroidNdkApi!)
                 : null,
           ),

--- a/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
@@ -32,24 +32,24 @@ void main() async {
 
       final targetOS = OS.current;
       final configBuilder = BuildConfigBuilder()
-        ..setupHookConfig(
+        ..setupHook(
           packageName: name,
           packageRoot: testPackageUri,
           buildAssetTypes: [CodeAsset.type],
         )
-        ..setupBuildConfig(dryRun: false, linkingEnabled: false)
-        ..setupBuildRunConfig(
+        ..setupBuild(dryRun: false, linkingEnabled: false)
+        ..setupBuildAfterChecksum(
           outputDirectory: outputDirectory,
           outputDirectoryShared: outputDirectoryShared,
         )
-        ..setupCodeConfig(
+        ..setupCode(
           targetArchitecture: Architecture.current,
           targetOS: targetOS,
-          macOSConfig: targetOS == OS.macOS
+          macOS: targetOS == OS.macOS
               ? MacOSConfig(targetVersion: defaultMacOSVersion)
               : null,
           linkModePreference: LinkModePreference.dynamic,
-          cCompilerConfig: cCompiler,
+          cCompiler: cCompiler,
         );
 
       final buildConfigUri = testTempUri.resolve('build_config.json');

--- a/pkgs/native_assets_builder/test/test_data/transformer_test.dart
+++ b/pkgs/native_assets_builder/test/test_data/transformer_test.dart
@@ -47,20 +47,20 @@ void main() async {
       final targetOS = OS.current;
       Future<void> runBuild(Architecture architecture) async {
         final configBuilder = BuildConfigBuilder()
-          ..setupHookConfig(
+          ..setupHook(
             packageName: packageName,
             packageRoot: packageUri,
             buildAssetTypes: [DataAsset.type],
           )
-          ..setupBuildConfig(dryRun: false, linkingEnabled: false)
-          ..setupBuildRunConfig(
+          ..setupBuild(dryRun: false, linkingEnabled: false)
+          ..setupBuildAfterChecksum(
             outputDirectory: outputDirectory,
             outputDirectoryShared: outputDirectoryShared,
           )
-          ..setupCodeConfig(
+          ..setupCode(
             targetArchitecture: architecture,
             targetOS: targetOS,
-            macOSConfig: targetOS == OS.macOS
+            macOS: targetOS == OS.macOS
                 ? MacOSConfig(targetVersion: defaultMacOSVersion)
                 : null,
             linkModePreference: LinkModePreference.dynamic,
@@ -101,7 +101,7 @@ void main() async {
         ]),
       );
       expect(
-        output.dataAssets,
+        output.data.assets,
         contains(
           DataAsset(
             file: outputDirectoryShared.resolve('data_transformed0.json'),

--- a/pkgs/native_assets_builder/test_data/add_asset_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/add_asset_link/hook/link.dart
@@ -6,9 +6,9 @@ import 'package:native_assets_cli/code_assets.dart';
 
 void main(List<String> arguments) async {
   await link(arguments, (config, output) async {
-    final builtDylib = config.codeAssets.first;
+    final builtDylib = config.code.assets.first;
     output
-      ..codeAssets.add(
+      ..code.addAsset(
         CodeAsset(
           package: 'add_asset_link',
           name: 'dylib_add_link',

--- a/pkgs/native_assets_builder/test_data/complex_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/complex_link/hook/build.dart
@@ -24,7 +24,7 @@ void main(List<String> args) async {
           .toFilePath(windows: false)
           .substring(config.packageRoot.toFilePath(windows: false).length);
 
-      output.dataAssets.add(
+      output.data.addAsset(
         DataAsset(
           package: packageName,
           name: name,

--- a/pkgs/native_assets_builder/test_data/complex_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/complex_link/hook/link.dart
@@ -8,7 +8,7 @@ void main(List<String> args) async {
   await link(
     args,
     (config, output) async =>
-        output.dataAssets.addAll(treeshake(config.dataAssets)),
+        output.data.addAssets(treeshake(config.data.assets)),
   );
 }
 

--- a/pkgs/native_assets_builder/test_data/complex_link_helper/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/complex_link_helper/hook/build.dart
@@ -25,7 +25,7 @@ void main(List<String> args) async {
           .substring(config.packageRoot.toFilePath(windows: false).length);
 
       final forLinking = name.contains('2') || name.contains('3');
-      output.dataAssets.add(
+      output.data.addAsset(
         DataAsset(
           package: packageName,
           name: name,

--- a/pkgs/native_assets_builder/test_data/drop_dylib_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/drop_dylib_link/hook/link.dart
@@ -6,10 +6,10 @@ import 'package:native_assets_cli/code_assets.dart';
 
 void main(List<String> arguments) async {
   await link(arguments, (config, output) async {
-    for (final codeAsset in config.codeAssets) {
+    for (final codeAsset in config.code.assets) {
       print('Got code asset: ${codeAsset.id}');
       if (codeAsset.id.endsWith('add')) {
-        output.codeAssets.add(codeAsset);
+        output.code.addAsset(codeAsset);
         print('-> Keeping ${codeAsset.id}');
       } else {
         print('-> Dropping ${codeAsset.id}');

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/hook/build.dart
@@ -14,16 +14,15 @@ const minMacOSVersionForThisPackage = 13;
 
 void main(List<String> arguments) async {
   await build(arguments, (config, output) async {
-    if (config.codeConfig.targetOS == OS.android) {
-      if (config.codeConfig.androidConfig.targetNdkApi <
-          minNdkApiVersionForThisPackage) {
+    if (config.code.targetOS == OS.android) {
+      if (config.code.android.targetNdkApi < minNdkApiVersionForThisPackage) {
         throw UnsupportedError(
           'The native assets for this package require at '
           'least Android NDK API level $minNdkApiVersionForThisPackage.',
         );
       }
-    } else if (config.codeConfig.targetOS == OS.iOS) {
-      final iosVersion = config.codeConfig.iOSConfig.targetVersion;
+    } else if (config.code.targetOS == OS.iOS) {
+      final iosVersion = config.code.iOS.targetVersion;
       // iosVersion is nullable to deal with version skew.
       if (iosVersion < minIosVersionForThisPackage) {
         throw UnsupportedError(
@@ -31,8 +30,8 @@ void main(List<String> arguments) async {
           'least iOS version $minIosVersionForThisPackage.',
         );
       }
-    } else if (config.codeConfig.targetOS == OS.macOS) {
-      final macosVersion = config.codeConfig.macOSConfig.targetVersion;
+    } else if (config.code.targetOS == OS.macOS) {
+      final macosVersion = config.code.macOS.targetVersion;
       // macosVersion is nullable to deal with version skew.
       if (macosVersion < minMacOSVersionForThisPackage) {
         throw UnsupportedError(

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/hook/build.dart
@@ -6,7 +6,7 @@ import 'package:native_assets_cli/data_assets.dart';
 
 void main(List<String> arguments) async {
   await build(arguments, (config, output) async {
-    output.dataAssets.add(
+    output.data.addAsset(
       DataAsset(
         name: 'data',
         file: config.packageRoot.resolve('assets/data.json'),

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/hook/link.dart
@@ -14,16 +14,15 @@ const minMacOSVersionForThisPackage = 13;
 
 void main(List<String> arguments) async {
   await link(arguments, (config, output) async {
-    if (config.codeConfig.targetOS == OS.android) {
-      if (config.codeConfig.androidConfig.targetNdkApi <
-          minNdkApiVersionForThisPackage) {
+    if (config.code.targetOS == OS.android) {
+      if (config.code.android.targetNdkApi < minNdkApiVersionForThisPackage) {
         throw UnsupportedError(
           'The native assets for this package require at '
           'least Android NDK API level $minNdkApiVersionForThisPackage.',
         );
       }
-    } else if (config.codeConfig.targetOS == OS.iOS) {
-      final iosVersion = config.codeConfig.iOSConfig.targetVersion;
+    } else if (config.code.targetOS == OS.iOS) {
+      final iosVersion = config.code.iOS.targetVersion;
       // iosVersion is nullable to deal with version skew.
       if (iosVersion < minIosVersionForThisPackage) {
         throw UnsupportedError(
@@ -31,8 +30,8 @@ void main(List<String> arguments) async {
           'least iOS version $minIosVersionForThisPackage.',
         );
       }
-    } else if (config.codeConfig.targetOS == OS.macOS) {
-      final macosVersion = config.codeConfig.macOSConfig.targetVersion;
+    } else if (config.code.targetOS == OS.macOS) {
+      final macosVersion = config.code.macOS.targetVersion;
       // macosVersion is nullable to deal with version skew.
       if (macosVersion < minMacOSVersionForThisPackage) {
         throw UnsupportedError(

--- a/pkgs/native_assets_builder/test_data/native_add_duplicate/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/native_add_duplicate/hook/build.dart
@@ -30,8 +30,8 @@ void main(List<String> arguments) async {
         }),
     );
     final tempBuildOutput = BuildOutput(outputBuilder.json);
-    output.codeAssets.add(
-      tempBuildOutput.codeAssets.single,
+    output.code.addAsset(
+      tempBuildOutput.code.assets.single,
       // Send dylib to linking if linking is enabled.
       linkInPackage: config.linkingEnabled ? packageName : null,
     );

--- a/pkgs/native_assets_builder/test_data/native_add_duplicate/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/native_add_duplicate/hook/link.dart
@@ -7,6 +7,6 @@ import 'package:native_assets_cli/code_assets.dart';
 void main(List<String> args) async {
   await link(args, (config, output) async {
     // Simply output the dylib in the link hook.
-    output.codeAssets.addAll(config.codeAssets);
+    output.code.addAssets(config.code.assets);
   });
 }

--- a/pkgs/native_assets_builder/test_data/no_asset_for_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/no_asset_for_link/hook/link.dart
@@ -7,7 +7,7 @@ import 'package:native_assets_cli/data_assets.dart';
 
 void main(List<String> arguments) async {
   await link(arguments, (config, output) async {
-    output.codeAssets.addAll(config.codeAssets);
-    output.dataAssets.addAll(config.dataAssets);
+    output.code.addAssets(config.code.assets);
+    output.data.addAssets(config.data.assets);
   });
 }

--- a/pkgs/native_assets_builder/test_data/simple_data_asset/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/simple_data_asset/hook/build.dart
@@ -24,7 +24,7 @@ void main(List<String> args) async {
             .toFilePath(windows: false)
             .substring(config.packageRoot.toFilePath(windows: false).length);
 
-        output.dataAssets.add(
+        output.data.addAsset(
           DataAsset(
             package: config.packageName,
             name: name,

--- a/pkgs/native_assets_builder/test_data/simple_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/simple_link/hook/build.dart
@@ -24,7 +24,7 @@ void main(List<String> args) async {
           .toFilePath(windows: false)
           .substring(config.packageRoot.toFilePath(windows: false).length);
 
-      output.dataAssets.add(
+      output.data.addAsset(
         DataAsset(
           package: packageName,
           name: name,

--- a/pkgs/native_assets_builder/test_data/simple_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/simple_link/hook/link.dart
@@ -6,13 +6,13 @@ import 'package:native_assets_cli/data_assets.dart';
 
 void main(List<String> args) async {
   await link(args, (config, output) async {
-    shake(output, config.dataAssets);
+    shake(output, config.data.assets);
   });
 }
 
 void shake(LinkOutputBuilder output, Iterable<DataAsset> assets) {
   for (final asset in assets.skip(2)) {
-    output.dataAssets.add(asset);
+    output.data.addAsset(asset);
 
     // If the file changes we'd like to re-run the linker.
     output.addDependency(asset.file);

--- a/pkgs/native_assets_builder/test_data/transformer/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/transformer/hook/build.dart
@@ -38,7 +38,7 @@ void main(List<String> arguments) async {
         cachedFiles++;
       }
 
-      output.dataAssets.add(
+      output.data.addAsset(
         DataAsset(
           package: config.packageName,
           name: name,

--- a/pkgs/native_assets_builder/test_data/treeshaking_native_libs/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/treeshaking_native_libs/hook/link.dart
@@ -12,9 +12,9 @@ void main(List<String> arguments) async {
     (config, output) async {
       final linker = CLinker.library(
         name: config.packageName,
-        assetName: config.codeAssets.single.id.split('/').skip(1).join('/'),
+        assetName: config.code.assets.single.id.split('/').skip(1).join('/'),
         linkerOptions: LinkerOptions.treeshake(symbols: ['add']),
-        sources: [config.codeAssets.single.file!.toFilePath()],
+        sources: [config.code.assets.single.file!.toFilePath()],
       );
       await linker.run(
         config: config,

--- a/pkgs/native_assets_builder/test_data/wrong_linker/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/wrong_linker/hook/build.dart
@@ -14,7 +14,7 @@ void main(List<String> arguments) async {
 
     await File.fromUri(assetUri).writeAsBytes([1, 2, 3]);
 
-    output.codeAssets.add(
+    output.code.addAsset(
       CodeAsset(
         package: config.packageName,
         name: 'foo',

--- a/pkgs/native_assets_builder/test_data/wrong_namespace_asset/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/wrong_namespace_asset/hook/build.dart
@@ -14,7 +14,7 @@ void main(List<String> arguments) async {
 
     await File.fromUri(assetUri).writeAsBytes([1, 2, 3]);
 
-    output.codeAssets.add(
+    output.code.addAsset(
       CodeAsset(
         package: 'other_package',
         name: 'foo',

--- a/pkgs/native_assets_cli/example/build/local_asset/hook/build.dart
+++ b/pkgs/native_assets_cli/example/build/local_asset/hook/build.dart
@@ -11,7 +11,7 @@ final packageAssetPath = Uri.file('assets/$assetName');
 
 Future<void> main(List<String> args) async {
   await build(args, (config, output) async {
-    if (config.codeConfig.linkModePreference == LinkModePreference.static) {
+    if (config.code.linkModePreference == LinkModePreference.static) {
       // Simulate that this build hook only supports dynamic libraries.
       throw UnsupportedError(
         'LinkModePreference.static is not supported.',
@@ -31,17 +31,17 @@ Future<void> main(List<String> args) async {
       ]);
     }
 
-    output.codeAssets.add(
+    output.code.addAsset(
       // TODO: Change to DataAsset once the Dart/Flutter SDK can consume it.
       CodeAsset(
         package: packageName,
         name: 'asset.txt',
         file: assetPath,
         linkMode: DynamicLoadingBundled(),
-        os: config.codeConfig.targetOS,
+        os: config.code.targetOS,
         architecture:
             // ignore: deprecated_member_use
-            config.dryRun ? null : config.codeConfig.targetArchitecture,
+            config.dryRun ? null : config.code.targetArchitecture,
       ),
     );
   });

--- a/pkgs/native_assets_cli/example/build/local_asset/test/build_test.dart
+++ b/pkgs/native_assets_cli/example/build/local_asset/test/build_test.dart
@@ -12,9 +12,9 @@ void main() async {
     await testCodeBuildHook(
       mainMethod: build.main,
       check: (_, output) {
-        expect(output.codeAssets, isNotEmpty);
+        expect(output.code.assets, isNotEmpty);
         expect(
-          output.codeAssets.first.id,
+          output.code.assets.first.id,
           'package:local_asset/asset.txt',
         );
       },

--- a/pkgs/native_assets_cli/example/link/package_with_assets/hook/build.dart
+++ b/pkgs/native_assets_cli/example/link/package_with_assets/hook/build.dart
@@ -24,7 +24,7 @@ void main(List<String> args) async {
           .toFilePath(windows: false)
           .substring(config.packageRoot.toFilePath(windows: false).length);
 
-      output.dataAssets.add(
+      output.data.addAsset(
         DataAsset(
           package: packageName,
           name: name,

--- a/pkgs/native_assets_cli/example/link/package_with_assets/hook/link.dart
+++ b/pkgs/native_assets_cli/example/link/package_with_assets/hook/link.dart
@@ -20,7 +20,7 @@ void main(List<String> args) async {
     final usedAssets = (usages.instancesOf(multiplyIdentifier) ?? []).map((e) =>
         (e.instanceConstant.fields.values.first as StringConstant).value);
 
-    output.dataAssets.addAll(config.dataAssets
+    output.data.addAssets(config.data.assets
         .where((dataAsset) => usedAssets.contains(dataAsset.name)));
   });
 }

--- a/pkgs/native_assets_cli/lib/code_assets.dart
+++ b/pkgs/native_assets_cli/lib/code_assets.dart
@@ -17,13 +17,18 @@ export 'src/code_assets/config.dart'
     show
         AndroidConfig,
         CodeAssetBuildConfig,
+        CodeAssetBuildOutput,
+        CodeAssetBuildOutput2,
         CodeAssetBuildOutputBuilder,
         CodeAssetBuildOutputBuilderAdd,
         CodeAssetLinkConfig,
+        CodeAssetLinkOutput,
+        CodeAssetLinkOutput2,
         CodeAssetLinkOutputBuilder,
         CodeAssetLinkOutputBuilderAdd,
         CodeConfig,
         IOSConfig,
+        LinkCodeConfig,
         MacOSConfig;
 export 'src/code_assets/ios_sdk.dart' show IOSSdk;
 export 'src/code_assets/link_mode.dart'

--- a/pkgs/native_assets_cli/lib/code_assets_builder.dart
+++ b/pkgs/native_assets_cli/lib/code_assets_builder.dart
@@ -8,8 +8,7 @@ library;
 export 'code_assets.dart' hide build, link;
 export 'native_assets_cli_builder.dart'
     hide EncodedAssetBuildOutputBuilder, EncodedAssetLinkOutputBuilder;
-export 'src/code_assets/config.dart'
-    show CodeAssetBuildConfigBuilder, CodeAssetBuildOutput, CodeAssetLinkOutput;
+export 'src/code_assets/config.dart' show CodeAssetBuildConfigBuilder;
 export 'src/code_assets/validation.dart'
     show
         validateCodeAssetBuildConfig,

--- a/pkgs/native_assets_cli/lib/data_assets.dart
+++ b/pkgs/native_assets_cli/lib/data_assets.dart
@@ -12,9 +12,13 @@ export 'native_assets_cli.dart'
         EncodedAssetLinkOutputBuilder;
 export 'src/data_assets/config.dart'
     show
+        DataAssetBuildOutput,
+        DataAssetBuildOutput2,
         DataAssetBuildOutputBuilder,
         DataAssetBuildOutputBuilderAdd,
         DataAssetLinkConfig,
+        DataAssetLinkOutput,
+        DataAssetLinkOutput2,
         DataAssetLinkOutputBuilder,
         DataAssetLinkOutputBuilderAdd;
 export 'src/data_assets/data_asset.dart' show DataAsset;

--- a/pkgs/native_assets_cli/lib/data_assets_builder.dart
+++ b/pkgs/native_assets_cli/lib/data_assets_builder.dart
@@ -8,8 +8,7 @@ library;
 export 'data_assets.dart' hide build, link;
 export 'native_assets_cli_builder.dart'
     hide EncodedAssetBuildOutputBuilder, EncodedAssetLinkOutputBuilder;
-export 'src/data_assets/config.dart'
-    show DataAssetBuildOutput, DataAssetLinkOutput;
+export 'src/data_assets/config.dart' show DataAssetEncodedAsset;
 export 'src/data_assets/validation.dart'
     show
         validateDataAssetBuildConfig,

--- a/pkgs/native_assets_cli/lib/src/api/build.dart
+++ b/pkgs/native_assets_cli/lib/src/api/build.dart
@@ -56,7 +56,7 @@ import '../validation.dart';
 ///
 /// void main(List<String> args) async {
 ///   await build(args, (config, output) async {
-///     if (config.codeConfig.linkModePreference == LinkModePreference.static) {
+///     if (config.code.linkModePreference == LinkModePreference.static) {
 ///       // Simulate that this hook only supports dynamic libraries.
 ///       throw UnsupportedError(
 ///         'LinkModePreference.static is not supported.',
@@ -75,15 +75,15 @@ import '../validation.dart';
 ///       ]);
 ///     }
 ///
-///     output.codeAssets.add(
+///     output.code.addAsset(
 ///       // TODO: Change to DataAsset once the Dart/Flutter SDK can consume it.
 ///       CodeAsset(
 ///         package: packageName,
 ///         name: 'asset.txt',
 ///         file: assetPath,
 ///         linkMode: DynamicLoadingBundled(),
-///         os: config.codeConfig.targetOS,
-///         architecture: config.codeConfig.targetArchitecture,
+///         os: config.code.targetOS,
+///         architecture: config.code.targetArchitecture,
 ///       ),
 ///     );
 ///   });

--- a/pkgs/native_assets_cli/lib/src/code_assets/config.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/config.dart
@@ -15,15 +15,38 @@ import 'os.dart';
 /// code assets (only available if code assets are supported).
 extension CodeAssetBuildConfig on BuildConfig {
   /// Code asset specific configuration.
-  CodeConfig get codeConfig => CodeConfig(this);
+  CodeConfig get code => CodeConfig(this);
 }
 
-/// Extension to the [LinkConfig] providing access to configuration specific to
-/// code assets as well as code asset inputs to the linker (only available if
-/// code assets are supported).
-extension CodeAssetLinkConfig on LinkConfig {
-  /// Code asset specific configuration.
-  CodeConfig get codeConfig => CodeConfig(this);
+// Weird class that combines `CodeConfig` getters and a getter for code assets.
+class LinkCodeConfig implements CodeConfig {
+  final LinkConfig _linkConfig;
+  late final CodeConfig _codeConfig;
+
+  LinkCodeConfig(this._linkConfig) {
+    _codeConfig = CodeConfig(_linkConfig);
+  }
+
+  @override
+  AndroidConfig get android => _codeConfig.android;
+
+  @override
+  CCompilerConfig? get cCompiler => _codeConfig.cCompiler;
+
+  @override
+  IOSConfig get iOS => _codeConfig.iOS;
+
+  @override
+  LinkModePreference get linkModePreference => _codeConfig.linkModePreference;
+
+  @override
+  MacOSConfig get macOS => _codeConfig.macOS;
+
+  @override
+  Architecture get targetArchitecture => _codeConfig.targetArchitecture;
+
+  @override
+  OS get targetOS => _codeConfig.targetOS;
 
   // Returns the code assets that were sent to this linker.
   //
@@ -32,9 +55,33 @@ extension CodeAssetLinkConfig on LinkConfig {
   // linker script has to add those files as dependencies via
   // [LinkOutput.addDependency] to ensure the linker script will be re-run if
   // the content of the files changes.
-  Iterable<CodeAsset> get codeAssets => encodedAssets
+  Iterable<CodeAsset> get assets => _linkConfig.encodedAssets
       .where((e) => e.type == CodeAsset.type)
       .map(CodeAsset.fromEncoded);
+
+  @override
+  AndroidConfig? get _androidConfig => throw UnimplementedError();
+  @override
+  IOSConfig? get _iOSConfig => throw UnimplementedError();
+  @override
+  MacOSConfig? get _macOSConfig => throw UnimplementedError();
+  @override
+  Architecture? get _targetArchitecture => throw UnimplementedError();
+  @override
+  set _androidConfig(AndroidConfig? androidConfig) =>
+      throw UnimplementedError();
+  @override
+  set _iOSConfig(IOSConfig? iOSConfig) => throw UnimplementedError();
+  @override
+  set _macOSConfig(MacOSConfig? macOSConfig) => throw UnimplementedError();
+}
+
+/// Extension to the [LinkConfig] providing access to configuration specific to
+/// code assets as well as code asset inputs to the linker (only available if
+/// code assets are supported).
+extension CodeAssetLinkConfig on LinkConfig {
+  /// Code asset specific configuration.
+  LinkCodeConfig get code => LinkCodeConfig(this);
 }
 
 /// Configuration for hook writers if code assets are supported.
@@ -86,30 +133,28 @@ class CodeConfig {
     if (_targetArchitecture == null) {
       throw StateError('Cannot access target architecture in dry runs.');
     }
-    return _targetArchitecture;
+    return _targetArchitecture!;
   }
 
   /// Configuration provided when [CodeConfig.targetOS] is [OS.macOS].
-  IOSConfig get iOSConfig => switch (_iOSConfig) {
-        null =>
-          throw StateError('Cannot access iOSConfig if targetOS is not iOS'
-              ' or in dry runs.'),
-        final c => c,
-      };
-
-  /// Configuration provided when [CodeConfig.targetOS] is [OS.android].
-  AndroidConfig get androidConfig => switch (_androidConfig) {
-        null => throw StateError(
-            'Cannot access androidConfig if targetOS is not android'
+  IOSConfig get iOS => switch (_iOSConfig) {
+        null => throw StateError('Cannot access iOS if targetOS is not iOS'
             ' or in dry runs.'),
         final c => c,
       };
 
-  /// Configuration provided when [CodeConfig.targetOS] is [OS.macOS].
-  MacOSConfig get macOSConfig => switch (_macOSConfig) {
+  /// Configuration provided when [CodeConfig.targetOS] is [OS.android].
+  AndroidConfig get android => switch (_androidConfig) {
         null =>
-          throw StateError('Cannot access macOSConfig if targetOS is not MacOS'
+          throw StateError('Cannot access android if targetOS is not android'
               ' or in dry runs.'),
+        final c => c,
+      };
+
+  /// Configuration provided when [CodeConfig.targetOS] is [OS.macOS].
+  MacOSConfig get macOS => switch (_macOSConfig) {
+        null => throw StateError('Cannot access macOS if targetOS is not MacOS'
+            ' or in dry runs.'),
         final c => c,
       };
 }
@@ -188,7 +233,7 @@ extension MacOSConfigSyntactic on MacOSConfig {
 /// assets (only available if code assets are supported).
 extension CodeAssetBuildOutputBuilder on BuildOutputBuilder {
   /// Provides access to emitting code assets.
-  CodeAssetBuildOutputBuilderAdd get codeAssets =>
+  CodeAssetBuildOutputBuilderAdd get code =>
       CodeAssetBuildOutputBuilderAdd._(this);
 }
 
@@ -196,14 +241,14 @@ extension CodeAssetBuildOutputBuilder on BuildOutputBuilder {
 extension type CodeAssetBuildOutputBuilderAdd._(BuildOutputBuilder _output) {
   /// Adds the given [asset] to the hook output (or send to [linkInPackage]
   /// for linking if provided).
-  void add(CodeAsset asset, {String? linkInPackage}) =>
+  void addAsset(CodeAsset asset, {String? linkInPackage}) =>
       _output.addEncodedAsset(asset.encode(), linkInPackage: linkInPackage);
 
   /// Adds the given [assets] to the hook output (or send to [linkInPackage]
   /// for linking if provided).
-  void addAll(Iterable<CodeAsset> assets, {String? linkInPackage}) {
+  void addAssets(Iterable<CodeAsset> assets, {String? linkInPackage}) {
     for (final asset in assets) {
-      add(asset, linkInPackage: linkInPackage);
+      addAsset(asset, linkInPackage: linkInPackage);
     }
   }
 }
@@ -212,65 +257,73 @@ extension type CodeAssetBuildOutputBuilderAdd._(BuildOutputBuilder _output) {
 /// assets (only available if code assets are supported).
 extension CodeAssetLinkOutputBuilder on LinkOutputBuilder {
   /// Provides access to emitting code assets.
-  CodeAssetLinkOutputBuilderAdd get codeAssets =>
+  CodeAssetLinkOutputBuilderAdd get code =>
       CodeAssetLinkOutputBuilderAdd._(this);
 }
 
 /// Extension on [LinkOutputBuilder] to emit code assets.
 extension type CodeAssetLinkOutputBuilderAdd._(LinkOutputBuilder _output) {
   /// Adds the given [asset] to the link hook output.
-  void add(CodeAsset asset) => _output.addEncodedAsset(asset.encode());
+  void addAsset(CodeAsset asset) => _output.addEncodedAsset(asset.encode());
 
   /// Adds the given [assets] to the link hook output.
-  void addAll(Iterable<CodeAsset> assets) => assets.forEach(add);
+  void addAssets(Iterable<CodeAsset> assets) => assets.forEach(addAsset);
 }
 
 /// Extension to initialize code specific configuration on link/build configs.
 extension CodeAssetBuildConfigBuilder on HookConfigBuilder {
-  void setupCodeConfig({
+  void setupCode({
     required Architecture? targetArchitecture,
     required OS targetOS,
     required LinkModePreference linkModePreference,
-    CCompilerConfig? cCompilerConfig,
-    AndroidConfig? androidConfig,
-    IOSConfig? iOSConfig,
-    MacOSConfig? macOSConfig,
+    CCompilerConfig? cCompiler,
+    AndroidConfig? android,
+    IOSConfig? iOS,
+    MacOSConfig? macOS,
   }) {
     if (targetArchitecture != null) {
       json[_targetArchitectureKey] = targetArchitecture.toString();
     }
     json[_targetOSConfigKey] = targetOS.toString();
     json[_linkModePreferenceKey] = linkModePreference.toString();
-    if (cCompilerConfig != null) {
-      json[_compilerKey] = cCompilerConfig.toJson();
+    if (cCompiler != null) {
+      json[_compilerKey] = cCompiler.toJson();
     }
 
     // Note, using ?. instead of !. makes missing data be a semantic error
     // rather than a syntactic error to be caught in the validation.
     if (targetOS == OS.android) {
-      json[_targetAndroidNdkApiKey] = androidConfig?.targetNdkApi;
+      json[_targetAndroidNdkApiKey] = android?.targetNdkApi;
     } else if (targetOS == OS.iOS) {
-      json[_targetIOSSdkKey] = iOSConfig?.targetSdk.toString();
-      json[_targetIOSVersionKey] = iOSConfig?.targetVersion;
+      json[_targetIOSSdkKey] = iOS?.targetSdk.toString();
+      json[_targetIOSVersionKey] = iOS?.targetVersion;
     } else if (targetOS == OS.macOS) {
-      json[_targetMacOSVersionKey] = macOSConfig?.targetVersion;
+      json[_targetMacOSVersionKey] = macOS?.targetVersion;
     }
   }
 }
 
-/// Provides access to [CodeAsset]s from a build hook output.
 extension CodeAssetBuildOutput on BuildOutput {
+  CodeAssetBuildOutput2 get code => CodeAssetBuildOutput2(this);
+}
+
+/// Provides access to [CodeAsset]s from a build hook output.
+extension type CodeAssetBuildOutput2(BuildOutput buildOutput) {
   /// The code assets emitted by the build hook.
-  List<CodeAsset> get codeAssets => encodedAssets
+  List<CodeAsset> get assets => buildOutput.encodedAssets
       .where((asset) => asset.type == CodeAsset.type)
       .map<CodeAsset>(CodeAsset.fromEncoded)
       .toList();
 }
 
-/// Provides access to [CodeAsset]s from a link hook output.
 extension CodeAssetLinkOutput on LinkOutput {
+  CodeAssetLinkOutput2 get code => CodeAssetLinkOutput2(this);
+}
+
+/// Provides access to [CodeAsset]s from a link hook output.
+extension type CodeAssetLinkOutput2(LinkOutput linkOutput) {
   /// The code assets emitted by the link hook.
-  List<CodeAsset> get codeAssets => encodedAssets
+  List<CodeAsset> get assets => linkOutput.encodedAssets
       .where((asset) => asset.type == CodeAsset.type)
       .map<CodeAsset>(CodeAsset.fromEncoded)
       .toList();

--- a/pkgs/native_assets_cli/lib/src/code_assets/testing.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/testing.dart
@@ -38,21 +38,21 @@ Future<void> testCodeBuildHook({
   await testBuildHook(
     mainMethod: mainMethod,
     extraConfigSetup: (config) {
-      config.setupCodeConfig(
+      config.setupCode(
         linkModePreference: linkModePreference ?? LinkModePreference.dynamic,
-        cCompilerConfig: cCompiler,
+        cCompiler: cCompiler,
         targetArchitecture: targetArchitecture ?? Architecture.current,
         targetOS: targetOS ?? OS.current,
-        iOSConfig: targetOS == OS.iOS
+        iOS: targetOS == OS.iOS
             ? IOSConfig(
                 targetSdk: targetIOSSdk!,
                 targetVersion: targetIOSVersion!,
               )
             : null,
-        macOSConfig: targetOS == OS.macOS
+        macOS: targetOS == OS.macOS
             ? MacOSConfig(targetVersion: targetMacOSVersion!)
             : null,
-        androidConfig: targetOS == OS.android
+        android: targetOS == OS.android
             ? AndroidConfig(targetNdkApi: targetAndroidNdkApi!)
             : null,
       );

--- a/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
@@ -14,14 +14,14 @@ Future<ValidationErrors> validateCodeAssetBuildConfig(
       'BuildConfig',
       // ignore: deprecated_member_use_from_same_package
       config.dryRun,
-      config.codeConfig,
+      config.code,
     );
 
 Future<ValidationErrors> validateCodeAssetLinkConfig(LinkConfig config) async =>
     _validateCodeConfig(
       'LinkConfig',
       false,
-      config.codeConfig,
+      config.code,
     );
 
 ValidationErrors _validateCodeConfig(
@@ -36,25 +36,25 @@ ValidationErrors _validateCodeConfig(
   final targetOS = codeConfig.targetOS;
   switch (targetOS) {
     case OS.macOS:
-      if (codeConfig.macOSConfig.targetVersionSyntactic == null) {
+      if (codeConfig.macOS.targetVersionSyntactic == null) {
         errors.add('$configName.targetOS is OS.macOS but '
-            '$configName.codeConfig.macOSConfig.targetVersion was missing');
+            '$configName.code.macOS.targetVersion was missing');
       }
       break;
     case OS.iOS:
-      if (codeConfig.iOSConfig.targetSdkSyntactic == null) {
+      if (codeConfig.iOS.targetSdkSyntactic == null) {
         errors.add('$configName.targetOS is OS.iOS but '
-            '$configName.codeConfig.targetIOSSdk was missing');
+            '$configName.code.iOS.targetSdk was missing');
       }
-      if (codeConfig.iOSConfig.targetVersionSyntactic == null) {
+      if (codeConfig.iOS.targetVersionSyntactic == null) {
         errors.add('$configName.targetOS is OS.iOS but '
-            '$configName.codeConfig.iOSConfig.targetVersion was missing');
+            '$configName.code.iOS.targetVersion was missing');
       }
       break;
     case OS.android:
-      if (codeConfig.androidConfig.targetNdkApiSyntactic == null) {
+      if (codeConfig.android.targetNdkApiSyntactic == null) {
         errors.add('$configName.targetOS is OS.android but '
-            '$configName.codeConfig.androidConfig.targetNdkApi was missing');
+            '$configName.code.android.targetNdkApi was missing');
       }
       break;
   }
@@ -62,20 +62,19 @@ ValidationErrors _validateCodeConfig(
   if (compilerConfig != null) {
     final compiler = compilerConfig.compiler.toFilePath();
     if (!File(compiler).existsSync()) {
-      errors.add('$configName.codeConfig.compiler ($compiler) does not exist.');
+      errors.add('$configName.code.compiler ($compiler) does not exist.');
     }
     final linker = compilerConfig.linker.toFilePath();
     if (!File(linker).existsSync()) {
-      errors.add('$configName.codeConfig.linker ($linker) does not exist.');
+      errors.add('$configName.code.linker ($linker) does not exist.');
     }
     final archiver = compilerConfig.archiver.toFilePath();
     if (!File(archiver).existsSync()) {
-      errors.add('$configName.codeConfig.archiver ($archiver) does not exist.');
+      errors.add('$configName.code.archiver ($archiver) does not exist.');
     }
     final envScript = compilerConfig.envScript?.toFilePath();
     if (envScript != null && !File(envScript).existsSync()) {
-      errors
-          .add('$configName.codeConfig.envScript ($envScript) does not exist.');
+      errors.add('$configName.code.envScript ($envScript) does not exist.');
     }
   }
   return errors;
@@ -87,7 +86,7 @@ Future<ValidationErrors> validateCodeAssetBuildOutput(
 ) =>
     _validateCodeAssetBuildOrLinkOutput(
       config,
-      config.codeConfig,
+      config.code,
       output.encodedAssets,
       // ignore: deprecated_member_use_from_same_package
       config.dryRun,
@@ -100,7 +99,7 @@ Future<ValidationErrors> validateCodeAssetLinkOutput(
   LinkOutput output,
 ) =>
     _validateCodeAssetBuildOrLinkOutput(
-        config, config.codeConfig, output.encodedAssets, false, output, false);
+        config, config.code, output.encodedAssets, false, output, false);
 
 /// Validates that the given code assets can be used together in an application.
 ///

--- a/pkgs/native_assets_cli/lib/src/config.dart
+++ b/pkgs/native_assets_cli/lib/src/config.dart
@@ -90,7 +90,7 @@ sealed class HookConfigBuilder {
     'version': latestVersion.toString(),
   };
 
-  void setupHookConfig({
+  void setupHook({
     required Uri packageRoot,
     required String packageName,
     required List<String> buildAssetTypes,
@@ -168,7 +168,7 @@ final class BuildConfig extends HookConfig {
 }
 
 final class BuildConfigBuilder extends HookConfigBuilder {
-  void setupBuildConfig({
+  void setupBuild({
     required bool dryRun,
     required bool linkingEnabled,
     Map<String, Metadata> metadata = const {},
@@ -184,7 +184,7 @@ final class BuildConfigBuilder extends HookConfigBuilder {
     }
   }
 
-  void setupBuildRunConfig({
+  void setupBuildAfterChecksum({
     required Uri outputDirectory,
     required Uri outputDirectoryShared,
   }) {
@@ -216,7 +216,7 @@ final class LinkConfigBuilder extends HookConfigBuilder {
     json[_buildModeConfigKeyDeprecated] = 'release';
   }
 
-  void setupLinkRunConfig({
+  void setupLinkAfterChecksum({
     required Uri outputDirectory,
     required Uri outputDirectoryShared,
     required Uri? recordedUsesFile,
@@ -373,8 +373,8 @@ const _dependencyMetadataKey = 'dependency_metadata';
 /// ```dart
 /// main(List<String> arguments) async {
 ///   await build((config, output) {
-///     output.codeAssets.add(CodeAsset(...));
-///     output.dataAssets.add(DataAsset(...));
+///     output.code.addAsset(CodeAsset(...));
+///     output.data.addAsset(DataAsset(...));
 ///   });
 /// }
 /// ```
@@ -413,8 +413,8 @@ extension EncodedAssetBuildOutputBuilder on BuildOutputBuilder {
   /// ```dart
   /// main(List<String> arguments) async {
   ///   await build((config, output) {
-  ///     output.codeAssets.add(CodeAsset(...));
-  ///     output.dataAssets.add(DataAsset(...));
+  ///     output.code.addAsset(CodeAsset(...));
+  ///     output.data.addAsset(DataAsset(...));
   ///   });
   /// }
   /// ```
@@ -436,8 +436,8 @@ extension EncodedAssetBuildOutputBuilder on BuildOutputBuilder {
   /// ```dart
   /// main(List<String> arguments) async {
   ///   await build((config, output) {
-  ///     output.codeAssets.addAll([CodeAsset(...), ...]);
-  ///     output.dataAssets.addAll([DataAsset(...), ...]);
+  ///     output.code.addAssets([CodeAsset(...), ...]);
+  ///     output.data.addAssets([DataAsset(...), ...]);
   ///   });
   /// }
   /// ```
@@ -486,8 +486,8 @@ class LinkOutput extends HookOutput {
 /// ```dart
 /// main(List<String> arguments) async {
 ///   await build((config, output) {
-///     output.codeAssets.add(CodeAsset(...));
-///     output.dataAssets.add(DataAsset(...));
+///     output.code.addAsset(CodeAsset(...));
+///     output.data.addAsset(DataAsset(...));
 ///   });
 /// }
 /// ```
@@ -504,8 +504,8 @@ extension EncodedAssetLinkOutputBuilder on LinkOutputBuilder {
   /// ```dart
   /// main(List<String> arguments) async {
   ///   await build((config, output) {
-  ///     output.codeAssets.add(CodeAsset(...));
-  ///     output.dataAssets.add(DataAsset(...));
+  ///     output.code.addAsset(CodeAsset(...));
+  ///     output.data.addAsset(DataAsset(...));
   ///   });
   /// }
   /// ```
@@ -523,8 +523,8 @@ extension EncodedAssetLinkOutputBuilder on LinkOutputBuilder {
   /// ```dart
   /// main(List<String> arguments) async {
   ///   await build((config, output) {
-  ///     output.codeAssets.addAll([CodeAsset(...), ...]);
-  ///     output.dataAssets.addAll([DataAsset(...), ...]);
+  ///     output.code.addAssets([CodeAsset(...), ...]);
+  ///     output.data.addAssets([DataAsset(...), ...]);
   ///   });
   /// }
   /// ```

--- a/pkgs/native_assets_cli/lib/src/data_assets/config.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/config.dart
@@ -4,6 +4,7 @@
 
 import '../config.dart';
 
+import '../encoded_asset.dart';
 import 'data_asset.dart';
 
 /// Link output extension for data assets.
@@ -15,7 +16,18 @@ extension DataAssetLinkConfig on LinkConfig {
   // then the linker script has to add those files as dependencies via
   // [LinkOutput.addDependency] to ensure the linker script will be re-run if
   // the content of the files changes.
-  Iterable<DataAsset> get dataAssets => encodedAssets
+  DataAssetLinkConfig2 get data => DataAssetLinkConfig2(this);
+}
+
+extension type DataAssetLinkConfig2(LinkConfig linkConfig) {
+  // Returns the data assets that were sent to this linker.
+  //
+  // NOTE: If the linker implementation depends on the contents of the files of
+  // the data assets (e.g. by transforming them, merging with other files, etc)
+  // then the linker script has to add those files as dependencies via
+  // [LinkOutput.addDependency] to ensure the linker script will be re-run if
+  // the content of the files changes.
+  Iterable<DataAsset> get assets => linkConfig.encodedAssets
       .where((e) => e.type == DataAsset.type)
       .map(DataAsset.fromEncoded);
 }
@@ -23,7 +35,7 @@ extension DataAssetLinkConfig on LinkConfig {
 /// Build output extension for data assets.
 extension DataAssetBuildOutputBuilder on BuildOutputBuilder {
   /// Provides access to emitting data assets.
-  DataAssetBuildOutputBuilderAdd get dataAssets =>
+  DataAssetBuildOutputBuilderAdd get data =>
       DataAssetBuildOutputBuilderAdd._(this);
 }
 
@@ -31,14 +43,14 @@ extension DataAssetBuildOutputBuilder on BuildOutputBuilder {
 extension type DataAssetBuildOutputBuilderAdd._(BuildOutputBuilder _output) {
   /// Adds the given [asset] to the hook output (or send to [linkInPackage]
   /// for linking if provided).
-  void add(DataAsset asset, {String? linkInPackage}) =>
+  void addAsset(DataAsset asset, {String? linkInPackage}) =>
       _output.addEncodedAsset(asset.encode(), linkInPackage: linkInPackage);
 
   /// Adds the given [assets] to the hook output (or send to [linkInPackage]
   /// for linking if provided).
   void addAll(Iterable<DataAsset> assets, {String? linkInPackage}) {
     for (final asset in assets) {
-      add(asset, linkInPackage: linkInPackage);
+      addAsset(asset, linkInPackage: linkInPackage);
     }
   }
 }
@@ -47,31 +59,44 @@ extension type DataAssetBuildOutputBuilderAdd._(BuildOutputBuilder _output) {
 /// assets (only available if data assets are supported).
 extension DataAssetLinkOutputBuilder on LinkOutputBuilder {
   /// Provides access to emitting data assets.
-  DataAssetLinkOutputBuilderAdd get dataAssets =>
-      DataAssetLinkOutputBuilderAdd(this);
+  DataAssetLinkOutputBuilderAdd get data => DataAssetLinkOutputBuilderAdd(this);
 }
 
 /// Extension on [LinkOutputBuilder] to emit data assets.
 extension type DataAssetLinkOutputBuilderAdd(LinkOutputBuilder _output) {
   /// Adds the given [asset] to the link hook output.
-  void add(DataAsset asset) => _output.addEncodedAsset(asset.encode());
+  void addAsset(DataAsset asset) => _output.addEncodedAsset(asset.encode());
 
   /// Adds the given [assets] to the link hook output.
-  void addAll(Iterable<DataAsset> assets) => assets.forEach(add);
+  void addAssets(Iterable<DataAsset> assets) => assets.forEach(addAsset);
+}
+
+extension DataAssetBuildOutput on BuildOutput {
+  DataAssetBuildOutput2 get data => DataAssetBuildOutput2(this);
 }
 
 /// Provides access to [DataAsset]s from a build hook output.
-extension DataAssetBuildOutput on BuildOutput {
-  List<DataAsset> get dataAssets => encodedAssets
+extension type DataAssetBuildOutput2(BuildOutput buildOutput) {
+  List<DataAsset> get assets => buildOutput.encodedAssets
       .where((asset) => asset.type == DataAsset.type)
       .map<DataAsset>(DataAsset.fromEncoded)
       .toList();
 }
 
-/// Provides access to [DataAsset]s from a link hook output.
 extension DataAssetLinkOutput on LinkOutput {
-  List<DataAsset> get dataAssets => encodedAssets
+  DataAssetLinkOutput2 get data => DataAssetLinkOutput2(this);
+}
+
+/// Provides access to [DataAsset]s from a link hook output.
+extension type DataAssetLinkOutput2(LinkOutput linkOutput) {
+  List<DataAsset> get assets => linkOutput.encodedAssets
       .where((asset) => asset.type == DataAsset.type)
+      .map<DataAsset>(DataAsset.fromEncoded)
+      .toList();
+}
+
+extension DataAssetEncodedAsset on List<EncodedAsset> {
+  List<DataAsset> get data => where((asset) => asset.type == DataAsset.type)
       .map<DataAsset>(DataAsset.fromEncoded)
       .toList();
 }

--- a/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
@@ -12,9 +12,9 @@ Future<ValidationErrors> validateDataAssetBuildConfig(
 
 Future<ValidationErrors> validateDataAssetLinkConfig(LinkConfig config) async {
   final errors = <String>[];
-  for (final asset in config.dataAssets) {
+  for (final asset in config.data.assets) {
     if (!File.fromUri(asset.file).existsSync()) {
-      errors.add('LinkConfig.dataAssets contained asset ${asset.id} with file '
+      errors.add('LinkConfig.assets.data contained asset ${asset.id} with file '
           '(${asset.file}) which does not exist.');
     }
   }

--- a/pkgs/native_assets_cli/lib/test.dart
+++ b/pkgs/native_assets_cli/lib/test.dart
@@ -49,16 +49,16 @@ Future<void> testBuildHook({
 
     final configBuilder = BuildConfigBuilder();
     configBuilder
-      ..setupHookConfig(
+      ..setupHook(
         packageRoot: Directory.current.uri,
         packageName: _readPackageNameFromPubspec(),
         buildAssetTypes: buildAssetTypes ?? [],
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         dryRun: false,
         linkingEnabled: true,
       )
-      ..setupBuildRunConfig(
+      ..setupBuildAfterChecksum(
         outputDirectory: outputDirectory,
         outputDirectoryShared: outputDirectoryShared,
       );

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -15,7 +15,7 @@ topics:
   - native-assets
 
 environment:
-  sdk: '>=3.5.0 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
   collection: ^1.17.1

--- a/pkgs/native_assets_cli/test/api/build_test.dart
+++ b/pkgs/native_assets_cli/test/api/build_test.dart
@@ -31,16 +31,16 @@ void main() async {
 
     final configBuilder = BuildConfigBuilder();
     configBuilder
-      ..setupHookConfig(
+      ..setupHook(
         packageRoot: tempUri,
         packageName: packageName,
         buildAssetTypes: ['foo'],
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         dryRun: false,
         linkingEnabled: false,
       )
-      ..setupBuildRunConfig(
+      ..setupBuildAfterChecksum(
         outputDirectory: outDirUri,
         outputDirectoryShared: outputDirectoryShared,
       );

--- a/pkgs/native_assets_cli/test/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/build_config_test.dart
@@ -37,17 +37,17 @@ void main() async {
 
   test('BuildConfigBuilder->JSON->BuildConfig', () {
     final configBuilder = BuildConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         packageName: packageName,
         packageRoot: packageRootUri,
         buildAssetTypes: ['my-asset-type'],
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         linkingEnabled: false,
         dryRun: false,
         metadata: metadata,
       )
-      ..setupBuildRunConfig(
+      ..setupBuildAfterChecksum(
         outputDirectory: outDirUri,
         outputDirectoryShared: outputDirectoryShared,
       );
@@ -92,16 +92,16 @@ void main() async {
 
   test('BuildConfig.dryRun', () {
     final configBuilder = BuildConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         packageName: packageName,
         packageRoot: packageRootUri,
         buildAssetTypes: ['my-asset-type'],
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         linkingEnabled: true,
         dryRun: true,
       )
-      ..setupBuildRunConfig(
+      ..setupBuildAfterChecksum(
         outputDirectory: outDirUri,
         outputDirectoryShared: outputDirectoryShared,
       );

--- a/pkgs/native_assets_cli/test/checksum_test.dart
+++ b/pkgs/native_assets_cli/test/checksum_test.dart
@@ -22,19 +22,19 @@ void main() {
             for (final dryRun in [true, false]) {
               for (final linking in [true, false]) {
                 final builder = BuildConfigBuilder()
-                  ..setupHookConfig(
+                  ..setupHook(
                     packageRoot: Uri.file('foo'),
                     packageName: packageName,
                     buildAssetTypes: [assetType],
                   )
-                  ..setupBuildConfig(
+                  ..setupBuild(
                     dryRun: dryRun,
                     linkingEnabled: linking,
                   )
-                  ..setupCodeConfig(
+                  ..setupCode(
                     targetArchitecture: architecture,
                     targetOS: os,
-                    macOSConfig: os == OS.macOS
+                    macOS: os == OS.macOS
                         ? MacOSConfig(targetVersion: defaultMacOSVersion)
                         : null,
                     linkModePreference: LinkModePreference.dynamic,

--- a/pkgs/native_assets_cli/test/code_assets/config_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/config_test.dart
@@ -53,7 +53,7 @@ void main() async {
     });
 
     expect(() => codeConfig.targetArchitecture, throwsStateError);
-    expect(() => codeConfig.androidConfig.targetNdkApi, throwsStateError);
+    expect(() => codeConfig.android.targetNdkApi, throwsStateError);
     expect(codeConfig.linkModePreference, LinkModePreference.preferStatic);
     expect(codeConfig.cCompiler, null);
   }
@@ -77,60 +77,60 @@ void main() async {
     });
 
     expect(codeConfig.targetArchitecture, Architecture.arm64);
-    expect(codeConfig.androidConfig.targetNdkApi, 30);
+    expect(codeConfig.android.targetNdkApi, 30);
     expect(codeConfig.linkModePreference, LinkModePreference.preferStatic);
     expect(codeConfig.cCompiler?.compiler, fakeClang);
     expect(codeConfig.cCompiler?.linker, fakeLd);
     expect(codeConfig.cCompiler?.archiver, fakeAr);
   }
 
-  test('BuildConfig.codeConfig (dry-run)', () {
+  test('BuildConfig.code (dry-run)', () {
     final configBuilder = BuildConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         packageName: packageName,
         packageRoot: packageRootUri,
         buildAssetTypes: [CodeAsset.type],
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         linkingEnabled: true,
         dryRun: true,
       )
-      ..setupBuildRunConfig(
+      ..setupBuildAfterChecksum(
         outputDirectory: outDirUri,
         outputDirectoryShared: outputDirectoryShared,
       )
-      ..setupCodeConfig(
+      ..setupCode(
         targetOS: OS.android,
-        androidConfig: null, // not available in dry run
+        android: null, // not available in dry run
         targetArchitecture: null, // not available in dry run
-        cCompilerConfig: null, // not available in dry run
+        cCompiler: null, // not available in dry run
         linkModePreference: LinkModePreference.preferStatic,
       );
     final config = BuildConfig(configBuilder.json);
-    expectCorrectCodeConfigDryRun(config.json, config.codeConfig);
+    expectCorrectCodeConfigDryRun(config.json, config.code);
   });
 
-  test('BuildConfig.codeConfig', () {
+  test('BuildConfig.code', () {
     final configBuilder = BuildConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         packageName: packageName,
         packageRoot: packageRootUri,
         buildAssetTypes: [CodeAsset.type],
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         linkingEnabled: false,
         dryRun: false,
       )
-      ..setupBuildRunConfig(
+      ..setupBuildAfterChecksum(
         outputDirectory: outDirUri,
         outputDirectoryShared: outputDirectoryShared,
       )
-      ..setupCodeConfig(
+      ..setupCode(
         targetOS: OS.android,
         targetArchitecture: Architecture.arm64,
-        androidConfig: AndroidConfig(targetNdkApi: 30),
+        android: AndroidConfig(targetNdkApi: 30),
         linkModePreference: LinkModePreference.preferStatic,
-        cCompilerConfig: CCompilerConfig(
+        cCompiler: CCompilerConfig(
           compiler: fakeClang,
           linker: fakeLd,
           archiver: fakeAr,
@@ -139,28 +139,28 @@ void main() async {
         ),
       );
     final config = BuildConfig(configBuilder.json);
-    expectCorrectCodeConfig(config.json, config.codeConfig);
+    expectCorrectCodeConfig(config.json, config.code);
   });
 
   test('LinkConfig.{codeConfig,codeAssets}', () {
     final configBuilder = LinkConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         packageName: packageName,
         packageRoot: packageRootUri,
         buildAssetTypes: [CodeAsset.type],
       )
       ..setupLinkConfig(assets: assets)
-      ..setupLinkRunConfig(
+      ..setupLinkAfterChecksum(
         outputDirectory: outDirUri,
         outputDirectoryShared: outputDirectoryShared,
         recordedUsesFile: null,
       )
-      ..setupCodeConfig(
+      ..setupCode(
         targetOS: OS.android,
         targetArchitecture: Architecture.arm64,
-        androidConfig: AndroidConfig(targetNdkApi: 30),
+        android: AndroidConfig(targetNdkApi: 30),
         linkModePreference: LinkModePreference.preferStatic,
-        cCompilerConfig: CCompilerConfig(
+        cCompiler: CCompilerConfig(
           compiler: fakeClang,
           linker: fakeLd,
           archiver: fakeAr,
@@ -169,11 +169,11 @@ void main() async {
         ),
       );
     final config = LinkConfig(configBuilder.json);
-    expectCorrectCodeConfig(config.json, config.codeConfig);
+    expectCorrectCodeConfig(config.json, config.code);
     expect(config.encodedAssets, assets);
   });
 
-  test('BuildConfig.codeConfig: invalid architecture', () {
+  test('BuildConfig.code: invalid architecture', () {
     final config = {
       'dry_run': false,
       'linking_enabled': false,
@@ -189,12 +189,12 @@ void main() async {
       'version': latestVersion.toString(),
     };
     expect(
-      () => BuildConfig(config).codeConfig,
+      () => BuildConfig(config).code,
       throwsFormatException,
     );
   });
 
-  test('LinkConfig.codeConfig: invalid architecture', () {
+  test('LinkConfig.code: invalid architecture', () {
     final config = {
       'build_asset_types': [CodeAsset.type],
       'dry_run': false,
@@ -209,7 +209,7 @@ void main() async {
       'version': latestVersion.toString(),
     };
     expect(
-      () => LinkConfig(config).codeConfig,
+      () => LinkConfig(config).code,
       throwsFormatException,
     );
   });

--- a/pkgs/native_assets_cli/test/data_assets/validation_test.dart
+++ b/pkgs/native_assets_cli/test/data_assets/validation_test.dart
@@ -31,15 +31,15 @@ void main() {
 
   BuildConfig makeDataBuildConfig() {
     final configBuilder = BuildConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
           packageName: packageName,
           packageRoot: tempUri,
           buildAssetTypes: [DataAsset.type])
-      ..setupBuildConfig(
+      ..setupBuild(
         linkingEnabled: false,
         dryRun: false,
       )
-      ..setupBuildRunConfig(
+      ..setupBuildAfterChecksum(
         outputDirectory: outDirUri,
         outputDirectoryShared: outDirSharedUri,
       );
@@ -50,7 +50,7 @@ void main() {
     final config = makeDataBuildConfig();
     final outputBuilder = BuildOutputBuilder();
     final assetFile = File.fromUri(outDirUri.resolve('foo.txt'));
-    outputBuilder.dataAssets.add(DataAsset(
+    outputBuilder.data.addAsset(DataAsset(
       package: config.packageName,
       name: 'foo.txt',
       file: assetFile.uri,
@@ -68,7 +68,7 @@ void main() {
     final outputBuilder = BuildOutputBuilder();
     final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
     await assetFile.writeAsBytes([1, 2, 3]);
-    outputBuilder.dataAssets.add(DataAsset(
+    outputBuilder.data.addAsset(DataAsset(
       package: 'different_package',
       name: 'foo.txt',
       file: assetFile.uri,
@@ -86,7 +86,7 @@ void main() {
     final outputBuilder = BuildOutputBuilder();
     final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
     await assetFile.writeAsBytes([1, 2, 3]);
-    outputBuilder.dataAssets.addAll([
+    outputBuilder.data.addAll([
       DataAsset(
         package: config.packageName,
         name: 'foo.txt',

--- a/pkgs/native_assets_cli/test/example/local_asset_test.dart
+++ b/pkgs/native_assets_cli/test/example/local_asset_test.dart
@@ -42,23 +42,23 @@ void main() async {
 
       final targetOS = OS.current;
       final configBuilder = BuildConfigBuilder()
-        ..setupHookConfig(
+        ..setupHook(
           packageRoot: testPackageUri,
           packageName: name,
           buildAssetTypes: [CodeAsset.type],
         )
-        ..setupBuildRunConfig(
+        ..setupBuildAfterChecksum(
             outputDirectory: outputDirectory,
             outputDirectoryShared: outputDirectoryShared)
-        ..setupBuildConfig(linkingEnabled: false, dryRun: dryRun)
-        ..setupCodeConfig(
+        ..setupBuild(linkingEnabled: false, dryRun: dryRun)
+        ..setupCode(
           targetOS: targetOS,
-          macOSConfig: targetOS == OS.macOS
+          macOS: targetOS == OS.macOS
               ? MacOSConfig(targetVersion: defaultMacOSVersion)
               : null,
           targetArchitecture: dryRun ? null : Architecture.current,
           linkModePreference: LinkModePreference.dynamic,
-          cCompilerConfig: dryRun ? null : cCompiler,
+          cCompiler: dryRun ? null : cCompiler,
         );
 
       final buildConfigUri = testTempUri.resolve('build_config.json');
@@ -87,7 +87,7 @@ void main() async {
       final assets = buildOutput.encodedAssets;
       final dependencies = buildOutput.dependencies;
       if (dryRun) {
-        final codeAsset = buildOutput.codeAssets.first;
+        final codeAsset = buildOutput.code.assets.first;
         expect(assets.length, greaterThanOrEqualTo(1));
         expect(await File.fromUri(codeAsset.file!).exists(), false);
         expect(dependencies, <Uri>[]);

--- a/pkgs/native_assets_cli/test/example/native_add_library_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_library_test.dart
@@ -42,23 +42,23 @@ void main() async {
 
       final targetOS = OS.current;
       final configBuilder = BuildConfigBuilder()
-        ..setupHookConfig(
+        ..setupHook(
           packageRoot: testPackageUri,
           packageName: name,
           buildAssetTypes: [CodeAsset.type],
         )
-        ..setupBuildRunConfig(
+        ..setupBuildAfterChecksum(
             outputDirectory: outputDirectory,
             outputDirectoryShared: outputDirectoryShared)
-        ..setupBuildConfig(linkingEnabled: false, dryRun: dryRun)
-        ..setupCodeConfig(
+        ..setupBuild(linkingEnabled: false, dryRun: dryRun)
+        ..setupCode(
           targetOS: OS.current,
-          macOSConfig: targetOS == OS.macOS
+          macOS: targetOS == OS.macOS
               ? MacOSConfig(targetVersion: defaultMacOSVersion)
               : null,
           targetArchitecture: dryRun ? null : Architecture.current,
           linkModePreference: LinkModePreference.dynamic,
-          cCompilerConfig: dryRun ? null : cCompiler,
+          cCompiler: dryRun ? null : cCompiler,
         );
 
       final buildConfigUri = testTempUri.resolve('build_config.json');

--- a/pkgs/native_assets_cli/test/example/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_dynamic_linking_test.dart
@@ -46,24 +46,24 @@ void main() async {
 
       final targetOS = OS.current;
       final configBuilder = BuildConfigBuilder()
-        ..setupHookConfig(
+        ..setupHook(
           packageRoot: testPackageUri,
           packageName: name,
           buildAssetTypes: [CodeAsset.type],
         )
-        ..setupBuildRunConfig(
+        ..setupBuildAfterChecksum(
           outputDirectory: outputDirectory,
           outputDirectoryShared: outputDirectoryShared,
         )
-        ..setupBuildConfig(linkingEnabled: false, dryRun: dryRun)
-        ..setupCodeConfig(
+        ..setupBuild(linkingEnabled: false, dryRun: dryRun)
+        ..setupCode(
           targetOS: targetOS,
-          macOSConfig: targetOS == OS.macOS
+          macOS: targetOS == OS.macOS
               ? MacOSConfig(targetVersion: defaultMacOSVersion)
               : null,
           targetArchitecture: dryRun ? null : Architecture.current,
           linkModePreference: LinkModePreference.dynamic,
-          cCompilerConfig: dryRun ? null : cCompiler,
+          cCompiler: dryRun ? null : cCompiler,
         );
 
       final buildConfigUri = testTempUri.resolve('build_config.json');

--- a/pkgs/native_assets_cli/test/link_config_test.dart
+++ b/pkgs/native_assets_cli/test/link_config_test.dart
@@ -30,13 +30,13 @@ void main() async {
 
   test('LinkConfigBuilder->JSON->LinkConfig', () {
     final configBuilder = LinkConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         packageName: packageName,
         packageRoot: packageRootUri,
         buildAssetTypes: ['asset-type-1', 'asset-type-2'],
       )
       ..setupLinkConfig(assets: assets)
-      ..setupLinkRunConfig(
+      ..setupLinkAfterChecksum(
         outputDirectory: outDirUri,
         outputDirectoryShared: outputDirectoryShared,
         recordedUsesFile: null,

--- a/pkgs/native_assets_cli/test/validation_test.dart
+++ b/pkgs/native_assets_cli/test/validation_test.dart
@@ -31,16 +31,16 @@ void main() {
 
   BuildConfig makeBuildConfig() {
     final configBuilder = BuildConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         packageName: packageName,
         packageRoot: tempUri,
         buildAssetTypes: ['my-asset-type'],
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         linkingEnabled: false,
         dryRun: false,
       )
-      ..setupBuildRunConfig(
+      ..setupBuildAfterChecksum(
         outputDirectory: outDirUri,
         outputDirectoryShared: outDirSharedUri,
       );

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -125,11 +125,11 @@ class CBuilder extends CTool implements Builder {
     final packageRoot = config.packageRoot;
     await Directory.fromUri(outDir).create(recursive: true);
     final linkMode =
-        getLinkMode(linkModePreference ?? config.codeConfig.linkModePreference);
-    final libUri = outDir
-        .resolve(config.codeConfig.targetOS.libraryFileName(name, linkMode));
+        getLinkMode(linkModePreference ?? config.code.linkModePreference);
+    final libUri =
+        outDir.resolve(config.code.targetOS.libraryFileName(name, linkMode));
     final exeUri =
-        outDir.resolve(config.codeConfig.targetOS.executableFileName(name));
+        outDir.resolve(config.code.targetOS.executableFileName(name));
     final sources = [
       for (final source in this.sources)
         packageRoot.resolveUri(Uri.file(source)),
@@ -150,7 +150,7 @@ class CBuilder extends CTool implements Builder {
     if (!config.dryRun) {
       final task = RunCBuilder(
         config: config,
-        codeConfig: config.codeConfig,
+        codeConfig: config.code,
         logger: logger,
         sources: sources,
         includes: includes,
@@ -183,16 +183,16 @@ class CBuilder extends CTool implements Builder {
     }
 
     if (assetName != null) {
-      output.codeAssets.add(
+      output.code.addAsset(
         CodeAsset(
           package: config.packageName,
           name: assetName!,
           file: libUri,
           linkMode: linkMode,
-          os: config.codeConfig.targetOS,
+          os: config.code.targetOS,
           architecture:
               // ignore: deprecated_member_use
-              config.dryRun ? null : config.codeConfig.targetArchitecture,
+              config.dryRun ? null : config.code.targetArchitecture,
         ),
         linkInPackage: linkInPackage,
       );

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
@@ -51,7 +51,7 @@ class CLinker extends CTool implements Linker {
     required LinkOutputBuilder output,
     required Logger? logger,
   }) async {
-    if (OS.current != OS.linux || config.codeConfig.targetOS != OS.linux) {
+    if (OS.current != OS.linux || config.code.targetOS != OS.linux) {
       throw UnsupportedError('Currently, only linux is supported for this '
           'feature. See also https://github.com/dart-lang/native/issues/1376');
     }
@@ -59,9 +59,9 @@ class CLinker extends CTool implements Linker {
     final packageRoot = config.packageRoot;
     await Directory.fromUri(outDir).create(recursive: true);
     final linkMode =
-        getLinkMode(linkModePreference ?? config.codeConfig.linkModePreference);
-    final libUri = outDir
-        .resolve(config.codeConfig.targetOS.libraryFileName(name, linkMode));
+        getLinkMode(linkModePreference ?? config.code.linkModePreference);
+    final libUri =
+        outDir.resolve(config.code.targetOS.libraryFileName(name, linkMode));
     final sources = [
       for (final source in this.sources)
         packageRoot.resolveUri(Uri.file(source)),
@@ -76,7 +76,7 @@ class CLinker extends CTool implements Linker {
     ];
     final task = RunCBuilder(
       config: config,
-      codeConfig: config.codeConfig,
+      codeConfig: config.code,
       linkerOptions: linkerOptions,
       logger: logger,
       sources: sources,
@@ -99,13 +99,13 @@ class CLinker extends CTool implements Linker {
     await task.run();
 
     if (assetName != null) {
-      output.codeAssets.add(CodeAsset(
+      output.code.addAsset(CodeAsset(
         package: config.packageName,
         name: assetName!,
         file: libUri,
         linkMode: linkMode,
-        os: config.codeConfig.targetOS,
-        architecture: config.codeConfig.targetArchitecture,
+        os: config.code.targetOS,
+        architecture: config.code.targetArchitecture,
       ));
     }
     final includeFiles = await Stream.fromIterable(includes)

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -140,7 +140,7 @@ class RunCBuilder {
 
     final IOSSdk? targetIosSdk;
     if (codeConfig.targetOS == OS.iOS) {
-      targetIosSdk = codeConfig.iOSConfig.targetSdk;
+      targetIosSdk = codeConfig.iOS.targetSdk;
     } else {
       targetIosSdk = null;
     }
@@ -152,18 +152,15 @@ class RunCBuilder {
     if (codeConfig.targetOS == OS.android) {
       final minimumApi =
           codeConfig.targetArchitecture == Architecture.riscv64 ? 35 : 21;
-      targetAndroidNdkApi =
-          max(codeConfig.androidConfig.targetNdkApi, minimumApi);
+      targetAndroidNdkApi = max(codeConfig.android.targetNdkApi, minimumApi);
     } else {
       targetAndroidNdkApi = null;
     }
 
-    final targetIOSVersion = codeConfig.targetOS == OS.iOS
-        ? codeConfig.iOSConfig.targetVersion
-        : null;
-    final targetMacOSVersion = codeConfig.targetOS == OS.macOS
-        ? codeConfig.macOSConfig.targetVersion
-        : null;
+    final targetIOSVersion =
+        codeConfig.targetOS == OS.iOS ? codeConfig.iOS.targetVersion : null;
+    final targetMacOSVersion =
+        codeConfig.targetOS == OS.macOS ? codeConfig.macOS.targetVersion : null;
 
     final architecture = codeConfig.targetArchitecture;
     final sourceFiles = sources.map((e) => e.toFilePath()).toList();

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
@@ -31,25 +31,25 @@ void main() {
 
     final targetOS = OS.current;
     final buildConfigBuilder = BuildConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         buildAssetTypes: [CodeAsset.type],
         packageName: name,
         packageRoot: tempUri,
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         linkingEnabled: false,
         dryRun: false,
       )
-      ..setupCodeConfig(
+      ..setupCode(
         targetOS: targetOS,
-        macOSConfig: targetOS == OS.macOS
+        macOS: targetOS == OS.macOS
             ? MacOSConfig(targetVersion: defaultMacOSVersion)
             : null,
         targetArchitecture: Architecture.current,
         linkModePreference: LinkModePreference.dynamic,
-        cCompilerConfig: cCompiler,
+        cCompiler: cCompiler,
       );
-    buildConfigBuilder.setupBuildRunConfig(
+    buildConfigBuilder.setupBuildAfterChecksum(
       outputDirectory: tempUri,
       outputDirectoryShared: tempUri2,
     );

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -145,25 +145,25 @@ Future<Uri> buildLib(
   final tempUriShared = tempUri.resolve('shared/');
   await Directory.fromUri(tempUriShared).create();
   final buildConfigBuilder = BuildConfigBuilder()
-    ..setupHookConfig(
+    ..setupHook(
       buildAssetTypes: [CodeAsset.type],
       packageName: name,
       packageRoot: tempUri,
     )
-    ..setupBuildConfig(
+    ..setupBuild(
       linkingEnabled: false,
       dryRun: false,
     )
-    ..setupCodeConfig(
+    ..setupCode(
       targetOS: OS.android,
       targetArchitecture: targetArchitecture,
-      cCompilerConfig: cCompiler,
-      androidConfig: AndroidConfig(targetNdkApi: androidNdkApi),
+      cCompiler: cCompiler,
+      android: AndroidConfig(targetNdkApi: androidNdkApi),
       linkModePreference: linkMode == DynamicLoadingBundled()
           ? LinkModePreference.dynamic
           : LinkModePreference.static,
     );
-  buildConfigBuilder.setupBuildRunConfig(
+  buildConfigBuilder.setupBuildAfterChecksum(
     outputDirectory: tempUri,
     outputDirectoryShared: tempUriShared,
   );

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -74,28 +74,28 @@ void main() {
               };
 
               final buildConfigBuilder = BuildConfigBuilder()
-                ..setupHookConfig(
+                ..setupHook(
                   buildAssetTypes: [CodeAsset.type],
                   packageName: name,
                   packageRoot: tempUri,
                 )
-                ..setupBuildConfig(
+                ..setupBuild(
                   linkingEnabled: false,
                   dryRun: false,
                 )
-                ..setupCodeConfig(
+                ..setupCode(
                   targetOS: OS.iOS,
                   targetArchitecture: target,
                   linkModePreference: linkMode == DynamicLoadingBundled()
                       ? LinkModePreference.dynamic
                       : LinkModePreference.static,
-                  iOSConfig: IOSConfig(
+                  iOS: IOSConfig(
                     targetSdk: targetIOSSdk,
                     targetVersion: flutteriOSHighestBestEffort,
                   ),
-                  cCompilerConfig: cCompiler,
+                  cCompiler: cCompiler,
                 );
-              buildConfigBuilder.setupBuildRunConfig(
+              buildConfigBuilder.setupBuildAfterChecksum(
                 outputDirectory: tempUri,
                 outputDirectoryShared: tempUri2,
               );
@@ -231,28 +231,28 @@ Future<Uri> buildLib(
   const name = 'add';
 
   final buildConfigBuilder = BuildConfigBuilder()
-    ..setupHookConfig(
+    ..setupHook(
       buildAssetTypes: [CodeAsset.type],
       packageName: name,
       packageRoot: tempUri,
     )
-    ..setupBuildConfig(
+    ..setupBuild(
       linkingEnabled: false,
       dryRun: false,
     )
-    ..setupCodeConfig(
+    ..setupCode(
       targetOS: OS.iOS,
       targetArchitecture: targetArchitecture,
       linkModePreference: linkMode == DynamicLoadingBundled()
           ? LinkModePreference.dynamic
           : LinkModePreference.static,
-      iOSConfig: IOSConfig(
+      iOS: IOSConfig(
         targetSdk: IOSSdk.iPhoneOS,
         targetVersion: targetIOSVersion,
       ),
-      cCompilerConfig: cCompiler,
+      cCompiler: cCompiler,
     );
-  buildConfigBuilder.setupBuildRunConfig(
+  buildConfigBuilder.setupBuildAfterChecksum(
     outputDirectory: tempUri,
     outputDirectoryShared: tempUri2,
   );

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -43,24 +43,24 @@ void main() {
         const name = 'add';
 
         final buildConfigBuilder = BuildConfigBuilder()
-          ..setupHookConfig(
+          ..setupHook(
             buildAssetTypes: [CodeAsset.type],
             packageName: name,
             packageRoot: tempUri,
           )
-          ..setupBuildConfig(
+          ..setupBuild(
             linkingEnabled: false,
             dryRun: false,
           )
-          ..setupCodeConfig(
+          ..setupCode(
             targetOS: OS.linux,
             targetArchitecture: target,
             linkModePreference: linkMode == DynamicLoadingBundled()
                 ? LinkModePreference.dynamic
                 : LinkModePreference.static,
-            cCompilerConfig: cCompiler,
+            cCompiler: cCompiler,
           );
-        buildConfigBuilder.setupBuildRunConfig(
+        buildConfigBuilder.setupBuildAfterChecksum(
           outputDirectory: tempUri,
           outputDirectoryShared: tempUri2,
         );

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -58,25 +58,25 @@ void main() {
           const name = 'add';
 
           final buildConfigBuilder = BuildConfigBuilder()
-            ..setupHookConfig(
+            ..setupHook(
               buildAssetTypes: [CodeAsset.type],
               packageName: name,
               packageRoot: tempUri,
             )
-            ..setupBuildConfig(
+            ..setupBuild(
               linkingEnabled: false,
               dryRun: false,
             )
-            ..setupCodeConfig(
+            ..setupCode(
               targetOS: OS.macOS,
               targetArchitecture: target,
               linkModePreference: linkMode == DynamicLoadingBundled()
                   ? LinkModePreference.dynamic
                   : LinkModePreference.static,
-              cCompilerConfig: cCompiler,
-              macOSConfig: MacOSConfig(targetVersion: defaultMacOSVersion),
+              cCompiler: cCompiler,
+              macOS: MacOSConfig(targetVersion: defaultMacOSVersion),
             );
-          buildConfigBuilder.setupBuildRunConfig(
+          buildConfigBuilder.setupBuildAfterChecksum(
             outputDirectory: tempUri,
             outputDirectoryShared: tempUri2,
           );
@@ -160,25 +160,25 @@ Future<Uri> buildLib(
   const name = 'add';
 
   final buildConfigBuilder = BuildConfigBuilder()
-    ..setupHookConfig(
+    ..setupHook(
       buildAssetTypes: [CodeAsset.type],
       packageName: name,
       packageRoot: tempUri,
     )
-    ..setupBuildConfig(
+    ..setupBuild(
       linkingEnabled: false,
       dryRun: false,
     )
-    ..setupCodeConfig(
+    ..setupCode(
       targetOS: OS.macOS,
       targetArchitecture: targetArchitecture,
       linkModePreference: linkMode == DynamicLoadingBundled()
           ? LinkModePreference.dynamic
           : LinkModePreference.static,
-      macOSConfig: MacOSConfig(targetVersion: targetMacOSVersion),
-      cCompilerConfig: cCompiler,
+      macOS: MacOSConfig(targetVersion: targetMacOSVersion),
+      cCompiler: cCompiler,
     );
-  buildConfigBuilder.setupBuildRunConfig(
+  buildConfigBuilder.setupBuildAfterChecksum(
     outputDirectory: tempUri,
     outputDirectoryShared: tempUri2,
   );

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -62,24 +62,24 @@ void main() {
         const name = 'add';
 
         final buildConfigBuilder = BuildConfigBuilder()
-          ..setupHookConfig(
+          ..setupHook(
             buildAssetTypes: [CodeAsset.type],
             packageName: name,
             packageRoot: tempUri,
           )
-          ..setupBuildConfig(
+          ..setupBuild(
             linkingEnabled: false,
             dryRun: false,
           )
-          ..setupCodeConfig(
+          ..setupCode(
             targetOS: OS.windows,
             targetArchitecture: target,
             linkModePreference: linkMode == DynamicLoadingBundled()
                 ? LinkModePreference.dynamic
                 : LinkModePreference.static,
-            cCompilerConfig: cCompiler,
+            cCompiler: cCompiler,
           );
-        buildConfigBuilder.setupBuildRunConfig(
+        buildConfigBuilder.setupBuildAfterChecksum(
           outputDirectory: tempUri,
           outputDirectoryShared: tempUri2,
         );

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -48,24 +48,24 @@ void main() {
         final logger = createCapturingLogger(logMessages);
 
         final buildConfigBuilder = BuildConfigBuilder()
-          ..setupHookConfig(
+          ..setupHook(
             buildAssetTypes: [CodeAsset.type],
             packageName: name,
             packageRoot: tempUri,
           )
-          ..setupBuildConfig(
+          ..setupBuild(
             linkingEnabled: false,
             dryRun: false,
           )
-          ..setupCodeConfig(
+          ..setupCode(
             targetOS: targetOS,
-            macOSConfig: macOSConfig,
+            macOS: macOSConfig,
             targetArchitecture: Architecture.current,
             // Ignored by executables.
             linkModePreference: LinkModePreference.dynamic,
-            cCompilerConfig: cCompiler,
+            cCompiler: cCompiler,
           );
-        buildConfigBuilder.setupBuildRunConfig(
+        buildConfigBuilder.setupBuildAfterChecksum(
           outputDirectory: tempUri,
           outputDirectoryShared: tempUri2,
         );
@@ -102,7 +102,7 @@ void main() {
           (message) => message.contains(helloWorldCUri.toFilePath()),
         );
 
-        switch ((buildConfig.codeConfig.targetOS, pic)) {
+        switch ((buildConfig.code.targetOS, pic)) {
           case (OS.windows, _) || (_, null):
             expect(compilerInvocation, isNot(contains('-fPIC')));
             expect(compilerInvocation, isNot(contains('-fPIE')));
@@ -131,23 +131,23 @@ void main() {
         final logger = createCapturingLogger(logMessages);
 
         final buildConfigBuilder = BuildConfigBuilder()
-          ..setupHookConfig(
+          ..setupHook(
             buildAssetTypes: [CodeAsset.type],
             packageName: name,
             packageRoot: tempUri,
           )
-          ..setupBuildConfig(
+          ..setupBuild(
             linkingEnabled: false,
             dryRun: dryRun,
           )
-          ..setupCodeConfig(
+          ..setupCode(
             targetOS: targetOS,
-            macOSConfig: macOSConfig,
+            macOS: macOSConfig,
             targetArchitecture: Architecture.current,
             linkModePreference: LinkModePreference.dynamic,
-            cCompilerConfig: dryRun ? null : cCompiler,
+            cCompiler: dryRun ? null : cCompiler,
           );
-        buildConfigBuilder.setupBuildRunConfig(
+        buildConfigBuilder.setupBuildAfterChecksum(
           outputDirectory: tempUri,
           outputDirectoryShared: tempUri2,
         );
@@ -178,7 +178,7 @@ void main() {
           final compilerInvocation = logMessages.singleWhere(
             (message) => message.contains(addCUri.toFilePath()),
           );
-          switch ((buildConfig.codeConfig.targetOS, pic)) {
+          switch ((buildConfig.code.targetOS, pic)) {
             case (OS.windows, _) || (_, null):
               expect(compilerInvocation, isNot(contains('-fPIC')));
               expect(compilerInvocation, isNot(contains('-fPIE')));
@@ -233,31 +233,31 @@ void main() {
     final logger = createCapturingLogger(logMessages);
 
     final buildConfigBuilder = BuildConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         buildAssetTypes: [CodeAsset.type],
         packageName: name,
         packageRoot: tempUri,
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         linkingEnabled: false,
         dryRun: false,
       )
-      ..setupCodeConfig(
+      ..setupCode(
         targetOS: targetOS,
-        macOSConfig: macOSConfig,
+        macOS: macOSConfig,
         targetArchitecture: Architecture.current,
         // Ignored by executables.
         linkModePreference: LinkModePreference.dynamic,
-        cCompilerConfig: cCompiler,
+        cCompiler: cCompiler,
       );
-    buildConfigBuilder.setupBuildRunConfig(
+    buildConfigBuilder.setupBuildAfterChecksum(
       outputDirectory: tempUri,
       outputDirectoryShared: tempUri2,
     );
     final buildConfig = BuildConfig(buildConfigBuilder.json);
     final buildOutput = BuildOutputBuilder();
 
-    final flag = switch (buildConfig.codeConfig.targetOS) {
+    final flag = switch (buildConfig.code.targetOS) {
       OS.windows => '/DFOO=USER_FLAG',
       _ => '-DFOO=USER_FLAG',
     };
@@ -301,24 +301,24 @@ void main() {
     const name = 'includes';
 
     final buildConfigBuilder = BuildConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         buildAssetTypes: [CodeAsset.type],
         packageName: name,
         packageRoot: tempUri,
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         linkingEnabled: false,
         dryRun: false,
       )
-      ..setupCodeConfig(
+      ..setupCode(
         targetOS: targetOS,
-        macOSConfig: macOSConfig,
+        macOS: macOSConfig,
         targetArchitecture: Architecture.current,
         // Ignored by executables.
         linkModePreference: LinkModePreference.dynamic,
-        cCompilerConfig: cCompiler,
+        cCompiler: cCompiler,
       );
-    buildConfigBuilder.setupBuildRunConfig(
+    buildConfigBuilder.setupBuildAfterChecksum(
       outputDirectory: tempUri,
       outputDirectoryShared: tempUri2,
     );
@@ -359,31 +359,31 @@ void main() {
 
     final targetOS = OS.current;
     final buildConfigBuilder = BuildConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         buildAssetTypes: [CodeAsset.type],
         packageName: name,
         packageRoot: tempUri,
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         linkingEnabled: false,
         dryRun: false,
       )
-      ..setupCodeConfig(
+      ..setupCode(
         targetOS: targetOS,
-        macOSConfig: macOSConfig,
+        macOS: macOSConfig,
         targetArchitecture: Architecture.current,
         // Ignored by executables.
         linkModePreference: LinkModePreference.dynamic,
-        cCompilerConfig: cCompiler,
+        cCompiler: cCompiler,
       );
-    buildConfigBuilder.setupBuildRunConfig(
+    buildConfigBuilder.setupBuildAfterChecksum(
       outputDirectory: tempUri,
       outputDirectoryShared: tempUri2,
     );
     final buildConfig = BuildConfig(buildConfigBuilder.json);
     final buildOutput = BuildOutputBuilder();
 
-    final stdFlag = switch (buildConfig.codeConfig.targetOS) {
+    final stdFlag = switch (buildConfig.code.targetOS) {
       OS.windows => '/std:$std',
       _ => '-std=$std',
     };
@@ -429,31 +429,31 @@ void main() {
 
     final targetOS = OS.current;
     final buildConfigBuilder = BuildConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         buildAssetTypes: [CodeAsset.type],
         packageName: name,
         packageRoot: tempUri,
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         linkingEnabled: false,
         dryRun: false,
       )
-      ..setupCodeConfig(
+      ..setupCode(
         targetOS: targetOS,
-        macOSConfig: macOSConfig,
+        macOS: macOSConfig,
         targetArchitecture: Architecture.current,
         // Ignored by executables.
         linkModePreference: LinkModePreference.dynamic,
-        cCompilerConfig: cCompiler,
+        cCompiler: cCompiler,
       );
-    buildConfigBuilder.setupBuildRunConfig(
+    buildConfigBuilder.setupBuildAfterChecksum(
       outputDirectory: tempUri,
       outputDirectoryShared: tempUri2,
     );
     final buildConfig = BuildConfig(buildConfigBuilder.json);
     final buildOutput = BuildOutputBuilder();
 
-    final defaultStdLibLinkFlag = switch (buildConfig.codeConfig.targetOS) {
+    final defaultStdLibLinkFlag = switch (buildConfig.code.targetOS) {
       OS.windows => null,
       OS.linux => '-l stdc++',
       OS.macOS => '-l c++',
@@ -504,24 +504,24 @@ void main() {
 
     final targetOS = OS.current;
     final buildConfigBuilder = BuildConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         buildAssetTypes: [CodeAsset.type],
         packageName: name,
         packageRoot: tempUri,
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         linkingEnabled: false,
         dryRun: false,
       )
-      ..setupCodeConfig(
+      ..setupCode(
         targetOS: targetOS,
-        macOSConfig: macOSConfig,
+        macOS: macOSConfig,
         targetArchitecture: Architecture.current,
         // Ignored by executables.
         linkModePreference: LinkModePreference.dynamic,
-        cCompilerConfig: cCompiler,
+        cCompiler: cCompiler,
       );
-    buildConfigBuilder.setupBuildRunConfig(
+    buildConfigBuilder.setupBuildAfterChecksum(
       outputDirectory: tempUri,
       outputDirectoryShared: tempUri2,
     );
@@ -536,7 +536,7 @@ void main() {
       buildMode: BuildMode.release,
     );
 
-    if (buildConfig.codeConfig.targetOS == OS.windows) {
+    if (buildConfig.code.targetOS == OS.windows) {
       await expectLater(
         () => cbuilder.run(
           config: buildConfig,
@@ -590,24 +590,24 @@ void main() {
 
     final targetOS = OS.current;
     final buildConfigBuilder = BuildConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         buildAssetTypes: [CodeAsset.type],
         packageName: name,
         packageRoot: tempUri,
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         linkingEnabled: false,
         dryRun: false,
       )
-      ..setupCodeConfig(
+      ..setupCode(
         targetOS: targetOS,
-        macOSConfig: macOSConfig,
+        macOS: macOSConfig,
         targetArchitecture: Architecture.current,
         // Ignored by executables.
         linkModePreference: LinkModePreference.dynamic,
-        cCompilerConfig: cCompiler,
+        cCompiler: cCompiler,
       );
-    buildConfigBuilder.setupBuildRunConfig(
+    buildConfigBuilder.setupBuildAfterChecksum(
       outputDirectory: tempUri,
       outputDirectoryShared: tempUri2,
     );
@@ -693,26 +693,26 @@ Future<void> testDefines({
 
   final targetOS = OS.current;
   final buildConfigBuilder = BuildConfigBuilder()
-    ..setupHookConfig(
+    ..setupHook(
       buildAssetTypes: [CodeAsset.type],
       packageName: name,
       packageRoot: tempUri,
     )
-    ..setupBuildConfig(
+    ..setupBuild(
       linkingEnabled: false,
       dryRun: false,
     )
-    ..setupCodeConfig(
+    ..setupCode(
       targetOS: targetOS,
-      macOSConfig: targetOS == OS.macOS
+      macOS: targetOS == OS.macOS
           ? MacOSConfig(targetVersion: defaultMacOSVersion)
           : null,
       targetArchitecture: Architecture.current,
       // Ignored by executables.
       linkModePreference: LinkModePreference.dynamic,
-      cCompilerConfig: cCompiler,
+      cCompiler: cCompiler,
     );
-  buildConfigBuilder.setupBuildRunConfig(
+  buildConfigBuilder.setupBuildAfterChecksum(
     outputDirectory: tempUri,
     outputDirectoryShared: tempUri2,
   );

--- a/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
@@ -43,62 +43,62 @@ void main() {
 
     final targetOS = OS.current;
     final buildConfigBuilder = BuildConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         buildAssetTypes: [CodeAsset.type],
         packageName: 'dummy',
         packageRoot: tempUri,
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         linkingEnabled: false,
         dryRun: false,
       )
-      ..setupCodeConfig(
+      ..setupCode(
         targetOS: targetOS,
-        macOSConfig: targetOS == OS.macOS
+        macOS: targetOS == OS.macOS
             ? MacOSConfig(targetVersion: defaultMacOSVersion)
             : null,
         targetArchitecture: Architecture.current,
         linkModePreference: LinkModePreference.dynamic,
-        cCompilerConfig: CCompilerConfig(
+        cCompiler: CCompilerConfig(
           archiver: ar,
           compiler: cc,
           linker: ld,
           envScript: envScript,
         ),
       );
-    buildConfigBuilder.setupBuildRunConfig(
+    buildConfigBuilder.setupBuildAfterChecksum(
       outputDirectory: tempUri,
       outputDirectoryShared: tempUri2,
     );
     final buildConfig = BuildConfig(buildConfigBuilder.json);
     final resolver =
-        CompilerResolver(codeConfig: buildConfig.codeConfig, logger: logger);
+        CompilerResolver(codeConfig: buildConfig.code, logger: logger);
     final compiler = await resolver.resolveCompiler();
     final archiver = await resolver.resolveArchiver();
-    expect(compiler.uri, buildConfig.codeConfig.cCompiler?.compiler);
-    expect(archiver.uri, buildConfig.codeConfig.cCompiler?.archiver);
+    expect(compiler.uri, buildConfig.code.cCompiler?.compiler);
+    expect(archiver.uri, buildConfig.code.cCompiler?.archiver);
   });
 
   test('No compiler found', () async {
     final tempUri = await tempDirForTest();
     final tempUri2 = await tempDirForTest();
     final buildConfigBuilder = BuildConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         buildAssetTypes: [CodeAsset.type],
         packageName: 'dummy',
         packageRoot: tempUri,
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         linkingEnabled: false,
         dryRun: false,
       )
-      ..setupCodeConfig(
+      ..setupCode(
         targetOS: OS.windows,
         targetArchitecture: Architecture.arm64,
         linkModePreference: LinkModePreference.dynamic,
-        cCompilerConfig: cCompiler,
+        cCompiler: cCompiler,
       );
-    buildConfigBuilder.setupBuildRunConfig(
+    buildConfigBuilder.setupBuildAfterChecksum(
       outputDirectoryShared: tempUri2,
       outputDirectory: tempUri,
     );
@@ -106,7 +106,7 @@ void main() {
     final buildConfig = BuildConfig(buildConfigBuilder.json);
 
     final resolver = CompilerResolver(
-      codeConfig: buildConfig.codeConfig,
+      codeConfig: buildConfig.code,
       logger: logger,
       hostOS: OS.android, // This is never a host.
       hostArchitecture: Architecture.arm64, // This is never a host.

--- a/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
@@ -37,25 +37,25 @@ void main() {
 
     final targetOS = OS.current;
     final buildConfigBuilder = BuildConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         buildAssetTypes: [CodeAsset.type],
         packageName: name,
         packageRoot: tempUri,
       )
-      ..setupBuildConfig(
+      ..setupBuild(
         linkingEnabled: false,
         dryRun: false,
       )
-      ..setupCodeConfig(
+      ..setupCode(
         targetOS: targetOS,
-        macOSConfig: targetOS == OS.macOS
+        macOS: targetOS == OS.macOS
             ? MacOSConfig(targetVersion: defaultMacOSVersion)
             : null,
         targetArchitecture: Architecture.current,
         linkModePreference: LinkModePreference.dynamic,
-        cCompilerConfig: cCompiler,
+        cCompiler: cCompiler,
       );
-    buildConfigBuilder.setupBuildRunConfig(
+    buildConfigBuilder.setupBuildAfterChecksum(
       outputDirectory: tempUri,
       outputDirectoryShared: tempUri2,
     );

--- a/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
+++ b/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
@@ -27,22 +27,22 @@ Future<Uri> buildTestArchive(
 
   assert(os == OS.linux); // Setup code config for other OSes.
   final buildConfigBuilder = BuildConfigBuilder()
-    ..setupHookConfig(
+    ..setupHook(
       buildAssetTypes: [CodeAsset.type],
       packageName: name,
       packageRoot: tempUri,
     )
-    ..setupBuildConfig(
+    ..setupBuild(
       linkingEnabled: false,
       dryRun: false,
     )
-    ..setupCodeConfig(
+    ..setupCode(
       targetOS: os,
       targetArchitecture: architecture,
       linkModePreference: LinkModePreference.dynamic,
-      cCompilerConfig: cCompiler,
+      cCompiler: cCompiler,
     );
-  buildConfigBuilder.setupBuildRunConfig(
+  buildConfigBuilder.setupBuildAfterChecksum(
     outputDirectory: tempUri,
     outputDirectoryShared: tempUri2,
   );
@@ -64,5 +64,5 @@ Future<Uri> buildTestArchive(
   );
 
   final buildOutput = BuildOutput(buildOutputBuilder.json);
-  return buildOutput.codeAssets.first.file!;
+  return buildOutput.code.assets.first.file!;
 }

--- a/pkgs/native_toolchain_c/test/clinker/objects_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/objects_test.dart
@@ -32,7 +32,7 @@ Future<void> main() async {
     final uri = await buildTestArchive(tempUri, tempUri2, os, architecture);
 
     final linkConfigBuilder = LinkConfigBuilder()
-      ..setupHookConfig(
+      ..setupHook(
         buildAssetTypes: [CodeAsset.type],
         packageName: 'testpackage',
         packageRoot: tempUri,
@@ -40,13 +40,13 @@ Future<void> main() async {
       ..setupLinkConfig(
         assets: [],
       )
-      ..setupCodeConfig(
+      ..setupCode(
         targetOS: os,
         targetArchitecture: architecture,
         linkModePreference: LinkModePreference.dynamic,
-        cCompilerConfig: cCompiler,
+        cCompiler: cCompiler,
       );
-    linkConfigBuilder.setupLinkRunConfig(
+    linkConfigBuilder.setupLinkAfterChecksum(
       outputDirectory: tempUri,
       outputDirectoryShared: tempUri2,
       recordedUsesFile: null,
@@ -54,7 +54,7 @@ Future<void> main() async {
     final linkConfig = LinkConfig(linkConfigBuilder.json);
     final linkOutput = LinkOutputBuilder();
 
-    printOnFailure(linkConfig.codeConfig.cCompiler.toString());
+    printOnFailure(linkConfig.code.cCompiler.toString());
     printOnFailure(Platform.environment.keys.toList().toString());
     await CLinker.library(
       name: name,
@@ -67,7 +67,7 @@ Future<void> main() async {
       logger: logger,
     );
 
-    final codeAssets = LinkOutput(linkOutput.json).codeAssets;
+    final codeAssets = LinkOutput(linkOutput.json).code.assets;
     expect(codeAssets, hasLength(1));
     final asset = codeAssets.first;
     expect(asset, isA<CodeAsset>());

--- a/pkgs/native_toolchain_c/test/clinker/throws_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/throws_test.dart
@@ -23,7 +23,7 @@ Future<void> main() async {
         final tempUri2 = await tempDirForTest();
 
         final linkConfigBuilder = LinkConfigBuilder()
-          ..setupHookConfig(
+          ..setupHook(
             buildAssetTypes: [CodeAsset.type],
             packageName: 'testpackage',
             packageRoot: tempUri,
@@ -31,13 +31,13 @@ Future<void> main() async {
           ..setupLinkConfig(
             assets: [],
           )
-          ..setupCodeConfig(
+          ..setupCode(
             targetOS: os,
             targetArchitecture: Architecture.x64,
             linkModePreference: LinkModePreference.dynamic,
-            cCompilerConfig: cCompiler,
+            cCompiler: cCompiler,
           );
-        linkConfigBuilder.setupLinkRunConfig(
+        linkConfigBuilder.setupLinkAfterChecksum(
           outputDirectoryShared: tempUri2,
           outputDirectory: tempUri,
           recordedUsesFile: null,

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
@@ -62,7 +62,7 @@ Future<void> runTests(List<Architecture> architectures) async {
         );
 
         final linkConfigBuilder = LinkConfigBuilder()
-          ..setupHookConfig(
+          ..setupHook(
             buildAssetTypes: [CodeAsset.type],
             packageName: 'testpackage',
             packageRoot: tempUri,
@@ -70,13 +70,13 @@ Future<void> runTests(List<Architecture> architectures) async {
           ..setupLinkConfig(
             assets: [],
           )
-          ..setupCodeConfig(
+          ..setupCode(
             targetOS: os,
             targetArchitecture: architecture,
             linkModePreference: LinkModePreference.dynamic,
-            cCompilerConfig: cCompiler,
+            cCompiler: cCompiler,
           );
-        linkConfigBuilder.setupLinkRunConfig(
+        linkConfigBuilder.setupLinkAfterChecksum(
           outputDirectory: tempUri,
           outputDirectoryShared: tempUri2,
           recordedUsesFile: null,
@@ -84,7 +84,7 @@ Future<void> runTests(List<Architecture> architectures) async {
         final linkConfig = LinkConfig(linkConfigBuilder.json);
         final linkOutputBuilder = LinkOutputBuilder();
 
-        printOnFailure(linkConfig.codeConfig.cCompiler.toString());
+        printOnFailure(linkConfig.code.cCompiler.toString());
         printOnFailure(Platform.environment.keys.toList().toString());
         await clinker.linker([testArchive.toFilePath()]).run(
           config: linkConfig,
@@ -93,7 +93,7 @@ Future<void> runTests(List<Architecture> architectures) async {
         );
 
         final linkOutput = LinkOutput(linkOutputBuilder.json);
-        final asset = linkOutput.codeAssets.first;
+        final asset = linkOutput.code.assets.first;
         final filePath = asset.file!.toFilePath();
 
         final machine = await readelfMachine(filePath);


### PR DESCRIPTION
Addresses:

* https://github.com/dart-lang/native/issues/1738#issuecomment-2535921222

A variant of:

* https://github.com/dart-lang/native/pull/1829

This PR normalizes the `code` and `data` specific APIs on the config, config builder, output and output builders under a `.code` and `.data` extension.

Example link hook code:

```dart
void main(List<String> args) async {
  await link(
    args,
    (config, output) async =>
        output.data.addAssets(treeshake(config.data.assets)),
  );
}
```

Example build hook code:

```dart

void main(List<String> arguments) async {
  await build(arguments, (config, output) async {
    if (config.code.targetOS == OS.android) {
      config.code.android.targetNdkApi;
    }

    output.code.addAsset( ... );
  });
}
```

This drops `Config` suffixes from the various config accessors.
This changes `output.codeAssets.add(` to `output.code.addAsset(`.

The weird quirk in this PR is that it has to provide an API for `LinkConfig.code` that gives both the `CodeConfig` getters and an `assets` getter. I tried using extension types to alleviate this, but extension types can only extend the type they are extending, not the first element of a tuple they are extending.

Separating the `linkConfig.code : CodeConfig` and `linkConfig.assets.code : Iterable<CodeAsset>` leads to a less symmetric API though:

* https://github.com/dart-lang/native/pull/1829

Alternatively, we could also opt to land neither of the PRs. And stick with `config.codeConfig.androidConfig` and `output.codeAssets`.