### PR TITLE
[swift2objc] Support Protocols

### DIFF
--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/protocol_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/protocol_declaration.dart
@@ -4,13 +4,14 @@
 
 import '../../_core/interfaces/compound_declaration.dart';
 import '../../_core/interfaces/nestable_declaration.dart';
+import '../../_core/interfaces/objc_annotatable.dart';
 import '../../_core/shared/referred_type.dart';
 import 'members/initializer_declaration.dart';
 import 'members/method_declaration.dart';
 import 'members/property_declaration.dart';
 
 /// Describes the declaration of a Swift protocol.
-class ProtocolDeclaration implements CompoundDeclaration {
+class ProtocolDeclaration implements CompoundDeclaration, ObjCAnnotatable {
   @override
   String id;
 
@@ -23,8 +24,19 @@ class ProtocolDeclaration implements CompoundDeclaration {
   @override
   covariant List<MethodDeclaration> methods;
 
+  /// Only present if indicated with `@objc`
+  @override
+  List<PropertyDeclaration> optionalProperties;
+
+  /// Only present if indicated with `@objc`
+  @override
+  List<MethodDeclaration> optionalMethods;
+
   @override
   List<DeclaredType<ProtocolDeclaration>> conformedProtocols;
+
+  @override
+  bool hasObjCAnnotation;
 
   @override
   List<GenericType> typeParams;
@@ -46,7 +58,10 @@ class ProtocolDeclaration implements CompoundDeclaration {
     required this.initializers,
     required this.conformedProtocols,
     required this.typeParams,
+    this.hasObjCAnnotation = false,
     this.nestingParent,
     this.nestedDeclarations = const [],
+    this.optionalMethods = const [],
+    this.optionalProperties = const [],
   });
 }

--- a/pkgs/swift2objc/lib/src/parser/_core/parsed_symbolgraph.dart
+++ b/pkgs/swift2objc/lib/src/parser/_core/parsed_symbolgraph.dart
@@ -35,6 +35,10 @@ class ParsedRelation {
 }
 
 enum ParsedRelationKind {
+  requirementOf,
+  defaultImplementationOf,
+  optionalRequirementOf,
+  conformsTo,
   memberOf;
 
   static final _supportedRelationKindsMap = {

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_compound_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_compound_declaration.dart
@@ -8,6 +8,7 @@ import '../../../ast/declarations/compounds/class_declaration.dart';
 import '../../../ast/declarations/compounds/members/initializer_declaration.dart';
 import '../../../ast/declarations/compounds/members/method_declaration.dart';
 import '../../../ast/declarations/compounds/members/property_declaration.dart';
+import '../../../ast/declarations/compounds/protocol_declaration.dart';
 import '../../../ast/declarations/compounds/struct_declaration.dart';
 import '../../_core/parsed_symbolgraph.dart';
 import '../../_core/utils.dart';
@@ -106,4 +107,13 @@ StructDeclaration parseStructDeclaration(
     StructDeclaration.new,
     symbolgraph,
   );
+}
+
+// This won't work as there's more for a protocol declaration
+// Placing this here as placeholder declaration
+ProtocolDeclaration parseProtocolDeclaration(
+  ParsedSymbol protocolSymbol,
+  ParsedSymbolgraph symbolgraph
+) {
+  return _parseCompoundDeclaration(protocolSymbol, ProtocolDeclaration.new, symbolgraph);
 }

--- a/pkgs/swift2objc/lib/src/parser/parsers/parse_declarations.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/parse_declarations.dart
@@ -56,6 +56,7 @@ Declaration parseDeclaration(
     'swift.init' => parseInitializerDeclaration(symbolJson, symbolgraph),
     'swift.func' => parseGlobalFunctionDeclaration(symbolJson, symbolgraph),
     'swift.var' => parseGlobalVariableDeclaration(symbolJson, symbolgraph),
+    'swift.protocol' => parseProtocolDeclaration(parsedSymbol, symbolgraph),
     _ => throw Exception(
         'Symbol of type $symbolType is not implemented yet.',
       ),


### PR DESCRIPTION
From https://docs.swift.org/swift-book/documentation/the-swift-programming-language/protocols/#Protocol-Extensions:
> A protocol defines a blueprint of methods, properties, and other requirements that suit a particular task or piece of functionality. The protocol can then be adopted by a class, structure, or enumeration to provide an actual implementation of those requirements. Any type that satisfies the requirements of a protocol is said to conform to that protocol.

This pull request adds support for parsing protocols by achieving the following:
- [x] Adding support for parsing basic protocols
- [x] Adding parsing support for optional methods and properties
- [x] Adding parsing support for conformed protocols (protocols that the given protocol inherits)
- [ ] Adding support for custom types in protocols via `associatedType`s
- [ ] Adding support for methods and properties that act as default initialisations for protocols
- [ ] Writing tests that cover all given requirements

See #1828 for more information