### PR TITLE
[native_toolchain_c] Skip building dylib if code asset type not reque…

### DIFF
--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -117,6 +117,11 @@ class CBuilder extends CTool implements Builder {
     required Logger? logger,
     String? linkInPackage,
   }) async {
+    if (!config.buildAssetTypes.contains(CodeAsset.type)) {
+      logger?.info('buildAssetTypes did not contain "${CodeAsset.type}", '
+          'skipping CodeAsset $assetName build.');
+      return;
+    }
     assert(
       config.linkingEnabled || linkInPackage == null,
       'linkInPackage can only be provided if config.linkingEnabled is true.',


### PR DESCRIPTION
Follow up of:

* https://github.com/dart-lang/native/pull/1786

Hooks should not fail early if an asset type is not requested to build.

In order to avoid hook writers having to wrap the `Builder`s for all the various asset types with statements checking that those asset types are requested, the builders themselves just no-op if the asset type is not requested.