### PR TITLE
[native_assets_builder] Try fix Flutter roll

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.1
+
+- Try fixing Flutter by passing in `FLUTTER_ROOT` to hook invocations.
+  https://github.com/dart-lang/native/issues/1847
+
 ## 0.10.0
 
 - Removed support for dry run (Flutter no long requires it).

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -426,6 +426,7 @@ ${e.message}
   /// compilers.
   static const _environmentVariablesFilter = {
     'ANDROID_HOME', // Needed for the NDK.
+    'FLUTTER_ROOT', // TODO(dacoharkes): Fix in a different way.
     'HOME', // Needed to find tools in default install locations.
     'PATH', // Needed to invoke native tools.
     'PROGRAMDATA', // Needed for vswhere.exe.

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -426,7 +426,7 @@ ${e.message}
   /// compilers.
   static const _environmentVariablesFilter = {
     'ANDROID_HOME', // Needed for the NDK.
-    'FLUTTER_ROOT', // TODO(dacoharkes): Fix in a different way.
+    'FLUTTER_ROOT', // TODO(dcharkes): Fix in a different way or revert.
     'HOME', // Needed to find tools in default install locations.
     'PATH', // Needed to invoke native tools.
     'PROGRAMDATA', // Needed for vswhere.exe.

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_assets_builder
 description: >-
   This package is the backend that invokes build hooks.
-version: 0.10.0
+version: 0.10.1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_builder
 
 # publish_to: none


### PR DESCRIPTION
Possibly fixes https://github.com/dart-lang/native/issues/1847.

It's impossible to test if this fix works without releasing a new version unfortunately. It doesn't reproduce for me locally, and [the CI on Flutter doesn't work with git dependencies](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8727097029219810449/+/u/download_dependencies__2_/stdout).

The only git commands I can find in the various `.bat` scripts are using `FLUTTER_ROOT`. And the invocation of the Dart executable is failing with a git error and git exit code. So it must be the wrapper script around `dart.exe` that's crashing.

The proper fix would be to let Flutter pass in the environment with `FLUTTER_ROOT`, but for now I simply want to unstuck the Flutter roll first.