### PR TITLE
[native_assets_builder] Make hook environment configurable

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1
+
+- Pass in the environment for hook invocations.
+
 ## 0.10.0
 
 - Removed support for dry run (Flutter no long requires it).

--- a/pkgs/native_assets_builder/lib/native_assets_builder.dart
+++ b/pkgs/native_assets_builder/lib/native_assets_builder.dart
@@ -2,7 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'package:native_assets_builder/src/build_runner/build_runner.dart';
+export 'package:native_assets_builder/src/build_runner/build_runner.dart'
+    show
+        ApplicationAssetValidator,
+        BuildConfigValidator,
+        BuildValidator,
+        LinkConfigValidator,
+        LinkValidator,
+        NativeAssetsBuildRunner;
 export 'package:native_assets_builder/src/model/build_result.dart';
 export 'package:native_assets_builder/src/model/kernel_assets.dart';
 export 'package:native_assets_builder/src/model/link_result.dart';

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_assets_builder
 description: >-
   This package is the backend that invokes build hooks.
-version: 0.10.0
+version: 0.10.1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_builder
 
 # publish_to: none

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_caching_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_caching_test.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:native_assets_builder/src/build_runner/build_runner.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';
@@ -221,75 +222,81 @@ void main() async {
     },
   );
 
-  test(
-    'change environment',
-    timeout: longTimeout,
-    () async {
-      await inTempDir((tempUri) async {
-        await copyTestProjects(targetUri: tempUri);
-        final packageUri = tempUri.resolve('native_add/');
+  for (final modifiedEnvKey in ['PATH', 'CUSTOM_KEY_123']) {
+    test(
+      'change environment $modifiedEnvKey',
+      timeout: longTimeout,
+      () async {
+        await inTempDir((tempUri) async {
+          await copyTestProjects(targetUri: tempUri);
+          final packageUri = tempUri.resolve('native_add/');
 
-        final logMessages = <String>[];
-        final logger = createCapturingLogger(logMessages);
+          final logMessages = <String>[];
+          final logger = createCapturingLogger(logMessages);
 
-        await runPubGet(workingDirectory: packageUri, logger: logger);
-        logMessages.clear();
+          await runPubGet(workingDirectory: packageUri, logger: logger);
+          logMessages.clear();
 
-        final result = (await build(
-          packageUri,
-          logger,
-          dartExecutable,
-          buildAssetTypes: [CodeAsset.type],
-          configValidator: validateCodeAssetBuildConfig,
-          buildValidator: validateCodeAssetBuildOutput,
-          applicationAssetValidator: validateCodeAssetInApplication,
-        ))!;
-        logMessages.clear();
+          final result = (await build(
+            packageUri,
+            logger,
+            dartExecutable,
+            buildAssetTypes: [CodeAsset.type],
+            configValidator: validateCodeAssetBuildConfig,
+            buildValidator: validateCodeAssetBuildOutput,
+            applicationAssetValidator: validateCodeAssetInApplication,
+            hookEnvironment: modifiedEnvKey == 'PATH'
+                ? null
+                : filteredEnvironment(
+                    NativeAssetsBuildRunner.hookEnvironmentVariablesFilter,
+                  ),
+          ))!;
+          logMessages.clear();
 
-        // Simulate that the environment variables changed by augmenting the
-        // persisted environment from the last invocation.
-        final dependenciesHashFile = File.fromUri(
-          CodeAsset.fromEncoded(result.encodedAssets.single)
-              .file!
-              .parent
-              .parent
-              .resolve('dependencies.dependencies_hash_file.json'),
-        );
-        expect(await dependenciesHashFile.exists(), true);
-        final dependenciesContent =
-            jsonDecode(await dependenciesHashFile.readAsString())
-                as Map<Object, Object?>;
-        const modifiedEnvKey = 'PATH';
-        (dependenciesContent['environment'] as List<dynamic>).add({
-          'key': modifiedEnvKey,
-          'hash': 123456789,
+          // Simulate that the environment variables changed by augmenting the
+          // persisted environment from the last invocation.
+          final dependenciesHashFile = File.fromUri(
+            CodeAsset.fromEncoded(result.encodedAssets.single)
+                .file!
+                .parent
+                .parent
+                .resolve('dependencies.dependencies_hash_file.json'),
+          );
+          expect(await dependenciesHashFile.exists(), true);
+          final dependenciesContent =
+              jsonDecode(await dependenciesHashFile.readAsString())
+                  as Map<Object, Object?>;
+          (dependenciesContent['environment'] as List<dynamic>).add({
+            'key': modifiedEnvKey,
+            'hash': 123456789,
+          });
+          await dependenciesHashFile
+              .writeAsString(jsonEncode(dependenciesContent));
+
+          (await build(
+            packageUri,
+            logger,
+            dartExecutable,
+            buildAssetTypes: [CodeAsset.type],
+            configValidator: validateCodeAssetBuildConfig,
+            buildValidator: validateCodeAssetBuildOutput,
+            applicationAssetValidator: validateCodeAssetInApplication,
+          ))!;
+          expect(
+            logMessages.join('\n'),
+            contains('hook.dill'),
+          );
+          expect(
+            logMessages.join('\n'),
+            isNot(contains('Skipping build for native_add')),
+          );
+          expect(
+            logMessages.join('\n'),
+            contains('Environment variable changed: $modifiedEnvKey.'),
+          );
+          logMessages.clear();
         });
-        await dependenciesHashFile
-            .writeAsString(jsonEncode(dependenciesContent));
-
-        (await build(
-          packageUri,
-          logger,
-          dartExecutable,
-          buildAssetTypes: [CodeAsset.type],
-          configValidator: validateCodeAssetBuildConfig,
-          buildValidator: validateCodeAssetBuildOutput,
-          applicationAssetValidator: validateCodeAssetInApplication,
-        ))!;
-        expect(
-          logMessages.join('\n'),
-          contains('hook.dill'),
-        );
-        expect(
-          logMessages.join('\n'),
-          isNot(contains('Skipping build for native_add')),
-        );
-        expect(
-          logMessages.join('\n'),
-          contains('Environment variable changed: $modifiedEnvKey.'),
-        );
-        logMessages.clear();
-      });
-    },
-  );
+      },
+    );
+  }
 }

--- a/pkgs/native_assets_builder/test/build_runner/helpers.dart
+++ b/pkgs/native_assets_builder/test/build_runner/helpers.dart
@@ -48,6 +48,7 @@ Future<BuildResult?> build(
   Target? target,
   bool linkingEnabled = false,
   required List<String> buildAssetTypes,
+  Map<String, String>? hookEnvironment,
 }) async {
   final targetOS = target?.os ?? OS.current;
   return await runWithLog(capturedLogs, () async {
@@ -55,6 +56,7 @@ Future<BuildResult?> build(
       logger: logger,
       dartExecutable: dartExecutable,
       fileSystem: const LocalFileSystem(),
+      hookEnvironment: hookEnvironment,
     ).build(
       configCreator: () {
         final configBuilder = BuildConfigBuilder();


### PR DESCRIPTION
Make the environment used to invoke hooks configurable.

The flutter roll is failing currently, and I suspect it has to do with our change to tie down the environment variables. The execution of the `dart` executable fails. https://github.com/dart-lang/native/issues/1847

We can't easily troubleshoot which env key is missing currently, because the environment is not configurable from the embedder.

Since we'd like the embedder to be able to configure the environment anyways (e.g. Flutter might want to pass in `ANDROID_HOME` but Dart not), make the change now.

Hopefully, we can then trouble-shoot what's going on. (At the very least we can try passing the full environment in flutter_tools to see if that fixes the issue.)

