### PR TITLE
[native_assets_builder] Make hook environment configurable - fix

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.2
+
+- Export types (fix for 0.10.1).
+
 ## 0.10.1
 
 - Pass in the environment for hook invocations.

--- a/pkgs/native_assets_builder/lib/native_assets_builder.dart
+++ b/pkgs/native_assets_builder/lib/native_assets_builder.dart
@@ -5,8 +5,10 @@
 export 'package:native_assets_builder/src/build_runner/build_runner.dart'
     show
         ApplicationAssetValidator,
+        BuildConfigCreator,
         BuildConfigValidator,
         BuildValidator,
+        LinkConfigCreator,
         LinkConfigValidator,
         LinkValidator,
         NativeAssetsBuildRunner;

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_assets_builder
 description: >-
   This package is the backend that invokes build hooks.
-version: 0.10.1
+version: 0.10.2
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_builder
 
 # publish_to: none


### PR DESCRIPTION
The health workflow is disabled currently, and https://github.com/dart-lang/native/pull/1853 accidentally hid too many public types.