### PR TITLE
[ffigen] Disable enum warning for ObjC

### DIFF
--- a/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
@@ -907,7 +907,7 @@ class YamlConfig implements Config {
         HeterogeneousMapEntry(
           key: strings.silenceEnumWarning,
           valueConfigSpec: BoolConfigSpec(),
-          defaultValue: (node) => false,
+          defaultValue: (node) => language == Language.objc,
           resultOrDefault: (node) => _silenceEnumWarning = node.value as bool,
         ),
         HeterogeneousMapEntry(


### PR DESCRIPTION
This warning is only relevant on Windows, so we don't need it for ObjC, which is only supported on iOS/macOS.

Fixes #1817