### PR TITLE
[infra] Flip `native_x` packages back to wip

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -6,7 +6,6 @@
             "[infra] ",
             "[jni] ",
             "[jnigen] ",
-            "[native_*] ",
             "[native_assets_builder] ",
             "[native_assets_cli] ",
             "[native_toolchain_c] ",

--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -6,6 +6,7 @@
             "[infra] ",
             "[jni] ",
             "[jnigen] ",
+            "[native_*] ",
             "[native_assets_builder] ",
             "[native_assets_cli] ",
             "[native_toolchain_c] ",

--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.3-wip
+
+- Nothing yet.
+
 ## 0.10.2
 
 - Export types (fix for 0.10.1).

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -1,10 +1,10 @@
 name: native_assets_builder
 description: >-
   This package is the backend that invokes build hooks.
-version: 0.10.2
+version: 0.10.3-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_builder
 
-# publish_to: none
+publish_to: none
 
 environment:
   sdk: '>=3.5.0 <4.0.0'
@@ -15,9 +15,9 @@ dependencies:
   file: ^7.0.1
   graphs: ^2.3.1
   logging: ^1.2.0
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../native_assets_cli/
   package_config: ^2.1.0
   yaml: ^3.1.2
   yaml_edit: ^2.1.0

--- a/pkgs/native_assets_builder/test_data/add_asset_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/add_asset_link/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
 dependencies:
   logging: ^1.1.1
   meta: ^1.12.0
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
-  native_toolchain_c: ^0.7.0
-  # native_toolchain_c:
-  #   path: ../../../native_toolchain_c/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+  # native_toolchain_c: ^0.7.0
+  native_toolchain_c:
+    path: ../../../native_toolchain_c/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_builder/test_data/complex_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/complex_link/pubspec.yaml
@@ -12,9 +12,9 @@ dependencies:
   complex_link_helper:
     path: ../complex_link_helper/
   logging: ^1.1.1
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_builder/test_data/complex_link_helper/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/complex_link_helper/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   cli_config: ^0.2.0
   logging: ^1.1.1
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_builder/test_data/cyclic_package_1/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/cyclic_package_1/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   cyclic_package_2:
     path: ../cyclic_package_2
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test_data/cyclic_package_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/cyclic_package_2/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   cyclic_package_1:
     path: ../cyclic_package_1
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test_data/depend_on_fail_build/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/depend_on_fail_build/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   fail_build:
     path: ../fail_build/
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/depend_on_fail_build_app/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/depend_on_fail_build_app/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   depend_on_fail_build:
     path: ../depend_on_fail_build/
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/drop_dylib_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/drop_dylib_link/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
-  native_toolchain_c: ^0.7.0
-  # native_toolchain_c:
-  #   path: ../../../native_toolchain_c/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+  # native_toolchain_c: ^0.7.0
+  native_toolchain_c:
+    path: ../../../native_toolchain_c/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_builder/test_data/fail_build/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_build/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   fail_on_os_sdk_version_linker:
     path: ../fail_on_os_sdk_version_linker/
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
-  native_toolchain_c: ^0.7.0
-  # native_toolchain_c:
-  #   path: ../../../native_toolchain_c/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+  # native_toolchain_c: ^0.7.0
+  native_toolchain_c:
+    path: ../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
-  native_toolchain_c: ^0.7.0
-  # native_toolchain_c:
-  #   path: ../../../native_toolchain_c/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+  # native_toolchain_c: ^0.7.0
+  native_toolchain_c:
+    path: ../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/native_add_duplicate/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_duplicate/pubspec.yaml
@@ -11,12 +11,12 @@ dependencies:
   logging: ^1.1.1
   native_add:
     path: ../native_add/
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
-  native_toolchain_c: ^0.7.0
-  # native_toolchain_c:
-  #   path: ../../../native_toolchain_c/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+  # native_toolchain_c: ^0.7.0
+  native_toolchain_c:
+    path: ../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/native_dynamic_linking/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_dynamic_linking/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
-  native_toolchain_c: ^0.7.0
-  # native_toolchain_c:
-  #   path: ../../../native_toolchain_c/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+  # native_toolchain_c: ^0.7.0
+  native_toolchain_c:
+    path: ../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
-  native_toolchain_c: ^0.7.0
-  # native_toolchain_c:
-  #   path: ../../../native_toolchain_c/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+  # native_toolchain_c: ^0.7.0
+  native_toolchain_c:
+    path: ../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/no_asset_for_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/no_asset_for_link/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   logging: ^1.1.1
   meta: ^1.12.0
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_builder/test_data/package_reading_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/package_reading_metadata/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   package_with_metadata:
     path: ../package_with_metadata/
   yaml: ^3.1.1

--- a/pkgs/native_assets_builder/test_data/package_with_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/package_with_metadata/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test_data/simple_data_asset/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/simple_data_asset/pubspec.yaml
@@ -9,9 +9,9 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_builder/test_data/simple_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/simple_link/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   cli_config: ^0.2.0
   logging: ^1.1.1
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_builder/test_data/transformer/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/transformer/pubspec.yaml
@@ -9,9 +9,9 @@ environment:
 
 dependencies:
   crypto: ^3.0.6
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/native_assets_builder/test_data/treeshaking_native_libs/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/treeshaking_native_libs/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
-  native_toolchain_c: ^0.7.0
-  # native_toolchain_c:
-  #   path: ../../../native_toolchain_c/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+  # native_toolchain_c: ^0.7.0
+  native_toolchain_c:
+    path: ../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/wrong_build_output/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test_data/wrong_build_output_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output_2/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test_data/wrong_build_output_3/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output_3/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test_data/wrong_linker/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_linker/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test_data/wrong_namespace_asset/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_namespace_asset/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
   yaml: ^3.1.1
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1
+
+- Nothing yet.
+
 ## 0.10.0
 
 - **Breaking change** The library import paths changed to be per asset type.

--- a/pkgs/native_assets_cli/example/build/local_asset/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/local_asset/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../../native_assets_cli/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_cli/example/build/native_add_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/native_add_library/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../../native_assets_cli/
-  native_toolchain_c: ^0.7.0
-  # native_toolchain_c:
-  #   path: ../../../../native_toolchain_c/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../../native_assets_cli/
+  # native_toolchain_c: ^0.7.0
+  native_toolchain_c:
+    path: ../../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_cli/example/build/native_dynamic_linking/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/native_dynamic_linking/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../../native_assets_cli/
-  native_toolchain_c: ^0.7.0
-  # native_toolchain_c:
-  #   path: ../../../../native_toolchain_c/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../../native_assets_cli/
+  # native_toolchain_c: ^0.7.0
+  native_toolchain_c:
+    path: ../../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_cli/example/build/use_dart_api/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/use_dart_api/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../../native_assets_cli/
-  native_toolchain_c: ^0.7.0
-  # native_toolchain_c:
-  #   path: ../../../../native_toolchain_c/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../../native_assets_cli/
+  # native_toolchain_c: ^0.7.0
+  native_toolchain_c:
+    path: ../../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^10.0.0

--- a/pkgs/native_assets_cli/example/link/package_with_assets/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/link/package_with_assets/pubspec.yaml
@@ -11,9 +11,9 @@ environment:
 dependencies:
   logging: ^1.1.1
   meta: ^1.12.0
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../../../../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../../native_assets_cli/
   record_use: ^0.3.0
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -4,10 +4,10 @@ description: >-
   native assets CLI.
 
 # Note: Bump BuildConfig.version and BuildOutput.version on breaking changes!
-version: 0.10.0
+version: 0.10.1-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
-# publish_to: none
+publish_to: none
 
 topics:
   - ffi

--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1-wip
+
+- Nothing yet.
+
 ## 0.7.0
 
 - For Android, produce dylibs with page-size set to 16kb by default.

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,10 +1,10 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.7.0
+version: 0.7.1-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
-# publish_to: none
+publish_to: none
 
 topics:
   - compiler
@@ -20,9 +20,9 @@ dependencies:
   glob: ^2.1.1
   logging: ^1.1.1
   meta: ^1.9.1
-  native_assets_cli: ^0.10.0
-  # native_assets_cli:
-  #   path: ../native_assets_cli/
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../native_assets_cli/
   pub_semver: ^2.1.3
 
 dev_dependencies:


### PR DESCRIPTION
We have published new versions of the following packages:

  * `package:native_assets_builder`
  * `package:native_assets_cli`
  * `package:native_toolchain_c`

So we can switch the repository back to "development mode" and use path dependencies.