### PR TITLE
[native_toolchain_c] Support environment for `cl.exe` already set up

### DIFF
--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -11,7 +11,6 @@ import '../native_toolchain/msvc.dart';
 import '../native_toolchain/tool_likeness.dart';
 import '../native_toolchain/xcode.dart';
 import '../tool/tool_instance.dart';
-import '../utils/env_from_bat.dart';
 import '../utils/run_process.dart';
 import 'compiler_resolver.dart';
 import 'language.dart';
@@ -334,10 +333,7 @@ class RunCBuilder {
   }
 
   Future<void> runCl({required ToolInstance tool}) async {
-    final vcvars = (await _resolver.toolchainEnvironmentScript(tool))!;
-    final vcvarsArgs = _resolver.toolchainEnvironmentScriptArguments();
-    final environment =
-        await environmentFromBatchFile(vcvars, arguments: vcvarsArgs ?? []);
+    final environment = await _resolver.resolveEnvironment(tool);
 
     final isStaticLib = staticLibrary != null;
     Uri? archiver_;


### PR DESCRIPTION
We'd like `flutter_tools` to invoke the `hook/build.dart` with the environment for `cl.exe` already set up and stop passing in `input.config.code.cCompiler.envScript`.

Therefore, `package:native_toolchain_c` should not go search for an vcvars batch script if the compiler has been provided in the code config but a vcvars script has not been provided.

Issue:

* https://github.com/dart-lang/native/issues/1606

