### PR TITLE
[native_assets_cli] Add `HookInput.outputFile`

### DIFF
--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -146,6 +146,7 @@ class NativeAssetsBuildRunner {
       inputBuilder.setupShared(
         packageName: package.name,
         packageRoot: packageLayout.packageRoot(package.name),
+        outputFile: outDirUri.resolve('../output.json'),
         outputDirectory: outDirUri,
         outputDirectoryShared: outDirSharedUri,
       );
@@ -244,6 +245,7 @@ class NativeAssetsBuildRunner {
       inputBuilder.setupShared(
         packageName: package.name,
         packageRoot: packageLayout.packageRoot(package.name),
+        outputFile: outDirUri.resolve('../output.json'),
         outputDirectory: outDirUri,
         outputDirectoryShared: outDirSharedUri,
       );
@@ -350,21 +352,26 @@ class NativeAssetsBuildRunner {
         }
         final (hookKernelFile, hookHashes) = hookCompileResult;
 
-        final buildOutputFile =
-            _fileSystem.file(input.outputDirectory.resolve(hook.outputName));
+        final buildOutputFile = _fileSystem.file(input.outputFile);
+        final buildOutputFileDeprecated = _fileSystem
+            .file(input.outputDirectory.resolve(hook.outputNameDeprecated));
+
         final dependenciesHashFile = input.outputDirectory
             .resolve('../dependencies.dependencies_hash_file.json');
         final dependenciesHashes =
             DependenciesHashFile(_fileSystem, fileUri: dependenciesHashFile);
         final lastModifiedCutoffTime = DateTime.now();
-        if (buildOutputFile.existsSync() && await dependenciesHashes.exists()) {
+        if ((buildOutputFile.existsSync() ||
+                buildOutputFileDeprecated.existsSync()) &&
+            await dependenciesHashes.exists()) {
           late final HookOutput output;
           try {
-            output = _readHookOutputFromUri(hook, buildOutputFile);
+            output = _readHookOutputFromUri(
+                hook, buildOutputFile, buildOutputFileDeprecated);
           } on FormatException catch (e) {
             logger.severe('''
 Building assets for package:${input.packageName} failed.
-${hook.outputName} contained a format error.
+${input.outputFile.toFilePath()} contained a format error.
 
 Contents: ${buildOutputFile.readAsStringSync()}.
 ${e.message}
@@ -458,11 +465,18 @@ ${e.message}
         const JsonEncoder.withIndent(' ').convert(input.json);
     logger.info('input.json contents: $inputFileContents');
     await _fileSystem.file(inputFile).writeAsString(inputFileContents);
-    final hookOutputUri = input.outputDirectory.resolve(hook.outputName);
+    final hookOutputUri = input.outputFile;
     final hookOutputFile = _fileSystem.file(hookOutputUri);
     if (await hookOutputFile.exists()) {
       // Ensure we'll never read outdated build results.
       await hookOutputFile.delete();
+    }
+    final hookOutputUriDeprecated =
+        input.outputDirectory.resolve(hook.outputNameDeprecated);
+    final hookOutputFileDeprecated = _fileSystem.file(hookOutputUriDeprecated);
+    if (await hookOutputFileDeprecated.exists()) {
+      // Ensure we'll never read outdated build results.
+      await hookOutputFileDeprecated.delete();
     }
 
     final arguments = [
@@ -508,7 +522,11 @@ ${e.message}
         return null;
       }
 
-      final output = _readHookOutputFromUri(hook, hookOutputFile);
+      final output = _readHookOutputFromUri(
+        hook,
+        hookOutputFile,
+        hookOutputFileDeprecated,
+      );
       final errors = await _validate(input, output, packageLayout, validator);
       if (errors.isNotEmpty) {
         _printErrors(
@@ -521,7 +539,7 @@ ${e.message}
     } on FormatException catch (e) {
       logger.severe('''
 Building assets for package:${input.packageName} failed.
-${hook.outputName} contained a format error.
+${input.outputFile.toFilePath()} contained a format error.
 
 Contents: ${hookOutputFile.readAsStringSync()}.
 ${e.message}
@@ -780,10 +798,17 @@ ${compileResult.stdout}
     return (buildPlan, packageGraph);
   }
 
-  HookOutput _readHookOutputFromUri(Hook hook, File hookOutputFile) {
+  HookOutput _readHookOutputFromUri(
+    Hook hook,
+    File hookOutputFile,
+    // TODO(dcharkes): Remove when hooks with 1.7.0 are no longer supported.
+    File hookOutputFileDeprecated,
+  ) {
     final decode = const Utf8Decoder().fuse(const JsonDecoder()).convert;
+    final file =
+        hookOutputFile.existsSync() ? hookOutputFile : hookOutputFileDeprecated;
     final hookOutputJson =
-        decode(hookOutputFile.readAsBytesSync()) as Map<String, Object?>;
+        decode(file.readAsBytesSync()) as Map<String, Object?>;
     return hook == Hook.build
         ? BuildOutput(hookOutputJson)
         : LinkOutput(hookOutputJson);

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_build_output_format_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_build_output_format_test.dart
@@ -49,7 +49,7 @@ void main() async {
           } else {
             expect(
               fullLog,
-              contains('build_output.json contained a format error.'),
+              contains('output.json contained a format error.'),
             );
           }
         }

--- a/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
@@ -21,6 +21,7 @@ void main() async {
   test(
     'native_dynamic_linking build',
     () => inTempDir((tempUri) async {
+      final buildOutputUri = tempUri.resolve('build_output.json');
       final outputDirectory = tempUri.resolve('out/');
       await Directory.fromUri(outputDirectory).create();
       final outputDirectoryShared = tempUri.resolve('out_shared/');
@@ -35,6 +36,7 @@ void main() async {
         ..setupShared(
           packageName: name,
           packageRoot: testPackageUri,
+          outputFile: buildOutputUri,
           outputDirectory: outputDirectory,
           outputDirectoryShared: outputDirectoryShared,
         )
@@ -69,7 +71,6 @@ void main() async {
       }
       expect(processResult.exitCode, 0);
 
-      final buildOutputUri = outputDirectory.resolve('build_output.json');
       final buildOutput = BuildOutput(
           json.decode(await File.fromUri(buildOutputUri).readAsString())
               as Map<String, Object?>);

--- a/pkgs/native_assets_builder/test/test_data/transformer_test.dart
+++ b/pkgs/native_assets_builder/test/test_data/transformer_test.dart
@@ -33,6 +33,7 @@ void main() async {
         logger: logger,
       );
 
+      final buildOutputUri = tempUri.resolve('build_output.json');
       final outputDirectory = tempUri.resolve('out/');
       await Directory.fromUri(outputDirectory).create();
       final outputDirectoryShared = tempUri.resolve('out_shared/');
@@ -50,6 +51,7 @@ void main() async {
           ..setupShared(
             packageName: packageName,
             packageRoot: packageUri,
+            outputFile: buildOutputUri,
             outputDirectory: outputDirectory,
             outputDirectoryShared: outputDirectoryShared,
           )
@@ -87,7 +89,6 @@ void main() async {
         expect(processResult.exitCode, 0);
         stdout = processResult.stdout as String;
 
-        final buildOutputUri = outputDirectory.resolve('build_output.json');
         output = BuildOutput(
             json.decode(await File.fromUri(buildOutputUri).readAsString())
                 as Map<String, Object?>);

--- a/pkgs/native_assets_builder/test_data/wrong_build_output/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output/hook/build.dart
@@ -12,8 +12,7 @@ void main(List<String> args) async {
   final inputPath = getInputArgument(args);
   final buildInput = BuildInput(
       json.decode(File(inputPath).readAsStringSync()) as Map<String, Object?>);
-  await File.fromUri(buildInput.outputDirectory.resolve('build_output.json'))
-      .writeAsString(_wrongContents);
+  await File.fromUri(buildInput.outputFile).writeAsString(_wrongContents);
 }
 
 const _wrongContents = '''

--- a/pkgs/native_assets_builder/test_data/wrong_build_output_2/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output_2/hook/build.dart
@@ -12,8 +12,7 @@ void main(List<String> args) async {
   final inputPath = getInputArgument(args);
   final buildInput = BuildInput(
       json.decode(File(inputPath).readAsStringSync()) as Map<String, Object?>);
-  await File.fromUri(buildInput.outputDirectory.resolve('build_output.json'))
-      .writeAsString(_wrongContents);
+  await File.fromUri(buildInput.outputFile).writeAsString(_wrongContents);
 }
 
 const _wrongContents = '''

--- a/pkgs/native_assets_builder/test_data/wrong_build_output_3/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output_3/hook/build.dart
@@ -12,8 +12,7 @@ void main(List<String> args) async {
   final inputPath = getInputArgument(args);
   final buildInput = BuildInput(
       json.decode(File(inputPath).readAsStringSync()) as Map<String, Object?>);
-  await File.fromUri(buildInput.outputDirectory.resolve('build_output.json'))
-      .writeAsString(_rightContents);
+  await File.fromUri(buildInput.outputFile).writeAsString(_rightContents);
   exit(1);
 }
 
@@ -22,5 +21,5 @@ const _rightContents = '''{
   "encodedAssets": [],
   "dependencies": [],
   "metadata": {},
-  "version": "1.7.0"
+  "version": "1.8.0"
 }''';

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -6,6 +6,7 @@
   shouldn't change on subsequent invocations of the same flutter or dart command
   for the same target. The `outputDirectory` is the same if the config is the
   same.
+- **Breaking change** The `output.json` is now part of `BuildInput`.
 
 ## 0.10.0
 

--- a/pkgs/native_assets_cli/example/build/download_asset/tool/build.dart
+++ b/pkgs/native_assets_cli/example/build/download_asset/tool/build.dart
@@ -76,6 +76,7 @@ BuildInput createBuildInput(
     ..setupShared(
         packageRoot: packageRoot,
         packageName: 'download_asset',
+        outputFile: outputDirectory.resolve('../output.json'),
         outputDirectory: outputDirectory,
         outputDirectoryShared: outputDirectoryShared)
     ..config.setupShared(

--- a/pkgs/native_assets_cli/lib/src/api/build.dart
+++ b/pkgs/native_assets_cli/lib/src/api/build.dart
@@ -110,8 +110,7 @@ Future<void> build(
   if (errors.isEmpty) {
     final jsonOutput =
         const JsonEncoder().fuse(const Utf8Encoder()).convert(output.json);
-    await File.fromUri(input.outputDirectory.resolve('build_output.json'))
-        .writeAsBytes(jsonOutput);
+    await File.fromUri(input.outputFile).writeAsBytes(jsonOutput);
   } else {
     final message = [
       'The output contained unsupported output:',

--- a/pkgs/native_assets_cli/lib/src/api/link.dart
+++ b/pkgs/native_assets_cli/lib/src/api/link.dart
@@ -51,8 +51,7 @@ Future<void> link(
   if (errors.isEmpty) {
     final jsonOutput =
         const JsonEncoder().fuse(const Utf8Encoder()).convert(output.json);
-    await File.fromUri(input.outputDirectory.resolve('link_output.json'))
-        .writeAsBytes(jsonOutput);
+    await File.fromUri(input.outputFile).writeAsBytes(jsonOutput);
   } else {
     final message = [
       'The output contained unsupported output:',

--- a/pkgs/native_assets_cli/lib/src/model/build_config_CHANGELOG.md
+++ b/pkgs/native_assets_cli/lib/src/model/build_config_CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.8.0
+
+- Add `BuildInput.outputFile` to specify the outfile. This means the out file 
+  can be outside the `outputDirectory` and avoid potential conflicts.
+  Compatibility with older hooks: If the file doesn't exist, try the previous
+  location.
+  Compatibility with older SDKs: Default the location to where it was.
+
+## 1.7.0
+
+- Complete rewrite of JSON
+  Compatibility with older hooks: also emit old structure.
+  Compatibility with older SDKs: keep parsing old structure.
+
 ## 1.6.0
 
 - `BuildConfig.supportedAssetTypes` renamed to `BuildConfig.buildAssetTypes`.

--- a/pkgs/native_assets_cli/lib/src/model/hook.dart
+++ b/pkgs/native_assets_cli/lib/src/model/hook.dart
@@ -16,5 +16,5 @@ enum Hook {
 
   String get scriptName => '$_scriptName.dart';
 
-  String get outputName => '${_scriptName}_output.json';
+  String get outputNameDeprecated => '${_scriptName}_output.json';
 }

--- a/pkgs/native_assets_cli/lib/test.dart
+++ b/pkgs/native_assets_cli/lib/test.dart
@@ -9,7 +9,6 @@ import 'dart:io';
 import 'package:yaml/yaml.dart';
 
 import 'native_assets_cli_builder.dart';
-import 'native_assets_cli_internal.dart' show Hook;
 import 'src/validation.dart';
 
 export 'native_assets_cli_builder.dart';
@@ -50,6 +49,7 @@ Future<void> testBuildHook({
       ..setupShared(
         packageRoot: Directory.current.uri,
         packageName: _readPackageNameFromPubspec(),
+        outputFile: outputDirectory.resolve('../output.json'),
         outputDirectory: outputDirectory,
         outputDirectoryShared: outputDirectoryShared,
       )
@@ -61,11 +61,10 @@ Future<void> testBuildHook({
 
     final input = BuildInput(inputBuilder.json);
 
-    final inputUri = tempUri.resolve(Hook.build.outputName);
+    final inputUri = tempUri.resolve('input.json');
     _writeJsonTo(inputUri, input.json);
     await mainMethod(['--config=${inputUri.toFilePath()}']);
-    final output = BuildOutput(
-        _readJsonFrom(input.outputDirectory.resolve(Hook.build.outputName)));
+    final output = BuildOutput(_readJsonFrom(input.outputFile));
 
     // Test conformance of protocol invariants.
     final validationErrors = await validateBuildOutput(input, output);

--- a/pkgs/native_assets_cli/test/api/build_test.dart
+++ b/pkgs/native_assets_cli/test/api/build_test.dart
@@ -8,11 +8,11 @@ import 'dart:io';
 import 'package:file_testing/file_testing.dart';
 import 'package:native_assets_cli/native_assets_cli.dart' show build;
 import 'package:native_assets_cli/native_assets_cli_builder.dart';
-import 'package:native_assets_cli/native_assets_cli_internal.dart' show Hook;
 import 'package:test/test.dart';
 
 void main() async {
   late Uri tempUri;
+  late Uri outFile;
   late Uri outDirUri;
   late Uri outputDirectoryShared;
   late String packageName;
@@ -22,6 +22,7 @@ void main() async {
 
   setUp(() async {
     tempUri = (await Directory.systemTemp.createTemp()).uri;
+    outFile = tempUri.resolve('output.json');
     outDirUri = tempUri.resolve('out1/');
     await Directory.fromUri(outDirUri).create();
     outputDirectoryShared = tempUri.resolve('out_shared1/');
@@ -34,6 +35,7 @@ void main() async {
       ..setupShared(
         packageRoot: tempUri,
         packageName: packageName,
+        outputFile: outFile,
         outputDirectory: outDirUri,
         outputDirectoryShared: outputDirectoryShared,
       )
@@ -45,7 +47,7 @@ void main() async {
     input = BuildInput(inputBuilder.json);
 
     final inputJson = json.encode(input.json);
-    buildInputUri = tempUri.resolve('build_input.json');
+    buildInputUri = tempUri.resolve('input.json');
     await File.fromUri(buildInputUri).writeAsString(inputJson);
   });
 
@@ -54,7 +56,7 @@ void main() async {
         (input, output) async {
       output.addDependency(packageRootUri.resolve('foo'));
     });
-    final buildOutputUri = input.outputDirectory.resolve(Hook.build.outputName);
+    final buildOutputUri = input.outputFile;
     expect(File.fromUri(buildOutputUri), exists);
   });
 }

--- a/pkgs/native_assets_cli/test/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/build_config_test.dart
@@ -12,6 +12,7 @@ import 'package:native_assets_cli/src/config.dart' show latestVersion;
 import 'package:test/test.dart';
 
 void main() async {
+  late Uri outFile;
   late Uri outDirUri;
   late Uri outputDirectoryShared;
   late String packageName;
@@ -20,6 +21,7 @@ void main() async {
 
   setUp(() async {
     final tempUri = Directory.systemTemp.uri;
+    outFile = tempUri.resolve('output.json');
     outDirUri = tempUri.resolve('out1/');
     outputDirectoryShared = tempUri.resolve('out_shared1/');
     packageName = 'my_package';
@@ -40,6 +42,7 @@ void main() async {
       ..setupShared(
         packageName: packageName,
         packageRoot: packageRootUri,
+        outputFile: outFile,
         outputDirectory: outDirUri,
         outputDirectoryShared: outputDirectoryShared,
       )
@@ -73,6 +76,7 @@ void main() async {
       'linking_enabled': false,
       'out_dir_shared': outputDirectoryShared.toFilePath(),
       'out_dir': outDirUri.toFilePath(),
+      'out_file': outFile.toFilePath(),
       'package_name': packageName,
       'package_root': packageRootUri.toFilePath(),
       'supported_asset_types': ['my-asset-type'],
@@ -99,6 +103,7 @@ void main() async {
       ..setupShared(
         packageName: packageName,
         packageRoot: packageRootUri,
+        outputFile: outFile,
         outputDirectory: outDirUri,
         outputDirectoryShared: outputDirectoryShared,
       )
@@ -121,6 +126,7 @@ void main() async {
       'linking_enabled': true,
       'out_dir_shared': outputDirectoryShared.toFilePath(),
       'out_dir': outDirUri.toFilePath(),
+      'out_file': outFile.toFilePath(),
       'package_name': packageName,
       'package_root': packageRootUri.toFilePath(),
       'supported_asset_types': ['my-asset-type'],
@@ -150,6 +156,7 @@ void main() async {
           'link_mode_preference': 'prefer-static',
           'out_dir': outDir.toFilePath(),
           'out_dir_shared': outputDirectoryShared.toFilePath(),
+          'out_file': outFile.toFilePath(),
           'package_root': packageRootUri.toFilePath(),
           'target_os': 'linux',
           'version': version,
@@ -203,6 +210,7 @@ void main() async {
           'version': latestVersion.toString(),
           'out_dir': outDirUri.toFilePath(),
           'out_dir_shared': outputDirectoryShared.toFilePath(),
+          'out_file': outFile.toFilePath(),
           'package_name': packageName,
           'package_root': packageRootUri.toFilePath(),
           'target_os': 'android',

--- a/pkgs/native_assets_cli/test/build_output_test.dart
+++ b/pkgs/native_assets_cli/test/build_output_test.dart
@@ -49,7 +49,7 @@ void main() {
 
     // The JSON format of the build output.
     <String, Object?>{
-      'version': '1.7.0',
+      'version': '1.8.0',
       'dependencies': ['path0', 'path1', 'path2'],
       'metadata': {
         'meta-a': 'meta-b',

--- a/pkgs/native_assets_cli/test/code_assets/config_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/config_test.dart
@@ -11,6 +11,7 @@ import 'package:test/test.dart';
 void main() async {
   late Uri outDirUri;
   late Uri outputDirectoryShared;
+  late Uri outFile;
   late String packageName;
   late Uri packageRootUri;
   late Uri fakeClang;
@@ -22,6 +23,7 @@ void main() async {
   setUp(() async {
     final tempUri = Directory.systemTemp.uri;
     outDirUri = tempUri.resolve('out1/');
+    outFile = tempUri.resolve('output.json');
     outputDirectoryShared = tempUri.resolve('out_shared1/');
     packageName = 'my_package';
     packageRootUri = tempUri.resolve('$packageName/');
@@ -116,6 +118,7 @@ void main() async {
         if (includeDeprecated) 'link_mode_preference': 'prefer-static',
         'out_dir_shared': outputDirectoryShared.toFilePath(),
         'out_dir': outDirUri.toFilePath(),
+        'out_file': outFile.toFilePath(),
         'package_name': packageName,
         'package_root': packageRootUri.toFilePath(),
         if (includeDeprecated) 'supported_asset_types': [CodeAsset.type],
@@ -123,7 +126,7 @@ void main() async {
           'target_android_ndk_api': 30,
         if (includeDeprecated) 'target_architecture': 'arm64',
         if (includeDeprecated) 'target_os': targetOS.name,
-        'version': '1.7.0',
+        'version': '1.8.0',
       };
 
   void expectCorrectCodeConfig(
@@ -152,6 +155,7 @@ void main() async {
       ..setupShared(
         packageName: packageName,
         packageRoot: packageRootUri,
+        outputFile: outFile,
         outputDirectory: outDirUri,
         outputDirectoryShared: outputDirectoryShared,
       )
@@ -176,6 +180,7 @@ void main() async {
       ..setupShared(
         packageName: packageName,
         packageRoot: packageRootUri,
+        outputFile: outFile,
         outputDirectory: outDirUri,
         outputDirectoryShared: outputDirectoryShared,
       )
@@ -225,6 +230,7 @@ void main() async {
       ..setupShared(
         packageName: packageName,
         packageRoot: packageRootUri,
+        outputFile: outFile,
         outputDirectory: outDirUri,
         outputDirectoryShared: outputDirectoryShared,
       )
@@ -275,6 +281,7 @@ void main() async {
       'link_mode_preference': 'prefer-static',
       'out_dir': outDirUri.toFilePath(),
       'out_dir_shared': outputDirectoryShared.toFilePath(),
+      'out_file': outFile.toFilePath(),
       'package_name': packageName,
       'package_root': packageRootUri.toFilePath(),
       'target_android_ndk_api': 30,
@@ -296,6 +303,7 @@ void main() async {
       'link_mode_preference': 'prefer-static',
       'out_dir': outDirUri.toFilePath(),
       'out_dir_shared': outputDirectoryShared.toFilePath(),
+      'out_file': outFile.toFilePath(),
       'package_name': packageName,
       'package_root': packageRootUri.toFilePath(),
       'target_android_ndk_api': 30,

--- a/pkgs/native_assets_cli/test/code_assets/validation_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/validation_test.dart
@@ -34,6 +34,7 @@ void main() {
       ..setupShared(
         packageName: packageName,
         packageRoot: tempUri,
+        outputFile: outDirUri.resolve('../output.json'),
         outputDirectory: outDirUri,
         outputDirectoryShared: outDirSharedUri,
       )

--- a/pkgs/native_assets_cli/test/data_assets/validation_test.dart
+++ b/pkgs/native_assets_cli/test/data_assets/validation_test.dart
@@ -34,6 +34,7 @@ void main() {
       ..setupShared(
         packageName: packageName,
         packageRoot: tempUri,
+        outputFile: outDirUri.resolve('../output.json'),
         outputDirectory: outDirUri,
         outputDirectoryShared: outDirSharedUri,
       )

--- a/pkgs/native_assets_cli/test/example/local_asset_test.dart
+++ b/pkgs/native_assets_cli/test/example/local_asset_test.dart
@@ -31,6 +31,7 @@ void main() async {
   for (final dryRun in [true, false]) {
     final testSuffix = dryRun ? ' dry_run' : '';
     test('local_asset build$testSuffix', () async {
+      final buildOutputUri = tempUri.resolve('build_output.json');
       final testTempUri = tempUri.resolve('test1/');
       await Directory.fromUri(testTempUri).create();
       final outputDirectory = tempUri.resolve('out/');
@@ -45,6 +46,7 @@ void main() async {
         ..setupShared(
           packageRoot: testPackageUri,
           packageName: name,
+          outputFile: buildOutputUri,
           outputDirectory: outputDirectory,
           outputDirectoryShared: outputDirectoryShared,
         )
@@ -79,7 +81,6 @@ void main() async {
       }
       expect(processResult.exitCode, 0);
 
-      final buildOutputUri = outputDirectory.resolve('build_output.json');
       final buildOutput = BuildOutput(
           json.decode(await File.fromUri(buildOutputUri).readAsString())
               as Map<String, Object?>);

--- a/pkgs/native_assets_cli/test/example/native_add_library_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_library_test.dart
@@ -31,6 +31,7 @@ void main() async {
   for (final dryRun in [true, false]) {
     final testSuffix = dryRun ? ' dry_run' : '';
     test('native_add build$testSuffix', () async {
+      final buildOutputUri = tempUri.resolve('build_output.json');
       final testTempUri = tempUri.resolve('test1/');
       await Directory.fromUri(testTempUri).create();
       final outputDirectory = tempUri.resolve('out/');
@@ -45,6 +46,7 @@ void main() async {
         ..setupShared(
           packageRoot: testPackageUri,
           packageName: name,
+          outputFile: buildOutputUri,
           outputDirectory: outputDirectory,
           outputDirectoryShared: outputDirectoryShared,
         )
@@ -79,7 +81,6 @@ void main() async {
       }
       expect(processResult.exitCode, 0);
 
-      final buildOutputUri = outputDirectory.resolve('build_output.json');
       final buildOutput = BuildOutput(
           json.decode(await File.fromUri(buildOutputUri).readAsString())
               as Map<String, Object?>);

--- a/pkgs/native_assets_cli/test/example/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_dynamic_linking_test.dart
@@ -35,6 +35,7 @@ void main() async {
   for (final dryRun in [true, false]) {
     final testSuffix = dryRun ? ' dry_run' : '';
     test('native_dynamic_linking build$testSuffix', () async {
+      final buildOutputUri = tempUri.resolve('build_output.json');
       final testTempUri = tempUri.resolve('test1/');
       await Directory.fromUri(testTempUri).create();
       final outputDirectory = tempUri.resolve('out/');
@@ -49,6 +50,7 @@ void main() async {
         ..setupShared(
           packageRoot: testPackageUri,
           packageName: name,
+          outputFile: buildOutputUri,
           outputDirectory: outputDirectory,
           outputDirectoryShared: outputDirectoryShared,
         )
@@ -83,7 +85,6 @@ void main() async {
       }
       expect(processResult.exitCode, 0);
 
-      final buildOutputUri = outputDirectory.resolve('build_output.json');
       final buildOutput = BuildOutput(
           json.decode(await File.fromUri(buildOutputUri).readAsString())
               as Map<String, Object?>);

--- a/pkgs/native_assets_cli/test/link_config_test.dart
+++ b/pkgs/native_assets_cli/test/link_config_test.dart
@@ -10,6 +10,7 @@ import 'package:native_assets_cli/src/config.dart' show latestVersion;
 import 'package:test/test.dart';
 
 void main() async {
+  late Uri outFile;
   late Uri outDirUri;
   late Uri outputDirectoryShared;
   late String packageName;
@@ -18,6 +19,7 @@ void main() async {
 
   setUp(() async {
     final tempUri = Directory.systemTemp.uri;
+    outFile = tempUri.resolve('output.json');
     outDirUri = tempUri.resolve('out1/');
     outputDirectoryShared = tempUri.resolve('out_shared1/');
     packageName = 'my_package';
@@ -33,6 +35,7 @@ void main() async {
       ..setupShared(
         packageName: packageName,
         packageRoot: packageRootUri,
+        outputFile: outFile,
         outputDirectory: outDirUri,
         outputDirectoryShared: outputDirectoryShared,
       )
@@ -52,6 +55,7 @@ void main() async {
       },
       'out_dir_shared': outputDirectoryShared.toFilePath(),
       'out_dir': outDirUri.toFilePath(),
+      'out_file': outFile.toFilePath(),
       'package_name': packageName,
       'package_root': packageRootUri.toFilePath(),
       'supported_asset_types': ['asset-type-1', 'asset-type-2'],
@@ -77,6 +81,7 @@ void main() async {
           'link_mode_preference': 'prefer-static',
           'out_dir': outDir.toFilePath(),
           'out_dir_shared': outputDirectoryShared.toFilePath(),
+          'out_file': outFile.toFilePath(),
           'package_root': packageRootUri.toFilePath(),
           'target_os': 'linux',
           'version': version,
@@ -127,6 +132,7 @@ void main() async {
           'build_asset_types': ['my-asset-type'],
           'out_dir': outDirUri.toFilePath(),
           'out_dir_shared': outputDirectoryShared.toFilePath(),
+          'out_file': outFile.toFilePath(),
           'package_name': packageName,
           'package_root': packageRootUri.toFilePath(),
           'target_os': 'android',

--- a/pkgs/native_assets_cli/test/link_output_test.dart
+++ b/pkgs/native_assets_cli/test/link_output_test.dart
@@ -35,7 +35,7 @@ void main() {
 
     // The JSON format of the link output.
     <String, Object?>{
-      'version': '1.7.0',
+      'version': '1.8.0',
       'dependencies': ['path0', 'path1', 'path2'],
       'assets': [
         {'a-0': 'v-0', 'type': 'my-asset-type'},

--- a/pkgs/native_assets_cli/test/validation_test.dart
+++ b/pkgs/native_assets_cli/test/validation_test.dart
@@ -34,6 +34,7 @@ void main() {
       ..setupShared(
         packageName: packageName,
         packageRoot: tempUri,
+        outputFile: outDirUri.resolve('../output.json'),
         outputDirectory: outDirUri,
         outputDirectoryShared: outDirSharedUri,
       )

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
@@ -34,6 +34,7 @@ void main() {
       ..setupShared(
         packageName: name,
         packageRoot: tempUri,
+        outputFile: tempUri.resolve('../output.json'),
         outputDirectory: tempUri,
         outputDirectoryShared: tempUri2,
       )

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -148,6 +148,7 @@ Future<Uri> buildLib(
     ..setupShared(
       packageName: name,
       packageRoot: tempUri,
+      outputFile: tempUri.resolve('../output.json'),
       outputDirectory: tempUri,
       outputDirectoryShared: tempUriShared,
     )

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -77,6 +77,7 @@ void main() {
                 ..setupShared(
                   packageName: name,
                   packageRoot: tempUri,
+                  outputFile: tempUri.resolve('../output.json'),
                   outputDirectory: tempUri,
                   outputDirectoryShared: tempUri2,
                 )
@@ -232,6 +233,7 @@ Future<Uri> buildLib(
     ..setupShared(
       packageName: name,
       packageRoot: tempUri,
+      outputFile: tempUri.resolve('../output.json'),
       outputDirectory: tempUri,
       outputDirectoryShared: tempUri2,
     )

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -46,6 +46,7 @@ void main() {
           ..setupShared(
             packageName: name,
             packageRoot: tempUri,
+            outputFile: tempUri.resolve('../output.json'),
             outputDirectory: tempUri,
             outputDirectoryShared: tempUri2,
           )

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -61,6 +61,7 @@ void main() {
             ..setupShared(
               packageName: name,
               packageRoot: tempUri,
+              outputFile: tempUri.resolve('../output.json'),
               outputDirectory: tempUri,
               outputDirectoryShared: tempUri2,
             )
@@ -161,6 +162,7 @@ Future<Uri> buildLib(
     ..setupShared(
       packageName: name,
       packageRoot: tempUri,
+      outputFile: tempUri.resolve('../output.json'),
       outputDirectory: tempUri,
       outputDirectoryShared: tempUri2,
     )

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -65,6 +65,7 @@ void main() {
           ..setupShared(
             packageName: name,
             packageRoot: tempUri,
+            outputFile: tempUri.resolve('../output.json'),
             outputDirectory: tempUri,
             outputDirectoryShared: tempUri2,
           )

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -51,6 +51,7 @@ void main() {
           ..setupShared(
             packageName: name,
             packageRoot: tempUri,
+            outputFile: tempUri.resolve('../output.json'),
             outputDirectory: tempUri,
             outputDirectoryShared: tempUri2,
           )
@@ -133,6 +134,7 @@ void main() {
             ..setupShared(
               packageName: name,
               packageRoot: tempUri,
+              outputFile: tempUri.resolve('../output.json'),
               outputDirectory: tempUri,
               outputDirectoryShared: tempUri2,
             )
@@ -242,6 +244,7 @@ void main() {
       ..setupShared(
         packageName: name,
         packageRoot: tempUri,
+        outputFile: tempUri.resolve('../output.json'),
         outputDirectory: tempUri,
         outputDirectoryShared: tempUri2,
       )
@@ -308,6 +311,7 @@ void main() {
       ..setupShared(
         packageName: name,
         packageRoot: tempUri,
+        outputFile: tempUri.resolve('../output.json'),
         outputDirectory: tempUri,
         outputDirectoryShared: tempUri2,
       )
@@ -365,6 +369,7 @@ void main() {
       ..setupShared(
         packageName: name,
         packageRoot: tempUri,
+        outputFile: tempUri.resolve('../output.json'),
         outputDirectory: tempUri,
         outputDirectoryShared: tempUri2,
       )
@@ -434,6 +439,7 @@ void main() {
       ..setupShared(
         packageName: name,
         packageRoot: tempUri,
+        outputFile: tempUri.resolve('../output.json'),
         outputDirectory: tempUri,
         outputDirectoryShared: tempUri2,
       )
@@ -507,6 +513,7 @@ void main() {
       ..setupShared(
         packageName: name,
         packageRoot: tempUri,
+        outputFile: tempUri.resolve('../output.json'),
         outputDirectory: tempUri,
         outputDirectoryShared: tempUri2,
       )
@@ -591,6 +598,7 @@ void main() {
       ..setupShared(
         packageName: name,
         packageRoot: tempUri,
+        outputFile: tempUri.resolve('../output.json'),
         outputDirectory: tempUri,
         outputDirectoryShared: tempUri2,
       )
@@ -692,6 +700,7 @@ Future<void> testDefines({
     ..setupShared(
       packageName: name,
       packageRoot: tempUri,
+      outputFile: tempUri.resolve('../output.json'),
       outputDirectory: tempUri,
       outputDirectoryShared: tempUri2,
     )

--- a/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
@@ -47,6 +47,7 @@ void main() {
         ..setupShared(
           packageName: 'dummy',
           packageRoot: tempUri,
+          outputFile: tempUri.resolve('../output.json'),
           outputDirectory: tempUri,
           outputDirectoryShared: tempUri2,
         )
@@ -92,6 +93,7 @@ void main() {
       ..setupShared(
         packageName: 'dummy',
         packageRoot: tempUri,
+        outputFile: tempUri.resolve('../output.json'),
         outputDirectoryShared: tempUri2,
         outputDirectory: tempUri,
       )

--- a/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
@@ -40,6 +40,7 @@ void main() {
       ..setupShared(
         packageName: name,
         packageRoot: tempUri,
+        outputFile: tempUri.resolve('../output.json'),
         outputDirectory: tempUri,
         outputDirectoryShared: tempUri2,
       )

--- a/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
+++ b/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
@@ -30,6 +30,7 @@ Future<Uri> buildTestArchive(
     ..setupShared(
       packageName: name,
       packageRoot: tempUri,
+      outputFile: tempUri.resolve('../output.json'),
       outputDirectory: tempUri,
       outputDirectoryShared: tempUri2,
     )

--- a/pkgs/native_toolchain_c/test/clinker/objects_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/objects_test.dart
@@ -35,6 +35,7 @@ Future<void> main() async {
       ..setupShared(
         packageName: 'testpackage',
         packageRoot: tempUri,
+        outputFile: tempUri.resolve('../output.json'),
         outputDirectory: tempUri,
         outputDirectoryShared: tempUri2,
       )

--- a/pkgs/native_toolchain_c/test/clinker/throws_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/throws_test.dart
@@ -26,6 +26,7 @@ Future<void> main() async {
           ..setupShared(
             packageName: 'testpackage',
             packageRoot: tempUri,
+            outputFile: tempUri.resolve('../output.json'),
             outputDirectoryShared: tempUri2,
             outputDirectory: tempUri,
           )

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
@@ -65,6 +65,7 @@ Future<void> runTests(List<Architecture> architectures) async {
           ..setupShared(
             packageName: 'testpackage',
             packageRoot: tempUri,
+            outputFile: tempUri.resolve('../output.json'),
             outputDirectory: tempUri,
             outputDirectoryShared: tempUri2,
           )


### PR DESCRIPTION
Pass in a path to where the `output.json` should be written.

This enables the output file to not be written into the output directory but next to it. This is cleaner.