### PR TITLE
[native_assets_cli] Fix system libraries and add documentation - fix test

### DIFF
--- a/pkgs/native_assets_builder/test_data/system_library/lib/memory_executable.dart
+++ b/pkgs/native_assets_builder/test_data/system_library/lib/memory_executable.dart
@@ -10,8 +10,8 @@ external Pointer malloc(int size);
 @Native<Void Function(Pointer)>()
 external void free(Pointer pointer);
 
-@Native<Pointer Function(Size)>()
+@Native<Pointer Function(Size)>(symbol: 'CoTaskMemAlloc')
 external Pointer coTaskMemAlloc(int cb);
 
-@Native<Void Function(Pointer)>()
+@Native<Void Function(Pointer)>(symbol: 'CoTaskMemFree')
 external void coTaskMemFree(Pointer pv);

--- a/pkgs/native_assets_builder/test_data/system_library/lib/memory_process.dart
+++ b/pkgs/native_assets_builder/test_data/system_library/lib/memory_process.dart
@@ -10,8 +10,8 @@ external Pointer malloc(int size);
 @Native<Void Function(Pointer)>()
 external void free(Pointer pointer);
 
-@Native<Pointer Function(Size)>()
+@Native<Pointer Function(Size)>(symbol: 'CoTaskMemAlloc')
 external Pointer coTaskMemAlloc(int cb);
 
-@Native<Void Function(Pointer)>()
+@Native<Void Function(Pointer)>(symbol: 'CoTaskMemFree')
 external void coTaskMemFree(Pointer pv);

--- a/pkgs/native_assets_builder/test_data/system_library/lib/memory_system.dart
+++ b/pkgs/native_assets_builder/test_data/system_library/lib/memory_system.dart
@@ -10,8 +10,8 @@ external Pointer malloc(int size);
 @Native<Void Function(Pointer)>()
 external void free(Pointer pointer);
 
-@Native<Pointer Function(Size)>()
+@Native<Pointer Function(Size)>(symbol: 'CoTaskMemAlloc')
 external Pointer coTaskMemAlloc(int cb);
 
-@Native<Void Function(Pointer)>()
+@Native<Void Function(Pointer)>(symbol: 'CoTaskMemFree')
 external void coTaskMemFree(Pointer pv);

--- a/pkgs/native_assets_cli/example/build/system_library/lib/memory.dart
+++ b/pkgs/native_assets_cli/example/build/system_library/lib/memory.dart
@@ -14,8 +14,8 @@ external Pointer malloc(int size);
 @Native<Void Function(Pointer)>()
 external void free(Pointer pointer);
 
-@Native<Pointer Function(Size)>()
+@Native<Pointer Function(Size)>(symbol: 'CoTaskMemAlloc')
 external Pointer coTaskMemAlloc(int cb);
 
-@Native<Void Function(Pointer)>()
+@Native<Void Function(Pointer)>(symbol: 'CoTaskMemFree')
 external void coTaskMemFree(Pointer pv);


### PR DESCRIPTION
I addressed the lint to have lower-case method names, but forgot that the native symbol in Windows is upper case.

Because the fix for using system/process/executable is not yet in Dart, this wasn't caught by the integration test on this repo running `dart test` because it's disabled until the fix rolls into dev.

[log](https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8726092053135135713/+/u/test_results/new_test_failures__logs_)

```
00:55 [32m+3[0m: package:system_library dart test[0m

00:00 +0: loading test\memory_test.dart
00:00 +0: test\memory_test.dart: executable
00:00 +0 -1: test\memory_test.dart: executable [E]
  Invalid argument(s): Couldn't resolve native function 'coTaskMemAlloc' in 'package:system_library/memory_executable.dart' : Failed to lookup symbol 'coTaskMemAlloc': The specified procedure could not be found.
   (error code: 127).
  
  dart:ffi                                       Native._ffi_resolver_function
  package:system_library/memory_executable.dart  coTaskMemAlloc
  test\memory_test.dart 16:34                    main.<fn>
  
00:00 +0 -1: test\memory_test.dart: process
00:00 +0 -2: test\memory_test.dart: process [E]
  Invalid argument(s): Couldn't resolve native function 'coTaskMemAlloc' in 'package:system_library/memory_process.dart' : Failed to lookup symbol 'coTaskMemAlloc': None of the loaded modules contained the requested symbol 'coTaskMemAlloc'..
  
  dart:ffi                                    Native._ffi_resolver_function
  package:system_library/memory_process.dart  coTaskMemAlloc
  test\memory_test.dart 28:31                 main.<fn>
  
00:00 +0 -2: test\memory_test.dart: system
00:00 +0 -3: test\memory_test.dart: system [E]
  Invalid argument(s): Couldn't resolve native function 'coTaskMemAlloc' in 'package:system_library/memory_system.dart' : Failed to lookup symbol 'coTaskMemAlloc': The specified procedure could not be found.
   (error code: 127).
  
  dart:ffi                                   Native._ffi_resolver_function
  package:system_library/memory_system.dart  coTaskMemAlloc
  test\memory_test.dart 40:30                main.<fn>
  
00:00 +0 -3: Some tests failed.
```