### PR TITLE
[native_assets_builder] Write hook stdout and stderr to disk

### DIFF
--- a/pkgs/native_assets_builder/test/build_runner/build_runner_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_test.dart
@@ -45,6 +45,20 @@ void main() async {
                   '${Platform.pathSeparator}build.dart',
             ]));
         expect(result.encodedAssets.length, 1);
+
+        // Check that invocation logs are written to disk.
+        final packgeBuildDirectory = Directory.fromUri(
+            packageUri.resolve('.dart_tool/native_assets_builder/native_add/'));
+        final buildDirectory =
+            packgeBuildDirectory.listSync().single as Directory;
+        final stdoutFile =
+            File.fromUri(buildDirectory.uri.resolve('stdout.txt'));
+        final stderrFile =
+            File.fromUri(buildDirectory.uri.resolve('stderr.txt'));
+        expect(stdoutFile.existsSync(), true);
+        expect(stdoutFile.readAsStringSync(), contains('Some stdout.'));
+        expect(stderrFile.existsSync(), true);
+        expect(stderrFile.readAsStringSync(), contains('Some stderr.'));
       }
 
       // Trigger a build, should not invoke anything.

--- a/pkgs/native_assets_builder/test_data/native_add/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/native_add/hook/build.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:logging/logging.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
@@ -25,5 +27,7 @@ void main(List<String> arguments) async {
           print('${record.level.name}: ${record.time}: ${record.message}');
         }),
     );
+    stdout.writeln('Some stdout.');
+    stderr.writeln('Some stderr.');
   });
 }


### PR DESCRIPTION
Write the stdout and stderr from hook invocations to disk.

The directory structure of the native assets builder now is as follows:

* `.dart_tool/`
  * `native_assets_builder/`
    * `$packageName/`
      * `$checksum/`
        * `input.json`
        * `output.json`
        * `out/`
        * `stderr.txt`
        * `stdout.txt`

Closes: https://github.com/dart-lang/native/issues/97