### PR TITLE
[native_assets_cli] Fix system libraries and add documentation - fix test 2

### DIFF
--- a/pkgs/native_assets_builder/test_data/system_library/lib/memory_executable.dart
+++ b/pkgs/native_assets_builder/test_data/system_library/lib/memory_executable.dart
@@ -9,9 +9,3 @@ external Pointer malloc(int size);
 
 @Native<Void Function(Pointer)>()
 external void free(Pointer pointer);
-
-@Native<Pointer Function(Size)>(symbol: 'CoTaskMemAlloc')
-external Pointer coTaskMemAlloc(int cb);
-
-@Native<Void Function(Pointer)>(symbol: 'CoTaskMemFree')
-external void coTaskMemFree(Pointer pv);

--- a/pkgs/native_assets_builder/test_data/system_library/test/memory_test.dart
+++ b/pkgs/native_assets_builder/test_data/system_library/test/memory_test.dart
@@ -12,11 +12,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('executable', () {
-    if (Platform.isWindows) {
-      final pointer = executable.coTaskMemAlloc(8);
-      expect(pointer, isNot(nullptr));
-      executable.coTaskMemFree(pointer);
-    } else {
+    if (!Platform.isWindows) {
       final pointer = executable.malloc(8);
       expect(pointer, isNot(nullptr));
       executable.free(pointer);


### PR DESCRIPTION
If only I knew how to write code for Windows. 🤓 

Fixing:

```
00:00 +0 -1: test\memory_test.dart: executable [E]
  Invalid argument(s): Couldn't resolve native function 'CoTaskMemAlloc' in 'package:system_library/memory_executable.dart' : Failed to lookup symbol 'CoTaskMemAlloc': The specified procedure could not be found.
   (error code: 127).
```

[log](https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8725836200960091649/+/u/test_results/new_test_failures__logs_)

The executable doesn't have access to `CoTaskMemAlloc`. It's in a win32 library that's loaded into the process. So, only `process` and `system` link mode work.