### PR TITLE
[jnigen] Respect top-type nullability of type arguments

### DIFF
--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Support nullability annotations that are on Java elements like methods and
   fields instead of directly on the return type or field type.
 - Fixed a bug where enum values were generated as nullable.
+- Fixed a bug where type arguments could be nullable when the top type of their
+  paramater was non-nullable.
 
 ## 0.13.0
 

--- a/pkgs/jnigen/lib/src/bindings/linker.dart
+++ b/pkgs/jnigen/lib/src/bindings/linker.dart
@@ -66,6 +66,8 @@ class Linker extends Visitor<Classes, Future<void>> {
           resolve(TypeUsage.object.name);
     }
 
+    (TypeUsage.object.type as DeclaredType).classDecl =
+        resolve(TypeUsage.object.name);
     final classLinker = _ClassLinker(
       config,
       resolve,
@@ -230,10 +232,10 @@ class _TypeLinker extends TypeVisitor<void> {
 
   @override
   void visitDeclaredType(DeclaredType node) {
+    node.classDecl = resolve(node.binaryName);
     for (final param in node.params) {
       param.accept(this);
     }
-    node.classDecl = resolve(node.binaryName);
   }
 
   @override

--- a/pkgs/jnigen/lib/src/elements/elements.dart
+++ b/pkgs/jnigen/lib/src/elements/elements.dart
@@ -223,7 +223,7 @@ class TypeUsage {
     required this.typeJson,
   });
 
-  static TypeUsage object = TypeUsage(
+  static final object = TypeUsage(
       kind: Kind.declared, shorthand: 'java.lang.Object', typeJson: {})
     ..type = DeclaredType(binaryName: 'java.lang.Object');
 

--- a/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
+++ b/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
@@ -945,6 +945,32 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
         .check();
   }
 
+  static final _id_self = _class.instanceMethodId(
+    r'self',
+    r'()Lcom/github/dart_lang/jnigen/Nullability;',
+  );
+
+  static final _self = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JniResult Function(
+                jni$_.Pointer<jni$_.Void>,
+                jni$_.JMethodIDPtr,
+              )>>('globalEnv_CallObjectMethod')
+      .asFunction<
+          jni$_.JniResult Function(
+            jni$_.Pointer<jni$_.Void>,
+            jni$_.JMethodIDPtr,
+          )>();
+
+  /// from: `public final com.github.dart_lang.jnigen.Nullability self()`
+  /// The returned object must be released after use, by calling the [release] method.
+  Nullability<jni$_.JObject?, jni$_.JObject> self() {
+    return _self(reference.pointer, _id_self as jni$_.JMethodIDPtr)
+        .object<Nullability<jni$_.JObject?, jni$_.JObject>>(
+            const $Nullability$Type<jni$_.JObject?, jni$_.JObject>(
+                jni$_.JObjectNullableType(), jni$_.JObjectType()));
+  }
+
   static final _id_hello = _class.instanceMethodId(
     r'hello',
     r'()Ljava/lang/String;',

--- a/pkgs/jnigen/test/kotlin_test/kotlin/src/main/kotlin/com/github/dart_lang/jnigen/Nullability.kt
+++ b/pkgs/jnigen/test/kotlin_test/kotlin/src/main/kotlin/com/github/dart_lang/jnigen/Nullability.kt
@@ -5,7 +5,11 @@
 
 package com.github.dart_lang.jnigen
 
-public class Nullability<T, U: Any>(val t: T, val u: U, var nullableU: U?) {
+public class Nullability<T, U : Any>(val t: T, val u: U, var nullableU: U?) {
+    public fun self(): Nullability<*, *> {
+        return this
+    }
+
     public fun hello(): String {
         return "hello"
     }
@@ -18,7 +22,7 @@ public class Nullability<T, U: Any>(val t: T, val u: U, var nullableU: U?) {
         return listOf("hello", 42)
     }
 
-    public fun <V: Any> methodGenericEcho(v: V): V {
+    public fun <V : Any> methodGenericEcho(v: V): V {
         return v
     }
 
@@ -50,7 +54,7 @@ public class Nullability<T, U: Any>(val t: T, val u: U, var nullableU: U?) {
         return list.first();
     }
 
-    public fun <V: Any> methodGenericFirstOf(list: List<V>): V {
+    public fun <V : Any> methodGenericFirstOf(list: List<V>): V {
         return list.first();
     }
 
@@ -74,7 +78,7 @@ public class Nullability<T, U: Any>(val t: T, val u: U, var nullableU: U?) {
         return listOf(element)
     }
 
-    public fun <V: Any> methodGenericListOf(element: V): List<V> {
+    public fun <V : Any> methodGenericListOf(element: V): List<V> {
         return listOf(element)
     }
 


### PR DESCRIPTION
Closes #1906.

Keep the original nullability of a type argument `T extends Foo`, so that even if the type provided is not explicitly identified as nullable or non-nullable (due to a missing annotation or being a kotlin wildcard), it's still generated with regards to the constraints of the top-type `Foo`.