### PR TITLE
[native_toolchain_c] Support Clang on Windows 2

### DIFF
--- a/pkgs/native_toolchain_c/lib/src/cbuilder/compiler_resolver.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/compiler_resolver.dart
@@ -218,7 +218,11 @@ class CompilerResolver {
     }
 
     final compilerTool = compiler.tool;
-    assert(compilerTool == cl);
+    if (compilerTool != cl) {
+      // If Clang is used on Windows, and we could discover the MSVC
+      // installation, then Clang should be able to discover it as well.
+      return {};
+    }
     final vcvarsScript =
         (await vcvars(compiler).defaultResolver!.resolve(logger: logger)).first;
     return await environmentFromBatchFile(

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -131,6 +131,9 @@ class RunCBuilder {
   }
 
   Future<void> runClangLike({required ToolInstance tool}) async {
+    // Clang for Windows requires the MSVC Developer Environment.
+    final environment = await _resolver.resolveEnvironment(tool);
+
     final isStaticLib = staticLibrary != null;
     Uri? archiver_;
     if (isStaticLib) {
@@ -176,6 +179,7 @@ class RunCBuilder {
           targetMacOSVersion,
           [sourceFiles[i]],
           objectFile,
+          environment,
         );
         objectFiles.add(objectFile);
       }
@@ -189,6 +193,7 @@ class RunCBuilder {
         logger: logger,
         captureOutput: false,
         throwOnUnexpectedExitCode: true,
+        environment: environment,
       );
     } else {
       await _compile(
@@ -200,6 +205,7 @@ class RunCBuilder {
         targetMacOSVersion,
         sourceFiles,
         dynamicLibrary != null ? outDir.resolveUri(dynamicLibrary!) : null,
+        environment,
       );
     }
   }
@@ -214,9 +220,11 @@ class RunCBuilder {
     int? targetMacOSVersion,
     Iterable<String> sourceFiles,
     Uri? outFile,
+    Map<String, String> environment,
   ) async {
     await runProcess(
       executable: toolInstance.uri,
+      environment: environment,
       arguments: [
         if (codeConfig.targetOS == OS.android) ...[
           '--target='


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/1892

Using clang on Windows requires being run with the windows dev environment _or_ an MSVC toolchain installed which is discoverable on the system.

On the GitHub bots, MSVC comes pre-installed, so we can't reproduce the case where Clang cannot find the MSVC dev environment.

I've tested this locally by (1) uninstalling visual studio, (2) seeing that the build with Clang fails, (3) hardcoding in a dev environment (from depot_tools) in `native_toolchain_c`, and (4) seeing that that the tests pass.