### PR TITLE
[native_assets_builder] Support pub workspaces

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.11.0-wip
 
+- **Breaking change** `runPackageName` is now required to properly support
+  pub workspaces.
 - Bump `package:native_assets_cli` to 0.11.0.
 
 ## 0.10.2

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_planner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_planner.dart
@@ -47,15 +47,13 @@ class NativeAssetsBuildPlanner {
     );
   }
 
-  List<Package>? plan({
-    String? runPackageName,
-  }) {
-    final PackageGraph packageGraph;
-    if (runPackageName != null) {
-      packageGraph = this.packageGraph.subGraph(runPackageName);
-    } else {
-      packageGraph = this.packageGraph;
-    }
+  /// Plans in what order to run build hooks.
+  ///
+  /// [runPackageName] provides the entry-point in the graph. The hooks of
+  /// packages not in the transitive dependencies of [runPackageName] will not
+  /// be run.
+  List<Package>? plan(String runPackageName) {
+    final packageGraph = this.packageGraph.subGraph(runPackageName);
     final packageMap = {
       for (final package in packagesWithNativeAssets) package.name: package
     };
@@ -135,5 +133,19 @@ class PackageGraph {
               if (subgraphVertices.contains(neighbor)) neighbor,
           ]
     });
+  }
+
+  @override
+  String toString() {
+    final buffer = StringBuffer();
+    buffer.writeln('PackageGraph(');
+    for (final node in vertices) {
+      buffer.writeln('  $node ->');
+      for (final neighbor in neighborsOf(node)) {
+        buffer.writeln('    $neighbor');
+      }
+    }
+    buffer.writeln(')');
+    return buffer.toString();
   }
 }

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_planner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_planner.dart
@@ -22,8 +22,8 @@ class NativeAssetsBuildPlanner {
     required this.logger,
   });
 
-  static Future<NativeAssetsBuildPlanner> fromRootPackageRoot({
-    required Uri rootPackageRoot,
+  static Future<NativeAssetsBuildPlanner> fromWorkingDirectory({
+    required Uri workingDirectory,
     required List<Package> packagesWithNativeAssets,
     required Uri dartExecutable,
     required Logger logger,
@@ -35,7 +35,7 @@ class NativeAssetsBuildPlanner {
         'deps',
         '--json',
       ],
-      workingDirectory: rootPackageRoot.toFilePath(),
+      workingDirectory: workingDirectory.toFilePath(),
     );
     final packageGraph =
         PackageGraph.fromPubDepsJsonString(result.stdout as String);

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -106,7 +106,7 @@ class NativeAssetsBuildRunner {
     required bool linkingEnabled,
   }) async {
     packageLayout ??=
-        await PackageLayout.fromRootPackageRoot(_fileSystem, workingDirectory);
+        await PackageLayout.fromWorkingDirectory(_fileSystem, workingDirectory);
 
     final (buildPlan, packageGraph) = await _makePlan(
       hook: Hook.build,
@@ -213,7 +213,7 @@ class NativeAssetsBuildRunner {
     required BuildResult buildResult,
   }) async {
     packageLayout ??=
-        await PackageLayout.fromRootPackageRoot(_fileSystem, workingDirectory);
+        await PackageLayout.fromWorkingDirectory(_fileSystem, workingDirectory);
 
     final (buildPlan, packageGraph) = await _makePlan(
       hook: Hook.link,
@@ -785,8 +785,8 @@ ${compileResult.stdout}
     final PackageGraph? packageGraph;
     switch (hook) {
       case Hook.build:
-        final planner = await NativeAssetsBuildPlanner.fromRootPackageRoot(
-          rootPackageRoot: packageLayout.rootPackageRoot,
+        final planner = await NativeAssetsBuildPlanner.fromWorkingDirectory(
+          workingDirectory: packageLayout.packageConfigUri.resolve('../'),
           packagesWithNativeAssets: packagesWithHook,
           dartExecutable: Uri.file(Platform.resolvedExecutable),
           logger: logger,

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -101,7 +101,7 @@ class NativeAssetsBuildRunner {
     required ApplicationAssetValidator applicationAssetValidator,
     required Uri workingDirectory,
     PackageLayout? packageLayout,
-    String? runPackageName,
+    required String runPackageName,
     required List<String> buildAssetTypes,
     required bool linkingEnabled,
   }) async {
@@ -208,7 +208,7 @@ class NativeAssetsBuildRunner {
     required ApplicationAssetValidator applicationAssetValidator,
     PackageLayout? packageLayout,
     Uri? resourceIdentifiers,
-    String? runPackageName,
+    required String runPackageName,
     required List<String> buildAssetTypes,
     required BuildResult buildResult,
   }) async {
@@ -775,7 +775,7 @@ ${compileResult.stdout}
 
   Future<(List<Package>? plan, PackageGraph? dependencyGraph)> _makePlan({
     required PackageLayout packageLayout,
-    String? runPackageName,
+    required String runPackageName,
     required Hook hook,
     // TODO(dacoharkes): How to share these two? Make them extend each other?
     BuildResult? buildResult,
@@ -785,24 +785,14 @@ ${compileResult.stdout}
     final PackageGraph? packageGraph;
     switch (hook) {
       case Hook.build:
-        // Build hooks are run in toplogical order.
-        if (packagesWithHook.length <= 1 && runPackageName == null) {
-          final dependencyGraph = PackageGraph({
-            for (final p in packagesWithHook) p.name: [],
-          });
-          return (packagesWithHook, dependencyGraph);
-        } else {
-          final planner = await NativeAssetsBuildPlanner.fromRootPackageRoot(
-            rootPackageRoot: packageLayout.rootPackageRoot,
-            packagesWithNativeAssets: packagesWithHook,
-            dartExecutable: Uri.file(Platform.resolvedExecutable),
-            logger: logger,
-          );
-          final plan = planner.plan(
-            runPackageName: runPackageName,
-          );
-          return (plan, planner.packageGraph);
-        }
+        final planner = await NativeAssetsBuildPlanner.fromRootPackageRoot(
+          rootPackageRoot: packageLayout.rootPackageRoot,
+          packagesWithNativeAssets: packagesWithHook,
+          dartExecutable: Uri.file(Platform.resolvedExecutable),
+          logger: logger,
+        );
+        final plan = planner.plan(runPackageName);
+        return (plan, planner.packageGraph);
       case Hook.link:
         // Link hooks are not run in any particular order.
         // Link hooks are skipped if no assets for linking are provided.

--- a/pkgs/native_assets_builder/lib/src/package_layout/package_layout.dart
+++ b/pkgs/native_assets_builder/lib/src/package_layout/package_layout.dart
@@ -16,11 +16,6 @@ import 'package:package_config/package_config.dart';
 class PackageLayout {
   final FileSystem _fileSystem;
 
-  /// The root folder of the current dart invocation root package.
-  ///
-  /// `$rootPackageRoot`.
-  final Uri rootPackageRoot;
-
   /// Package config containing the information of where to foot the root [Uri]s
   /// of other packages.
   ///
@@ -30,8 +25,11 @@ class PackageLayout {
 
   final Uri packageConfigUri;
 
-  PackageLayout._(this._fileSystem, this.rootPackageRoot, this.packageConfig,
-      this.packageConfigUri);
+  PackageLayout._(
+    this._fileSystem,
+    this.packageConfig,
+    this.packageConfigUri,
+  );
 
   factory PackageLayout.fromPackageConfig(
     FileSystem fileSystem,
@@ -40,26 +38,23 @@ class PackageLayout {
   ) {
     assert(fileSystem.file(packageConfigUri).existsSync());
     packageConfigUri = packageConfigUri.normalizePath();
-    final rootPackageRoot = packageConfigUri.resolve('../');
     return PackageLayout._(
       fileSystem,
-      rootPackageRoot,
       packageConfig,
       packageConfigUri,
     );
   }
 
-  static Future<PackageLayout> fromRootPackageRoot(
+  static Future<PackageLayout> fromWorkingDirectory(
     FileSystem fileSystem,
-    Uri rootPackageRoot,
+    Uri workingDirectory,
   ) async {
-    rootPackageRoot = rootPackageRoot.normalizePath();
+    workingDirectory = workingDirectory.normalizePath();
     final packageConfigUri =
-        await findPackageConfig(fileSystem, rootPackageRoot);
+        await findPackageConfig(fileSystem, workingDirectory);
     assert(await fileSystem.file(packageConfigUri).exists());
     final packageConfig = await loadPackageConfigUri(packageConfigUri!);
-    return PackageLayout._(
-        fileSystem, rootPackageRoot, packageConfig, packageConfigUri);
+    return PackageLayout._(fileSystem, packageConfig, packageConfigUri);
   }
 
   static Future<Uri?> findPackageConfig(

--- a/pkgs/native_assets_builder/test/build_runner/build_planner_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_planner_test.dart
@@ -46,7 +46,7 @@ void main() async {
         dartExecutable: Uri.file(Platform.resolvedExecutable),
         logger: logger,
       );
-      final buildPlan = planner.plan();
+      final buildPlan = planner.plan('native_add');
       expect(buildPlan!.length, 1);
       expect(buildPlan.single.name, 'native_add');
     });
@@ -71,7 +71,7 @@ void main() async {
         dartExecutable: Uri.file(Platform.resolvedExecutable),
         logger: logger,
       );
-      final buildPlan = nativeAssetsBuildPlanner.plan();
+      final buildPlan = nativeAssetsBuildPlanner.plan('native_add');
       expect(buildPlan!.length, 1);
       expect(buildPlan.single.name, 'native_add');
     });
@@ -98,9 +98,7 @@ void main() async {
           dartExecutable: Uri.file(Platform.resolvedExecutable),
           logger: logger,
         );
-        final buildPlan = nativeAssetsBuildPlanner.plan(
-          runPackageName: runPackageName,
-        );
+        final buildPlan = nativeAssetsBuildPlanner.plan(runPackageName);
         expect(buildPlan!.length, 0);
       });
     });

--- a/pkgs/native_assets_builder/test/build_runner/build_planner_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_planner_test.dart
@@ -35,7 +35,7 @@ void main() async {
 
       final graph = PackageGraph.fromPubDepsJsonString(result.stdout);
 
-      final packageLayout = await PackageLayout.fromRootPackageRoot(
+      final packageLayout = await PackageLayout.fromWorkingDirectory(
           const LocalFileSystem(), nativeAddUri);
       final packagesWithNativeAssets =
           await packageLayout.packagesWithAssets(Hook.build);
@@ -60,13 +60,13 @@ void main() async {
       // First, run `pub get`, we need pub to resolve our dependencies.
       await runPubGet(workingDirectory: nativeAddUri, logger: logger);
 
-      final packageLayout = await PackageLayout.fromRootPackageRoot(
+      final packageLayout = await PackageLayout.fromWorkingDirectory(
           const LocalFileSystem(), nativeAddUri);
       final packagesWithNativeAssets =
           await packageLayout.packagesWithAssets(Hook.build);
       final nativeAssetsBuildPlanner =
-          await NativeAssetsBuildPlanner.fromRootPackageRoot(
-        rootPackageRoot: nativeAddUri,
+          await NativeAssetsBuildPlanner.fromWorkingDirectory(
+        workingDirectory: nativeAddUri,
         packagesWithNativeAssets: packagesWithNativeAssets,
         dartExecutable: Uri.file(Platform.resolvedExecutable),
         logger: logger,
@@ -87,13 +87,13 @@ void main() async {
         // First, run `pub get`, we need pub to resolve our dependencies.
         await runPubGet(workingDirectory: nativeAddUri, logger: logger);
 
-        final packageLayout = await PackageLayout.fromRootPackageRoot(
+        final packageLayout = await PackageLayout.fromWorkingDirectory(
             const LocalFileSystem(), nativeAddUri);
         final packagesWithNativeAssets =
             await packageLayout.packagesWithAssets(Hook.build);
         final nativeAssetsBuildPlanner =
-            await NativeAssetsBuildPlanner.fromRootPackageRoot(
-          rootPackageRoot: nativeAddUri,
+            await NativeAssetsBuildPlanner.fromWorkingDirectory(
+          workingDirectory: nativeAddUri,
           packagesWithNativeAssets: packagesWithNativeAssets,
           dartExecutable: Uri.file(Platform.resolvedExecutable),
           logger: logger,

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
@@ -15,7 +15,8 @@ void main() async {
   test('multiple  build invocations', timeout: longTimeout, () async {
     await inTempDir((tempUri) async {
       await copyTestProjects(targetUri: tempUri);
-      final packageUri = tempUri.resolve('package_reading_metadata/');
+      const packageName = 'package_reading_metadata';
+      final packageUri = tempUri.resolve('$packageName/');
 
       // First, run `pub get`, we need pub to resolve our dependencies.
       await runPubGet(
@@ -49,6 +50,7 @@ void main() async {
         inputValidator: (input) async => [],
         buildValidator: (input, output) async => [],
         applicationAssetValidator: (_) async => [],
+        runPackageName: packageName,
       );
       await buildRunner.build(
         inputCreator: inputCreator,
@@ -58,6 +60,7 @@ void main() async {
         inputValidator: (input) async => [],
         buildValidator: (input, output) async => [],
         applicationAssetValidator: (_) async => [],
+        runPackageName: packageName,
       );
     });
   });

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_test.dart
@@ -65,7 +65,7 @@ void main() async {
       for (final passPackageLayout in [true, false]) {
         PackageLayout? packageLayout;
         if (passPackageLayout) {
-          packageLayout = await PackageLayout.fromRootPackageRoot(
+          packageLayout = await PackageLayout.fromWorkingDirectory(
               const LocalFileSystem(), packageUri);
         }
         final logMessages = <String>[];

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test_helper.dart
@@ -11,6 +11,7 @@ import '../helpers.dart';
 // Is invoked concurrently multiple times in separate processes.
 void main(List<String> args) async {
   final packageUri = Uri.directory(args[0]);
+  final packageName = packageUri.pathSegments.lastWhere((e) => e.isNotEmpty);
   final target = Target.fromString(args[1]);
 
   final logger = Logger('')
@@ -49,6 +50,7 @@ void main(List<String> args) async {
       ...await validateCodeAssetBuildOutput(input, output),
     ],
     applicationAssetValidator: validateCodeAssetInApplication,
+    runPackageName: packageName,
   );
   if (result == null) {
     throw Error();

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
@@ -12,6 +12,7 @@ import 'helpers.dart';
 // Is invoked concurrently multiple times in separate processes.
 void main(List<String> args) async {
   final packageUri = Uri.directory(args[0]);
+  final packageName = packageUri.pathSegments.lastWhere((e) => e.isNotEmpty);
   Duration? timeout;
   if (args.length >= 2) {
     timeout = Duration(milliseconds: int.parse(args[1]));
@@ -50,6 +51,7 @@ void main(List<String> args) async {
       ...await validateDataAssetBuildOutput(input, output),
     ],
     applicationAssetValidator: validateCodeAssetInApplication,
+    runPackageName: packageName,
   );
   if (result == null) {
     throw Error();

--- a/pkgs/native_assets_builder/test/build_runner/helpers.dart
+++ b/pkgs/native_assets_builder/test/build_runner/helpers.dart
@@ -29,6 +29,23 @@ Future<void> runPubGet({
   expect(result.exitCode, 0);
 }
 
+Future<BuildResult?> buildCodeAssets(
+  Uri packageUri, {
+  String? runPackageName,
+  List<String>? capturedLogs,
+}) =>
+    build(
+      packageUri,
+      logger,
+      dartExecutable,
+      capturedLogs: capturedLogs,
+      inputValidator: validateCodeAssetBuildInput,
+      buildAssetTypes: [CodeAsset.type],
+      buildValidator: validateCodeAssetBuildOutput,
+      applicationAssetValidator: validateCodeAssetInApplication,
+      runPackageName: runPackageName,
+    );
+
 Future<BuildResult?> build(
   Uri packageUri,
   Logger logger,
@@ -51,6 +68,10 @@ Future<BuildResult?> build(
   Map<String, String>? hookEnvironment,
 }) async {
   final targetOS = target?.os ?? OS.current;
+  final runPackageName_ = runPackageName ??
+      (packageLayout?.rootPackageRoot ?? packageUri)
+          .pathSegments
+          .lastWhere((e) => e.isNotEmpty);
   return await runWithLog(capturedLogs, () async {
     final result = await NativeAssetsBuildRunner(
       logger: logger,
@@ -86,7 +107,7 @@ Future<BuildResult?> build(
       inputValidator: inputValidator,
       workingDirectory: packageUri,
       packageLayout: packageLayout,
-      runPackageName: runPackageName,
+      runPackageName: runPackageName_,
       linkingEnabled: linkingEnabled,
       buildAssetTypes: buildAssetTypes,
       buildValidator: buildValidator,
@@ -116,6 +137,7 @@ Future<LinkResult?> link(
   CCompilerConfig? cCompiler,
   List<String>? capturedLogs,
   PackageLayout? packageLayout,
+  String? runPackageName,
   required BuildResult buildResult,
   Uri? resourceIdentifiers,
   IOSSdk? targetIOSSdk,
@@ -126,6 +148,10 @@ Future<LinkResult?> link(
   required List<String> buildAssetTypes,
 }) async {
   final targetOS = target?.os ?? OS.current;
+  final runPackageName_ = runPackageName ??
+      (packageLayout?.rootPackageRoot ?? packageUri)
+          .pathSegments
+          .lastWhere((e) => e.isNotEmpty);
   return await runWithLog(capturedLogs, () async {
     final result = await NativeAssetsBuildRunner(
       logger: logger,
@@ -165,6 +191,7 @@ Future<LinkResult?> link(
       buildAssetTypes: buildAssetTypes,
       linkValidator: linkValidator,
       applicationAssetValidator: applicationAssetValidator,
+      runPackageName: runPackageName_,
     );
 
     if (result != null) {
@@ -198,6 +225,10 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
   required List<String> buildAssetTypes,
 }) async =>
     await runWithLog(capturedLogs, () async {
+      final runPackageName_ = runPackageName ??
+          (packageLayout?.rootPackageRoot ?? packageUri)
+              .pathSegments
+              .lastWhere((e) => e.isNotEmpty);
       final buildRunner = NativeAssetsBuildRunner(
         logger: logger,
         dartExecutable: dartExecutable,
@@ -233,7 +264,7 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
         inputValidator: buildInputValidator,
         workingDirectory: packageUri,
         packageLayout: packageLayout,
-        runPackageName: runPackageName,
+        runPackageName: runPackageName_,
         linkingEnabled: true,
         buildAssetTypes: buildAssetTypes,
         buildValidator: buildValidator,
@@ -284,6 +315,7 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
         buildAssetTypes: buildAssetTypes,
         linkValidator: linkValidator,
         applicationAssetValidator: applicationAssetValidator,
+        runPackageName: runPackageName_,
       );
 
       if (linkResult != null) {

--- a/pkgs/native_assets_builder/test/build_runner/helpers.dart
+++ b/pkgs/native_assets_builder/test/build_runner/helpers.dart
@@ -68,10 +68,8 @@ Future<BuildResult?> build(
   Map<String, String>? hookEnvironment,
 }) async {
   final targetOS = target?.os ?? OS.current;
-  final runPackageName_ = runPackageName ??
-      (packageLayout?.rootPackageRoot ?? packageUri)
-          .pathSegments
-          .lastWhere((e) => e.isNotEmpty);
+  final runPackageName_ =
+      runPackageName ?? packageUri.pathSegments.lastWhere((e) => e.isNotEmpty);
   return await runWithLog(capturedLogs, () async {
     final result = await NativeAssetsBuildRunner(
       logger: logger,
@@ -148,10 +146,8 @@ Future<LinkResult?> link(
   required List<String> buildAssetTypes,
 }) async {
   final targetOS = target?.os ?? OS.current;
-  final runPackageName_ = runPackageName ??
-      (packageLayout?.rootPackageRoot ?? packageUri)
-          .pathSegments
-          .lastWhere((e) => e.isNotEmpty);
+  final runPackageName_ =
+      runPackageName ?? packageUri.pathSegments.lastWhere((e) => e.isNotEmpty);
   return await runWithLog(capturedLogs, () async {
     final result = await NativeAssetsBuildRunner(
       logger: logger,
@@ -226,9 +222,7 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
 }) async =>
     await runWithLog(capturedLogs, () async {
       final runPackageName_ = runPackageName ??
-          (packageLayout?.rootPackageRoot ?? packageUri)
-              .pathSegments
-              .lastWhere((e) => e.isNotEmpty);
+          packageUri.pathSegments.lastWhere((e) => e.isNotEmpty);
       final buildRunner = NativeAssetsBuildRunner(
         logger: logger,
         dartExecutable: dartExecutable,

--- a/pkgs/native_assets_builder/test/build_runner/package_layout_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/package_layout_test.dart
@@ -10,7 +10,7 @@ import '../helpers.dart';
 import 'helpers.dart';
 
 void main() async {
-  test('fromRootPackageRoot', () async {
+  test('fromWorkingDirectory', () async {
     await inTempDir((tempUri) async {
       await copyTestProjects(targetUri: tempUri);
       final nativeAddUri = tempUri.resolve('native_add/');
@@ -20,13 +20,13 @@ void main() async {
 
       const fileSystem = LocalFileSystem();
       final packageLayout =
-          await PackageLayout.fromRootPackageRoot(fileSystem, nativeAddUri);
+          await PackageLayout.fromWorkingDirectory(fileSystem, nativeAddUri);
       final packageLayout2 = PackageLayout.fromPackageConfig(
         fileSystem,
         packageLayout.packageConfig,
         packageLayout.packageConfigUri,
       );
-      expect(packageLayout.rootPackageRoot, packageLayout2.rootPackageRoot);
+      expect(packageLayout.packageConfigUri, packageLayout2.packageConfigUri);
     });
   });
 }

--- a/pkgs/native_assets_builder/test/build_runner/pub_workspace_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/pub_workspace_test.dart
@@ -1,0 +1,87 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+import 'helpers.dart';
+
+void main() async {
+  late Uri tempUri;
+  setUp(() async {
+    tempUri = await tempDirForTest();
+    await copyTestProjects(targetUri: tempUri);
+  });
+
+  Future<void> makePubWorkspace(List<String> packages) async {
+    for (final package in packages) {
+      final packageUri = tempUri.resolve('$package/');
+      final pubspecUri = packageUri.resolve('pubspec.yaml');
+      var pubspec = await File.fromUri(pubspecUri).readAsString();
+      pubspec += '''
+
+resolution: workspace
+''';
+      await File.fromUri(pubspecUri).writeAsString(pubspec);
+    }
+
+    final workspacePubSpecUri = tempUri.resolve('pubspec.yaml');
+    var workspacePubSpec = '''
+name: dart_lang_native_workspace
+
+environment:
+  sdk: ^3.6.0
+
+workspace:
+''';
+    for (final package in packages) {
+      workspacePubSpec += '''
+  - $package/
+''';
+    }
+    await File.fromUri(workspacePubSpecUri).writeAsString(workspacePubSpec);
+
+    await runPubGet(
+      workingDirectory: tempUri,
+      logger: logger,
+    );
+  }
+
+  test('pub workspaces', () async {
+    final packageUri = tempUri.resolve('named_add_renamed/');
+    await Directory.fromUri(tempUri.resolve('native_add/'))
+        .rename(packageUri.toFilePath());
+    await makePubWorkspace([
+      'dart_app',
+      'native_subtract',
+      // Do not fail on package with different name than directory
+      'named_add_renamed',
+      // Do not fail on issues on packages not in dependencies.
+      'cyclic_package_1',
+      'cyclic_package_2',
+    ]);
+
+    (await buildCodeAssets(packageUri, runPackageName: 'native_add'))!;
+    final buildDirectory = tempUri.resolve('.dart_tool/native_assets_builder/');
+    final buildDirs = Directory.fromUri(buildDirectory)
+        .listSync()
+        .whereType<Directory>()
+        .map((e) => e.uri.pathSegments.lastWhere((e) => e.isNotEmpty))
+        .toList()
+      ..sort();
+    expect(buildDirs, contains('native_add'));
+    // Do not build packages not in dependencies of runPackageName.
+    expect(buildDirs, isNot(contains('native_subtract')));
+
+    final logs = <String>[];
+    (await buildCodeAssets(
+      tempUri.resolve('dart_app/'),
+      capturedLogs: logs,
+    ))!;
+    // Reuse hook results of other packages in the same workspace
+    expect(logs.join('\n'), contains('Skipping build for native_add'));
+  });
+}

--- a/pkgs/native_assets_builder/test_data/cyclic_package_1/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/cyclic_package_1/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
   cyclic_package_2:

--- a/pkgs/native_assets_builder/test_data/cyclic_package_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/cyclic_package_2/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
   cyclic_package_1:

--- a/pkgs/native_assets_builder/test_data/dart_app/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/dart_app/pubspec.yaml
@@ -3,7 +3,7 @@ name: dart_app
 publish_to: none
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
   native_add:

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/pubspec.yaml
@@ -1,4 +1,4 @@
-name: fail_on_os_sdk_version
+name: fail_on_os_sdk_version_link
 description: Fails the build due to OS API levels.
 version: 0.1.0
 

--- a/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
   logging: ^1.1.1

--- a/pkgs/native_assets_builder/test_data/native_add_version_skew/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/native_add_version_skew/hook/build.dart
@@ -11,9 +11,9 @@ void main(List<String> arguments) async {
     final packageName = config.packageName;
     final cbuilder = CBuilder.library(
       name: packageName,
-      assetName: 'src/${packageName}_bindings_generated.dart',
+      assetName: 'src/native_add_bindings_generated.dart',
       sources: [
-        'src/$packageName.c',
+        'src/native_add.c',
       ],
     );
     await cbuilder.run(

--- a/pkgs/native_assets_builder/test_data/native_add_version_skew/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_version_skew/pubspec.yaml
@@ -1,4 +1,4 @@
-name: native_add
+name: native_add_version_skew
 description: Sums two numbers with native code.
 version: 0.1.0
 

--- a/pkgs/native_assets_builder/test_data/native_add_version_skew/test/native_add_test.dart
+++ b/pkgs/native_assets_builder/test_data/native_add_version_skew/test/native_add_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:native_add/native_add.dart';
+import 'package:native_add_version_skew/native_add.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
   logging: ^1.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_linker/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_linker/pubspec.yaml
@@ -1,4 +1,4 @@
-name: wrong_namespace_asset
+name: wrong_linker
 description: Package that tries to add an asset with an id not prefixed by its package name.
 version: 0.1.0
 


### PR DESCRIPTION
Bug: https://github.com/dart-lang/native/issues/1905

* `.dart_tool/package_config.json` is possibly in a ancestor directory
* `runPackageName` argument is now required for build/link hooks.
  * Only native assets that are a dependency are built (instead of all packages in the package resolution of the whole workspace).
  * Don't crash if the root package directory name is not identical to the package name.
* Native assets are now shared for the whole workspace. (The package resolution is identical, so the native assets should be identical.

Doesn't yet address:

* `runPackageName` argument should be required for "if there are packages with native assets", the native assets experiment only has to be enabled if a dependency has a hook. (requires a bigger refactoring)