### PR TITLE
[native_assets_builder] Move `runPackageName` into `PackageLayout`

### DIFF
--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -83,9 +83,6 @@ class NativeAssetsBuildRunner {
   /// This method is invoked by launchers such as dartdev (for `dart run`) and
   /// flutter_tools (for `flutter run` and `flutter build`).
   ///
-  /// If provided, only assets of all transitive dependencies of
-  /// [runPackageName] are built.
-  ///
   /// The given [applicationAssetValidator] is only used if the build is
   /// performed without linking (i.e. [linkingEnabled] is `false`).
   ///
@@ -98,7 +95,6 @@ class NativeAssetsBuildRunner {
     required BuildValidator buildValidator,
     required ApplicationAssetValidator applicationAssetValidator,
     required PackageLayout packageLayout,
-    required String runPackageName,
     required List<String> buildAssetTypes,
     required bool linkingEnabled,
   }) async {
@@ -106,7 +102,6 @@ class NativeAssetsBuildRunner {
       hook: Hook.build,
       packageLayout: packageLayout,
       buildResult: null,
-      runPackageName: runPackageName,
     );
     if (buildPlan == null) return null;
 
@@ -185,9 +180,6 @@ class NativeAssetsBuildRunner {
   /// This method is invoked by launchers such as dartdev (for `dart run`) and
   /// flutter_tools (for `flutter run` and `flutter build`).
   ///
-  /// If provided, only assets of all transitive dependencies of
-  /// [runPackageName] are linked.
-  ///
   /// The native assets build runner does not support reentrancy for identical
   /// [BuildInput] and [LinkInput]! For more info see:
   /// https://github.com/dart-lang/native/issues/1319
@@ -198,7 +190,6 @@ class NativeAssetsBuildRunner {
     required ApplicationAssetValidator applicationAssetValidator,
     required PackageLayout packageLayout,
     Uri? resourceIdentifiers,
-    required String runPackageName,
     required List<String> buildAssetTypes,
     required BuildResult buildResult,
   }) async {
@@ -206,7 +197,6 @@ class NativeAssetsBuildRunner {
       hook: Hook.link,
       packageLayout: packageLayout,
       buildResult: buildResult,
-      runPackageName: runPackageName,
     );
     if (buildPlan == null) return null;
 
@@ -756,7 +746,6 @@ ${compileResult.stdout}
 
   Future<(List<Package>? plan, PackageGraph? dependencyGraph)> _makePlan({
     required PackageLayout packageLayout,
-    required String runPackageName,
     required Hook hook,
     // TODO(dacoharkes): How to share these two? Make them extend each other?
     BuildResult? buildResult,
@@ -772,7 +761,7 @@ ${compileResult.stdout}
           dartExecutable: Uri.file(Platform.resolvedExecutable),
           logger: logger,
         );
-        final plan = planner.plan(runPackageName);
+        final plan = planner.plan(packageLayout.runPackageName);
         return (plan, planner.packageGraph);
       case Hook.link:
         // Link hooks are not run in any particular order.

--- a/pkgs/native_assets_builder/lib/src/package_layout/package_layout.dart
+++ b/pkgs/native_assets_builder/lib/src/package_layout/package_layout.dart
@@ -25,16 +25,21 @@ class PackageLayout {
 
   final Uri packageConfigUri;
 
+  /// Only assets of transitive dependencies of [runPackageName] are built.
+  final String runPackageName;
+
   PackageLayout._(
     this._fileSystem,
     this.packageConfig,
     this.packageConfigUri,
+    this.runPackageName,
   );
 
   factory PackageLayout.fromPackageConfig(
     FileSystem fileSystem,
     PackageConfig packageConfig,
     Uri packageConfigUri,
+    String runPackageName,
   ) {
     assert(fileSystem.file(packageConfigUri).existsSync());
     packageConfigUri = packageConfigUri.normalizePath();
@@ -42,19 +47,26 @@ class PackageLayout {
       fileSystem,
       packageConfig,
       packageConfigUri,
+      runPackageName,
     );
   }
 
   static Future<PackageLayout> fromWorkingDirectory(
     FileSystem fileSystem,
     Uri workingDirectory,
+    String runPackgeName,
   ) async {
     workingDirectory = workingDirectory.normalizePath();
     final packageConfigUri =
         await findPackageConfig(fileSystem, workingDirectory);
     assert(await fileSystem.file(packageConfigUri).exists());
     final packageConfig = await loadPackageConfigUri(packageConfigUri!);
-    return PackageLayout._(fileSystem, packageConfig, packageConfigUri);
+    return PackageLayout._(
+      fileSystem,
+      packageConfig,
+      packageConfigUri,
+      runPackgeName,
+    );
   }
 
   static Future<Uri?> findPackageConfig(

--- a/pkgs/native_assets_builder/test/build_runner/build_planner_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_planner_test.dart
@@ -36,7 +36,7 @@ void main() async {
       final graph = PackageGraph.fromPubDepsJsonString(result.stdout);
 
       final packageLayout = await PackageLayout.fromWorkingDirectory(
-          const LocalFileSystem(), nativeAddUri);
+          const LocalFileSystem(), nativeAddUri, 'native_add');
       final packagesWithNativeAssets =
           await packageLayout.packagesWithAssets(Hook.build);
 
@@ -61,7 +61,7 @@ void main() async {
       await runPubGet(workingDirectory: nativeAddUri, logger: logger);
 
       final packageLayout = await PackageLayout.fromWorkingDirectory(
-          const LocalFileSystem(), nativeAddUri);
+          const LocalFileSystem(), nativeAddUri, 'native_add');
       final packagesWithNativeAssets =
           await packageLayout.packagesWithAssets(Hook.build);
       final nativeAssetsBuildPlanner =
@@ -90,7 +90,10 @@ void main() async {
         await runPubGet(workingDirectory: nativeAddUri, logger: logger);
 
         final packageLayout = await PackageLayout.fromWorkingDirectory(
-            const LocalFileSystem(), nativeAddUri);
+          const LocalFileSystem(),
+          nativeAddUri,
+          runPackageName,
+        );
         final packagesWithNativeAssets =
             await packageLayout.packagesWithAssets(Hook.build);
         final nativeAssetsBuildPlanner =

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
@@ -46,6 +46,7 @@ void main() async {
       final packageLayout = await PackageLayout.fromWorkingDirectory(
         const LocalFileSystem(),
         packageUri,
+        packageName,
       );
       await buildRunner.build(
         inputCreator: inputCreator,
@@ -55,7 +56,6 @@ void main() async {
         inputValidator: (input) async => [],
         buildValidator: (input, output) async => [],
         applicationAssetValidator: (_) async => [],
-        runPackageName: packageName,
       );
       await buildRunner.build(
         inputCreator: inputCreator,
@@ -65,7 +65,6 @@ void main() async {
         inputValidator: (input) async => [],
         buildValidator: (input, output) async => [],
         applicationAssetValidator: (_) async => [],
-        runPackageName: packageName,
       );
     });
   });

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test_helper.dart
@@ -40,6 +40,7 @@ void main(List<String> args) async {
     packageLayout: await PackageLayout.fromWorkingDirectory(
       const LocalFileSystem(),
       packageUri,
+      packageName,
     ),
     linkingEnabled: false,
     buildAssetTypes: [DataAsset.type, CodeAsset.type],
@@ -52,7 +53,6 @@ void main(List<String> args) async {
       ...await validateCodeAssetBuildOutput(input, output),
     ],
     applicationAssetValidator: validateCodeAssetInApplication,
-    runPackageName: packageName,
   );
   if (result == null) {
     throw Error();

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
@@ -42,6 +42,7 @@ void main(List<String> args) async {
     packageLayout: await PackageLayout.fromWorkingDirectory(
       const LocalFileSystem(),
       packageUri,
+      packageName,
     ),
     linkingEnabled: false,
     buildAssetTypes: [CodeAsset.type, DataAsset.type],
@@ -54,7 +55,6 @@ void main(List<String> args) async {
       ...await validateDataAssetBuildOutput(input, output),
     ],
     applicationAssetValidator: validateCodeAssetInApplication,
-    runPackageName: packageName,
   );
   if (result == null) {
     throw Error();

--- a/pkgs/native_assets_builder/test/build_runner/helpers.dart
+++ b/pkgs/native_assets_builder/test/build_runner/helpers.dart
@@ -72,6 +72,7 @@ Future<BuildResult?> build(
   final packageLayout = await PackageLayout.fromWorkingDirectory(
     const LocalFileSystem(),
     packageUri,
+    runPackageName_,
   );
   return await runWithLog(capturedLogs, () async {
     final result = await NativeAssetsBuildRunner(
@@ -107,7 +108,6 @@ Future<BuildResult?> build(
       },
       inputValidator: inputValidator,
       packageLayout: packageLayout,
-      runPackageName: runPackageName_,
       linkingEnabled: linkingEnabled,
       buildAssetTypes: buildAssetTypes,
       buildValidator: buildValidator,
@@ -152,6 +152,7 @@ Future<LinkResult?> link(
   final packageLayout = await PackageLayout.fromWorkingDirectory(
     const LocalFileSystem(),
     packageUri,
+    runPackageName_,
   );
   return await runWithLog(capturedLogs, () async {
     final result = await NativeAssetsBuildRunner(
@@ -191,7 +192,6 @@ Future<LinkResult?> link(
       buildAssetTypes: buildAssetTypes,
       linkValidator: linkValidator,
       applicationAssetValidator: applicationAssetValidator,
-      runPackageName: runPackageName_,
     );
 
     if (result != null) {
@@ -230,6 +230,7 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
       final packageLayout = await PackageLayout.fromWorkingDirectory(
         const LocalFileSystem(),
         packageUri,
+        runPackageName_,
       );
       final buildRunner = NativeAssetsBuildRunner(
         logger: logger,
@@ -265,7 +266,6 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
         },
         inputValidator: buildInputValidator,
         packageLayout: packageLayout,
-        runPackageName: runPackageName_,
         linkingEnabled: true,
         buildAssetTypes: buildAssetTypes,
         buildValidator: buildValidator,
@@ -315,7 +315,6 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
         buildAssetTypes: buildAssetTypes,
         linkValidator: linkValidator,
         applicationAssetValidator: applicationAssetValidator,
-        runPackageName: runPackageName_,
       );
 
       if (linkResult != null) {

--- a/pkgs/native_assets_builder/test/build_runner/package_layout_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/package_layout_test.dart
@@ -19,12 +19,16 @@ void main() async {
       await runPubGet(workingDirectory: nativeAddUri, logger: logger);
 
       const fileSystem = LocalFileSystem();
-      final packageLayout =
-          await PackageLayout.fromWorkingDirectory(fileSystem, nativeAddUri);
+      final packageLayout = await PackageLayout.fromWorkingDirectory(
+        fileSystem,
+        nativeAddUri,
+        'native_add',
+      );
       final packageLayout2 = PackageLayout.fromPackageConfig(
         fileSystem,
         packageLayout.packageConfig,
         packageLayout.packageConfigUri,
+        'native_add',
       );
       expect(packageLayout.packageConfigUri, packageLayout2.packageConfigUri);
     });


### PR DESCRIPTION
We don't ever invoke the native assets builder with a different `runPackageName` and the same `packageConfig`. All Dart and Flutter commands have a single runPackageName` in mind.

In a subsequent refactoring, the `PackageLayout` will move to the native assets builder constructor so that the build planner can cache the package graph fully.

(Part of a larger refactoring that will make the `NativeAssetsBuildRunner` take more arguments in the constructor such as the package config, and reduces the number of arguments to the `build` and `link` methods.)