### PR TITLE
[native_assets_builder] Move `packageLayout` to builder constructor

### DIFF
--- a/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
@@ -25,10 +25,16 @@ void main() async {
         logger: logger,
       );
 
+      final packageLayout = await PackageLayout.fromWorkingDirectory(
+        const LocalFileSystem(),
+        packageUri,
+        packageName,
+      );
       final buildRunner = NativeAssetsBuildRunner(
         logger: logger,
         dartExecutable: dartExecutable,
         fileSystem: const LocalFileSystem(),
+        packageLayout: packageLayout,
       );
 
       final targetOS = OS.current;
@@ -43,14 +49,8 @@ void main() async {
           linkModePreference: LinkModePreference.dynamic,
         );
 
-      final packageLayout = await PackageLayout.fromWorkingDirectory(
-        const LocalFileSystem(),
-        packageUri,
-        packageName,
-      );
       await buildRunner.build(
         inputCreator: inputCreator,
-        packageLayout: packageLayout,
         linkingEnabled: false,
         buildAssetTypes: [],
         inputValidator: (input) async => [],
@@ -59,7 +59,6 @@ void main() async {
       );
       await buildRunner.build(
         inputCreator: inputCreator,
-        packageLayout: packageLayout,
         linkingEnabled: false,
         buildAssetTypes: [],
         inputValidator: (input) async => [],

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test_helper.dart
@@ -19,10 +19,16 @@ void main(List<String> args) async {
     ..onRecord.listen((event) => print(event.message));
 
   final targetOS = target.os;
+  final packageLayout = await PackageLayout.fromWorkingDirectory(
+    const LocalFileSystem(),
+    packageUri,
+    packageName,
+  );
   final result = await NativeAssetsBuildRunner(
     logger: logger,
     dartExecutable: dartExecutable,
     fileSystem: const LocalFileSystem(),
+    packageLayout: packageLayout,
   ).build(
     // Set up the code input, so that the builds for different targets are
     // in different directories.
@@ -37,11 +43,6 @@ void main(List<String> args) async {
             targetOS == OS.android ? AndroidCodeConfig(targetNdkApi: 30) : null,
         linkModePreference: LinkModePreference.dynamic,
       ),
-    packageLayout: await PackageLayout.fromWorkingDirectory(
-      const LocalFileSystem(),
-      packageUri,
-      packageName,
-    ),
     linkingEnabled: false,
     buildAssetTypes: [DataAsset.type, CodeAsset.type],
     inputValidator: (input) async => [

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
@@ -23,11 +23,17 @@ void main(List<String> args) async {
     ..onRecord.listen((event) => print(event.message));
 
   final targetOS = OS.current;
+  final packageLayout = await PackageLayout.fromWorkingDirectory(
+    const LocalFileSystem(),
+    packageUri,
+    packageName,
+  );
   final result = await NativeAssetsBuildRunner(
     logger: logger,
     dartExecutable: dartExecutable,
     singleHookTimeout: timeout,
     fileSystem: const LocalFileSystem(),
+    packageLayout: packageLayout,
   ).build(
     inputCreator: () => BuildInputBuilder()
       ..config.setupCode(
@@ -39,11 +45,6 @@ void main(List<String> args) async {
             ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
             : null,
       ),
-    packageLayout: await PackageLayout.fromWorkingDirectory(
-      const LocalFileSystem(),
-      packageUri,
-      packageName,
-    ),
     linkingEnabled: false,
     buildAssetTypes: [CodeAsset.type, DataAsset.type],
     inputValidator: (input) async => [

--- a/pkgs/native_assets_builder/test/build_runner/helpers.dart
+++ b/pkgs/native_assets_builder/test/build_runner/helpers.dart
@@ -80,6 +80,7 @@ Future<BuildResult?> build(
       dartExecutable: dartExecutable,
       fileSystem: const LocalFileSystem(),
       hookEnvironment: hookEnvironment,
+      packageLayout: packageLayout,
     ).build(
       inputCreator: () {
         final inputBuilder = BuildInputBuilder();
@@ -107,7 +108,6 @@ Future<BuildResult?> build(
         return inputBuilder;
       },
       inputValidator: inputValidator,
-      packageLayout: packageLayout,
       linkingEnabled: linkingEnabled,
       buildAssetTypes: buildAssetTypes,
       buildValidator: buildValidator,
@@ -159,6 +159,7 @@ Future<LinkResult?> link(
       logger: logger,
       dartExecutable: dartExecutable,
       fileSystem: const LocalFileSystem(),
+      packageLayout: packageLayout,
     ).link(
       inputCreator: () {
         final inputBuilder = LinkInputBuilder();
@@ -186,7 +187,6 @@ Future<LinkResult?> link(
         return inputBuilder;
       },
       inputValidator: inputValidator,
-      packageLayout: packageLayout,
       buildResult: buildResult,
       resourceIdentifiers: resourceIdentifiers,
       buildAssetTypes: buildAssetTypes,
@@ -236,6 +236,7 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
         logger: logger,
         dartExecutable: dartExecutable,
         fileSystem: const LocalFileSystem(),
+        packageLayout: packageLayout,
       );
       final targetOS = target?.os ?? OS.current;
       final buildResult = await buildRunner.build(
@@ -265,7 +266,6 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
           return inputBuilder;
         },
         inputValidator: buildInputValidator,
-        packageLayout: packageLayout,
         linkingEnabled: true,
         buildAssetTypes: buildAssetTypes,
         buildValidator: buildValidator,
@@ -309,7 +309,6 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
           return inputBuilder;
         },
         inputValidator: linkInputValidator,
-        packageLayout: packageLayout,
         buildResult: buildResult,
         resourceIdentifiers: resourceIdentifiers,
         buildAssetTypes: buildAssetTypes,


### PR DESCRIPTION
All Dart and Flutter commands have a single package config and runPackageName.

Part of a larger refactoring that will make the `NativeAssetsBuildRunner` take more arguments in the constructor such as the package config, and reduces the number of arguments to the `build` and `link` methods.

This will enable:

* Caching `BuildPlanner` logic (only one `runPackageName`)
* Changing `packagesWithAssets` to take `runPackageName` into account (and possibly moving it to the native assets builder instead). https://github.com/dart-lang/native/issues/1905