### PR TITLE
[native_assets_builder] Support pub workspaces 2

### DIFF
--- a/pkgs/native_assets_builder/lib/native_assets_builder.dart
+++ b/pkgs/native_assets_builder/lib/native_assets_builder.dart
@@ -12,7 +12,10 @@ export 'package:native_assets_builder/src/build_runner/build_runner.dart'
         LinkInputValidator,
         LinkValidator,
         NativeAssetsBuildRunner;
-export 'package:native_assets_builder/src/model/build_result.dart';
+export 'package:native_assets_builder/src/model/build_result.dart'
+    show BuildResult;
 export 'package:native_assets_builder/src/model/kernel_assets.dart';
-export 'package:native_assets_builder/src/model/link_result.dart';
-export 'package:native_assets_builder/src/package_layout/package_layout.dart';
+export 'package:native_assets_builder/src/model/link_result.dart'
+    show LinkResult;
+export 'package:native_assets_builder/src/package_layout/package_layout.dart'
+    show PackageLayout;

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -723,9 +723,9 @@ ${compileResult.stdout}
     errors.addAll(await validator(input, output));
 
     if (input is BuildInput) {
+      final planner = await _planner;
       final packagesWithLink =
-          (await (await _planner).packagesWithHook(Hook.link))
-              .map((p) => p.name);
+          (await planner.packagesWithHook(Hook.link)).map((p) => p.name);
       for (final targetPackage
           in (output as BuildOutput).assets.encodedAssetsForLinking.keys) {
         if (!packagesWithLink.contains(targetPackage)) {

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   file: ^7.0.1
   graphs: ^2.3.1
   logging: ^1.2.0
+  meta: ^1.16.0
   # native_assets_cli: ^0.10.0
   native_assets_cli:
     path: ../native_assets_cli/

--- a/pkgs/native_assets_builder/test_data/manifest.yaml
+++ b/pkgs/native_assets_builder/test_data/manifest.yaml
@@ -101,6 +101,8 @@
 - native_subtract/src/native_subtract.h
 - no_asset_for_link/hook/link.dart
 - no_asset_for_link/pubspec.yaml
+- no_hook/lib/no_hook.dart
+- no_hook/pubspec.yaml
 - package_reading_metadata/hook/build.dart
 - package_reading_metadata/pubspec.yaml
 - package_with_metadata/hook/build.dart
@@ -121,6 +123,12 @@
 - simple_link/pubspec.yaml
 - some_dev_dep/bin/some_dev_dep.dart
 - some_dev_dep/pubspec.yaml
+- system_library/hook/build.dart
+- system_library/lib/memory_executable.dart
+- system_library/lib/memory_process.dart
+- system_library/lib/memory_system.dart
+- system_library/pubspec.yaml
+- system_library/test/memory_test.dart
 - transformer/data/data0.json
 - transformer/data/data1.json
 - transformer/data/data2.json
@@ -157,9 +165,3 @@
 - wrong_linker/pubspec.yaml
 - wrong_namespace_asset/hook/build.dart
 - wrong_namespace_asset/pubspec.yaml
-- system_library/pubspec.yaml
-- system_library/hook/build.dart
-- system_library/lib/memory_executable.dart
-- system_library/lib/memory_process.dart
-- system_library/lib/memory_system.dart
-- system_library/test/memory_test.dart

--- a/pkgs/native_assets_builder/test_data/no_hook/lib/no_hook.dart
+++ b/pkgs/native_assets_builder/test_data/no_hook/lib/no_hook.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:native_assets_cli/code_assets.dart';
+
+String get useSomeNativeAssetsCli => CodeAsset.type;

--- a/pkgs/native_assets_builder/test_data/no_hook/manifest.yaml
+++ b/pkgs/native_assets_builder/test_data/no_hook/manifest.yaml
@@ -1,0 +1,2 @@
+- lib/no_hook.dart
+- pubspec.yaml

--- a/pkgs/native_assets_builder/test_data/no_hook/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/no_hook/pubspec.yaml
@@ -1,0 +1,24 @@
+name: no_hook
+description: Has no hook, but has a dep on native_assets_cli.
+version: 0.1.0
+
+publish_to: none
+
+environment:
+  sdk: '>=3.6.0 <4.0.0'
+
+dependencies:
+  logging: ^1.1.1
+  # native_assets_cli: ^0.10.0
+  native_assets_cli:
+    path: ../../../native_assets_cli/
+  # native_toolchain_c: ^0.7.0
+  native_toolchain_c:
+    path: ../../../native_toolchain_c/
+
+dev_dependencies:
+  ffigen: ^8.0.2
+  lints: ^3.0.0
+  some_dev_dep:
+    path: ../some_dev_dep/
+  test: ^1.23.1


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/1905

This does a bigger refactoring to take `runPackageName` into account when checking for "if there are packages with native assets".

It changes the public API in the following way:

* `PackageLayout` no longer has methods for if packages have hooks, as it does not take into account the dependency graph
* `NativeAssetsBuildRunner` now exposes a method to query whether any packages in the dependencies have build hooks
* (The implementation is in the `BuildPlanner`, and this class stays internal.)

This means that `PackageLayout` has the API to provide the right package layout to the `NativeAssetsBuildRunner`, and the `NativeAssetsBuildRunner` has the methods to be queried by embedders/launchers.