### PR TITLE
[native_assets_builder] Fail early on too old `native_assets_cli`

### DIFF
--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -72,6 +72,9 @@ jobs:
       - run: dart pub get -C test_data/native_add_version_skew/
         if: ${{ matrix.package == 'native_assets_builder' }}
 
+      - run: dart pub get -C test_data/native_add_version_skew_2/
+        if: ${{ matrix.package == 'native_assets_builder' }}
+
       - run: dart pub get -C test_data/native_subtract/
         if: ${{ matrix.package == 'native_assets_builder' }}
 
@@ -103,6 +106,9 @@ jobs:
         if: ${{ matrix.package == 'native_assets_builder' }}
 
       - run: dart pub get -C test_data/native_dynamic_linking/
+        if: ${{ matrix.package == 'native_assets_builder' }}
+
+      - run: dart pub get -C test_data/no_hook/
         if: ${{ matrix.package == 'native_assets_builder' }}
 
       - run: dart pub get -C example/build/download_asset/

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   native_assets_cli:
     path: ../native_assets_cli/
   package_config: ^2.1.0
+  pub_semver: ^2.1.5
   yaml: ^3.1.2
   yaml_edit: ^2.1.0
 

--- a/pkgs/native_assets_builder/test/build_runner/version_skew_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/version_skew_test.dart
@@ -36,4 +36,33 @@ void main() async {
       }
     });
   });
+
+  test('Test hook using a too old version of native_assets_cli',
+      timeout: longTimeout, () async {
+    await inTempDir((tempUri) async {
+      await copyTestProjects(targetUri: tempUri);
+      final packageUri = tempUri.resolve('native_add_version_skew_2/');
+
+      // First, run `pub get`, we need pub to resolve our dependencies.
+      await runPubGet(
+        workingDirectory: packageUri,
+        logger: logger,
+      );
+
+      final logMessages = <String>[];
+      final result = await buildCodeAssets(
+        packageUri,
+        capturedLogs: logMessages,
+      );
+      expect(result, isNull);
+      expect(
+          logMessages.join('\n'),
+          stringContainsInOrder([
+            'The protocol version of ',
+            'native_assets_cli',
+            ' is 1.3.0, which is no longer supported.',
+            'Please update your dependencies.'
+          ]));
+    });
+  });
 }

--- a/pkgs/native_assets_builder/test_data/manifest.yaml
+++ b/pkgs/native_assets_builder/test_data/manifest.yaml
@@ -69,6 +69,8 @@
 - native_add_version_skew/src/native_add.c
 - native_add_version_skew/src/native_add.h
 - native_add_version_skew/test/native_add_test.dart
+- native_add_version_skew_2/hook/build.dart
+- native_add_version_skew_2/pubspec.yaml
 - native_add/ffigen.yaml
 - native_add/hook/build.dart
 - native_add/lib/native_add.dart

--- a/pkgs/native_assets_builder/test_data/native_add_version_skew_2/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/native_add_version_skew_2/hook/build.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:logging/logging.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_toolchain_c/native_toolchain_c.dart';
+
+void main(List<String> arguments) async {
+  await build(arguments, (config, output) async {
+    final packageName = config.packageName;
+    final cbuilder = CBuilder.library(
+      name: packageName,
+      assetName: 'src/native_add_bindings_generated.dart',
+      sources: [
+        'src/native_add.c',
+      ],
+      dartBuildFiles: [],
+    );
+    await cbuilder.run(
+      config: config,
+      output: output,
+      logger: Logger('')
+        ..level = Level.ALL
+        ..onRecord.listen((record) {
+          print('${record.level.name}: ${record.time}: ${record.message}');
+        }),
+    );
+  });
+}

--- a/pkgs/native_assets_builder/test_data/native_add_version_skew_2/manifest.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_version_skew_2/manifest.yaml
@@ -1,0 +1,2 @@
+- hook/build.dart
+- pubspec.yaml

--- a/pkgs/native_assets_builder/test_data/native_add_version_skew_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_version_skew_2/pubspec.yaml
@@ -1,0 +1,20 @@
+name: native_add_version_skew_2
+description: This package should no longer work due to being too old.
+version: 0.1.0
+
+publish_to: none
+
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+
+dependencies:
+  logging: ^1.1.1
+  native_assets_cli: ^0.6.0
+  native_toolchain_c: ^0.5.0
+
+dev_dependencies:
+  ffigen: ^8.0.2
+  lints: ^3.0.0
+  some_dev_dep:
+    path: ../some_dev_dep/
+  test: ^1.23.1

--- a/pkgs/native_assets_cli/lib/native_assets_cli_internal.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli_internal.dart
@@ -6,4 +6,5 @@
 library;
 
 export 'native_assets_cli_builder.dart';
+export 'src/config.dart' show latestParsableVersion;
 export 'src/model/hook.dart';


### PR DESCRIPTION
Since we know the `PackageConfig`, we can check in the native assets builder what version of `native_assets_cli` is used in the hook implementations.

Since we know the `PackageConfig`, we also know the package root of `native_assets_cli` and try to find the version of the protocol it's using.

If we find that the protocol version is no longer supported, give an error message early and stop building native assets instead of actually invoking the hook.