### PR TITLE
[native_assets_builder] Fix hook compile caching 

### DIFF
--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.1
+
+- Don't recompile hooks on `package_config.json` having an updated timestamp.
+
 ## 0.11.0
 
 - **Breaking change** Complete overhaul of the use of `NativeAssetsBuildRunner`

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -585,7 +585,7 @@ ${e.message}
     final environmentForCaching = <String, String>{};
     final packageConfigHashable =
         outputDirectory.resolve('../package_config_hashable.json');
-    await makeHashablePackageConfig(packageConfigHashable);
+    await _makeHashablePackageConfig(packageConfigHashable);
     final kernelFile = _fileSystem.file(
       outputDirectory.resolve('../hook.dill'),
     );
@@ -644,7 +644,7 @@ ${e.message}
     return (kernelFile, dependenciesHashes);
   }
 
-  Future<void> makeHashablePackageConfig(Uri uri) async {
+  Future<void> _makeHashablePackageConfig(Uri uri) async {
     final contents =
         await _fileSystem.file(packageLayout.packageConfigUri).readAsString();
     final jsonData = jsonDecode(contents) as Map<String, Object?>;

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_assets_builder
 description: >-
   This package is the backend that invokes build hooks.
-version: 0.11.0
+version: 0.11.1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_builder
 
 # publish_to: none


### PR DESCRIPTION
The `package_config.json` can update with irrelevant information (such as the timestamp). Don't recompile the hooks if only the timestamp changed.

Testing: The existing tests started failing. Possibly after `dartdev` started running `pub get` more often automatically after https://dart-review.googlesource.com/c/sdk/+/404583.