### PR TITLE
[jni] Add support for JArray.of()

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -7,6 +7,8 @@
   java types.
 - Do not require a `dylibDir` when running `Jni.spawn` from Dart standalone,
   instead use the default value of `build/jni_libs`.
+- Added `JArray.of`, which allows a `JArray` to be constructed from an
+  `Iterable`.
 
 ## 0.13.0
 

--- a/pkgs/jni/lib/src/jarray.dart
+++ b/pkgs/jni/lib/src/jarray.dart
@@ -125,9 +125,12 @@ class JArray<E extends JObject?> extends JObject with Iterable<E> {
   factory JArray(JObjType<E> elementType, int length) {
     RangeError.checkNotNegative(length);
     if (!elementType.isNullable) {
-      throw StateError('Element type of JArray must be nullable when '
-          'all elements with null\n\n'
-          'Try using .nullableType instead');
+      throw ArgumentError.value(
+          elementType,
+          'elementType',
+          'Element type of JArray must be nullable when constructed with a '
+              'length (because the elements will be initialized to null).\n\n'
+              'Try using .nullableType instead');
     }
     return _newArray<E>(elementType, length);
   }
@@ -157,6 +160,13 @@ class JArray<E extends JObject?> extends JObject with Iterable<E> {
     RangeError.checkNotNegative(length);
     E ??= fill.$type as JObjType<$E>;
     return _newArray<$E>(E, length, fill);
+  }
+
+  /// Creates a [JArray] from `elements`.
+  static JArray<$E> of<$E extends JObject?>(
+      JObjType<$E> elementType, Iterable<$E> elements) {
+    return _newArray<$E>(elementType, elements.length)
+      ..setRange(0, elements.length, elements);
   }
 
   /// The number of elements in this array.

--- a/pkgs/jni/test/jarray_test.dart
+++ b/pkgs/jni/test/jarray_test.dart
@@ -411,6 +411,8 @@ void run({required TestRunnerCallback testRunner}) {
       expect(array[0], isNull);
       expect(array[1], isNull);
       expect(array[2], isNull);
+
+      expect(() => JArray(JObject.type, 3), throwsArgumentError);
     });
   });
   testRunner('Java 2d array', () {
@@ -445,6 +447,28 @@ void run({required TestRunnerCallback testRunner}) {
       expect(array[0].toDartString(releaseOriginal: true), 'abc');
       expect(array[1].toDartString(releaseOriginal: true), 'abc');
       expect(array[2].toDartString(releaseOriginal: true), 'abc');
+    });
+  });
+  testRunner('JArray.of', () {
+    using((arena) {
+      final array1 = JArray.of(JString.type, [
+        'apple'.toJString()..releasedBy(arena),
+        'banana'.toJString()..releasedBy(arena)
+      ])
+        ..releasedBy(arena);
+      expect(array1.length, 2);
+      expect(array1[0].toDartString(releaseOriginal: true), 'apple');
+      expect(array1[1].toDartString(releaseOriginal: true), 'banana');
+
+      final array2 = JArray.of(JString.nullableType, [
+        'apple'.toJString()..releasedBy(arena),
+        null,
+        'banana'.toJString()..releasedBy(arena)
+      ]);
+      expect(array2.length, 3);
+      expect(array2[0]!.toDartString(releaseOriginal: true), 'apple');
+      expect(array2[1], isNull);
+      expect(array2[2]!.toDartString(releaseOriginal: true), 'banana');
     });
   });
   testRunner('JArray of JByte', () {

--- a/pkgs/jni/test/jarray_test.dart
+++ b/pkgs/jni/test/jarray_test.dart
@@ -469,6 +469,12 @@ void run({required TestRunnerCallback testRunner}) {
       expect(array2[0]!.toDartString(releaseOriginal: true), 'apple');
       expect(array2[1], isNull);
       expect(array2[2]!.toDartString(releaseOriginal: true), 'banana');
+
+      final array3 = JArray.of<JObject>(JString.type, []);
+      expect(array3.length, 0);
+
+      final array4 = JArray.of<JObject?>(JString.nullableType, []);
+      expect(array4.length, 0);
     });
   });
   testRunner('JArray of JByte', () {


### PR DESCRIPTION
Allows a JArray to be constructed from an iterable of elements.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
