### PR TITLE
[ffigen] Bumped dart_style to 3.0

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/library.dart
+++ b/pkgs/ffigen/lib/src/code_generator/library.dart
@@ -94,8 +94,9 @@ class Library {
     if (!file.existsSync()) file.createSync(recursive: true);
     var bindings = generate();
     if (format) {
-      final formatter =
-          DartFormatter(languageVersion: DartFormatter.latestLanguageVersion);
+      final formatter = DartFormatter(
+        languageVersion: DartFormatter.latestShortStyleLanguageVersion,
+      );
       bindings = formatter.format(bindings);
     }
     file.writeAsStringSync(bindings);

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   args: ^2.6.0
   cli_util: ^0.4.2
   collection: ^1.18.0
-  dart_style: ^2.3.7
+  dart_style: ^3.0.0
   ffi: ^2.0.1
   file: ^7.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Was hitting an issue in some of my projects that `ffigen: ^16.0.0` depends on `dart_style: <3.0.0` which depends on `analyzer: <7.0.0`, but analyzer `7.0.0` is being used by some other packages, which makes ffigen the bottleneck. This PR fixes that by simply bumping `dart_style` from `^2.3.7` to `^3.0.0`.

The biggest change from `dart_style` (see [the changelog](https://pub.dev/packages/dart_style/changelog)) is the _mandatory_ inclusion of the language version, in order to facilitate the new 3.7 formatter. Luckily, ffigen already passed this parameter voluntarily, so no code change was necessary. 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
