### PR TITLE
[infra] Skip autopublishing for Flutter SDK packages

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,8 @@ on:
   pull_request:
     branches: [ main ]
   push:
-    tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+' ]
+    # TODO: Enable autopublishing for these when Flutter SDK is supported.
+    tags: [ '(?!ffigen-v|jni-v|jnigen-v|objective_c-v)[A-z]+-v[0-9]+.[0-9]+.[0-9]+' ]
 
 jobs:
   publish:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
   push:
     # TODO: Enable autopublishing for these when Flutter SDK is supported.
-    tags: [ '(?!ffigen-v|jni-v|jnigen-v|objective_c-v)[A-z]+-v[0-9]+.[0-9]+.[0-9]+' ]
+    tags: [ '(?!ffigen-v|jni-v|jnigen-v|objective_c-v)[A-z0-9_-]+-v[0-9]+.[0-9]+.[0-9]+' ]
 
 jobs:
   publish:


### PR DESCRIPTION
I believe it would be good if we were to add tags for FFIgen and JNIgen, but autopublishing currently doesn't work. So we should skip the workflow for those.