### PR TITLE
[infra] Skip autopublishing for Flutter SDK packages - 2

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
   push:
     # TODO: Enable autopublishing for these when Flutter SDK is supported.
-    tags: [ '(?!ffigen-v|jni-v|jnigen-v|objective_c-v)[A-z0-9_\-]+-v[0-9]+.[0-9]+.[0-9]+' ]
+    tags: [ '(?!ffigen-v|jni-v|jnigen-v|objective_c-v)[A-z0-9_]+-v[0-9]+.[0-9]+.[0-9]+' ]
 
 jobs:
   publish:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
   push:
     # TODO: Enable autopublishing for these when Flutter SDK is supported.
-    tags: [ '(?!ffigen-v|jni-v|jnigen-v|objective_c-v)[A-z0-9]+-v[0-9]+.[0-9]+.[0-9]+' ]
+    tags: [ '(?!ffigen-v|jni-v|jnigen-v|objective_c-v)[A-z0-9\_]+-v[0-9]+.[0-9]+.[0-9]+' ]
 
 jobs:
   publish:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
   push:
     # TODO: Enable autopublishing for these when Flutter SDK is supported.
-    tags: [ '(?!ffigen-v|jni-v|jnigen-v|objective_c-v)[A-z0-9_]+-v[0-9]+.[0-9]+.[0-9]+' ]
+    tags: [ '(?!ffigen-v|jni-v|jnigen-v|objective_c-v)[A-z0-9]+-v[0-9]+.[0-9]+.[0-9]+' ]
 
 jobs:
   publish:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,7 +7,12 @@ on:
     branches: [ main ]
   push:
     # TODO: Enable autopublishing for these when Flutter SDK is supported.
-    tags: [ '(?!ffigen-v|jni-v|jnigen-v|objective_c-v)[A-z0-9\_]+-v[0-9]+.[0-9]+.[0-9]+' ]
+    tags:
+      - '[A-z0-9]+-v[0-9]+.[0-9]+.[0-9]+'
+      - '!ffigen-v**'
+      - '!jni-v**'
+      - '!jnigen-v**'
+      - '!objective_c-v**'
 
 jobs:
   publish:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
   push:
     # TODO: Enable autopublishing for these when Flutter SDK is supported.
-    tags: [ '(?!ffigen-v|jni-v|jnigen-v|objective_c-v)[A-z0-9_-]+-v[0-9]+.[0-9]+.[0-9]+' ]
+    tags: [ '(?!ffigen-v|jni-v|jnigen-v|objective_c-v)[A-z0-9_\-]+-v[0-9]+.[0-9]+.[0-9]+' ]
 
 jobs:
   publish:


### PR DESCRIPTION
Aparently autosubmit wasn't stopped by https://github.com/dart-lang/native/actions/runs/13030317922 🙈 

Documentation on how to use this correctly:

* https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-branches-and-tags (It doesn't detail what a "pattern" is, apparently not really a regex?
* https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet (apparently underscore patterns are not supported. However, the autopublisher has been working just fine for `native_assets_cli-v0.11.0`...)