### PR TITLE
[ffigen] Handle ConstantArray in Global

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Use package:objective_c 5.0.0
 - Support transitive categories of built-in types:
   https://github.com/dart-lang/native/issues/1820
+- Fix global arrays handling to remove extra pointer reference.
 
 ## 16.1.0
 

--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Use package:objective_c 5.0.0
 - Support transitive categories of built-in types:
   https://github.com/dart-lang/native/issues/1820
-- Fix global arrays handling to remove extra pointer reference.
+- Fix the handling of global arrays to remove the extra pointer reference.
 
 ## 16.1.0
 

--- a/pkgs/ffigen/lib/src/code_generator/global.dart
+++ b/pkgs/ffigen/lib/src/code_generator/global.dart
@@ -49,7 +49,12 @@ class Global extends LookUpBinding {
     }
     final dartType = type.getDartType(w);
     final ffiDartType = type.getFfiDartType(w);
-    final cType = type.getCType(w);
+
+    // Removing pointer reference for ConstantArray cType since we always wrap
+    // globals with pointer below.
+    final cType = (type is ConstantArray && !nativeConfig.enabled)
+        ? (type as ConstantArray).child.getCType(w)
+        : type.getCType(w);
 
     void generateConvertingGetterAndSetter(String pointerValue) {
       final getValue =
@@ -117,6 +122,8 @@ class Global extends LookUpBinding {
         } else {
           s.write('$ffiDartType get $globalVarName => $pointerName.ref;\n\n');
         }
+      } else if (baseTypealiasType is ConstantArray) {
+        s.write('$ffiDartType get $globalVarName => $pointerName;\n\n');
       } else if (type.sameDartAndFfiDartType) {
         s.write('$dartType get $globalVarName => $pointerName.value;\n\n');
         if (!constant) {

--- a/pkgs/ffigen/test/code_generator_tests/expected_bindings/_expected_global_bindings.dart
+++ b/pkgs/ffigen/test/code_generator_tests/expected_bindings/_expected_global_bindings.dart
@@ -33,10 +33,9 @@ class Bindings {
 
   ffi.Pointer<ffi.Float> get test2 => _test2.value;
 
-  late final ffi.Pointer<ffi.Pointer<ffi.Float>> _test3 =
-      _lookup<ffi.Pointer<ffi.Float>>('test3');
+  late final ffi.Pointer<ffi.Float> _test3 = _lookup<ffi.Float>('test3');
 
-  ffi.Pointer<ffi.Float> get test3 => _test3.value;
+  ffi.Pointer<ffi.Float> get test3 => _test3;
 
   late final ffi.Pointer<ffi.Pointer<Some>> _test5 =
       _lookup<ffi.Pointer<Some>>('test5');

--- a/pkgs/ffigen/test/header_parser_tests/globals.h
+++ b/pkgs/ffigen/test/header_parser_tests/globals.h
@@ -14,6 +14,8 @@ const int32_t *const aGlobalPointer3 = nullptr;
 long double longDouble;
 long double *pointerToLongDouble;
 
+int globalArray0[3];
+
 // This should be ignored
 int GlobalIgnore;
 

--- a/pkgs/ffigen/test/header_parser_tests/globals_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/globals_test.dart
@@ -119,6 +119,12 @@ Library expectedLibrary() {
         exposeSymbolAddress: true,
         constant: true,
       ),
+      Global(
+        type: ConstantArray(3, intType, useArrayType: false),
+        name: 'globalArray0',
+        exposeSymbolAddress: true,
+        constant: true,
+      ),
       globalStruct,
       Global(
         name: 'globalStruct',

--- a/pkgs/ffigen/test/native_test/_expected_native_test_bindings.dart
+++ b/pkgs/ffigen/test/native_test/_expected_native_test_bindings.dart
@@ -278,6 +278,11 @@ class NativeLibrary {
           'getStructWithEnums');
   late final _getStructWithEnums =
       _getStructWithEnumsPtr.asFunction<StructWithEnums Function()>();
+
+  late final ffi.Pointer<ffi.Int> _globalArray =
+      _lookup<ffi.Int>('globalArray');
+
+  ffi.Pointer<ffi.Int> get globalArray => _globalArray;
 }
 
 final class Struct1 extends ffi.Struct {

--- a/pkgs/ffigen/test/native_test/native_test.c
+++ b/pkgs/ffigen/test/native_test/native_test.c
@@ -115,3 +115,5 @@ StructWithEnums getStructWithEnums() {
     }
     return s;
 }
+
+int globalArray[3];

--- a/pkgs/ffigen/test/native_test/native_test.dart
+++ b/pkgs/ffigen/test/native_test/native_test.dart
@@ -101,6 +101,14 @@ void main() {
     test('double', () {
       expect(bindings.Function1Double(0), 42.0);
     });
+    test('array global', () {
+      bindings.globalArray[0] = 1;
+      bindings.globalArray[1] = 2;
+      expect(bindings.globalArray[0], 1);
+      expect(bindings.globalArray[1], 2);
+      bindings.globalArray[1] = 3;
+      expect(bindings.globalArray[1], 3);
+    });
     test('Array Test: Order of access', () {
       final struct1 = bindings.getStruct1();
       var expectedValue = 1;

--- a/pkgs/ffigen/test/native_test/native_test.def
+++ b/pkgs/ffigen/test/native_test/native_test.def
@@ -21,3 +21,4 @@ Function1StructPassByValue
 funcWithEnum1
 funcWithEnum2
 getStructWithEnums
+globalArray


### PR DESCRIPTION
Closes #1922

- Handled ConstantArray declaration (`a[3]`) in global variables to remove extra Pointer reference.
- Updated tests, changelog
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
