### PR TITLE
[jni] Add `JByteArray.from`

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Added `JObject.isA`, which checks whether a `JObject` is a instance of a
   java class.
 - Do not require JWT when building for desktop.
+- Added `JByteArray.from`, which allows a `JByteArray` to be constructed
+  from an `Iterable<int>`.
 
 ## 0.13.0
 

--- a/pkgs/jni/lib/src/jarray.dart
+++ b/pkgs/jni/lib/src/jarray.dart
@@ -468,6 +468,13 @@ final class JByteArrayType extends JObjType<JByteArray> {
   }
 }
 
+/// A fixed-length array of Java [`Byte`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Byte.html).
+///
+/// Integers stored in the list are truncated to their low eight bits,
+/// interpreted as a signed 8-bit two's complement integer with values in the
+/// range -128 to +127.
+///
+/// Java equivalent of [Int8List].
 class JByteArray extends JObject with Iterable<int> {
   @internal
   @override
@@ -484,6 +491,16 @@ class JByteArray extends JObject with Iterable<int> {
   JByteArray.fromReference(super.reference)
       : $type = type,
         super.fromReference();
+
+  /// Creates a [JByteArray] containing all `elements`.
+  ///
+  /// The [Iterator] of elements provides the order of the elements.
+  ///
+  /// Elements outside of the range -128 to +127 are truncated to their low
+  /// eight bits and interpreted as signed 8-bit two's complement integers.
+  factory JByteArray.from(Iterable<int> elements) {
+    return JByteArray(elements.length)..setRange(0, elements.length, elements);
+  }
 
   /// Creates a [JByteArray] of the given [length].
   ///

--- a/pkgs/jni/test/jarray_test.dart
+++ b/pkgs/jni/test/jarray_test.dart
@@ -106,6 +106,13 @@ void run({required TestRunnerCallback testRunner}) {
   });
   testRunner('Java byte array', () {
     using((arena) {
+      expect(JByteArray.from([]), isEmpty);
+      expect(JByteArray.from([1]), containsAllInOrder([1]));
+      expect(JByteArray.from([1, 2]), containsAllInOrder([1, 2]));
+      expect(JByteArray.from([-1, -2]), containsAllInOrder([-1, -2]));
+      expect(JByteArray.from([127, 128, 129]),
+          containsAllInOrder([127, -128, -127]));
+
       final array = JByteArray(3)..releasedBy(arena);
       var counter = 0;
       for (final element in array) {


### PR DESCRIPTION
- Much of the documentation is taken from `Int8List` and `List`.
- The difference between the `of`, `from` and `fromList` factories might be confusing. `from` and `fromList` are consistent with Dart. `of` is an extra method for converting Java objects stored in Dart lists into Java arrays.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
