### PR TITLE
[jnigen] Fix doclet type parameter parsing

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -11,7 +11,7 @@
   `Iterable`.
 - Added `JObject.isA`, which checks whether a `JObject` is a instance of a
   java class.
-- Do not require JWT when building for desktop.
+- Do not require JAWT when building for desktop.
 - Added `JByteArray.from`, which allows a `JByteArray` to be constructed
   from an `Iterable<int>`.
 

--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.14.0-wip
+
+- Fixed a bug where the source parser would not have all of the type paremeters
+  of the types.
+
 ## 0.13.1
 
 - Fixed a bug where Kotlin wildcards would crash the code generation.

--- a/pkgs/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/doclet/ElementBuilders.java
+++ b/pkgs/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/doclet/ElementBuilders.java
@@ -7,6 +7,7 @@ package com.github.dart_lang.jnigen.apisummarizer.doclet;
 import com.github.dart_lang.jnigen.apisummarizer.elements.*;
 import com.github.dart_lang.jnigen.apisummarizer.util.StreamUtil;
 import com.sun.source.doctree.DocCommentTree;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -144,10 +145,22 @@ public class ElementBuilders {
                   ? env.elements.getBinaryName((TypeElement) element).toString()
                   : element.getSimpleName().toString();
           assert (type instanceof DeclaredType);
-          List<TypeUsage> params =
+          List<TypeUsage> params = new ArrayList<>();
+          List<Integer> typeParamIndices = new ArrayList<>();
+          var enclosingType = ((DeclaredType) type).getEnclosingType();
+          if (enclosingType instanceof DeclaredType) {
+            var enclosingTypeUsage = (TypeUsage.DeclaredType) typeUsage(enclosingType).type;
+            params.addAll(enclosingTypeUsage.params);
+            typeParamIndices.addAll(enclosingTypeUsage.typeParamIndices);
+          }
+          if (!params.isEmpty()) {
+            typeParamIndices.add(params.size());
+          }
+          params.addAll(
               ((DeclaredType) type)
-                  .getTypeArguments().stream().map(this::typeUsage).collect(Collectors.toList());
+                  .getTypeArguments().stream().map(this::typeUsage).collect(Collectors.toList()));
           u.type = new TypeUsage.DeclaredType(name, element.getSimpleName().toString(), params);
+          ((TypeUsage.DeclaredType) u.type).typeParamIndices = typeParamIndices;
           break;
         }
       case TYPEVAR:

--- a/pkgs/jnigen/pubspec.yaml
+++ b/pkgs/jnigen/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jnigen
 description: A Dart bindings generator for Java and Kotlin that uses JNI under the hood to interop with Java virtual machine.
-version: 0.13.1
+version: 0.14.0-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jnigen
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Ajnigen
 

--- a/pkgs/jnigen/test/simple_package_test/generate.dart
+++ b/pkgs/jnigen/test/simple_package_test/generate.dart
@@ -63,7 +63,7 @@ void compileJavaSources(String workingDir, List<String> files) async {
   }
 }
 
-Config getConfig([SummarizerBackend backend = SummarizerBackend.asm]) {
+Config getConfig({SummarizerBackend backend = SummarizerBackend.asm}) {
   compileJavaSources(javaPath, javaFiles);
   final dartWrappersRoot = Uri.directory(
     join(testRoot, 'bindings'),

--- a/pkgs/jnigen/test/simple_package_test/generate.dart
+++ b/pkgs/jnigen/test/simple_package_test/generate.dart
@@ -63,7 +63,7 @@ void compileJavaSources(String workingDir, List<String> files) async {
   }
 }
 
-Config getConfig() {
+Config getConfig([SummarizerBackend backend = SummarizerBackend.asm]) {
   compileJavaSources(javaPath, javaFiles);
   final dartWrappersRoot = Uri.directory(
     join(testRoot, 'bindings'),
@@ -71,7 +71,7 @@ Config getConfig() {
   final config = Config(
     sourcePath: [Uri.directory(javaPath)],
     classPath: [Uri.directory(javaPath)],
-    summarizerOptions: SummarizerOptions(backend: SummarizerBackend.asm),
+    summarizerOptions: SummarizerOptions(backend: backend),
     classes: [
       'com.github.dart_lang.jnigen.simple_package',
       'com.github.dart_lang.jnigen.pkg2',

--- a/pkgs/jnigen/test/simple_package_test/generated_files_test.dart
+++ b/pkgs/jnigen/test/simple_package_test/generated_files_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:jnigen/src/config/config.dart';
+import 'package:test/test.dart';
+
 import '../test_util/test_util.dart';
 import 'generate.dart';
 
@@ -12,4 +15,9 @@ void main() async {
     'Generate and compare bindings for simple_package java files',
     getConfig(),
   );
+
+  test('Generate and analyze bindings for simple_package java files - doclet',
+      () async {
+    await generateAndAnalyzeBindings(getConfig(SummarizerBackend.doclet));
+  });
 }

--- a/pkgs/jnigen/test/simple_package_test/generated_files_test.dart
+++ b/pkgs/jnigen/test/simple_package_test/generated_files_test.dart
@@ -18,6 +18,7 @@ void main() async {
 
   test('Generate and analyze bindings for simple_package java files - doclet',
       () async {
-    await generateAndAnalyzeBindings(getConfig(SummarizerBackend.doclet));
+    await generateAndAnalyzeBindings(
+        getConfig(backend: SummarizerBackend.doclet));
   });
 }

--- a/pkgs/jnigen/test/summary_test.dart
+++ b/pkgs/jnigen/test/summary_test.dart
@@ -64,7 +64,6 @@ void registerCommonTests(Classes classes) {
     expect(example.getMethod('getNumber').modifiers, isPublic);
     expect(example.getMethod('privateMethod').modifiers, isPrivate);
     expect(example.getMethod('protectedMethod').modifiers, isProtected);
-    print(example.fields.map((f) => f.name).toList());
     expect(example.getField('OFF').modifiers, isPublic);
     expect(example.getField('number').modifiers, isPrivate);
     expect(example.getField('protectedField').modifiers, isProtected);
@@ -150,13 +149,19 @@ void registerCommonTests(Classes classes) {
     expect(mapType.params, hasLength(2));
     final strType = mapType.params[0];
     expect(strType.name, 'java.lang.String');
-    // TODO(#141): Wildcard implementation.
-    /*
     final wildcardType = mapType.params[1];
     expect(wildcardType.kind, equals(Kind.wildcard));
     expect((wildcardType.type as Wildcard).extendsBound?.name,
         equals('java.lang.CharSequence'));
-    */
+  });
+
+  test('typeParameters', () {
+    final grandParent = classes.getClass('generics', 'GrandParent');
+    final stringParent = grandParent.getMethod('stringParent');
+    final returnType = stringParent.returnType.type as DeclaredType;
+    expect(returnType.params, hasLength(2));
+    expect(returnType.params[0].type, isA<TypeVar>());
+    expect(returnType.params[1].type, isA<DeclaredType>());
   });
 
   test('superclass', () {


### PR DESCRIPTION
The doclet parser (unlike asm) would not deeply parse all of the type parameters in nested classes. For example in `Foo<T>.Bar<U>.Baz<S>`, it'd only have `[S]` instead of `[T, U, S]`.

This is not a breaking change. Bumped the version of jnigen to 0.14.0 only to match jni's to prepare for today's publishing.

Closes #1901.