### PR TITLE
[infra] Configure dependabot commit messages

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,3 +12,5 @@ updates:
       github-actions:
         patterns:
           - "*"
+    commit-message:
+      prefix: "[infra] "


### PR DESCRIPTION
Trying https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#prefix to satisfy our PR title checker.