### PR TITLE
[jnigen] Support Kotlin operators

### DIFF
--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.14.1-wip
+- Added support for generating matching Kotlin operators as Dart operators.
+
 ## 0.14.0
 
 - Fixed a bug where the source parser would not have all of the type paremeters

--- a/pkgs/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/elements/KotlinFunction.java
+++ b/pkgs/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/elements/KotlinFunction.java
@@ -26,6 +26,7 @@ public class KotlinFunction {
   public List<KotlinTypeParameter> typeParameters;
   public int flags;
   public boolean isSuspend;
+  public boolean isOperator;
 
   public static KotlinFunction fromKmFunction(KmFunction f) {
     var fun = new KotlinFunction();
@@ -36,6 +37,7 @@ public class KotlinFunction {
     fun.flags = f.getFlags();
     // Processing the information needed from the flags.
     fun.isSuspend = Flag.Function.IS_SUSPEND.invoke(fun.flags);
+    fun.isOperator = Flag.Function.IS_OPERATOR.invoke(fun.flags);
     fun.valueParameters =
         f.getValueParameters().stream()
             .map(KotlinValueParameter::fromKmValueParameter)

--- a/pkgs/jnigen/lib/src/bindings/kotlin_processor.dart
+++ b/pkgs/jnigen/lib/src/bindings/kotlin_processor.dart
@@ -136,6 +136,7 @@ class _KotlinMethodProcessor extends Visitor<Method, void> {
   @override
   void visit(Method node) {
     _processParams(node.params, function.valueParameters);
+    node.kotlinFunction = function;
     for (var i = 0; i < node.typeParams.length; ++i) {
       node.typeParams[i]
           .accept(_KotlinTypeParamProcessor(function.typeParameters[i]));

--- a/pkgs/jnigen/lib/src/elements/elements.g.dart
+++ b/pkgs/jnigen/lib/src/elements/elements.g.dart
@@ -280,6 +280,7 @@ KotlinFunction _$KotlinFunctionFromJson(Map<String, dynamic> json) =>
           const [],
       flags: (json['flags'] as num).toInt(),
       isSuspend: json['isSuspend'] as bool,
+      isOperator: json['isOperator'] as bool,
     );
 
 KotlinConstructor _$KotlinConstructorFromJson(Map<String, dynamic> json) =>

--- a/pkgs/jnigen/pubspec.yaml
+++ b/pkgs/jnigen/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jnigen
 description: A Dart bindings generator for Java and Kotlin that uses JNI under the hood to interop with Java virtual machine.
-version: 0.14.0
+version: 0.14.1-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jnigen
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Ajnigen
 

--- a/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
+++ b/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
@@ -1617,6 +1617,444 @@ final class $Nullability$Type<$T extends jni$_.JObject?,
   }
 }
 
+/// from: `com.github.dart_lang.jnigen.Operators`
+class Operators extends jni$_.JObject {
+  @jni$_.internal
+  @core$_.override
+  final jni$_.JObjType<Operators> $type;
+
+  @jni$_.internal
+  Operators.fromReference(
+    jni$_.JReference reference,
+  )   : $type = type,
+        super.fromReference(reference);
+
+  static final _class =
+      jni$_.JClass.forName(r'com/github/dart_lang/jnigen/Operators');
+
+  /// The type which includes information such as the signature of this class.
+  static const nullableType = $Operators$NullableType();
+  static const type = $Operators$Type();
+  static final _id_new$ = _class.constructorId(
+    r'(I)V',
+  );
+
+  static final _new$ = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JniResult Function(
+                  jni$_.Pointer<jni$_.Void>,
+                  jni$_.JMethodIDPtr,
+                  jni$_.VarArgs<(jni$_.Int32,)>)>>('globalEnv_NewObject')
+      .asFunction<
+          jni$_.JniResult Function(
+              jni$_.Pointer<jni$_.Void>, jni$_.JMethodIDPtr, int)>();
+
+  /// from: `public void <init>(int i)`
+  /// The returned object must be released after use, by calling the [release] method.
+  factory Operators(
+    int i,
+  ) {
+    return Operators.fromReference(
+        _new$(_class.reference.pointer, _id_new$ as jni$_.JMethodIDPtr, i)
+            .reference);
+  }
+
+  static final _id_getValue = _class.instanceMethodId(
+    r'getValue',
+    r'()I',
+  );
+
+  static final _getValue = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JniResult Function(
+                jni$_.Pointer<jni$_.Void>,
+                jni$_.JMethodIDPtr,
+              )>>('globalEnv_CallIntMethod')
+      .asFunction<
+          jni$_.JniResult Function(
+            jni$_.Pointer<jni$_.Void>,
+            jni$_.JMethodIDPtr,
+          )>();
+
+  /// from: `public final int getValue()`
+  int getValue() {
+    return _getValue(reference.pointer, _id_getValue as jni$_.JMethodIDPtr)
+        .integer;
+  }
+
+  static final _id_setValue = _class.instanceMethodId(
+    r'setValue',
+    r'(I)V',
+  );
+
+  static final _setValue = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JThrowablePtr Function(
+                  jni$_.Pointer<jni$_.Void>,
+                  jni$_.JMethodIDPtr,
+                  jni$_.VarArgs<(jni$_.Int32,)>)>>('globalEnv_CallVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(
+              jni$_.Pointer<jni$_.Void>, jni$_.JMethodIDPtr, int)>();
+
+  /// from: `public final void setValue(int i)`
+  void setValue(
+    int i,
+  ) {
+    _setValue(reference.pointer, _id_setValue as jni$_.JMethodIDPtr, i).check();
+  }
+
+  static final _id_plus = _class.instanceMethodId(
+    r'plus',
+    r'(Lcom/github/dart_lang/jnigen/Operators;)Lcom/github/dart_lang/jnigen/Operators;',
+  );
+
+  static final _plus = jni$_.ProtectedJniExtensions.lookup<
+              jni$_.NativeFunction<
+                  jni$_.JniResult Function(
+                      jni$_.Pointer<jni$_.Void>,
+                      jni$_.JMethodIDPtr,
+                      jni$_.VarArgs<(jni$_.Pointer<jni$_.Void>,)>)>>(
+          'globalEnv_CallObjectMethod')
+      .asFunction<
+          jni$_.JniResult Function(jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `public final com.github.dart_lang.jnigen.Operators plus(com.github.dart_lang.jnigen.Operators operators)`
+  /// The returned object must be released after use, by calling the [release] method.
+  Operators plus(
+    Operators operators,
+  ) {
+    final _$operators = operators.reference;
+    return _plus(reference.pointer, _id_plus as jni$_.JMethodIDPtr,
+            _$operators.pointer)
+        .object<Operators>(const $Operators$Type());
+  }
+
+  static final _id_plus$1 = _class.instanceMethodId(
+    r'plus',
+    r'(I)Lcom/github/dart_lang/jnigen/Operators;',
+  );
+
+  static final _plus$1 = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JniResult Function(
+                  jni$_.Pointer<jni$_.Void>,
+                  jni$_.JMethodIDPtr,
+                  jni$_.VarArgs<(jni$_.Int32,)>)>>('globalEnv_CallObjectMethod')
+      .asFunction<
+          jni$_.JniResult Function(
+              jni$_.Pointer<jni$_.Void>, jni$_.JMethodIDPtr, int)>();
+
+  /// from: `public final com.github.dart_lang.jnigen.Operators plus(int i)`
+  /// The returned object must be released after use, by calling the [release] method.
+  Operators plus$1(
+    int i,
+  ) {
+    return _plus$1(reference.pointer, _id_plus$1 as jni$_.JMethodIDPtr, i)
+        .object<Operators>(const $Operators$Type());
+  }
+
+  static final _id_minus = _class.instanceMethodId(
+    r'minus',
+    r'(Lcom/github/dart_lang/jnigen/Operators;)Lcom/github/dart_lang/jnigen/Operators;',
+  );
+
+  static final _minus = jni$_.ProtectedJniExtensions.lookup<
+              jni$_.NativeFunction<
+                  jni$_.JniResult Function(
+                      jni$_.Pointer<jni$_.Void>,
+                      jni$_.JMethodIDPtr,
+                      jni$_.VarArgs<(jni$_.Pointer<jni$_.Void>,)>)>>(
+          'globalEnv_CallObjectMethod')
+      .asFunction<
+          jni$_.JniResult Function(jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `public final com.github.dart_lang.jnigen.Operators minus(com.github.dart_lang.jnigen.Operators operators)`
+  /// The returned object must be released after use, by calling the [release] method.
+  Operators minus(
+    Operators operators,
+  ) {
+    final _$operators = operators.reference;
+    return _minus(reference.pointer, _id_minus as jni$_.JMethodIDPtr,
+            _$operators.pointer)
+        .object<Operators>(const $Operators$Type());
+  }
+
+  static final _id_times = _class.instanceMethodId(
+    r'times',
+    r'(Lcom/github/dart_lang/jnigen/Operators;)Lcom/github/dart_lang/jnigen/Operators;',
+  );
+
+  static final _times = jni$_.ProtectedJniExtensions.lookup<
+              jni$_.NativeFunction<
+                  jni$_.JniResult Function(
+                      jni$_.Pointer<jni$_.Void>,
+                      jni$_.JMethodIDPtr,
+                      jni$_.VarArgs<(jni$_.Pointer<jni$_.Void>,)>)>>(
+          'globalEnv_CallObjectMethod')
+      .asFunction<
+          jni$_.JniResult Function(jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `public final com.github.dart_lang.jnigen.Operators times(com.github.dart_lang.jnigen.Operators operators)`
+  /// The returned object must be released after use, by calling the [release] method.
+  Operators times(
+    Operators operators,
+  ) {
+    final _$operators = operators.reference;
+    return _times(reference.pointer, _id_times as jni$_.JMethodIDPtr,
+            _$operators.pointer)
+        .object<Operators>(const $Operators$Type());
+  }
+
+  static final _id_div = _class.instanceMethodId(
+    r'div',
+    r'(Lcom/github/dart_lang/jnigen/Operators;)Lcom/github/dart_lang/jnigen/Operators;',
+  );
+
+  static final _div = jni$_.ProtectedJniExtensions.lookup<
+              jni$_.NativeFunction<
+                  jni$_.JniResult Function(
+                      jni$_.Pointer<jni$_.Void>,
+                      jni$_.JMethodIDPtr,
+                      jni$_.VarArgs<(jni$_.Pointer<jni$_.Void>,)>)>>(
+          'globalEnv_CallObjectMethod')
+      .asFunction<
+          jni$_.JniResult Function(jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `public final com.github.dart_lang.jnigen.Operators div(com.github.dart_lang.jnigen.Operators operators)`
+  /// The returned object must be released after use, by calling the [release] method.
+  Operators div(
+    Operators operators,
+  ) {
+    final _$operators = operators.reference;
+    return _div(reference.pointer, _id_div as jni$_.JMethodIDPtr,
+            _$operators.pointer)
+        .object<Operators>(const $Operators$Type());
+  }
+
+  static final _id_rem = _class.instanceMethodId(
+    r'rem',
+    r'(Lcom/github/dart_lang/jnigen/Operators;)Lcom/github/dart_lang/jnigen/Operators;',
+  );
+
+  static final _rem = jni$_.ProtectedJniExtensions.lookup<
+              jni$_.NativeFunction<
+                  jni$_.JniResult Function(
+                      jni$_.Pointer<jni$_.Void>,
+                      jni$_.JMethodIDPtr,
+                      jni$_.VarArgs<(jni$_.Pointer<jni$_.Void>,)>)>>(
+          'globalEnv_CallObjectMethod')
+      .asFunction<
+          jni$_.JniResult Function(jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `public final com.github.dart_lang.jnigen.Operators rem(com.github.dart_lang.jnigen.Operators operators)`
+  /// The returned object must be released after use, by calling the [release] method.
+  Operators rem(
+    Operators operators,
+  ) {
+    final _$operators = operators.reference;
+    return _rem(reference.pointer, _id_rem as jni$_.JMethodIDPtr,
+            _$operators.pointer)
+        .object<Operators>(const $Operators$Type());
+  }
+
+  static final _id_get = _class.instanceMethodId(
+    r'get',
+    r'(I)Z',
+  );
+
+  static final _get = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JniResult Function(
+                  jni$_.Pointer<jni$_.Void>,
+                  jni$_.JMethodIDPtr,
+                  jni$_
+                      .VarArgs<(jni$_.Int32,)>)>>('globalEnv_CallBooleanMethod')
+      .asFunction<
+          jni$_.JniResult Function(
+              jni$_.Pointer<jni$_.Void>, jni$_.JMethodIDPtr, int)>();
+
+  /// from: `public final boolean get(int i)`
+  bool get(
+    int i,
+  ) {
+    return _get(reference.pointer, _id_get as jni$_.JMethodIDPtr, i).boolean;
+  }
+
+  static final _id_set = _class.instanceMethodId(
+    r'set',
+    r'(IZ)V',
+  );
+
+  static final _set = jni$_.ProtectedJniExtensions.lookup<
+              jni$_.NativeFunction<
+                  jni$_.JThrowablePtr Function(
+                      jni$_.Pointer<jni$_.Void>,
+                      jni$_.JMethodIDPtr,
+                      jni$_.VarArgs<(jni$_.Int32, jni$_.Int32)>)>>(
+          'globalEnv_CallVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(
+              jni$_.Pointer<jni$_.Void>, jni$_.JMethodIDPtr, int, int)>();
+
+  /// from: `public final void set(int i, boolean z)`
+  void set(
+    int i,
+    bool z,
+  ) {
+    _set(reference.pointer, _id_set as jni$_.JMethodIDPtr, i, z ? 1 : 0)
+        .check();
+  }
+
+  static final _id_compareTo = _class.instanceMethodId(
+    r'compareTo',
+    r'(Lcom/github/dart_lang/jnigen/Operators;)I',
+  );
+
+  static final _compareTo = jni$_.ProtectedJniExtensions.lookup<
+              jni$_.NativeFunction<
+                  jni$_.JniResult Function(
+                      jni$_.Pointer<jni$_.Void>,
+                      jni$_.JMethodIDPtr,
+                      jni$_.VarArgs<(jni$_.Pointer<jni$_.Void>,)>)>>(
+          'globalEnv_CallIntMethod')
+      .asFunction<
+          jni$_.JniResult Function(jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr, jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `public final int compareTo(com.github.dart_lang.jnigen.Operators operators)`
+  int compareTo(
+    Operators operators,
+  ) {
+    final _$operators = operators.reference;
+    return _compareTo(reference.pointer, _id_compareTo as jni$_.JMethodIDPtr,
+            _$operators.pointer)
+        .integer;
+  }
+
+  Operators operator +(Operators operators) {
+    return plus(operators);
+  }
+
+  Operators operator -(Operators operators) {
+    return minus(operators);
+  }
+
+  Operators operator *(Operators operators) {
+    return times(operators);
+  }
+
+  Operators operator /(Operators operators) {
+    return div(operators);
+  }
+
+  Operators operator %(Operators operators) {
+    return rem(operators);
+  }
+
+  bool operator [](int i) {
+    return get(i);
+  }
+
+  void operator []=(int i, bool z) {
+    set(i, z);
+  }
+
+  bool operator <(Operators operators) {
+    return compareTo(operators) < 0;
+  }
+
+  bool operator <=(Operators operators) {
+    return compareTo(operators) <= 0;
+  }
+
+  bool operator >(Operators operators) {
+    return compareTo(operators) > 0;
+  }
+
+  bool operator >=(Operators operators) {
+    return compareTo(operators) >= 0;
+  }
+}
+
+final class $Operators$NullableType extends jni$_.JObjType<Operators?> {
+  @jni$_.internal
+  const $Operators$NullableType();
+
+  @jni$_.internal
+  @core$_.override
+  String get signature => r'Lcom/github/dart_lang/jnigen/Operators;';
+
+  @jni$_.internal
+  @core$_.override
+  Operators? fromReference(jni$_.JReference reference) => reference.isNull
+      ? null
+      : Operators.fromReference(
+          reference,
+        );
+  @jni$_.internal
+  @core$_.override
+  jni$_.JObjType get superType => const jni$_.JObjectType();
+
+  @jni$_.internal
+  @core$_.override
+  jni$_.JObjType<Operators?> get nullableType => this;
+
+  @jni$_.internal
+  @core$_.override
+  final superCount = 1;
+
+  @core$_.override
+  int get hashCode => ($Operators$NullableType).hashCode;
+
+  @core$_.override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($Operators$NullableType) &&
+        other is $Operators$NullableType;
+  }
+}
+
+final class $Operators$Type extends jni$_.JObjType<Operators> {
+  @jni$_.internal
+  const $Operators$Type();
+
+  @jni$_.internal
+  @core$_.override
+  String get signature => r'Lcom/github/dart_lang/jnigen/Operators;';
+
+  @jni$_.internal
+  @core$_.override
+  Operators fromReference(jni$_.JReference reference) =>
+      Operators.fromReference(
+        reference,
+      );
+  @jni$_.internal
+  @core$_.override
+  jni$_.JObjType get superType => const jni$_.JObjectType();
+
+  @jni$_.internal
+  @core$_.override
+  jni$_.JObjType<Operators?> get nullableType =>
+      const $Operators$NullableType();
+
+  @jni$_.internal
+  @core$_.override
+  final superCount = 1;
+
+  @core$_.override
+  int get hashCode => ($Operators$Type).hashCode;
+
+  @core$_.override
+  bool operator ==(Object other) {
+    return other.runtimeType == ($Operators$Type) && other is $Operators$Type;
+  }
+}
+
 /// from: `com.github.dart_lang.jnigen.Speed`
 class Speed extends Measure<SpeedUnit> {
   @jni$_.internal

--- a/pkgs/jnigen/test/kotlin_test/kotlin/src/main/kotlin/com/github/dart_lang/jnigen/Operators.kt
+++ b/pkgs/jnigen/test/kotlin_test/kotlin/src/main/kotlin/com/github/dart_lang/jnigen/Operators.kt
@@ -1,0 +1,42 @@
+package com.github.dart_lang.jnigen
+
+class Operators(var value: Int) {
+    operator fun plus(op: Operators): Operators {
+        return Operators(value + op.value)
+    }
+
+    operator fun plus(int: Int): Operators {
+        return Operators(value + int)
+    }
+
+    operator fun minus(op: Operators): Operators {
+        return Operators(value - op.value)
+    }
+
+    operator fun times(op: Operators): Operators {
+        return Operators(value * op.value)
+    }
+
+    operator fun div(op: Operators): Operators {
+        return Operators(value / op.value)
+    }
+
+    operator fun rem(op: Operators): Operators {
+        return Operators(value % op.value)
+    }
+
+    operator fun get(index: Int): Boolean {
+        return ((value shr index) and 1)  == 1
+    }
+
+    operator fun set(index: Int, bit: Boolean) {
+        if (get(index) == bit) {
+            return
+        }
+        value = (value xor (1 shl index))
+    }
+
+    fun compareTo(op: Operators): Int {
+        return value.compareTo(op.value)
+    }
+}

--- a/pkgs/jnigen/test/kotlin_test/runtime_test_registrant.dart
+++ b/pkgs/jnigen/test/kotlin_test/runtime_test_registrant.dart
@@ -41,6 +41,89 @@ void registerTests(String groupName, TestRunnerCallback test) {
       });
     });
 
+    group('Operators', () {
+      Operators testObject(int value, Arena arena) {
+        return Operators(value)..releasedBy(arena);
+      }
+
+      test('+', () {
+        using((arena) {
+          final o24 = testObject(24, arena);
+          final o18 = testObject(18, arena);
+          expect((o24.plus(o18)..releasedBy(arena)).getValue(), 42);
+          expect(((o24 + o18)..releasedBy(arena)).getValue(), 42);
+        });
+      });
+
+      test('-', () {
+        using((arena) {
+          final o24 = testObject(24, arena);
+          final o18 = testObject(18, arena);
+          expect((o24.minus(o18)..releasedBy(arena)).getValue(), 6);
+          expect(((o24 - o18)..releasedBy(arena)).getValue(), 6);
+        });
+      });
+
+      test('*', () {
+        using((arena) {
+          final o2 = testObject(2, arena);
+          final o3 = testObject(3, arena);
+          expect((o2.times(o3)..releasedBy(arena)).getValue(), 6);
+          expect(((o2 * o3)..releasedBy(arena)).getValue(), 6);
+        });
+      });
+
+      test('/', () {
+        using((arena) {
+          final o24 = testObject(24, arena);
+          final o3 = testObject(3, arena);
+          expect((o24.div(o3)..releasedBy(arena)).getValue(), 8);
+          expect(((o24 / o3)..releasedBy(arena)).getValue(), 8);
+        });
+      });
+
+      test('%', () {
+        using((arena) {
+          final o24 = testObject(24, arena);
+          final o5 = testObject(5, arena);
+          expect((o24.rem(o5)..releasedBy(arena)).getValue(), 4);
+          expect(((o24 % o5)..releasedBy(arena)).getValue(), 4);
+        });
+      });
+
+      test('[], []=', () {
+        using((arena) {
+          // 25 in binary: 11001
+          final o = testObject(25, arena);
+          expect(o[0], true); // 1100[1]
+          expect(o[1], false); // 110[0]1
+          expect(o.get(2), false); // 11[0]01
+
+          o[0] = false; // 1100[0]
+          expect(o[0], false); // 1100[0]
+          o.set(1, true); // 110[1]0
+          expect(o[1], true); // 110[1]0
+        });
+      });
+
+      test('<, <=, >, >=', () {
+        using((arena) {
+          final o24 = testObject(24, arena);
+          final o18 = testObject(18, arena);
+          expect(o24.compareTo(o18), greaterThan(0));
+          expect(o18.compareTo(o24), lessThan(0));
+
+          expect(o24 < o18, isFalse);
+          expect(o24 <= o18, isFalse);
+          expect(o24 > o18, isTrue);
+          expect(o24 >= o18, isTrue);
+
+          expect(o24 >= o24, isTrue);
+          expect(o18 <= o18, isTrue);
+        });
+      });
+    });
+
     group('Nullability', () {
       Nullability<JString?, JString> testObject(Arena arena) {
         return Nullability(


### PR DESCRIPTION
Generate `+`, `-`, `*`, `/`, `%`, `[]`, `[]=` operators in Dart. Some of Dart operators don't exist in Kotlin and vice-versa. These are the group of operators that make sense. Also we only generate them if they fit the Dart model (For example, `[]` can take multiple parameters in Kotlin, while in Dart it can only get 1). If there are multiple overloads, only generate the first matching one as an operator.

We still generate the original method, this is consistent with Kotlin, as `a.add(b)` and `a + b` are equivalent.