### PR TITLE
[jnigen] small fix for renaming constructors

### DIFF
--- a/pkgs/jnigen/lib/src/bindings/renamer.dart
+++ b/pkgs/jnigen/lib/src/bindings/renamer.dart
@@ -236,7 +236,7 @@ class _MethodRenamer implements Visitor<Method, void> {
   @override
   void visit(Method node) {
     final name = _preprocess(
-        node.isConstructor ? 'new' : node.userDefinedName ?? node.name);
+        node.userDefinedName ?? (node.isConstructor ? 'new' : node.name));
     final sig = node.javaSig;
     // If node is in super class, assign its number, overriding it.
     final superClass =

--- a/pkgs/jnigen/lib/src/elements/j_elements.dart
+++ b/pkgs/jnigen/lib/src/elements/j_elements.dart
@@ -70,6 +70,8 @@ class Method implements Element {
 
   String get originalName => _method.name;
 
+  bool get isConstructor => _method.isConstructor;
+
   @override
   void accept(Visitor visitor) {
     visitor.visitMethod(this);

--- a/pkgs/jnigen/test/user_visitors.dart
+++ b/pkgs/jnigen/test/user_visitors.dart
@@ -67,6 +67,9 @@ class UserRenamer extends Visitor {
     if (method.originalName.contains('Foo')) {
       method.name = method.originalName.replaceAll('Foo', 'Bar');
     }
+    if (method.isConstructor) {
+      method.name = 'constructor';
+    }
   }
 
   @override
@@ -172,6 +175,7 @@ void main() {
             ast.Param(name: 'Foo', type: ast.TypeUsage.object),
             ast.Param(name: 'Foo1', type: ast.TypeUsage.object),
           ]),
+          ast.Method(name: '<init>', returnType: ast.TypeUsage.object)
         ],
       ),
     });
@@ -189,6 +193,8 @@ void main() {
 
     expect(classes.decls['Foo']?.methods.finalNames,
         [r'Bar$2', r'Bar$3', r'Bar1$2', r'Bar1$3']);
+
+    expect(classes.decls['y.Foo']?.methods.finalNames, [r'Bar', 'constructor']);
 
     expect(classes.decls['y.Foo']?.methods.first.params.finalNames,
         ['Bar', 'Bar1']);


### PR DESCRIPTION
- small fix for renaming constructors.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
