### PR TITLE
[objective_c] Wrap `Dart_InitializeApiDL` in `DOBJC_InitializeApi`

### DIFF
--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Add various ObjC protocols to the bindings.
 - Make all visible API types public.
 - Add a `osVersion` getter, which returns the current MacOS/iOS version.
+- Fixed [a bug](https://github.com/dart-lang/native/issues/1978) where Dart API
+  symbols could be null despite Dart_InitializeApiDL returning successfully.
 
 ## 4.1.0
 

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.0.0-wip
+## 5.0.0
 
 - __Breaking change__: Rename the `NSString` to `String` conversion method from
   `toString()` to `toDartString()`.

--- a/pkgs/objective_c/ffigen_c.yaml
+++ b/pkgs/objective_c/ffigen_c.yaml
@@ -21,7 +21,6 @@ functions:
     - 'sel_getName'
     - 'protocol_getMethodDescription'
     - 'protocol_getName'
-    - 'Dart_InitializeApiDL'
     - 'newFinalizableHandle'
     - 'DOBJC_.*'
   leaf:

--- a/pkgs/objective_c/lib/src/c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/c_bindings_generated.dart
@@ -35,23 +35,6 @@ external void DOBJC_runOnMainThread(
   ffi.Pointer<ffi.Void> arg,
 );
 
-/// \mainpage Dynamically Linked Dart API
-///
-/// This exposes a subset of symbols from dart_api.h and dart_native_api.h
-/// available in every Dart embedder through dynamic linking.
-///
-/// All symbols are postfixed with _DL to indicate that they are dynamically
-/// linked and to prevent conflicts with the original symbol.
-///
-/// Link `dart_api_dl.c` file into your library and invoke
-/// `Dart_InitializeApiDL` with `NativeApi.initializeApiDLData`.
-///
-/// Returns 0 on success.
-@ffi.Native<ffi.IntPtr Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external int Dart_InitializeApiDL(
-  ffi.Pointer<ffi.Void> data,
-);
-
 @ffi.Array.multi([32])
 @ffi.Native<ffi.Array<ffi.Pointer<ffi.Void>>>(symbol: "_NSConcreteAutoBlock")
 external ffi.Array<ffi.Pointer<ffi.Void>> NSConcreteAutoBlock;

--- a/pkgs/objective_c/lib/src/c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/c_bindings_generated.dart
@@ -20,6 +20,11 @@ library;
 
 import 'dart:ffi' as ffi;
 
+@ffi.Native<ffi.IntPtr Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
+external int DOBJC_InitializeApi(
+  ffi.Pointer<ffi.Void> data,
+);
+
 @ffi.Native<
     ffi.Void Function(
         ffi.Pointer<

--- a/pkgs/objective_c/lib/src/internal.dart
+++ b/pkgs/objective_c/lib/src/internal.dart
@@ -177,7 +177,7 @@ bool _dartAPIInitialized = false;
 void _ensureDartAPI() {
   if (!_dartAPIInitialized) {
     _dartAPIInitialized = true;
-    c.Dart_InitializeApiDL(NativeApi.initializeApiDLData);
+    c.DOBJC_InitializeApi(NativeApi.initializeApiDLData);
   }
 }
 

--- a/pkgs/objective_c/lib/src/internal.dart
+++ b/pkgs/objective_c/lib/src/internal.dart
@@ -176,8 +176,9 @@ final class _FinalizablePointer<T extends NativeType> implements Finalizable {
 bool _dartAPIInitialized = false;
 void _ensureDartAPI() {
   if (!_dartAPIInitialized) {
+    final result = c.DOBJC_InitializeApi(NativeApi.initializeApiDLData);
+    assert(result == 0);
     _dartAPIInitialized = true;
-    c.DOBJC_InitializeApi(NativeApi.initializeApiDLData);
   }
 }
 

--- a/pkgs/objective_c/pubspec.yaml
+++ b/pkgs/objective_c/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: objective_c
 description: 'A library to access Objective C from Flutter that acts as a support library for package:ffigen.'
-version: 5.0.0-wip
+version: 5.0.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/objective_c
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aobjective_c
 
@@ -28,7 +28,7 @@ dev_dependencies:
   args: ^2.6.0
   coverage: ^1.11.0
   dart_flutter_team_lints: ^2.0.0
-  ffigen: ^17.0.0
+  ffigen: ^16.1.0
   flutter_lints: ^3.0.0
   flutter_test:
     sdk: flutter

--- a/pkgs/objective_c/src/objective_c.c
+++ b/pkgs/objective_c/src/objective_c.c
@@ -46,3 +46,5 @@ bool* DOBJC_newFinalizableBool(Dart_Handle owner) {
   Dart_NewFinalizableHandle_DL(owner, pointer, 1, finalizeMalloc);
   return pointer;
 }
+
+intptr_t DOBJC_InitializeApi(void* data) { return Dart_InitializeApiDL(data); }

--- a/pkgs/objective_c/src/objective_c.c
+++ b/pkgs/objective_c/src/objective_c.c
@@ -12,11 +12,11 @@
 
 // Dispose helper for ObjC blocks that wrap a Dart closure. For these blocks,
 // the target is an int ID, and the dispose_port is listening for these IDs.
-void DOBJC_disposeObjCBlockWithClosure(ObjCBlockImpl* block) {
+FFI_EXPORT void DOBJC_disposeObjCBlockWithClosure(ObjCBlockImpl* block) {
   Dart_PostInteger_DL(block->dispose_port, (int64_t)block->target);
 }
 
-bool DOBJC_isValidBlock(ObjCBlockImpl* block) {
+FFI_EXPORT bool DOBJC_isValidBlock(ObjCBlockImpl* block) {
   if (block == NULL) return false;
   void* isa = block->isa;
   return isa == &_NSConcreteStackBlock || isa == &_NSConcreteMallocBlock ||
@@ -24,27 +24,32 @@ bool DOBJC_isValidBlock(ObjCBlockImpl* block) {
          isa == &_NSConcreteGlobalBlock || isa == &_NSConcreteWeakBlockVariable;
 }
 
-void DOBJC_finalizeObject(void* isolate_callback_data, void* peer) {
+FFI_EXPORT void DOBJC_finalizeObject(void* isolate_callback_data, void* peer) {
   // objc_release works for Objects and Blocks.
   DOBJC_runOnMainThread((void (*)(void*))objc_release, peer);
 }
 
-Dart_FinalizableHandle DOBJC_newFinalizableHandle(Dart_Handle owner,
-                                            ObjCObject* object) {
+FFI_EXPORT Dart_FinalizableHandle
+DOBJC_newFinalizableHandle(Dart_Handle owner, ObjCObject* object) {
   return Dart_NewFinalizableHandle_DL(owner, object, 0, DOBJC_finalizeObject);
 }
 
-void DOBJC_deleteFinalizableHandle(Dart_FinalizableHandle handle, Dart_Handle owner) {
+FFI_EXPORT void DOBJC_deleteFinalizableHandle(Dart_FinalizableHandle handle,
+                                              Dart_Handle owner) {
   Dart_DeleteFinalizableHandle_DL(handle, owner);
 }
 
-static void finalizeMalloc(void* isolate_callback_data, void* peer) { free(peer); }
+static void finalizeMalloc(void* isolate_callback_data, void* peer) {
+  free(peer);
+}
 
-bool* DOBJC_newFinalizableBool(Dart_Handle owner) {
+FFI_EXPORT bool* DOBJC_newFinalizableBool(Dart_Handle owner) {
   bool* pointer = (bool*)malloc(1);
   *pointer = false;
   Dart_NewFinalizableHandle_DL(owner, pointer, 1, finalizeMalloc);
   return pointer;
 }
 
-intptr_t DOBJC_InitializeApi(void* data) { return Dart_InitializeApiDL(data); }
+FFI_EXPORT intptr_t DOBJC_InitializeApi(void* data) {
+  return Dart_InitializeApiDL(data);
+}

--- a/pkgs/objective_c/src/objective_c.h
+++ b/pkgs/objective_c/src/objective_c.h
@@ -46,4 +46,6 @@ FFI_EXPORT void* DOBJC_newWaiter(void);
 FFI_EXPORT void DOBJC_signalWaiter(void* waiter);
 FFI_EXPORT void DOBJC_awaitWaiter(void* waiter);
 
+intptr_t DOBJC_InitializeApi(void* data);
+
 #endif // OBJECTIVE_C_SRC_OBJECTIVE_C_H_

--- a/pkgs/objective_c/src/objective_c.h
+++ b/pkgs/objective_c/src/objective_c.h
@@ -9,6 +9,9 @@
 #include "include/dart_api_dl.h"
 #include "objective_c_runtime.h"
 
+// Initialize the Dart API.
+FFI_EXPORT intptr_t DOBJC_InitializeApi(void *data);
+
 // Dispose helper for ObjC blocks that wrap a Dart closure.
 FFI_EXPORT void DOBJC_disposeObjCBlockWithClosure(ObjCBlockImpl *block);
 
@@ -42,10 +45,8 @@ FFI_EXPORT void DOBJC_runOnMainThread(void (*fn)(void *), void *arg);
 // Functions for creating a waiter, signaling it, and waiting for the signal. A
 // waiter is one-time-use, and the object that newWaiter creates will be
 // destroyed once signalWaiter and awaitWaiter are called exactly once.
-FFI_EXPORT void* DOBJC_newWaiter(void);
-FFI_EXPORT void DOBJC_signalWaiter(void* waiter);
-FFI_EXPORT void DOBJC_awaitWaiter(void* waiter);
+FFI_EXPORT void *DOBJC_newWaiter(void);
+FFI_EXPORT void DOBJC_signalWaiter(void *waiter);
+FFI_EXPORT void DOBJC_awaitWaiter(void *waiter);
 
-intptr_t DOBJC_InitializeApi(void* data);
-
-#endif // OBJECTIVE_C_SRC_OBJECTIVE_C_H_
+#endif  // OBJECTIVE_C_SRC_OBJECTIVE_C_H_


### PR DESCRIPTION
`Dart_InitializeApiDL` stores function pointers for various Dart API methods in static variables. Those variables are global per dylib. There may be multiple dylibs in an app that contain `Dart_InitializeApiDL`, thus multiple copies of the static variables. If we're not careful about which `Dart_InitializeApiDL` we're invoking, we'll initialize the wrong static variables, causing NPEs when we later try to invoke those Dart API functions.

Wrapping `Dart_InitializeApiDL` in `DOBJC_InitializeApi` (a wrapper function that only exists in our dylib) ensures that we're invoking the correct copy of `Dart_InitializeApiDL`.

Also, prepare to immediately publish package:objective_c v5.0.0

Fixes https://github.com/dart-lang/native/issues/1978