### PR TITLE
[ffigen] Add external-versions.*.max

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -14,6 +14,8 @@
       `id` is used: `id<FooProtocol, BarProtocol>` becomes `FooProtocol`. The
       `FooProtocol.castFrom` method can help work around issues this may cause.
 - Fix the handling of global arrays to remove the extra pointer reference.
+- Add a `max` field to the `external-versions` config, and use it to determine
+  which APIs are generated.
 
 ## 16.1.0
 

--- a/pkgs/ffigen/lib/src/code_generator/compound.dart
+++ b/pkgs/ffigen/lib/src/code_generator/compound.dart
@@ -116,9 +116,7 @@ abstract class Compound extends BindingType {
 
     final s = StringBuffer();
     final enclosingClassName = name;
-    if (dartDoc != null) {
-      s.write(makeDartDoc(dartDoc!));
-    }
+    s.write(makeDartDoc(dartDoc));
 
     /// Adding [enclosingClassName] because dart doesn't allow class member
     /// to have the same name as the class.

--- a/pkgs/ffigen/lib/src/code_generator/constant.dart
+++ b/pkgs/ffigen/lib/src/code_generator/constant.dart
@@ -43,10 +43,7 @@ class Constant extends NoLookUpBinding {
     final s = StringBuffer();
     final constantName = name;
 
-    if (dartDoc != null) {
-      s.write(makeDartDoc(dartDoc!));
-    }
-
+    s.write(makeDartDoc(dartDoc));
     s.write('\nconst $rawType $constantName = $rawValue;\n\n');
 
     return BindingString(

--- a/pkgs/ffigen/lib/src/code_generator/enum_class.dart
+++ b/pkgs/ffigen/lib/src/code_generator/enum_class.dart
@@ -206,9 +206,7 @@ class EnumClass extends BindingType {
 
   /// Writes the DartDoc string for this enum.
   void writeDartDoc(StringBuffer s) {
-    if (dartDoc != null) {
-      s.write(makeDartDoc(dartDoc!));
-    }
+    s.write(makeDartDoc(dartDoc));
   }
 
   /// Writes a sealed class when no members exist, because Dart enums cannot be

--- a/pkgs/ffigen/lib/src/code_generator/func.dart
+++ b/pkgs/ffigen/lib/src/code_generator/func.dart
@@ -102,9 +102,8 @@ class Func extends LookUpBinding {
     final s = StringBuffer();
     final enclosingFuncName = name;
 
-    if (dartDoc != null) {
-      s.write(makeDartDoc(dartDoc!));
-    }
+    s.write(makeDartDoc(dartDoc));
+
     // Resolve name conflicts in function parameter names.
     final paramNamer = UniqueNamer({});
     for (final p in functionType.dartTypeParameters) {

--- a/pkgs/ffigen/lib/src/code_generator/global.dart
+++ b/pkgs/ffigen/lib/src/code_generator/global.dart
@@ -44,9 +44,7 @@ class Global extends LookUpBinding {
   BindingString toBindingString(Writer w) {
     final s = StringBuffer();
     final globalVarName = name;
-    if (dartDoc != null) {
-      s.write(makeDartDoc(dartDoc!));
-    }
+    s.write(makeDartDoc(dartDoc));
     final dartType = type.getDartType(w);
     final ffiDartType = type.getFfiDartType(w);
 

--- a/pkgs/ffigen/lib/src/code_generator/objc_category.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_category.dart
@@ -47,7 +47,7 @@ class ObjCCategory extends NoLookUpBinding with ObjCMethods {
   BindingString toBindingString(Writer w) {
     final s = StringBuffer();
     s.write('\n');
-    s.write(makeDartDoc(dartDoc ?? originalName));
+    s.write(makeDartDoc(dartDoc));
     s.write('''
 extension $name on ${parent.getDartType(w)} {
 ${generateMethodBindings(w, parent)}

--- a/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
@@ -69,7 +69,7 @@ class ObjCInterface extends BindingType with ObjCMethods {
 ///
 ''');
     }
-    s.write(makeDartDoc(dartDoc ?? originalName));
+    s.write(makeDartDoc(dartDoc));
 
     final rawObjType = PointerType(objCObjectType).getCType(w);
     final wrapObjType = ObjCBuiltInFunctions.objectBase.gen(w);

--- a/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
@@ -20,6 +20,7 @@ class ObjCInterface extends BindingType with ObjCMethods {
   final protocols = <ObjCProtocol>[];
   final categories = <ObjCCategory>[];
   final subtypes = <ObjCInterface>[];
+  final bool unavailable;
 
   @override
   final ObjCBuiltInFunctions builtInFunctions;
@@ -34,6 +35,7 @@ class ObjCInterface extends BindingType with ObjCMethods {
     String? lookupName,
     super.dartDoc,
     required this.builtInFunctions,
+    this.unavailable = false,
   })  : lookupName = lookupName ?? originalName,
         super(name: name ?? originalName) {
     classObject = ObjCInternalGlobal('_class_$originalName',

--- a/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
@@ -348,7 +348,7 @@ class ObjCMethod extends AstNode {
     ].join(', ');
 
     // The method declaration.
-    s.write('\n  ${makeDartDoc(dartDoc ?? originalName)}  ');
+    s.write('\n  ${makeDartDoc(dartDoc)}  ');
     late String targetStr;
     if (isClassMethod) {
       targetStr = target.classObject.name;

--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -15,6 +15,7 @@ class ObjCProtocol extends BindingType with ObjCMethods {
   final ObjCInternalGlobal _protocolPointer;
   late final ObjCInternalGlobal _conformsTo;
   late final ObjCMsgSendFunc _conformsToMsgSend;
+  final bool unavailable;
 
   // Filled by ListBindingsVisitation.
   bool generateAsStub = false;
@@ -29,6 +30,7 @@ class ObjCProtocol extends BindingType with ObjCMethods {
     String? lookupName,
     super.dartDoc,
     required this.builtInFunctions,
+    this.unavailable = false,
   })  : lookupName = lookupName ?? originalName,
         _protocolPointer = ObjCInternalGlobal(
             '_protocol_$originalName',

--- a/pkgs/ffigen/lib/src/code_generator/typealias.dart
+++ b/pkgs/ffigen/lib/src/code_generator/typealias.dart
@@ -100,9 +100,7 @@ class Typealias extends BindingType {
     }
 
     final sb = StringBuffer();
-    if (dartDoc != null) {
-      sb.write(makeDartDoc(dartDoc!));
-    }
+    sb.write(makeDartDoc(dartDoc));
     sb.write('typedef $name = ${type.getCType(w)};\n');
     if (_ffiDartAliasName != null) {
       sb.write('typedef $_ffiDartAliasName = ${type.getFfiDartType(w)};\n');

--- a/pkgs/ffigen/lib/src/code_generator/writer.dart
+++ b/pkgs/ffigen/lib/src/code_generator/writer.dart
@@ -272,9 +272,7 @@ class Writer {
     /// Write [lookUpBindings].
     if (lookUpBindings.isNotEmpty) {
       // Write doc comment for wrapper class.
-      if (classDocComment != null) {
-        s.write(makeDartDoc(classDocComment!));
-      }
+      s.write(makeDartDoc(classDocComment));
       // Write wrapper classs.
       s.write('class $_className{\n');
       // Write dylib.

--- a/pkgs/ffigen/lib/src/config_provider/config_types.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config_types.dart
@@ -470,9 +470,6 @@ class ExternalVersions {
 
 class Versions {
   final Version? min;
-
-  // TODO(https://github.com/dart-lang/native/issues/300): max isn't supported
-  // yet.
   final Version? max;
 
   const Versions({this.min, this.max});

--- a/pkgs/ffigen/lib/src/config_provider/spec_utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/spec_utils.dart
@@ -676,6 +676,7 @@ Versions? versionsExtractor(dynamic yamlConfig) {
   if (yamlMap == null) return null;
   return Versions(
     min: versionExtractor(yamlMap[strings.externalVersionsMin]),
+    max: versionExtractor(yamlMap[strings.externalVersionsMax]),
   );
 }
 

--- a/pkgs/ffigen/lib/src/header_parser/parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/parser.dart
@@ -195,6 +195,9 @@ List<Binding> transformBindings(Config config, List<Binding> bindings) {
               config, included, directlyIncluded),
           included)
       .directTransitives;
+  // print("\n\nDirectly Included:\n  ${directlyIncluded.whereType<ObjCCategory>().map((p) => '${p.name}').join('\n  ')}");
+  // print("\n\nTransitives:\n  ${transitives.whereType<ObjCCategory>().map((p) => '${p.name}').join('\n  ')}");
+  // print("\n\nDirect Transitives:\n  ${directTransitives.whereType<ObjCCategory>().map((p) => '${p.name}').join('\n  ')}");
 
   final finalBindings = visit(
           ListBindingsVisitation(

--- a/pkgs/ffigen/lib/src/header_parser/parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/parser.dart
@@ -195,9 +195,6 @@ List<Binding> transformBindings(Config config, List<Binding> bindings) {
               config, included, directlyIncluded),
           included)
       .directTransitives;
-  // print("\n\nDirectly Included:\n  ${directlyIncluded.whereType<ObjCCategory>().map((p) => '${p.name}').join('\n  ')}");
-  // print("\n\nTransitives:\n  ${transitives.whereType<ObjCCategory>().map((p) => '${p.name}').join('\n  ')}");
-  // print("\n\nDirect Transitives:\n  ${directTransitives.whereType<ObjCCategory>().map((p) => '${p.name}').join('\n  ')}");
 
   final finalBindings = visit(
           ListBindingsVisitation(

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/api_availability.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/api_availability.dart
@@ -96,9 +96,9 @@ class ApiAvailability {
     return api;
   }
 
-  Availability getAvailability(ExternalVersions extVers) {
-    final macosVer = _normalizeVersions(extVers.macos);
-    final iosVer = _normalizeVersions(extVers.ios);
+  Availability getAvailability(ExternalVersions externalVersions) {
+    final macosVer = _normalizeVersions(externalVersions.macos);
+    final iosVer = _normalizeVersions(externalVersions.ios);
 
     // If no versions are specified, everything is available.
     if (iosVer == null && macosVer == null) {
@@ -110,14 +110,15 @@ class ApiAvailability {
     }
 
     Availability? availability;
-    for (final (plat, ver) in [(ios, iosVer), (macos, macosVer)]) {
+    for (final (platform, version) in [(ios, iosVer), (macos, macosVer)]) {
       // If the user hasn't specified any versions for this platform, defer to
       // the other platforms.
-      if (ver == null) {
+      if (version == null) {
         continue;
       }
       // If the API is available on any platform, return that it's available.
-      final platAvailability = plat?.getAvailability(ver) ?? Availability.all;
+      final platAvailability =
+          platform?.getAvailability(version) ?? Availability.all;
       availability = _mergeAvailability(availability, platAvailability);
     }
     return availability ?? Availability.none;
@@ -131,7 +132,7 @@ class ApiAvailability {
       x == null ? y : (x == y ? x : Availability.some);
 
   String get dartDoc =>
-      [ios, macos].nonNulls.map((plat) => plat.dartDoc).join('\n');
+      [ios, macos].nonNulls.map((platform) => platform.dartDoc).join('\n');
 
   @override
   String toString() => '''Availability {
@@ -166,15 +167,15 @@ class PlatformAvailability {
   }
 
   @visibleForTesting
-  Availability getAvailability(Versions ver) {
+  Availability getAvailability(Versions version) {
     if (unavailable) {
       return Availability.none;
     }
 
     // Note: _greaterThan treats null as Version(infinity). For lower bound
     // versions, null should be Version(0).
-    final confMin = ver.min ?? Version(0, 0, 0);
-    final confMax = ver.max;
+    final confMin = version.min ?? Version(0, 0, 0);
+    final confMax = version.max;
     final apiMin = introduced ?? Version(0, 0, 0);
     final apiMax = deprecatedOrObsoleted;
     if (_lessThanOrEqual(apiMin, confMin) && _greaterThan(apiMax, confMax)) {

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/api_availability.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/api_availability.dart
@@ -19,12 +19,6 @@ enum Availability {
   all,
 }
 
-// TODO: Remove this.
-// bool isApiAvailable(clang_types.CXCursor cursor) {
-//   final api = ApiAvailability.fromCursor(cursor);
-//   return api.getAvailability(config.externalVersions) != Availability.none;
-// }
-
 typedef ApiAvailabilityReport = ({
   Availability availability,
   String? dartDoc,

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
@@ -107,7 +107,8 @@ Compound? parseCompoundDeclaration(
     declName = '';
   }
 
-  if (!isApiAvailable(cursor)) {
+  final report = getApiAvailability(cursor);
+  if (report.availability == Availability.none) {
     _logger.info('Omitting deprecated $className $declName');
     return null;
   }
@@ -119,7 +120,7 @@ Compound? parseCompoundDeclaration(
       type: compoundType,
       name: incrementalNamer.name('Unnamed$className'),
       usr: declUsr,
-      dartDoc: getCursorDocComment(cursor),
+      dartDoc: getCursorDocComment(cursor, availability: report.dartDoc),
       objCBuiltInFunctions: objCBuiltInFunctions,
       nativeType: cursor.type().spelling(),
     );
@@ -132,7 +133,7 @@ Compound? parseCompoundDeclaration(
       usr: declUsr,
       originalName: declName,
       name: configDecl.rename(decl),
-      dartDoc: getCursorDocComment(cursor),
+      dartDoc: getCursorDocComment(cursor, availability: report.dartDoc),
       objCBuiltInFunctions: objCBuiltInFunctions,
       nativeType: cursor.type().spelling(),
     );
@@ -250,7 +251,7 @@ void _compoundMembersVisitor(
           CompoundMember(
             dartDoc: getCursorDocComment(
               cursor,
-              nesting.length + commentPrefix.length,
+              indent: nesting.length + commentPrefix.length,
             ),
             originalName: cursor.spelling(),
             name: config.structDecl.renameMember(decl, cursor.spelling()),
@@ -284,7 +285,7 @@ void _compoundMembersVisitor(
           CompoundMember(
             dartDoc: getCursorDocComment(
               cursor,
-              nesting.length + commentPrefix.length,
+              indent: nesting.length + commentPrefix.length,
             ),
             originalName: spelling,
             name: config.structDecl.renameMember(decl, spelling),

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/enumdecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/enumdecl_parser.dart
@@ -39,7 +39,8 @@ final _logger = Logger('ffigen.header_parser.enumdecl_parser');
   nativeType = signedToUnsignedNativeIntType[nativeType] ?? nativeType;
   var hasNegativeEnumConstants = false;
 
-  if (!isApiAvailable(cursor)) {
+  final report = getApiAvailability(cursor);
+  if (report.availability == Availability.none) {
     _logger.info('Omitting deprecated enum $enumName');
     return (null, nativeType);
   }
@@ -54,7 +55,7 @@ final _logger = Logger('ffigen.header_parser.enumdecl_parser');
     _logger.fine('++++ Adding Enum: ${cursor.completeStringRepr()}');
     enumClass = EnumClass(
       usr: enumUsr,
-      dartDoc: getCursorDocComment(cursor),
+      dartDoc: getCursorDocComment(cursor, availability: report.dartDoc),
       originalName: enumName,
       name: config.enumClassDecl.rename(decl),
       nativeType: nativeType,
@@ -71,7 +72,7 @@ final _logger = Logger('ffigen.header_parser.enumdecl_parser');
               EnumConstant(
                   dartDoc: getCursorDocComment(
                     child,
-                    nesting.length + commentPrefix.length,
+                    indent: nesting.length + commentPrefix.length,
                   ),
                   originalName: child.spelling(),
                   name: config.enumClassDecl.renameMember(

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
@@ -22,7 +22,8 @@ List<Func> parseFunctionDeclaration(clang_types.CXCursor cursor) {
   final funcUsr = cursor.usr();
   final funcName = cursor.spelling();
 
-  if (!isApiAvailable(cursor)) {
+  final report = getApiAvailability(cursor);
+  if (report.availability == Availability.none) {
     _logger.info('Omitting deprecated function $funcName');
     return funcs;
   }
@@ -119,7 +120,8 @@ List<Func> parseFunctionDeclaration(clang_types.CXCursor cursor) {
       funcs.add(Func(
         dartDoc: getCursorDocComment(
           cursor,
-          nesting.length + commentPrefix.length,
+          indent: nesting.length + commentPrefix.length,
+          availability: report.dartDoc,
         ),
         usr: funcUsr + vaFunc.postfix,
         name: config.functionDecl.rename(decl) + vaFunc.postfix,

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objccategorydecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objccategorydecl_parser.dart
@@ -26,7 +26,8 @@ ObjCCategory? parseObjCCategoryDeclaration(clang_types.CXCursor cursor) {
     return cachedCategory;
   }
 
-  if (!isApiAvailable(cursor)) {
+  final report = getApiAvailability(cursor);
+  if (report.availability == Availability.none) {
     _logger.info('Omitting deprecated category $name');
     return null;
   }
@@ -53,7 +54,7 @@ ObjCCategory? parseObjCCategoryDeclaration(clang_types.CXCursor cursor) {
     originalName: name,
     name: config.objcCategories.rename(decl),
     parent: parentInterface,
-    dartDoc: getCursorDocComment(cursor),
+    dartDoc: getCursorDocComment(cursor, availability: report.dartDoc) ?? name,
     builtInFunctions: objCBuiltInFunctions,
   );
 

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objccategorydecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objccategorydecl_parser.dart
@@ -54,7 +54,8 @@ ObjCCategory? parseObjCCategoryDeclaration(clang_types.CXCursor cursor) {
     originalName: name,
     name: config.objcCategories.rename(decl),
     parent: parentInterface,
-    dartDoc: getCursorDocComment(cursor, availability: report.dartDoc) ?? name,
+    dartDoc: getCursorDocComment(cursor,
+        fallbackComment: name, availability: report.dartDoc),
     builtInFunctions: objCBuiltInFunctions,
   );
 

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
@@ -37,8 +37,8 @@ Type? parseObjCInterfaceDeclaration(clang_types.CXCursor cursor) {
     originalName: itfName,
     name: config.objcInterfaces.rename(decl),
     lookupName: applyModulePrefix(itfName, config.interfaceModule(decl)),
-    dartDoc:
-        getCursorDocComment(cursor, availability: report.dartDoc) ?? itfName,
+    dartDoc: getCursorDocComment(cursor,
+        fallbackComment: itfName, availability: report.dartDoc),
     builtInFunctions: objCBuiltInFunctions,
   );
 }
@@ -211,8 +211,8 @@ ObjCMethod? parseObjCMethod(clang_types.CXCursor cursor, Declaration itfDecl,
     builtInFunctions: objCBuiltInFunctions,
     originalName: methodName,
     name: filters.renameMember(itfDecl, methodName),
-    dartDoc:
-        getCursorDocComment(cursor, availability: report.dartDoc) ?? methodName,
+    dartDoc: getCursorDocComment(cursor,
+        fallbackComment: methodName, availability: report.dartDoc),
     kind: ObjCMethodKind.method,
     isClassMethod: isClassMethod,
     isOptional: isOptionalMethod,

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
@@ -23,7 +23,8 @@ Type? parseObjCInterfaceDeclaration(clang_types.CXCursor cursor) {
   final itfName = cursor.spelling();
   final decl = Declaration(usr: itfUsr, originalName: itfName);
 
-  if (!isApiAvailable(cursor)) {
+  final report = getApiAvailability(cursor);
+  if (report.availability == Availability.none) {
     _logger.info('Omitting deprecated interface $itfName');
     return null;
   }
@@ -36,7 +37,8 @@ Type? parseObjCInterfaceDeclaration(clang_types.CXCursor cursor) {
     originalName: itfName,
     name: config.objcInterfaces.rename(decl),
     lookupName: applyModulePrefix(itfName, config.interfaceModule(decl)),
-    dartDoc: getCursorDocComment(cursor),
+    dartDoc:
+        getCursorDocComment(cursor, availability: report.dartDoc) ?? itfName,
     builtInFunctions: objCBuiltInFunctions,
   );
 }
@@ -113,7 +115,8 @@ void _parseSuperType(clang_types.CXCursor cursor, ObjCInterface itf) {
   final fieldName = cursor.spelling();
   final fieldType = cursor.type().toCodeGenType();
 
-  if (!isApiAvailable(cursor)) {
+  final report = getApiAvailability(cursor);
+  if (report.availability == Availability.none) {
     _logger
         .info('Omitting deprecated property ${decl.originalName}.$fieldName');
     return (null, null);
@@ -125,7 +128,7 @@ void _parseSuperType(clang_types.CXCursor cursor, ObjCInterface itf) {
     return (null, null);
   }
 
-  final dartDoc = getCursorDocComment(cursor);
+  final dartDoc = getCursorDocComment(cursor, availability: report.dartDoc);
 
   final propertyAttributes =
       clang.clang_Cursor_getObjCPropertyAttributes(cursor, 0);
@@ -152,7 +155,7 @@ void _parseSuperType(clang_types.CXCursor cursor, ObjCInterface itf) {
     originalName: getterName,
     name: getterName,
     property: property,
-    dartDoc: dartDoc,
+    dartDoc: dartDoc ?? getterName,
     kind: ObjCMethodKind.propertyGetter,
     isClassMethod: isClassMethod,
     isOptional: isOptionalMethod,
@@ -170,7 +173,7 @@ void _parseSuperType(clang_types.CXCursor cursor, ObjCInterface itf) {
       originalName: setterName,
       name: setterName,
       property: property,
-      dartDoc: dartDoc,
+      dartDoc: dartDoc ?? setterName,
       kind: ObjCMethodKind.propertySetter,
       isClassMethod: isClassMethod,
       isOptional: isOptionalMethod,
@@ -197,7 +200,8 @@ ObjCMethod? parseObjCMethod(clang_types.CXCursor cursor, Declaration itfDecl,
     return null;
   }
 
-  if (!isApiAvailable(cursor)) {
+  final report = getApiAvailability(cursor);
+  if (report.availability == Availability.none) {
     _logger
         .info('Omitting deprecated method ${itfDecl.originalName}.$methodName');
     return null;
@@ -207,7 +211,8 @@ ObjCMethod? parseObjCMethod(clang_types.CXCursor cursor, Declaration itfDecl,
     builtInFunctions: objCBuiltInFunctions,
     originalName: methodName,
     name: filters.renameMember(itfDecl, methodName),
-    dartDoc: getCursorDocComment(cursor),
+    dartDoc:
+        getCursorDocComment(cursor, availability: report.dartDoc) ?? methodName,
     kind: ObjCMethodKind.method,
     isClassMethod: isClassMethod,
     isOptional: isOptionalMethod,

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
@@ -22,12 +22,7 @@ Type? parseObjCInterfaceDeclaration(clang_types.CXCursor cursor) {
   final itfUsr = cursor.usr();
   final itfName = cursor.spelling();
   final decl = Declaration(usr: itfUsr, originalName: itfName);
-
   final report = getApiAvailability(cursor);
-  if (report.availability == Availability.none) {
-    _logger.info('Omitting deprecated interface $itfName');
-    return null;
-  }
 
   _logger.fine('++++ Adding ObjC interface: '
       'Name: $itfName, ${cursor.completeStringRepr()}');
@@ -40,6 +35,7 @@ Type? parseObjCInterfaceDeclaration(clang_types.CXCursor cursor) {
     dartDoc: getCursorDocComment(cursor,
         fallbackComment: itfName, availability: report.dartDoc),
     builtInFunctions: objCBuiltInFunctions,
+    unavailable: report.availability == Availability.none,
   );
 }
 

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcprotocoldecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcprotocoldecl_parser.dart
@@ -55,7 +55,8 @@ ObjCProtocol? parseObjCProtocolDeclaration(clang_types.CXCursor cursor) {
     originalName: name,
     name: config.objcProtocols.rename(decl),
     lookupName: applyModulePrefix(name, config.protocolModule(decl)),
-    dartDoc: getCursorDocComment(cursor, fallbackComment: name, availability: report.dartDoc),
+    dartDoc: getCursorDocComment(cursor,
+        fallbackComment: name, availability: report.dartDoc),
     builtInFunctions: objCBuiltInFunctions,
     unavailable: report.availability == Availability.none,
   );

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcprotocoldecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcprotocoldecl_parser.dart
@@ -46,10 +46,6 @@ ObjCProtocol? parseObjCProtocolDeclaration(clang_types.CXCursor cursor) {
   }
 
   final report = getApiAvailability(cursor);
-  if (report.availability == Availability.none) {
-    _logger.info('Omitting deprecated protocol $name');
-    return null;
-  }
 
   _logger.fine('++++ Adding ObjC protocol: '
       'Name: $name, ${cursor.completeStringRepr()}');
@@ -59,8 +55,9 @@ ObjCProtocol? parseObjCProtocolDeclaration(clang_types.CXCursor cursor) {
     originalName: name,
     name: config.objcProtocols.rename(decl),
     lookupName: applyModulePrefix(name, config.protocolModule(decl)),
-    dartDoc: getCursorDocComment(cursor, availability: report.dartDoc),
+    dartDoc: getCursorDocComment(cursor, fallbackComment: name, availability: report.dartDoc),
     builtInFunctions: objCBuiltInFunctions,
+    unavailable: report.availability == Availability.none,
   );
 
   // Make sure to add the protocol to the index before parsing the AST, to break

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcprotocoldecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcprotocoldecl_parser.dart
@@ -45,7 +45,8 @@ ObjCProtocol? parseObjCProtocolDeclaration(clang_types.CXCursor cursor) {
     cursor = clang.clang_getCursorDefinition(selfSuperCursor);
   }
 
-  if (!isApiAvailable(cursor)) {
+  final report = getApiAvailability(cursor);
+  if (report.availability == Availability.none) {
     _logger.info('Omitting deprecated protocol $name');
     return null;
   }
@@ -58,7 +59,7 @@ ObjCProtocol? parseObjCProtocolDeclaration(clang_types.CXCursor cursor) {
     originalName: name,
     name: config.objcProtocols.rename(decl),
     lookupName: applyModulePrefix(name, config.protocolModule(decl)),
-    dartDoc: getCursorDocComment(cursor),
+    dartDoc: getCursorDocComment(cursor, availability: report.dartDoc),
     builtInFunctions: objCBuiltInFunctions,
   );
 

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/unnamed_enumdecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/unnamed_enumdecl_parser.dart
@@ -44,7 +44,8 @@ List<Constant> saveUnNamedEnum(clang_types.CXCursor cursor) {
 
 /// Adds the parameter to func in functiondecl_parser.dart.
 Constant? _addUnNamedEnumConstant(clang_types.CXCursor cursor) {
-  if (!isApiAvailable(cursor)) {
+  final report = getApiAvailability(cursor);
+  if (report.availability == Availability.none) {
     _logger.info('Omitting deprecated unnamed enum value ${cursor.spelling()}');
     return null;
   }
@@ -57,6 +58,7 @@ Constant? _addUnNamedEnumConstant(clang_types.CXCursor cursor) {
     name: config.unnamedEnumConstants.rename(
       Declaration(usr: cursor.usr(), originalName: cursor.spelling()),
     ),
+    dartDoc: report.dartDoc,
     rawType: 'int',
     rawValue: clang.clang_getEnumConstantDeclValue(cursor).toString(),
   );

--- a/pkgs/ffigen/lib/src/header_parser/utils.dart
+++ b/pkgs/ffigen/lib/src/header_parser/utils.dart
@@ -243,7 +243,9 @@ clang_types.CXSourceRange? lastCommentRange;
 /// [commentPrefix].length by default because a comment starts with
 /// [commentPrefix].
 String? getCursorDocComment(clang_types.CXCursor cursor,
-    {int indent = commentPrefix.length, String? availability}) {
+    {int indent = commentPrefix.length,
+    String? fallbackComment,
+    String? availability}) {
   String? formattedDocComment;
   final currentCommentRange = clang.clang_Cursor_getCommentRange(cursor);
 
@@ -268,7 +270,7 @@ String? getCursorDocComment(clang_types.CXCursor cursor,
     }
   }
   lastCommentRange = currentCommentRange;
-  final docs = [formattedDocComment, availability].nonNulls;
+  final docs = [formattedDocComment ?? fallbackComment, availability].nonNulls;
   return docs.isEmpty ? null : docs.join('\n\n');
 }
 

--- a/pkgs/ffigen/lib/src/header_parser/utils.dart
+++ b/pkgs/ffigen/lib/src/header_parser/utils.dart
@@ -243,7 +243,7 @@ clang_types.CXSourceRange? lastCommentRange;
 /// [commentPrefix].length by default because a comment starts with
 /// [commentPrefix].
 String? getCursorDocComment(clang_types.CXCursor cursor,
-    [int indent = commentPrefix.length]) {
+    {int indent = commentPrefix.length, String? availability}) {
   String? formattedDocComment;
   final currentCommentRange = clang.clang_Cursor_getCommentRange(cursor);
 
@@ -268,7 +268,8 @@ String? getCursorDocComment(clang_types.CXCursor cursor,
     }
   }
   lastCommentRange = currentCommentRange;
-  return formattedDocComment;
+  final docs = [formattedDocComment, availability].nonNulls;
+  return docs.isEmpty ? null : docs.join('\n\n');
 }
 
 /// Wraps [string] according to given [lineWidth].

--- a/pkgs/ffigen/lib/src/strings.dart
+++ b/pkgs/ffigen/lib/src/strings.dart
@@ -62,6 +62,7 @@ const ios = 'ios';
 const externalVersions = 'external-versions';
 const externalVersionsPlatforms = [ios, macos];
 const externalVersionsMin = 'min';
+const externalVersionsMax = 'max';
 
 const compilerOptsAuto = 'compiler-opts-automatic';
 // Sub-fields of compilerOptsAuto.macos

--- a/pkgs/ffigen/lib/src/visitor/apply_config_filters.dart
+++ b/pkgs/ffigen/lib/src/visitor/apply_config_filters.dart
@@ -38,6 +38,8 @@ class ApplyConfigFiltersVisitation extends Visitation {
 
   @override
   void visitObjCInterface(ObjCInterface node) {
+    if (node.unavailable) return;
+
     node.filterMethods(
         (m) => config.objcInterfaces.shouldIncludeMember(node, m.originalName));
     _visitImpl(node, config.objcInterfaces);
@@ -61,6 +63,8 @@ class ApplyConfigFiltersVisitation extends Visitation {
 
   @override
   void visitObjCProtocol(ObjCProtocol node) {
+    if (node.unavailable) return;
+
     node.filterMethods((m) {
       // TODO(https://github.com/dart-lang/native/issues/1149): Support class
       // methods on protocols if there's a use case. For now filter them. We

--- a/pkgs/ffigen/lib/src/visitor/list_bindings.dart
+++ b/pkgs/ffigen/lib/src/visitor/list_bindings.dart
@@ -60,12 +60,12 @@ class ListBindingsVisitation extends Visitation {
 
   @override
   void visitObjCInterface(ObjCInterface node) {
-    if (!_visitImpl(
+    bool omit = node.unavailable || !_visitImpl(
             node,
             config.includeTransitiveObjCInterfaces
                 ? _IncludeBehavior.configOrTransitive
-                : _IncludeBehavior.configOnly) &&
-        directTransitives.contains(node)) {
+                : _IncludeBehavior.configOnly);
+    if (omit && directTransitives.contains(node)) {
       node.generateAsStub = true;
       bindings.add(node);
     }
@@ -80,12 +80,12 @@ class ListBindingsVisitation extends Visitation {
 
   @override
   void visitObjCProtocol(ObjCProtocol node) {
-    if (!_visitImpl(
+    bool omit = node.unavailable || !_visitImpl(
             node,
             config.includeTransitiveObjCProtocols
                 ? _IncludeBehavior.configOrTransitive
-                : _IncludeBehavior.configOnly) &&
-        directTransitives.contains(node)) {
+                : _IncludeBehavior.configOnly);
+    if (omit && directTransitives.contains(node)) {
       node.generateAsStub = true;
       bindings.add(node);
     }

--- a/pkgs/ffigen/lib/src/visitor/list_bindings.dart
+++ b/pkgs/ffigen/lib/src/visitor/list_bindings.dart
@@ -60,7 +60,8 @@ class ListBindingsVisitation extends Visitation {
 
   @override
   void visitObjCInterface(ObjCInterface node) {
-    bool omit = node.unavailable || !_visitImpl(
+    final omit = node.unavailable ||
+        !_visitImpl(
             node,
             config.includeTransitiveObjCInterfaces
                 ? _IncludeBehavior.configOrTransitive
@@ -80,7 +81,8 @@ class ListBindingsVisitation extends Visitation {
 
   @override
   void visitObjCProtocol(ObjCProtocol node) {
-    bool omit = node.unavailable || !_visitImpl(
+    final omit = node.unavailable ||
+        !_visitImpl(
             node,
             config.includeTransitiveObjCProtocols
                 ? _IncludeBehavior.configOrTransitive

--- a/pkgs/ffigen/test/native_objc_test/deprecated_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/deprecated_test.dart
@@ -640,5 +640,311 @@ void main() {
         expect(bindings, isNot(contains('deprecatedUnnamedEnum')));
       });
     });
+
+    group('ios <=1.5, macos >=1.5', () {
+      late final String bindings;
+      setUpAll(() {
+        bindings = bindingsForVersion(
+          iosVers: Versions(max: Version(1, 5, 0)),
+          macosVers: Versions(min: Version(1, 5, 0)),
+        );
+      });
+
+      test('interfaces', () {
+        expect(bindings, contains('DeprecatedInterface '));
+        expect(bindings, contains('DeprecatedInterfaceMethods '));
+      });
+
+      test('protocols', () {
+        expect(bindings, contains('DeprecatedProtocol '));
+        expect(bindings, contains('DeprecatedProtocolMethods '));
+      });
+
+      test('interface methods', () {
+        expect(bindings, contains('normalMethod'));
+        expect(bindings, contains('unavailableMac'));
+        expect(bindings, contains('unavailableIos'));
+        expect(bindings, isNot(contains('unavailableBoth')));
+        expect(bindings, contains('depMac2'));
+        expect(bindings, contains('depMac3'));
+        expect(bindings, contains('depIos2'));
+        expect(bindings, contains('depIos2Mac2'));
+        expect(bindings, contains('depIos2Mac3'));
+        expect(bindings, contains('depIos3'));
+        expect(bindings, contains('depIos3Mac2'));
+        expect(bindings, contains('depIos3Mac3'));
+        expect(bindings, isNot(contains('alwaysDeprecated')));
+        expect(bindings, isNot(contains('alwaysUnavailable')));
+      });
+
+      test('interface properties', () {
+        expect(bindings, contains('get normalProperty'));
+        expect(bindings, contains('set normalProperty'));
+        expect(bindings, contains('get deprecatedProperty'));
+        expect(bindings, contains('set deprecatedProperty'));
+      });
+
+      test('protocol methods', () {
+        expect(bindings, contains('protNormalMethod'));
+        expect(bindings, contains('protUnavailableMac'));
+        expect(bindings, contains('protUnavailableIos'));
+        expect(bindings, isNot(contains('protUnavailableBoth')));
+        expect(bindings, contains('protDepMac2'));
+        expect(bindings, contains('protDepMac3'));
+        expect(bindings, contains('protDepIos2'));
+        expect(bindings, contains('protDepIos2Mac2'));
+        expect(bindings, contains('protDepIos2Mac3'));
+        expect(bindings, contains('protDepIos3'));
+        expect(bindings, contains('protDepIos3Mac2'));
+        expect(bindings, contains('protDepIos3Mac3'));
+        expect(bindings, isNot(contains('protAlwaysDeprecated')));
+        expect(bindings, isNot(contains('protAlwaysUnavailable')));
+      });
+
+      test('protocol properties', () {
+        expect(bindings, contains('protNormalProperty'));
+        expect(bindings, contains('setProtNormalProperty'));
+        expect(bindings, contains('protDeprecatedProperty'));
+        expect(bindings, contains('setProtDeprecatedProperty'));
+      });
+
+      test('category methods', () {
+        expect(bindings, contains('catNormalMethod'));
+        expect(bindings, contains('catUnavailableMac'));
+        expect(bindings, contains('catUnavailableIos'));
+        expect(bindings, isNot(contains('catUnavailableBoth')));
+        expect(bindings, contains('catDepMac2'));
+        expect(bindings, contains('catDepMac3'));
+        expect(bindings, contains('catDepIos2'));
+        expect(bindings, contains('catDepIos2Mac2'));
+        expect(bindings, contains('catDepIos2Mac3'));
+        expect(bindings, contains('catDepIos3'));
+        expect(bindings, contains('catDepIos3Mac2'));
+        expect(bindings, contains('catDepIos3Mac3'));
+        expect(bindings, isNot(contains('catAlwaysDeprecated')));
+        expect(bindings, isNot(contains('catAlwaysUnavailable')));
+      });
+
+      test('category properties', () {
+        expect(bindings, contains('get catNormalProperty'));
+        expect(bindings, contains('set catNormalProperty'));
+        expect(bindings, contains('get catDeprecatedProperty'));
+        expect(bindings, contains('set catDeprecatedProperty'));
+      });
+
+      test('functions', () {
+        expect(bindings, contains('normalFunction'));
+        expect(bindings, contains('deprecatedFunction'));
+      });
+
+      test('structs', () {
+        expect(bindings, contains('NormalStruct'));
+        expect(bindings, contains('DeprecatedStruct'));
+      });
+
+      test('unions', () {
+        expect(bindings, contains('NormalUnion'));
+        expect(bindings, contains('DeprecatedUnion'));
+      });
+
+      test('enums', () {
+        expect(bindings, contains('NormalEnum'));
+        expect(bindings, contains('DeprecatedEnum'));
+      });
+
+      test('unnamed enums', () {
+        expect(bindings, contains('normalUnnamedEnum'));
+        expect(bindings, contains('deprecatedUnnamedEnum'));
+      });
+
+      test('dart doc', () {
+        final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+
+        expect(trimmed, contains('''
+/// iOS: introduced 1.0.0, deprecated 2.0.0
+/// macOS: introduced 1.0.0, deprecated 2.0.0
+final class DeprecatedStruct extends ffi.Struct'''));
+
+        expect(trimmed, contains('''
+/// iOS: introduced 1.0.0, deprecated 2.0.0
+/// macOS: introduced 1.0.0, deprecated 2.0.0
+final class DeprecatedUnion extends ffi.Union'''));
+
+        expect(trimmed, contains('''
+/// iOS: introduced 1.0.0, deprecated 2.0.0
+/// macOS: introduced 1.0.0, deprecated 2.0.0
+enum DeprecatedEnum'''));
+
+        expect(trimmed, contains('''
+/// iOS: introduced 1.0.0, deprecated 2.0.0
+/// macOS: introduced 1.0.0, deprecated 2.0.0
+
+const int deprecatedUnnamedEnum = 1;
+'''));
+
+        expect(trimmed, contains('''
+/// iOS: introduced 1.0.0, deprecated 2.0.0
+/// macOS: introduced 1.0.0, deprecated 2.0.0
+int deprecatedFunction()'''));
+
+        expect(trimmed, contains('''
+/// DeprecatedInterface
+///
+/// iOS: introduced 1.0.0, deprecated 2.0.0
+/// macOS: introduced 1.0.0, deprecated 2.0.0
+'''));
+
+        expect(trimmed, contains('''
+/// depIos2Mac2
+///
+/// iOS: introduced 1.0.0, deprecated 2.0.0
+/// macOS: introduced 1.0.0, deprecated 2.0.0
+'''));
+
+        expect(trimmed, contains('''
+/// DeprecatedProtocol
+///
+/// iOS: introduced 1.0.0, deprecated 2.0.0
+/// macOS: introduced 1.0.0, deprecated 2.0.0
+'''));
+
+        expect(trimmed, contains('''
+/// protDepIos3
+///
+/// iOS: introduced 1.0.0, deprecated 3.0.0
+'''));
+
+        expect(trimmed, contains('''
+/// DeprecatedCategory
+///
+/// iOS: introduced 1.0.0, deprecated 2.0.0
+/// macOS: introduced 1.0.0, deprecated 2.0.0
+'''));
+
+        expect(trimmed, contains('''
+/// DeprecatedCategoryMethods
+///
+/// iOS: introduced 2.0.0
+/// macOS: introduced 10.0.0
+'''));
+      });
+    });
+
+    group('ios >=0.5 <=0.9, macos >=0.5 <=0.9', () {
+      late final String bindings;
+      setUpAll(() {
+        bindings = bindingsForVersion(
+          iosVers: Versions(min: Version(0, 5, 0), max: Version(0, 9, 0)),
+          macosVers: Versions(min: Version(0, 5, 0), max: Version(0, 9, 0)),
+        );
+      });
+
+      test('interfaces', () {
+        expect(bindings, isNot(contains('DeprecatedInterface ')));
+        expect(bindings, contains('DeprecatedInterfaceMethods '));
+      });
+
+      test('protocols', () {
+        expect(bindings, isNot(contains('DeprecatedProtocol ')));
+        expect(bindings, contains('DeprecatedProtocolMethods '));
+      });
+
+      test('interface methods', () {
+        expect(bindings, contains('normalMethod'));
+        expect(bindings, contains('unavailableMac'));
+        expect(bindings, contains('unavailableIos'));
+        expect(bindings, isNot(contains('unavailableBoth')));
+        expect(bindings, contains('depMac2'));
+        expect(bindings, contains('depMac3'));
+        expect(bindings, contains('depIos2'));
+        expect(bindings, isNot(contains('depIos2Mac2')));
+        expect(bindings, isNot(contains('depIos2Mac3')));
+        expect(bindings, contains('depIos3'));
+        expect(bindings, isNot(contains('depIos3Mac2')));
+        expect(bindings, isNot(contains('depIos3Mac3')));
+        expect(bindings, isNot(contains('alwaysDeprecated')));
+        expect(bindings, isNot(contains('alwaysUnavailable')));
+      });
+
+      test('interface properties', () {
+        expect(bindings, contains('get normalProperty'));
+        expect(bindings, contains('set normalProperty'));
+        expect(bindings, isNot(contains('get deprecatedProperty')));
+        expect(bindings, isNot(contains('set deprecatedProperty')));
+      });
+
+      test('protocol methods', () {
+        expect(bindings, contains('protNormalMethod'));
+        expect(bindings, contains('protUnavailableMac'));
+        expect(bindings, contains('protUnavailableIos'));
+        expect(bindings, isNot(contains('protUnavailableBoth')));
+        expect(bindings, contains('protDepMac2'));
+        expect(bindings, contains('protDepMac3'));
+        expect(bindings, contains('protDepIos2'));
+        expect(bindings, isNot(contains('protDepIos2Mac2')));
+        expect(bindings, isNot(contains('protDepIos2Mac3')));
+        expect(bindings, contains('protDepIos3'));
+        expect(bindings, isNot(contains('protDepIos3Mac2')));
+        expect(bindings, isNot(contains('protDepIos3Mac3')));
+        expect(bindings, isNot(contains('protAlwaysDeprecated')));
+        expect(bindings, isNot(contains('protAlwaysUnavailable')));
+      });
+
+      test('protocol properties', () {
+        expect(bindings, contains('protNormalProperty'));
+        expect(bindings, contains('setProtNormalProperty'));
+        expect(bindings, isNot(contains('protDeprecatedProperty')));
+        expect(bindings, isNot(contains('setProtDeprecatedProperty')));
+      });
+
+      test('category methods', () {
+        expect(bindings, isNot(contains('catNormalMethod')));
+        expect(bindings, isNot(contains('catUnavailableMac')));
+        expect(bindings, isNot(contains('catUnavailableIos')));
+        expect(bindings, isNot(contains('catUnavailableBoth')));
+        expect(bindings, isNot(contains('catDepMac2')));
+        expect(bindings, isNot(contains('catDepMac3')));
+        expect(bindings, isNot(contains('catDepIos2')));
+        expect(bindings, isNot(contains('catDepIos2Mac2')));
+        expect(bindings, isNot(contains('catDepIos2Mac3')));
+        expect(bindings, isNot(contains('catDepIos3')));
+        expect(bindings, isNot(contains('catDepIos3Mac2')));
+        expect(bindings, isNot(contains('catDepIos3Mac3')));
+        expect(bindings, isNot(contains('catAlwaysDeprecated')));
+        expect(bindings, isNot(contains('catAlwaysUnavailable')));
+      });
+
+      test('category properties', () {
+        expect(bindings, isNot(contains('get catNormalProperty')));
+        expect(bindings, isNot(contains('set catNormalProperty')));
+        expect(bindings, isNot(contains('get catDeprecatedProperty')));
+        expect(bindings, isNot(contains('set catDeprecatedProperty')));
+      });
+
+      test('functions', () {
+        expect(bindings, contains('normalFunction'));
+        expect(bindings, isNot(contains('deprecatedFunction')));
+      });
+
+      test('structs', () {
+        expect(bindings, contains('NormalStruct'));
+        expect(bindings, isNot(contains('DeprecatedStruct')));
+      });
+
+      test('unions', () {
+        expect(bindings, contains('NormalUnion'));
+        expect(bindings, isNot(contains('DeprecatedUnion')));
+      });
+
+      test('enums', () {
+        expect(bindings, contains('NormalEnum'));
+        expect(bindings, isNot(contains('DeprecatedEnum')));
+      });
+
+      test('unnamed enums', () {
+        expect(bindings, contains('normalUnnamedEnum'));
+        expect(bindings, isNot(contains('deprecatedUnnamedEnum')));
+      });
+    });
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/deprecated_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/deprecated_test.dart
@@ -18,7 +18,7 @@ import 'package:test/test.dart';
 import '../test_utils.dart';
 import 'util.dart';
 
-String bindingsForVersion({Version? iosMinVer, Version? macosMinVer}) {
+String bindingsForVersion({Versions? iosVers, Versions? macosVers}) {
   final config = Config(
     wrapperName: 'DeprecatedTestObjCLibrary',
     wrapperDocComment: 'Tests API deprecation',
@@ -41,10 +41,7 @@ String bindingsForVersion({Version? iosMinVer, Version? macosMinVer}) {
     enumClassDecl: DeclarationFilters.include({'NormalEnum', 'DeprecatedEnum'}),
     unnamedEnumConstants: DeclarationFilters.include(
         {'normalUnnamedEnum', 'deprecatedUnnamedEnum'}),
-    externalVersions: ExternalVersions(
-      ios: Versions(min: iosMinVer),
-      macos: Versions(min: macosMinVer),
-    ),
+    externalVersions: ExternalVersions(ios: iosVers, macos: macosVers),
   );
   FfiGen(logLevel: Level.SEVERE).run(config);
   return File('test/native_objc_test/deprecated_bindings.dart')
@@ -172,11 +169,11 @@ void main() {
       });
     });
 
-    group('ios 2.5, no macos version', () {
+    group('ios >=2.5, no macos version', () {
       late final String bindings;
       setUpAll(() {
         bindings = bindingsForVersion(
-          iosMinVer: Version(2, 5, 0),
+          iosVers: Versions(min: Version(2, 5, 0)),
         );
       });
 
@@ -293,12 +290,12 @@ void main() {
       });
     });
 
-    group('ios 2.5, macos 2.5', () {
+    group('ios >=2.5, macos >=2.5', () {
       late final String bindings;
       setUpAll(() {
         bindings = bindingsForVersion(
-          iosMinVer: Version(2, 5, 0),
-          macosMinVer: Version(2, 5, 0),
+          iosVers: Versions(min: Version(2, 5, 0)),
+          macosVers: Versions(min: Version(2, 5, 0)),
         );
       });
 
@@ -410,12 +407,12 @@ void main() {
       });
     });
 
-    group('ios 3.5, macos 3.5', () {
+    group('ios >=3.5, macos >=3.5', () {
       late final String bindings;
       setUpAll(() {
         bindings = bindingsForVersion(
-          iosMinVer: Version(3, 5, 0),
-          macosMinVer: Version(3, 5, 0),
+          iosVers: Versions(min: Version(3, 5, 0)),
+          macosVers: Versions(min: Version(3, 5, 0)),
         );
       });
 
@@ -490,6 +487,123 @@ void main() {
         expect(bindings, contains('catDepIos3'));
         expect(bindings, isNot(contains('catDepIos3Mac2')));
         expect(bindings, isNot(contains('catDepIos3Mac3')));
+        expect(bindings, isNot(contains('catAlwaysDeprecated')));
+        expect(bindings, isNot(contains('catAlwaysUnavailable')));
+      });
+
+      test('category properties', () {
+        expect(bindings, contains('get catNormalProperty'));
+        expect(bindings, contains('set catNormalProperty'));
+        expect(bindings, isNot(contains('get catDeprecatedProperty')));
+        expect(bindings, isNot(contains('set catDeprecatedProperty')));
+      });
+
+      test('functions', () {
+        expect(bindings, contains('normalFunction'));
+        expect(bindings, isNot(contains('deprecatedFunction')));
+      });
+
+      test('structs', () {
+        expect(bindings, contains('NormalStruct'));
+        expect(bindings, isNot(contains('DeprecatedStruct')));
+      });
+
+      test('unions', () {
+        expect(bindings, contains('NormalUnion'));
+        expect(bindings, isNot(contains('DeprecatedUnion')));
+      });
+
+      test('enums', () {
+        expect(bindings, contains('NormalEnum'));
+        expect(bindings, isNot(contains('DeprecatedEnum')));
+      });
+
+      test('unnamed enums', () {
+        expect(bindings, contains('normalUnnamedEnum'));
+        expect(bindings, isNot(contains('deprecatedUnnamedEnum')));
+      });
+    });
+
+    group('ios >=2.5 <=3.5, macos >=2.5 <=3.5', () {
+      late final String bindings;
+      setUpAll(() {
+        bindings = bindingsForVersion(
+          iosVers: Versions(min: Version(2, 5, 0), max: Version(3, 5, 0)),
+          macosVers: Versions(min: Version(2, 5, 0), max: Version(3, 5, 0)),
+        );
+      });
+
+      test('interfaces', () {
+        expect(bindings, isNot(contains('DeprecatedInterface ')));
+        expect(bindings, contains('DeprecatedInterfaceMethods '));
+      });
+
+      test('protocols', () {
+        expect(bindings, isNot(contains('DeprecatedProtocol ')));
+        expect(bindings, contains('DeprecatedProtocolMethods '));
+      });
+
+      test('interface methods', () {
+        expect(bindings, contains('normalMethod'));
+        expect(bindings, contains('unavailableMac'));
+        expect(bindings, contains('unavailableIos'));
+        expect(bindings, isNot(contains('unavailableBoth')));
+        expect(bindings, contains('depMac2'));
+        expect(bindings, contains('depMac3'));
+        expect(bindings, contains('depIos2'));
+        expect(bindings, isNot(contains('depIos2Mac2')));
+        expect(bindings, contains('depIos2Mac3'));
+        expect(bindings, contains('depIos3'));
+        expect(bindings, contains('depIos3Mac2'));
+        expect(bindings, contains('depIos3Mac3'));
+        expect(bindings, isNot(contains('alwaysDeprecated')));
+        expect(bindings, isNot(contains('alwaysUnavailable')));
+      });
+
+      test('interface properties', () {
+        expect(bindings, contains('get normalProperty'));
+        expect(bindings, contains('set normalProperty'));
+        expect(bindings, isNot(contains('get deprecatedProperty')));
+        expect(bindings, isNot(contains('set deprecatedProperty')));
+      });
+
+      test('protocol methods', () {
+        expect(bindings, contains('protNormalMethod'));
+        expect(bindings, contains('protUnavailableMac'));
+        expect(bindings, contains('protUnavailableIos'));
+        expect(bindings, isNot(contains('protUnavailableBoth')));
+        expect(bindings, contains('protDepMac2'));
+        expect(bindings, contains('protDepMac3'));
+        expect(bindings, contains('protDepIos2'));
+        expect(bindings, isNot(contains('protDepIos2Mac2')));
+        expect(bindings, contains('protDepIos2Mac3'));
+        expect(bindings, contains('protDepIos3'));
+        expect(bindings, contains('protDepIos3Mac2'));
+        expect(bindings, contains('protDepIos3Mac3'));
+        expect(bindings, isNot(contains('protAlwaysDeprecated')));
+        expect(bindings, isNot(contains('protAlwaysUnavailable')));
+      });
+
+      test('protocol properties', () {
+        expect(bindings, contains('protNormalProperty'));
+        expect(bindings, contains('setProtNormalProperty'));
+        expect(bindings, isNot(contains('protDeprecatedProperty')));
+        expect(bindings, isNot(contains('setProtDeprecatedProperty')));
+      });
+
+      test('category methods', () {
+        expect(bindings, contains('catNormalMethod'));
+        expect(bindings, contains('catUnavailableMac'));
+        expect(bindings, contains('catUnavailableIos'));
+        expect(bindings, isNot(contains('catUnavailableBoth')));
+        expect(bindings, contains('catDepMac2'));
+        expect(bindings, contains('catDepMac3'));
+        expect(bindings, contains('catDepIos2'));
+        expect(bindings, isNot(contains('catDepIos2Mac2')));
+        expect(bindings, contains('catDepIos2Mac3'));
+        expect(bindings, contains('catDepIos3'));
+        expect(bindings, contains('catDepIos3Mac2'));
+        expect(bindings, contains('catDepIos3Mac3'));
         expect(bindings, isNot(contains('catAlwaysDeprecated')));
         expect(bindings, isNot(contains('catAlwaysUnavailable')));
       });

--- a/pkgs/ffigen/test/unit_tests/api_availability_test.dart
+++ b/pkgs/ffigen/test/unit_tests/api_availability_test.dart
@@ -30,10 +30,13 @@ void main() {
   });
 
   test('PlatformAvailability.getAvailability', () {
-    expect(PlatformAvailability(unavailable: true).getAvailability(Versions()),
+    expect(
+        PlatformAvailability(unavailable: true)
+            .getAvailability(const Versions()),
         Availability.none);
 
-    Availability getAvailability(apiMin, apiMax, confMin, confMax) =>
+    Availability getAvailability(Version? apiMin, Version? apiMax,
+            Version? confMin, Version? confMax) =>
         PlatformAvailability(introduced: apiMin, deprecated: apiMax)
             .getAvailability(Versions(min: confMin, max: confMax));
 
@@ -98,7 +101,8 @@ void main() {
     expect(getAvailability(v3, v6, v5, v8), Availability.some);
     expect(getAvailability(v3, v6, v6, null), Availability.none);
     expect(getAvailability(v3, v6, v6, v8), Availability.none);
-    expect(getAvailability(v3, v6, v8, null), Availability.none);
+    expect(getAvailability(v3, v6, v7, null), Availability.none);
+    expect(getAvailability(v3, v6, v7, v8), Availability.none);
   });
 
   group('Availability.getAvailability', () {
@@ -180,9 +184,13 @@ void main() {
       final verInside = Versions(min: v2, max: v3);
       final verOverlap = Versions(min: v2, max: v6);
       final verOutside = Versions(min: v5, max: v6);
-      final verEmpty = Versions();
+      final verEmpty = const Versions();
 
-      Availability getAvail(iosAvail, macosAvail, iosVer, macosVer) =>
+      Availability getAvail(
+              PlatformAvailability? iosAvail,
+              PlatformAvailability? macosAvail,
+              Versions? iosVer,
+              Versions? macosVer) =>
           ApiAvailability(
             ios: iosAvail,
             macos: macosAvail,

--- a/pkgs/ffigen/test/unit_tests/api_availability_test.dart
+++ b/pkgs/ffigen/test/unit_tests/api_availability_test.dart
@@ -8,71 +8,92 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test('PlatformAvailability.deprecatedOrObsoleted', () {
+    expect(PlatformAvailability().deprecatedOrObsoleted, null);
+    expect(
+        PlatformAvailability(deprecated: Version(1, 2, 3))
+            .deprecatedOrObsoleted,
+        Version(1, 2, 3));
+    expect(
+        PlatformAvailability(obsoleted: Version(1, 2, 3)).deprecatedOrObsoleted,
+        Version(1, 2, 3));
+    expect(
+        PlatformAvailability(
+                deprecated: Version(1, 2, 3), obsoleted: Version(4, 5, 6))
+            .deprecatedOrObsoleted,
+        Version(1, 2, 3));
+    expect(
+        PlatformAvailability(
+                deprecated: Version(4, 5, 6), obsoleted: Version(1, 2, 3))
+            .deprecatedOrObsoleted,
+        Version(1, 2, 3));
+  });
+
   group('API availability', () {
     test('empty', () {
       final api = ApiAvailability();
 
-      expect(api.isAvailable(const ExternalVersions()), true);
+      expect(api.getAvailability(const ExternalVersions()), Availability.all);
       expect(
-          api.isAvailable(ExternalVersions(
-            ios: Versions(min: Version(1, 2, 3)),
+          api.getAvailability(ExternalVersions(
+            ios: Versions(min: Version(1, 2, 3), max: Version(4, 5, 6)),
           )),
-          true);
+          Availability.all);
       expect(
-          api.isAvailable(ExternalVersions(
-            macos: Versions(min: Version(1, 2, 3)),
+          api.getAvailability(ExternalVersions(
+            macos: Versions(min: Version(1, 2, 3), max: Version(4, 5, 6)),
           )),
-          true);
+          Availability.all);
       expect(
-          api.isAvailable(ExternalVersions(
-            ios: Versions(min: Version(1, 2, 3)),
-            macos: Versions(min: Version(1, 2, 3)),
+          api.getAvailability(ExternalVersions(
+            ios: Versions(min: Version(1, 2, 3), max: Version(4, 5, 6)),
+            macos: Versions(min: Version(1, 2, 3), max: Version(4, 5, 6)),
           )),
-          true);
+          Availability.all);
     });
 
     test('always deprecated', () {
       final api = ApiAvailability(alwaysDeprecated: true);
 
-      expect(api.isAvailable(const ExternalVersions()), true);
+      expect(api.getAvailability(const ExternalVersions()), Availability.all);
       expect(
-          api.isAvailable(ExternalVersions(
-            ios: Versions(min: Version(1, 2, 3)),
+          api.getAvailability(ExternalVersions(
+            ios: Versions(min: Version(1, 2, 3), max: Version(4, 5, 6)),
           )),
-          false);
+          Availability.none);
       expect(
-          api.isAvailable(ExternalVersions(
-            macos: Versions(min: Version(1, 2, 3)),
+          api.getAvailability(ExternalVersions(
+            macos: Versions(min: Version(1, 2, 3), max: Version(4, 5, 6)),
           )),
-          false);
+          Availability.none);
       expect(
-          api.isAvailable(ExternalVersions(
-            ios: Versions(min: Version(1, 2, 3)),
-            macos: Versions(min: Version(1, 2, 3)),
+          api.getAvailability(ExternalVersions(
+            ios: Versions(min: Version(1, 2, 3), max: Version(4, 5, 6)),
+            macos: Versions(min: Version(1, 2, 3), max: Version(4, 5, 6)),
           )),
-          false);
+          Availability.none);
     });
 
     test('always unavailable', () {
       final api = ApiAvailability(alwaysUnavailable: true);
 
-      expect(api.isAvailable(const ExternalVersions()), true);
+      expect(api.getAvailability(const ExternalVersions()), Availability.all);
       expect(
-          api.isAvailable(ExternalVersions(
-            ios: Versions(min: Version(1, 2, 3)),
+          api.getAvailability(ExternalVersions(
+            ios: Versions(min: Version(1, 2, 3), max: Version(4, 5, 6)),
           )),
-          false);
+          Availability.none);
       expect(
-          api.isAvailable(ExternalVersions(
-            macos: Versions(min: Version(1, 2, 3)),
+          api.getAvailability(ExternalVersions(
+            macos: Versions(min: Version(1, 2, 3), max: Version(4, 5, 6)),
           )),
-          false);
+          Availability.none);
       expect(
-          api.isAvailable(ExternalVersions(
-            ios: Versions(min: Version(1, 2, 3)),
-            macos: Versions(min: Version(1, 2, 3)),
+          api.getAvailability(ExternalVersions(
+            ios: Versions(min: Version(1, 2, 3), max: Version(4, 5, 6)),
+            macos: Versions(min: Version(1, 2, 3), max: Version(4, 5, 6)),
           )),
-          false);
+          Availability.none);
     });
 
     test('ios', () {
@@ -84,48 +105,48 @@ void main() {
         ),
       );
 
-      expect(api.isAvailable(const ExternalVersions()), true);
+      expect(api.getAvailability(const ExternalVersions()), Availability.all);
 
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(1, 0, 0)),
           )),
-          true);
+          Availability.some);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(5, 0, 0)),
           )),
-          false);
+          Availability.none);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(10, 0, 0)),
           )),
-          false);
+          Availability.none);
 
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             macos: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.all);
 
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(1, 0, 0)),
             macos: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.some);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(5, 0, 0)),
             macos: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.some);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(10, 0, 0)),
             macos: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.some);
     });
 
     test('ios, empty PlatformAvailability', () {
@@ -133,23 +154,23 @@ void main() {
         ios: PlatformAvailability(),
       );
 
-      expect(api.isAvailable(const ExternalVersions()), true);
+      expect(api.getAvailability(const ExternalVersions()), Availability.all);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.all);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             macos: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.all);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(10, 0, 0)),
             macos: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.all);
     });
 
     test('ios, unavailable', () {
@@ -159,23 +180,23 @@ void main() {
         ),
       );
 
-      expect(api.isAvailable(const ExternalVersions()), true);
+      expect(api.getAvailability(const ExternalVersions()), Availability.all);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(10, 0, 0)),
           )),
-          false);
+          Availability.none);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             macos: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.all);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(10, 0, 0)),
             macos: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.some);
     });
 
     test('macos', () {
@@ -187,48 +208,48 @@ void main() {
         ),
       );
 
-      expect(api.isAvailable(const ExternalVersions()), true);
+      expect(api.getAvailability(const ExternalVersions()), Availability.all);
 
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             macos: Versions(min: Version(1, 0, 0)),
           )),
-          true);
+          Availability.some);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             macos: Versions(min: Version(5, 0, 0)),
           )),
-          false);
+          Availability.none);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             macos: Versions(min: Version(10, 0, 0)),
           )),
-          false);
+          Availability.none);
 
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.all);
 
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             macos: Versions(min: Version(1, 0, 0)),
             ios: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.some);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             macos: Versions(min: Version(5, 0, 0)),
             ios: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.some);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             macos: Versions(min: Version(10, 0, 0)),
             ios: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.some);
     });
 
     test('macos, empty PlatformAvailability', () {
@@ -236,23 +257,23 @@ void main() {
         macos: PlatformAvailability(),
       );
 
-      expect(api.isAvailable(const ExternalVersions()), true);
+      expect(api.getAvailability(const ExternalVersions()), Availability.all);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             macos: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.all);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.all);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             macos: Versions(min: Version(10, 0, 0)),
             ios: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.all);
     });
 
     test('macos, unavailable', () {
@@ -262,23 +283,23 @@ void main() {
         ),
       );
 
-      expect(api.isAvailable(const ExternalVersions()), true);
+      expect(api.getAvailability(const ExternalVersions()), Availability.all);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             macos: Versions(min: Version(10, 0, 0)),
           )),
-          false);
+          Availability.none);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.all);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             macos: Versions(min: Version(10, 0, 0)),
             ios: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.some);
     });
 
     test('both', () {
@@ -296,61 +317,61 @@ void main() {
       );
 
       expect(
-          api.isAvailable(const ExternalVersions(
+          api.getAvailability(const ExternalVersions(
             ios: null,
             macos: null,
           )),
-          true);
+          Availability.all);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(1, 0, 0)),
             macos: null,
           )),
-          true);
+          Availability.some);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(10, 0, 0)),
             macos: null,
           )),
-          false);
+          Availability.none);
 
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: null,
             macos: Versions(min: Version(1, 0, 0)),
           )),
-          true);
+          Availability.some);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(1, 0, 0)),
             macos: Versions(min: Version(1, 0, 0)),
           )),
-          true);
+          Availability.some);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(10, 0, 0)),
             macos: Versions(min: Version(1, 0, 0)),
           )),
-          true);
+          Availability.some);
 
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: null,
             macos: Versions(min: Version(10, 0, 0)),
           )),
-          false);
+          Availability.none);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(1, 0, 0)),
             macos: Versions(min: Version(10, 0, 0)),
           )),
-          true);
+          Availability.some);
       expect(
-          api.isAvailable(ExternalVersions(
+          api.getAvailability(ExternalVersions(
             ios: Versions(min: Version(10, 0, 0)),
             macos: Versions(min: Version(10, 0, 0)),
           )),
-          false);
+          Availability.none);
     });
   });
 }

--- a/pkgs/ffigen/test/unit_tests/api_availability_test.dart
+++ b/pkgs/ffigen/test/unit_tests/api_availability_test.dart
@@ -29,7 +29,79 @@ void main() {
         Version(1, 2, 3));
   });
 
-  group('API availability', () {
+  test('PlatformAvailability.getAvailability', () {
+    expect(PlatformAvailability(unavailable: true).getAvailability(Versions()),
+        Availability.none);
+
+    Availability getAvailability(apiMin, apiMax, confMin, confMax) =>
+        PlatformAvailability(introduced: apiMin, deprecated: apiMax)
+            .getAvailability(Versions(min: confMin, max: confMax));
+
+    final v1 = Version(1, 0, 0);
+    final v2 = Version(2, 0, 0);
+    final v3 = Version(3, 0, 0);
+    final v4 = Version(4, 0, 0);
+    final v5 = Version(5, 0, 0);
+    final v6 = Version(6, 0, 0);
+    final v7 = Version(7, 0, 0);
+    final v8 = Version(8, 0, 0);
+
+    expect(getAvailability(null, null, null, null), Availability.all);
+    expect(getAvailability(null, null, null, v2), Availability.all);
+    expect(getAvailability(null, null, v1, null), Availability.all);
+    expect(getAvailability(null, null, v1, v2), Availability.all);
+
+    expect(getAvailability(v3, null, null, null), Availability.some);
+    expect(getAvailability(v3, null, null, v2), Availability.none);
+    expect(getAvailability(v3, null, null, v3), Availability.some);
+    expect(getAvailability(v3, null, null, v5), Availability.some);
+    expect(getAvailability(v3, null, v1, null), Availability.some);
+    expect(getAvailability(v3, null, v1, v2), Availability.none);
+    expect(getAvailability(v3, null, v1, v3), Availability.some);
+    expect(getAvailability(v3, null, v1, v5), Availability.some);
+    expect(getAvailability(v3, null, v3, null), Availability.all);
+    expect(getAvailability(v3, null, v3, v5), Availability.all);
+    expect(getAvailability(v3, null, v4, null), Availability.all);
+    expect(getAvailability(v3, null, v4, v5), Availability.all);
+
+    expect(getAvailability(null, v3, null, null), Availability.some);
+    expect(getAvailability(null, v3, null, v2), Availability.all);
+    expect(getAvailability(null, v3, null, v3), Availability.some);
+    expect(getAvailability(null, v3, null, v5), Availability.some);
+    expect(getAvailability(null, v3, v1, null), Availability.some);
+    expect(getAvailability(null, v3, v1, v2), Availability.all);
+    expect(getAvailability(null, v3, v1, v3), Availability.some);
+    expect(getAvailability(null, v3, v1, v5), Availability.some);
+    expect(getAvailability(null, v3, v3, null), Availability.none);
+    expect(getAvailability(null, v3, v3, v5), Availability.none);
+    expect(getAvailability(null, v3, v4, null), Availability.none);
+    expect(getAvailability(null, v3, v4, v5), Availability.none);
+
+    expect(getAvailability(v3, v6, null, null), Availability.some);
+    expect(getAvailability(v3, v6, null, v2), Availability.none);
+    expect(getAvailability(v3, v6, null, v3), Availability.some);
+    expect(getAvailability(v3, v6, null, v5), Availability.some);
+    expect(getAvailability(v3, v6, null, v6), Availability.some);
+    expect(getAvailability(v3, v6, null, v8), Availability.some);
+    expect(getAvailability(v3, v6, v1, null), Availability.some);
+    expect(getAvailability(v3, v6, v1, v2), Availability.none);
+    expect(getAvailability(v3, v6, v1, v3), Availability.some);
+    expect(getAvailability(v3, v6, v1, v5), Availability.some);
+    expect(getAvailability(v3, v6, v1, v6), Availability.some);
+    expect(getAvailability(v3, v6, v1, v8), Availability.some);
+    expect(getAvailability(v3, v6, v3, null), Availability.some);
+    expect(getAvailability(v3, v6, v3, v5), Availability.all);
+    expect(getAvailability(v3, v6, v3, v6), Availability.some);
+    expect(getAvailability(v3, v6, v3, v8), Availability.some);
+    expect(getAvailability(v3, v6, v5, null), Availability.some);
+    expect(getAvailability(v3, v6, v5, v6), Availability.some);
+    expect(getAvailability(v3, v6, v5, v8), Availability.some);
+    expect(getAvailability(v3, v6, v6, null), Availability.none);
+    expect(getAvailability(v3, v6, v6, v8), Availability.none);
+    expect(getAvailability(v3, v6, v8, null), Availability.none);
+  });
+
+  group('Availability.getAvailability', () {
     test('empty', () {
       final api = ApiAvailability();
 
@@ -96,282 +168,114 @@ void main() {
           Availability.none);
     });
 
-    test('ios', () {
-      final api = ApiAvailability(
-        ios: PlatformAvailability(
-          introduced: Version(1, 2, 3),
-          deprecated: Version(4, 5, 6),
-          obsoleted: Version(7, 8, 9),
-        ),
-      );
+    test('versions', () {
+      final v1 = Version(1, 0, 0);
+      final v2 = Version(2, 0, 0);
+      final v3 = Version(3, 0, 0);
+      final v4 = Version(4, 0, 0);
+      final v5 = Version(5, 0, 0);
+      final v6 = Version(6, 0, 0);
 
-      expect(api.getAvailability(const ExternalVersions()), Availability.all);
+      final plat = PlatformAvailability(introduced: v1, deprecated: v4);
+      final verInside = Versions(min: v2, max: v3);
+      final verOverlap = Versions(min: v2, max: v6);
+      final verOutside = Versions(min: v5, max: v6);
+      final verEmpty = Versions();
 
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(1, 0, 0)),
-          )),
-          Availability.some);
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(5, 0, 0)),
-          )),
-          Availability.none);
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.none);
+      Availability getAvail(iosAvail, macosAvail, iosVer, macosVer) =>
+          ApiAvailability(
+            ios: iosAvail,
+            macos: macosAvail,
+          ).getAvailability(ExternalVersions(ios: iosVer, macos: macosVer));
 
-      expect(
-          api.getAvailability(ExternalVersions(
-            macos: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.all);
+      expect(getAvail(null, null, null, null), Availability.all);
+      expect(getAvail(null, null, verEmpty, verEmpty), Availability.all);
+      expect(getAvail(plat, plat, null, null), Availability.all);
+      expect(getAvail(plat, plat, verEmpty, verEmpty), Availability.all);
 
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(1, 0, 0)),
-            macos: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.some);
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(5, 0, 0)),
-            macos: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.some);
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(10, 0, 0)),
-            macos: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.some);
+      expect(getAvail(plat, plat, null, verInside), Availability.all);
+      expect(getAvail(plat, plat, null, verOverlap), Availability.some);
+      expect(getAvail(plat, plat, null, verOutside), Availability.none);
+      expect(getAvail(plat, plat, verInside, null), Availability.all);
+      expect(getAvail(plat, plat, verOverlap, null), Availability.some);
+      expect(getAvail(plat, plat, verOutside, null), Availability.none);
+
+      expect(getAvail(plat, plat, verEmpty, verInside), Availability.all);
+      expect(getAvail(plat, plat, verEmpty, verOverlap), Availability.some);
+      expect(getAvail(plat, plat, verEmpty, verOutside), Availability.none);
+      expect(getAvail(plat, plat, verInside, verEmpty), Availability.all);
+      expect(getAvail(plat, plat, verOverlap, verEmpty), Availability.some);
+      expect(getAvail(plat, plat, verOutside, verEmpty), Availability.none);
+
+      expect(getAvail(plat, plat, verInside, verInside), Availability.all);
+      expect(getAvail(plat, plat, verInside, verOverlap), Availability.some);
+      expect(getAvail(plat, plat, verInside, verOutside), Availability.some);
+      expect(getAvail(plat, plat, verOverlap, verInside), Availability.some);
+      expect(getAvail(plat, plat, verOverlap, verOverlap), Availability.some);
+      expect(getAvail(plat, plat, verOverlap, verOutside), Availability.some);
+      expect(getAvail(plat, plat, verOutside, verInside), Availability.some);
+      expect(getAvail(plat, plat, verOutside, verOverlap), Availability.some);
+      expect(getAvail(plat, plat, verOutside, verOutside), Availability.none);
+
+      expect(getAvail(null, plat, verInside, verInside), Availability.all);
+      expect(getAvail(null, plat, verInside, verOverlap), Availability.some);
+      expect(getAvail(null, plat, verInside, verOutside), Availability.some);
+      expect(getAvail(null, plat, verOverlap, verInside), Availability.all);
+      expect(getAvail(null, plat, verOverlap, verOverlap), Availability.some);
+      expect(getAvail(null, plat, verOverlap, verOutside), Availability.some);
+      expect(getAvail(null, plat, verOutside, verInside), Availability.all);
+      expect(getAvail(null, plat, verOutside, verOverlap), Availability.some);
+      expect(getAvail(null, plat, verOutside, verOutside), Availability.some);
+
+      expect(getAvail(plat, null, verInside, verInside), Availability.all);
+      expect(getAvail(plat, null, verInside, verOverlap), Availability.all);
+      expect(getAvail(plat, null, verInside, verOutside), Availability.all);
+      expect(getAvail(plat, null, verOverlap, verInside), Availability.some);
+      expect(getAvail(plat, null, verOverlap, verOverlap), Availability.some);
+      expect(getAvail(plat, null, verOverlap, verOutside), Availability.some);
+      expect(getAvail(plat, null, verOutside, verInside), Availability.some);
+      expect(getAvail(plat, null, verOutside, verOverlap), Availability.some);
+      expect(getAvail(plat, null, verOutside, verOutside), Availability.some);
     });
+  });
 
-    test('ios, empty PlatformAvailability', () {
-      final api = ApiAvailability(
-        ios: PlatformAvailability(),
-      );
+  test('ApiAvailability.dartDoc', () {
+    expect(
+        ApiAvailability(
+          ios: PlatformAvailability(
+            name: 'iOS',
+            introduced: Version(1, 2, 3),
+            deprecated: Version(4, 5, 6),
+            obsoleted: Version(7, 8, 9),
+          ),
+          macos: PlatformAvailability(
+            name: 'macOS',
+            deprecated: Version(10, 11, 12),
+          ),
+        ).dartDoc,
+        '''
+iOS: introduced 1.2.3, deprecated 4.5.6, obsoleted 7.8.9
+macOS: deprecated 10.11.12''');
 
-      expect(api.getAvailability(const ExternalVersions()), Availability.all);
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.all);
-      expect(
-          api.getAvailability(ExternalVersions(
-            macos: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.all);
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(10, 0, 0)),
-            macos: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.all);
-    });
+    expect(
+        ApiAvailability(
+          ios: PlatformAvailability(
+            name: 'iOS',
+            introduced: Version(1, 2, 3),
+            obsoleted: Version(4, 5, 6),
+          ),
+        ).dartDoc,
+        'iOS: introduced 1.2.3, obsoleted 4.5.6');
 
-    test('ios, unavailable', () {
-      final api = ApiAvailability(
-        ios: PlatformAvailability(
-          unavailable: true,
-        ),
-      );
+    expect(
+        ApiAvailability(
+          ios: PlatformAvailability(
+            name: 'macOS',
+            unavailable: true,
+          ),
+        ).dartDoc,
+        'macOS: unavailable');
 
-      expect(api.getAvailability(const ExternalVersions()), Availability.all);
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.none);
-      expect(
-          api.getAvailability(ExternalVersions(
-            macos: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.all);
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(10, 0, 0)),
-            macos: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.some);
-    });
-
-    test('macos', () {
-      final api = ApiAvailability(
-        macos: PlatformAvailability(
-          introduced: Version(1, 2, 3),
-          deprecated: Version(4, 5, 6),
-          obsoleted: Version(7, 8, 9),
-        ),
-      );
-
-      expect(api.getAvailability(const ExternalVersions()), Availability.all);
-
-      expect(
-          api.getAvailability(ExternalVersions(
-            macos: Versions(min: Version(1, 0, 0)),
-          )),
-          Availability.some);
-      expect(
-          api.getAvailability(ExternalVersions(
-            macos: Versions(min: Version(5, 0, 0)),
-          )),
-          Availability.none);
-      expect(
-          api.getAvailability(ExternalVersions(
-            macos: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.none);
-
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.all);
-
-      expect(
-          api.getAvailability(ExternalVersions(
-            macos: Versions(min: Version(1, 0, 0)),
-            ios: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.some);
-      expect(
-          api.getAvailability(ExternalVersions(
-            macos: Versions(min: Version(5, 0, 0)),
-            ios: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.some);
-      expect(
-          api.getAvailability(ExternalVersions(
-            macos: Versions(min: Version(10, 0, 0)),
-            ios: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.some);
-    });
-
-    test('macos, empty PlatformAvailability', () {
-      final api = ApiAvailability(
-        macos: PlatformAvailability(),
-      );
-
-      expect(api.getAvailability(const ExternalVersions()), Availability.all);
-      expect(
-          api.getAvailability(ExternalVersions(
-            macos: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.all);
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.all);
-      expect(
-          api.getAvailability(ExternalVersions(
-            macos: Versions(min: Version(10, 0, 0)),
-            ios: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.all);
-    });
-
-    test('macos, unavailable', () {
-      final api = ApiAvailability(
-        macos: PlatformAvailability(
-          unavailable: true,
-        ),
-      );
-
-      expect(api.getAvailability(const ExternalVersions()), Availability.all);
-      expect(
-          api.getAvailability(ExternalVersions(
-            macos: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.none);
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.all);
-      expect(
-          api.getAvailability(ExternalVersions(
-            macos: Versions(min: Version(10, 0, 0)),
-            ios: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.some);
-    });
-
-    test('both', () {
-      final api = ApiAvailability(
-        ios: PlatformAvailability(
-          introduced: Version(1, 2, 3),
-          deprecated: Version(4, 5, 6),
-          obsoleted: Version(7, 8, 9),
-        ),
-        macos: PlatformAvailability(
-          introduced: Version(2, 3, 4),
-          deprecated: Version(5, 6, 7),
-          obsoleted: Version(8, 9, 10),
-        ),
-      );
-
-      expect(
-          api.getAvailability(const ExternalVersions(
-            ios: null,
-            macos: null,
-          )),
-          Availability.all);
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(1, 0, 0)),
-            macos: null,
-          )),
-          Availability.some);
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(10, 0, 0)),
-            macos: null,
-          )),
-          Availability.none);
-
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: null,
-            macos: Versions(min: Version(1, 0, 0)),
-          )),
-          Availability.some);
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(1, 0, 0)),
-            macos: Versions(min: Version(1, 0, 0)),
-          )),
-          Availability.some);
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(10, 0, 0)),
-            macos: Versions(min: Version(1, 0, 0)),
-          )),
-          Availability.some);
-
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: null,
-            macos: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.none);
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(1, 0, 0)),
-            macos: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.some);
-      expect(
-          api.getAvailability(ExternalVersions(
-            ios: Versions(min: Version(10, 0, 0)),
-            macos: Versions(min: Version(10, 0, 0)),
-          )),
-          Availability.none);
-    });
+    expect(ApiAvailability().dartDoc, '');
   });
 }

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -1224,6 +1224,9 @@ class NSData extends NSObject
   }
 
   /// compressedDataUsingAlgorithm:error:
+  ///
+  /// iOS: introduced 13.0.0
+  /// macOS: introduced 10.15.0
   NSData? compressedDataUsingAlgorithm_error_(
       NSDataCompressionAlgorithm algorithm,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
@@ -1235,6 +1238,9 @@ class NSData extends NSObject
   }
 
   /// decompressedDataUsingAlgorithm:error:
+  ///
+  /// iOS: introduced 13.0.0
+  /// macOS: introduced 10.15.0
   NSData? decompressedDataUsingAlgorithm_error_(
       NSDataCompressionAlgorithm algorithm,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
@@ -1410,6 +1416,8 @@ enum NSDataBase64EncodingOptions {
       };
 }
 
+/// iOS: introduced 13.0.0
+/// macOS: introduced 10.15.0
 enum NSDataCompressionAlgorithm {
   NSDataCompressionAlgorithmLZFSE(0),
   NSDataCompressionAlgorithmLZ4(1),
@@ -2099,7 +2107,8 @@ class NSError extends NSObject implements NSCopying, NSSecureCoding {
         : objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
-  /// underlyingErrors
+  /// iOS: introduced 14.5.0
+  /// macOS: introduced 11.3.0
   NSArray get underlyingErrors {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_underlyingErrors);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
@@ -4480,6 +4489,9 @@ class NSMutableData extends NSData {
   }
 
   /// compressedDataUsingAlgorithm:error:
+  ///
+  /// iOS: introduced 13.0.0
+  /// macOS: introduced 10.15.0
   NSMutableData? compressedDataUsingAlgorithm_error_(
       NSDataCompressionAlgorithm algorithm,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
@@ -4491,6 +4503,9 @@ class NSMutableData extends NSData {
   }
 
   /// decompressedDataUsingAlgorithm:error:
+  ///
+  /// iOS: introduced 13.0.0
+  /// macOS: introduced 10.15.0
   NSMutableData? decompressedDataUsingAlgorithm_error_(
       NSDataCompressionAlgorithm algorithm,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
@@ -5874,6 +5889,9 @@ class NSMutableString extends NSString {
   }
 
   /// initWithValidatedFormat:validFormatSpecifiers:error:
+  ///
+  /// iOS: introduced 16.0.0
+  /// macOS: introduced 13.0.0
   NSMutableString? initWithValidatedFormat_validFormatSpecifiers_error_(
       NSString format,
       NSString validFormatSpecifiers,
@@ -5890,6 +5908,9 @@ class NSMutableString extends NSString {
   }
 
   /// initWithValidatedFormat:validFormatSpecifiers:locale:error:
+  ///
+  /// iOS: introduced 16.0.0
+  /// macOS: introduced 13.0.0
   NSMutableString? initWithValidatedFormat_validFormatSpecifiers_locale_error_(
       NSString format,
       NSString validFormatSpecifiers,
@@ -7496,6 +7517,9 @@ interface class NSObjectProtocol extends objc.ObjCProtocolBase {
 }
 
 /// NSOrderedCollectionDifference
+///
+/// iOS: introduced 13.0.0
+/// macOS: introduced 10.15.0
 class NSOrderedCollectionDifference extends NSObject
     implements NSFastEnumeration {
   NSOrderedCollectionDifference._(ffi.Pointer<objc.ObjCObject> pointer,
@@ -7553,7 +7577,8 @@ class NSOrderedCollectionDifference extends NSObject
         _sel_countByEnumeratingWithState_objects_count_, state, buffer, len);
   }
 
-  /// hasChanges
+  /// iOS: introduced 13.0.0
+  /// macOS: introduced 10.15.0
   bool get hasChanges {
     return _objc_msgSend_91o635(this.ref.pointer, _sel_hasChanges);
   }
@@ -7567,6 +7592,9 @@ class NSOrderedCollectionDifference extends NSObject
   }
 
   /// initWithChanges:
+  ///
+  /// iOS: introduced 13.0.0
+  /// macOS: introduced 10.15.0
   NSOrderedCollectionDifference initWithChanges_(objc.ObjCObjectBase changes) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithChanges_, changes.ref.pointer);
@@ -7575,6 +7603,9 @@ class NSOrderedCollectionDifference extends NSObject
   }
 
   /// initWithInsertIndexes:insertedObjects:removeIndexes:removedObjects:
+  ///
+  /// iOS: introduced 13.0.0
+  /// macOS: introduced 10.15.0
   NSOrderedCollectionDifference
       initWithInsertIndexes_insertedObjects_removeIndexes_removedObjects_(
           NSIndexSet inserts,
@@ -7593,6 +7624,9 @@ class NSOrderedCollectionDifference extends NSObject
   }
 
   /// initWithInsertIndexes:insertedObjects:removeIndexes:removedObjects:additionalChanges:
+  ///
+  /// iOS: introduced 13.0.0
+  /// macOS: introduced 10.15.0
   NSOrderedCollectionDifference
       initWithInsertIndexes_insertedObjects_removeIndexes_removedObjects_additionalChanges_(
           NSIndexSet inserts,
@@ -7612,13 +7646,17 @@ class NSOrderedCollectionDifference extends NSObject
         retain: false, release: true);
   }
 
-  /// insertions
+  /// iOS: introduced 13.0.0
+  /// macOS: introduced 10.15.0
   objc.ObjCObjectBase get insertions {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_insertions);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
   /// inverseDifference
+  ///
+  /// iOS: introduced 13.0.0
+  /// macOS: introduced 10.15.0
   NSOrderedCollectionDifference inverseDifference() {
     final _ret =
         _objc_msgSend_151sglz(this.ref.pointer, _sel_inverseDifference);
@@ -7626,13 +7664,16 @@ class NSOrderedCollectionDifference extends NSObject
         retain: true, release: true);
   }
 
-  /// removals
+  /// iOS: introduced 13.0.0
+  /// macOS: introduced 10.15.0
   objc.ObjCObjectBase get removals {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_removals);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 }
 
+/// iOS: introduced 13.0.0
+/// macOS: introduced 10.15.0
 enum NSOrderedCollectionDifferenceCalculationOptions {
   NSOrderedCollectionDifferenceCalculationOmitInsertedObjects(1),
   NSOrderedCollectionDifferenceCalculationOmitRemovedObjects(2),
@@ -9237,6 +9278,9 @@ class NSString extends NSObject
   }
 
   /// initWithValidatedFormat:validFormatSpecifiers:error:
+  ///
+  /// iOS: introduced 16.0.0
+  /// macOS: introduced 13.0.0
   NSString? initWithValidatedFormat_validFormatSpecifiers_error_(
       NSString format,
       NSString validFormatSpecifiers,
@@ -9253,6 +9297,9 @@ class NSString extends NSObject
   }
 
   /// initWithValidatedFormat:validFormatSpecifiers:locale:error:
+  ///
+  /// iOS: introduced 16.0.0
+  /// macOS: introduced 13.0.0
   NSString? initWithValidatedFormat_validFormatSpecifiers_locale_error_(
       NSString format,
       NSString validFormatSpecifiers,
@@ -10204,6 +10251,9 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// URLWithString:encodingInvalidCharacters:
+  ///
+  /// iOS: introduced 17.0.0
+  /// macOS: introduced 14.0.0
   static NSURL? URLWithString_encodingInvalidCharacters_(
       NSString URLString, bool encodingInvalidCharacters) {
     final _ret = _objc_msgSend_17amj0z(
@@ -10599,6 +10649,9 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// initWithString:encodingInvalidCharacters:
+  ///
+  /// iOS: introduced 17.0.0
+  /// macOS: introduced 14.0.0
   NSURL? initWithString_encodingInvalidCharacters_(
       NSString URLString, bool encodingInvalidCharacters) {
     final _ret = _objc_msgSend_17amj0z(
@@ -10633,7 +10686,8 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
     return _objc_msgSend_91o635(this.ref.pointer, _sel_isFileURL);
   }
 
-  /// parameterString
+  /// iOS: introduced 2.0.0, deprecated 13.0.0
+  /// macOS: introduced 10.2.0, deprecated 10.15.0
   NSString? get parameterString {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_parameterString);
     return _ret.address == 0


### PR DESCRIPTION
Add a `max` field to the `external-versions` config, and extend the API versioning checks to check the max version vs the version that the API was introduced. Also, if an API is available in some versions, but not all of them, generate documentation describing the versions.

The main changes are in api_availability.dart. Instead of just returning a bool for whether the API is available, we now return an `Availability` enum, to also represent partial availability.

The version check itself has also become more complicated, since we're now checking the overlap of two ranges, instead of just checking one version vs a range. Broadly speaking, if `apiMin <= configMin && apiMax >= configMax`, the API is `Availability.all`, and if `apiMin <= confMax && apiMax > confMin` then the API is `Availability.some`, otherwise it's `Availability.none`. There are a bunch of other edge cases to deal with, but that's the main logic.

### Details

- If an interface or category is unavailable due to API versioning, but is depended on by other APIs, generate them as a stub. Don't omit them from the AST because it breaks things. Had to add an `unavailable` flag to their AST nodes, and use it in some of the transformers to get this behavior.
- Had to refactor `getCursorDocComment` a bit to handle the versioning documentation.
- Unrelated change: `makeDartDoc` is already null aware, so removed some `if (dartDoc != null)` checks.

Fixes https://github.com/dart-lang/native/issues/1422