### PR TITLE
[ffigen] Add variable substitutions for ObjC SDKs

### DIFF
--- a/pkgs/ffigen/lib/src/config_provider/spec_utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/spec_utils.dart
@@ -18,28 +18,9 @@ import '../code_generator/utils.dart';
 import '../header_parser/type_extractor/cxtypekindmap.dart';
 import '../strings.dart' as strings;
 import 'config_types.dart';
+import 'utils.dart';
 
 final _logger = Logger('ffigen.config_provider.spec_utils');
-
-/// Replaces the path separators according to current platform.
-String _replaceSeparators(String path) {
-  if (Platform.isWindows) {
-    return path.replaceAll(p.posix.separator, p.windows.separator);
-  } else {
-    return path.replaceAll(p.windows.separator, p.posix.separator);
-  }
-}
-
-/// Replaces the path separators according to current platform, and normalizes .
-/// and .. in the path. If a relative path is passed in, it is resolved relative
-/// to the config path, and the absolute path is returned.
-String normalizePath(String path, String? configFilename) {
-  final resolveInConfigDir =
-      (configFilename == null) || p.isAbsolute(path) || path.startsWith('**');
-  return _replaceSeparators(p.normalize(resolveInConfigDir
-      ? path
-      : p.absolute(p.join(p.dirname(configFilename), path))));
-}
 
 Map<String, LibraryImport> libraryImportsExtractor(
     Map<String, String>? typeMap) {
@@ -276,7 +257,7 @@ YamlHeaders headersExtractor(
   for (final key in yamlConfig.keys) {
     if (key == strings.entryPoints) {
       for (final h in yamlConfig[key]!) {
-        final headerGlob = normalizePath(h, configFilename);
+        final headerGlob = normalizePath(substituteVars(h), configFilename);
         // Add file directly to header if it's not a Glob but a File.
         if (File(headerGlob).existsSync()) {
           final osSpecificPath = headerGlob;
@@ -295,9 +276,8 @@ YamlHeaders headersExtractor(
     }
     if (key == strings.includeDirectives) {
       for (final h in yamlConfig[key]!) {
-        final headerGlob = h;
-        final fixedGlob = normalizePath(headerGlob, configFilename);
-        includeGlobs.add(quiver.Glob(fixedGlob));
+        final headerGlob = normalizePath(substituteVars(h), configFilename);
+        includeGlobs.add(quiver.Glob(headerGlob));
       }
     }
   }

--- a/pkgs/ffigen/lib/src/config_provider/utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/utils.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+// Replaces the path separators according to current platform.
+String _replaceSeparators(String path) {
+  if (Platform.isWindows) {
+    return path.replaceAll(p.posix.separator, p.windows.separator);
+  } else {
+    return path.replaceAll(p.windows.separator, p.posix.separator);
+  }
+}
+
+/// Replaces the path separators according to current platform, and normalizes .
+/// and .. in the path. If a relative path is passed in, it is resolved relative
+/// to the config path, and the absolute path is returned.
+String normalizePath(String path, String? configFilename) {
+  final resolveInConfigDir =
+      (configFilename == null) || p.isAbsolute(path) || path.startsWith('**');
+  return _replaceSeparators(p.normalize(resolveInConfigDir
+      ? path
+      : p.absolute(p.join(p.dirname(configFilename), path))));
+}
+
+/// Replaces any variable names in the path with the corresponding value.
+String substituteVars(String path) {
+  for (final variable in _variables) {
+    final key = '\$${variable.key}';
+    if (path.contains(key)) {
+      path = path.replaceAll(key, variable.value);
+    }
+  }
+  return path;
+}
+
+class _LazyVariable {
+  _LazyVariable(this.key, this._cmd, this._args);
+  final String key;
+  final String _cmd;
+  final List<String> _args;
+  String? _value;
+  String get value => _value ??= firstLineOfStdout(_cmd, _args);
+}
+
+final _variables = <_LazyVariable>[
+  _LazyVariable('XCODE', 'xcode-select', ['-p']),
+  _LazyVariable('IOS_SDK', 'xcrun', ['--show-sdk-path', '--sdk', 'iphoneos']),
+  _LazyVariable('MACOS_SDK', 'xcrun', ['--show-sdk-path', '--sdk', 'macosx']),
+];
+
+String firstLineOfStdout(String cmd, List<String> args) {
+  final result = Process.runSync(cmd, args);
+  assert(result.exitCode == 0);
+  return (result.stdout as String)
+      .split('\n')
+      .where((line) => line.isNotEmpty)
+      .first;
+}

--- a/pkgs/ffigen/lib/src/header_parser/parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/parser.dart
@@ -13,6 +13,7 @@ import 'package:meta/meta.dart';
 import '../code_generator.dart';
 import '../code_generator/utils.dart';
 import '../config_provider.dart';
+import '../config_provider/utils.dart';
 import '../strings.dart' as strings;
 import '../visitor/apply_config_filters.dart';
 import '../visitor/ast.dart';
@@ -159,17 +160,10 @@ List<Binding> parseToBindings(Config c) {
   return bindings.toList();
 }
 
-List<String> _findObjectiveCSysroot() {
-  final result = Process.runSync('xcrun', ['--show-sdk-path']);
-  if (result.exitCode == 0) {
-    for (final line in (result.stdout as String).split('\n')) {
-      if (line.isNotEmpty) {
-        return ['-isysroot', line];
-      }
-    }
-  }
-  return [];
-}
+List<String> _findObjectiveCSysroot() => [
+      '-isysroot',
+      firstLineOfStdout('xcrun', ['--show-sdk-path'])
+    ];
 
 @visibleForTesting
 List<Binding> transformBindings(Config config, List<Binding> bindings) {

--- a/pkgs/ffigen/test/native_objc_test/sdk_variable_config.yaml
+++ b/pkgs/ffigen/test/native_objc_test/sdk_variable_config.yaml
@@ -1,0 +1,17 @@
+name: SdkVariableTestObjCLibrary
+description: 'Tests the ObjC SDK variables'
+language: objc
+output: 'sdk_variable_bindings.dart'
+exclude-all-by-default: true
+objc-interfaces:
+  include:
+    - NSColorPicker
+    - UIPickerView
+    - NSTextList
+headers:
+  entry-points:
+    - '$XCODE/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSColorPicker.h'
+    - '$IOS_SDK/System/Library/Frameworks/UIKit.framework/Headers/UIPickerView.h'
+    - '$MACOS_SDK/System/Library/Frameworks/AppKit.framework/Headers/NSTextList.h'
+preamble: |
+  // ignore_for_file: camel_case_types, non_constant_identifier_names, unnecessary_non_null_assertion, unused_element, unused_field

--- a/pkgs/ffigen/test/native_objc_test/sdk_variable_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/sdk_variable_test.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Objective C support is only available on mac.
+@TestOn('mac-os')
+
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:test/test.dart';
+import '../test_utils.dart';
+import 'util.dart';
+
+void main() {
+  group('SDK variable', () {
+    late String bindings;
+
+    setUpAll(() {
+      // TODO(https://github.com/dart-lang/native/issues/1068): Remove this.
+      DynamicLibrary.open('../objective_c/test/objective_c.dylib');
+      final dylib = File('test/native_objc_test/objc_test.dylib');
+      verifySetupFile(dylib);
+      DynamicLibrary.open(dylib.absolute.path);
+      generateBindingsForCoverage('rename');
+      bindings = File('test/native_objc_test/transitive_bindings.dart')
+          .readAsStringSync();
+    });
+
+    test('XCODE', () {
+      expect(bindings, contains('class NSColorPicker '));
+    });
+
+    test('IOS_SDK', () {
+      expect(bindings, contains('class UIPickerView '));
+    });
+
+    test('MACOS_SDK', () {
+      expect(bindings, contains('class NSTextList '));
+    });
+  });
+}

--- a/pkgs/ffigen/test/native_objc_test/sdk_variable_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/sdk_variable_test.dart
@@ -23,7 +23,7 @@ void main() {
       verifySetupFile(dylib);
       DynamicLibrary.open(dylib.absolute.path);
       generateBindingsForCoverage('rename');
-      bindings = File('test/native_objc_test/transitive_bindings.dart')
+      bindings = File('test/native_objc_test/sdk_variable_bindings.dart')
           .readAsStringSync();
     });
 

--- a/pkgs/ffigen/test/unit_tests/normalize_path_test.dart
+++ b/pkgs/ffigen/test/unit_tests/normalize_path_test.dart
@@ -4,7 +4,7 @@
 
 import 'dart:io';
 
-import 'package:ffigen/src/config_provider/spec_utils.dart';
+import 'package:ffigen/src/config_provider/utils.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 


### PR DESCRIPTION
- `$XCODE`: `xcode-select -p`
  - eg `/Applications/Xcode.app/Contents/Developer`
- `$IOS_SDK`: `xcrun --show-sdk-path --sdk iphoneos`
  - eg `/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.2.sdk`
- `$MACOS_SDK`: `xcrun --show-sdk-path --sdk macosx`
  - eg `/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk`

Fixes https://github.com/dart-lang/native/issues/471