### PR TITLE
[native_toolchain_c] Don't fail on uninstalled NDKs

### DIFF
--- a/pkgs/native_toolchain_c/lib/src/native_toolchain/android_ndk.dart
+++ b/pkgs/native_toolchain_c/lib/src/native_toolchain/android_ndk.dart
@@ -83,6 +83,9 @@ class _AndroidNdkResolver implements ToolResolver {
       'toolchains/llvm/prebuilt/',
     );
     final prebuiltDir = Directory.fromUri(prebuiltUri);
+    if (!prebuiltDir.existsSync()) {
+      return [];
+    }
     final hostArchDirs =
         (await prebuiltDir.list().toList()).whereType<Directory>().toList();
     for (final hostArchDir in hostArchDirs) {


### PR DESCRIPTION
NDK directories can be empty (apart from `.installer/`) after uninstalling NDK directories.