### PR TITLE
[native_assets_cli] Cleanup protocol pre 1.7.0

### DIFF
--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -135,7 +135,7 @@ class NativeAssetsBuildRunner {
       final inputBuilder =
           inputCreator()
             ..config.setupShared(buildAssetTypes: buildAssetTypes)
-            ..config.setupBuild(dryRun: false, linkingEnabled: linkingEnabled)
+            ..config.setupBuild(linkingEnabled: linkingEnabled)
             ..setupBuildInput(metadata: metadata);
 
       final (buildDirUri, outDirUri, outDirSharedUri) = await _setupDirectories(

--- a/pkgs/native_assets_builder/lib/src/model/link_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/link_result.dart
@@ -4,8 +4,8 @@
 
 import 'package:native_assets_cli/native_assets_cli_internal.dart';
 
-/// The result of executing the link hooks in dry run mode from all packages in
-/// the dependency tree of the entry point application.
+/// The result of executing the link hooks from all packages in the dependency
+/// tree of the entry point application.
 abstract interface class LinkResult {
   /// All assets (produced by the build & link hooks) that have to be bundled
   /// with the app.

--- a/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
@@ -38,7 +38,7 @@ void main() async {
               outputDirectory: outputDirectory,
               outputDirectoryShared: outputDirectoryShared,
             )
-            ..config.setupBuild(dryRun: false, linkingEnabled: false)
+            ..config.setupBuild(linkingEnabled: false)
             ..config.setupShared(buildAssetTypes: [CodeAsset.type])
             ..config.setupCode(
               targetArchitecture: Architecture.current,

--- a/pkgs/native_assets_builder/test/test_data/transformer_test.dart
+++ b/pkgs/native_assets_builder/test/test_data/transformer_test.dart
@@ -50,7 +50,7 @@ void main() async {
                 outputDirectory: outputDirectory,
                 outputDirectoryShared: outputDirectoryShared,
               )
-              ..config.setupBuild(dryRun: false, linkingEnabled: false)
+              ..config.setupBuild(linkingEnabled: false)
               ..config.setupShared(
                 buildAssetTypes: [CodeAsset.type, DataAsset.type],
               )

--- a/pkgs/native_assets_builder/test_data/native_add_version_skew/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/native_add_version_skew/hook/build.dart
@@ -7,15 +7,15 @@ import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
 void main(List<String> arguments) async {
-  await build(arguments, (config, output) async {
-    final packageName = config.packageName;
+  await build(arguments, (input, output) async {
+    final packageName = input.packageName;
     final cbuilder = CBuilder.library(
       name: packageName,
       assetName: 'src/native_add_bindings_generated.dart',
       sources: ['src/native_add.c'],
     );
     await cbuilder.run(
-      config: config,
+      input: input,
       output: output,
       logger:
           Logger('')

--- a/pkgs/native_assets_builder/test_data/native_add_version_skew/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_version_skew/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.9.0
-  native_toolchain_c: ^0.6.0
+  native_assets_cli: ^0.11.0
+  native_toolchain_c: ^0.8.0
 
 dev_dependencies:
   ffigen: ^8.0.2

--- a/pkgs/native_assets_builder/test_data/use_all_api/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/use_all_api/hook/build.dart
@@ -19,7 +19,6 @@ void main(List<String> args) async {
     // c. target config
     // c.1. per hook
     input.config.linkingEnabled; // build only
-    input.config.dryRun; // build only, deleted soon
     // c.2. per asset
     input.config.buildAssetTypes;
     input.config.code.linkModePreference;

--- a/pkgs/native_assets_cli/example/build/download_asset/tool/build.dart
+++ b/pkgs/native_assets_cli/example/build/download_asset/tool/build.dart
@@ -83,7 +83,7 @@ BuildInput createBuildInput(
           outputDirectoryShared: outputDirectoryShared,
         )
         ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-        ..config.setupBuild(dryRun: false, linkingEnabled: false)
+        ..config.setupBuild(linkingEnabled: false)
         ..config.setupCode(
           targetArchitecture: Architecture.fromString(architecture),
           targetOS: os,

--- a/pkgs/native_assets_cli/example/build/local_asset/hook/build.dart
+++ b/pkgs/native_assets_cli/example/build/local_asset/hook/build.dart
@@ -19,13 +19,11 @@ Future<void> main(List<String> args) async {
     final packageName = input.packageName;
     final assetPath = input.outputDirectory.resolve(assetName);
     final assetSourcePath = input.packageRoot.resolveUri(packageAssetPath);
-    // ignore: deprecated_member_use
-    if (!input.config.dryRun) {
-      // Insert code that downloads or builds the asset to `assetPath`.
-      await File.fromUri(assetSourcePath).copy(assetPath.toFilePath());
 
-      output.addDependencies([assetSourcePath]);
-    }
+    // Insert code that downloads or builds the asset to `assetPath`.
+    await File.fromUri(assetSourcePath).copy(assetPath.toFilePath());
+
+    output.addDependencies([assetSourcePath]);
 
     output.assets.code.add(
       // TODO: Change to DataAsset once the Dart/Flutter SDK can consume it.
@@ -35,9 +33,7 @@ Future<void> main(List<String> args) async {
         file: assetPath,
         linkMode: DynamicLoadingBundled(),
         os: input.config.code.targetOS,
-        architecture:
-            // ignore: deprecated_member_use
-            input.config.dryRun ? null : input.config.code.targetArchitecture,
+        architecture: input.config.code.targetArchitecture,
       ),
     );
   });

--- a/pkgs/native_assets_cli/lib/src/api/build.dart
+++ b/pkgs/native_assets_cli/lib/src/api/build.dart
@@ -67,14 +67,12 @@ import '../validation.dart';
 ///     final packageName = input.packageName;
 ///     final assetPath = input.outputDirectory.resolve(assetName);
 ///     final assetSourcePath = input.packageRoot.resolveUri(packageAssetPath);
-///     if (!input.dryRun) {
-///       // Insert code that downloads or builds the asset to `assetPath`.
-///       await File.fromUri(assetSourcePath).copy(assetPath.toFilePath());
+///     // Insert code that downloads or builds the asset to `assetPath`.
+///     await File.fromUri(assetSourcePath).copy(assetPath.toFilePath());
 ///
-///       output.addDependencies([
-///         assetSourcePath,
-///       ]);
-///     }
+///     output.addDependencies([
+///       assetSourcePath,
+///     ]);
 ///
 ///     output.assets.code.add(
 ///       // TODO: Change to DataAsset once the Dart/Flutter SDK can consume it.

--- a/pkgs/native_assets_cli/lib/src/code_assets/c_compiler_config.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/c_compiler_config.dart
@@ -77,10 +77,7 @@ final class CCompilerConfig {
   ///
   /// The returned json can be used in [CCompilerConfig.fromJson] to
   /// obtain a [CCompilerConfig] again.
-  ///
-  /// If [deprecatedTopLevel], does not nest developerCommandPrompt.
-  // TODO: Remove deprecatedTopLevel once protocol 1.8.0 is no longer supported.
-  Map<String, Object> toJson({bool deprecatedTopLevel = false}) =>
+  Map<String, Object> toJson() =>
       {
         _arConfigKey: archiver.toFilePath(),
         _ccConfigKey: compiler.toFilePath(),
@@ -91,7 +88,7 @@ final class CCompilerConfig {
         if (_windows?.developerCommandPrompt?.arguments != null)
           _envScriptArgsConfigKeyDeprecated:
               _windows!.developerCommandPrompt!.arguments,
-        if (_windows != null && !deprecatedTopLevel)
+        if (_windows != null)
           _windowsConfigKey: {
             if (_windows.developerCommandPrompt != null)
               _developerCommandPromptConfigKey: {

--- a/pkgs/native_assets_cli/lib/src/code_assets/config.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/config.dart
@@ -91,8 +91,7 @@ class CodeConfig {
       json.code?.optionalString(_targetOSConfigKey) ??
           json.string(_targetOSConfigKey),
     );
-    final cCompiler = switch (json.code?.optionalMap(_compilerKey) ??
-        json.optionalMap(_compilerKey)) {
+    final cCompiler = switch (json.code?.optionalMap(_compilerKey)) {
       final Map<String, Object?> map => CCompilerConfig.fromJson(map),
       null => null,
     };
@@ -315,7 +314,6 @@ extension CodeAssetBuildInputBuilder on HookConfigBuilder {
       _linkModePreferenceKey,
     ], linkModePreference.toString());
     if (cCompiler != null) {
-      json[_compilerKey] = cCompiler.toJson(deprecatedTopLevel: true);
       json.setNested([_configKey, _codeKey, _compilerKey], cCompiler.toJson());
     }
 

--- a/pkgs/native_assets_cli/lib/src/code_assets/config.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/config.dart
@@ -75,8 +75,7 @@ class CodeConfig {
 
   factory CodeConfig.fromJson(Map<String, Object?> json) {
     final linkModePreference = LinkModePreference.fromString(
-      json.code?.optionalString(_linkModePreferenceKey) ??
-          json.string(_linkModePreferenceKey),
+      json.code!.string(_linkModePreferenceKey),
     );
     final targetArchitecture = Architecture.fromString(
       json.code?.optionalString(
@@ -281,7 +280,6 @@ extension CodeAssetBuildInputBuilder on HookConfigBuilder {
       _codeKey,
       _targetOSConfigKey,
     ], targetOS.toString());
-    json[_linkModePreferenceKey] = linkModePreference.toString();
     json.setNested([
       _configKey,
       _codeKey,

--- a/pkgs/native_assets_cli/lib/src/code_assets/config.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/config.dart
@@ -78,19 +78,12 @@ class CodeConfig {
       json.code!.string(_linkModePreferenceKey),
     );
     final targetArchitecture = Architecture.fromString(
-      json.code?.optionalString(
-            _targetArchitectureKey,
-            validValues: Architecture.values.map((a) => a.name),
-          ) ??
-          json.string(
-            _targetArchitectureKey,
-            validValues: Architecture.values.map((a) => a.name),
-          ),
+      json.code!.string(
+        _targetArchitectureKey,
+        validValues: Architecture.values.map((a) => a.name),
+      ),
     );
-    final targetOS = OS.fromString(
-      json.code?.optionalString(_targetOSConfigKey) ??
-          json.string(_targetOSConfigKey),
-    );
+    final targetOS = OS.fromString(json.code!.string(_targetOSConfigKey));
     final cCompiler = switch (json.code?.optionalMap(_compilerKey)) {
       final Map<String, Object?> map => CCompilerConfig.fromJson(map),
       null => null,
@@ -153,13 +146,12 @@ class IOSCodeConfig {
       _targetVersion = targetVersion;
 
   IOSCodeConfig.fromJson(Map<String, Object?> json)
-    : _targetVersion =
-          json.code?.optionalMap(_iosKey)?.optionalInt(_targetVersionKey) ??
-          json.optionalInt(_targetIOSVersionKeyDeprecated),
+    : _targetVersion = json.code
+          ?.optionalMap(_iosKey)
+          ?.optionalInt(_targetVersionKey),
       _targetSdk = switch (json.code
-              ?.optionalMap(_iosKey)
-              ?.optionalString(_targetSdkKey) ??
-          json.optionalString(_targetIOSSdkKeyDeprecated)) {
+          ?.optionalMap(_iosKey)
+          ?.optionalString(_targetSdkKey)) {
         null => null,
         String e => IOSSdk.fromString(e),
       };
@@ -181,9 +173,9 @@ class AndroidCodeConfig {
   AndroidCodeConfig({required int targetNdkApi}) : _targetNdkApi = targetNdkApi;
 
   AndroidCodeConfig.fromJson(Map<String, Object?> json)
-    : _targetNdkApi =
-          json.code?.optionalMap(_androidKey)?.optionalInt(_targetNdkApiKey) ??
-          json.optionalInt(_targetAndroidNdkApiKeyDeprecated);
+    : _targetNdkApi = json.code
+          ?.optionalMap(_androidKey)
+          ?.optionalInt(_targetNdkApiKey);
 }
 
 extension AndroidConfigSyntactic on AndroidCodeConfig {
@@ -201,9 +193,9 @@ class MacOSCodeConfig {
     : _targetVersion = targetVersion;
 
   MacOSCodeConfig.fromJson(Map<String, Object?> json)
-    : _targetVersion =
-          json.code?.optionalMap(_macosKey)?.optionalInt(_targetVersionKey) ??
-          json.optionalInt(_targetMacOSVersionKeyDeprecated);
+    : _targetVersion = json.code
+          ?.optionalMap(_macosKey)
+          ?.optionalInt(_targetVersionKey);
 }
 
 extension MacOSConfigSyntactic on MacOSCodeConfig {
@@ -267,14 +259,12 @@ extension CodeAssetBuildInputBuilder on HookConfigBuilder {
     MacOSCodeConfig? macOS,
   }) {
     if (targetArchitecture != null) {
-      json[_targetArchitectureKey] = targetArchitecture.toString();
       json.setNested([
         _configKey,
         _codeKey,
         _targetArchitectureKey,
       ], targetArchitecture.toString());
     }
-    json[_targetOSConfigKey] = targetOS.toString();
     json.setNested([
       _configKey,
       _codeKey,
@@ -292,7 +282,6 @@ extension CodeAssetBuildInputBuilder on HookConfigBuilder {
     // Note, using ?. instead of !. makes missing data be a semantic error
     // rather than a syntactic error to be caught in the validation.
     if (targetOS == OS.android) {
-      json[_targetAndroidNdkApiKeyDeprecated] = android?.targetNdkApi;
       json.setNested([
         _configKey,
         _codeKey,
@@ -300,8 +289,6 @@ extension CodeAssetBuildInputBuilder on HookConfigBuilder {
         _targetNdkApiKey,
       ], android?.targetNdkApi);
     } else if (targetOS == OS.iOS) {
-      json[_targetIOSSdkKeyDeprecated] = iOS?.targetSdk.toString();
-      json[_targetIOSVersionKeyDeprecated] = iOS?.targetVersion;
       json.setNested([
         _configKey,
         _codeKey,
@@ -315,7 +302,6 @@ extension CodeAssetBuildInputBuilder on HookConfigBuilder {
         _targetVersionKey,
       ], iOS?.targetVersion);
     } else if (targetOS == OS.macOS) {
-      json[_targetMacOSVersionKeyDeprecated] = macOS?.targetVersion;
       json.setNested([
         _configKey,
         _codeKey,
@@ -349,13 +335,9 @@ extension CodeAssetLinkOutput on LinkOutputAssets {
 const String _compilerKey = 'c_compiler';
 const String _linkModePreferenceKey = 'link_mode_preference';
 const String _targetNdkApiKey = 'target_ndk_api';
-const String _targetAndroidNdkApiKeyDeprecated = 'target_android_ndk_api';
 const String _targetArchitectureKey = 'target_architecture';
 const String _targetSdkKey = 'target_sdk';
-const String _targetIOSSdkKeyDeprecated = 'target_ios_sdk';
 const String _targetVersionKey = 'target_version';
-const String _targetIOSVersionKeyDeprecated = 'target_ios_version';
-const String _targetMacOSVersionKeyDeprecated = 'target_macos_version';
 const String _targetOSConfigKey = 'target_os';
 
 const _configKey = 'config';

--- a/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
@@ -11,22 +11,15 @@ import 'link_mode.dart';
 Future<ValidationErrors> validateCodeAssetBuildInput(BuildInput input) async =>
     _validateCodeConfig(
       'BuildInput.config.code',
+
       // ignore: deprecated_member_use_from_same_package
-      input.config.dryRun,
       input.config.code,
     );
 
 Future<ValidationErrors> validateCodeAssetLinkInput(LinkInput input) async =>
-    _validateCodeConfig('LinkInput.config.code', false, input.config.code);
+    _validateCodeConfig('LinkInput.config.code', input.config.code);
 
-ValidationErrors _validateCodeConfig(
-  String inputName,
-  bool dryRun,
-  CodeConfig code,
-) {
-  // The dry run will be removed soon.
-  if (dryRun) return const [];
-
+ValidationErrors _validateCodeConfig(String inputName, CodeConfig code) {
   final errors = <String>[];
   final targetOS = code.targetOS;
   switch (targetOS) {
@@ -88,8 +81,6 @@ Future<ValidationErrors> validateCodeAssetBuildOutput(
   input,
   input.config.code,
   output.assets.encodedAssets,
-  // ignore: deprecated_member_use_from_same_package
-  input.config.dryRun,
   output,
   true,
 );
@@ -101,7 +92,6 @@ Future<ValidationErrors> validateCodeAssetLinkOutput(
   input,
   input.config.code,
   output.assets.encodedAssets,
-  false,
   output,
   false,
 );
@@ -131,7 +121,6 @@ Future<ValidationErrors> _validateCodeAssetBuildOrLinkOutput(
   HookInput input,
   CodeConfig codeConfig,
   List<EncodedAsset> encodedAssets,
-  bool dryRun,
   HookOutput output,
   bool isBuild,
 ) async {
@@ -144,7 +133,6 @@ Future<ValidationErrors> _validateCodeAssetBuildOrLinkOutput(
     _validateCodeAssets(
       input,
       codeConfig,
-      dryRun,
       CodeAsset.fromEncoded(asset),
       errors,
       ids,
@@ -162,7 +150,6 @@ Future<ValidationErrors> _validateCodeAssetBuildOrLinkOutput(
 void _validateCodeAssets(
   HookInput input,
   CodeConfig codeConfig,
-  bool dryRun,
   CodeAsset codeAsset,
   List<String> errors,
   Set<String> ids,
@@ -197,25 +184,22 @@ void _validateCodeAssets(
   }
 
   final architecture = codeAsset.architecture;
-  if (!dryRun) {
-    if (architecture == null) {
-      errors.add('CodeAsset "$id" has no architecture.');
-    } else if (architecture != codeConfig.targetArchitecture) {
-      errors.add(
-        'CodeAsset "$id" has an architecture "$architecture", which '
-        'is not the target architecture "${codeConfig.targetArchitecture}".',
-      );
-    }
+
+  if (architecture == null) {
+    errors.add('CodeAsset "$id" has no architecture.');
+  } else if (architecture != codeConfig.targetArchitecture) {
+    errors.add(
+      'CodeAsset "$id" has an architecture "$architecture", which '
+      'is not the target architecture "${codeConfig.targetArchitecture}".',
+    );
   }
 
   final file = codeAsset.file;
-  if (file == null && !dryRun && _mustHaveFile(codeAsset.linkMode)) {
+  if (file == null && _mustHaveFile(codeAsset.linkMode)) {
     errors.add('CodeAsset "$id" has no file.');
   }
   if (file != null) {
-    errors.addAll(
-      _validateFile('Code asset "$id" file', file, mustExist: !dryRun),
-    );
+    errors.addAll(_validateFile('Code asset "$id" file', file));
   }
 }
 

--- a/pkgs/native_assets_cli/lib/src/config.dart
+++ b/pkgs/native_assets_cli/lib/src/config.dart
@@ -123,15 +123,12 @@ sealed class HookInputBuilder {
   HookConfigBuilder get config => HookConfigBuilder._(this);
 }
 
-// TODO: Bump min-SDK constraint to 3.7 and remove once stable.
-const _buildModeInputKeyDeprecated = 'build_mode';
 const _metadataConfigKey = 'metadata';
 const _outputFileKey = 'out_file';
 const _outDirInputKey = 'out_dir';
 const _outDirSharedInputKey = 'out_dir_shared';
 const _packageNameInputKey = 'package_name';
 const _packageRootInputKey = 'package_root';
-const _supportedAssetTypesKey = 'supported_asset_types';
 const _buildAssetTypesKey = 'build_asset_types';
 
 const _configKey = 'config';
@@ -178,8 +175,6 @@ final class HookConfigBuilder {
   HookConfigBuilder._(this.builder);
 
   void setupShared({required List<String> buildAssetTypes}) {
-    json[_buildAssetTypesKey] = buildAssetTypes;
-    json[_supportedAssetTypesKey] = buildAssetTypes;
     json.setNested([_configKey, _buildAssetTypesKey], buildAssetTypes);
   }
 }
@@ -193,11 +188,6 @@ extension BuildConfigBuilderSetup on BuildConfigBuilder {
     json[_dryRunConfigKey] = dryRun;
     json[_linkingEnabledKey] = linkingEnabled;
     json.setNested([_configKey, _linkingEnabledKey], linkingEnabled);
-
-    // TODO: Bump min-SDK constraint to 3.7 and remove once stable.
-    if (!dryRun) {
-      json[_buildModeInputKeyDeprecated] = 'release';
-    }
   }
 }
 
@@ -234,8 +224,6 @@ final class LinkInputBuilder extends HookInputBuilder {
     required Uri? recordedUsesFile,
   }) {
     json[_assetsKey] = [for (final asset in assets) asset.toJson()];
-    // TODO: Bump min-SDK constraint to 3.7 and remove once stable.
-    json[_buildModeInputKeyDeprecated] = 'release';
     if (recordedUsesFile != null) {
       json[_recordedUsagesFileInputKey] = recordedUsesFile.toFilePath();
     }
@@ -606,7 +594,7 @@ final latestVersion = Version(1, 9, 0);
 ///
 /// When updating this number, update the version_skew_test.dart. (This test
 /// catches issues with 2.)
-final latestParsableVersion = Version(1, 5, 0);
+final latestParsableVersion = Version(1, 7, 0);
 
 /// The configuration for a build or link hook invocation.
 final class HookConfig {
@@ -634,8 +622,6 @@ final class HookConfig {
           json
               .optionalMap(_configKey)
               ?.optionalStringList(_buildAssetTypesKey) ??
-          json.optionalStringList(_buildAssetTypesKey) ??
-          json.optionalStringList(_supportedAssetTypesKey) ??
           const [];
 }
 

--- a/pkgs/native_assets_cli/lib/src/config.dart
+++ b/pkgs/native_assets_cli/lib/src/config.dart
@@ -184,14 +184,12 @@ final class BuildConfigBuilder extends HookConfigBuilder {
 }
 
 extension BuildConfigBuilderSetup on BuildConfigBuilder {
-  void setupBuild({required bool dryRun, required bool linkingEnabled}) {
-    json[_dryRunConfigKey] = dryRun;
+  void setupBuild({required bool linkingEnabled}) {
     json[_linkingEnabledKey] = linkingEnabled;
     json.setNested([_configKey, _linkingEnabledKey], linkingEnabled);
   }
 }
 
-const _dryRunConfigKey = 'dry_run';
 const _linkingEnabledKey = 'linking_enabled';
 
 final class LinkInput extends HookInput {
@@ -323,9 +321,6 @@ sealed class HookOutputBuilder {
 
 class BuildOutput extends HookOutput {
   /// The assets produced by this build.
-  ///
-  /// In dry runs, the assets for all [Architecture]s for the [OS] specified in
-  /// the dry run must be provided.
   final List<EncodedAsset> _encodedAssets;
 
   /// The assets produced by this build which should be linked.
@@ -333,9 +328,6 @@ class BuildOutput extends HookOutput {
   /// Every key in the map is a package name. These assets in the values are not
   /// bundled with the application, but are sent to the link hook of the package
   /// specified in the key, which can decide if they are bundled or not.
-  ///
-  /// In dry runs, the assets for all [Architecture]s for the [OS] specified in
-  /// the dry run must be provided.
   final Map<String, List<EncodedAsset>> _encodedAssetsForLinking;
 
   /// Metadata passed to dependent build hook invocations.
@@ -356,9 +348,6 @@ class BuildOutput extends HookOutput {
 
 extension type BuildOutputAssets._(BuildOutput _output) {
   /// The assets produced by this build.
-  ///
-  /// In dry runs, the assets for all [Architecture]s for the [OS] specified in
-  /// the dry run must be provided.
   List<EncodedAsset> get encodedAssets => _output._encodedAssets;
 
   /// The assets produced by this build which should be linked.
@@ -366,9 +355,6 @@ extension type BuildOutputAssets._(BuildOutput _output) {
   /// Every key in the map is a package name. These assets in the values are not
   /// bundled with the application, but are sent to the link hook of the package
   /// specified in the key, which can decide if they are bundled or not.
-  ///
-  /// In dry runs, the assets for all [Architecture]s for the [OS] specified in
-  /// the dry run must be provided.
   Map<String, List<EncodedAsset>> get encodedAssetsForLinking =>
       _output._encodedAssetsForLinking;
 }
@@ -422,7 +408,7 @@ class BuildOutputBuilder extends HookOutputBuilder {
 }
 
 extension type EncodedAssetBuildOutputBuilder._(BuildOutputBuilder _output) {
-  /// Adds [EncodedAsset]s produced by this build or dry run.
+  /// Adds [EncodedAsset]s produced by this build.
   ///
   /// If the [linkInPackage] argument is specified, the asset will not be
   /// bundled during the build step, but sent as input to the link hook of the
@@ -444,7 +430,7 @@ extension type EncodedAssetBuildOutputBuilder._(BuildOutputBuilder _output) {
     list.add(asset.toJson());
   }
 
-  /// Adds [EncodedAsset]s produced by this build or dry run.
+  /// Adds [EncodedAsset]s produced by this build.
   ///
   /// If the [linkInPackage] argument is specified, the assets will not be
   /// bundled during the build step, but sent as input to the link hook of the
@@ -492,9 +478,6 @@ List<Object?> _getEncodedAssetsList(
 
 class LinkOutput extends HookOutput {
   /// The assets produced by this build.
-  ///
-  /// In dry runs, the assets for all [Architecture]s for the [OS] specified in
-  /// the dry run must be provided.
   final List<EncodedAsset> _encodedAssets;
 
   /// Creates a [BuildOutput] from the given [json].
@@ -506,9 +489,6 @@ class LinkOutput extends HookOutput {
 
 extension type LinkOutputAssets._(LinkOutput _output) {
   /// The assets produced by this build.
-  ///
-  /// In dry runs, the assets for all [Architecture]s for the [OS] specified in
-  /// the dry run must be provided.
   List<EncodedAsset> get encodedAssets => _output._encodedAssets;
 }
 
@@ -626,21 +606,10 @@ final class HookConfig {
 }
 
 final class BuildConfig extends HookConfig {
-  // TODO(dcharkes): Remove after 3.7.0 stable is released and bump the SDK
-  // constraint in the pubspec. Ditto for all uses in related packages.
-  /// Whether this run is a dry-run, which doesn't build anything.
-  ///
-  /// A dry-run only reports information about which assets a build would
-  /// create, but doesn't actually create files.
-  @Deprecated('Flutter will no longer invoke dry run as of 3.28.')
-  final bool dryRun;
-
   final bool linkingEnabled;
 
   BuildConfig(super.json)
-    // ignore: deprecated_member_use_from_same_package
-    : dryRun = json.getOptional<bool>(_dryRunConfigKey) ?? false,
-      linkingEnabled =
+    : linkingEnabled =
           json.optionalMap(_configKey)?.optionalBool(_linkingEnabledKey) ??
           json.get<bool>(_linkingEnabledKey);
 }

--- a/pkgs/native_assets_cli/lib/src/config.dart
+++ b/pkgs/native_assets_cli/lib/src/config.dart
@@ -9,8 +9,6 @@ import 'package:crypto/crypto.dart' show sha256;
 import 'package:pub_semver/pub_semver.dart';
 
 import 'api/deprecation_messages.dart';
-import 'code_assets/architecture.dart';
-import 'code_assets/os.dart';
 import 'encoded_asset.dart';
 import 'json_utils.dart';
 import 'metadata.dart';
@@ -185,7 +183,6 @@ final class BuildConfigBuilder extends HookConfigBuilder {
 
 extension BuildConfigBuilderSetup on BuildConfigBuilder {
   void setupBuild({required bool linkingEnabled}) {
-    json[_linkingEnabledKey] = linkingEnabled;
     json.setNested([_configKey, _linkingEnabledKey], linkingEnabled);
   }
 }
@@ -609,7 +606,5 @@ final class BuildConfig extends HookConfig {
   final bool linkingEnabled;
 
   BuildConfig(super.json)
-    : linkingEnabled =
-          json.optionalMap(_configKey)?.optionalBool(_linkingEnabledKey) ??
-          json.get<bool>(_linkingEnabledKey);
+    : linkingEnabled = json.map$(_configKey).bool(_linkingEnabledKey);
 }

--- a/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
@@ -26,8 +26,6 @@ Future<ValidationErrors> validateDataAssetBuildOutput(
 ) => _validateDataAssetBuildOrLinkOutput(
   input,
   output.assets.encodedAssets,
-  // ignore: deprecated_member_use_from_same_package
-  input.config.dryRun,
   true,
 );
 
@@ -38,13 +36,11 @@ Future<ValidationErrors> validateDataAssetLinkOutput(
   input,
   output.assets.encodedAssets,
   false,
-  false,
 );
 
 Future<ValidationErrors> _validateDataAssetBuildOrLinkOutput(
   HookInput input,
   List<EncodedAsset> encodedAssets,
-  bool dryRun,
   bool isBuild,
 ) async {
   final errors = <String>[];
@@ -54,7 +50,6 @@ Future<ValidationErrors> _validateDataAssetBuildOrLinkOutput(
     if (asset.type != DataAsset.type) continue;
     _validateDataAsset(
       input,
-      dryRun,
       DataAsset.fromEncoded(asset),
       errors,
       ids,
@@ -66,7 +61,6 @@ Future<ValidationErrors> _validateDataAssetBuildOrLinkOutput(
 
 void _validateDataAsset(
   HookInput input,
-  bool dryRun,
   DataAsset dataAsset,
   List<String> errors,
   Set<String> ids,
@@ -79,13 +73,7 @@ void _validateDataAsset(
     errors.add('More than one data asset with same "${dataAsset.name}" name.');
   }
   final file = dataAsset.file;
-  errors.addAll(
-    _validateFile(
-      'Data asset ${dataAsset.name} file',
-      file,
-      mustExist: !dryRun,
-    ),
-  );
+  errors.addAll(_validateFile('Data asset ${dataAsset.name} file', file));
 }
 
 ValidationErrors _validateFile(

--- a/pkgs/native_assets_cli/lib/src/json_utils.dart
+++ b/pkgs/native_assets_cli/lib/src/json_utils.dart
@@ -30,7 +30,8 @@ extension MapJsonUtils on Map<String, Object?> {
     return value;
   }
 
-  bool? optionalBool(String key) => getOptional<bool>(key);
+  core.bool bool(String key) => get<core.bool>(key);
+  core.bool? optionalBool(String key) => getOptional<core.bool>(key);
   core.int int(String key) => get<core.int>(key);
   core.int? optionalInt(String key) => getOptional<core.int>(key);
 

--- a/pkgs/native_assets_cli/lib/test.dart
+++ b/pkgs/native_assets_cli/lib/test.dart
@@ -54,7 +54,7 @@ Future<void> testBuildHook({
         outputDirectory: outputDirectory,
         outputDirectoryShared: outputDirectoryShared,
       )
-      ..config.setupBuild(dryRun: false, linkingEnabled: true);
+      ..config.setupBuild(linkingEnabled: true);
     extraInputSetup(inputBuilder);
 
     final input = BuildInput(inputBuilder.json);

--- a/pkgs/native_assets_cli/test/api/build_test.dart
+++ b/pkgs/native_assets_cli/test/api/build_test.dart
@@ -40,7 +40,7 @@ void main() async {
         outputDirectoryShared: outputDirectoryShared,
       )
       ..config.setupShared(buildAssetTypes: ['foo'])
-      ..config.setupBuild(dryRun: false, linkingEnabled: false);
+      ..config.setupBuild(linkingEnabled: false);
     input = BuildInput(inputBuilder.json);
 
     final inputJson = json.encode(input.json);

--- a/pkgs/native_assets_cli/test/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/build_config_test.dart
@@ -51,8 +51,6 @@ void main() async {
     final input = BuildInput(inputBuilder.json);
 
     final expectedInputJson = {
-      'build_asset_types': ['my-asset-type'],
-      'build_mode': 'release',
       'config': {
         'build_asset_types': ['my-asset-type'],
         'linking_enabled': false,
@@ -71,7 +69,6 @@ void main() async {
       'out_file': outFile.toFilePath(),
       'package_name': packageName,
       'package_root': packageRootUri.toFilePath(),
-      'supported_asset_types': ['my-asset-type'],
       'version': latestVersion.toString(),
     };
 
@@ -106,7 +103,6 @@ void main() async {
     final input = BuildInput(inputBuilder.json);
 
     final expectedInputJson = {
-      'build_asset_types': ['my-asset-type'],
       'config': {
         'build_asset_types': ['my-asset-type'],
         'linking_enabled': true,
@@ -119,7 +115,6 @@ void main() async {
       'out_file': outFile.toFilePath(),
       'package_name': packageName,
       'package_root': packageRootUri.toFilePath(),
-      'supported_asset_types': ['my-asset-type'],
       'version': latestVersion.toString(),
     };
 
@@ -151,7 +146,6 @@ void main() async {
           'target_os': 'linux',
           'version': version,
           'package_name': packageName,
-          'build_asset_types': ['my-asset-type'],
           'dry_run': true,
           'linking_enabled': false,
         };
@@ -187,7 +181,6 @@ void main() async {
           'package_root': packageRootUri.toFilePath(),
           'target_os': 'android',
           'linking_enabled': true,
-          'build_asset_types': ['my-asset-type'],
         }),
         throwsA(
           predicate(
@@ -209,7 +202,6 @@ void main() async {
           'package_root': packageRootUri.toFilePath(),
           'target_os': 'android',
           'linking_enabled': true,
-          'build_asset_types': ['my-asset-type'],
           'dependency_metadata': {
             'bar': {'key': 'value'},
             'foo': <int>[],

--- a/pkgs/native_assets_cli/test/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/build_config_test.dart
@@ -46,7 +46,7 @@ void main() async {
             outputDirectoryShared: outputDirectoryShared,
           )
           ..config.setupShared(buildAssetTypes: ['my-asset-type'])
-          ..config.setupBuild(linkingEnabled: false, dryRun: false)
+          ..config.setupBuild(linkingEnabled: false)
           ..setupBuildInput(metadata: metadata);
     final input = BuildInput(inputBuilder.json);
 
@@ -62,7 +62,6 @@ void main() async {
         },
         'foo': {'key': 321},
       },
-      'dry_run': false,
       'linking_enabled': false,
       'out_dir_shared': outputDirectoryShared.toFilePath(),
       'out_dir': outDirUri.toFilePath(),
@@ -83,54 +82,7 @@ void main() async {
     expect(input.config.buildAssetTypes, ['my-asset-type']);
 
     expect(input.config.linkingEnabled, false);
-    expect(input.config.dryRun, false);
     expect(input.metadata, metadata);
-  });
-
-  test('BuildInput.config.dryRun', () {
-    final inputBuilder =
-        BuildInputBuilder()
-          ..setupShared(
-            packageName: packageName,
-            packageRoot: packageRootUri,
-            outputFile: outFile,
-            outputDirectory: outDirUri,
-            outputDirectoryShared: outputDirectoryShared,
-          )
-          ..config.setupShared(buildAssetTypes: ['my-asset-type'])
-          ..config.setupBuild(linkingEnabled: true, dryRun: true)
-          ..setupBuildInput();
-    final input = BuildInput(inputBuilder.json);
-
-    final expectedInputJson = {
-      'config': {
-        'build_asset_types': ['my-asset-type'],
-        'linking_enabled': true,
-      },
-      'dependency_metadata': <String, Object?>{},
-      'dry_run': true,
-      'linking_enabled': true,
-      'out_dir_shared': outputDirectoryShared.toFilePath(),
-      'out_dir': outDirUri.toFilePath(),
-      'out_file': outFile.toFilePath(),
-      'package_name': packageName,
-      'package_root': packageRootUri.toFilePath(),
-      'version': latestVersion.toString(),
-    };
-
-    expect(input.json, expectedInputJson);
-    expect(json.decode(input.toString()), expectedInputJson);
-
-    expect(input.outputDirectory, outDirUri);
-    expect(input.outputDirectoryShared, outputDirectoryShared);
-
-    expect(input.packageName, packageName);
-    expect(input.packageRoot, packageRootUri);
-    expect(input.config.buildAssetTypes, ['my-asset-type']);
-
-    expect(input.config.linkingEnabled, true);
-    expect(input.config.dryRun, true);
-    expect(input.metadata, <String, Object?>{});
   });
 
   group('BuildInput format issues', () {
@@ -146,7 +98,6 @@ void main() async {
           'target_os': 'linux',
           'version': version,
           'package_name': packageName,
-          'dry_run': true,
           'linking_enabled': false,
         };
         expect(

--- a/pkgs/native_assets_cli/test/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/build_config_test.dart
@@ -92,13 +92,13 @@ void main() async {
           'config': {
             'build_asset_types': ['my-asset-type'],
             'linking_enabled': false,
+            'target_os': 'linux',
+            'link_mode_preference': 'prefer-static',
           },
-          'link_mode_preference': 'prefer-static',
           'out_dir': outDir.toFilePath(),
           'out_dir_shared': outputDirectoryShared.toFilePath(),
           'out_file': outFile.toFilePath(),
           'package_root': packageRootUri.toFilePath(),
-          'target_os': 'linux',
           'version': version,
           'package_name': packageName,
         };

--- a/pkgs/native_assets_cli/test/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/build_config_test.dart
@@ -62,7 +62,6 @@ void main() async {
         },
         'foo': {'key': 321},
       },
-      'linking_enabled': false,
       'out_dir_shared': outputDirectoryShared.toFilePath(),
       'out_dir': outDirUri.toFilePath(),
       'out_file': outFile.toFilePath(),
@@ -90,6 +89,10 @@ void main() async {
       test('BuildInput version $version', () {
         final outDir = outDirUri;
         final input = {
+          'config': {
+            'build_asset_types': ['my-asset-type'],
+            'linking_enabled': false,
+          },
           'link_mode_preference': 'prefer-static',
           'out_dir': outDir.toFilePath(),
           'out_dir_shared': outputDirectoryShared.toFilePath(),
@@ -98,7 +101,6 @@ void main() async {
           'target_os': 'linux',
           'version': version,
           'package_name': packageName,
-          'linking_enabled': false,
         };
         expect(
           () => BuildInput(input),
@@ -131,7 +133,6 @@ void main() async {
           'package_name': packageName,
           'package_root': packageRootUri.toFilePath(),
           'target_os': 'android',
-          'linking_enabled': true,
         }),
         throwsA(
           predicate(
@@ -145,6 +146,10 @@ void main() async {
       );
       expect(
         () => BuildInput({
+          'config': {
+            'build_asset_types': ['my-asset-type'],
+            'linking_enabled': false,
+          },
           'version': latestVersion.toString(),
           'out_dir': outDirUri.toFilePath(),
           'out_dir_shared': outputDirectoryShared.toFilePath(),
@@ -152,7 +157,6 @@ void main() async {
           'package_name': packageName,
           'package_root': packageRootUri.toFilePath(),
           'target_os': 'android',
-          'linking_enabled': true,
           'dependency_metadata': {
             'bar': {'key': 'value'},
             'foo': <int>[],

--- a/pkgs/native_assets_cli/test/checksum_test.dart
+++ b/pkgs/native_assets_cli/test/checksum_test.dart
@@ -45,7 +45,7 @@ void main() {
                   final builder = BuildInputBuilder();
                   if (hook == 'build') {
                     builder.config.setupBuild(
-                      dryRun: false, // no embedders will pass true anymore
+                      // no embedders will pass true anymore
                       linkingEnabled: linking,
                     );
                   }

--- a/pkgs/native_assets_cli/test/code_assets/config_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/config_test.dart
@@ -81,8 +81,6 @@ void main() async {
           'type': 'native_code',
         },
       ],
-    if (includeDeprecated) 'build_asset_types': [CodeAsset.type],
-    if (includeDeprecated) 'build_mode': 'release',
     'config': {
       'build_asset_types': ['native_code'],
       if (hookType == 'build') 'linking_enabled': false,
@@ -125,7 +123,6 @@ void main() async {
     'out_file': outFile.toFilePath(),
     'package_name': packageName,
     'package_root': packageRootUri.toFilePath(),
-    if (includeDeprecated) 'supported_asset_types': [CodeAsset.type],
     if (includeDeprecated && targetOS == OS.android)
       'target_android_ndk_api': 30,
     if (includeDeprecated) 'target_architecture': 'arm64',
@@ -153,29 +150,6 @@ void main() async {
     expect(codeCondig.cCompiler?.linker, fakeLd);
     expect(codeCondig.cCompiler?.archiver, fakeAr);
   }
-
-  test('BuildInput.config.code (dry-run)', () {
-    final inputBuilder =
-        BuildInputBuilder()
-          ..setupShared(
-            packageName: packageName,
-            packageRoot: packageRootUri,
-            outputFile: outFile,
-            outputDirectory: outDirUri,
-            outputDirectoryShared: outputDirectoryShared,
-          )
-          ..config.setupBuild(linkingEnabled: true, dryRun: true)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: OS.android,
-            android: null, // not available in dry run
-            targetArchitecture: null, // not available in dry run
-            cCompiler: null, // not available in dry run
-            linkModePreference: LinkModePreference.preferStatic,
-          );
-    final input = BuildInput(inputBuilder.json);
-    expectCorrectCodeConfigDryRun(input.json, input.config.code);
-  });
 
   test('BuildInput.config.code', () {
     final inputBuilder =
@@ -294,7 +268,6 @@ void main() async {
       'target_android_ndk_api': 30,
       'target_architecture': 'invalid_architecture',
       'target_os': 'android',
-      'build_asset_types': ['my-asset-type'],
       'version': latestVersion.toString(),
     };
     expect(() => BuildInput(input).config.code, throwsFormatException);
@@ -302,7 +275,6 @@ void main() async {
 
   test('LinkInput.config.code: invalid architecture', () {
     final input = {
-      'build_asset_types': [CodeAsset.type],
       'dry_run': false,
       'link_mode_preference': 'prefer-static',
       'out_dir': outDirUri.toFilePath(),

--- a/pkgs/native_assets_cli/test/code_assets/config_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/config_test.dart
@@ -89,8 +89,6 @@ void main() async {
           'ios': {'target_sdk': 'iphoneos', 'target_version': 13},
       },
     },
-
-    if (hookType == 'build' && includeDeprecated) 'linking_enabled': false,
     'out_dir_shared': outputDirectoryShared.toFilePath(),
     'out_dir': outDirUri.toFilePath(),
     'out_file': outFile.toFilePath(),
@@ -228,9 +226,9 @@ void main() async {
 
   test('BuildInput.config.code: invalid architecture', () {
     final input = {
-      'linking_enabled': false,
       'config': {
         'code': {'link_mode_preference': 'prefer-static'},
+        'linking_enabled': false,
       },
       'out_dir': outDirUri.toFilePath(),
       'out_dir_shared': outputDirectoryShared.toFilePath(),

--- a/pkgs/native_assets_cli/test/code_assets/config_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/config_test.dart
@@ -107,14 +107,6 @@ void main() async {
           'ios': {'target_sdk': 'iphoneos', 'target_version': 13},
       },
     },
-    if (includeDeprecated)
-      'c_compiler': {
-        'ar': fakeAr.toFilePath(),
-        'ld': fakeLd.toFilePath(),
-        'cc': fakeClang.toFilePath(),
-        'env_script': fakeVcVars.toFilePath(),
-        'env_script_arguments': ['arg0', 'arg1'],
-      },
     if (hookType == 'build' && includeDeprecated) 'dry_run': false,
     if (hookType == 'build' && includeDeprecated) 'linking_enabled': false,
     if (includeDeprecated) 'link_mode_preference': 'prefer-static',

--- a/pkgs/native_assets_cli/test/code_assets/config_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/config_test.dart
@@ -94,10 +94,6 @@ void main() async {
     'out_file': outFile.toFilePath(),
     'package_name': packageName,
     'package_root': packageRootUri.toFilePath(),
-    if (includeDeprecated && targetOS == OS.android)
-      'target_android_ndk_api': 30,
-    if (includeDeprecated) 'target_architecture': 'arm64',
-    if (includeDeprecated) 'target_os': targetOS.name,
     'version': '1.9.0',
   };
 
@@ -227,7 +223,12 @@ void main() async {
   test('BuildInput.config.code: invalid architecture', () {
     final input = {
       'config': {
-        'code': {'link_mode_preference': 'prefer-static'},
+        'code': {
+          'link_mode_preference': 'prefer-static',
+          'android': {'target_ndk_api': 30},
+          'target_architecture': 'invalid_architecture',
+          'target_os': 'android',
+        },
         'linking_enabled': false,
       },
       'out_dir': outDirUri.toFilePath(),
@@ -235,9 +236,6 @@ void main() async {
       'out_file': outFile.toFilePath(),
       'package_name': packageName,
       'package_root': packageRootUri.toFilePath(),
-      'target_android_ndk_api': 30,
-      'target_architecture': 'invalid_architecture',
-      'target_os': 'android',
       'version': latestVersion.toString(),
     };
     expect(() => BuildInput(input).config.code, throwsFormatException);
@@ -246,16 +244,18 @@ void main() async {
   test('LinkInput.config.code: invalid architecture', () {
     final input = {
       'config': {
-        'code': {'link_mode_preference': 'prefer-static'},
+        'code': {
+          'link_mode_preference': 'prefer-static',
+          'android': {'target_ndk_api': 30},
+          'target_architecture': 'invalid_architecture',
+          'target_os': 'android',
+        },
       },
       'out_dir': outDirUri.toFilePath(),
       'out_dir_shared': outputDirectoryShared.toFilePath(),
       'out_file': outFile.toFilePath(),
       'package_name': packageName,
       'package_root': packageRootUri.toFilePath(),
-      'target_android_ndk_api': 30,
-      'target_architecture': 'invalid_architecture',
-      'target_os': 'android',
       'version': latestVersion.toString(),
     };
     expect(() => LinkInput(input).config.code, throwsFormatException);

--- a/pkgs/native_assets_cli/test/code_assets/config_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/config_test.dart
@@ -44,24 +44,6 @@ void main() async {
     ];
   });
 
-  // Tests JSON encoding & accessors of code-asset configuration.
-  void expectCorrectCodeConfigDryRun(
-    Map<String, Object?> json,
-    CodeConfig codeConfig,
-  ) {
-    <String, Object?>{
-      'build_asset_types': [CodeAsset.type],
-      'link_mode_preference': 'prefer-static',
-    }.forEach((k, v) {
-      expect(json[k], v);
-    });
-
-    expect(() => codeConfig.targetArchitecture, throwsStateError);
-    expect(() => codeConfig.android.targetNdkApi, throwsStateError);
-    expect(codeConfig.linkModePreference, LinkModePreference.preferStatic);
-    expect(codeConfig.cCompiler, null);
-  }
-
   // Full JSON to see where the config sits in the full JSON.
   // When removing the non-hierarchical JSON, we can change this test to only
   // check the nested key.
@@ -107,7 +89,7 @@ void main() async {
           'ios': {'target_sdk': 'iphoneos', 'target_version': 13},
       },
     },
-    if (hookType == 'build' && includeDeprecated) 'dry_run': false,
+
     if (hookType == 'build' && includeDeprecated) 'linking_enabled': false,
     if (includeDeprecated) 'link_mode_preference': 'prefer-static',
     'out_dir_shared': outputDirectoryShared.toFilePath(),
@@ -153,7 +135,7 @@ void main() async {
             outputDirectory: outDirUri,
             outputDirectoryShared: outputDirectoryShared,
           )
-          ..config.setupBuild(linkingEnabled: false, dryRun: false)
+          ..config.setupBuild(linkingEnabled: false)
           ..config.setupShared(buildAssetTypes: [CodeAsset.type])
           ..config.setupCode(
             targetOS: OS.android,
@@ -187,8 +169,6 @@ void main() async {
       expect(input.outputDirectory, outDirUri);
       expect(input.outputDirectoryShared, outputDirectoryShared);
       expect(input.config.linkingEnabled, false);
-      // ignore: deprecated_member_use_from_same_package
-      expect(input.config.dryRun, false);
       expect(input.config.buildAssetTypes, [CodeAsset.type]);
       expectCorrectCodeConfig(input.config.code, targetOS: targetOS);
     }
@@ -249,7 +229,6 @@ void main() async {
 
   test('BuildInput.config.code: invalid architecture', () {
     final input = {
-      'dry_run': false,
       'linking_enabled': false,
       'link_mode_preference': 'prefer-static',
       'out_dir': outDirUri.toFilePath(),
@@ -267,7 +246,6 @@ void main() async {
 
   test('LinkInput.config.code: invalid architecture', () {
     final input = {
-      'dry_run': false,
       'link_mode_preference': 'prefer-static',
       'out_dir': outDirUri.toFilePath(),
       'out_dir_shared': outputDirectoryShared.toFilePath(),

--- a/pkgs/native_assets_cli/test/code_assets/config_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/config_test.dart
@@ -91,7 +91,6 @@ void main() async {
     },
 
     if (hookType == 'build' && includeDeprecated) 'linking_enabled': false,
-    if (includeDeprecated) 'link_mode_preference': 'prefer-static',
     'out_dir_shared': outputDirectoryShared.toFilePath(),
     'out_dir': outDirUri.toFilePath(),
     'out_file': outFile.toFilePath(),
@@ -230,7 +229,9 @@ void main() async {
   test('BuildInput.config.code: invalid architecture', () {
     final input = {
       'linking_enabled': false,
-      'link_mode_preference': 'prefer-static',
+      'config': {
+        'code': {'link_mode_preference': 'prefer-static'},
+      },
       'out_dir': outDirUri.toFilePath(),
       'out_dir_shared': outputDirectoryShared.toFilePath(),
       'out_file': outFile.toFilePath(),
@@ -246,7 +247,9 @@ void main() async {
 
   test('LinkInput.config.code: invalid architecture', () {
     final input = {
-      'link_mode_preference': 'prefer-static',
+      'config': {
+        'code': {'link_mode_preference': 'prefer-static'},
+      },
       'out_dir': outDirUri.toFilePath(),
       'out_dir_shared': outputDirectoryShared.toFilePath(),
       'out_file': outFile.toFilePath(),

--- a/pkgs/native_assets_cli/test/code_assets/validation_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/validation_test.dart
@@ -39,7 +39,7 @@ void main() {
             outputDirectory: outDirUri,
             outputDirectoryShared: outDirSharedUri,
           )
-          ..config.setupBuild(linkingEnabled: false, dryRun: false);
+          ..config.setupBuild(linkingEnabled: false);
     return inputBuilder;
   }
 

--- a/pkgs/native_assets_cli/test/data_assets/validation_test.dart
+++ b/pkgs/native_assets_cli/test/data_assets/validation_test.dart
@@ -39,7 +39,7 @@ void main() {
             outputDirectory: outDirUri,
             outputDirectoryShared: outDirSharedUri,
           )
-          ..config.setupBuild(linkingEnabled: false, dryRun: false)
+          ..config.setupBuild(linkingEnabled: false)
           ..config.setupShared(buildAssetTypes: [DataAsset.type]);
     return BuildInput(inputBuilder.json);
   }

--- a/pkgs/native_assets_cli/test/example/local_asset_test.dart
+++ b/pkgs/native_assets_cli/test/example/local_asset_test.dart
@@ -25,74 +25,64 @@ void main() async {
     await Directory.fromUri(tempUri).delete(recursive: true);
   });
 
-  for (final dryRun in [true, false]) {
-    final testSuffix = dryRun ? ' dry_run' : '';
-    test('local_asset build$testSuffix', () async {
-      final buildOutputUri = tempUri.resolve('build_output.json');
-      final testTempUri = tempUri.resolve('test1/');
-      await Directory.fromUri(testTempUri).create();
-      final outputDirectory = tempUri.resolve('out/');
-      await Directory.fromUri(outputDirectory).create();
-      final outputDirectoryShared = tempUri.resolve('out_shared/');
-      await Directory.fromUri(outputDirectoryShared).create();
-      final testPackageUri = packageUri.resolve('example/build/$name/');
-      final dartUri = Uri.file(Platform.resolvedExecutable);
+  test('local_asset build', () async {
+    final buildOutputUri = tempUri.resolve('build_output.json');
+    final testTempUri = tempUri.resolve('test1/');
+    await Directory.fromUri(testTempUri).create();
+    final outputDirectory = tempUri.resolve('out/');
+    await Directory.fromUri(outputDirectory).create();
+    final outputDirectoryShared = tempUri.resolve('out_shared/');
+    await Directory.fromUri(outputDirectoryShared).create();
+    final testPackageUri = packageUri.resolve('example/build/$name/');
+    final dartUri = Uri.file(Platform.resolvedExecutable);
 
-      final targetOS = OS.current;
-      final inputBuilder =
-          BuildInputBuilder()
-            ..setupShared(
-              packageRoot: testPackageUri,
-              packageName: name,
-              outputFile: buildOutputUri,
-              outputDirectory: outputDirectory,
-              outputDirectoryShared: outputDirectoryShared,
-            )
-            ..config.setupBuild(linkingEnabled: false, dryRun: dryRun)
-            ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-            ..config.setupCode(
-              targetOS: targetOS,
-              macOS:
-                  targetOS == OS.macOS
-                      ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                      : null,
-              targetArchitecture: dryRun ? null : Architecture.current,
-              linkModePreference: LinkModePreference.dynamic,
-              cCompiler: dryRun ? null : cCompiler,
-            );
+    final targetOS = OS.current;
+    final inputBuilder =
+        BuildInputBuilder()
+          ..setupShared(
+            packageRoot: testPackageUri,
+            packageName: name,
+            outputFile: buildOutputUri,
+            outputDirectory: outputDirectory,
+            outputDirectoryShared: outputDirectoryShared,
+          )
+          ..config.setupBuild(linkingEnabled: false)
+          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
+          ..config.setupCode(
+            targetOS: targetOS,
+            macOS:
+                targetOS == OS.macOS
+                    ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+                    : null,
+            targetArchitecture: Architecture.current,
+            linkModePreference: LinkModePreference.dynamic,
+            cCompiler: cCompiler,
+          );
 
-      final buildInputUri = testTempUri.resolve('build_input.json');
-      await File.fromUri(
-        buildInputUri,
-      ).writeAsString(jsonEncode(inputBuilder.json));
+    final buildInputUri = testTempUri.resolve('build_input.json');
+    await File.fromUri(
+      buildInputUri,
+    ).writeAsString(jsonEncode(inputBuilder.json));
 
-      final processResult = await Process.run(dartUri.toFilePath(), [
-        'hook/build.dart',
-        '--config=${buildInputUri.toFilePath()}',
-      ], workingDirectory: testPackageUri.toFilePath());
-      if (processResult.exitCode != 0) {
-        print(processResult.stdout);
-        print(processResult.stderr);
-        print(processResult.exitCode);
-      }
-      expect(processResult.exitCode, 0);
+    final processResult = await Process.run(dartUri.toFilePath(), [
+      'hook/build.dart',
+      '--config=${buildInputUri.toFilePath()}',
+    ], workingDirectory: testPackageUri.toFilePath());
+    if (processResult.exitCode != 0) {
+      print(processResult.stdout);
+      print(processResult.stderr);
+      print(processResult.exitCode);
+    }
+    expect(processResult.exitCode, 0);
 
-      final buildOutput = BuildOutput(
-        json.decode(await File.fromUri(buildOutputUri).readAsString())
-            as Map<String, Object?>,
-      );
-      final assets = buildOutput.assets.encodedAssets;
-      final dependencies = buildOutput.dependencies;
-      if (dryRun) {
-        final codeAsset = buildOutput.assets.code.first;
-        expect(assets.length, greaterThanOrEqualTo(1));
-        expect(await File.fromUri(codeAsset.file!).exists(), false);
-        expect(dependencies, <Uri>[]);
-      } else {
-        expect(assets.length, 1);
-        expect(await assets.allExist(), true);
-        expect(dependencies, [testPackageUri.resolve('assets/asset.txt')]);
-      }
-    });
-  }
+    final buildOutput = BuildOutput(
+      json.decode(await File.fromUri(buildOutputUri).readAsString())
+          as Map<String, Object?>,
+    );
+    final assets = buildOutput.assets.encodedAssets;
+    final dependencies = buildOutput.dependencies;
+    expect(assets.length, 1);
+    expect(await assets.allExist(), true);
+    expect(dependencies, [testPackageUri.resolve('assets/asset.txt')]);
+  });
 }

--- a/pkgs/native_assets_cli/test/example/native_add_library_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_library_test.dart
@@ -25,72 +25,64 @@ void main() async {
     await Directory.fromUri(tempUri).delete(recursive: true);
   });
 
-  for (final dryRun in [true, false]) {
-    final testSuffix = dryRun ? ' dry_run' : '';
-    test('native_add build$testSuffix', () async {
-      final buildOutputUri = tempUri.resolve('build_output.json');
-      final testTempUri = tempUri.resolve('test1/');
-      await Directory.fromUri(testTempUri).create();
-      final outputDirectory = tempUri.resolve('out/');
-      await Directory.fromUri(outputDirectory).create();
-      final outputDirectoryShared = tempUri.resolve('out_shared/');
-      await Directory.fromUri(outputDirectoryShared).create();
-      final testPackageUri = packageUri.resolve('example/build/$name/');
-      final dartUri = Uri.file(Platform.resolvedExecutable);
+  test('native_add build', () async {
+    final buildOutputUri = tempUri.resolve('build_output.json');
+    final testTempUri = tempUri.resolve('test1/');
+    await Directory.fromUri(testTempUri).create();
+    final outputDirectory = tempUri.resolve('out/');
+    await Directory.fromUri(outputDirectory).create();
+    final outputDirectoryShared = tempUri.resolve('out_shared/');
+    await Directory.fromUri(outputDirectoryShared).create();
+    final testPackageUri = packageUri.resolve('example/build/$name/');
+    final dartUri = Uri.file(Platform.resolvedExecutable);
 
-      final targetOS = OS.current;
-      final inputBuilder =
-          BuildInputBuilder()
-            ..setupShared(
-              packageRoot: testPackageUri,
-              packageName: name,
-              outputFile: buildOutputUri,
-              outputDirectory: outputDirectory,
-              outputDirectoryShared: outputDirectoryShared,
-            )
-            ..config.setupBuild(linkingEnabled: false, dryRun: dryRun)
-            ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-            ..config.setupCode(
-              targetOS: OS.current,
-              macOS:
-                  targetOS == OS.macOS
-                      ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                      : null,
-              targetArchitecture: dryRun ? null : Architecture.current,
-              linkModePreference: LinkModePreference.dynamic,
-              cCompiler: dryRun ? null : cCompiler,
-            );
+    final targetOS = OS.current;
+    final inputBuilder =
+        BuildInputBuilder()
+          ..setupShared(
+            packageRoot: testPackageUri,
+            packageName: name,
+            outputFile: buildOutputUri,
+            outputDirectory: outputDirectory,
+            outputDirectoryShared: outputDirectoryShared,
+          )
+          ..config.setupBuild(linkingEnabled: false)
+          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
+          ..config.setupCode(
+            targetOS: OS.current,
+            macOS:
+                targetOS == OS.macOS
+                    ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+                    : null,
+            targetArchitecture: Architecture.current,
+            linkModePreference: LinkModePreference.dynamic,
+            cCompiler: cCompiler,
+          );
 
-      final buildInputUri = testTempUri.resolve('build_input.json');
-      await File.fromUri(
-        buildInputUri,
-      ).writeAsString(jsonEncode(inputBuilder.json));
+    final buildInputUri = testTempUri.resolve('build_input.json');
+    await File.fromUri(
+      buildInputUri,
+    ).writeAsString(jsonEncode(inputBuilder.json));
 
-      final processResult = await Process.run(dartUri.toFilePath(), [
-        'hook/build.dart',
-        '--config=${buildInputUri.toFilePath()}',
-      ], workingDirectory: testPackageUri.toFilePath());
-      if (processResult.exitCode != 0) {
-        print(processResult.stdout);
-        print(processResult.stderr);
-        print(processResult.exitCode);
-      }
-      expect(processResult.exitCode, 0);
+    final processResult = await Process.run(dartUri.toFilePath(), [
+      'hook/build.dart',
+      '--config=${buildInputUri.toFilePath()}',
+    ], workingDirectory: testPackageUri.toFilePath());
+    if (processResult.exitCode != 0) {
+      print(processResult.stdout);
+      print(processResult.stderr);
+      print(processResult.exitCode);
+    }
+    expect(processResult.exitCode, 0);
 
-      final buildOutput = BuildOutput(
-        json.decode(await File.fromUri(buildOutputUri).readAsString())
-            as Map<String, Object?>,
-      );
-      final assets = buildOutput.assets.encodedAssets;
-      final dependencies = buildOutput.dependencies;
-      if (dryRun) {
-        expect(assets.length, greaterThanOrEqualTo(1));
-        expect(dependencies, <Uri>[]);
-      } else {
-        expect(assets.length, 1);
-        expect(await assets.allExist(), true);
-        expect(dependencies, [testPackageUri.resolve('src/$name.c')]);
-      }
-    });
-  }
+    final buildOutput = BuildOutput(
+      json.decode(await File.fromUri(buildOutputUri).readAsString())
+          as Map<String, Object?>,
+    );
+    final assets = buildOutput.assets.encodedAssets;
+    final dependencies = buildOutput.dependencies;
+    expect(assets.length, 1);
+    expect(await assets.allExist(), true);
+    expect(dependencies, [testPackageUri.resolve('src/$name.c')]);
+  });
 }

--- a/pkgs/native_assets_cli/test/link_config_test.dart
+++ b/pkgs/native_assets_cli/test/link_config_test.dart
@@ -79,7 +79,6 @@ void main() async {
           'out_dir_shared': outputDirectoryShared.toFilePath(),
           'out_file': outFile.toFilePath(),
           'package_root': packageRootUri.toFilePath(),
-          'target_os': 'linux',
           'version': version,
           'package_name': packageName,
         };
@@ -112,7 +111,6 @@ void main() async {
           'version': latestVersion.toString(),
           'package_name': packageName,
           'package_root': packageRootUri.toFilePath(),
-          'target_os': 'android',
           'assets': <String>[],
         }),
         throwsA(
@@ -133,7 +131,6 @@ void main() async {
           'out_file': outFile.toFilePath(),
           'package_name': packageName,
           'package_root': packageRootUri.toFilePath(),
-          'target_os': 'android',
           'assets': 'astring',
         }),
         throwsA(

--- a/pkgs/native_assets_cli/test/link_config_test.dart
+++ b/pkgs/native_assets_cli/test/link_config_test.dart
@@ -83,7 +83,6 @@ void main() async {
           'target_os': 'linux',
           'version': version,
           'package_name': packageName,
-          'dry_run': true,
         };
         expect(
           () => LinkInput(input),

--- a/pkgs/native_assets_cli/test/link_config_test.dart
+++ b/pkgs/native_assets_cli/test/link_config_test.dart
@@ -75,7 +75,6 @@ void main() async {
       test('LinkInput version $version', () {
         final outDir = outDirUri;
         final input = {
-          'link_mode_preference': 'prefer-static',
           'out_dir': outDir.toFilePath(),
           'out_dir_shared': outputDirectoryShared.toFilePath(),
           'out_file': outFile.toFilePath(),

--- a/pkgs/native_assets_cli/test/link_config_test.dart
+++ b/pkgs/native_assets_cli/test/link_config_test.dart
@@ -48,8 +48,6 @@ void main() async {
 
     final expectedInputJson = {
       'assets': [for (final asset in assets) asset.toJson()],
-      'build_asset_types': ['asset-type-1', 'asset-type-2'],
-      'build_mode': 'release',
       'config': {
         'build_asset_types': ['asset-type-1', 'asset-type-2'],
       },
@@ -58,7 +56,6 @@ void main() async {
       'out_file': outFile.toFilePath(),
       'package_name': packageName,
       'package_root': packageRootUri.toFilePath(),
-      'supported_asset_types': ['asset-type-1', 'asset-type-2'],
       'version': latestVersion.toString(),
     };
     expect(input.json, expectedInputJson);
@@ -86,7 +83,6 @@ void main() async {
           'target_os': 'linux',
           'version': version,
           'package_name': packageName,
-          'build_asset_types': ['my-asset-type'],
           'dry_run': true,
         };
         expect(
@@ -116,7 +112,6 @@ void main() async {
       expect(
         () => LinkInput({
           'version': latestVersion.toString(),
-          'build_asset_types': ['my-asset-type'],
           'package_name': packageName,
           'package_root': packageRootUri.toFilePath(),
           'target_os': 'android',
@@ -135,7 +130,6 @@ void main() async {
       expect(
         () => LinkInput({
           'version': latestVersion.toString(),
-          'build_asset_types': ['my-asset-type'],
           'out_dir': outDirUri.toFilePath(),
           'out_dir_shared': outputDirectoryShared.toFilePath(),
           'out_file': outFile.toFilePath(),

--- a/pkgs/native_assets_cli/test/validation_test.dart
+++ b/pkgs/native_assets_cli/test/validation_test.dart
@@ -40,7 +40,7 @@ void main() {
             outputDirectoryShared: outDirSharedUri,
           )
           ..config.setupShared(buildAssetTypes: ['my-asset-type'])
-          ..config.setupBuild(linkingEnabled: false, dryRun: false);
+          ..config.setupBuild(linkingEnabled: false);
     return BuildInput(inputBuilder.json);
   }
 

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -157,42 +157,40 @@ class CBuilder extends CTool implements Builder {
       for (final directory in this.libraryDirectories)
         outDir.resolveUri(Uri.file(directory)),
     ];
-    // ignore: deprecated_member_use
-    if (!input.config.dryRun) {
-      final task = RunCBuilder(
-        input: input,
-        codeConfig: input.config.code,
-        logger: logger,
-        sources: sources,
-        includes: includes,
-        frameworks: frameworks,
-        libraries: libraries,
-        libraryDirectories: libraryDirectories,
-        dynamicLibrary:
-            type == OutputType.library && linkMode == DynamicLoadingBundled()
-                ? libUri
-                : null,
-        staticLibrary:
-            type == OutputType.library && linkMode == StaticLinking()
-                ? libUri
-                : null,
-        executable: type == OutputType.executable ? exeUri : null,
-        // ignore: invalid_use_of_visible_for_testing_member
-        installName: installName,
-        flags: flags,
-        defines: {
-          ...defines,
-          if (buildModeDefine) buildMode.name.toUpperCase(): null,
-          if (ndebugDefine && buildMode != BuildMode.debug) 'NDEBUG': null,
-        },
-        pic: pic,
-        std: std,
-        language: language,
-        cppLinkStdLib: cppLinkStdLib,
-        optimizationLevel: optimizationLevel,
-      );
-      await task.run();
-    }
+
+    final task = RunCBuilder(
+      input: input,
+      codeConfig: input.config.code,
+      logger: logger,
+      sources: sources,
+      includes: includes,
+      frameworks: frameworks,
+      libraries: libraries,
+      libraryDirectories: libraryDirectories,
+      dynamicLibrary:
+          type == OutputType.library && linkMode == DynamicLoadingBundled()
+              ? libUri
+              : null,
+      staticLibrary:
+          type == OutputType.library && linkMode == StaticLinking()
+              ? libUri
+              : null,
+      executable: type == OutputType.executable ? exeUri : null,
+      // ignore: invalid_use_of_visible_for_testing_member
+      installName: installName,
+      flags: flags,
+      defines: {
+        ...defines,
+        if (buildModeDefine) buildMode.name.toUpperCase(): null,
+        if (ndebugDefine && buildMode != BuildMode.debug) 'NDEBUG': null,
+      },
+      pic: pic,
+      std: std,
+      language: language,
+      cppLinkStdLib: cppLinkStdLib,
+      optimizationLevel: optimizationLevel,
+    );
+    await task.run();
 
     if (assetName != null) {
       output.assets.code.add(
@@ -202,31 +200,27 @@ class CBuilder extends CTool implements Builder {
           file: libUri,
           linkMode: linkMode,
           os: input.config.code.targetOS,
-          architecture:
-              // ignore: deprecated_member_use
-              input.config.dryRun ? null : input.config.code.targetArchitecture,
+          architecture: input.config.code.targetArchitecture,
         ),
         linkInPackage: linkInPackage,
       );
     }
-    // ignore: deprecated_member_use
-    if (!input.config.dryRun) {
-      final includeFiles =
-          await Stream.fromIterable(includes)
-              .asyncExpand(
-                (include) => Directory(include.toFilePath())
-                    .list(recursive: true)
-                    .where((entry) => entry is File)
-                    .map((file) => file.uri),
-              )
-              .toList();
 
-      output.addDependencies({
-        // Note: We use a Set here to deduplicate the dependencies.
-        ...sources,
-        ...includeFiles,
-        ...dartBuildFiles,
-      });
-    }
+    final includeFiles =
+        await Stream.fromIterable(includes)
+            .asyncExpand(
+              (include) => Directory(include.toFilePath())
+                  .list(recursive: true)
+                  .where((entry) => entry is File)
+                  .map((file) => file.uri),
+            )
+            .toList();
+
+    output.addDependencies({
+      // Note: We use a Set here to deduplicate the dependencies.
+      ...sources,
+      ...includeFiles,
+      ...dartBuildFiles,
+    });
   }
 }

--- a/pkgs/native_toolchain_c/lib/src/native_toolchain/android_ndk.dart
+++ b/pkgs/native_toolchain_c/lib/src/native_toolchain/android_ndk.dart
@@ -83,6 +83,9 @@ class _AndroidNdkResolver implements ToolResolver {
       'toolchains/llvm/prebuilt/',
     );
     final prebuiltDir = Directory.fromUri(prebuiltUri);
+    if (!prebuiltDir.existsSync()) {
+      return [];
+    }
     final hostArchDirs =
         (await prebuiltDir.list().toList()).whereType<Directory>().toList();
     for (final hostArchDir in hostArchDirs) {

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
@@ -39,7 +39,7 @@ void main() {
             outputDirectory: tempUri,
             outputDirectoryShared: tempUri2,
           )
-          ..config.setupBuild(linkingEnabled: false, dryRun: false)
+          ..config.setupBuild(linkingEnabled: false)
           ..config.setupShared(buildAssetTypes: [CodeAsset.type])
           ..config.setupCode(
             targetOS: targetOS,

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -152,7 +152,7 @@ Future<Uri> buildLib(
           outputDirectory: tempUri,
           outputDirectoryShared: tempUriShared,
         )
-        ..config.setupBuild(linkingEnabled: false, dryRun: false)
+        ..config.setupBuild(linkingEnabled: false)
         ..config.setupShared(buildAssetTypes: [CodeAsset.type])
         ..config.setupCode(
           targetOS: OS.android,

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -80,7 +80,7 @@ void main() {
                         outputDirectory: tempUri,
                         outputDirectoryShared: tempUri2,
                       )
-                      ..config.setupBuild(linkingEnabled: false, dryRun: false)
+                      ..config.setupBuild(linkingEnabled: false)
                       ..config.setupShared(buildAssetTypes: [CodeAsset.type])
                       ..config.setupCode(
                         targetOS: OS.iOS,
@@ -243,7 +243,7 @@ Future<Uri> buildLib(
           outputDirectory: tempUri,
           outputDirectoryShared: tempUri2,
         )
-        ..config.setupBuild(linkingEnabled: false, dryRun: false)
+        ..config.setupBuild(linkingEnabled: false)
         ..config.setupShared(buildAssetTypes: [CodeAsset.type])
         ..config.setupCode(
           targetOS: OS.iOS,

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -52,7 +52,7 @@ void main() {
                 outputDirectory: tempUri,
                 outputDirectoryShared: tempUri2,
               )
-              ..config.setupBuild(linkingEnabled: false, dryRun: false)
+              ..config.setupBuild(linkingEnabled: false)
               ..config.setupShared(buildAssetTypes: [CodeAsset.type])
               ..config.setupCode(
                 targetOS: OS.linux,

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -64,7 +64,7 @@ void main() {
                     outputDirectory: tempUri,
                     outputDirectoryShared: tempUri2,
                   )
-                  ..config.setupBuild(linkingEnabled: false, dryRun: false)
+                  ..config.setupBuild(linkingEnabled: false)
                   ..config.setupShared(buildAssetTypes: [CodeAsset.type])
                   ..config.setupCode(
                     targetOS: OS.macOS,
@@ -166,7 +166,7 @@ Future<Uri> buildLib(
           outputDirectory: tempUri,
           outputDirectoryShared: tempUri2,
         )
-        ..config.setupBuild(linkingEnabled: false, dryRun: false)
+        ..config.setupBuild(linkingEnabled: false)
         ..config.setupShared(buildAssetTypes: [CodeAsset.type])
         ..config.setupCode(
           targetOS: OS.macOS,

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -94,7 +94,7 @@ void main() async {
                   outputDirectory: tempUri,
                   outputDirectoryShared: tempUri2,
                 )
-                ..config.setupBuild(linkingEnabled: false, dryRun: false)
+                ..config.setupBuild(linkingEnabled: false)
                 ..config.setupShared(buildAssetTypes: [CodeAsset.type])
                 ..config.setupCode(
                   targetOS: OS.windows,

--- a/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
@@ -52,7 +52,7 @@ void main() {
             outputDirectory: tempUri,
             outputDirectoryShared: tempUri2,
           )
-          ..config.setupBuild(linkingEnabled: false, dryRun: false)
+          ..config.setupBuild(linkingEnabled: false)
           ..config.setupShared(buildAssetTypes: [CodeAsset.type])
           ..config.setupCode(
             targetOS: targetOS,
@@ -106,7 +106,7 @@ void main() {
             outputDirectoryShared: tempUri2,
             outputDirectory: tempUri,
           )
-          ..config.setupBuild(linkingEnabled: false, dryRun: false)
+          ..config.setupBuild(linkingEnabled: false)
           ..config.setupShared(buildAssetTypes: [CodeAsset.type])
           ..config.setupCode(
             targetOS: OS.windows,

--- a/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
@@ -43,7 +43,7 @@ void main() {
             outputDirectory: tempUri,
             outputDirectoryShared: tempUri2,
           )
-          ..config.setupBuild(linkingEnabled: false, dryRun: false)
+          ..config.setupBuild(linkingEnabled: false)
           ..config.setupShared(buildAssetTypes: [CodeAsset.type])
           ..config.setupCode(
             targetOS: targetOS,

--- a/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
+++ b/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
@@ -35,7 +35,7 @@ Future<Uri> buildTestArchive(
           outputDirectory: tempUri,
           outputDirectoryShared: tempUri2,
         )
-        ..config.setupBuild(linkingEnabled: false, dryRun: false)
+        ..config.setupBuild(linkingEnabled: false)
         ..config.setupShared(buildAssetTypes: [CodeAsset.type])
         ..config.setupCode(
           targetOS: os,

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -23,13 +23,13 @@ export 'package:native_assets_cli/code_assets_builder.dart';
 ///
 /// The instances of the test below will have the following descriptions:
 ///
-/// - `My test`
-/// - `My test (dry_run)`
+/// - `My test (debug)`
+/// - `My test (release)`
 ///
 /// ```dart
 /// void main() {
-///   for (final dryRun in [true, false]) {
-///     final suffix = testSuffix([if (dryRun) 'dry_run']);
+///   for (final buildMode in BuildMode.values) {
+///     final suffix = testSuffix([buildMode]);
 ///
 ///     test('My test$suffix', () {});
 ///   }


### PR DESCRIPTION
Remove all support for protocol pre-1.7:

* Remove all dry run!
* Remove the non-hierarchical config

Closes: https://github.com/dart-lang/native/issues/1485

The minimum SDK constraint on `native_assets_cli` has been bumped to 3.7, and Dart and Flutter 3.8.0 dev contain a builder that emits at least 1.7. So, `native_asset_cli` usages shouldn't start failing.

Once this change rolls into dartdev and flutter_tools, users will be see failing hooks with old `native_assets_cli` deps. They should `pub upgrade`. This is expected behavior when depending on an experimental feature.