### PR TITLE
[ffigen] Fix flaky test

### DIFF
--- a/pkgs/ffigen/test/native_objc_test/block_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test.dart
@@ -879,10 +879,10 @@ void main() {
         }
       });
 
-      var isExited = false;
+      final isExited = Completer<void>();
       late final RawReceivePort exitPort;
       exitPort = RawReceivePort((_) {
-        isExited = true;
+        isExited.complete();
         exitPort.close();
       });
 
@@ -912,7 +912,7 @@ void main() {
       await Future<void>.delayed(Duration.zero); // Let exit message arrive.
 
       // Both blocks are still alive.
-      expect(isExited, isFalse);
+      expect(isExited.isCompleted, isFalse);
 
       (await isolateSendPort.future).send('Destroy blkKeepAlive');
       await blkKeepAliveDestroyed.future;
@@ -923,7 +923,7 @@ void main() {
       await Future<void>.delayed(Duration.zero); // Let exit message arrive.
 
       // Only blkDontKeepAlive is alive.
-      expect(isExited, isTrue);
+      await isExited;
 
       receivePort.close();
     }, skip: !canDoGC);
@@ -942,10 +942,10 @@ void main() {
         }
       });
 
-      var isExited = false;
+      final isExited = Completer<void>();
       late final RawReceivePort exitPort;
       exitPort = RawReceivePort((_) {
-        isExited = true;
+        isExited.complete();
         exitPort.close();
       });
 
@@ -974,7 +974,7 @@ void main() {
       await Future<void>.delayed(Duration.zero); // Let exit message arrive.
 
       // Both blocks are still alive.
-      expect(isExited, isFalse);
+      expect(isExited.isCompleted, isFalse);
 
       (await isolateSendPort.future).send('Destroy blkKeepAlive');
       await blkKeepAliveDestroyed.future;
@@ -985,7 +985,7 @@ void main() {
       await Future<void>.delayed(Duration.zero); // Let exit message arrive.
 
       // Only blkDontKeepAlive is alive.
-      expect(isExited, isTrue);
+      await isExited;
 
       receivePort.close();
     }, skip: !canDoGC);
@@ -1004,10 +1004,10 @@ void main() {
         }
       });
 
-      var isExited = false;
+      final isExited = Completer<void>();
       late final RawReceivePort exitPort;
       exitPort = RawReceivePort((_) {
-        isExited = true;
+        isExited.complete();
         exitPort.close();
       });
 
@@ -1036,7 +1036,7 @@ void main() {
       await Future<void>.delayed(Duration.zero); // Let exit message arrive.
 
       // Both blocks are still alive.
-      expect(isExited, isFalse);
+      expect(isExited.isCompleted, isFalse);
 
       (await isolateSendPort.future).send('Destroy blkKeepAlive');
       await blkKeepAliveDestroyed.future;
@@ -1047,7 +1047,7 @@ void main() {
       await Future<void>.delayed(Duration.zero); // Let exit message arrive.
 
       // Only blkDontKeepAlive is alive.
-      expect(isExited, isTrue);
+      await isExited;
 
       receivePort.close();
     }, skip: !canDoGC);

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -558,10 +558,10 @@ void main() {
         }
       });
 
-      var isExited = false;
+      final isExited = Completer<void>();
       late final RawReceivePort exitPort;
       exitPort = RawReceivePort((_) {
-        isExited = true;
+        isExited.complete();
         exitPort.close();
       });
 
@@ -591,7 +591,7 @@ void main() {
       await Future<void>.delayed(Duration.zero); // Let exit message arrive.
 
       // Both blocks are still alive.
-      expect(isExited, isFalse);
+      expect(isExited.isCompleted, isFalse);
 
       (await isolateSendPort.future).send('Destroy protoKeepAlive');
       await protoKeepAliveDestroyed.future;
@@ -602,7 +602,7 @@ void main() {
       await Future<void>.delayed(Duration.zero); // Let exit message arrive.
 
       // Only protoDontKeepAlive is alive.
-      expect(isExited, isTrue);
+      await isExited;
 
       receivePort.close();
     }, skip: !canDoGC);


### PR DESCRIPTION
Looks like the tests added in https://github.com/dart-lang/native/pull/2017 are slightly flaky: https://github.com/dart-lang/native/actions/runs/13424159867/job/37503744811#step:7:838