### PR TITLE
[ffigen] Remove experimental ObjC warning

### DIFF
--- a/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
@@ -405,9 +405,6 @@ class YamlConfig implements Config {
             allowedValues: {strings.langC, strings.langObjC},
             transform: (node) {
               if (node.value == strings.langObjC) {
-                _logger.severe(
-                    'Objective C support is EXPERIMENTAL. The API may change '
-                    'in a breaking way without notice.');
                 return Language.objc;
               } else {
                 return Language.c;


### PR DESCRIPTION
The next release of ffigen, v18, is the "Feature Readiness" version, so it's probably time to remove the experimental warning. We will still have breaking changes from time to time, but we've been doing major version bumps for such changes for a while. So it's not really true that "the API may change in a breaking way without notice" anymore.

Fixes https://github.com/dart-lang/native/issues/2000