### PR TITLE
[jni] Fix interface implementation deadlock on the main thread

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -4,6 +4,9 @@
   and bootstrap jars [#2003](https://github.com/dart-lang/native/issues/2003)
 - Added `JObject.isInstanceOf` which checks whether a `JObject` is an instance 
   of a java class.
+- Fixed a [bug](https://github.com/dart-lang/native/issues/1908) where
+  Java interfaces implemented in on the main thread in Dart could deadlock when
+  invoked from the main thread outside the context of a Dart isolate.
 
 ## 0.14.0
 

--- a/pkgs/jni/src/dartjni.c
+++ b/pkgs/jni/src/dartjni.c
@@ -471,6 +471,8 @@ Java_com_github_dart_1lang_jni_PortProxyBuilder__1invoke(
     //
     // When the current isolate is `null`, enter the main isolate that is pinned
     // to the main thread first before invoking the `functionPtr`.
+    assert(Dart_CurrentIsolate_DL() == NULL ||
+           Dart_CurrentIsolate_DL() == (Dart_Isolate)isolateId);
     bool mustEnterIsolate = Dart_CurrentIsolate_DL() == NULL && mayEnterIsolate;
     if (mustEnterIsolate) {
       Dart_EnterIsolate_DL((Dart_Isolate)isolateId);


### PR DESCRIPTION
Closes #1908 using the proposed method in https://github.com/dart-lang/native/issues/1908#issuecomment-2651104303.

I tested this locally, but we don't have the setup to automate Android tests on CI: #1155.