### PR TITLE
[jnigen] `factory` can be used as a method name without renaming

### DIFF
--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.2-wip
+
+- The name `factory` can now also be used in a method name without renaming.
+
 ## 0.14.1
 
 - Added support for generating matching Kotlin operators as Dart operators.

--- a/pkgs/jnigen/lib/src/bindings/renamer.dart
+++ b/pkgs/jnigen/lib/src/bindings/renamer.dart
@@ -46,7 +46,7 @@ const _keywords = {
   'extends': _Allowed.none,
   'extension': _Allowed.fields | _Allowed.methods,
   'external': _Allowed.fields | _Allowed.methods,
-  'factory': _Allowed.fields | _Allowed.fields,
+  'factory': _Allowed.fields | _Allowed.methods,
   'false': _Allowed.none,
   'final': _Allowed.none,
   'finally': _Allowed.none,

--- a/pkgs/jnigen/pubspec.yaml
+++ b/pkgs/jnigen/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jnigen
 description: A Dart bindings generator for Java and Kotlin that uses JNI under the hood to interop with Java virtual machine.
-version: 0.14.1
+version: 0.14.2-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jnigen
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Ajnigen
 


### PR DESCRIPTION
Fixed a copy pasta error.