### PR TITLE
[swift2objc] Transformation and Generator Updates/Fixes

### DIFF
--- a/pkgs/swift2objc/lib/src/generator/generators/class_generator.dart
+++ b/pkgs/swift2objc/lib/src/generator/generators/class_generator.dart
@@ -134,6 +134,7 @@ List<String> _generateClassProperties(ClassDeclaration declaration) => [
         ..._generateClassProperty(property),
     ];
 
+// TODO: Generate Class properties for constants (i.e let)
 List<String> _generateClassProperty(PropertyDeclaration property) {
   final header = StringBuffer();
 

--- a/pkgs/swift2objc/lib/src/transformer/transform.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transform.dart
@@ -14,6 +14,9 @@ import '_core/unique_namer.dart';
 import 'transformers/transform_compound.dart';
 import 'transformers/transform_globals.dart';
 
+// TODO: Update TransformationMap to make referencing types easy.
+//  Would want to just add wrapper suffix but due to unique naming,
+//  can't take chances
 typedef TransformationMap = Map<Declaration, Declaration>;
 
 Set<Declaration> generateDependencies(Iterable<Declaration> decls) =>


### PR DESCRIPTION
This pull request makes some updates and fixes to transformation and generation logic to better suit upcoming features. Some of these changes are:

- [ ] Update `TransformationMap` to look-ahead on declarations before they are completely transformed 
<!--- Since transformations do not work in a particular order at the moment, and Swift doesn't order statements, the solution is to either reorder transformations (i.e delay certain transformations until others are done, then visit those ones), or to pre-populate the transformation map. The latter is easier to implement and works well as long as the only necessary info needed to be extracted from prepopulating the TransformationMap is the name -->
- [ ] Update the code generator
- [ ] Other refactorings as they come...