### PR TITLE
[ffigen] Protocol polish

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/objc_built_in_functions.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_built_in_functions.dart
@@ -43,6 +43,7 @@ class ObjCBuiltInFunctions {
   static const protocolMethod = ObjCImport('ObjCProtocolMethod');
   static const protocolListenableMethod =
       ObjCImport('ObjCProtocolListenableMethod');
+  static const protocolClass = ObjCImport('Protocol');
   static const protocolBuilder = ObjCImport('ObjCProtocolBuilder');
   static const unimplementedOptionalMethodException =
       ObjCImport('UnimplementedOptionalMethodException');

--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -182,7 +182,7 @@ interface class $name extends $protocolBase $impls{
       final args = '{${buildArgs.join(', ')}}';
       final builders = '''
   /// Returns the [$protocolClass] object for this protocol.
-  static get \$protocol =>
+  static $protocolClass get \$protocol =>
       $protocolClass.castFromPointer(${_protocolPointer.name}.cast());
 
   /// Builds an object that implements the $originalName protocol. To implement

--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -62,6 +62,7 @@ class ObjCProtocol extends BindingType with ObjCMethods {
 
   @override
   BindingString toBindingString(Writer w) {
+    final protocolClass = ObjCBuiltInFunctions.protocolClass.gen(w);
     final protocolBase = ObjCBuiltInFunctions.protocolBase.gen(w);
     final protocolMethod = ObjCBuiltInFunctions.protocolMethod.gen(w);
     final protocolListenableMethod =
@@ -180,6 +181,10 @@ interface class $name extends $protocolBase $impls{
       buildArgs.add('bool \$keepIsolateAlive = true');
       final args = '{${buildArgs.join(', ')}}';
       final builders = '''
+  /// Returns the [$protocolClass] object for this protocol.
+  static get \$protocol =>
+      $protocolClass.castFromPointer(${_protocolPointer.name}.cast());
+
   /// Builds an object that implements the $originalName protocol. To implement
   /// multiple protocols, use [addToBuilder] or [$protocolBuilder] directly.
   ///
@@ -188,6 +193,7 @@ interface class $name extends $protocolBase $impls{
   static $name implement($args) {
     final builder = $protocolBuilder(debugName: '$originalName');
     $buildImplementations
+    builder.addProtocol(\$protocol);
     return $name.castFrom(builder.build(keepIsolateAlive: \$keepIsolateAlive));
   }
 
@@ -197,6 +203,7 @@ interface class $name extends $protocolBase $impls{
   /// Note: You cannot call this method after you have called `builder.build`.
   static void addToBuilder($protocolBuilder builder, $args) {
     $buildImplementations
+    builder.addProtocol(\$protocol);
   }
 ''';
 
@@ -212,6 +219,7 @@ interface class $name extends $protocolBase $impls{
   static $name implementAsListener($args) {
     final builder = $protocolBuilder(debugName: '$originalName');
     $buildListenerImplementations
+    builder.addProtocol(\$protocol);
     return $name.castFrom(builder.build(keepIsolateAlive: \$keepIsolateAlive));
   }
 
@@ -222,6 +230,7 @@ interface class $name extends $protocolBase $impls{
   /// Note: You cannot call this method after you have called `builder.build`.
   static void addToBuilderAsListener($protocolBuilder builder, $args) {
     $buildListenerImplementations
+    builder.addProtocol(\$protocol);
   }
 
   /// Builds an object that implements the $originalName protocol. To implement
@@ -233,6 +242,7 @@ interface class $name extends $protocolBase $impls{
   static $name implementAsBlocking($args) {
     final builder = $protocolBuilder(debugName: '$originalName');
     $buildBlockingImplementations
+    builder.addProtocol(\$protocol);
     return $name.castFrom(builder.build(keepIsolateAlive: \$keepIsolateAlive));
   }
 
@@ -243,6 +253,7 @@ interface class $name extends $protocolBase $impls{
   /// Note: You cannot call this method after you have called `builder.build`.
   static void addToBuilderAsBlocking($protocolBuilder builder, $args) {
     $buildBlockingImplementations
+    builder.addProtocol(\$protocol);
   }
 ''';
       }

--- a/pkgs/ffigen/test/native_objc_test/protocol_config.yaml
+++ b/pkgs/ffigen/test/native_objc_test/protocol_config.yaml
@@ -5,6 +5,10 @@ output:
   bindings: 'protocol_bindings.dart'
   objc-bindings: 'protocol_bindings.m'
 exclude-all-by-default: true
+functions:
+  include:
+    - getClass
+    - getClassName
 objc-interfaces:
   include:
     - ProtocolConsumer

--- a/pkgs/ffigen/test/native_objc_test/protocol_config.yaml
+++ b/pkgs/ffigen/test/native_objc_test/protocol_config.yaml
@@ -9,6 +9,8 @@ functions:
   include:
     - getClass
     - getClassName
+    - objc_autoreleasePoolPop
+    - objc_autoreleasePoolPush
 objc-interfaces:
   include:
     - ProtocolConsumer

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -446,43 +446,35 @@ void main() {
           .implementWithBlock(protocolBuilder, block);
       final protocol = protocolBuilder.build();
 
-      final protocolPtr = protocol.ref.pointer;
       final blockPtr = block.ref.pointer;
 
       // There are 2 references to the block. One owned by the Dart wrapper
       // object, and the other owned by the protocol.
       doGC();
-      // expect(objectRetainCount(protocolPtr), 1);
       expect(blockRetainCount(blockPtr), 2);
-
-      expect(protocol, isNotNull); // Force protocol to stay in scope.
-      expect(block, isNotNull); // Force block to stay in scope.
 
       return (protocol, blockPtr);
     }
 
-    (Pointer<ObjCObject>, Pointer<ObjCBlockImpl>) blockRefCountTest() {
+    Pointer<ObjCBlockImpl> blockRefCountTest() {
       final (protocol, blockPtr) = blockRefCountTestInner();
-      final protocolPtr = protocol.ref.pointer;
 
       // The Dart side block pointer has gone out of scope, but the protocol
       // still owns a reference to it.
       doGC();
-      expect(objectRetainCount(protocolPtr), 1);
       expect(blockRetainCount(blockPtr), 1);
 
       expect(protocol, isNotNull); // Force protocol to stay in scope.
 
-      return (protocolPtr, blockPtr);
+      return blockPtr;
     }
 
     test('Block ref counting', () {
-      final (protocolPtr, blockPtr) = blockRefCountTest();
+      final blockPtr = blockRefCountTest();
 
       // The protocol object has gone out of scope, so it should be cleaned up.
       // So should the block.
       doGC();
-      expect(objectRetainCount(protocolPtr), 0);
       expect(blockRetainCount(blockPtr), 0);
     }, skip: !canDoGC);
 

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -452,7 +452,7 @@ void main() {
       // There are 2 references to the block. One owned by the Dart wrapper
       // object, and the other owned by the protocol.
       doGC();
-      expect(objectRetainCount(protocolPtr), 1);
+      // expect(objectRetainCount(protocolPtr), 1);
       expect(blockRetainCount(blockPtr), 2);
 
       expect(protocol, isNotNull); // Force protocol to stay in scope.

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -450,8 +450,7 @@ void main() {
       final blockPtr = block.ref.pointer;
 
       // There are 2 references to the block. One owned by the Dart wrapper
-      // object, and the other owned by the protocol. The method signature is
-      // also an ObjC object, so the same is true for it.
+      // object, and the other owned by the protocol.
       doGC();
       expect(objectRetainCount(protocolPtr), 1);
       expect(blockRetainCount(blockPtr), 2);
@@ -467,7 +466,7 @@ void main() {
       final protocolPtr = protocol.ref.pointer;
 
       // The Dart side block pointer has gone out of scope, but the protocol
-      // still owns a reference to it. Same for the signature.
+      // still owns a reference to it.
       doGC();
       expect(objectRetainCount(protocolPtr), 1);
       expect(blockRetainCount(blockPtr), 1);
@@ -481,7 +480,7 @@ void main() {
       final (protocolPtr, blockPtr) = blockRefCountTest();
 
       // The protocol object has gone out of scope, so it should be cleaned up.
-      // So should the block and the signature.
+      // So should the block.
       doGC();
       expect(objectRetainCount(protocolPtr), 0);
       expect(blockRetainCount(blockPtr), 0);

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -442,8 +442,8 @@ void main() {
 
       final block = InstanceMethodBlock.fromFunction(
           (Pointer<Void> p, NSString s, double x) => 'Hello'.toNSString());
-      MyProtocol.instanceMethod_withDouble_.implementWithBlock(
-          protocolBuilder, block);
+      MyProtocol.instanceMethod_withDouble_
+          .implementWithBlock(protocolBuilder, block);
       final protocol = protocolBuilder.build();
 
       final protocolPtr = protocol.ref.pointer;
@@ -546,7 +546,8 @@ void main() {
     }, skip: !canDoGC);
 
     test('class disposal, builder first', () {
-      ObjCProtocolBuilder? protocolBuilder = ObjCProtocolBuilder(debugName: 'Foo');
+      ObjCProtocolBuilder? protocolBuilder =
+          ObjCProtocolBuilder(debugName: 'Foo');
 
       NSObject? protocol = protocolBuilder.build();
       final clazz = lib.getClass(protocol);
@@ -564,7 +565,8 @@ void main() {
     }, skip: !canDoGC);
 
     test('class disposal, instance first', () {
-      ObjCProtocolBuilder? protocolBuilder = ObjCProtocolBuilder(debugName: 'Foo');
+      ObjCProtocolBuilder? protocolBuilder =
+          ObjCProtocolBuilder(debugName: 'Foo');
 
       NSObject? protocol = protocolBuilder.build();
       final clazz = lib.getClass(protocol);

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -12,6 +12,7 @@ import 'dart:isolate';
 
 import 'package:ffi/ffi.dart';
 import 'package:objective_c/objective_c.dart';
+import 'package:objective_c/src/internal.dart' show getProtocol;
 import 'package:test/test.dart';
 
 import '../test_utils.dart';
@@ -128,6 +129,9 @@ void main() {
           },
         );
 
+        expect(MyProtocol.conformsTo(myProtocol), isTrue);
+        expect(SecondaryProtocol.conformsTo(myProtocol), isFalse);
+
         // Required instance method.
         final result = consumer.callInstanceMethod_(myProtocol);
         expect(result.toDartString(), 'MyProtocol: Hello from ObjC: 3.14');
@@ -158,6 +162,9 @@ void main() {
         final MyProtocol asMyProtocol = MyProtocol.castFrom(protocolImpl);
         final SecondaryProtocol asSecondaryProtocol =
             SecondaryProtocol.castFrom(protocolImpl);
+
+        expect(MyProtocol.conformsTo(protocolImpl), isTrue);
+        expect(SecondaryProtocol.conformsTo(protocolImpl), isTrue);
 
         // Required instance method.
         final result = consumer.callInstanceMethod_(asMyProtocol);

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -456,6 +456,9 @@ void main() {
       expect(objectRetainCount(protocolPtr), 1);
       expect(blockRetainCount(blockPtr), 2);
 
+      expect(protocol, isNotNull); // Force protocol to stay in scope.
+      expect(block, isNotNull); // Force block to stay in scope.
+
       return (protocol, blockPtr);
     }
 
@@ -468,6 +471,8 @@ void main() {
       doGC();
       expect(objectRetainCount(protocolPtr), 1);
       expect(blockRetainCount(blockPtr), 1);
+
+      expect(protocol, isNotNull); // Force protocol to stay in scope.
 
       return (protocolPtr, blockPtr);
     }

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -545,7 +545,7 @@ void main() {
       receivePort.close();
     }, skip: !canDoGC);
 
-    test('class disposal', () {
+    test('class disposal, builder first', () {
       ObjCProtocolBuilder? protocolBuilder = ObjCProtocolBuilder(debugName: 'Foo');
 
       NSObject? protocol = protocolBuilder.build();
@@ -555,9 +555,29 @@ void main() {
       expect(isValidClass(clazz), isTrue);
 
       protocolBuilder = null;
+      doGC();
+      expect(isValidClass(clazz), isTrue);
+
       protocol = null;
       doGC();
+      expect(isValidClass(clazz), isFalse);
+    }, skip: !canDoGC);
 
+    test('class disposal, instance first', () {
+      ObjCProtocolBuilder? protocolBuilder = ObjCProtocolBuilder(debugName: 'Foo');
+
+      NSObject? protocol = protocolBuilder.build();
+      final clazz = lib.getClass(protocol);
+      expect(lib.getClassName(clazz).cast<Utf8>().toDartString(),
+          startsWith('Foo'));
+      expect(isValidClass(clazz), isTrue);
+
+      protocolBuilder = null;
+      doGC();
+      expect(isValidClass(clazz), isTrue);
+
+      protocol = null;
+      doGC();
       expect(isValidClass(clazz), isFalse);
     }, skip: !canDoGC);
   });

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.h
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.h
@@ -7,6 +7,8 @@
 
 const char* getClassName(void* cls);
 void* getClass(id object);
+void objc_autoreleasePoolPop(void *pool);
+void *objc_autoreleasePoolPush();
 
 typedef struct {
   int32_t x;

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.h
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.h
@@ -5,6 +5,9 @@
 #import <Foundation/NSObject.h>
 #import <Foundation/NSString.h>
 
+const char* getClassName(void* cls);
+void* getClass(id object);
+
 typedef struct {
   int32_t x;
   int32_t y;

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.m
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.m
@@ -8,6 +8,16 @@
 
 #include "protocol_test.h"
 
+const char* class_getName(Class cls);
+
+const char* getClassName(void* cls) {
+  return class_getName((__bridge Class)cls);
+}
+
+void* getClass(id object) {
+  return (__bridge void*)[object class];
+}
+
 @implementation ProtocolConsumer : NSObject
 - (NSString*)callInstanceMethod:(id<SuperProtocol>)protocol {
   return [protocol instanceMethod:@"Hello from ObjC" withDouble:3.14];

--- a/pkgs/ffigen/test/native_objc_test/util.dart
+++ b/pkgs/ffigen/test/native_objc_test/util.dart
@@ -95,4 +95,4 @@ int objectRetainCount(Pointer<ObjCObject> object) {
 }
 
 bool isValidClass(Pointer<Void> clazz) =>
-    internal_for_testing.isValidClass(clazz.cast(), bypassCache: true);
+    internal_for_testing.isValidClass(clazz.cast(), forceReloadClasses: true);

--- a/pkgs/ffigen/test/native_objc_test/util.dart
+++ b/pkgs/ffigen/test/native_objc_test/util.dart
@@ -93,3 +93,6 @@ int objectRetainCount(Pointer<ObjCObject> object) {
   if (!internal_for_testing.isValidClass(clazz)) return 0;
   return _getObjectRetainCount(object.cast());
 }
+
+bool isValidClass(Pointer<Void> clazz) =>
+    internal_for_testing.isValidClass(clazz.cast(), bypassCache: true);

--- a/pkgs/objective_c/ffigen_c.yaml
+++ b/pkgs/objective_c/ffigen_c.yaml
@@ -22,7 +22,6 @@ functions:
     - 'protocol_getMethodDescription'
     - 'protocol_getName'
     - 'newFinalizableHandle'
-    - 'class_addMethod'
     - 'DOBJC_.*'
   leaf:
     include:
@@ -56,10 +55,7 @@ functions:
     'objc_msgSend_stret': 'msgSendStret'
     'object_getClass': 'getObjectClass'
     'objc_copyClassList': 'copyClassList'
-    'objc_allocateClassPair': 'allocateClassPair'
-    'objc_registerClassPair': 'registerClassPair'
     'objc_getProtocol': 'getProtocol'
-    'class_addMethod': 'addMethod'
     'protocol_getMethodDescription': 'getMethodDescription'
     'protocol_getName': 'getProtocolName'
 globals:

--- a/pkgs/objective_c/lib/src/c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/c_bindings_generated.dart
@@ -56,30 +56,6 @@ external ffi.Array<ffi.Pointer<ffi.Void>> NSConcreteMallocBlock;
 @ffi.Native<ffi.Array<ffi.Pointer<ffi.Void>>>(symbol: '_NSConcreteStackBlock')
 external ffi.Array<ffi.Pointer<ffi.Void>> NSConcreteStackBlock;
 
-@ffi.Native<
-    ffi.Bool Function(
-        ffi.Pointer<ObjCObject>,
-        ffi.Pointer<ObjCSelector>,
-        ffi.Pointer<ffi.Void>,
-        ffi.Pointer<ffi.Char>)>(symbol: 'class_addMethod', isLeaf: true)
-external bool addMethod(
-  ffi.Pointer<ObjCObject> cls,
-  ffi.Pointer<ObjCSelector> name,
-  ffi.Pointer<ffi.Void> imp,
-  ffi.Pointer<ffi.Char> types,
-);
-
-@ffi.Native<
-    ffi.Pointer<ObjCObject> Function(
-        ffi.Pointer<ObjCObject>,
-        ffi.Pointer<ffi.Char>,
-        ffi.Size)>(symbol: 'objc_allocateClassPair', isLeaf: true)
-external ffi.Pointer<ObjCObject> allocateClassPair(
-  ffi.Pointer<ObjCObject> superclass,
-  ffi.Pointer<ffi.Char> name,
-  int extraBytes,
-);
-
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(
     symbol: 'DOBJC_awaitWaiter')
 external void awaitWaiter(
@@ -209,12 +185,6 @@ external void objectRelease(
     symbol: 'objc_retain', isLeaf: true)
 external ffi.Pointer<ObjCObject> objectRetain(
   ffi.Pointer<ObjCObject> object,
-);
-
-@ffi.Native<ffi.Void Function(ffi.Pointer<ObjCObject>)>(
-    symbol: 'objc_registerClassPair', isLeaf: true)
-external void registerClassPair(
-  ffi.Pointer<ObjCObject> cls,
 );
 
 @ffi.Native<ffi.Pointer<ObjCSelector> Function(ffi.Pointer<ffi.Char>)>(

--- a/pkgs/objective_c/lib/src/internal.dart
+++ b/pkgs/objective_c/lib/src/internal.dart
@@ -295,8 +295,8 @@ bool _isValidObject(ObjectPtr ptr) {
 
 final _allClasses = <ObjectPtr>{};
 
-bool _isValidClass(ObjectPtr clazz, {bool bypassCache = false}) {
-  if (!bypassCache && _allClasses.contains(clazz)) return true;
+bool _isValidClass(ObjectPtr clazz, {bool forceReloadClasses = false}) {
+  if (!forceReloadClasses && _allClasses.contains(clazz)) return true;
 
   // If the class is missing from the list, it either means we haven't created
   // the set yet, or more classes have been loaded since we created the set, or
@@ -446,6 +446,6 @@ BlockPtr wrapBlockingBlock(
 bool blockHasRegisteredClosure(BlockPtr block) =>
     _blockClosureRegistry.containsKey(block.ref.target.address);
 bool isValidBlock(BlockPtr block) => c.isValidBlock(block);
-bool isValidClass(ObjectPtr clazz, {bool bypassCache = false}) =>
-    _isValidClass(clazz, bypassCache: bypassCache);
+bool isValidClass(ObjectPtr clazz, {bool forceReloadClasses = false}) =>
+    _isValidClass(clazz, forceReloadClasses: forceReloadClasses);
 bool isValidObject(ObjectPtr object) => _isValidObject(object);

--- a/pkgs/objective_c/lib/src/internal.dart
+++ b/pkgs/objective_c/lib/src/internal.dart
@@ -295,8 +295,8 @@ bool _isValidObject(ObjectPtr ptr) {
 
 final _allClasses = <ObjectPtr>{};
 
-bool _isValidClass(ObjectPtr clazz) {
-  if (_allClasses.contains(clazz)) return true;
+bool _isValidClass(ObjectPtr clazz, {bool bypassCache = false}) {
+  if (!bypassCache && _allClasses.contains(clazz)) return true;
 
   // If the class is missing from the list, it either means we haven't created
   // the set yet, or more classes have been loaded since we created the set, or
@@ -446,5 +446,6 @@ BlockPtr wrapBlockingBlock(
 bool blockHasRegisteredClosure(BlockPtr block) =>
     _blockClosureRegistry.containsKey(block.ref.target.address);
 bool isValidBlock(BlockPtr block) => c.isValidBlock(block);
-bool isValidClass(ObjectPtr clazz) => _isValidClass(clazz);
+bool isValidClass(ObjectPtr clazz, {bool bypassCache = false}) =>
+    _isValidClass(clazz, bypassCache: bypassCache);
 bool isValidObject(ObjectPtr object) => _isValidObject(object);

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -597,6 +597,12 @@ class DartProtocolBuilder extends NSObject {
         retain: false, release: true);
   }
 
+  /// addProtocol:
+  void addProtocol_(Protocol protocol) {
+    _objc_msgSend_xtuoz7(
+        this.ref.pointer, _sel_addProtocol_, protocol.ref.pointer);
+  }
+
   /// autorelease
   DartProtocolBuilder autorelease() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_autorelease);
@@ -1153,6 +1159,10 @@ interface class NSCoding extends objc.ObjCProtocolBase {
         obj.ref.pointer, _sel_conformsToProtocol_, _protocol_NSCoding);
   }
 
+  /// Returns the [objc.Protocol] object for this protocol.
+  static get $protocol =>
+      objc.Protocol.castFromPointer(_protocol_NSCoding.cast());
+
   /// Builds an object that implements the NSCoding protocol. To implement
   /// multiple protocols, use [addToBuilder] or [objc.ObjCProtocolBuilder] directly.
   ///
@@ -1165,6 +1175,7 @@ interface class NSCoding extends objc.ObjCProtocolBase {
     final builder = objc.ObjCProtocolBuilder(debugName: 'NSCoding');
     NSCoding.encodeWithCoder_.implement(builder, encodeWithCoder_);
     NSCoding.initWithCoder_.implement(builder, initWithCoder_);
+    builder.addProtocol($protocol);
     return NSCoding.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -1179,6 +1190,7 @@ interface class NSCoding extends objc.ObjCProtocolBase {
       bool $keepIsolateAlive = true}) {
     NSCoding.encodeWithCoder_.implement(builder, encodeWithCoder_);
     NSCoding.initWithCoder_.implement(builder, initWithCoder_);
+    builder.addProtocol($protocol);
   }
 
   /// Builds an object that implements the NSCoding protocol. To implement
@@ -1194,6 +1206,7 @@ interface class NSCoding extends objc.ObjCProtocolBase {
     final builder = objc.ObjCProtocolBuilder(debugName: 'NSCoding');
     NSCoding.encodeWithCoder_.implementAsListener(builder, encodeWithCoder_);
     NSCoding.initWithCoder_.implement(builder, initWithCoder_);
+    builder.addProtocol($protocol);
     return NSCoding.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -1209,6 +1222,7 @@ interface class NSCoding extends objc.ObjCProtocolBase {
       bool $keepIsolateAlive = true}) {
     NSCoding.encodeWithCoder_.implementAsListener(builder, encodeWithCoder_);
     NSCoding.initWithCoder_.implement(builder, initWithCoder_);
+    builder.addProtocol($protocol);
   }
 
   /// Builds an object that implements the NSCoding protocol. To implement
@@ -1224,6 +1238,7 @@ interface class NSCoding extends objc.ObjCProtocolBase {
     final builder = objc.ObjCProtocolBuilder(debugName: 'NSCoding');
     NSCoding.encodeWithCoder_.implementAsBlocking(builder, encodeWithCoder_);
     NSCoding.initWithCoder_.implement(builder, initWithCoder_);
+    builder.addProtocol($protocol);
     return NSCoding.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -1239,6 +1254,7 @@ interface class NSCoding extends objc.ObjCProtocolBase {
       bool $keepIsolateAlive = true}) {
     NSCoding.encodeWithCoder_.implementAsBlocking(builder, encodeWithCoder_);
     NSCoding.initWithCoder_.implement(builder, initWithCoder_);
+    builder.addProtocol($protocol);
   }
 
   /// encodeWithCoder:
@@ -1328,6 +1344,10 @@ interface class NSCopying extends objc.ObjCProtocolBase {
         obj.ref.pointer, _sel_conformsToProtocol_, _protocol_NSCopying);
   }
 
+  /// Returns the [objc.Protocol] object for this protocol.
+  static get $protocol =>
+      objc.Protocol.castFromPointer(_protocol_NSCopying.cast());
+
   /// Builds an object that implements the NSCopying protocol. To implement
   /// multiple protocols, use [addToBuilder] or [objc.ObjCProtocolBuilder] directly.
   ///
@@ -1338,6 +1358,7 @@ interface class NSCopying extends objc.ObjCProtocolBase {
       bool $keepIsolateAlive = true}) {
     final builder = objc.ObjCProtocolBuilder(debugName: 'NSCopying');
     NSCopying.copyWithZone_.implement(builder, copyWithZone_);
+    builder.addProtocol($protocol);
     return NSCopying.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -1350,6 +1371,7 @@ interface class NSCopying extends objc.ObjCProtocolBase {
       {required objc.ObjCObjectBase Function(ffi.Pointer<NSZone>) copyWithZone_,
       bool $keepIsolateAlive = true}) {
     NSCopying.copyWithZone_.implement(builder, copyWithZone_);
+    builder.addProtocol($protocol);
   }
 
   /// copyWithZone:
@@ -3685,6 +3707,10 @@ interface class NSFastEnumeration extends objc.ObjCProtocolBase {
         obj.ref.pointer, _sel_conformsToProtocol_, _protocol_NSFastEnumeration);
   }
 
+  /// Returns the [objc.Protocol] object for this protocol.
+  static get $protocol =>
+      objc.Protocol.castFromPointer(_protocol_NSFastEnumeration.cast());
+
   /// Builds an object that implements the NSFastEnumeration protocol. To implement
   /// multiple protocols, use [addToBuilder] or [objc.ObjCProtocolBuilder] directly.
   ///
@@ -3698,6 +3724,7 @@ interface class NSFastEnumeration extends objc.ObjCProtocolBase {
     final builder = objc.ObjCProtocolBuilder(debugName: 'NSFastEnumeration');
     NSFastEnumeration.countByEnumeratingWithState_objects_count_
         .implement(builder, countByEnumeratingWithState_objects_count_);
+    builder.addProtocol($protocol);
     return NSFastEnumeration.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -3713,6 +3740,7 @@ interface class NSFastEnumeration extends objc.ObjCProtocolBase {
       bool $keepIsolateAlive = true}) {
     NSFastEnumeration.countByEnumeratingWithState_objects_count_
         .implement(builder, countByEnumeratingWithState_objects_count_);
+    builder.addProtocol($protocol);
   }
 
   /// countByEnumeratingWithState:objects:count:
@@ -4318,6 +4346,10 @@ interface class NSItemProviderReading extends objc.ObjCProtocolBase
         _protocol_NSItemProviderReading);
   }
 
+  /// Returns the [objc.Protocol] object for this protocol.
+  static get $protocol =>
+      objc.Protocol.castFromPointer(_protocol_NSItemProviderReading.cast());
+
   /// Builds an object that implements the NSItemProviderReading protocol. To implement
   /// multiple protocols, use [addToBuilder] or [objc.ObjCProtocolBuilder] directly.
   ///
@@ -4327,6 +4359,7 @@ interface class NSItemProviderReading extends objc.ObjCProtocolBase
     final builder =
         objc.ObjCProtocolBuilder(debugName: 'NSItemProviderReading');
 
+    builder.addProtocol($protocol);
     return NSItemProviderReading.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -4336,7 +4369,9 @@ interface class NSItemProviderReading extends objc.ObjCProtocolBase
   ///
   /// Note: You cannot call this method after you have called `builder.build`.
   static void addToBuilder(objc.ObjCProtocolBuilder builder,
-      {bool $keepIsolateAlive = true}) {}
+      {bool $keepIsolateAlive = true}) {
+    builder.addProtocol($protocol);
+  }
 }
 
 enum NSItemProviderRepresentationVisibility {
@@ -4381,6 +4416,10 @@ interface class NSItemProviderWriting extends objc.ObjCProtocolBase
         _protocol_NSItemProviderWriting);
   }
 
+  /// Returns the [objc.Protocol] object for this protocol.
+  static get $protocol =>
+      objc.Protocol.castFromPointer(_protocol_NSItemProviderWriting.cast());
+
   /// Builds an object that implements the NSItemProviderWriting protocol. To implement
   /// multiple protocols, use [addToBuilder] or [objc.ObjCProtocolBuilder] directly.
   ///
@@ -4399,6 +4438,7 @@ interface class NSItemProviderWriting extends objc.ObjCProtocolBase
             itemProviderVisibilityForRepresentationWithTypeIdentifier_);
     NSItemProviderWriting.writableTypeIdentifiersForItemProvider
         .implement(builder, writableTypeIdentifiersForItemProvider);
+    builder.addProtocol($protocol);
     return NSItemProviderWriting.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -4418,6 +4458,7 @@ interface class NSItemProviderWriting extends objc.ObjCProtocolBase
             itemProviderVisibilityForRepresentationWithTypeIdentifier_);
     NSItemProviderWriting.writableTypeIdentifiersForItemProvider
         .implement(builder, writableTypeIdentifiersForItemProvider);
+    builder.addProtocol($protocol);
   }
 
   /// itemProviderVisibilityForRepresentationWithTypeIdentifier:
@@ -4840,6 +4881,10 @@ interface class NSMutableCopying extends objc.ObjCProtocolBase {
         obj.ref.pointer, _sel_conformsToProtocol_, _protocol_NSMutableCopying);
   }
 
+  /// Returns the [objc.Protocol] object for this protocol.
+  static get $protocol =>
+      objc.Protocol.castFromPointer(_protocol_NSMutableCopying.cast());
+
   /// Builds an object that implements the NSMutableCopying protocol. To implement
   /// multiple protocols, use [addToBuilder] or [objc.ObjCProtocolBuilder] directly.
   ///
@@ -4852,6 +4897,7 @@ interface class NSMutableCopying extends objc.ObjCProtocolBase {
     final builder = objc.ObjCProtocolBuilder(debugName: 'NSMutableCopying');
     NSMutableCopying.mutableCopyWithZone_
         .implement(builder, mutableCopyWithZone_);
+    builder.addProtocol($protocol);
     return NSMutableCopying.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -4866,6 +4912,7 @@ interface class NSMutableCopying extends objc.ObjCProtocolBase {
       bool $keepIsolateAlive = true}) {
     NSMutableCopying.mutableCopyWithZone_
         .implement(builder, mutableCopyWithZone_);
+    builder.addProtocol($protocol);
   }
 
   /// mutableCopyWithZone:
@@ -7567,6 +7614,10 @@ interface class NSObjectProtocol extends objc.ObjCProtocolBase {
         obj.ref.pointer, _sel_conformsToProtocol_, _protocol_NSObject);
   }
 
+  /// Returns the [objc.Protocol] object for this protocol.
+  static get $protocol =>
+      objc.Protocol.castFromPointer(_protocol_NSObject.cast());
+
   /// Builds an object that implements the NSObject protocol. To implement
   /// multiple protocols, use [addToBuilder] or [objc.ObjCProtocolBuilder] directly.
   ///
@@ -7625,6 +7676,7 @@ interface class NSObjectProtocol extends objc.ObjCProtocolBase {
     NSObjectProtocol.self$1.implement(builder, self$1);
     NSObjectProtocol.superclass.implement(builder, superclass);
     NSObjectProtocol.zone.implement(builder, zone);
+    builder.addProtocol($protocol);
     return NSObjectProtocol.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -7685,6 +7737,7 @@ interface class NSObjectProtocol extends objc.ObjCProtocolBase {
     NSObjectProtocol.self$1.implement(builder, self$1);
     NSObjectProtocol.superclass.implement(builder, superclass);
     NSObjectProtocol.zone.implement(builder, zone);
+    builder.addProtocol($protocol);
   }
 
   /// Builds an object that implements the NSObject protocol. To implement
@@ -7746,6 +7799,7 @@ interface class NSObjectProtocol extends objc.ObjCProtocolBase {
     NSObjectProtocol.self$1.implement(builder, self$1);
     NSObjectProtocol.superclass.implement(builder, superclass);
     NSObjectProtocol.zone.implement(builder, zone);
+    builder.addProtocol($protocol);
     return NSObjectProtocol.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -7807,6 +7861,7 @@ interface class NSObjectProtocol extends objc.ObjCProtocolBase {
     NSObjectProtocol.self$1.implement(builder, self$1);
     NSObjectProtocol.superclass.implement(builder, superclass);
     NSObjectProtocol.zone.implement(builder, zone);
+    builder.addProtocol($protocol);
   }
 
   /// Builds an object that implements the NSObject protocol. To implement
@@ -7868,6 +7923,7 @@ interface class NSObjectProtocol extends objc.ObjCProtocolBase {
     NSObjectProtocol.self$1.implement(builder, self$1);
     NSObjectProtocol.superclass.implement(builder, superclass);
     NSObjectProtocol.zone.implement(builder, zone);
+    builder.addProtocol($protocol);
     return NSObjectProtocol.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -7929,6 +7985,7 @@ interface class NSObjectProtocol extends objc.ObjCProtocolBase {
     NSObjectProtocol.self$1.implement(builder, self$1);
     NSObjectProtocol.superclass.implement(builder, superclass);
     NSObjectProtocol.zone.implement(builder, zone);
+    builder.addProtocol($protocol);
   }
 
   /// autorelease
@@ -9104,6 +9161,10 @@ interface class NSSecureCoding extends objc.ObjCProtocolBase
         obj.ref.pointer, _sel_conformsToProtocol_, _protocol_NSSecureCoding);
   }
 
+  /// Returns the [objc.Protocol] object for this protocol.
+  static get $protocol =>
+      objc.Protocol.castFromPointer(_protocol_NSSecureCoding.cast());
+
   /// Builds an object that implements the NSSecureCoding protocol. To implement
   /// multiple protocols, use [addToBuilder] or [objc.ObjCProtocolBuilder] directly.
   ///
@@ -9116,6 +9177,7 @@ interface class NSSecureCoding extends objc.ObjCProtocolBase
     final builder = objc.ObjCProtocolBuilder(debugName: 'NSSecureCoding');
     NSSecureCoding.encodeWithCoder_.implement(builder, encodeWithCoder_);
     NSSecureCoding.initWithCoder_.implement(builder, initWithCoder_);
+    builder.addProtocol($protocol);
     return NSSecureCoding.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -9130,6 +9192,7 @@ interface class NSSecureCoding extends objc.ObjCProtocolBase
       bool $keepIsolateAlive = true}) {
     NSSecureCoding.encodeWithCoder_.implement(builder, encodeWithCoder_);
     NSSecureCoding.initWithCoder_.implement(builder, initWithCoder_);
+    builder.addProtocol($protocol);
   }
 
   /// Builds an object that implements the NSSecureCoding protocol. To implement
@@ -9146,6 +9209,7 @@ interface class NSSecureCoding extends objc.ObjCProtocolBase
     NSSecureCoding.encodeWithCoder_
         .implementAsListener(builder, encodeWithCoder_);
     NSSecureCoding.initWithCoder_.implement(builder, initWithCoder_);
+    builder.addProtocol($protocol);
     return NSSecureCoding.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -9162,6 +9226,7 @@ interface class NSSecureCoding extends objc.ObjCProtocolBase
     NSSecureCoding.encodeWithCoder_
         .implementAsListener(builder, encodeWithCoder_);
     NSSecureCoding.initWithCoder_.implement(builder, initWithCoder_);
+    builder.addProtocol($protocol);
   }
 
   /// Builds an object that implements the NSSecureCoding protocol. To implement
@@ -9178,6 +9243,7 @@ interface class NSSecureCoding extends objc.ObjCProtocolBase
     NSSecureCoding.encodeWithCoder_
         .implementAsBlocking(builder, encodeWithCoder_);
     NSSecureCoding.initWithCoder_.implement(builder, initWithCoder_);
+    builder.addProtocol($protocol);
     return NSSecureCoding.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -9194,6 +9260,7 @@ interface class NSSecureCoding extends objc.ObjCProtocolBase
     NSSecureCoding.encodeWithCoder_
         .implementAsBlocking(builder, encodeWithCoder_);
     NSSecureCoding.initWithCoder_.implement(builder, initWithCoder_);
+    builder.addProtocol($protocol);
   }
 
   /// encodeWithCoder:
@@ -9597,6 +9664,10 @@ interface class NSStreamDelegate extends objc.ObjCProtocolBase
         obj.ref.pointer, _sel_conformsToProtocol_, _protocol_NSStreamDelegate);
   }
 
+  /// Returns the [objc.Protocol] object for this protocol.
+  static get $protocol =>
+      objc.Protocol.castFromPointer(_protocol_NSStreamDelegate.cast());
+
   /// Builds an object that implements the NSStreamDelegate protocol. To implement
   /// multiple protocols, use [addToBuilder] or [objc.ObjCProtocolBuilder] directly.
   ///
@@ -9608,6 +9679,7 @@ interface class NSStreamDelegate extends objc.ObjCProtocolBase
     final builder = objc.ObjCProtocolBuilder(debugName: 'NSStreamDelegate');
     NSStreamDelegate.stream_handleEvent_
         .implement(builder, stream_handleEvent_);
+    builder.addProtocol($protocol);
     return NSStreamDelegate.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -9621,6 +9693,7 @@ interface class NSStreamDelegate extends objc.ObjCProtocolBase
       bool $keepIsolateAlive = true}) {
     NSStreamDelegate.stream_handleEvent_
         .implement(builder, stream_handleEvent_);
+    builder.addProtocol($protocol);
   }
 
   /// Builds an object that implements the NSStreamDelegate protocol. To implement
@@ -9635,6 +9708,7 @@ interface class NSStreamDelegate extends objc.ObjCProtocolBase
     final builder = objc.ObjCProtocolBuilder(debugName: 'NSStreamDelegate');
     NSStreamDelegate.stream_handleEvent_
         .implementAsListener(builder, stream_handleEvent_);
+    builder.addProtocol($protocol);
     return NSStreamDelegate.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -9649,6 +9723,7 @@ interface class NSStreamDelegate extends objc.ObjCProtocolBase
       bool $keepIsolateAlive = true}) {
     NSStreamDelegate.stream_handleEvent_
         .implementAsListener(builder, stream_handleEvent_);
+    builder.addProtocol($protocol);
   }
 
   /// Builds an object that implements the NSStreamDelegate protocol. To implement
@@ -9663,6 +9738,7 @@ interface class NSStreamDelegate extends objc.ObjCProtocolBase
     final builder = objc.ObjCProtocolBuilder(debugName: 'NSStreamDelegate');
     NSStreamDelegate.stream_handleEvent_
         .implementAsBlocking(builder, stream_handleEvent_);
+    builder.addProtocol($protocol);
     return NSStreamDelegate.castFrom(
         builder.build(keepIsolateAlive: $keepIsolateAlive));
   }
@@ -9677,6 +9753,7 @@ interface class NSStreamDelegate extends objc.ObjCProtocolBase
       bool $keepIsolateAlive = true}) {
     NSStreamDelegate.stream_handleEvent_
         .implementAsBlocking(builder, stream_handleEvent_);
+    builder.addProtocol($protocol);
   }
 
   /// stream:handleEvent:
@@ -17400,6 +17477,7 @@ late final _sel_addObject_ = objc.registerName("addObject:");
 late final _sel_addObjectsFromArray_ =
     objc.registerName("addObjectsFromArray:");
 late final _sel_addObjects_count_ = objc.registerName("addObjects:count:");
+late final _sel_addProtocol_ = objc.registerName("addProtocol:");
 late final _sel_allKeys = objc.registerName("allKeys");
 late final _sel_allKeysForObject_ = objc.registerName("allKeysForObject:");
 late final _sel_allObjects = objc.registerName("allObjects");

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -603,11 +603,26 @@ class DartProtocolBuilder extends NSObject {
         retain: true, release: true);
   }
 
-  /// implementMethod:withBlock:
-  void implementMethod_withBlock_(
-      ffi.Pointer<objc.ObjCSelector> sel, ffi.Pointer<ffi.Void> block) {
-    _objc_msgSend_1iqj6b6(
-        this.ref.pointer, _sel_implementMethod_withBlock_, sel, block);
+  /// buildInstance:
+  DartProtocol buildInstance_(int port) {
+    final _ret =
+        _objc_msgSend_1ya1kjn(this.ref.pointer, _sel_buildInstance_, port);
+    return DartProtocol.castFromPointer(_ret, retain: true, release: true);
+  }
+
+  /// implementMethod:withBlock:withTrampoline:withSignature:
+  void implementMethod_withBlock_withTrampoline_withSignature_(
+      ffi.Pointer<objc.ObjCSelector> sel,
+      ffi.Pointer<ffi.Void> block,
+      ffi.Pointer<ffi.Void> trampoline,
+      ffi.Pointer<ffi.Char> signature) {
+    _objc_msgSend_1s2gdyk(
+        this.ref.pointer,
+        _sel_implementMethod_withBlock_withTrampoline_withSignature_,
+        sel,
+        block,
+        trampoline,
+        signature);
   }
 
   /// init
@@ -620,12 +635,17 @@ class DartProtocolBuilder extends NSObject {
         retain: false, release: true);
   }
 
-  /// initWithClass:
-  DartProtocolBuilder initWithClass_(ffi.Pointer<ffi.Void> cls) {
-    final _ret = _objc_msgSend_1mbt9g9(
-        this.ref.retainAndReturnPointer(), _sel_initWithClass_, cls);
+  /// initWithClassName:
+  DartProtocolBuilder initWithClassName_(ffi.Pointer<ffi.Char> name) {
+    final _ret = _objc_msgSend_56zxyn(
+        this.ref.retainAndReturnPointer(), _sel_initWithClassName_, name);
     return DartProtocolBuilder.castFromPointer(_ret,
         retain: false, release: true);
+  }
+
+  /// registerClass
+  void registerClass() {
+    _objc_msgSend_1pl9qdv(this.ref.pointer, _sel_registerClass);
   }
 
   /// retain
@@ -15862,20 +15882,6 @@ final _objc_msgSend_1i9r4xy = objc.msgSendPointer
     .asFunction<
         void Function(ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<objc.ObjCSelector>, int)>();
-final _objc_msgSend_1iqj6b6 = objc.msgSendPointer
-    .cast<
-        ffi.NativeFunction<
-            ffi.Void Function(
-                ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<objc.ObjCSelector>,
-                ffi.Pointer<ffi.Void>)>>()
-    .asFunction<
-        void Function(
-            ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>,
-            ffi.Pointer<objc.ObjCSelector>,
-            ffi.Pointer<ffi.Void>)>();
 final _objc_msgSend_1iyq28l = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -16032,14 +16038,6 @@ final _objc_msgSend_1lv8yz3 = objc.msgSendPointer
     .asFunction<
         bool Function(ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<ffi.Char>, int, int)>();
-final _objc_msgSend_1mbt9g9 = objc.msgSendPointer
-    .cast<
-        ffi.NativeFunction<
-            ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
-                ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<ffi.Void>)>>()
-    .asFunction<
-        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
-            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<ffi.Void>)>();
 final _objc_msgSend_1n40f6p = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -16200,6 +16198,24 @@ final _objc_msgSend_1qv0eq4 = objc.msgSendPointer
             ffi.Pointer<objc.ObjCSelector>,
             ffi.Pointer<objc.ObjCSelector>,
             ffi.Pointer<objc.ObjCObject>)>();
+final _objc_msgSend_1s2gdyk = objc.msgSendPointer
+    .cast<
+        ffi.NativeFunction<
+            ffi.Void Function(
+                ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<objc.ObjCSelector>,
+                ffi.Pointer<ffi.Void>,
+                ffi.Pointer<ffi.Void>,
+                ffi.Pointer<ffi.Char>)>>()
+    .asFunction<
+        void Function(
+            ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>,
+            ffi.Pointer<objc.ObjCSelector>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<ffi.Void>,
+            ffi.Pointer<ffi.Char>)>();
 final _objc_msgSend_1sotr3r = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -17417,6 +17433,7 @@ late final _sel_bookmarkDataWithOptions_includingResourceValuesForKeys_relativeT
     objc.registerName(
         "bookmarkDataWithOptions:includingResourceValuesForKeys:relativeToURL:error:");
 late final _sel_boolValue = objc.registerName("boolValue");
+late final _sel_buildInstance_ = objc.registerName("buildInstance:");
 late final _sel_bytes = objc.registerName("bytes");
 late final _sel_cStringUsingEncoding_ =
     objc.registerName("cStringUsingEncoding:");
@@ -17622,8 +17639,8 @@ late final _sel_hash = objc.registerName("hash");
 late final _sel_helpAnchor = objc.registerName("helpAnchor");
 late final _sel_host = objc.registerName("host");
 late final _sel_illegalCharacterSet = objc.registerName("illegalCharacterSet");
-late final _sel_implementMethod_withBlock_ =
-    objc.registerName("implementMethod:withBlock:");
+late final _sel_implementMethod_withBlock_withTrampoline_withSignature_ = objc
+    .registerName("implementMethod:withBlock:withTrampoline:withSignature:");
 late final _sel_increaseLengthBy_ = objc.registerName("increaseLengthBy:");
 late final _sel_indexGreaterThanIndex_ =
     objc.registerName("indexGreaterThanIndex:");
@@ -17699,7 +17716,7 @@ late final _sel_initWithCharactersNoCopy_length_freeWhenDone_ =
     objc.registerName("initWithCharactersNoCopy:length:freeWhenDone:");
 late final _sel_initWithCharacters_length_ =
     objc.registerName("initWithCharacters:length:");
-late final _sel_initWithClass_ = objc.registerName("initWithClass:");
+late final _sel_initWithClassName_ = objc.registerName("initWithClassName:");
 late final _sel_initWithCoder_ = objc.registerName("initWithCoder:");
 late final _sel_initWithContentsOfFile_ =
     objc.registerName("initWithContentsOfFile:");
@@ -18050,6 +18067,7 @@ late final _sel_rangeOfString_options_range_locale_ =
     objc.registerName("rangeOfString:options:range:locale:");
 late final _sel_read_maxLength_ = objc.registerName("read:maxLength:");
 late final _sel_recoveryAttempter = objc.registerName("recoveryAttempter");
+late final _sel_registerClass = objc.registerName("registerClass");
 late final _sel_registerObject_visibility_ =
     objc.registerName("registerObject:visibility:");
 late final _sel_registeredTypeIdentifiers =

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -1160,7 +1160,7 @@ interface class NSCoding extends objc.ObjCProtocolBase {
   }
 
   /// Returns the [objc.Protocol] object for this protocol.
-  static get $protocol =>
+  static objc.Protocol get $protocol =>
       objc.Protocol.castFromPointer(_protocol_NSCoding.cast());
 
   /// Builds an object that implements the NSCoding protocol. To implement
@@ -1345,7 +1345,7 @@ interface class NSCopying extends objc.ObjCProtocolBase {
   }
 
   /// Returns the [objc.Protocol] object for this protocol.
-  static get $protocol =>
+  static objc.Protocol get $protocol =>
       objc.Protocol.castFromPointer(_protocol_NSCopying.cast());
 
   /// Builds an object that implements the NSCopying protocol. To implement
@@ -3708,7 +3708,7 @@ interface class NSFastEnumeration extends objc.ObjCProtocolBase {
   }
 
   /// Returns the [objc.Protocol] object for this protocol.
-  static get $protocol =>
+  static objc.Protocol get $protocol =>
       objc.Protocol.castFromPointer(_protocol_NSFastEnumeration.cast());
 
   /// Builds an object that implements the NSFastEnumeration protocol. To implement
@@ -4347,7 +4347,7 @@ interface class NSItemProviderReading extends objc.ObjCProtocolBase
   }
 
   /// Returns the [objc.Protocol] object for this protocol.
-  static get $protocol =>
+  static objc.Protocol get $protocol =>
       objc.Protocol.castFromPointer(_protocol_NSItemProviderReading.cast());
 
   /// Builds an object that implements the NSItemProviderReading protocol. To implement
@@ -4417,7 +4417,7 @@ interface class NSItemProviderWriting extends objc.ObjCProtocolBase
   }
 
   /// Returns the [objc.Protocol] object for this protocol.
-  static get $protocol =>
+  static objc.Protocol get $protocol =>
       objc.Protocol.castFromPointer(_protocol_NSItemProviderWriting.cast());
 
   /// Builds an object that implements the NSItemProviderWriting protocol. To implement
@@ -4882,7 +4882,7 @@ interface class NSMutableCopying extends objc.ObjCProtocolBase {
   }
 
   /// Returns the [objc.Protocol] object for this protocol.
-  static get $protocol =>
+  static objc.Protocol get $protocol =>
       objc.Protocol.castFromPointer(_protocol_NSMutableCopying.cast());
 
   /// Builds an object that implements the NSMutableCopying protocol. To implement
@@ -7615,7 +7615,7 @@ interface class NSObjectProtocol extends objc.ObjCProtocolBase {
   }
 
   /// Returns the [objc.Protocol] object for this protocol.
-  static get $protocol =>
+  static objc.Protocol get $protocol =>
       objc.Protocol.castFromPointer(_protocol_NSObject.cast());
 
   /// Builds an object that implements the NSObject protocol. To implement
@@ -9162,7 +9162,7 @@ interface class NSSecureCoding extends objc.ObjCProtocolBase
   }
 
   /// Returns the [objc.Protocol] object for this protocol.
-  static get $protocol =>
+  static objc.Protocol get $protocol =>
       objc.Protocol.castFromPointer(_protocol_NSSecureCoding.cast());
 
   /// Builds an object that implements the NSSecureCoding protocol. To implement
@@ -9665,7 +9665,7 @@ interface class NSStreamDelegate extends objc.ObjCProtocolBase
   }
 
   /// Returns the [objc.Protocol] object for this protocol.
-  static get $protocol =>
+  static objc.Protocol get $protocol =>
       objc.Protocol.castFromPointer(_protocol_NSStreamDelegate.cast());
 
   /// Builds an object that implements the NSStreamDelegate protocol. To implement

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -456,7 +456,7 @@ class DartInputStreamAdapter extends NSInputStream implements NSStreamDelegate {
   }
 }
 
-/// DOBJCDartProtocol
+/// Base class of all classes DOBJCDartProtocolBuilder creates.
 class DartProtocol extends NSObject {
   DartProtocol._(ffi.Pointer<objc.ObjCObject> pointer,
       {bool retain = false, bool release = false})
@@ -551,7 +551,8 @@ class DartProtocol extends NSObject {
   factory DartProtocol() => new$();
 }
 
-/// DOBJCDartProtocolBuilder
+/// Used by the Dart ObjCProtocolBuilder to construct ObjC classes at runtime to
+/// implement protocols.
 class DartProtocolBuilder extends NSObject {
   DartProtocolBuilder._(ffi.Pointer<objc.ObjCObject> pointer,
       {bool retain = false, bool release = false})

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -620,6 +620,14 @@ class DartProtocolBuilder extends NSObject {
         retain: false, release: true);
   }
 
+  /// initWithClass:
+  DartProtocolBuilder initWithClass_(ffi.Pointer<ffi.Void> cls) {
+    final _ret = _objc_msgSend_1mbt9g9(
+        this.ref.retainAndReturnPointer(), _sel_initWithClass_, cls);
+    return DartProtocolBuilder.castFromPointer(_ret,
+        retain: false, release: true);
+  }
+
   /// retain
   DartProtocolBuilder retain() {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_retain);
@@ -16024,6 +16032,14 @@ final _objc_msgSend_1lv8yz3 = objc.msgSendPointer
     .asFunction<
         bool Function(ffi.Pointer<objc.ObjCObject>,
             ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<ffi.Char>, int, int)>();
+final _objc_msgSend_1mbt9g9 = objc.msgSendPointer
+    .cast<
+        ffi.NativeFunction<
+            ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
+                ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<ffi.Void>)>>()
+    .asFunction<
+        ffi.Pointer<objc.ObjCObject> Function(ffi.Pointer<objc.ObjCObject>,
+            ffi.Pointer<objc.ObjCSelector>, ffi.Pointer<ffi.Void>)>();
 final _objc_msgSend_1n40f6p = objc.msgSendPointer
     .cast<
         ffi.NativeFunction<
@@ -17683,6 +17699,7 @@ late final _sel_initWithCharactersNoCopy_length_freeWhenDone_ =
     objc.registerName("initWithCharactersNoCopy:length:freeWhenDone:");
 late final _sel_initWithCharacters_length_ =
     objc.registerName("initWithCharacters:length:");
+late final _sel_initWithClass_ = objc.registerName("initWithClass:");
 late final _sel_initWithCoder_ = objc.registerName("initWithCoder:");
 late final _sel_initWithContentsOfFile_ =
     objc.registerName("initWithContentsOfFile:");

--- a/pkgs/objective_c/lib/src/protocol_builder.dart
+++ b/pkgs/objective_c/lib/src/protocol_builder.dart
@@ -59,7 +59,7 @@ class ObjCProtocolBuilder {
     }
     final obj = objc.DartProtocol.castFromPointer(
         _msgSendAlloc(_class, _selAlloc),
-        retain: true,
+        retain: false,
         release: true);
 
     var disposePort = c.ILLEGAL_PORT;

--- a/pkgs/objective_c/lib/src/protocol_builder.dart
+++ b/pkgs/objective_c/lib/src/protocol_builder.dart
@@ -58,6 +58,13 @@ class ObjCProtocolBuilder {
     return _builder.buildInstance_(disposePort);
   }
 
+  /// Add the [protocol] to this implementation.
+  ///
+  /// This essentially declares that the implementation implements the protocol.
+  /// There is no automatic check that ensures that the implementation actually
+  /// implements all the methods of the protocol.
+  void addProtocol(objc.Protocol protocol) => _builder.addProtocol_(protocol);
+
   static final _rand = Random();
   static objc.DartProtocolBuilder _createBuilder(String debugName) {
     final name = '${debugName}_${_rand.nextInt(1 << 32)}'.toNativeUtf8();

--- a/pkgs/objective_c/lib/src/protocol_builder.dart
+++ b/pkgs/objective_c/lib/src/protocol_builder.dart
@@ -26,8 +26,9 @@ class ObjCProtocolBuilder {
   final Pointer<c.ObjCObject> _class;
   var _built = false;
 
-  ObjCProtocolBuilder._(this._class) :
-      _builder = objc.DartProtocolBuilder.alloc().initWithClass_(_class.cast());
+  ObjCProtocolBuilder._(this._class)
+      : _builder =
+            objc.DartProtocolBuilder.alloc().initWithClass_(_class.cast());
 
   ObjCProtocolBuilder({String? debugName})
       : this._(_createProtocolClass(debugName));

--- a/pkgs/objective_c/lib/src/protocol_builder.dart
+++ b/pkgs/objective_c/lib/src/protocol_builder.dart
@@ -10,28 +10,19 @@ import 'package:ffi/ffi.dart';
 
 import 'c_bindings_generated.dart' as c;
 import 'internal.dart'
-    show
-        FailedToLoadProtocolMethodException,
-        GetProtocolName,
-        ObjCBlockBase,
-        getClass,
-        msgSendPointer,
-        registerName;
+    show FailedToLoadProtocolMethodException, GetProtocolName, ObjCBlockBase;
 import 'objective_c_bindings_generated.dart' as objc;
 import 'selector.dart';
 
 /// Helper class for building Objective C objects that implement protocols.
 class ObjCProtocolBuilder {
   final objc.DartProtocolBuilder _builder;
-  final Pointer<c.ObjCObject> _class;
   var _built = false;
 
-  ObjCProtocolBuilder._(this._class)
-      : _builder =
-            objc.DartProtocolBuilder.alloc().initWithClass_(_class.cast());
+  objc.DartProtocolBuilder get builder => _builder;
 
-  ObjCProtocolBuilder({String? debugName})
-      : this._(_createProtocolClass(debugName));
+  ObjCProtocolBuilder({String debugName = 'DOBJCDartProtocol'})
+      : _builder = _createBuilder(debugName);
 
   /// Add a method implementation to the protocol.
   ///
@@ -44,8 +35,8 @@ class ObjCProtocolBuilder {
     if (_built) {
       throw StateError('Protocol is already built');
     }
-    c.addMethod(_class, sel, trampoline, signature);
-    _builder.implementMethod_withBlock_(sel, block.ref.pointer.cast());
+    _builder.implementMethod_withBlock_withTrampoline_withSignature_(
+        sel, block.ref.pointer.cast(), trampoline, signature);
   }
 
   /// Builds the object.
@@ -54,13 +45,9 @@ class ObjCProtocolBuilder {
   /// that all implement the same protocol methods using the same functions.
   objc.NSObject build({bool keepIsolateAlive = true}) {
     if (!_built) {
-      c.registerClassPair(_class);
+      _builder.registerClass();
       _built = true;
     }
-    final obj = objc.DartProtocol.castFromPointer(
-        _msgSendAlloc(_class, _selAlloc),
-        retain: false,
-        release: true);
 
     var disposePort = c.ILLEGAL_PORT;
     if (keepIsolateAlive) {
@@ -68,28 +55,16 @@ class ObjCProtocolBuilder {
       keepAlivePort = RawReceivePort((_) => keepAlivePort.close());
       disposePort = keepAlivePort.sendPort.nativePort;
     }
-    return obj.initDOBJCDartProtocolFromDartProtocolBuilder_withDisposePort_(
-        _builder, disposePort);
+    return _builder.buildInstance_(disposePort);
   }
 
-  static final _msgSendAlloc = msgSendPointer
-      .cast<
-          NativeFunction<
-              Pointer<c.ObjCObject> Function(
-                  Pointer<c.ObjCObject>, Pointer<c.ObjCSelector>)>>()
-      .asFunction<
-          Pointer<c.ObjCObject> Function(
-              Pointer<c.ObjCObject>, Pointer<c.ObjCSelector>)>();
-  static final _selAlloc = registerName('alloc');
-
-  static final _protocolClass = getClass('DOBJCDartProtocol');
   static final _rand = Random();
-  static Pointer<c.ObjCObject> _createProtocolClass(String? debugName) {
-    debugName ??= 'DOBJCDartProtocol';
+  static objc.DartProtocolBuilder _createBuilder(String debugName) {
     final name = '${debugName}_${_rand.nextInt(1 << 32)}'.toNativeUtf8();
-    final cls = c.allocateClassPair(_protocolClass, name.cast(), 0);
+    final builder =
+        objc.DartProtocolBuilder.alloc().initWithClassName_(name.cast());
     calloc.free(name);
-    return cls;
+    return builder;
   }
 }
 

--- a/pkgs/objective_c/lib/src/protocol_builder.dart
+++ b/pkgs/objective_c/lib/src/protocol_builder.dart
@@ -59,7 +59,7 @@ class ObjCProtocolBuilder {
     }
     final obj = objc.DartProtocol.castFromPointer(
         _msgSendAlloc(_class, _selAlloc),
-        retain: false,
+        retain: true,
         release: true);
 
     var disposePort = c.ILLEGAL_PORT;

--- a/pkgs/objective_c/lib/src/protocol_builder.dart
+++ b/pkgs/objective_c/lib/src/protocol_builder.dart
@@ -22,12 +22,15 @@ import 'selector.dart';
 
 /// Helper class for building Objective C objects that implement protocols.
 class ObjCProtocolBuilder {
-  final _builder = objc.DartProtocolBuilder();
+  final objc.DartProtocolBuilder _builder;
   final Pointer<c.ObjCObject> _class;
   var _built = false;
 
+  ObjCProtocolBuilder._(this._class) :
+      _builder = objc.DartProtocolBuilder.alloc().initWithClass_(_class.cast());
+
   ObjCProtocolBuilder({String? debugName})
-      : _class = _createProtocolClass(debugName);
+      : this._(_createProtocolClass(debugName));
 
   /// Add a method implementation to the protocol.
   ///

--- a/pkgs/objective_c/src/objective_c_runtime.h
+++ b/pkgs/objective_c/src/objective_c_runtime.h
@@ -9,8 +9,6 @@
 #ifndef OBJECTIVE_C_SRC_OBJECTIVE_C_RUNTIME_H_
 #define OBJECTIVE_C_SRC_OBJECTIVE_C_RUNTIME_H_
 
-#include <stddef.h>
-
 #include "include/dart_api_dl.h"
 
 typedef struct _ObjCSelector ObjCSelector;
@@ -26,11 +24,6 @@ void objc_release(ObjCObject *object);
 ObjCObject *objc_autorelease(ObjCObject *object);
 ObjCObject *object_getClass(ObjCObject *object);
 ObjCObject** objc_copyClassList(unsigned int* count);
-ObjCObject *objc_allocateClassPair(
-    ObjCObject *superclass, const char *name, size_t extraBytes);
-void objc_registerClassPair(ObjCObject *cls);
-bool class_addMethod(
-    ObjCObject *cls, ObjCSelector *name, void *imp, const char *types);
 
 // The signature of this function is just a placeholder. This function is used
 // by every method invocation, and is cast to every signature we need.

--- a/pkgs/objective_c/src/protocol.h
+++ b/pkgs/objective_c/src/protocol.h
@@ -10,8 +10,7 @@
 #include "include/dart_api_dl.h"
 
 @interface DOBJCDartProtocolBuilder : NSObject
-+ (instancetype)new;
-- (instancetype)init;
+- (instancetype)initWithClass: (void*)cls;
 - (void)implementMethod:(SEL) sel withBlock:(void*)block;
 @end
 

--- a/pkgs/objective_c/src/protocol.h
+++ b/pkgs/objective_c/src/protocol.h
@@ -19,6 +19,7 @@
 - (instancetype)initWithClassName: (const char*)name;
 - (void)implementMethod:(SEL)sel withBlock:(void*)block
     withTrampoline:(void*)trampoline withSignature:(char*)signature;
+- (void)addProtocol:(Protocol*) protocol;
 - (void)registerClass;
 - (DOBJCDartProtocol*)buildInstance: (Dart_Port)port;
 @end

--- a/pkgs/objective_c/src/protocol.h
+++ b/pkgs/objective_c/src/protocol.h
@@ -11,6 +11,10 @@
 
 @class DOBJCDartProtocol;
 
+/**
+ * Used by the Dart ObjCProtocolBuilder to construct ObjC classes at runtime to
+ * implement protocols.
+ */
 @interface DOBJCDartProtocolBuilder : NSObject
 - (instancetype)initWithClassName: (const char*)name;
 - (void)implementMethod:(SEL)sel withBlock:(void*)block
@@ -19,6 +23,9 @@
 - (DOBJCDartProtocol*)buildInstance: (Dart_Port)port;
 @end
 
+/**
+ * Base class of all classes DOBJCDartProtocolBuilder creates.
+ */
 @interface DOBJCDartProtocol : NSObject
 - (instancetype)initDOBJCDartProtocolFromDartProtocolBuilder:
     (DOBJCDartProtocolBuilder*)builder

--- a/pkgs/objective_c/src/protocol.h
+++ b/pkgs/objective_c/src/protocol.h
@@ -9,9 +9,14 @@
 
 #include "include/dart_api_dl.h"
 
+@class DOBJCDartProtocol;
+
 @interface DOBJCDartProtocolBuilder : NSObject
-- (instancetype)initWithClass: (void*)cls;
-- (void)implementMethod:(SEL) sel withBlock:(void*)block;
+- (instancetype)initWithClassName: (const char*)name;
+- (void)implementMethod:(SEL)sel withBlock:(void*)block
+    withTrampoline:(void*)trampoline withSignature:(char*)signature;
+- (void)registerClass;
+- (DOBJCDartProtocol*)buildInstance: (Dart_Port)port;
 @end
 
 @interface DOBJCDartProtocol : NSObject

--- a/pkgs/objective_c/src/protocol.m
+++ b/pkgs/objective_c/src/protocol.m
@@ -18,10 +18,10 @@
   Class clazz;
 }
 
-- (instancetype)initWithClass: (void*)cls {
+- (instancetype)initWithClassName: (const char*)name {
   if (self) {
     methods = [NSMutableDictionary new];
-    clazz = (__bridge Class)cls;
+    clazz = objc_allocateClassPair([DOBJCDartProtocol class], name, 0);
   }
   return self;
 }
@@ -32,8 +32,20 @@
   }
 }
 
-- (void)implementMethod:(SEL)sel withBlock:(void*)block {
+- (void)implementMethod:(SEL)sel withBlock:(void*)block
+    withTrampoline:(void*)trampoline withSignature:(char*)signature {
+  class_addMethod(clazz, sel, trampoline, signature);
   [self implement:sel withBlock:(__bridge id)block];
+}
+
+- (void)registerClass {
+  objc_registerClassPair(clazz);
+}
+
+- (DOBJCDartProtocol*)buildInstance: (Dart_Port)port {
+  DOBJCDartProtocol* inst = [clazz alloc];
+  return [inst initDOBJCDartProtocolFromDartProtocolBuilder:self
+               withDisposePort:port];
 }
 
 - (void)dealloc {

--- a/pkgs/objective_c/src/protocol.m
+++ b/pkgs/objective_c/src/protocol.m
@@ -19,10 +19,8 @@
 }
 
 - (instancetype)initWithClassName: (const char*)name {
-  if (self) {
-    methods = [NSMutableDictionary new];
-    clazz = objc_allocateClassPair([DOBJCDartProtocol class], name, 0);
-  }
+  methods = [NSMutableDictionary new];
+  clazz = objc_allocateClassPair([DOBJCDartProtocol class], name, 0);
   return self;
 }
 
@@ -66,10 +64,8 @@
 - (instancetype)initDOBJCDartProtocolFromDartProtocolBuilder:
     (DOBJCDartProtocolBuilder*)builder_
     withDisposePort:(Dart_Port)port {
-  if (self) {
-    builder = builder_;
-    dispose_port = port;
-  }
+  builder = builder_;
+  dispose_port = port;
   return self;
 }
 

--- a/pkgs/objective_c/src/protocol.m
+++ b/pkgs/objective_c/src/protocol.m
@@ -13,36 +13,15 @@
 #error "This file must be compiled with ARC enabled"
 #endif
 
-@interface DOBJCDartProtocolClass : NSObject
-- (instancetype)initWithClass: (Class)cls;
-@end
-
-@implementation DOBJCDartProtocolClass {
-  Class clazz;
-}
-
-- (instancetype)initWithClass: (Class)cls {
-  if (self) {
-    clazz = cls;
-  }
-  return self;
-}
-
-- (void)dealloc {
-  objc_disposeClassPair(clazz);
-}
-
-@end
-
 @implementation DOBJCDartProtocolBuilder {
-  NSMutableDictionary *methods;
-  DOBJCDartProtocolClass* clazz;
+  @public NSMutableDictionary *methods;
+  Class clazz;
 }
 
 - (instancetype)initWithClass: (void*)cls {
   if (self) {
     methods = [NSMutableDictionary new];
-    clazz = [[DOBJCDartProtocolClass alloc] initWithClass: (__bridge Class)cls];
+    clazz = (__bridge Class)cls;
   }
   return self;
 }
@@ -57,32 +36,26 @@
   [self implement:sel withBlock:(__bridge id)block];
 }
 
-- (NSDictionary*)getMethods {
-  return methods;
-}
-
-- (DOBJCDartProtocolClass*)getClass {
-  return clazz;
+- (void)dealloc {
+  objc_disposeClassPair(clazz);
 }
 
 @end
 
 @implementation DOBJCDartProtocol {
-  NSDictionary *methods;
-  DOBJCDartProtocolClass* clazz;
+  DOBJCDartProtocolBuilder* builder;
   Dart_Port dispose_port;
 }
 
 - (id)getDOBJCDartProtocolMethodForSelector:(SEL)sel {
-  return [methods objectForKey:[NSValue valueWithPointer:sel]];
+  return [builder->methods objectForKey:[NSValue valueWithPointer:sel]];
 }
 
 - (instancetype)initDOBJCDartProtocolFromDartProtocolBuilder:
-    (DOBJCDartProtocolBuilder*)builder
+    (DOBJCDartProtocolBuilder*)builder_
     withDisposePort:(Dart_Port)port {
   if (self) {
-    methods = [builder getMethods];
-    clazz = [builder getClass];
+    builder = builder_;
     dispose_port = port;
   }
   return self;

--- a/pkgs/objective_c/src/protocol.m
+++ b/pkgs/objective_c/src/protocol.m
@@ -14,14 +14,14 @@
 #endif
 
 @interface DOBJCDartProtocolClass : NSObject
-- (instancetype)initWithClass: (void*)cls;
+- (instancetype)initWithClass: (Class)cls;
 @end
 
 @implementation DOBJCDartProtocolClass {
-  void* clazz;
+  Class clazz;
 }
 
-- (instancetype)initWithClass: (void*)cls {
+- (instancetype)initWithClass: (Class)cls {
   if (self) {
     clazz = cls;
   }
@@ -29,7 +29,7 @@
 }
 
 - (void)dealloc {
-  objc_disposeClassPair((__bridge Class)clazz);
+  objc_disposeClassPair(clazz);
 }
 
 @end
@@ -42,7 +42,7 @@
 - (instancetype)initWithClass: (void*)cls {
   if (self) {
     methods = [NSMutableDictionary new];
-    clazz = [[DOBJCDartProtocolClass alloc] initWithClass: cls];
+    clazz = [[DOBJCDartProtocolClass alloc] initWithClass: (__bridge Class)cls];
   }
   return self;
 }

--- a/pkgs/objective_c/src/protocol.m
+++ b/pkgs/objective_c/src/protocol.m
@@ -37,8 +37,8 @@
   [self implement:sel withBlock:(__bridge id)block];
 }
 
-- (NSDictionary*)copyMethods NS_RETURNS_RETAINED {
-  return [methods copy];
+- (NSDictionary*)getMethods NS_RETURNS_RETAINED {
+  return methods;
 }
 @end
 
@@ -55,7 +55,7 @@
     (DOBJCDartProtocolBuilder*)builder
     withDisposePort:(Dart_Port)port {
   if (self) {
-    methods = [builder copyMethods];
+    methods = [builder getMethods];
     dispose_port = port;
   }
   return self;

--- a/pkgs/objective_c/src/protocol.m
+++ b/pkgs/objective_c/src/protocol.m
@@ -24,16 +24,17 @@
   return self;
 }
 
-- (void)implement:(SEL)sel withBlock:(id)block {
-  @synchronized(methods) {
-    [methods setObject:block forKey:[NSValue valueWithPointer:sel]];
-  }
-}
-
 - (void)implementMethod:(SEL)sel withBlock:(void*)block
     withTrampoline:(void*)trampoline withSignature:(char*)signature {
   class_addMethod(clazz, sel, trampoline, signature);
-  [self implement:sel withBlock:(__bridge id)block];
+  NSValue* key = [NSValue valueWithPointer:sel];
+  @synchronized(methods) {
+    [methods setObject:(__bridge id)block forKey:key];
+  }
+}
+
+- (void)addProtocol:(Protocol*) protocol {
+  class_addProtocol(clazz, protocol);
 }
 
 - (void)registerClass {


### PR DESCRIPTION
Clean up the class object when the implementation object and the builder have been destroyed, by wrapping it in a `DOBJCDartProtocolClass` object that calls `objc_disposeClassPair` in its `dispose` method, and having the builder and instances hold a reference to this object.

Also, since we're not allowing adding more methods after building the protocol, we don't have to copy the method table during instantiation anymore.

Finally, re-add a bunch of other GC tests that I accidentally deleted.

Fixes #2042