### PR TITLE
[native_toolchain_c] Correctly set up hook input

### DIFF
--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -141,10 +141,10 @@ void main() {
                 outputDirectoryShared: tempUri2,
               )
               ..config.setupBuild(linkingEnabled: false);
+        buildInputBuilder.config.setupShared(
+          buildAssetTypes: [if (buildCodeAssets) CodeAsset.type],
+        );
         if (buildCodeAssets) {
-          buildInputBuilder.config.setupShared(
-            buildAssetTypes: [CodeAsset.type],
-          );
           buildInputBuilder.config.setupCode(
             targetOS: targetOS,
             macOS: macOSConfig,


### PR DESCRIPTION
The builder API is rather error prone (https://github.com/dart-lang/native/issues/2059).

Here is one wrong invocation.