### PR TITLE
[ffigen] Use isolate ownership API to fix blocking block deadlocks

### DIFF
--- a/.github/workflows/ffigen.yml
+++ b/.github/workflows/ffigen.yml
@@ -76,11 +76,14 @@ jobs:
     defaults:
       run:
         working-directory: pkgs/ffigen/
+    strategy:
+      matrix:
+        channel: [stable, dev]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff
         with:
-          channel: 'stable'
+          channel: ${{ matrix.channel }}
       - name: Install dependencies
         run: flutter pub get && flutter pub get --directory="../objective_c" && flutter pub get --directory="../jni"
       - name: Install clang-format

--- a/pkgs/ffigen/lib/src/code_generator/imports.dart
+++ b/pkgs/ffigen/lib/src/code_generator/imports.dart
@@ -169,3 +169,5 @@ final objCBlockType =
     ImportedType(objcPkgImport, 'ObjCBlockImpl', 'ObjCBlockImpl', 'id');
 final objCProtocolType =
     ImportedType(objcPkgImport, 'ObjCProtocol', 'ObjCProtocol', 'void');
+final objCContextType = ImportedType(
+    objcPkgImport, 'DOBJC_Context', 'DOBJC_Context', 'DOBJC_Context');

--- a/pkgs/ffigen/lib/src/code_generator/objc_block.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_block.dart
@@ -405,23 +405,14 @@ typedef ${returnType.getNativeType()} (^$blockingName)($blockingArgStr);
 __attribute__((visibility("default"))) __attribute__((used))
 $listenerName $blockingWrapper(
     $blockingName block, $blockingName listenerBlock,
-    DOBJC_Context* context) NS_RETURNS_RETAINED {
-  assert(context->version >= 1);
-  void* targetIsolate = context->currentIsolate();
-  // int64_t targetIsolatePort = context->getMainPortId();
-  return ^void($argStr) {
-    void* currentIsolate = context->currentIsolate();
-    if (currentIsolate == targetIsolate) {
-      ${generateRetain('block')};
-      block(${blockingRetains.join(', ')});
-    // } else if (context->getMainPortId()) {
-    } else {
-      void* waiter = context->newWaiter();
-      ${generateRetain('listenerBlock')};
-      listenerBlock(${blockingListenerRetains.join(', ')});
-      context->awaitWaiter(waiter);
-    }
-  };
+    DOBJC_Context* ctx) NS_RETURNS_RETAINED {
+  BLOCKING_BLOCK_IMPL(ctx, ^void($argStr), {
+    ${generateRetain('block')};
+    block(${blockingRetains.join(', ')});
+  }, {
+    ${generateRetain('listenerBlock')};
+    listenerBlock(${blockingListenerRetains.join(', ')});
+  });
 }
 ''';
   }

--- a/pkgs/ffigen/lib/src/code_generator/objc_built_in_functions.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_built_in_functions.dart
@@ -34,7 +34,7 @@ class ObjCBuiltInFunctions {
   static const getProtocol = ObjCImport('getProtocol');
   static const objectRelease = ObjCImport('objectRelease');
   static const signalWaiter = ObjCImport('signalWaiter');
-  static const wrapBlockingBlock = ObjCImport('wrapBlockingBlock');
+  static const objCContext = ObjCImport('objCContext');
   static const objectBase = ObjCImport('ObjCObjectBase');
   static const protocolBase = ObjCImport('ObjCProtocolBase');
   static const blockType = ObjCImport('ObjCBlock');
@@ -260,16 +260,8 @@ class ObjCBuiltInFunctions {
                 type: PointerType(objCBlockType),
                 objCConsumed: false),
             Parameter(
-                name: 'newWaiter',
-                type: PointerType(NativeFunc(FunctionType(
-                    returnType: PointerType(voidType), parameters: []))),
-                objCConsumed: false),
-            Parameter(
-                name: 'awaitWaiter',
-                type: PointerType(
-                    NativeFunc(FunctionType(returnType: voidType, parameters: [
-                  Parameter(type: PointerType(voidType), objCConsumed: false),
-                ]))),
+                name: 'context',
+                type: PointerType(objCContextType),
                 objCConsumed: false),
           ],
         ],

--- a/pkgs/ffigen/lib/src/code_generator/writer.dart
+++ b/pkgs/ffigen/lib/src/code_generator/writer.dart
@@ -441,6 +441,17 @@ class Writer {
 #error "This file must be compiled with ARC enabled"
 #endif
 
+typedef struct {
+  int64_t version;
+  void* (*newWaiter)(void);
+  void (*awaitWaiter)(void*);
+  void* (*currentIsolate)(void);
+  void (*enterIsolate)(void*);
+  void (*exitIsolate)(void);
+  int64_t (*getMainPortId)(void);
+  bool (*getCurrentThreadOwnsIsolate)(int64_t);
+} DOBJC_Context;
+
 id objc_retainBlock(id);
 ''');
 

--- a/pkgs/ffigen/test/native_objc_test/block_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test.dart
@@ -53,6 +53,8 @@ void main() {
       lib = BlockTestObjCLibrary(DynamicLibrary.open(dylib.absolute.path));
 
       generateBindingsForCoverage('block');
+
+      BlockTester.setup_(NativeApi.initializeApiDLData);
     });
 
     test('BlockTester is working', () {
@@ -1051,6 +1053,17 @@ void main() {
 
       receivePort.close();
     }, skip: !canDoGC);
+
+    test('Blocking block deadlock', () {
+      // Regression test for https://github.com/dart-lang/native/issues/1967
+      int value = 0;
+      final block = VoidBlock.blocking(() {
+        waitSync(Duration(milliseconds: 100));
+        value = 123;
+      });
+      BlockTester.callOnSameThreadOutsideIsolate_(block);
+      expect(value, 123);
+    });
   });
 }
 

--- a/pkgs/ffigen/test/native_objc_test/block_test.h
+++ b/pkgs/ffigen/test/native_objc_test/block_test.h
@@ -55,6 +55,7 @@ typedef void (^ResultBlock)(int32_t);
   __strong IntBlock myBlock;
   __strong ObjectListenerBlock myListener;
 }
++ (void)setup:(void*)apiData;
 + (BlockTester*)newFromBlock:(IntBlock)block;
 + (BlockTester*)newFromMultiplier:(int32_t)mult;
 + (BlockTester*)newFromListener:(ObjectListenerBlock)block;
@@ -62,6 +63,7 @@ typedef void (^ResultBlock)(int32_t);
 - (IntBlock)getBlock NS_RETURNS_RETAINED;
 - (void)pokeBlock;
 + (void)callOnSameThread:(VoidBlock)block;
++ (void)callOnSameThreadOutsideIsolate:(VoidBlock)block;
 + (NSThread*)callOnNewThread:(VoidBlock)block NS_RETURNS_RETAINED;
 + (NSThread*)callWithBlockOnNewThread:(ListenerBlock)block NS_RETURNS_RETAINED;
 + (float)callFloatBlock:(FloatBlock)block;

--- a/pkgs/ffigen/test/native_objc_test/block_test.m
+++ b/pkgs/ffigen/test/native_objc_test/block_test.m
@@ -7,6 +7,7 @@
 #import <Foundation/NSThread.h>
 
 #include "block_test.h"
+#include "../../../objective_c/src/include/dart_api_dl.h"
 
 @implementation DummyObject
 
@@ -32,6 +33,10 @@
 @end
 
 @implementation BlockTester
+
++ (void)setup:(void*)apiData {
+  Dart_InitializeApiDL(apiData);
+}
 
 + (BlockTester*)newFromBlock:(IntBlock)block {
   BlockTester* bt = [BlockTester new];
@@ -70,6 +75,13 @@ void objc_release(id value);
 
 + (void)callOnSameThread:(VoidBlock)block {
   block();
+}
+
++ (void)callOnSameThreadOutsideIsolate:(VoidBlock)block {
+  Dart_Isolate isolate = Dart_CurrentIsolate_DL();
+  Dart_ExitIsolate_DL();
+  block();
+  Dart_EnterIsolate_DL(isolate);
 }
 
 + (NSThread*)callOnNewThread:(VoidBlock)block NS_RETURNS_RETAINED {

--- a/pkgs/ffigen/test/native_objc_test/setup.dart
+++ b/pkgs/ffigen/test/native_objc_test/setup.dart
@@ -24,12 +24,14 @@ Future<void> _runClang(List<String> flags, String output) async {
   print('Generated file: $output');
 }
 
-Future<String> _buildObject(String input) async {
+Future<String> _buildObject(String input, {bool objc = false}) async {
   final output = '$input.o';
   await _runClang([
-    '-x',
-    'objective-c',
-    if (!arcDisabledFiles.contains(input)) '-fobjc-arc',
+    if (objc) ...[
+      '-x',
+      'objective-c',
+    ],
+    if (objc && !arcDisabledFiles.contains(input)) '-fobjc-arc',
     '-Wno-nullability-completeness',
     '-c',
     input,
@@ -48,8 +50,10 @@ Future<void> _linkLib(List<String> inputs, String output) => _runClang([
 Future<void> _buildLib(List<String> inputs, String output) async {
   final objFiles = <String>[];
   for (final input in inputs) {
-    objFiles.add(await _buildObject(input));
+    objFiles.add(await _buildObject(input, objc: true));
   }
+  objFiles.add(await _buildObject(
+      '../../../objective_c/src/include/dart_api_dl.c'));
   await _linkLib(objFiles, output);
 }
 

--- a/pkgs/objective_c/ffigen_c.yaml
+++ b/pkgs/objective_c/ffigen_c.yaml
@@ -35,15 +35,7 @@ functions:
       - 'DOBJC_newFinalizableHandle'
       - 'DOBJC_awaitWaiter'
   rename:
-    'DOBJC_disposeObjCBlockWithClosure': 'disposeObjCBlockWithClosure'
-    'DOBJC_isValidBlock': 'isValidBlock'
-    'DOBJC_newFinalizableHandle': 'newFinalizableHandle'
-    'DOBJC_deleteFinalizableHandle': 'deleteFinalizableHandle'
-    'DOBJC_newFinalizableBool': 'newFinalizableBool'
-    'DOBJC_newWaiter': 'newWaiter'
-    'DOBJC_signalWaiter': 'signalWaiter'
-    'DOBJC_awaitWaiter': 'awaitWaiter'
-    'DOBJC_getOsVesion': 'getOsVesion'
+    'DOBJC_(.*)': '$1'
     'sel_registerName': 'registerName'
     'sel_getName': 'getName'
     'objc_getClass': 'getClass'
@@ -71,9 +63,12 @@ typedefs:
   include:
     - 'Dart_FinalizableHandle'
 structs:
+  include :
+    - '_DOBJC_Context'
   rename:
     '_ObjC(.*)': 'ObjC$1'
     '_Dart_FinalizableHandle': 'Dart_FinalizableHandle_'
+    '_DOBJC_Context': 'DOBJC_Context'
 macros:
   include:
     - 'ILLEGAL_PORT'

--- a/pkgs/objective_c/lib/objective_c.dart
+++ b/pkgs/objective_c/lib/objective_c.dart
@@ -6,6 +6,7 @@ export 'package:pub_semver/pub_semver.dart' show Version;
 export 'src/block.dart';
 export 'src/c_bindings_generated.dart'
     show
+        DOBJC_Context,
         Dart_FinalizableHandle_,
         ObjCBlockDesc,
         ObjCBlockImpl,

--- a/pkgs/objective_c/lib/src/c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/c_bindings_generated.dart
@@ -20,19 +20,10 @@ library;
 
 import 'dart:ffi' as ffi;
 
-@ffi.Native<ffi.IntPtr Function(ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external int DOBJC_InitializeApi(
+@ffi.Native<ffi.IntPtr Function(ffi.Pointer<ffi.Void>)>(
+    symbol: "DOBJC_InitializeApi", isLeaf: true)
+external int InitializeApi(
   ffi.Pointer<ffi.Void> data,
-);
-
-@ffi.Native<
-    ffi.Void Function(
-        ffi.Pointer<
-            ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>,
-        ffi.Pointer<ffi.Void>)>(isLeaf: true)
-external void DOBJC_runOnMainThread(
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>> fn,
-  ffi.Pointer<ffi.Void> arg,
 );
 
 @ffi.Array.multi([32])
@@ -111,6 +102,12 @@ external void deleteFinalizableHandle(
     symbol: "DOBJC_disposeObjCBlockWithClosure")
 external void disposeObjCBlockWithClosure(
   ffi.Pointer<ObjCBlockImpl> block,
+);
+
+@ffi.Native<ffi.Pointer<DOBJC_Context> Function(ffi.Pointer<DOBJC_Context>)>(
+    symbol: "DOBJC_fillContext", isLeaf: true)
+external ffi.Pointer<DOBJC_Context> fillContext(
+  ffi.Pointer<DOBJC_Context> context,
 );
 
 @ffi.Native<ffi.Pointer<ObjCObject> Function(ffi.Pointer<ffi.Char>)>(
@@ -223,11 +220,47 @@ external ffi.Pointer<ObjCSelector> registerName(
   ffi.Pointer<ffi.Char> name,
 );
 
+@ffi.Native<
+    ffi.Void Function(
+        ffi.Pointer<
+            ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>,
+        ffi.Pointer<ffi.Void>)>(symbol: "DOBJC_runOnMainThread", isLeaf: true)
+external void runOnMainThread(
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>> fn,
+  ffi.Pointer<ffi.Void> arg,
+);
+
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(
     symbol: "DOBJC_signalWaiter", isLeaf: true)
 external void signalWaiter(
   ffi.Pointer<ffi.Void> waiter,
 );
+
+final class DOBJC_Context extends ffi.Struct {
+  @ffi.Int64()
+  external int version;
+
+  external ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function()>>
+      newWaiter;
+
+  external ffi
+      .Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>
+      awaitWaiter;
+
+  external ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function()>>
+      currentIsolate;
+
+  external ffi
+      .Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>
+      enterIsolate;
+
+  external ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> exitIsolate;
+
+  external ffi.Pointer<ffi.NativeFunction<ffi.Int64 Function()>> getMainPortId;
+
+  external ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(ffi.Int64)>>
+      getCurrentThreadOwnsIsolate;
+}
 
 typedef Dart_FinalizableHandle = ffi.Pointer<Dart_FinalizableHandle_>;
 

--- a/pkgs/objective_c/lib/src/c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/c_bindings_generated.dart
@@ -20,12 +20,6 @@ library;
 
 import 'dart:ffi' as ffi;
 
-@ffi.Native<ffi.IntPtr Function(ffi.Pointer<ffi.Void>)>(
-    symbol: "DOBJC_InitializeApi", isLeaf: true)
-external int InitializeApi(
-  ffi.Pointer<ffi.Void> data,
-);
-
 @ffi.Array.multi([32])
 @ffi.Native<ffi.Array<ffi.Pointer<ffi.Void>>>(symbol: "_NSConcreteAutoBlock")
 external ffi.Array<ffi.Pointer<ffi.Void>> NSConcreteAutoBlock;
@@ -157,6 +151,12 @@ external ffi.Pointer<ffi.Char> getProtocolName(
   ffi.Pointer<ObjCProtocol> proto,
 );
 
+@ffi.Native<ffi.IntPtr Function(ffi.Pointer<ffi.Void>)>(
+    symbol: "DOBJC_initializeApi", isLeaf: true)
+external int initializeApi(
+  ffi.Pointer<ffi.Void> data,
+);
+
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ObjCBlockImpl>)>(
     symbol: "DOBJC_isValidBlock", isLeaf: true)
 external bool isValidBlock(
@@ -247,11 +247,12 @@ final class DOBJC_Context extends ffi.Struct {
       .Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>
       awaitWaiter;
 
-  external ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function()>>
+  external ffi
+      .Pointer<ffi.NativeFunction<ffi.Pointer<_Dart_Isolate> Function()>>
       currentIsolate;
 
-  external ffi
-      .Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>
+  external ffi.Pointer<
+          ffi.NativeFunction<ffi.Void Function(ffi.Pointer<_Dart_Isolate>)>>
       enterIsolate;
 
   external ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> exitIsolate;
@@ -318,6 +319,8 @@ final class ObjCObject extends ffi.Opaque {}
 final class ObjCProtocol extends ffi.Opaque {}
 
 final class ObjCSelector extends ffi.Opaque {}
+
+final class _Dart_Isolate extends ffi.Opaque {}
 
 final class _Version extends ffi.Struct {
   @ffi.Int()

--- a/pkgs/objective_c/lib/src/internal.dart
+++ b/pkgs/objective_c/lib/src/internal.dart
@@ -432,6 +432,8 @@ typedef AwaitWaiterFn = NativeFunction<Void Function(VoidPtr)>;
 typedef NativeWrapperFn = BlockPtr Function(
     BlockPtr, BlockPtr, Pointer<NewWaiterFn>, Pointer<AwaitWaiterFn>);
 
+
+
 /// Only for use by ffigen bindings.
 BlockPtr wrapBlockingBlock(
         NativeWrapperFn nativeWrapper, BlockPtr raw, BlockPtr rawListener) =>

--- a/pkgs/objective_c/lib/src/internal.dart
+++ b/pkgs/objective_c/lib/src/internal.dart
@@ -165,7 +165,7 @@ final class _FinalizablePointer<T extends NativeType> implements Finalizable {
 bool _dartAPIInitialized = false;
 void _ensureDartAPI() {
   if (!_dartAPIInitialized) {
-    final result = c.DOBJC_InitializeApi(NativeApi.initializeApiDLData);
+    final result = c.initializeApi(NativeApi.initializeApiDLData);
     assert(result == 0);
     _dartAPIInitialized = true;
   }
@@ -427,22 +427,9 @@ Function getBlockClosure(BlockPtr block) {
   return _blockClosureRegistry[id]!.closure;
 }
 
-typedef NewWaiterFn = NativeFunction<VoidPtr Function()>;
-typedef AwaitWaiterFn = NativeFunction<Void Function(VoidPtr)>;
-typedef NativeWrapperFn = BlockPtr Function(
-    BlockPtr, BlockPtr, Pointer<NewWaiterFn>, Pointer<AwaitWaiterFn>);
-
-
-
 /// Only for use by ffigen bindings.
-BlockPtr wrapBlockingBlock(
-        NativeWrapperFn nativeWrapper, BlockPtr raw, BlockPtr rawListener) =>
-    nativeWrapper(
-      raw,
-      rawListener,
-      Native.addressOf<NewWaiterFn>(c.newWaiter),
-      Native.addressOf<AwaitWaiterFn>(c.awaitWaiter),
-    );
+final Pointer<c.DOBJC_Context> objCContext =
+    c.fillContext(calloc<c.DOBJC_Context>());
 
 // Not exported by ../objective_c.dart, because they're only for testing.
 bool blockHasRegisteredClosure(BlockPtr block) =>

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -211,88 +211,63 @@ external instancetype _ObjectiveCBindings_protocolTrampoline_xr62hr(
 );
 
 @ffi.Native<
-        ffi.Pointer<objc.ObjCBlockImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function()>>,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>)>(
-    isLeaf: true)
+    ffi.Pointer<objc.ObjCBlockImpl> Function(
+        ffi.Pointer<objc.ObjCBlockImpl>,
+        ffi.Pointer<objc.ObjCBlockImpl>,
+        ffi.Pointer<objc.DOBJC_Context>)>(isLeaf: true)
 external ffi.Pointer<objc.ObjCBlockImpl>
     _ObjectiveCBindings_wrapBlockingBlock_18v1jvf(
   ffi.Pointer<objc.ObjCBlockImpl> block,
   ffi.Pointer<objc.ObjCBlockImpl> listnerBlock,
-  ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function()>> newWaiter,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>
-      awaitWaiter,
+  ffi.Pointer<objc.DOBJC_Context> context,
 );
 
 @ffi.Native<
-        ffi.Pointer<objc.ObjCBlockImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function()>>,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>)>(
-    isLeaf: true)
+    ffi.Pointer<objc.ObjCBlockImpl> Function(
+        ffi.Pointer<objc.ObjCBlockImpl>,
+        ffi.Pointer<objc.ObjCBlockImpl>,
+        ffi.Pointer<objc.DOBJC_Context>)>(isLeaf: true)
 external ffi.Pointer<objc.ObjCBlockImpl>
     _ObjectiveCBindings_wrapBlockingBlock_1b3bb6a(
   ffi.Pointer<objc.ObjCBlockImpl> block,
   ffi.Pointer<objc.ObjCBlockImpl> listnerBlock,
-  ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function()>> newWaiter,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>
-      awaitWaiter,
+  ffi.Pointer<objc.DOBJC_Context> context,
 );
 
 @ffi.Native<
-        ffi.Pointer<objc.ObjCBlockImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function()>>,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>)>(
-    isLeaf: true)
+    ffi.Pointer<objc.ObjCBlockImpl> Function(
+        ffi.Pointer<objc.ObjCBlockImpl>,
+        ffi.Pointer<objc.ObjCBlockImpl>,
+        ffi.Pointer<objc.DOBJC_Context>)>(isLeaf: true)
 external ffi.Pointer<objc.ObjCBlockImpl>
     _ObjectiveCBindings_wrapBlockingBlock_hoampi(
   ffi.Pointer<objc.ObjCBlockImpl> block,
   ffi.Pointer<objc.ObjCBlockImpl> listnerBlock,
-  ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function()>> newWaiter,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>
-      awaitWaiter,
+  ffi.Pointer<objc.DOBJC_Context> context,
 );
 
 @ffi.Native<
-        ffi.Pointer<objc.ObjCBlockImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function()>>,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>)>(
-    isLeaf: true)
+    ffi.Pointer<objc.ObjCBlockImpl> Function(
+        ffi.Pointer<objc.ObjCBlockImpl>,
+        ffi.Pointer<objc.ObjCBlockImpl>,
+        ffi.Pointer<objc.DOBJC_Context>)>(isLeaf: true)
 external ffi.Pointer<objc.ObjCBlockImpl>
     _ObjectiveCBindings_wrapBlockingBlock_ovsamd(
   ffi.Pointer<objc.ObjCBlockImpl> block,
   ffi.Pointer<objc.ObjCBlockImpl> listnerBlock,
-  ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function()>> newWaiter,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>
-      awaitWaiter,
+  ffi.Pointer<objc.DOBJC_Context> context,
 );
 
 @ffi.Native<
-        ffi.Pointer<objc.ObjCBlockImpl> Function(
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<objc.ObjCBlockImpl>,
-            ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function()>>,
-            ffi.Pointer<
-                ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>)>(
-    isLeaf: true)
+    ffi.Pointer<objc.ObjCBlockImpl> Function(
+        ffi.Pointer<objc.ObjCBlockImpl>,
+        ffi.Pointer<objc.ObjCBlockImpl>,
+        ffi.Pointer<objc.DOBJC_Context>)>(isLeaf: true)
 external ffi.Pointer<objc.ObjCBlockImpl>
     _ObjectiveCBindings_wrapBlockingBlock_pfv6jd(
   ffi.Pointer<objc.ObjCBlockImpl> block,
   ffi.Pointer<objc.ObjCBlockImpl> listnerBlock,
-  ffi.Pointer<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function()>> newWaiter,
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>
-      awaitWaiter,
+  ffi.Pointer<objc.DOBJC_Context> context,
 );
 
 @ffi.Native<
@@ -13367,8 +13342,8 @@ abstract final class ObjCBlock_ffiVoid_NSItemProviderCompletionHandler_objcObjCO
                 NSDictionary.castFromPointer(arg2,
                     retain: false, release: true)),
         keepIsolateAlive);
-    final wrapper = objc.wrapBlockingBlock(
-        _ObjectiveCBindings_wrapBlockingBlock_1b3bb6a, raw, rawListener);
+    final wrapper = _ObjectiveCBindings_wrapBlockingBlock_1b3bb6a(
+        raw, rawListener, objc.objCContext);
     objc.objectRelease(raw.cast());
     objc.objectRelease(rawListener.cast());
     return objc.ObjCBlock<
@@ -13561,8 +13536,8 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid {
             .cast(),
         (ffi.Pointer<ffi.Void> arg0) => fn(arg0),
         keepIsolateAlive);
-    final wrapper = objc.wrapBlockingBlock(
-        _ObjectiveCBindings_wrapBlockingBlock_ovsamd, raw, rawListener);
+    final wrapper = _ObjectiveCBindings_wrapBlockingBlock_ovsamd(
+        raw, rawListener, objc.objCContext);
     objc.objectRelease(raw.cast());
     objc.objectRelease(rawListener.cast());
     return objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>)>(wrapper,
@@ -13776,8 +13751,8 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSCoder {
         (ffi.Pointer<ffi.Void> arg0, ffi.Pointer<objc.ObjCObject> arg1) => fn(
             arg0, NSCoder.castFromPointer(arg1, retain: false, release: true)),
         keepIsolateAlive);
-    final wrapper = objc.wrapBlockingBlock(
-        _ObjectiveCBindings_wrapBlockingBlock_18v1jvf, raw, rawListener);
+    final wrapper = _ObjectiveCBindings_wrapBlockingBlock_18v1jvf(
+        raw, rawListener, objc.objCContext);
     objc.objectRelease(raw.cast());
     objc.objectRelease(rawListener.cast());
     return objc.ObjCBlock<ffi.Void Function(ffi.Pointer<ffi.Void>, NSCoder)>(
@@ -14039,8 +14014,8 @@ abstract final class ObjCBlock_ffiVoid_ffiVoid_NSStream_NSStreamEvent {
                 NSStream.castFromPointer(arg1, retain: false, release: true),
                 NSStreamEvent.fromValue(arg2)),
         keepIsolateAlive);
-    final wrapper = objc.wrapBlockingBlock(
-        _ObjectiveCBindings_wrapBlockingBlock_hoampi, raw, rawListener);
+    final wrapper = _ObjectiveCBindings_wrapBlockingBlock_hoampi(
+        raw, rawListener, objc.objCContext);
     objc.objectRelease(raw.cast());
     objc.objectRelease(rawListener.cast());
     return objc.ObjCBlock<
@@ -14295,8 +14270,8 @@ abstract final class ObjCBlock_ffiVoid_idNSSecureCoding_NSError {
                         retain: false, release: true),
                 NSError.castFromPointer(arg1, retain: false, release: true)),
         keepIsolateAlive);
-    final wrapper = objc.wrapBlockingBlock(
-        _ObjectiveCBindings_wrapBlockingBlock_pfv6jd, raw, rawListener);
+    final wrapper = _ObjectiveCBindings_wrapBlockingBlock_pfv6jd(
+        raw, rawListener, objc.objCContext);
     objc.objectRelease(raw.cast());
     objc.objectRelease(rawListener.cast());
     return objc.ObjCBlock<

--- a/pkgs/objective_c/src/include/bin/native_assets_api.h
+++ b/pkgs/objective_c/src/include/bin/native_assets_api.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#ifndef RUNTIME_INCLUDE_BIN_NATIVE_ASSETS_API_H_
+#define RUNTIME_INCLUDE_BIN_NATIVE_ASSETS_API_H_
+
+namespace dart {
+namespace bin {
+
+class NativeAssets {
+ public:
+  static void* DlopenAbsolute(const char* path, char** error);
+  static void* DlopenRelative(const char* path,
+                              const char* script_uri,
+                              char** error);
+  static void* DlopenSystem(const char* path, char** error);
+  static void* DlopenProcess(char** error);
+  static void* DlopenExecutable(char** error);
+  static void* Dlsym(void* handle, const char* symbol, char** error);
+};
+
+}  // namespace bin
+}  // namespace dart
+
+#endif  // RUNTIME_INCLUDE_BIN_NATIVE_ASSETS_API_H_

--- a/pkgs/objective_c/src/include/dart_api_dl.h
+++ b/pkgs/objective_c/src/include/dart_api_dl.h
@@ -38,6 +38,10 @@ DART_EXPORT intptr_t Dart_InitializeApiDL(void* data);
 // are typechecked nominally in C/C++, so they are not copied, instead a
 // comment is added to their definition.
 typedef int64_t Dart_Port_DL;
+typedef struct {
+  int64_t port_id;
+  int64_t origin_id;
+} Dart_PortEx_DL;
 
 typedef void (*Dart_NativeMessageHandler_DL)(Dart_Port_DL dest_port_id,
                                              Dart_CObject* message);
@@ -92,10 +96,15 @@ typedef void (*Dart_NativeMessageHandler_DL)(Dart_Port_DL dest_port_id,
   F(Dart_ExitIsolate, void, (void))                                            \
   F(Dart_EnterIsolate, void, (Dart_Isolate))                                   \
   /* Dart_Port */                                                              \
+  F(Dart_GetMainPortId, Dart_Port, (void))                                     \
   F(Dart_Post, bool, (Dart_Port_DL port_id, Dart_Handle object))               \
   F(Dart_NewSendPort, Dart_Handle, (Dart_Port_DL port_id))                     \
+  F(Dart_NewSendPortEx, Dart_Handle, (Dart_PortEx_DL portex_id))               \
   F(Dart_SendPortGetId, Dart_Handle,                                           \
     (Dart_Handle port, Dart_Port_DL * port_id))                                \
+  F(Dart_SendPortGetIdEx, Dart_Handle,                                         \
+    (Dart_Handle port, Dart_PortEx_DL * portex_id))                            \
+  F(Dart_GetCurrentThreadOwnsIsolate, bool, (Dart_Port))                       \
   /* Scopes */                                                                 \
   F(Dart_EnterScope, void, (void))                                             \
   F(Dart_ExitScope, void, (void))                                              \

--- a/pkgs/objective_c/src/include/dart_embedder_api.h
+++ b/pkgs/objective_c/src/include/dart_embedder_api.h
@@ -18,7 +18,7 @@ namespace embedder {
 //
 // Returns true on success and false otherwise, in which case error would
 // contain error message.
-DART_WARN_UNUSED_RESULT bool InitOnce(char** error);
+DART_API_WARN_UNUSED_RESULT bool InitOnce(char** error);
 
 // Cleans up all subsystems of the embedder.
 //
@@ -51,7 +51,7 @@ struct IsolateCreationData {
 // script_uri.
 // The isolate is created from the given snapshot (might be kernel data or
 // app-jit snapshot).
-DART_WARN_UNUSED_RESULT Dart_Isolate
+DART_API_WARN_UNUSED_RESULT Dart_Isolate
 CreateKernelServiceIsolate(const IsolateCreationData& data,
                            const uint8_t* buffer,
                            intptr_t buffer_size,
@@ -81,7 +81,7 @@ struct VmServiceConfiguration {
 // is expected to contain all necessary 'vm-service' libraries.
 // This method should be used when VM invokes isolate creation callback with
 // DART_VM_SERVICE_ISOLATE_NAME as script_uri.
-DART_WARN_UNUSED_RESULT Dart_Isolate
+DART_API_WARN_UNUSED_RESULT Dart_Isolate
 CreateVmServiceIsolate(const IsolateCreationData& data,
                        const VmServiceConfiguration& config,
                        const uint8_t* isolate_data,
@@ -92,7 +92,7 @@ CreateVmServiceIsolate(const IsolateCreationData& data,
 // is expected to contain all necessary 'vm-service' libraries.
 // This method should be used when VM invokes isolate creation callback with
 // DART_VM_SERVICE_ISOLATE_NAME as script_uri.
-DART_WARN_UNUSED_RESULT Dart_Isolate
+DART_API_WARN_UNUSED_RESULT Dart_Isolate
 CreateVmServiceIsolateFromKernel(const IsolateCreationData& data,
                                  const VmServiceConfiguration& config,
                                  const uint8_t* kernel_buffer,

--- a/pkgs/objective_c/src/include/dart_native_api.h
+++ b/pkgs/objective_c/src/include/dart_native_api.h
@@ -166,7 +166,23 @@ typedef void (*Dart_NativeMessageHandler)(Dart_Port dest_port_id,
 DART_EXPORT Dart_Port Dart_NewNativePort(const char* name,
                                          Dart_NativeMessageHandler handler,
                                          bool handle_concurrently);
-/* TODO(turnidge): Currently handle_concurrently is ignored. */
+
+/**
+ * Creates a new native port.  When messages are received on this
+ * native port, then they will be dispatched to the provided native
+ * message handler using up to |max_concurrency| concurrent threads.
+ *
+ * \param name The name of this port in debugging messages.
+ * \param handler The C handler to run when messages arrive on the port.
+ * \param max_concurrency Size of the thread pool used by the native port.
+ *
+ * \return If successful, returns the port id for the native port.  In
+ *   case of error, returns ILLEGAL_PORT.
+ */
+DART_EXPORT Dart_Port
+Dart_NewConcurrentNativePort(const char* name,
+                             Dart_NativeMessageHandler handler,
+                             intptr_t max_concurrency);
 
 /**
  * Closes the native port with the given id.
@@ -191,12 +207,13 @@ DART_EXPORT bool Dart_CloseNativePort(Dart_Port native_port_id);
  *
  * TODO(turnidge): Document.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_CompileAll(void);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle Dart_CompileAll(void);
 
 /**
  * Finalizes all classes.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_FinalizeAllClasses(void);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_FinalizeAllClasses(void);
 
 /*  This function is intentionally undocumented.
  *

--- a/pkgs/objective_c/src/include/dart_tools_api.h
+++ b/pkgs/objective_c/src/include/dart_tools_api.h
@@ -573,7 +573,7 @@ DART_EXPORT Dart_Handle Dart_SetCurrentUserTag(Dart_Handle user_tag);
  * \return The UserTag's label. NULL if the user_tag is invalid. The caller is
  *   responsible for freeing the returned label.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_GetUserTagLabel(
+DART_EXPORT DART_API_WARN_UNUSED_RESULT char* Dart_GetUserTagLabel(
     Dart_Handle user_tag);
 
 /*

--- a/pkgs/objective_c/src/include/dart_version.h
+++ b/pkgs/objective_c/src/include/dart_version.h
@@ -11,6 +11,6 @@
 // On backwards compatible changes the minor version is increased.
 // The versioning covers the symbols exposed in dart_api_dl.h
 #define DART_API_DL_MAJOR_VERSION 2
-#define DART_API_DL_MINOR_VERSION 4
+#define DART_API_DL_MINOR_VERSION 6
 
 #endif /* RUNTIME_INCLUDE_DART_VERSION_H_ */ /* NOLINT */

--- a/pkgs/objective_c/src/objective_c.c
+++ b/pkgs/objective_c/src/objective_c.c
@@ -53,3 +53,15 @@ FFI_EXPORT bool* DOBJC_newFinalizableBool(Dart_Handle owner) {
 FFI_EXPORT intptr_t DOBJC_InitializeApi(void* data) {
   return Dart_InitializeApiDL(data);
 }
+
+FFI_EXPORT DOBJC_Context* DOBJC_fillContext(DOBJC_Context* context) {
+  context->version = 1;
+  context->newWaiter = DOBJC_newWaiter;
+  context->awaitWaiter = DOBJC_awaitWaiter;
+  context->currentIsolate = Dart_CurrentIsolateDL;
+  context->enterIsolate = Dart_EnterIsolateDL;
+  context->exitIsolate = Dart_ExitIsolateDL;
+  context->getMainPortId = Dart_GetMainPortIdDL;
+  context->getCurrentThreadOwnsIsolate = Dart_GetCurrentThreadOwnsIsolateDL;
+  return context;
+}

--- a/pkgs/objective_c/src/objective_c.c
+++ b/pkgs/objective_c/src/objective_c.c
@@ -50,7 +50,7 @@ FFI_EXPORT bool* DOBJC_newFinalizableBool(Dart_Handle owner) {
   return pointer;
 }
 
-FFI_EXPORT intptr_t DOBJC_InitializeApi(void* data) {
+FFI_EXPORT intptr_t DOBJC_initializeApi(void* data) {
   return Dart_InitializeApiDL(data);
 }
 
@@ -58,10 +58,10 @@ FFI_EXPORT DOBJC_Context* DOBJC_fillContext(DOBJC_Context* context) {
   context->version = 1;
   context->newWaiter = DOBJC_newWaiter;
   context->awaitWaiter = DOBJC_awaitWaiter;
-  context->currentIsolate = Dart_CurrentIsolateDL;
-  context->enterIsolate = Dart_EnterIsolateDL;
-  context->exitIsolate = Dart_ExitIsolateDL;
-  context->getMainPortId = Dart_GetMainPortIdDL;
-  context->getCurrentThreadOwnsIsolate = Dart_GetCurrentThreadOwnsIsolateDL;
+  context->currentIsolate = Dart_CurrentIsolate_DL;
+  context->enterIsolate = Dart_EnterIsolate_DL;
+  context->exitIsolate = Dart_ExitIsolate_DL;
+  context->getMainPortId = Dart_GetMainPortId_DL;
+  context->getCurrentThreadOwnsIsolate = Dart_GetCurrentThreadOwnsIsolate_DL;
   return context;
 }

--- a/pkgs/objective_c/src/objective_c.h
+++ b/pkgs/objective_c/src/objective_c.h
@@ -49,4 +49,20 @@ FFI_EXPORT void *DOBJC_newWaiter(void);
 FFI_EXPORT void DOBJC_signalWaiter(void *waiter);
 FFI_EXPORT void DOBJC_awaitWaiter(void *waiter);
 
+// Context object containing functions needed by the ffigen bindings. Any
+// changes to this struct should bump the `version` field filled in by
+// package:objective_c, and checked by ffigen. Never change or delete existing
+// fields. Keep in sync with the struct defined in ffigen's writer.dart.
+typedef struct _DOBJC_Context {
+  int64_t version;
+  void* (*newWaiter)(void);
+  void (*awaitWaiter)(void*);
+  void* (*currentIsolate)(void);
+  void (*enterIsolate)(void*);
+  void (*exitIsolate)(void);
+  int64_t (*getMainPortId)(void);
+  bool (*getCurrentThreadOwnsIsolate)(int64_t);
+} DOBJC_Context;
+FFI_EXPORT DOBJC_Context* DOBJC_fillContext(DOBJC_Context* context);
+
 #endif  // OBJECTIVE_C_SRC_OBJECTIVE_C_H_

--- a/pkgs/objective_c/src/objective_c.h
+++ b/pkgs/objective_c/src/objective_c.h
@@ -10,7 +10,7 @@
 #include "objective_c_runtime.h"
 
 // Initialize the Dart API.
-FFI_EXPORT intptr_t DOBJC_InitializeApi(void *data);
+FFI_EXPORT intptr_t DOBJC_initializeApi(void *data);
 
 // Dispose helper for ObjC blocks that wrap a Dart closure.
 FFI_EXPORT void DOBJC_disposeObjCBlockWithClosure(ObjCBlockImpl *block);
@@ -57,8 +57,8 @@ typedef struct _DOBJC_Context {
   int64_t version;
   void* (*newWaiter)(void);
   void (*awaitWaiter)(void*);
-  void* (*currentIsolate)(void);
-  void (*enterIsolate)(void*);
+  Dart_Isolate (*currentIsolate)(void);
+  void (*enterIsolate)(Dart_Isolate);
   void (*exitIsolate)(void);
   int64_t (*getMainPortId)(void);
   bool (*getCurrentThreadOwnsIsolate)(int64_t);

--- a/pkgs/objective_c/src/objective_c_bindings_generated.m
+++ b/pkgs/objective_c/src/objective_c_bindings_generated.m
@@ -9,6 +9,17 @@
 #error "This file must be compiled with ARC enabled"
 #endif
 
+typedef struct {
+  int64_t version;
+  void* (*newWaiter)(void);
+  void (*awaitWaiter)(void*);
+  void* (*currentIsolate)(void);
+  void (*enterIsolate)(void*);
+  void (*exitIsolate)(void);
+  int64_t (*getMainPortId)(void);
+  bool (*getCurrentThreadOwnsIsolate)(int64_t);
+} DOBJC_Context;
+
 id objc_retainBlock(id);
 
 Protocol* _ObjectiveCBindings_NSCoding(void) { return @protocol(NSCoding); }
@@ -90,17 +101,19 @@ typedef void  (^_BlockingTrampoline)(void * waiter, id arg0, id arg1, id arg2);
 __attribute__((visibility("default"))) __attribute__((used))
 _ListenerTrampoline _ObjectiveCBindings_wrapBlockingBlock_1b3bb6a(
     _BlockingTrampoline block, _BlockingTrampoline listenerBlock,
-    void* (*newWaiter)(), void (*awaitWaiter)(void*)) NS_RETURNS_RETAINED {
-  NSThread *targetThread = [NSThread currentThread];
+    DOBJC_Context* context) NS_RETURNS_RETAINED {
+  assert(context->version > 1);
+  void* targetIsolate = context.currentIsolate();
   return ^void(id arg0, id arg1, id arg2) {
-    if ([NSThread currentThread] == targetThread) {
+    void* currentIsolate = context.currentIsolate();
+    if (currentIsolate == targetIsolate) {
       objc_retainBlock(block);
       block(nil, objc_retainBlock(arg0), (__bridge id)(__bridge_retained void*)(arg1), (__bridge id)(__bridge_retained void*)(arg2));
     } else {
-      void* waiter = newWaiter();
+      void* waiter = context.newWaiter();
       objc_retainBlock(listenerBlock);
       listenerBlock(waiter, objc_retainBlock(arg0), (__bridge id)(__bridge_retained void*)(arg1), (__bridge id)(__bridge_retained void*)(arg2));
-      awaitWaiter(waiter);
+      context.awaitWaiter(waiter);
     }
   };
 }
@@ -118,17 +131,19 @@ typedef void  (^_BlockingTrampoline1)(void * waiter, void * arg0);
 __attribute__((visibility("default"))) __attribute__((used))
 _ListenerTrampoline1 _ObjectiveCBindings_wrapBlockingBlock_ovsamd(
     _BlockingTrampoline1 block, _BlockingTrampoline1 listenerBlock,
-    void* (*newWaiter)(), void (*awaitWaiter)(void*)) NS_RETURNS_RETAINED {
-  NSThread *targetThread = [NSThread currentThread];
+    DOBJC_Context* context) NS_RETURNS_RETAINED {
+  assert(context->version > 1);
+  void* targetIsolate = context.currentIsolate();
   return ^void(void * arg0) {
-    if ([NSThread currentThread] == targetThread) {
+    void* currentIsolate = context.currentIsolate();
+    if (currentIsolate == targetIsolate) {
       objc_retainBlock(block);
       block(nil, arg0);
     } else {
-      void* waiter = newWaiter();
+      void* waiter = context.newWaiter();
       objc_retainBlock(listenerBlock);
       listenerBlock(waiter, arg0);
-      awaitWaiter(waiter);
+      context.awaitWaiter(waiter);
     }
   };
 }
@@ -152,17 +167,19 @@ typedef void  (^_BlockingTrampoline2)(void * waiter, void * arg0, id arg1);
 __attribute__((visibility("default"))) __attribute__((used))
 _ListenerTrampoline2 _ObjectiveCBindings_wrapBlockingBlock_18v1jvf(
     _BlockingTrampoline2 block, _BlockingTrampoline2 listenerBlock,
-    void* (*newWaiter)(), void (*awaitWaiter)(void*)) NS_RETURNS_RETAINED {
-  NSThread *targetThread = [NSThread currentThread];
+    DOBJC_Context* context) NS_RETURNS_RETAINED {
+  assert(context->version > 1);
+  void* targetIsolate = context.currentIsolate();
   return ^void(void * arg0, id arg1) {
-    if ([NSThread currentThread] == targetThread) {
+    void* currentIsolate = context.currentIsolate();
+    if (currentIsolate == targetIsolate) {
       objc_retainBlock(block);
       block(nil, arg0, (__bridge id)(__bridge_retained void*)(arg1));
     } else {
-      void* waiter = newWaiter();
+      void* waiter = context.newWaiter();
       objc_retainBlock(listenerBlock);
       listenerBlock(waiter, arg0, (__bridge id)(__bridge_retained void*)(arg1));
-      awaitWaiter(waiter);
+      context.awaitWaiter(waiter);
     }
   };
 }
@@ -186,17 +203,19 @@ typedef void  (^_BlockingTrampoline3)(void * waiter, void * arg0, id arg1, NSStr
 __attribute__((visibility("default"))) __attribute__((used))
 _ListenerTrampoline3 _ObjectiveCBindings_wrapBlockingBlock_hoampi(
     _BlockingTrampoline3 block, _BlockingTrampoline3 listenerBlock,
-    void* (*newWaiter)(), void (*awaitWaiter)(void*)) NS_RETURNS_RETAINED {
-  NSThread *targetThread = [NSThread currentThread];
+    DOBJC_Context* context) NS_RETURNS_RETAINED {
+  assert(context->version > 1);
+  void* targetIsolate = context.currentIsolate();
   return ^void(void * arg0, id arg1, NSStreamEvent arg2) {
-    if ([NSThread currentThread] == targetThread) {
+    void* currentIsolate = context.currentIsolate();
+    if (currentIsolate == targetIsolate) {
       objc_retainBlock(block);
       block(nil, arg0, (__bridge id)(__bridge_retained void*)(arg1), arg2);
     } else {
-      void* waiter = newWaiter();
+      void* waiter = context.newWaiter();
       objc_retainBlock(listenerBlock);
       listenerBlock(waiter, arg0, (__bridge id)(__bridge_retained void*)(arg1), arg2);
-      awaitWaiter(waiter);
+      context.awaitWaiter(waiter);
     }
   };
 }
@@ -220,17 +239,19 @@ typedef void  (^_BlockingTrampoline4)(void * waiter, id arg0, id arg1);
 __attribute__((visibility("default"))) __attribute__((used))
 _ListenerTrampoline4 _ObjectiveCBindings_wrapBlockingBlock_pfv6jd(
     _BlockingTrampoline4 block, _BlockingTrampoline4 listenerBlock,
-    void* (*newWaiter)(), void (*awaitWaiter)(void*)) NS_RETURNS_RETAINED {
-  NSThread *targetThread = [NSThread currentThread];
+    DOBJC_Context* context) NS_RETURNS_RETAINED {
+  assert(context->version > 1);
+  void* targetIsolate = context.currentIsolate();
   return ^void(id arg0, id arg1) {
-    if ([NSThread currentThread] == targetThread) {
+    void* currentIsolate = context.currentIsolate();
+    if (currentIsolate == targetIsolate) {
       objc_retainBlock(block);
       block(nil, (__bridge id)(__bridge_retained void*)(arg0), (__bridge id)(__bridge_retained void*)(arg1));
     } else {
-      void* waiter = newWaiter();
+      void* waiter = context.newWaiter();
       objc_retainBlock(listenerBlock);
       listenerBlock(waiter, (__bridge id)(__bridge_retained void*)(arg0), (__bridge id)(__bridge_retained void*)(arg1));
-      awaitWaiter(waiter);
+      context.awaitWaiter(waiter);
     }
   };
 }

--- a/pkgs/objective_c/src/objective_c_bindings_generated.m
+++ b/pkgs/objective_c/src/objective_c_bindings_generated.m
@@ -102,18 +102,18 @@ __attribute__((visibility("default"))) __attribute__((used))
 _ListenerTrampoline _ObjectiveCBindings_wrapBlockingBlock_1b3bb6a(
     _BlockingTrampoline block, _BlockingTrampoline listenerBlock,
     DOBJC_Context* context) NS_RETURNS_RETAINED {
-  assert(context->version > 1);
-  void* targetIsolate = context.currentIsolate();
+  assert(context->version >= 1);
+  void* targetIsolate = context->currentIsolate();
   return ^void(id arg0, id arg1, id arg2) {
-    void* currentIsolate = context.currentIsolate();
+    void* currentIsolate = context->currentIsolate();
     if (currentIsolate == targetIsolate) {
       objc_retainBlock(block);
       block(nil, objc_retainBlock(arg0), (__bridge id)(__bridge_retained void*)(arg1), (__bridge id)(__bridge_retained void*)(arg2));
     } else {
-      void* waiter = context.newWaiter();
+      void* waiter = context->newWaiter();
       objc_retainBlock(listenerBlock);
       listenerBlock(waiter, objc_retainBlock(arg0), (__bridge id)(__bridge_retained void*)(arg1), (__bridge id)(__bridge_retained void*)(arg2));
-      context.awaitWaiter(waiter);
+      context->awaitWaiter(waiter);
     }
   };
 }
@@ -132,18 +132,18 @@ __attribute__((visibility("default"))) __attribute__((used))
 _ListenerTrampoline1 _ObjectiveCBindings_wrapBlockingBlock_ovsamd(
     _BlockingTrampoline1 block, _BlockingTrampoline1 listenerBlock,
     DOBJC_Context* context) NS_RETURNS_RETAINED {
-  assert(context->version > 1);
-  void* targetIsolate = context.currentIsolate();
+  assert(context->version >= 1);
+  void* targetIsolate = context->currentIsolate();
   return ^void(void * arg0) {
-    void* currentIsolate = context.currentIsolate();
+    void* currentIsolate = context->currentIsolate();
     if (currentIsolate == targetIsolate) {
       objc_retainBlock(block);
       block(nil, arg0);
     } else {
-      void* waiter = context.newWaiter();
+      void* waiter = context->newWaiter();
       objc_retainBlock(listenerBlock);
       listenerBlock(waiter, arg0);
-      context.awaitWaiter(waiter);
+      context->awaitWaiter(waiter);
     }
   };
 }
@@ -168,18 +168,18 @@ __attribute__((visibility("default"))) __attribute__((used))
 _ListenerTrampoline2 _ObjectiveCBindings_wrapBlockingBlock_18v1jvf(
     _BlockingTrampoline2 block, _BlockingTrampoline2 listenerBlock,
     DOBJC_Context* context) NS_RETURNS_RETAINED {
-  assert(context->version > 1);
-  void* targetIsolate = context.currentIsolate();
+  assert(context->version >= 1);
+  void* targetIsolate = context->currentIsolate();
   return ^void(void * arg0, id arg1) {
-    void* currentIsolate = context.currentIsolate();
+    void* currentIsolate = context->currentIsolate();
     if (currentIsolate == targetIsolate) {
       objc_retainBlock(block);
       block(nil, arg0, (__bridge id)(__bridge_retained void*)(arg1));
     } else {
-      void* waiter = context.newWaiter();
+      void* waiter = context->newWaiter();
       objc_retainBlock(listenerBlock);
       listenerBlock(waiter, arg0, (__bridge id)(__bridge_retained void*)(arg1));
-      context.awaitWaiter(waiter);
+      context->awaitWaiter(waiter);
     }
   };
 }
@@ -204,18 +204,18 @@ __attribute__((visibility("default"))) __attribute__((used))
 _ListenerTrampoline3 _ObjectiveCBindings_wrapBlockingBlock_hoampi(
     _BlockingTrampoline3 block, _BlockingTrampoline3 listenerBlock,
     DOBJC_Context* context) NS_RETURNS_RETAINED {
-  assert(context->version > 1);
-  void* targetIsolate = context.currentIsolate();
+  assert(context->version >= 1);
+  void* targetIsolate = context->currentIsolate();
   return ^void(void * arg0, id arg1, NSStreamEvent arg2) {
-    void* currentIsolate = context.currentIsolate();
+    void* currentIsolate = context->currentIsolate();
     if (currentIsolate == targetIsolate) {
       objc_retainBlock(block);
       block(nil, arg0, (__bridge id)(__bridge_retained void*)(arg1), arg2);
     } else {
-      void* waiter = context.newWaiter();
+      void* waiter = context->newWaiter();
       objc_retainBlock(listenerBlock);
       listenerBlock(waiter, arg0, (__bridge id)(__bridge_retained void*)(arg1), arg2);
-      context.awaitWaiter(waiter);
+      context->awaitWaiter(waiter);
     }
   };
 }
@@ -240,18 +240,18 @@ __attribute__((visibility("default"))) __attribute__((used))
 _ListenerTrampoline4 _ObjectiveCBindings_wrapBlockingBlock_pfv6jd(
     _BlockingTrampoline4 block, _BlockingTrampoline4 listenerBlock,
     DOBJC_Context* context) NS_RETURNS_RETAINED {
-  assert(context->version > 1);
-  void* targetIsolate = context.currentIsolate();
+  assert(context->version >= 1);
+  void* targetIsolate = context->currentIsolate();
   return ^void(id arg0, id arg1) {
-    void* currentIsolate = context.currentIsolate();
+    void* currentIsolate = context->currentIsolate();
     if (currentIsolate == targetIsolate) {
       objc_retainBlock(block);
       block(nil, (__bridge id)(__bridge_retained void*)(arg0), (__bridge id)(__bridge_retained void*)(arg1));
     } else {
-      void* waiter = context.newWaiter();
+      void* waiter = context->newWaiter();
       objc_retainBlock(listenerBlock);
       listenerBlock(waiter, (__bridge id)(__bridge_retained void*)(arg0), (__bridge id)(__bridge_retained void*)(arg1));
-      context.awaitWaiter(waiter);
+      context->awaitWaiter(waiter);
     }
   };
 }


### PR DESCRIPTION
Add logic to blocking blocks that checks if there's no current isolate, but we're on the thread that owns the target isolate. If so, enter the isolate before invoking the isolate local block. I haven't bumped the minimum SDK version yet. Instead the trampoline only does these checks if the new isolate ownership functions are non-null.

This required a bit of refactoring of the blocking block native trampoline. There are now so many functions needed here that it makes sense to group them into a struct, instead of passing them down individually. Another approach would be to have the generated native code `#include "dart_api_dl.h"`, but I'm not sure how to do that ergonomically for users. So instead I'm grouping all the native functions needed by the trampoline into a `DOBJC_Context` struct.

The trampoline logic is also complicated enough that it's a bit silly to repeat it in every trampoline. So I've factored it out using macros (this was unfortunately the cleanest way of doing it).

To test it, I wrote a test that spawns a new isolate, calls `Dart_SetCurrentThreadOwnsIsolate`, exits the isolate, invokes the blocking block, then reenters the isolate. This deadlocked before the changes were implemented.