### PR TITLE
[native_assets_cli] Generate syntax from schemas

### DIFF
--- a/.github/workflows/hook.yaml
+++ b/.github/workflows/hook.yaml
@@ -54,6 +54,7 @@ jobs:
       - run: dart test
 
       - run: |
+          dart tool/generate.dart
           dart tool/normalize.dart
           git diff --exit-code
         working-directory: pkgs/${{ matrix.package }}/

--- a/pkgs/hook/tool/generate.dart
+++ b/pkgs/hook/tool/generate.dart
@@ -1267,6 +1267,6 @@ extension on JsonSchema {
 extension on String {
   bool startsWithUpperCase() {
     final codeUnit = codeUnitAt(0);
-    return codeUnit >= 65 && codeUnit <= 90;
+    return codeUnit >= 'A'.codeUnitAt(0) && codeUnit <= 'Z'.codeUnitAt(0);
   }
 }

--- a/pkgs/hook/tool/generate.dart
+++ b/pkgs/hook/tool/generate.dart
@@ -1,0 +1,1272 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// ignore_for_file: prefer_expression_function_bodies
+
+import 'dart:io';
+
+import 'package:json_schema/json_schema.dart';
+
+import '../test/schema/helpers.dart';
+
+const generateFor = ['hook', 'code_assets', 'data_assets'];
+
+final rootSchemas = loadSchemas([
+  packageUri.resolve('doc/schema/'),
+  packageUri.resolve('../code_assets/doc/schema/'),
+  packageUri.resolve('../data_assets/doc/schema/'),
+]);
+final rootSchemas2 = rootSchemas.map((key, value) => MapEntry(value, key));
+
+const packageImports = {
+  'code_assets': ['hook'],
+  'data_assets': ['hook'],
+  'hook': <String>[],
+};
+
+/// These classes are constructed peacemeal instead of in one go.
+///
+/// Generate public setters.
+const _publicSetters = {
+  'BuildOutput',
+  'Config',
+  'HookInput',
+  'HookOutput',
+  'LinkOutput',
+};
+
+String dependency(List<String> packages) {
+  if (packages.length != 2) {
+    throw UnimplementedError();
+  }
+  if (packageImports[packages[0]]!.contains(packages[1])) {
+    return packages[1];
+  }
+  if (packageImports[packages[1]]!.contains(packages[0])) {
+    return packages[0];
+  }
+  throw UnimplementedError();
+}
+
+String importer(List<String> packages) {
+  if (packages.length != 2) {
+    throw UnimplementedError();
+  }
+  if (packageImports[packages[0]]!.contains(packages[1])) {
+    return packages[0];
+  }
+  if (packageImports[packages[1]]!.contains(packages[0])) {
+    return packages[1];
+  }
+  throw UnimplementedError();
+}
+
+void main() {
+  if (rootSchemas.length != rootSchemas2.length) {
+    throw StateError(
+      'Some schemas are not unique, try adding a unique title field.',
+    );
+  }
+
+  for (final packageName in generateFor) {
+    const schemaName = 'shared';
+    final schemaUri = packageUri.resolve(
+      '../$packageName/doc/schema/$schemaName/shared_definitions.schema.json',
+    );
+    final outputUri = packageUri.resolve(
+      '../native_assets_cli/lib/src/$packageName/syntax.g.dart',
+    );
+    generate(
+      JsonSchemas(rootSchemas[schemaUri]!),
+      schemaName,
+      packageName,
+      outputUri,
+    );
+  }
+}
+
+Uri packageUri = findPackageRoot('hook');
+
+const remapPropertyKeys = <String, String>{
+  // TODO: Fix the casing in the schema.
+  // 'assetsForLinking': 'assets_for_linking_old',
+};
+
+String remapPropertyKey(String name) {
+  return remapPropertyKeys[name] ?? name;
+}
+
+void generate(
+  JsonSchemas schemas,
+  String schemaName,
+  String packageName,
+  Uri outputUri,
+) {
+  final classes = <String>[];
+  for (final definitionKey in schemas.definitionKeys) {
+    final definitionSchemas = schemas.getDefinition(definitionKey);
+    if (definitionSchemas.generateOpenEnum) {
+      classes.add(generateEnumClass(definitionSchemas, name: definitionKey));
+    } else if (definitionSchemas.generateExtension(packageName)) {
+      classes.add(generateExtension(definitionSchemas));
+    } else if (definitionSchemas.generateClass) {
+      classes.add(generateClass(definitionSchemas, name: definitionKey));
+    }
+  }
+
+  final imports = [
+    if (packageName != 'hook') "import '../hook/syntax.g.dart';",
+    "import '../utils/json.dart';",
+  ];
+
+  final output2 = '''
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// This file is generated, do not edit.
+
+${imports.join()}
+
+${classes.join('\n\n')}
+''';
+  final file = File.fromUri(outputUri);
+  file.createSync(recursive: true);
+  file.writeAsStringSync(output2);
+  Process.runSync(Platform.executable, ['format', outputUri.toFilePath()]);
+}
+
+String generateExtension(JsonSchemas schemas) {
+  final typeName = schemas.className!;
+  final extensionSchemas = schemas.extensionSchemas;
+  final baseSchemas = schemas.baseSchemas;
+  final baseName = baseSchemas.className;
+  if (baseName != typeName) {
+    throw UnimplementedError();
+  }
+  final basePropertyKeys = baseSchemas.propertyKeys;
+  final extensionPropertyKeys =
+      extensionSchemas.propertyKeys
+          .where((e) => !basePropertyKeys.contains(e))
+          .toList();
+
+  final accessors = <String>[];
+  final classes = <String>[];
+  for (final propertyKey in extensionPropertyKeys) {
+    final propertySchemas = schemas.property(propertyKey);
+    final required = schemas.propertyRequired(propertyKey);
+    accessors.add(
+      generateAccessor(
+        propertyKey,
+        propertySchemas,
+        required,
+        setterPrivate: false,
+      ),
+    );
+    if (propertySchemas.generateClass && propertySchemas.refs.isEmpty) {
+      classes.add(generateClass(propertySchemas, name: propertyKey));
+    }
+  }
+
+  if (schemas.generateSubClasses) {
+    classes.addAll(generateSubClasses(schemas));
+  }
+
+  return [
+    if (extensionPropertyKeys.isNotEmpty)
+      '''
+extension ${baseName}Extension on $baseName {
+  ${accessors.join('\n\n')}
+}
+''',
+    ...classes,
+  ].join('\n\n');
+}
+
+List<String> generateSubClasses(JsonSchemas schemas) {
+  final classes = <String>[];
+  final typeName = schemas.className;
+  final propertyKey = schemas.propertyKeys.single;
+  final typeProperty = schemas.property(propertyKey);
+  final anyOf = typeProperty.anyOfs.single;
+  final subTypes = anyOf.map((e) => e.constValue).whereType<String>().toList();
+  final ifThenSchemas = schemas.ifThenSchemas;
+  for (final subType in subTypes) {
+    final subTypeNameShort = ucFirst(snakeToCamelCase(subType));
+    final subTypeName = '$subTypeNameShort$typeName';
+    JsonSchemas? subtypeSchema;
+    for (final (ifSchema, thenSchema) in ifThenSchemas) {
+      if (ifSchema.property(propertyKey).constValue == subType) {
+        subtypeSchema = thenSchema;
+        break;
+      }
+    }
+    if (subtypeSchema != null) {
+      classes.add(
+        generateClass(
+          subtypeSchema,
+          name: subTypeName,
+          superclass: typeName,
+          identifyingSubtype: subType,
+        ),
+      );
+    } else {
+      classes.add('''
+class $subTypeName extends $typeName {
+  $subTypeName.fromJson(super.json) : super.fromJson();
+
+  $subTypeName() : super(
+    type: '$subType'
+  );
+}
+''');
+    }
+    classes.add('''
+extension ${subTypeName}Extension on $typeName {
+  bool get is$subTypeName => type == '$subType';
+
+  $subTypeName get as$subTypeName => $subTypeName.fromJson(json);
+}
+''');
+  }
+
+  return classes;
+}
+
+String generateClass(
+  JsonSchemas schemas, {
+  String? name,
+  String? superclass,
+  String? identifyingSubtype,
+}) {
+  var typeName = schemas.className;
+  typeName ??= ucFirst(snakeToCamelCase(name!));
+  final accessors = <String>[];
+  final constructorParams = <String>[];
+  final setupParams = <String>[];
+  final constructorSuperParams = <String>[];
+  final constructorSetterCalls = <String>[];
+  final classes = <String>[];
+  final superClassName = schemas.superClassName;
+  superclass ??= superClassName;
+  final superSchemas = schemas.superClassSchemas;
+  final propertyKeys = schemas.propertyKeys;
+  final settersPrivate = !_publicSetters.contains(typeName);
+  for (final propertyKey in propertyKeys) {
+    if (propertyKey == r'$schema') continue;
+    final propertySchemas = schemas.property(propertyKey);
+    final required = schemas.propertyRequired(propertyKey);
+    final allowEnum = !schemas.generateSubClasses;
+    final parentPropertySchemas = superSchemas?.property(propertyKey);
+    final dartType = generateDartType(
+      propertyKey,
+      propertySchemas,
+      required,
+      allowEnum: allowEnum,
+    );
+    final fieldName = snakeToCamelCase(remapPropertyKey(propertyKey));
+
+    if (parentPropertySchemas == null) {
+      accessors.add(
+        generateAccessor(
+          propertyKey,
+          propertySchemas,
+          required,
+          allowEnum: allowEnum,
+          setterPrivate: settersPrivate,
+        ),
+      );
+      constructorParams.add(
+        '${required ? 'required' : ''} $dartType $fieldName',
+      );
+      setupParams.add('${required ? 'required' : ''} $dartType $fieldName');
+      if (settersPrivate) {
+        constructorSetterCalls.add('_$fieldName = $fieldName;');
+      } else {
+        constructorSetterCalls.add('this.$fieldName = $fieldName;');
+      }
+    } else {
+      if (parentPropertySchemas.className != propertySchemas.className ||
+          propertySchemas.type != parentPropertySchemas.type) {
+        final override =
+            parentPropertySchemas?.type != null ||
+            propertySchemas.className != null;
+        accessors.add(
+          generateAccessor(
+            propertyKey,
+            propertySchemas,
+            required,
+            override: override,
+            setterPrivate: settersPrivate,
+          ),
+        );
+        if (override) {
+          constructorParams.add(
+            '${required ? 'required' : ''} super.$fieldName',
+          );
+        } else {
+          constructorParams.add(
+            '${required ? 'required' : ''} $dartType $fieldName',
+          );
+          setupParams.add('${required ? 'required' : ''} $dartType $fieldName');
+          if (settersPrivate) {
+            constructorSetterCalls.add('_$fieldName = $fieldName;');
+          } else {
+            constructorSetterCalls.add('this.$fieldName = $fieldName;');
+          }
+        }
+      } else {
+        constructorParams.add('${required ? 'required' : ''} super.$fieldName');
+      }
+    }
+    if (propertySchemas.generateClass && propertySchemas.refs.isEmpty) {
+      classes.add(generateClass(propertySchemas, name: propertyKey));
+    }
+  }
+
+  if (schemas.generateSubClasses) {
+    classes.addAll(generateSubClasses(schemas));
+  }
+
+  if (identifyingSubtype != null) {
+    constructorSuperParams.add("type: '$identifyingSubtype'");
+  }
+
+  if (constructorSetterCalls.isNotEmpty) {
+    constructorSetterCalls.add('json.sortOnKey();');
+  }
+
+  String wrapBracesIfNotEmpty(String input) =>
+      input.isEmpty ? input : '{$input}';
+
+  String wrapInBracesOrSemicolon(String input) =>
+      input.isEmpty ? ';' : '{ $input }';
+
+  if (superclass != null) {
+    return '''
+class $typeName extends $superclass  {
+  $typeName.fromJson(super.json) : super.fromJson();
+
+  $typeName({
+    ${constructorParams.join(',')}
+  }) : super(
+    ${constructorSuperParams.join(',')}
+  ) ${wrapInBracesOrSemicolon(constructorSetterCalls.join('\n'))}
+
+  /// Setup all fields for [$typeName] that are not in
+  /// [$superclass].
+  void setup (
+    ${wrapBracesIfNotEmpty(setupParams.join(','))}
+  ) {
+    ${constructorSetterCalls.join('\n')}
+  }
+
+  ${accessors.join('\n\n')}
+
+  @override
+  String toString() => '$typeName(\$json)';
+}
+
+${classes.join('\n\n')}
+''';
+  }
+
+  return '''
+class $typeName {
+  final Map<String, Object?> json;
+
+  $typeName.fromJson(this.json);
+
+  $typeName({
+    ${constructorParams.join(',')}
+  }) : json = {} {
+    ${constructorSetterCalls.join('\n')}
+  }
+
+  ${accessors.join('\n\n')}
+
+  @override
+  String toString() => '$typeName(\$json)';
+}
+
+${classes.join('\n\n')}
+''';
+}
+
+String generateEnumClass(JsonSchemas schemas, {String? name}) {
+  if (schemas.type != SchemaType.string) {
+    throw UnimplementedError(schemas.type.toString());
+  }
+  var typeName = schemas.className;
+  typeName ??= ucFirst(snakeToCamelCase(name!));
+
+  final anyOf = schemas.anyOfs.single;
+  final values =
+      anyOf.map((e) => e.constValue).whereType<String>().toList()..sort();
+
+  final staticFinals = <String>[];
+
+  for (final value in values) {
+    final valueName = snakeToCamelCase(value);
+    staticFinals.add('''
+static const $valueName = $typeName._('$value');
+''');
+  }
+
+  return '''
+  class $typeName {
+    final String name;
+
+    const $typeName._(this.name);
+
+    ${staticFinals.join('\n\n')}
+
+    static const List<$typeName> values = [
+      ${values.map(snakeToCamelCase).join(',')}
+    ];
+
+    static final Map<String, $typeName> _byName = {
+      for (final value in values) value.name: value,
+    };
+
+    $typeName.unknown(this.name) : assert(!_byName.keys.contains(name));
+
+    factory $typeName.fromJson(String name) {
+      final knownValue = _byName[name];
+      if(knownValue != null) {
+        return knownValue;
+      }
+      return $typeName.unknown(name);
+    }
+
+    bool get isKnown => _byName[name] != null;
+
+    @override
+    String toString() => name;
+  }
+  ''';
+}
+
+String generateDartType(
+  String propertyKey,
+  JsonSchemas schemas,
+  bool required, {
+  bool allowEnum = true,
+}) {
+  final type = schemas.type;
+  final String dartTypeNonNullable;
+  switch (type) {
+    case SchemaType.boolean:
+      dartTypeNonNullable = 'bool';
+    case SchemaType.integer:
+      dartTypeNonNullable = 'int';
+    case SchemaType.string:
+      if (schemas.generateUri) {
+        dartTypeNonNullable = 'Uri';
+      } else if (schemas.generateEnum && allowEnum) {
+        dartTypeNonNullable = schemas.className!;
+      } else {
+        dartTypeNonNullable = 'String';
+      }
+    case SchemaType.object:
+      final additionalPropertiesSchema = schemas.additionalPropertiesSchemas;
+      if (schemas.generateMapOf) {
+        final additionalPropertiesType = additionalPropertiesSchema.type;
+        switch (additionalPropertiesType) {
+          case SchemaType.array:
+            final items = additionalPropertiesSchema.items;
+            final itemType = items.type;
+            switch (itemType) {
+              case SchemaType.object:
+                if (required) throw UnimplementedError();
+                final typeName = items.className!;
+                dartTypeNonNullable = 'Map<String, List<$typeName>>';
+              default:
+                throw UnimplementedError(itemType.toString());
+            }
+          case SchemaType.object:
+            final additionalPropertiesBool =
+                additionalPropertiesSchema.additionalPropertiesBool;
+            if (additionalPropertiesBool != true) {
+              throw UnimplementedError(additionalPropertiesBool.toString());
+            }
+            dartTypeNonNullable = 'Map<String, Map<String, Object?>>';
+          case null:
+            if (schemas.additionalPropertiesBool != true) {
+              throw UnimplementedError();
+            }
+            dartTypeNonNullable = 'Map<String, Object?>';
+          default:
+            throw UnimplementedError(additionalPropertiesType.toString());
+        }
+      } else {
+        var typeName = schemas.className;
+        typeName ??= ucFirst(snakeToCamelCase(propertyKey));
+        dartTypeNonNullable = typeName;
+      }
+    case SchemaType.array:
+      final items = schemas.items;
+      final itemType = items.type;
+      switch (itemType) {
+        case SchemaType.string:
+          if (items.patterns.isNotEmpty) {
+            dartTypeNonNullable = 'List<Uri>';
+          } else {
+            dartTypeNonNullable = 'List<String>';
+          }
+        case SchemaType.object:
+          final typeName = items.className!;
+          dartTypeNonNullable = 'List<$typeName>';
+        default:
+          throw UnimplementedError(itemType.toString());
+      }
+
+    default:
+      throw UnimplementedError(type.toString());
+  }
+  if (required) {
+    return dartTypeNonNullable;
+  }
+  return '$dartTypeNonNullable?';
+}
+
+String generateAccessor(
+  String propertyKey,
+  JsonSchemas schemas,
+  bool required, {
+  bool override = false,
+  bool allowEnum = true,
+  bool setterPrivate = true,
+}) {
+  var result = '';
+  final type = schemas.type;
+  final fieldName = snakeToCamelCase(remapPropertyKey(propertyKey));
+  final setterName = setterPrivate ? '_$fieldName' : fieldName;
+  final sortOnKey = setterPrivate ? '' : 'json.sortOnKey();';
+  if (override) {
+    result += '@override\n';
+  }
+  switch (type) {
+    case SchemaType.string:
+      if (schemas.generateUri) {
+        if (required) {
+          result += '''
+Uri get $fieldName => json.path('$propertyKey');
+
+set $setterName(Uri value){
+  json['$propertyKey'] = value.toFilePath();
+  $sortOnKey
+}
+''';
+        } else {
+          result += '''
+Uri? get $fieldName => json.optionalPath('$propertyKey');
+
+set $setterName(Uri? value) {
+  if (value == null) {
+    json.remove('$propertyKey');
+  }
+  else {
+    json['$propertyKey'] = value.toFilePath();
+  }
+  $sortOnKey
+}
+''';
+        }
+      } else if (schemas.generateEnum && allowEnum) {
+        var typeName = schemas.className;
+        typeName ??= ucFirst(snakeToCamelCase(propertyKey));
+        if (required) {
+          result += '''
+$typeName get $fieldName => $typeName.fromJson(json.string('$propertyKey'));
+
+set $setterName($typeName value) {
+  json['$propertyKey'] = value.name;
+  $sortOnKey
+}
+''';
+        } else {
+          result += '''
+$typeName? get $fieldName {
+  final string = json.optionalString('$propertyKey');
+  if(string == null) return null;
+  return $typeName.fromJson(string);
+}
+
+set $setterName($typeName? value) {
+  if (value == null) {
+    json.remove('$propertyKey');
+  }
+  else {
+    json['$propertyKey'] = value.name;
+  }
+  $sortOnKey
+} 
+''';
+        }
+      } else {
+        if (required) {
+          result += '''
+String get $fieldName => json.string('$propertyKey');
+
+set $setterName(String value) {
+  json['$propertyKey'] = value;
+  $sortOnKey
+}
+''';
+        } else {
+          result += '''
+String? get $fieldName => json.optionalString('$propertyKey');
+
+set $setterName(String? value) {
+  if (value == null) {
+    json.remove('$propertyKey');
+  }
+  else {
+    json['$propertyKey'] = value;
+  }
+  $sortOnKey
+}
+''';
+        }
+      }
+    case SchemaType.object:
+      final additionalPropertiesSchema = schemas.additionalPropertiesSchemas;
+      if (schemas.generateMapOf) {
+        final additionalPropertiesType = additionalPropertiesSchema.type;
+        switch (additionalPropertiesType) {
+          case SchemaType.array:
+            final items = additionalPropertiesSchema.items;
+            final itemType = items.type;
+            switch (itemType) {
+              case SchemaType.object:
+                if (required) throw UnimplementedError();
+                final typeName = items.className!;
+                result += '''
+Map<String, List<$typeName>>? get $fieldName {
+  final map_ = json.optionalMap('$propertyKey');
+  if(map_ == null){
+    return null;
+  }
+  return {
+    for (final MapEntry(:key, :value) in map_.entries)
+      key : [
+        for (final item in value as List<Object?>)
+          $typeName.fromJson(item as Map<String, Object?>)
+      ],
+  };
+}
+
+set $setterName(Map<String, List<$typeName>>? value) {
+  if (value == null) {
+    json.remove('$propertyKey');
+  }
+  else {
+    json['$propertyKey'] = {
+      for (final MapEntry(:key, :value) in value.entries)
+        key : [
+          for (final item in value)
+            item.json,
+        ],
+    };
+  }
+  $sortOnKey
+}
+''';
+              default:
+                throw UnimplementedError(itemType.toString());
+            }
+          case SchemaType.object:
+            final additionalPropertiesBool =
+                additionalPropertiesSchema.additionalPropertiesBool;
+            if (additionalPropertiesBool != true) {
+              throw UnimplementedError(additionalPropertiesBool.toString());
+            }
+            result += '''
+Map<String, Map<String, Object?>>? get $fieldName =>
+  json.optionalMap<Map<String, Object?>>('$propertyKey');
+
+set $setterName(Map<String, Map<String, Object?>>? value) {
+  if (value == null) {
+    json.remove('$propertyKey');
+  }
+  else {
+    json['$propertyKey'] = value;
+  }
+  $sortOnKey
+}
+''';
+          case null:
+            if (schemas.additionalPropertiesBool != true) {
+              throw UnimplementedError();
+            }
+            result += '''
+Map<String, Object?>? get $fieldName => json.optionalMap('$propertyKey');
+
+set $setterName(Map<String, Object?>? value) {
+  if (value == null) {
+    json.remove('$propertyKey');
+  }
+  else {
+    json['$propertyKey'] = value;
+  }
+  $sortOnKey
+}
+''';
+          default:
+            throw UnimplementedError(additionalPropertiesType.toString());
+        }
+      } else {
+        var typeName = schemas.className;
+        typeName ??= ucFirst(snakeToCamelCase(propertyKey));
+        if (required) {
+          result += '''
+$typeName get $fieldName => $typeName.fromJson( json.map\$('$propertyKey') );
+''';
+          if (!override) {
+            result += '''
+set $setterName($typeName value) => json['$propertyKey'] = value.json;
+''';
+          }
+        } else {
+          result += '''
+$typeName? get $fieldName {
+  final map_ = json.optionalMap('$propertyKey');
+  if(map_ == null){
+    return null;
+  }
+  return $typeName.fromJson(map_);
+}
+
+set $setterName($typeName? value) {
+  if (value == null) {
+    json.remove('$propertyKey');
+  }
+  else {
+    json['$propertyKey'] = value.json;
+  }
+  $sortOnKey
+}
+''';
+        }
+      }
+    case SchemaType.boolean:
+      if (required) {
+        result += '''
+bool get $fieldName => json.get<bool>('$propertyKey');
+
+set $setterName(bool value) {
+  json['$propertyKey'] = value;
+  $sortOnKey
+}
+''';
+      } else {
+        result += '''
+bool? get $fieldName => json.getOptional<bool>('$propertyKey');
+
+set $setterName(bool? value) {
+  if (value == null) {
+    json.remove('$propertyKey');
+  }
+  else {
+    json['$propertyKey'] = value;
+  }
+  $sortOnKey
+};
+''';
+      }
+    case SchemaType.integer:
+      if (required) {
+        result += '''
+int get $fieldName => json.get<int>('$propertyKey');
+
+set $setterName(int value) => json['$propertyKey'] = value;
+''';
+      } else {
+        result += '''
+int? get $fieldName => json.getOptional<int>('$propertyKey');
+
+set $setterName(int? value) {
+  if (value == null) {
+    json.remove('$propertyKey');
+  }
+  else {
+    json['$propertyKey'] = value;
+  }
+  $sortOnKey
+}
+''';
+      }
+    case SchemaType.array:
+      final items = schemas.items;
+      final itemType = items.type;
+      switch (itemType) {
+        case SchemaType.string:
+          if (items.patterns.isNotEmpty) {
+            if (required) {
+              result += '''
+List<Uri> get $fieldName => json.pathList('$propertyKey');
+
+set $setterName(List<Uri> value) => json['$propertyKey'] = value.toJson();
+''';
+            } else {
+              result += '''
+List<Uri>? get $fieldName => json.optionalPathList('$propertyKey');
+
+set $setterName(List<Uri>? value) {
+  if (value == null) {
+    json.remove('$propertyKey');
+  }
+  else {
+    json['$propertyKey'] = value.toJson();
+  }
+  $sortOnKey
+}
+''';
+            }
+          } else {
+            if (required) {
+              result += '''
+List<String> get $fieldName => json.stringList('$propertyKey');
+
+set $setterName(List<String> value) {
+  json['$propertyKey'] = value;
+  $sortOnKey
+} 
+''';
+            } else {
+              result += '''
+List<String>? get $fieldName => json.optionalStringList('$propertyKey');
+
+set $setterName(List<String>? value) {
+  if (value == null) {
+    json.remove('$propertyKey');
+  }
+  else {
+    json['$propertyKey'] = value;
+  }
+  $sortOnKey
+}
+''';
+            }
+          }
+        case SchemaType.object:
+          final typeName = items.className!;
+          if (required) {
+            throw UnimplementedError();
+          } else {
+            result += '''
+List<$typeName>? get $fieldName {
+  final list_ = json.optionalList('$propertyKey')?.cast<Map<String, Object?>>();
+  if(list_ == null){
+    return null;
+  }
+  final result = <$typeName>[];
+  for(final item in list_){
+    result.add($typeName.fromJson(item));
+  }
+  return result;
+}
+
+set $setterName(List<$typeName>? value) {
+  if (value == null) {
+    json.remove('$propertyKey');
+  }
+  else {
+    json['$propertyKey'] = [
+      for (final item in value)
+        item.json
+    ];
+  }
+  $sortOnKey
+}
+''';
+          }
+        default:
+          throw UnimplementedError(itemType.toString());
+      }
+
+    default:
+      throw UnimplementedError(type.toString());
+  }
+  return result;
+}
+
+String snakeToCamelCase(String string) {
+  if (string.isEmpty) {
+    return '';
+  }
+
+  final parts = string.replaceAll('-', '_').split('_');
+
+  const capitalizationOverrides = {
+    'ios': 'iOS',
+    'Ios': 'IOS',
+    'macos': 'macOS',
+    'Macos': 'MacOS',
+  };
+
+  String remapCapitalization(String input) =>
+      capitalizationOverrides[input] ?? input;
+
+  var camelStr = remapCapitalization(parts[0]);
+
+  for (var i = 1; i < parts.length; i++) {
+    if (parts[i].isNotEmpty) {
+      camelStr += remapCapitalization(
+        parts[i][0].toUpperCase() + parts[i].substring(1),
+      );
+    }
+  }
+
+  return camelStr;
+}
+
+String ucFirst(String str) {
+  if (str.isEmpty) {
+    return '';
+  }
+  return str[0].toUpperCase() + str.substring(1);
+}
+
+/// A view on [JsonSchema]s that extend/override each other.
+extension type JsonSchemas._(List<JsonSchema> _schemas) {
+  factory JsonSchemas(JsonSchema schema) => JsonSchemas._([schema])._flatten();
+
+  JsonSchemas _flatten() {
+    final flattened = <JsonSchema>[];
+    final queue = <JsonSchema>[..._schemas];
+    while (queue.isNotEmpty) {
+      final item = queue.first;
+      queue.removeAt(0);
+      if (flattened.contains(item)) {
+        continue;
+      }
+      flattened.add(item);
+      queue.addAll(item.allOf);
+      final ref = item.ref;
+      if (ref != null) {
+        queue.add(item.resolvePath(ref));
+      }
+    }
+    final result = JsonSchemas._(flattened);
+    if (result.dartPackages.length > 2) {
+      throw UnimplementedError();
+    }
+    return result;
+  }
+
+  List<String> get propertyKeys =>
+      {for (final schema in _schemas) ...schema.properties.keys}.toList()
+        ..sort();
+
+  JsonSchemas property(String key) {
+    final propertySchemas = <JsonSchema>[];
+    for (final schema in _schemas) {
+      final propertySchema = schema.properties[key];
+      if (propertySchema != null) {
+        propertySchemas.add(propertySchema);
+      }
+    }
+    return JsonSchemas._(propertySchemas)._flatten();
+  }
+
+  bool propertyRequired(String? property) =>
+      _schemas.any((e) => e.propertyRequired(property));
+
+  SchemaType? get type {
+    final types = <SchemaType>{};
+    for (final schema in _schemas) {
+      final schemaTypes = schema.typeList;
+      if (schemaTypes != null) {
+        for (final schemaType in schemaTypes) {
+          if (schemaType != null) types.add(schemaType);
+        }
+      }
+    }
+    if (types.length > 1) {
+      throw StateError('Multiple types found');
+    }
+    return types.singleOrNull;
+  }
+
+  List<RegExp> get patterns {
+    final patterns = <RegExp>{};
+    for (final schema in _schemas) {
+      final pattern = schema.pattern;
+      if (pattern != null) {
+        patterns.add(pattern);
+      }
+    }
+    return patterns.toList();
+  }
+
+  JsonSchemas get items {
+    final items = <JsonSchema>[];
+    for (final schema in _schemas) {
+      final item = schema.items;
+      if (item != null) {
+        items.add(item);
+      }
+    }
+    return JsonSchemas._(items)._flatten();
+  }
+
+  List<String> get paths {
+    final paths = <String>{};
+    for (final schema in _schemas) {
+      final path = schema.path;
+      if (path != null) paths.add(path);
+    }
+    return paths.toList();
+  }
+
+  List<String> get definitionKeys =>
+      {for (final schema in _schemas) ...schema.definitions.keys}.toList()
+        ..sort();
+
+  JsonSchemas getDefinition(String key) {
+    final definitionSchemas = <JsonSchema>[];
+    for (final schema in _schemas) {
+      final propertySchema = schema.definitions[key];
+      if (propertySchema != null) {
+        definitionSchemas.add(propertySchema);
+      }
+    }
+    return JsonSchemas._(definitionSchemas)._flatten();
+  }
+
+  JsonSchemas get additionalPropertiesSchemas {
+    final schemas = <JsonSchema>[];
+    for (final schema in _schemas) {
+      final additionalPropertiesSchema = schema.additionalPropertiesSchema;
+      if (additionalPropertiesSchema != null) {
+        schemas.add(additionalPropertiesSchema);
+      }
+    }
+    return JsonSchemas._(schemas)._flatten();
+  }
+
+  bool? get additionalPropertiesBool {
+    final result = <bool>[];
+    for (final schema in _schemas) {
+      final additionalPropertiesBool = schema.additionalPropertiesBool;
+      if (additionalPropertiesBool != null) {
+        result.add(additionalPropertiesBool);
+      }
+    }
+    if (result.length > 1) {
+      throw UnimplementedError();
+    }
+    return result.singleOrNull;
+  }
+
+  bool get isNotEmpty => _schemas.isNotEmpty;
+
+  List<List<JsonSchemas>> get anyOfs {
+    final result = <List<JsonSchemas>>[];
+    for (final schema in _schemas) {
+      final anyOf = schema.anyOf;
+      final tempResult = <JsonSchemas>[];
+      for (final option in anyOf) {
+        tempResult.add(JsonSchemas(option)._flatten());
+      }
+      if (tempResult.isNotEmpty) {
+        result.add(tempResult);
+      }
+    }
+    return result;
+  }
+
+  Object? get constValue {
+    final result = <Object>[];
+    for (final schema in _schemas) {
+      final item = schema.constValue;
+      if (item != null) {
+        result.add(item as Object);
+      }
+    }
+    if (result.length > 1) {
+      throw UnimplementedError();
+    }
+    return result.singleOrNull;
+  }
+
+  List<Uri> get refs {
+    final result = <Uri>[];
+    for (final schema in _schemas) {
+      final ref = schema.ref;
+      if (ref != null) {
+        result.add(ref);
+      }
+    }
+    return result;
+  }
+
+  List<(JsonSchemas, JsonSchemas)> get ifThenSchemas {
+    final result = <(JsonSchemas, JsonSchemas)>[];
+    for (final schema in _schemas) {
+      final ifSchema = schema.ifSchema;
+      final thenSchema = schema.thenSchema;
+      if (ifSchema != null && thenSchema != null) {
+        result.add((
+          JsonSchemas(ifSchema)._flatten(),
+          JsonSchemas(thenSchema)._flatten(),
+        ));
+      }
+    }
+    return result;
+  }
+}
+
+extension CodeGenDecisions on JsonSchemas {
+  /// Either [generateClosedEnum] or [generateOpenEnum].
+  bool get generateEnum => type == SchemaType.string && anyOfs.isNotEmpty;
+
+  /// A class with opaque members.
+  bool get generateClosedEnum =>
+      generateEnum && !anyOfs.single.any((e) => e.type != null);
+
+  /// A class with opaque members and an `unknown` option.
+  bool get generateOpenEnum =>
+      generateEnum && anyOfs.single.any((e) => e.type != null);
+
+  /// Generate getters/setters as `Map<String, ...>.
+  bool get generateMapOf =>
+      type == SchemaType.object &&
+      (additionalPropertiesSchemas.isNotEmpty ||
+          additionalPropertiesBool == true);
+
+  bool get generateSubClasses =>
+      type == SchemaType.object &&
+      propertyKeys.length == 1 &&
+      property(propertyKeys.single).anyOfs.isNotEmpty;
+
+  bool get generateClass => type == SchemaType.object && !generateMapOf;
+
+  /// Generate getters/setters as `Uri`.
+  bool get generateUri => type == SchemaType.string && patterns.isNotEmpty;
+
+  static String? _pathToClassName(String path) {
+    if (path.contains('#/definitions/')) {
+      final splits = path.split('/');
+      final indexOf = splits.indexOf('definitions');
+      final nameParts = splits.skip(indexOf + 1).where((e) => e.isNotEmpty);
+      if (nameParts.length == 1 && nameParts.single.startsWithUpperCase()) {
+        return nameParts.single;
+      }
+    }
+    return null;
+  }
+
+  /// This is all the inferred class names from definitions in order of
+  /// traversal.
+  List<String> get classNames {
+    final result = <String>[];
+    for (final path in paths) {
+      final className = _pathToClassName(path);
+      if (className != null) {
+        if (!result.contains(className)) {
+          result.add(className);
+        }
+      }
+    }
+    return result;
+  }
+
+  String? get className => classNames.firstOrNull;
+
+  String? get superClassName {
+    final names = classNames;
+    if (names.length == 2) {
+      return names[1];
+    }
+    if (names.length > 2) {
+      throw UnimplementedError();
+    }
+    return null;
+  }
+
+  JsonSchemas? get superClassSchemas {
+    final parentClassName = superClassName;
+    if (parentClassName == null) {
+      return null;
+    }
+    for (final schema in _schemas) {
+      final path = schema.path;
+      if (path == null) continue;
+      final className = _pathToClassName(path);
+      if (className != parentClassName) continue;
+      return JsonSchemas(schema)._flatten();
+    }
+    throw UnimplementedError();
+  }
+
+  JsonSchemas get baseSchemas {
+    final packages = dartPackages;
+    if (packages.length == 1) {
+      return this;
+    }
+    if (packages.length != 2) {
+      throw UnimplementedError();
+    }
+    final package = dependency(packages);
+    final result = <JsonSchema>[];
+    for (final schema in _schemas) {
+      if (schema.dartPackage == package) {
+        result.add(schema);
+      }
+    }
+    return JsonSchemas._(result);
+  }
+
+  JsonSchemas get extensionSchemas {
+    final packages = dartPackages;
+    if (packages.length == 1) {
+      return JsonSchemas._([]);
+    }
+    if (packages.length != 2) {
+      throw UnimplementedError();
+    }
+    final package = importer(packages);
+    final result = <JsonSchema>[];
+    for (final schema in _schemas) {
+      if (schema.dartPackage == package) {
+        result.add(schema);
+      }
+    }
+    return JsonSchemas._(result);
+  }
+
+  bool generateExtension(String currentPackage) =>
+      dartPackages.length > 1 ||
+      dartPackages[0] != currentPackage && className != null;
+
+  List<String> get dartPackages {
+    final result = <String>[];
+    for (final schema in _schemas) {
+      final pkg = schema.dartPackage;
+      if (!result.contains(pkg)) {
+        result.add(pkg);
+      }
+    }
+    return result;
+  }
+}
+
+extension on JsonSchema {
+  String get dartPackage {
+    final schemaUri = rootSchemas2[root]!;
+    final segments = schemaUri.pathSegments;
+    final pkgName = segments[segments.indexOf('pkgs') + 1];
+    return pkgName;
+  }
+}
+
+extension on String {
+  bool startsWithUpperCase() {
+    final codeUnit = codeUnitAt(0);
+    return codeUnit >= 65 && codeUnit <= 90;
+  }
+}

--- a/pkgs/hook/tool/generate.dart
+++ b/pkgs/hook/tool/generate.dart
@@ -38,7 +38,10 @@ const _publicSetters = {
 
 String dependency(List<String> packages) {
   if (packages.length != 2) {
-    throw UnimplementedError();
+    throw UnimplementedError(
+      'Extensions on extensions not supported. '
+      'So, only expect at most two packages.',
+    );
   }
   if (packageImports[packages[0]]!.contains(packages[1])) {
     return packages[1];
@@ -46,12 +49,15 @@ String dependency(List<String> packages) {
   if (packageImports[packages[1]]!.contains(packages[0])) {
     return packages[0];
   }
-  throw UnimplementedError();
+  throw StateError('Unknown packages: $packages');
 }
 
 String importer(List<String> packages) {
   if (packages.length != 2) {
-    throw UnimplementedError();
+    throw UnimplementedError(
+      'Extensions on extensions not supported. '
+      'So, only expect at most two packages.',
+    );
   }
   if (packageImports[packages[0]]!.contains(packages[1])) {
     return packages[0];
@@ -59,7 +65,7 @@ String importer(List<String> packages) {
   if (packageImports[packages[1]]!.contains(packages[0])) {
     return packages[1];
   }
-  throw UnimplementedError();
+  throw StateError('Unknown packages: $packages');
 }
 
 void main() {
@@ -143,7 +149,10 @@ String generateExtension(JsonSchemas schemas) {
   final baseSchemas = schemas.baseSchemas;
   final baseName = baseSchemas.className;
   if (baseName != typeName) {
-    throw UnimplementedError();
+    throw StateError(
+      'Expected the class name of the extension '
+      'to be identical to the base schema class name.',
+    );
   }
   final basePropertyKeys = baseSchemas.propertyKeys;
   final extensionPropertyKeys =
@@ -479,7 +488,6 @@ String generateDartType(
             final itemType = items.type;
             switch (itemType) {
               case SchemaType.object:
-                if (required) throw UnimplementedError();
                 final typeName = items.className!;
                 dartTypeNonNullable = 'Map<String, List<$typeName>>';
               default:
@@ -489,12 +497,16 @@ String generateDartType(
             final additionalPropertiesBool =
                 additionalPropertiesSchema.additionalPropertiesBool;
             if (additionalPropertiesBool != true) {
-              throw UnimplementedError(additionalPropertiesBool.toString());
+              throw UnimplementedError(
+                'Expected an object with arbitrary properties.',
+              );
             }
             dartTypeNonNullable = 'Map<String, Map<String, Object?>>';
           case null:
             if (schemas.additionalPropertiesBool != true) {
-              throw UnimplementedError();
+              throw UnimplementedError(
+                'Expected an object with arbitrary properties.',
+              );
             }
             dartTypeNonNullable = 'Map<String, Object?>';
           default:
@@ -641,7 +653,11 @@ set $setterName(String? value) {
             final itemType = items.type;
             switch (itemType) {
               case SchemaType.object:
-                if (required) throw UnimplementedError();
+                if (required) {
+                  throw UnimplementedError(
+                    'Only implemented for nullable property.',
+                  );
+                }
                 final typeName = items.className!;
                 result += '''
 Map<String, List<$typeName>>? get $fieldName {
@@ -681,7 +697,9 @@ set $setterName(Map<String, List<$typeName>>? value) {
             final additionalPropertiesBool =
                 additionalPropertiesSchema.additionalPropertiesBool;
             if (additionalPropertiesBool != true) {
-              throw UnimplementedError(additionalPropertiesBool.toString());
+              throw UnimplementedError(
+                'Expected an object with arbitrary properties.',
+              );
             }
             result += '''
 Map<String, Map<String, Object?>>? get $fieldName =>
@@ -699,7 +717,9 @@ set $setterName(Map<String, Map<String, Object?>>? value) {
 ''';
           case null:
             if (schemas.additionalPropertiesBool != true) {
-              throw UnimplementedError();
+              throw UnimplementedError(
+                'Expected an object with arbitrary properties.',
+              );
             }
             result += '''
 Map<String, Object?>? get $fieldName => json.optionalMap('$propertyKey');
@@ -854,7 +874,7 @@ set $setterName(List<String>? value) {
         case SchemaType.object:
           final typeName = items.className!;
           if (required) {
-            throw UnimplementedError();
+            throw UnimplementedError('Expected an optional property.');
           } else {
             result += '''
 List<$typeName>? get $fieldName {
@@ -953,7 +973,10 @@ extension type JsonSchemas._(List<JsonSchema> _schemas) {
     }
     final result = JsonSchemas._(flattened);
     if (result.dartPackages.length > 2) {
-      throw UnimplementedError();
+      throw UnimplementedError(
+        'Extensions on extensions not implemented. '
+        'So only two package names are expected here.',
+      );
     }
     return result;
   }
@@ -1058,7 +1081,7 @@ extension type JsonSchemas._(List<JsonSchema> _schemas) {
       }
     }
     if (result.length > 1) {
-      throw UnimplementedError();
+      throw StateError('Both yes and no for additional properties.');
     }
     return result.singleOrNull;
   }
@@ -1089,7 +1112,7 @@ extension type JsonSchemas._(List<JsonSchema> _schemas) {
       }
     }
     if (result.length > 1) {
-      throw UnimplementedError();
+      throw UnimplementedError('Conflicting const values.');
     }
     return result.singleOrNull;
   }
@@ -1184,7 +1207,7 @@ extension CodeGenDecisions on JsonSchemas {
       return names[1];
     }
     if (names.length > 2) {
-      throw UnimplementedError();
+      throw UnimplementedError('Deeper inheritance not implemented.');
     }
     return null;
   }
@@ -1201,7 +1224,7 @@ extension CodeGenDecisions on JsonSchemas {
       if (className != parentClassName) continue;
       return JsonSchemas(schema)._flatten();
     }
-    throw UnimplementedError();
+    throw StateError('No super class schema found for $parentClassName.');
   }
 
   JsonSchemas get baseSchemas {
@@ -1210,7 +1233,10 @@ extension CodeGenDecisions on JsonSchemas {
       return this;
     }
     if (packages.length != 2) {
-      throw UnimplementedError();
+      throw UnimplementedError(
+        'No extensions on extensions supported. '
+        'So, only two package names expected.',
+      );
     }
     final package = dependency(packages);
     final result = <JsonSchema>[];
@@ -1228,7 +1254,10 @@ extension CodeGenDecisions on JsonSchemas {
       return JsonSchemas._([]);
     }
     if (packages.length != 2) {
-      throw UnimplementedError();
+      throw UnimplementedError(
+        'No extensions on extensions supported. '
+        'So, only two package names expected.',
+      );
     }
     final package = importer(packages);
     final result = <JsonSchema>[];

--- a/pkgs/hook/tool/generate.dart
+++ b/pkgs/hook/tool/generate.dart
@@ -539,7 +539,7 @@ String generateAccessor(
   bool allowEnum = true,
   bool setterPrivate = true,
 }) {
-  var result = '';
+  var result = StringBuffer();
   final type = schemas.type;
   final fieldName = snakeToCamelCase(remapPropertyKey(propertyKey));
   final setterName = setterPrivate ? '_$fieldName' : fieldName;
@@ -890,7 +890,7 @@ set $setterName(List<$typeName>? value) {
     default:
       throw UnimplementedError(type.toString());
   }
-  return result;
+  return result.toString();
 }
 
 String snakeToCamelCase(String string) {
@@ -910,17 +910,18 @@ String snakeToCamelCase(String string) {
   String remapCapitalization(String input) =>
       capitalizationOverrides[input] ?? input;
 
-  var camelStr = remapCapitalization(parts[0]);
+  var result = StringBuffer();
+  result += remapCapitalization(parts[0]);
 
   for (var i = 1; i < parts.length; i++) {
     if (parts[i].isNotEmpty) {
-      camelStr += remapCapitalization(
+      result += remapCapitalization(
         parts[i][0].toUpperCase() + parts[i].substring(1),
       );
     }
   }
 
-  return camelStr;
+  return result.toString();
 }
 
 String ucFirst(String str) {
@@ -1269,4 +1270,8 @@ extension on String {
     final codeUnit = codeUnitAt(0);
     return codeUnit >= 'A'.codeUnitAt(0) && codeUnit <= 'Z'.codeUnitAt(0);
   }
+}
+
+extension on StringBuffer {
+  StringBuffer operator +(String value) => this..write(value);
 }

--- a/pkgs/native_assets_cli/lib/src/code_assets/architecture.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/architecture.dart
@@ -4,6 +4,8 @@
 
 import 'dart:ffi' show Abi;
 
+import 'syntax.g.dart' as syntax;
+
 /// A hardware architecture which the Dart VM can run on.
 final class Architecture {
   /// The name of this architecture.
@@ -75,16 +77,34 @@ final class Architecture {
   @override
   String toString() => name;
 
-  static final Map<String, Architecture> _architectureByName = {
-    for (var architecture in values) architecture.name: architecture,
-  };
-
   /// Creates an [Architecture] from the given [name].
   ///
   /// The name can be obtained from [Architecture.name] or
   /// [Architecture.toString].
-  factory Architecture.fromString(String name) => _architectureByName[name]!;
+  factory Architecture.fromString(String name) =>
+      ArchitectureSyntax.fromSyntax(syntax.Architecture.fromJson(name));
 
   /// The current [Architecture].
   static final Architecture current = _abiToArch[Abi.current()]!;
+}
+
+extension ArchitectureSyntax on Architecture {
+  static final _toSyntax = {
+    for (final item in Architecture.values)
+      item: syntax.Architecture.fromJson(item.name),
+  };
+
+  static final _fromSyntax = {
+    for (var entry in _toSyntax.entries) entry.value: entry.key,
+  };
+
+  syntax.Architecture toSyntax() => _toSyntax[this]!;
+
+  static Architecture fromSyntax(
+    syntax.Architecture syntax,
+  ) => switch (_fromSyntax[syntax]) {
+    null =>
+      throw FormatException('The architecture "${syntax.name}" is not known'),
+    final arch => arch,
+  };
 }

--- a/pkgs/native_assets_cli/lib/src/code_assets/link_mode_preference.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/link_mode_preference.dart
@@ -4,6 +4,8 @@
 
 import 'code_asset.dart';
 
+import 'syntax.g.dart' as syntax;
+
 /// The preferred linkMode method for [CodeAsset]s.
 final class LinkModePreference {
   /// The name for this link mode.
@@ -12,7 +14,9 @@ final class LinkModePreference {
   const LinkModePreference(this.name);
 
   factory LinkModePreference.fromString(String name) =>
-      values.firstWhere((element) => element.name == name);
+      LinkModePreferenceSyntax.fromSyntax(
+        syntax.LinkModePreference.fromJson(name),
+      );
 
   /// Provide native assets as dynamic libraries.
   ///
@@ -43,4 +47,20 @@ final class LinkModePreference {
 
   @override
   String toString() => name;
+}
+
+extension LinkModePreferenceSyntax on LinkModePreference {
+  static final _toSyntax = {
+    for (final item in LinkModePreference.values)
+      item: syntax.LinkModePreference.fromJson(item.name),
+  };
+
+  static final _fromSyntax = {
+    for (var entry in _toSyntax.entries) entry.value: entry.key,
+  };
+
+  syntax.LinkModePreference toSyntax() => _toSyntax[this]!;
+
+  static LinkModePreference fromSyntax(syntax.LinkModePreference syntax) =>
+      _fromSyntax[syntax]!;
 }

--- a/pkgs/native_assets_cli/lib/src/code_assets/os.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/os.dart
@@ -4,6 +4,8 @@
 
 import 'dart:io';
 
+import 'syntax.g.dart' as syntax;
+
 /// An operating system the Dart VM runs on.
 final class OS {
   /// The name of this operating system.
@@ -44,8 +46,6 @@ final class OS {
     OS.windows: [OS.windows, OS.android],
   };
 
-  static const String configKey = 'target_os';
-
   /// The name of this [OS].
   ///
   /// This returns a stable string that can be used to construct a
@@ -53,19 +53,31 @@ final class OS {
   @override
   String toString() => name;
 
-  /// Mapping from strings as used in [OS.toString] to
-  /// [OS]s.
-  static final Map<String, OS> _stringToOS = {
-    for (var os in OS.values) os.toString(): os,
-  };
-
   /// Creates a [OS] from the given [name].
   ///
   /// The name can be obtained from [OS.name] or [OS.toString].
-  factory OS.fromString(String name) => _stringToOS[name]!;
+  factory OS.fromString(String name) =>
+      OSSyntax.fromSyntax(syntax.OS.fromJson(name));
 
   /// The current [OS].
   ///
   /// Consisten with the [Platform.version] string.
   static final OS current = OS.fromString(Platform.operatingSystem);
+}
+
+extension OSSyntax on OS {
+  static final _toSyntax = {
+    for (final item in OS.values) item: syntax.OS.fromJson(item.name),
+  };
+
+  static final _fromSyntax = {
+    for (var entry in _toSyntax.entries) entry.value: entry.key,
+  };
+
+  syntax.OS toSyntax() => _toSyntax[this]!;
+
+  static OS fromSyntax(syntax.OS syntax) => switch (_fromSyntax[syntax]) {
+    null => throw FormatException('The OS "${syntax.name}" is not known'),
+    final e => e,
+  };
 }

--- a/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
@@ -1,0 +1,693 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// This file is generated, do not edit.
+
+import '../hook/syntax.g.dart';
+import '../utils/json.dart';
+
+class AndroidCodeConfig {
+  final Map<String, Object?> json;
+
+  AndroidCodeConfig.fromJson(this.json);
+
+  AndroidCodeConfig({int? targetNdkApi}) : json = {} {
+    _targetNdkApi = targetNdkApi;
+    json.sortOnKey();
+  }
+
+  int? get targetNdkApi => json.getOptional<int>('target_ndk_api');
+
+  set _targetNdkApi(int? value) {
+    if (value == null) {
+      json.remove('target_ndk_api');
+    } else {
+      json['target_ndk_api'] = value;
+    }
+  }
+
+  @override
+  String toString() => 'AndroidCodeConfig($json)';
+}
+
+class Architecture {
+  final String name;
+
+  const Architecture._(this.name);
+
+  static const arm = Architecture._('arm');
+
+  static const arm64 = Architecture._('arm64');
+
+  static const ia32 = Architecture._('ia32');
+
+  static const riscv32 = Architecture._('riscv32');
+
+  static const riscv64 = Architecture._('riscv64');
+
+  static const x64 = Architecture._('x64');
+
+  static const List<Architecture> values = [
+    arm,
+    arm64,
+    ia32,
+    riscv32,
+    riscv64,
+    x64,
+  ];
+
+  static final Map<String, Architecture> _byName = {
+    for (final value in values) value.name: value,
+  };
+
+  Architecture.unknown(this.name) : assert(!_byName.keys.contains(name));
+
+  factory Architecture.fromJson(String name) {
+    final knownValue = _byName[name];
+    if (knownValue != null) {
+      return knownValue;
+    }
+    return Architecture.unknown(name);
+  }
+
+  bool get isKnown => _byName[name] != null;
+
+  @override
+  String toString() => name;
+}
+
+class NativeCodeAsset extends Asset {
+  NativeCodeAsset.fromJson(super.json) : super.fromJson();
+
+  NativeCodeAsset({
+    Architecture? architecture,
+    Uri? file,
+    required String id,
+    required LinkMode linkMode,
+    required OS os,
+  }) : super(type: 'native_code') {
+    _architecture = architecture;
+    _file = file;
+    _id = id;
+    _linkMode = linkMode;
+    _os = os;
+    json.sortOnKey();
+  }
+
+  /// Setup all fields for [NativeCodeAsset] that are not in
+  /// [Asset].
+  void setup({
+    Architecture? architecture,
+    Uri? file,
+    required String id,
+    required LinkMode linkMode,
+    required OS os,
+  }) {
+    _architecture = architecture;
+    _file = file;
+    _id = id;
+    _linkMode = linkMode;
+    _os = os;
+    json.sortOnKey();
+  }
+
+  Architecture? get architecture {
+    final string = json.optionalString('architecture');
+    if (string == null) return null;
+    return Architecture.fromJson(string);
+  }
+
+  set _architecture(Architecture? value) {
+    if (value == null) {
+      json.remove('architecture');
+    } else {
+      json['architecture'] = value.name;
+    }
+  }
+
+  Uri? get file => json.optionalPath('file');
+
+  set _file(Uri? value) {
+    if (value == null) {
+      json.remove('file');
+    } else {
+      json['file'] = value.toFilePath();
+    }
+  }
+
+  String get id => json.string('id');
+
+  set _id(String value) {
+    json['id'] = value;
+  }
+
+  LinkMode get linkMode => LinkMode.fromJson(json.map$('link_mode'));
+  set _linkMode(LinkMode value) => json['link_mode'] = value.json;
+
+  OS get os => OS.fromJson(json.string('os'));
+
+  set _os(OS value) {
+    json['os'] = value.name;
+  }
+
+  @override
+  String toString() => 'NativeCodeAsset($json)';
+}
+
+extension NativeCodeAssetExtension on Asset {
+  bool get isNativeCodeAsset => type == 'native_code';
+
+  NativeCodeAsset get asNativeCodeAsset => NativeCodeAsset.fromJson(json);
+}
+
+extension BuildConfigExtension on BuildConfig {
+  CodeConfig? get code {
+    final map_ = json.optionalMap('code');
+    if (map_ == null) {
+      return null;
+    }
+    return CodeConfig.fromJson(map_);
+  }
+
+  set code(CodeConfig? value) {
+    if (value == null) {
+      json.remove('code');
+    } else {
+      json['code'] = value.json;
+    }
+    json.sortOnKey();
+  }
+}
+
+class CCompilerConfig {
+  final Map<String, Object?> json;
+
+  CCompilerConfig.fromJson(this.json);
+
+  CCompilerConfig({
+    required Uri ar,
+    required Uri cc,
+    Uri? envScript,
+    List<String>? envScriptArguments,
+    required Uri ld,
+    Windows? windows,
+  }) : json = {} {
+    _ar = ar;
+    _cc = cc;
+    _envScript = envScript;
+    _envScriptArguments = envScriptArguments;
+    _ld = ld;
+    _windows = windows;
+    json.sortOnKey();
+  }
+
+  Uri get ar => json.path('ar');
+
+  set _ar(Uri value) {
+    json['ar'] = value.toFilePath();
+  }
+
+  Uri get cc => json.path('cc');
+
+  set _cc(Uri value) {
+    json['cc'] = value.toFilePath();
+  }
+
+  Uri? get envScript => json.optionalPath('env_script');
+
+  set _envScript(Uri? value) {
+    if (value == null) {
+      json.remove('env_script');
+    } else {
+      json['env_script'] = value.toFilePath();
+    }
+  }
+
+  List<String>? get envScriptArguments =>
+      json.optionalStringList('env_script_arguments');
+
+  set _envScriptArguments(List<String>? value) {
+    if (value == null) {
+      json.remove('env_script_arguments');
+    } else {
+      json['env_script_arguments'] = value;
+    }
+  }
+
+  Uri get ld => json.path('ld');
+
+  set _ld(Uri value) {
+    json['ld'] = value.toFilePath();
+  }
+
+  Windows? get windows {
+    final map_ = json.optionalMap('windows');
+    if (map_ == null) {
+      return null;
+    }
+    return Windows.fromJson(map_);
+  }
+
+  set _windows(Windows? value) {
+    if (value == null) {
+      json.remove('windows');
+    } else {
+      json['windows'] = value.json;
+    }
+  }
+
+  @override
+  String toString() => 'CCompilerConfig($json)';
+}
+
+class Windows {
+  final Map<String, Object?> json;
+
+  Windows.fromJson(this.json);
+
+  Windows({DeveloperCommandPrompt? developerCommandPrompt}) : json = {} {
+    _developerCommandPrompt = developerCommandPrompt;
+    json.sortOnKey();
+  }
+
+  DeveloperCommandPrompt? get developerCommandPrompt {
+    final map_ = json.optionalMap('developer_command_prompt');
+    if (map_ == null) {
+      return null;
+    }
+    return DeveloperCommandPrompt.fromJson(map_);
+  }
+
+  set _developerCommandPrompt(DeveloperCommandPrompt? value) {
+    if (value == null) {
+      json.remove('developer_command_prompt');
+    } else {
+      json['developer_command_prompt'] = value.json;
+    }
+  }
+
+  @override
+  String toString() => 'Windows($json)';
+}
+
+class DeveloperCommandPrompt {
+  final Map<String, Object?> json;
+
+  DeveloperCommandPrompt.fromJson(this.json);
+
+  DeveloperCommandPrompt({required List<String> arguments, required Uri script})
+    : json = {} {
+    _arguments = arguments;
+    _script = script;
+    json.sortOnKey();
+  }
+
+  List<String> get arguments => json.stringList('arguments');
+
+  set _arguments(List<String> value) {
+    json['arguments'] = value;
+  }
+
+  Uri get script => json.path('script');
+
+  set _script(Uri value) {
+    json['script'] = value.toFilePath();
+  }
+
+  @override
+  String toString() => 'DeveloperCommandPrompt($json)';
+}
+
+class CodeConfig {
+  final Map<String, Object?> json;
+
+  CodeConfig.fromJson(this.json);
+
+  CodeConfig({
+    AndroidCodeConfig? android,
+    CCompilerConfig? cCompiler,
+    IOSCodeConfig? iOS,
+    required LinkModePreference linkModePreference,
+    MacOSCodeConfig? macOS,
+    required Architecture targetArchitecture,
+    required OS targetOs,
+  }) : json = {} {
+    _android = android;
+    _cCompiler = cCompiler;
+    _iOS = iOS;
+    _linkModePreference = linkModePreference;
+    _macOS = macOS;
+    _targetArchitecture = targetArchitecture;
+    _targetOs = targetOs;
+    json.sortOnKey();
+  }
+
+  AndroidCodeConfig? get android {
+    final map_ = json.optionalMap('android');
+    if (map_ == null) {
+      return null;
+    }
+    return AndroidCodeConfig.fromJson(map_);
+  }
+
+  set _android(AndroidCodeConfig? value) {
+    if (value == null) {
+      json.remove('android');
+    } else {
+      json['android'] = value.json;
+    }
+  }
+
+  CCompilerConfig? get cCompiler {
+    final map_ = json.optionalMap('c_compiler');
+    if (map_ == null) {
+      return null;
+    }
+    return CCompilerConfig.fromJson(map_);
+  }
+
+  set _cCompiler(CCompilerConfig? value) {
+    if (value == null) {
+      json.remove('c_compiler');
+    } else {
+      json['c_compiler'] = value.json;
+    }
+  }
+
+  IOSCodeConfig? get iOS {
+    final map_ = json.optionalMap('ios');
+    if (map_ == null) {
+      return null;
+    }
+    return IOSCodeConfig.fromJson(map_);
+  }
+
+  set _iOS(IOSCodeConfig? value) {
+    if (value == null) {
+      json.remove('ios');
+    } else {
+      json['ios'] = value.json;
+    }
+  }
+
+  LinkModePreference get linkModePreference =>
+      LinkModePreference.fromJson(json.string('link_mode_preference'));
+
+  set _linkModePreference(LinkModePreference value) {
+    json['link_mode_preference'] = value.name;
+  }
+
+  MacOSCodeConfig? get macOS {
+    final map_ = json.optionalMap('macos');
+    if (map_ == null) {
+      return null;
+    }
+    return MacOSCodeConfig.fromJson(map_);
+  }
+
+  set _macOS(MacOSCodeConfig? value) {
+    if (value == null) {
+      json.remove('macos');
+    } else {
+      json['macos'] = value.json;
+    }
+  }
+
+  Architecture get targetArchitecture =>
+      Architecture.fromJson(json.string('target_architecture'));
+
+  set _targetArchitecture(Architecture value) {
+    json['target_architecture'] = value.name;
+  }
+
+  OS get targetOs => OS.fromJson(json.string('target_os'));
+
+  set _targetOs(OS value) {
+    json['target_os'] = value.name;
+  }
+
+  @override
+  String toString() => 'CodeConfig($json)';
+}
+
+extension ConfigExtension on Config {
+  CodeConfig? get code {
+    final map_ = json.optionalMap('code');
+    if (map_ == null) {
+      return null;
+    }
+    return CodeConfig.fromJson(map_);
+  }
+
+  set code(CodeConfig? value) {
+    if (value == null) {
+      json.remove('code');
+    } else {
+      json['code'] = value.json;
+    }
+    json.sortOnKey();
+  }
+}
+
+class IOSCodeConfig {
+  final Map<String, Object?> json;
+
+  IOSCodeConfig.fromJson(this.json);
+
+  IOSCodeConfig({String? targetSdk, int? targetVersion}) : json = {} {
+    _targetSdk = targetSdk;
+    _targetVersion = targetVersion;
+    json.sortOnKey();
+  }
+
+  String? get targetSdk => json.optionalString('target_sdk');
+
+  set _targetSdk(String? value) {
+    if (value == null) {
+      json.remove('target_sdk');
+    } else {
+      json['target_sdk'] = value;
+    }
+  }
+
+  int? get targetVersion => json.getOptional<int>('target_version');
+
+  set _targetVersion(int? value) {
+    if (value == null) {
+      json.remove('target_version');
+    } else {
+      json['target_version'] = value;
+    }
+  }
+
+  @override
+  String toString() => 'IOSCodeConfig($json)';
+}
+
+class LinkMode {
+  final Map<String, Object?> json;
+
+  LinkMode.fromJson(this.json);
+
+  LinkMode({required String type}) : json = {} {
+    _type = type;
+    json.sortOnKey();
+  }
+
+  String get type => json.string('type');
+
+  set _type(String value) {
+    json['type'] = value;
+  }
+
+  @override
+  String toString() => 'LinkMode($json)';
+}
+
+class DynamicLoadingBundleLinkMode extends LinkMode {
+  DynamicLoadingBundleLinkMode.fromJson(super.json) : super.fromJson();
+
+  DynamicLoadingBundleLinkMode() : super(type: 'dynamic_loading_bundle');
+}
+
+extension DynamicLoadingBundleLinkModeExtension on LinkMode {
+  bool get isDynamicLoadingBundleLinkMode => type == 'dynamic_loading_bundle';
+
+  DynamicLoadingBundleLinkMode get asDynamicLoadingBundleLinkMode =>
+      DynamicLoadingBundleLinkMode.fromJson(json);
+}
+
+class DynamicLoadingExecutableLinkMode extends LinkMode {
+  DynamicLoadingExecutableLinkMode.fromJson(super.json) : super.fromJson();
+
+  DynamicLoadingExecutableLinkMode()
+    : super(type: 'dynamic_loading_executable');
+}
+
+extension DynamicLoadingExecutableLinkModeExtension on LinkMode {
+  bool get isDynamicLoadingExecutableLinkMode =>
+      type == 'dynamic_loading_executable';
+
+  DynamicLoadingExecutableLinkMode get asDynamicLoadingExecutableLinkMode =>
+      DynamicLoadingExecutableLinkMode.fromJson(json);
+}
+
+class DynamicLoadingProcessLinkMode extends LinkMode {
+  DynamicLoadingProcessLinkMode.fromJson(super.json) : super.fromJson();
+
+  DynamicLoadingProcessLinkMode() : super(type: 'dynamic_loading_process');
+}
+
+extension DynamicLoadingProcessLinkModeExtension on LinkMode {
+  bool get isDynamicLoadingProcessLinkMode => type == 'dynamic_loading_process';
+
+  DynamicLoadingProcessLinkMode get asDynamicLoadingProcessLinkMode =>
+      DynamicLoadingProcessLinkMode.fromJson(json);
+}
+
+class DynamicLoadingSystemLinkMode extends LinkMode {
+  DynamicLoadingSystemLinkMode.fromJson(super.json) : super.fromJson();
+
+  DynamicLoadingSystemLinkMode({required Uri uri})
+    : super(type: 'dynamic_loading_system') {
+    _uri = uri;
+    json.sortOnKey();
+  }
+
+  /// Setup all fields for [DynamicLoadingSystemLinkMode] that are not in
+  /// [LinkMode].
+  void setup({required Uri uri}) {
+    _uri = uri;
+    json.sortOnKey();
+  }
+
+  Uri get uri => json.path('uri');
+
+  set _uri(Uri value) {
+    json['uri'] = value.toFilePath();
+  }
+
+  @override
+  String toString() => 'DynamicLoadingSystemLinkMode($json)';
+}
+
+extension DynamicLoadingSystemLinkModeExtension on LinkMode {
+  bool get isDynamicLoadingSystemLinkMode => type == 'dynamic_loading_system';
+
+  DynamicLoadingSystemLinkMode get asDynamicLoadingSystemLinkMode =>
+      DynamicLoadingSystemLinkMode.fromJson(json);
+}
+
+class StaticLinkMode extends LinkMode {
+  StaticLinkMode.fromJson(super.json) : super.fromJson();
+
+  StaticLinkMode() : super(type: 'static');
+}
+
+extension StaticLinkModeExtension on LinkMode {
+  bool get isStaticLinkMode => type == 'static';
+
+  StaticLinkMode get asStaticLinkMode => StaticLinkMode.fromJson(json);
+}
+
+class LinkModePreference {
+  final String name;
+
+  const LinkModePreference._(this.name);
+
+  static const dynamic = LinkModePreference._('dynamic');
+
+  static const preferDynamic = LinkModePreference._('prefer-dynamic');
+
+  static const preferStatic = LinkModePreference._('prefer-static');
+
+  static const static = LinkModePreference._('static');
+
+  static const List<LinkModePreference> values = [
+    dynamic,
+    preferDynamic,
+    preferStatic,
+    static,
+  ];
+
+  static final Map<String, LinkModePreference> _byName = {
+    for (final value in values) value.name: value,
+  };
+
+  LinkModePreference.unknown(this.name) : assert(!_byName.keys.contains(name));
+
+  factory LinkModePreference.fromJson(String name) {
+    final knownValue = _byName[name];
+    if (knownValue != null) {
+      return knownValue;
+    }
+    return LinkModePreference.unknown(name);
+  }
+
+  bool get isKnown => _byName[name] != null;
+
+  @override
+  String toString() => name;
+}
+
+class MacOSCodeConfig {
+  final Map<String, Object?> json;
+
+  MacOSCodeConfig.fromJson(this.json);
+
+  MacOSCodeConfig({int? targetVersion}) : json = {} {
+    _targetVersion = targetVersion;
+    json.sortOnKey();
+  }
+
+  int? get targetVersion => json.getOptional<int>('target_version');
+
+  set _targetVersion(int? value) {
+    if (value == null) {
+      json.remove('target_version');
+    } else {
+      json['target_version'] = value;
+    }
+  }
+
+  @override
+  String toString() => 'MacOSCodeConfig($json)';
+}
+
+class OS {
+  final String name;
+
+  const OS._(this.name);
+
+  static const android = OS._('android');
+
+  static const iOS = OS._('ios');
+
+  static const linux = OS._('linux');
+
+  static const macOS = OS._('macos');
+
+  static const windows = OS._('windows');
+
+  static const List<OS> values = [android, iOS, linux, macOS, windows];
+
+  static final Map<String, OS> _byName = {
+    for (final value in values) value.name: value,
+  };
+
+  OS.unknown(this.name) : assert(!_byName.keys.contains(name));
+
+  factory OS.fromJson(String name) {
+    final knownValue = _byName[name];
+    if (knownValue != null) {
+      return knownValue;
+    }
+    return OS.unknown(name);
+  }
+
+  bool get isKnown => _byName[name] != null;
+
+  @override
+  String toString() => name;
+}

--- a/pkgs/native_assets_cli/lib/src/data_assets/data_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/data_asset.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../encoded_asset.dart';
-import '../utils/json.dart';
+import 'syntax.g.dart' as syntax;
 
 /// Data bundled with a Dart or Flutter application.
 ///
@@ -44,10 +44,11 @@ final class DataAsset {
   factory DataAsset.fromEncoded(EncodedAsset asset) {
     assert(asset.type == DataAsset.type);
     final jsonMap = asset.encoding;
+    final syntaxNode = syntax.DataAsset.fromJson(jsonMap);
     return DataAsset(
-      name: jsonMap.string(_nameKey),
-      package: jsonMap.string(_packageKey),
-      file: jsonMap.path(_fileKey),
+      file: syntaxNode.file,
+      name: syntaxNode.name,
+      package: syntaxNode.package,
     );
   }
 
@@ -64,21 +65,15 @@ final class DataAsset {
   @override
   int get hashCode => Object.hash(package, name, file.toFilePath());
 
-  EncodedAsset encode() => EncodedAsset(
-    DataAsset.type,
-    <String, Object>{
-      _nameKey: name,
-      _packageKey: package,
-      _fileKey: file.toFilePath(),
-    }..sortOnKey(),
-  );
+  EncodedAsset encode() {
+    final dataAsset = syntax.DataAsset.fromJson({});
+    dataAsset.setup(file: file, name: name, package: package);
+    final json = dataAsset.json;
+    return EncodedAsset(DataAsset.type, json);
+  }
 
   @override
   String toString() => 'DataAsset(${encode().encoding})';
 
   static const String type = 'data';
 }
-
-const _nameKey = 'name';
-const _packageKey = 'package';
-const _fileKey = 'file';

--- a/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// This file is generated, do not edit.
+
+import '../hook/syntax.g.dart';
+import '../utils/json.dart';
+
+class DataAsset extends Asset {
+  DataAsset.fromJson(super.json) : super.fromJson();
+
+  DataAsset({required Uri file, required String name, required String package})
+    : super(type: 'data') {
+    _file = file;
+    _name = name;
+    _package = package;
+    json.sortOnKey();
+  }
+
+  /// Setup all fields for [DataAsset] that are not in
+  /// [Asset].
+  void setup({
+    required Uri file,
+    required String name,
+    required String package,
+  }) {
+    _file = file;
+    _name = name;
+    _package = package;
+    json.sortOnKey();
+  }
+
+  Uri get file => json.path('file');
+
+  set _file(Uri value) {
+    json['file'] = value.toFilePath();
+  }
+
+  String get name => json.string('name');
+
+  set _name(String value) {
+    json['name'] = value;
+  }
+
+  String get package => json.string('package');
+
+  set _package(String value) {
+    json['package'] = value;
+  }
+
+  @override
+  String toString() => 'DataAsset($json)';
+}
+
+extension DataAssetExtension on Asset {
+  bool get isDataAsset => type == 'data';
+
+  DataAsset get asDataAsset => DataAsset.fromJson(json);
+}

--- a/pkgs/native_assets_cli/lib/src/encoded_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/encoded_asset.dart
@@ -31,6 +31,7 @@ final class EncodedAsset {
   @override
   String toString() => 'EncodedAsset($type, $encoding)';
 
+  // TODO(https://github.com/dart-lang/native/issues/2045): Fix this.
   @override
   int get hashCode => Object.hash(type, const DeepCollectionEquality().hash);
 

--- a/pkgs/native_assets_cli/lib/src/hook/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/hook/syntax.g.dart
@@ -1,0 +1,408 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// This file is generated, do not edit.
+
+import '../utils/json.dart';
+
+class Asset {
+  final Map<String, Object?> json;
+
+  Asset.fromJson(this.json);
+
+  Asset({required String type}) : json = {} {
+    _type = type;
+    json.sortOnKey();
+  }
+
+  String get type => json.string('type');
+
+  set _type(String value) {
+    json['type'] = value;
+  }
+
+  @override
+  String toString() => 'Asset($json)';
+}
+
+class BuildConfig extends Config {
+  BuildConfig.fromJson(super.json) : super.fromJson();
+
+  BuildConfig({required super.buildAssetTypes, required bool linkingEnabled})
+    : super() {
+    _linkingEnabled = linkingEnabled;
+    json.sortOnKey();
+  }
+
+  /// Setup all fields for [BuildConfig] that are not in
+  /// [Config].
+  void setup({required bool linkingEnabled}) {
+    _linkingEnabled = linkingEnabled;
+    json.sortOnKey();
+  }
+
+  bool get linkingEnabled => json.get<bool>('linking_enabled');
+
+  set _linkingEnabled(bool value) {
+    json['linking_enabled'] = value;
+  }
+
+  @override
+  String toString() => 'BuildConfig($json)';
+}
+
+class BuildInput extends HookInput {
+  BuildInput.fromJson(super.json) : super.fromJson();
+
+  BuildInput({
+    required super.config,
+    Map<String, Map<String, Object?>>? dependencyMetadata,
+    required super.outDir,
+    required super.outDirShared,
+    super.outFile,
+    required super.packageName,
+    required super.packageRoot,
+    required super.version,
+  }) : super() {
+    _dependencyMetadata = dependencyMetadata;
+    json.sortOnKey();
+  }
+
+  /// Setup all fields for [BuildInput] that are not in
+  /// [HookInput].
+  void setup({Map<String, Map<String, Object?>>? dependencyMetadata}) {
+    _dependencyMetadata = dependencyMetadata;
+    json.sortOnKey();
+  }
+
+  @override
+  BuildConfig get config => BuildConfig.fromJson(json.map$('config'));
+
+  Map<String, Map<String, Object?>>? get dependencyMetadata =>
+      json.optionalMap<Map<String, Object?>>('dependency_metadata');
+
+  set _dependencyMetadata(Map<String, Map<String, Object?>>? value) {
+    if (value == null) {
+      json.remove('dependency_metadata');
+    } else {
+      json['dependency_metadata'] = value;
+    }
+  }
+
+  @override
+  String toString() => 'BuildInput($json)';
+}
+
+class BuildOutput extends HookOutput {
+  BuildOutput.fromJson(super.json) : super.fromJson();
+
+  BuildOutput({
+    super.assets,
+    Map<String, List<Asset>>? assetsForLinking,
+    super.dependencies,
+    Map<String, Object?>? metadata,
+    required super.timestamp,
+    required super.version,
+  }) : super() {
+    this.assetsForLinking = assetsForLinking;
+    this.metadata = metadata;
+    json.sortOnKey();
+  }
+
+  /// Setup all fields for [BuildOutput] that are not in
+  /// [HookOutput].
+  void setup({
+    Map<String, List<Asset>>? assetsForLinking,
+    Map<String, Object?>? metadata,
+  }) {
+    this.assetsForLinking = assetsForLinking;
+    this.metadata = metadata;
+    json.sortOnKey();
+  }
+
+  Map<String, List<Asset>>? get assetsForLinking {
+    final map_ = json.optionalMap('assetsForLinking');
+    if (map_ == null) {
+      return null;
+    }
+    return {
+      for (final MapEntry(:key, :value) in map_.entries)
+        key: [
+          for (final item in value as List<Object?>)
+            Asset.fromJson(item as Map<String, Object?>),
+        ],
+    };
+  }
+
+  set assetsForLinking(Map<String, List<Asset>>? value) {
+    if (value == null) {
+      json.remove('assetsForLinking');
+    } else {
+      json['assetsForLinking'] = {
+        for (final MapEntry(:key, :value) in value.entries)
+          key: [for (final item in value) item.json],
+      };
+    }
+    json.sortOnKey();
+  }
+
+  Map<String, Object?>? get metadata => json.optionalMap('metadata');
+
+  set metadata(Map<String, Object?>? value) {
+    if (value == null) {
+      json.remove('metadata');
+    } else {
+      json['metadata'] = value;
+    }
+    json.sortOnKey();
+  }
+
+  @override
+  String toString() => 'BuildOutput($json)';
+}
+
+class Config {
+  final Map<String, Object?> json;
+
+  Config.fromJson(this.json);
+
+  Config({required List<String> buildAssetTypes}) : json = {} {
+    this.buildAssetTypes = buildAssetTypes;
+    json.sortOnKey();
+  }
+
+  List<String> get buildAssetTypes => json.stringList('build_asset_types');
+
+  set buildAssetTypes(List<String> value) {
+    json['build_asset_types'] = value;
+    json.sortOnKey();
+  }
+
+  @override
+  String toString() => 'Config($json)';
+}
+
+class HookInput {
+  final Map<String, Object?> json;
+
+  HookInput.fromJson(this.json);
+
+  HookInput({
+    required Config config,
+    required Uri outDir,
+    required Uri outDirShared,
+    Uri? outFile,
+    required String packageName,
+    required Uri packageRoot,
+    required String version,
+  }) : json = {} {
+    this.config = config;
+    this.outDir = outDir;
+    this.outDirShared = outDirShared;
+    this.outFile = outFile;
+    this.packageName = packageName;
+    this.packageRoot = packageRoot;
+    this.version = version;
+    json.sortOnKey();
+  }
+
+  Config get config => Config.fromJson(json.map$('config'));
+  set config(Config value) => json['config'] = value.json;
+
+  Uri get outDir => json.path('out_dir');
+
+  set outDir(Uri value) {
+    json['out_dir'] = value.toFilePath();
+    json.sortOnKey();
+  }
+
+  Uri get outDirShared => json.path('out_dir_shared');
+
+  set outDirShared(Uri value) {
+    json['out_dir_shared'] = value.toFilePath();
+    json.sortOnKey();
+  }
+
+  Uri? get outFile => json.optionalPath('out_file');
+
+  set outFile(Uri? value) {
+    if (value == null) {
+      json.remove('out_file');
+    } else {
+      json['out_file'] = value.toFilePath();
+    }
+    json.sortOnKey();
+  }
+
+  String get packageName => json.string('package_name');
+
+  set packageName(String value) {
+    json['package_name'] = value;
+    json.sortOnKey();
+  }
+
+  Uri get packageRoot => json.path('package_root');
+
+  set packageRoot(Uri value) {
+    json['package_root'] = value.toFilePath();
+    json.sortOnKey();
+  }
+
+  String get version => json.string('version');
+
+  set version(String value) {
+    json['version'] = value;
+    json.sortOnKey();
+  }
+
+  @override
+  String toString() => 'HookInput($json)';
+}
+
+class HookOutput {
+  final Map<String, Object?> json;
+
+  HookOutput.fromJson(this.json);
+
+  HookOutput({
+    List<Asset>? assets,
+    List<Uri>? dependencies,
+    required String timestamp,
+    required String version,
+  }) : json = {} {
+    this.assets = assets;
+    this.dependencies = dependencies;
+    this.timestamp = timestamp;
+    this.version = version;
+    json.sortOnKey();
+  }
+
+  List<Asset>? get assets {
+    final list_ = json.optionalList('assets')?.cast<Map<String, Object?>>();
+    if (list_ == null) {
+      return null;
+    }
+    final result = <Asset>[];
+    for (final item in list_) {
+      result.add(Asset.fromJson(item));
+    }
+    return result;
+  }
+
+  set assets(List<Asset>? value) {
+    if (value == null) {
+      json.remove('assets');
+    } else {
+      json['assets'] = [for (final item in value) item.json];
+    }
+    json.sortOnKey();
+  }
+
+  List<Uri>? get dependencies => json.optionalPathList('dependencies');
+
+  set dependencies(List<Uri>? value) {
+    if (value == null) {
+      json.remove('dependencies');
+    } else {
+      json['dependencies'] = value.toJson();
+    }
+    json.sortOnKey();
+  }
+
+  String get timestamp => json.string('timestamp');
+
+  set timestamp(String value) {
+    json['timestamp'] = value;
+    json.sortOnKey();
+  }
+
+  String get version => json.string('version');
+
+  set version(String value) {
+    json['version'] = value;
+    json.sortOnKey();
+  }
+
+  @override
+  String toString() => 'HookOutput($json)';
+}
+
+class LinkInput extends HookInput {
+  LinkInput.fromJson(super.json) : super.fromJson();
+
+  LinkInput({
+    List<Asset>? assets,
+    required super.config,
+    required super.outDir,
+    required super.outDirShared,
+    super.outFile,
+    required super.packageName,
+    required super.packageRoot,
+    Uri? resourceIdentifiers,
+    required super.version,
+  }) : super() {
+    _assets = assets;
+    _resourceIdentifiers = resourceIdentifiers;
+    json.sortOnKey();
+  }
+
+  /// Setup all fields for [LinkInput] that are not in
+  /// [HookInput].
+  void setup({List<Asset>? assets, Uri? resourceIdentifiers}) {
+    _assets = assets;
+    _resourceIdentifiers = resourceIdentifiers;
+    json.sortOnKey();
+  }
+
+  List<Asset>? get assets {
+    final list_ = json.optionalList('assets')?.cast<Map<String, Object?>>();
+    if (list_ == null) {
+      return null;
+    }
+    final result = <Asset>[];
+    for (final item in list_) {
+      result.add(Asset.fromJson(item));
+    }
+    return result;
+  }
+
+  set _assets(List<Asset>? value) {
+    if (value == null) {
+      json.remove('assets');
+    } else {
+      json['assets'] = [for (final item in value) item.json];
+    }
+  }
+
+  Uri? get resourceIdentifiers => json.optionalPath('resource_identifiers');
+
+  set _resourceIdentifiers(Uri? value) {
+    if (value == null) {
+      json.remove('resource_identifiers');
+    } else {
+      json['resource_identifiers'] = value.toFilePath();
+    }
+  }
+
+  @override
+  String toString() => 'LinkInput($json)';
+}
+
+class LinkOutput extends HookOutput {
+  LinkOutput.fromJson(super.json) : super.fromJson();
+
+  LinkOutput({
+    super.assets,
+    super.dependencies,
+    required super.timestamp,
+    required super.version,
+  }) : super();
+
+  /// Setup all fields for [LinkOutput] that are not in
+  /// [HookOutput].
+  void setup() {}
+
+  @override
+  String toString() => 'LinkOutput($json)';
+}

--- a/pkgs/native_assets_cli/lib/src/metadata.dart
+++ b/pkgs/native_assets_cli/lib/src/metadata.dart
@@ -7,14 +7,14 @@ import 'package:collection/collection.dart';
 import 'utils/json.dart';
 
 class Metadata {
-  final Map<String, Object> metadata;
+  final Map<String, Object?> metadata;
 
   const Metadata(this.metadata);
 
   factory Metadata.fromJson(Map<Object?, Object?>? jsonMap) =>
       Metadata(jsonMap?.formatCast<String, Object>() ?? {});
 
-  Map<String, Object> toJson() => {...metadata}..sortOnKey();
+  Map<String, Object?> toJson() => metadata;
 
   @override
   bool operator ==(Object other) {

--- a/pkgs/native_assets_cli/test/build_config_test.dart
+++ b/pkgs/native_assets_cli/test/build_config_test.dart
@@ -166,8 +166,10 @@ void main() async {
           predicate(
             (e) =>
                 e is FormatException &&
-                e.message.contains("Unexpected value '[]' ") &&
-                e.message.contains('Expected a Map<String, Object?>'),
+                e.message.contains('Unexpected value') &&
+                e.message.contains(
+                  'Expected a Map<String, Map<String, Object?>>?',
+                ),
           ),
         ),
       );


### PR DESCRIPTION
Bug:

* https://github.com/dart-lang/native/issues/1826

This PR generates a Dart syntax from the JSON schemas for hooks and the extensions.

Moreover, it uses the generated syntax in in `package:native_assets_cli` to replace the manually written JSON serialization and deserialization.

This PR is meant to be behavior preserving for the current implementation. Any issues with the existing implementation are carried forward, and will be addressed later.

_(It is a non-goal of this PR to change the current state.)_

### Design with Syntax and Semantic API

Before this PR, the semantic API immediately had a `toJson` and `fromJson` that took care of any migrations in progress from old to new syntax.

After this PR, the semantic API produces and consumes syntax object (and takes care of migrations in progress), and the syntax does `toJson` and `fromJson`. This means we have two layers now instead of one.

The mapping between semantic API and syntax is as follows:

* For classes in the semantic API that occur both in the input and output (and have an `equals` and `hashCode` override), accessing the semantic API constructs semantic objects with their read-out fields.
* For the classes in the semantic API that only occur on one side the readers are simply views on the syntax objects that forward the getters (and implement fallback behavior).
* For the classes in the semantic API that occur only on one side, the writers simply contain a syntax node and forward the writes (and implement fallback behavior).

One interesting case is the `EncodedAsset` because it intentionally "leaks" the underlying JSON encoding into the semantic API as an extension point.
(The extension point for configs doesn't have the same "leakage", because it's never passed from input to output, so there is no need to extra _all_ data including keys one doesn't know about.)

### Testing

This implementation passes all the existing test suites.

### Open issues

This PR does not use the schemas yet for syntax checking. Unfortunately `package:json_schema` does not produce useful error messages. Moreover, introducing a concept of syntax errors next to semantic errors is a larger refactoring.