### PR TITLE
[native_assets_builder] add `WINDIR` and `SYSTEMDRIVE` to allowed env list

### DIFF
--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -428,13 +428,13 @@ ${e.message}
     'HOME', // Needed to find tools in default install locations.
     'PATH', // Needed to invoke native tools.
     'PROGRAMDATA', // Needed for vswhere.exe.
+    'SYSTEMDRIVE', // Needed for CMake.
     'SYSTEMROOT', // Needed for process invocations on Windows.
     'TEMP', // Needed for temp dirs in Dart process.
     'TMP', // Needed for temp dirs in Dart process.
     'TMPDIR', // Needed for temp dirs in Dart process.
     'USER_PROFILE', // Needed to find tools in default install locations.
     'WINDIR', // Needed for CMake.
-    'SYSTEMDRIVE', // Needed for CMake.
   };
 
   Future<HookOutput?> _runHookForPackage(

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -433,6 +433,8 @@ ${e.message}
     'TMP', // Needed for temp dirs in Dart process.
     'TMPDIR', // Needed for temp dirs in Dart process.
     'USER_PROFILE', // Needed to find tools in default install locations.
+    'WINDIR', // Needed for CMake.
+    'SYSTEMDRIVE', // Needed for CMake.
   };
 
   Future<HookOutput?> _runHookForPackage(


### PR DESCRIPTION
- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

Closes: #2077 

As @dcharkes suggested, this PR add `WINDIR` and `SYSTEMDRIVE` to `hookEnvironmentVariablesFilter` at https://github.com/dart-lang/native/blob/318f841b7520ae29d93f4678f3b759849369f5c1/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart#L426-L436

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
