### PR TITLE
[native_assets_builder] Refactor API to `ProtocolExtension`s

### DIFF
--- a/pkgs/native_assets_builder/lib/native_assets_builder.dart
+++ b/pkgs/native_assets_builder/lib/native_assets_builder.dart
@@ -3,15 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 export 'package:native_assets_builder/src/build_runner/build_runner.dart'
-    show
-        ApplicationAssetValidator,
-        BuildInputCreator,
-        BuildInputValidator,
-        BuildValidator,
-        LinkInputCreator,
-        LinkInputValidator,
-        LinkValidator,
-        NativeAssetsBuildRunner;
+    show BuildInputCreator, LinkInputCreator, NativeAssetsBuildRunner;
 export 'package:native_assets_builder/src/model/build_result.dart'
     show BuildResult;
 export 'package:native_assets_builder/src/model/kernel_assets.dart';

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -78,6 +78,9 @@ class NativeAssetsBuildRunner {
   /// The native assets build runner does not support reentrancy for identical
   /// [BuildInput] and [LinkInput]! For more info see:
   /// https://github.com/dart-lang/native/issues/1319
+  ///
+  /// The base protocol can be extended with [extensions]. See
+  /// [ProtocolExtension] for more documentation.
   Future<BuildResult?> build({
     required List<ProtocolExtension> extensions,
     required bool linkingEnabled,
@@ -177,6 +180,9 @@ class NativeAssetsBuildRunner {
   /// The native assets build runner does not support reentrancy for identical
   /// [BuildInput] and [LinkInput]! For more info see:
   /// https://github.com/dart-lang/native/issues/1319
+  ///
+  /// The base protocol can be extended with [extensions]. See
+  /// [ProtocolExtension] for more documentation.
   Future<LinkResult?> link({
     required List<ProtocolExtension> extensions,
     Uri? resourceIdentifiers,

--- a/pkgs/native_assets_builder/test/build_runner/build_dependencies_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_dependencies_test.dart
@@ -30,9 +30,6 @@ void main() async {
               dartExecutable,
               capturedLogs: logMessages,
               buildAssetTypes: [CodeAsset.type],
-              inputValidator: validateCodeAssetBuildInput,
-              buildValidator: validateCodeAssetBuildOutput,
-              applicationAssetValidator: validateCodeAssetInApplication,
             ))!;
         expect(
           logMessages.join('\n'),

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_asset_id_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_asset_id_test.dart
@@ -25,9 +25,6 @@ void main() async {
           createCapturingLogger(logMessages, level: Level.SEVERE),
           dartExecutable,
           buildAssetTypes: [CodeAsset.type],
-          inputValidator: validateCodeAssetBuildInput,
-          buildValidator: validateCodeAssetBuildOutput,
-          applicationAssetValidator: validateCodeAssetInApplication,
         );
         final fullLog = logMessages.join('\n');
         expect(result, isNull);
@@ -56,9 +53,6 @@ void main() async {
           logger,
           dartExecutable,
           buildAssetTypes: [CodeAsset.type],
-          inputValidator: validateCodeAssetBuildInput,
-          buildValidator: validateCodeAssetBuildOutput,
-          applicationAssetValidator: validateCodeAssetInApplication,
         );
         expect(result, isNotNull);
       }

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_build_output_format_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_build_output_format_test.dart
@@ -31,9 +31,6 @@ void main() async {
             createCapturingLogger(logMessages, level: Level.SEVERE),
             dartExecutable,
             buildAssetTypes: [],
-            inputValidator: (input) async => [],
-            buildValidator: (input, output) async => [],
-            applicationAssetValidator: validateCodeAssetInApplication,
           );
           final fullLog = logMessages.join('\n');
           expect(result, isNull);

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_caching_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_caching_test.dart
@@ -30,9 +30,6 @@ void main() async {
               dartExecutable,
               capturedLogs: logMessages,
               buildAssetTypes: [CodeAsset.type],
-              inputValidator: validateCodeAssetBuildInput,
-              buildValidator: validateCodeAssetBuildOutput,
-              applicationAssetValidator: validateCodeAssetInApplication,
             ))!;
         expect(
           logMessages.join('\n'),
@@ -56,9 +53,6 @@ void main() async {
               dartExecutable,
               capturedLogs: logMessages,
               buildAssetTypes: [CodeAsset.type],
-              inputValidator: validateCodeAssetBuildInput,
-              buildValidator: validateCodeAssetBuildOutput,
-              applicationAssetValidator: validateCodeAssetInApplication,
             ))!;
         final hookUri = packageUri.resolve('hook/build.dart');
         expect(
@@ -104,9 +98,6 @@ void main() async {
               logger,
               dartExecutable,
               buildAssetTypes: [CodeAsset.type],
-              inputValidator: validateCodeAssetBuildInput,
-              buildValidator: validateCodeAssetBuildOutput,
-              applicationAssetValidator: validateCodeAssetInApplication,
             ))!;
         await expectSymbols(
           asset: CodeAsset.fromEncoded(result.encodedAssets.single),
@@ -127,9 +118,6 @@ void main() async {
               logger,
               dartExecutable,
               buildAssetTypes: [CodeAsset.type],
-              inputValidator: validateCodeAssetBuildInput,
-              buildValidator: validateCodeAssetBuildOutput,
-              applicationAssetValidator: validateCodeAssetInApplication,
             ))!;
 
         final cUri = packageUri.resolve('src/').resolve('native_add.c');
@@ -166,9 +154,6 @@ void main() async {
             logger,
             dartExecutable,
             buildAssetTypes: [CodeAsset.type],
-            inputValidator: validateCodeAssetBuildInput,
-            buildValidator: validateCodeAssetBuildOutput,
-            applicationAssetValidator: validateCodeAssetInApplication,
           ))!;
       {
         final compiledHook =
@@ -199,9 +184,6 @@ void main() async {
               logger,
               dartExecutable,
               buildAssetTypes: [CodeAsset.type],
-              inputValidator: validateCodeAssetBuildInput,
-              buildValidator: validateCodeAssetBuildOutput,
-              applicationAssetValidator: validateCodeAssetInApplication,
             ))!;
 
         final hookUri = packageUri.resolve('hook/build.dart');
@@ -237,9 +219,6 @@ void main() async {
               logger,
               dartExecutable,
               buildAssetTypes: [CodeAsset.type],
-              inputValidator: validateCodeAssetBuildInput,
-              buildValidator: validateCodeAssetBuildOutput,
-              applicationAssetValidator: validateCodeAssetInApplication,
               hookEnvironment:
                   modifiedEnvKey == 'PATH'
                       ? null
@@ -272,9 +251,6 @@ void main() async {
           logger,
           dartExecutable,
           buildAssetTypes: [CodeAsset.type],
-          inputValidator: validateCodeAssetBuildInput,
-          buildValidator: validateCodeAssetBuildOutput,
-          applicationAssetValidator: validateCodeAssetInApplication,
         ))!;
         expect(logMessages.join('\n'), contains('hook.dill'));
         expect(

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_cycle_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_cycle_test.dart
@@ -25,9 +25,6 @@ void main() async {
           createCapturingLogger(logMessages, level: Level.SEVERE),
           dartExecutable,
           buildAssetTypes: [],
-          inputValidator: (input) async => [],
-          buildValidator: (input, output) async => [],
-          applicationAssetValidator: (_) async => [],
         );
         final fullLog = logMessages.join('\n');
         expect(result, isNull);

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_failure_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_failure_test.dart
@@ -27,9 +27,6 @@ void main() async {
               logger,
               dartExecutable,
               buildAssetTypes: [CodeAsset.type],
-              inputValidator: validateCodeAssetBuildInput,
-              buildValidator: validateCodeAssetBuildOutput,
-              applicationAssetValidator: validateCodeAssetInApplication,
             ))!;
         expect(result.encodedAssets.length, 1);
         await expectSymbols(
@@ -54,9 +51,6 @@ void main() async {
           createCapturingLogger(logMessages, level: Level.SEVERE),
           dartExecutable,
           buildAssetTypes: [CodeAsset.type],
-          inputValidator: validateCodeAssetBuildInput,
-          buildValidator: validateCodeAssetBuildOutput,
-          applicationAssetValidator: validateCodeAssetInApplication,
         );
         final fullLog = logMessages.join('\n');
         expect(result, isNull);
@@ -87,9 +81,6 @@ void main() async {
               logger,
               dartExecutable,
               buildAssetTypes: [CodeAsset.type],
-              inputValidator: validateCodeAssetBuildInput,
-              buildValidator: validateCodeAssetBuildOutput,
-              applicationAssetValidator: validateCodeAssetInApplication,
             ))!;
         expect(result.encodedAssets.length, 1);
         await expectSymbols(
@@ -121,9 +112,6 @@ void main() async {
           capturedLogs: logMessages,
           dartExecutable,
           buildAssetTypes: [CodeAsset.type],
-          inputValidator: validateCodeAssetBuildInput,
-          buildValidator: validateCodeAssetBuildOutput,
-          applicationAssetValidator: validateCodeAssetInApplication,
         );
         Matcher stringContainsBuildHookCompilation(String packageName) =>
             stringContainsInOrder([

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_non_root_package_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_non_root_package_test.dart
@@ -29,9 +29,6 @@ void main() async {
               capturedLogs: logMessages,
               runPackageName: 'some_dev_dep',
               buildAssetTypes: [CodeAsset.type],
-              inputValidator: validateDataAssetBuildInput,
-              buildValidator: validateCodeAssetBuildOutput,
-              applicationAssetValidator: validateCodeAssetInApplication,
             ))!;
         expect(result.encodedAssets, isEmpty);
         expect(result.dependencies, isEmpty);
@@ -47,9 +44,6 @@ void main() async {
               capturedLogs: logMessages,
               runPackageName: 'native_add',
               buildAssetTypes: [CodeAsset.type],
-              inputValidator: validateDataAssetBuildInput,
-              buildValidator: validateCodeAssetBuildOutput,
-              applicationAssetValidator: validateCodeAssetInApplication,
             ))!;
         expect(result.encodedAssets, isNotEmpty);
         expect(

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
@@ -36,34 +36,18 @@ void main() async {
 
       final targetOS = OS.current;
       const defaultMacOSVersion = 13;
-      BuildInputBuilder inputCreator() =>
-          BuildInputBuilder()
-            ..config.setupCode(
-              targetArchitecture: Architecture.current,
-              targetOS: OS.current,
-              macOS:
-                  targetOS == OS.macOS
-                      ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                      : null,
-              linkModePreference: LinkModePreference.dynamic,
-            );
+      final extension = CodeAssetExtension(
+        targetArchitecture: Architecture.current,
+        targetOS: OS.current,
+        macOS:
+            targetOS == OS.macOS
+                ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+                : null,
+        linkModePreference: LinkModePreference.dynamic,
+      );
 
-      await buildRunner.build(
-        inputCreator: inputCreator,
-        linkingEnabled: false,
-        buildAssetTypes: [],
-        inputValidator: (input) async => [],
-        buildValidator: (input, output) async => [],
-        applicationAssetValidator: (_) async => [],
-      );
-      await buildRunner.build(
-        inputCreator: inputCreator,
-        linkingEnabled: false,
-        buildAssetTypes: [],
-        inputValidator: (input) async => [],
-        buildValidator: (input, output) async => [],
-        applicationAssetValidator: (_) async => [],
-      );
+      await buildRunner.build(extensions: [extension], linkingEnabled: false);
+      await buildRunner.build(extensions: [extension], linkingEnabled: false);
     });
   });
 }

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_test.dart
@@ -29,10 +29,7 @@ void main() async {
               logger,
               dartExecutable,
               capturedLogs: logMessages,
-              inputValidator: validateCodeAssetBuildInput,
               buildAssetTypes: [CodeAsset.type],
-              buildValidator: validateCodeAssetBuildOutput,
-              applicationAssetValidator: validateCodeAssetInApplication,
             ))!;
         expect(
           logMessages.join('\n'),
@@ -76,9 +73,6 @@ void main() async {
             dartExecutable,
             capturedLogs: logMessages,
             buildAssetTypes: [CodeAsset.type],
-            inputValidator: validateCodeAssetBuildInput,
-            buildValidator: validateCodeAssetBuildOutput,
-            applicationAssetValidator: validateCodeAssetInApplication,
           ))!;
       expect(
         false,

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test_helper.dart
@@ -33,35 +33,21 @@ void main(List<String> args) async {
   ).build(
     // Set up the code input, so that the builds for different targets are
     // in different directories.
-    inputCreator:
-        () =>
-            BuildInputBuilder()
-              ..config.setupCode(
-                targetArchitecture: target.architecture,
-                targetOS: targetOS,
-                macOS:
-                    targetOS == OS.macOS
-                        ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                        : null,
-                android:
-                    targetOS == OS.android
-                        ? AndroidCodeConfig(targetNdkApi: 30)
-                        : null,
-                linkModePreference: LinkModePreference.dynamic,
-              ),
+    extensions: [
+      CodeAssetExtension(
+        targetArchitecture: target.architecture,
+        targetOS: targetOS,
+        macOS:
+            targetOS == OS.macOS
+                ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+                : null,
+        android:
+            targetOS == OS.android ? AndroidCodeConfig(targetNdkApi: 30) : null,
+        linkModePreference: LinkModePreference.dynamic,
+      ),
+      DataAssetsExtension(),
+    ],
     linkingEnabled: false,
-    buildAssetTypes: [DataAsset.type, CodeAsset.type],
-    inputValidator:
-        (input) async => [
-          ...await validateDataAssetBuildInput(input),
-          ...await validateCodeAssetBuildInput(input),
-        ],
-    buildValidator:
-        (input, output) async => [
-          ...await validateDataAssetBuildOutput(input, output),
-          ...await validateCodeAssetBuildOutput(input, output),
-        ],
-    applicationAssetValidator: validateCodeAssetInApplication,
   );
   if (result == null) {
     throw Error();

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
@@ -36,32 +36,20 @@ void main(List<String> args) async {
     fileSystem: const LocalFileSystem(),
     packageLayout: packageLayout,
   ).build(
-    inputCreator:
-        () =>
-            BuildInputBuilder()
-              ..config.setupCode(
-                targetArchitecture: Architecture.current,
-                targetOS: targetOS,
-                linkModePreference: LinkModePreference.dynamic,
-                cCompiler: dartCICompilerConfig,
-                macOS:
-                    targetOS == OS.macOS
-                        ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                        : null,
-              ),
+    extensions: [
+      CodeAssetExtension(
+        targetArchitecture: Architecture.current,
+        targetOS: targetOS,
+        linkModePreference: LinkModePreference.dynamic,
+        cCompiler: dartCICompilerConfig,
+        macOS:
+            targetOS == OS.macOS
+                ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+                : null,
+      ),
+      DataAssetsExtension(),
+    ],
     linkingEnabled: false,
-    buildAssetTypes: [CodeAsset.type, DataAsset.type],
-    inputValidator:
-        (input) async => [
-          ...await validateDataAssetBuildInput(input),
-          ...await validateCodeAssetBuildInput(input),
-        ],
-    buildValidator:
-        (input, output) async => [
-          ...await validateCodeAssetBuildOutput(input, output),
-          ...await validateDataAssetBuildOutput(input, output),
-        ],
-    applicationAssetValidator: validateCodeAssetInApplication,
   );
   if (result == null) {
     throw Error();

--- a/pkgs/native_assets_builder/test/build_runner/conflicting_dylib_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/conflicting_dylib_test.dart
@@ -25,9 +25,6 @@ void main() async {
           createCapturingLogger(logMessages, level: Level.SEVERE),
           dartExecutable,
           buildAssetTypes: [CodeAsset.type],
-          inputValidator: validateCodeAssetBuildInput,
-          buildValidator: validateCodeAssetBuildOutput,
-          applicationAssetValidator: validateCodeAssetInApplication,
         );
         final fullLog = logMessages.join('\n');
         expect(result, isNull);
@@ -53,9 +50,6 @@ void main() async {
               linkingEnabled: true,
               dartExecutable,
               buildAssetTypes: [CodeAsset.type],
-              inputValidator: validateCodeAssetBuildInput,
-              buildValidator: validateCodeAssetBuildOutput,
-              applicationAssetValidator: validateCodeAssetInApplication,
             ))!;
 
         final linkResult = await link(
@@ -64,9 +58,6 @@ void main() async {
           dartExecutable,
           buildResult: buildResult,
           buildAssetTypes: [CodeAsset.type],
-          inputValidator: validateCodeAssetLinkInput,
-          linkValidator: validateCodeAssetLinkOutput,
-          applicationAssetValidator: validateCodeAssetInApplication,
         );
         // Application validation error due to conflicting dylib name.
         expect(linkResult, isNull);

--- a/pkgs/native_assets_builder/test/build_runner/fail_on_os_sdk_version_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/fail_on_os_sdk_version_test.dart
@@ -74,27 +74,6 @@ void main() async {
                   createCapturingLogger(logMessages, level: Level.SEVERE),
                   dartExecutable,
                   buildAssetTypes: [CodeAsset.type, DataAsset.type],
-                  buildInputValidator:
-                      (input) async => [
-                        ...await validateDataAssetBuildInput(input),
-                        ...await validateCodeAssetBuildInput(input),
-                      ],
-                  buildValidator:
-                      (input, output) async => [
-                        ...await validateCodeAssetBuildOutput(input, output),
-                        ...await validateDataAssetBuildOutput(input, output),
-                      ],
-                  linkInputValidator:
-                      (input) async => [
-                        ...await validateDataAssetLinkInput(input),
-                        ...await validateCodeAssetLinkInput(input),
-                      ],
-                  linkValidator:
-                      (input, output) async => [
-                        ...await validateCodeAssetLinkOutput(input, output),
-                        ...await validateDataAssetLinkOutput(input, output),
-                      ],
-                  applicationAssetValidator: validateCodeAssetInApplication,
                 );
                 final fullLog = logMessages.join('\n');
                 if (hook == 'build') {

--- a/pkgs/native_assets_builder/test/build_runner/link_caching_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/link_caching_test.dart
@@ -44,9 +44,6 @@ void main() async {
               buildResult: buildResult,
               buildAssetTypes: [DataAsset.type],
               capturedLogs: logMessages,
-              inputValidator: validateDataAssetLinkInput,
-              linkValidator: validateDataAssetLinkOutput,
-              applicationAssetValidator: (_) async => [],
             ))!;
       }
 

--- a/pkgs/native_assets_builder/test/build_runner/link_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/link_test.dart
@@ -31,9 +31,6 @@ void main() async {
             dartExecutable,
             buildResult: buildResult,
             buildAssetTypes: [DataAsset.type],
-            inputValidator: validateDataAssetLinkInput,
-            linkValidator: validateDataAssetLinkOutput,
-            applicationAssetValidator: (_) async => [],
           ))!;
       expect(linkResult.encodedAssets.length, 2);
 
@@ -88,9 +85,6 @@ void main() async {
         dartExecutable,
         buildResult: buildResult,
         buildAssetTypes: [DataAsset.type],
-        inputValidator: validateDataAssetLinkInput,
-        linkValidator: validateDataAssetLinkOutput,
-        applicationAssetValidator: (_) async => [],
       );
       expect(linkResult, isNotNull);
 
@@ -123,9 +117,6 @@ void main() async {
             buildResult: buildResult,
             capturedLogs: logMessages,
             buildAssetTypes: [DataAsset.type],
-            inputValidator: validateDataAssetLinkInput,
-            linkValidator: validateDataAssetLinkOutput,
-            applicationAssetValidator: (_) async => [],
           ))!;
       expect(linkResult.encodedAssets.length, 0);
       expect(
@@ -158,9 +149,6 @@ void main() async {
             dartExecutable,
             linkingEnabled: true,
             buildAssetTypes: [CodeAsset.type],
-            inputValidator: validateCodeAssetBuildInput,
-            buildValidator: validateCodeAssetBuildOutput,
-            applicationAssetValidator: validateCodeAssetInApplication,
           ))!;
       expect(buildResult.encodedAssets.length, 0);
       expect(buildResult.encodedAssetsForLinking.length, 1);
@@ -174,9 +162,6 @@ void main() async {
             buildResult: buildResult,
             capturedLogs: logMessages,
             buildAssetTypes: [CodeAsset.type],
-            inputValidator: validateCodeAssetLinkInput,
-            linkValidator: validateCodeAssetLinkOutput,
-            applicationAssetValidator: validateCodeAssetInApplication,
           ))!;
       expect(linkResult.encodedAssets.length, 1);
       expect(linkResult.encodedAssets.first.type, CodeAsset.type);

--- a/pkgs/native_assets_builder/test/build_runner/metadata_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/metadata_test.dart
@@ -29,9 +29,6 @@ void main() async {
           dartExecutable,
           capturedLogs: logMessages,
           buildAssetTypes: ['foo'],
-          inputValidator: (input) async => [],
-          buildValidator: (input, output) async => [],
-          applicationAssetValidator: (_) async => [],
         );
         expect(
           logMessages.join('\n'),

--- a/pkgs/native_assets_builder/test/build_runner/packaging_preference_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/packaging_preference_test.dart
@@ -25,9 +25,6 @@ void main() async {
             dartExecutable,
             linkModePreference: LinkModePreference.dynamic,
             buildAssetTypes: [CodeAsset.type],
-            inputValidator: validateCodeAssetBuildInput,
-            buildValidator: validateCodeAssetBuildOutput,
-            applicationAssetValidator: validateCodeAssetInApplication,
           ))!;
 
       final resultPreferDynamic =
@@ -37,9 +34,6 @@ void main() async {
             dartExecutable,
             linkModePreference: LinkModePreference.preferDynamic,
             buildAssetTypes: [CodeAsset.type],
-            inputValidator: validateCodeAssetBuildInput,
-            buildValidator: validateCodeAssetBuildOutput,
-            applicationAssetValidator: validateCodeAssetInApplication,
           ))!;
 
       final resultStatic =
@@ -49,9 +43,6 @@ void main() async {
             dartExecutable,
             linkModePreference: LinkModePreference.static,
             buildAssetTypes: [CodeAsset.type],
-            inputValidator: validateCodeAssetBuildInput,
-            buildValidator: validateCodeAssetBuildOutput,
-            applicationAssetValidator: validateCodeAssetInApplication,
           ))!;
 
       final resultPreferStatic =
@@ -61,9 +52,6 @@ void main() async {
             dartExecutable,
             linkModePreference: LinkModePreference.preferStatic,
             buildAssetTypes: [CodeAsset.type],
-            inputValidator: validateCodeAssetBuildInput,
-            buildValidator: validateCodeAssetBuildOutput,
-            applicationAssetValidator: validateCodeAssetInApplication,
           ))!;
 
       // This package honors preferences.

--- a/pkgs/native_assets_builder/test/build_runner/resources_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/resources_test.dart
@@ -39,9 +39,6 @@ void main() async {
         buildResult: buildResult,
         resourceIdentifiers: resourcesUri,
         buildAssetTypes: [DataAsset.type],
-        inputValidator: validateDataAssetLinkInput,
-        linkValidator: validateDataAssetLinkOutput,
-        applicationAssetValidator: (_) async => [],
       );
       expect(buildFiles(), anyElement(endsWith('resources.json')));
     });

--- a/pkgs/native_assets_builder/test/build_runner/system_library_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/system_library_test.dart
@@ -24,10 +24,7 @@ void main() async {
             logger,
             dartExecutable,
             capturedLogs: logMessages,
-            inputValidator: validateCodeAssetBuildInput,
             buildAssetTypes: [CodeAsset.type],
-            buildValidator: validateCodeAssetBuildOutput,
-            applicationAssetValidator: validateCodeAssetInApplication,
           ))!;
       expect(result.encodedAssets.length, 3);
     });

--- a/pkgs/native_assets_builder/test/build_runner/version_skew_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/version_skew_test.dart
@@ -26,10 +26,7 @@ void main() async {
             packageUri,
             logger,
             dartExecutable,
-            inputValidator: validateCodeAssetBuildInput,
             buildAssetTypes: [CodeAsset.type],
-            buildValidator: validateCodeAssetBuildOutput,
-            applicationAssetValidator: validateCodeAssetInApplication,
           );
           expect(result?.encodedAssets.length, 1);
         }

--- a/pkgs/native_assets_builder/test/build_runner/wrong_linker_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/wrong_linker_test.dart
@@ -25,9 +25,7 @@ void main() async {
           createCapturingLogger(logMessages, level: Level.SEVERE),
           dartExecutable,
           buildAssetTypes: [CodeAsset.type],
-          inputValidator: validateCodeAssetBuildInput,
-          buildValidator: validateCodeAssetBuildOutput,
-          applicationAssetValidator: validateCodeAssetInApplication,
+
           linkingEnabled: true,
         );
         final fullLog = logMessages.join('\n');

--- a/pkgs/native_assets_cli/lib/code_assets_builder.dart
+++ b/pkgs/native_assets_cli/lib/code_assets_builder.dart
@@ -10,10 +10,4 @@ export 'native_assets_cli_builder.dart'
     hide EncodedAssetBuildOutputBuilder, EncodedAssetLinkOutputBuilder;
 export 'src/code_assets/config.dart'
     show CodeAssetBuildInputBuilder, CodeAssetBuildOutput, CodeAssetLinkOutput;
-export 'src/code_assets/validation.dart'
-    show
-        validateCodeAssetBuildInput,
-        validateCodeAssetBuildOutput,
-        validateCodeAssetInApplication,
-        validateCodeAssetLinkInput,
-        validateCodeAssetLinkOutput;
+export 'src/code_assets/extension.dart';

--- a/pkgs/native_assets_cli/lib/data_assets_builder.dart
+++ b/pkgs/native_assets_cli/lib/data_assets_builder.dart
@@ -10,9 +10,4 @@ export 'native_assets_cli_builder.dart'
     hide EncodedAssetBuildOutputBuilder, EncodedAssetLinkOutputBuilder;
 export 'src/data_assets/config.dart'
     show DataAssetBuildInputBuilder, DataAssetBuildOutput, DataAssetLinkOutput;
-export 'src/data_assets/validation.dart'
-    show
-        validateDataAssetBuildInput,
-        validateDataAssetBuildOutput,
-        validateDataAssetLinkInput,
-        validateDataAssetLinkOutput;
+export 'src/data_assets/extension.dart';

--- a/pkgs/native_assets_cli/lib/native_assets_cli_builder.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli_builder.dart
@@ -15,12 +15,12 @@ export 'src/config.dart'
         HookOutput,
         LinkInputBuilder,
         LinkOutput;
+export 'src/extension.dart';
 export 'src/model/dependencies.dart';
 export 'src/model/resource_identifiers.dart';
 export 'src/target.dart' show Target;
 export 'src/validation.dart'
     show
-        ValidationErrors,
         validateBuildInput,
         validateBuildOutput,
         validateLinkInput,

--- a/pkgs/native_assets_cli/lib/src/code_assets/extension.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/extension.dart
@@ -5,6 +5,8 @@
 import '../../code_assets_builder.dart';
 import 'validation.dart';
 
+/// The protocol extension for the `hook/build.dart` and `hook/link.dart`
+/// with [CodeAsset]s and [CodeConfig].
 final class CodeAssetExtension implements ProtocolExtension {
   final Architecture targetArchitecture;
   final OS targetOS;

--- a/pkgs/native_assets_cli/lib/src/code_assets/extension.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/extension.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../../code_assets_builder.dart';
+import 'validation.dart';
+
+final class CodeAssetExtension implements ProtocolExtension {
+  final Architecture targetArchitecture;
+  final OS targetOS;
+  final LinkModePreference linkModePreference;
+  final CCompilerConfig? cCompiler;
+  final AndroidCodeConfig? android;
+  final IOSCodeConfig? iOS;
+  final MacOSCodeConfig? macOS;
+
+  CodeAssetExtension({
+    required this.targetArchitecture,
+    required this.targetOS,
+    required this.linkModePreference,
+    this.cCompiler,
+    this.android,
+    this.iOS,
+    this.macOS,
+  });
+
+  @override
+  List<String> get buildAssetTypes => [CodeAsset.type];
+
+  @override
+  void setupBuildInput(BuildInputBuilder input) {
+    _setupConfig(input);
+  }
+
+  @override
+  void setupLinkInput(LinkInputBuilder input) {
+    _setupConfig(input);
+  }
+
+  void _setupConfig(HookInputBuilder input) {
+    input.config.setupCode(
+      targetArchitecture: targetArchitecture,
+      targetOS: targetOS,
+      linkModePreference: linkModePreference,
+      cCompiler: cCompiler,
+      android: android,
+      iOS: iOS,
+      macOS: macOS,
+    );
+  }
+
+  @override
+  Future<ValidationErrors> validateBuildInput(BuildInput input) =>
+      validateCodeAssetBuildInput(input);
+
+  @override
+  Future<ValidationErrors> validateLinkInput(LinkInput input) =>
+      validateCodeAssetLinkInput(input);
+
+  @override
+  Future<ValidationErrors> validateBuildOutput(
+    BuildInput input,
+    BuildOutput output,
+  ) => validateCodeAssetBuildOutput(input, output);
+
+  @override
+  Future<ValidationErrors> validateLinkOutput(
+    LinkInput input,
+    LinkOutput output,
+  ) => validateCodeAssetLinkOutput(input, output);
+
+  @override
+  Future<ValidationErrors> validateApplicationAssets(
+    List<EncodedAsset> assets,
+  ) => validateCodeAssetInApplication(assets);
+}

--- a/pkgs/native_assets_cli/lib/src/code_assets/testing.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/testing.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import '../../code_assets_builder.dart';
 import '../../test.dart';
 import '../validation.dart';
+import 'validation.dart';
 
 /// Validate a code build hook; this will throw an exception on validation
 /// errors.

--- a/pkgs/native_assets_cli/lib/src/data_assets/extension.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/extension.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../../data_assets_builder.dart';
+import 'validation.dart';
+
+final class DataAssetsExtension implements ProtocolExtension {
+  DataAssetsExtension();
+
+  @override
+  List<String> get buildAssetTypes => [DataAsset.type];
+
+  @override
+  void setupBuildInput(BuildInputBuilder input) {}
+
+  @override
+  void setupLinkInput(LinkInputBuilder input) {}
+
+  @override
+  Future<ValidationErrors> validateBuildInput(BuildInput input) =>
+      validateDataAssetBuildInput(input);
+
+  @override
+  Future<ValidationErrors> validateLinkInput(LinkInput input) =>
+      validateDataAssetLinkInput(input);
+
+  @override
+  Future<ValidationErrors> validateBuildOutput(
+    BuildInput input,
+    BuildOutput output,
+  ) => validateDataAssetBuildOutput(input, output);
+
+  @override
+  Future<ValidationErrors> validateLinkOutput(
+    LinkInput input,
+    LinkOutput output,
+  ) => validateDataAssetLinkOutput(input, output);
+
+  @override
+  Future<ValidationErrors> validateApplicationAssets(
+    List<EncodedAsset> assets,
+  ) async => [];
+}

--- a/pkgs/native_assets_cli/lib/src/data_assets/extension.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/extension.dart
@@ -5,6 +5,8 @@
 import '../../data_assets_builder.dart';
 import 'validation.dart';
 
+/// The protocol extension for the `hook/build.dart` and `hook/link.dart`
+/// with [DataAsset]s.
 final class DataAssetsExtension implements ProtocolExtension {
   DataAssetsExtension();
 

--- a/pkgs/native_assets_cli/lib/src/extension.dart
+++ b/pkgs/native_assets_cli/lib/src/extension.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'config.dart';
+import 'encoded_asset.dart';
+
+typedef ValidationErrors = List<String>;
+
+/// An extension to the base protocol for `hook/build.dart` and
+/// `hook/link.dart`.
+///
+/// The extension contains callbacks to
+/// 1. setup the input, and
+/// 2. validate semantic constraints.
+abstract interface class ProtocolExtension {
+  /// The [HookConfig.buildAssetTypes] this extension adds.
+  List<String> get buildAssetTypes;
+
+  /// Setup the [BuildConfig] for this extension.
+  void setupBuildInput(BuildInputBuilder input);
+
+  /// Setup the [HookConfig] for this extension.
+  void setupLinkInput(LinkInputBuilder input);
+
+  /// Reports semantic errors from this extension on the [BuildInput].
+  Future<ValidationErrors> validateBuildInput(BuildInput input);
+
+  /// Reports semantic errors from this extension on the [LinkInput].
+  Future<ValidationErrors> validateBuildOutput(
+    BuildInput input,
+    BuildOutput output,
+  );
+
+  /// Reports semantic errors from this extension on the [LinkInput].
+  Future<ValidationErrors> validateLinkInput(LinkInput input);
+
+  /// Reports semantic errors from this extension on the [LinkOutput].
+  Future<ValidationErrors> validateLinkOutput(
+    LinkInput input,
+    LinkOutput output,
+  );
+
+  /// Reports errors on the complete set of assets after all hooks are run.
+  ///
+  /// Can be used to validate that there are no asset-id or shared library name
+  /// collisions.
+  Future<ValidationErrors> validateApplicationAssets(List<EncodedAsset> assets);
+}

--- a/pkgs/native_assets_cli/test/code_assets/validation_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/validation_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/src/code_assets/validation.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/pkgs/native_assets_cli/test/data_assets/validation_test.dart
+++ b/pkgs/native_assets_cli/test/data_assets/validation_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:native_assets_cli/data_assets_builder.dart';
+import 'package:native_assets_cli/src/data_assets/validation.dart';
 import 'package:test/test.dart';
 
 void main() {


### PR DESCRIPTION
This PR introduces a concept of protocol extensions, which package together everything belonging to a protocol extension.

Closes: https://github.com/dart-lang/native/issues/2088

As a bonus, this better abstraction reduces LOC.

The `validation` methods are now all internal to the extensions. The `setup` methods stay exported because they are used extensively in hook-helper-packages (e.g. `native_toolchain_c`).