### PR TITLE
[native_toolchain_c] Forced includes

### DIFF
--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -55,6 +55,7 @@ class CBuilder extends CTool implements Builder {
     super.assetName,
     super.sources = const [],
     super.includes = const [],
+    super.forcedIncludes = const [],
     super.frameworks = CTool.defaultFrameworks,
     super.libraries = const [],
     super.libraryDirectories = CTool.defaultLibraryDirectories,
@@ -81,6 +82,7 @@ class CBuilder extends CTool implements Builder {
     required super.name,
     super.sources = const [],
     super.includes = const [],
+    super.forcedIncludes = const [],
     super.frameworks = CTool.defaultFrameworks,
     super.libraries = const [],
     super.libraryDirectories = CTool.defaultLibraryDirectories,
@@ -149,6 +151,10 @@ class CBuilder extends CTool implements Builder {
       for (final directory in this.includes)
         packageRoot.resolveUri(Uri.file(directory)),
     ];
+    final forcedIncludes = [
+      for (final file in this.forcedIncludes)
+        packageRoot.resolveUri(Uri.file(file)),
+    ];
     final dartBuildFiles = [
       // ignore: deprecated_member_use_from_same_package
       for (final source in this.dartBuildFiles) packageRoot.resolve(source),
@@ -164,6 +170,7 @@ class CBuilder extends CTool implements Builder {
       logger: logger,
       sources: sources,
       includes: includes,
+      forcedIncludes: forcedIncludes,
       frameworks: frameworks,
       libraries: libraries,
       libraryDirectories: libraryDirectories,
@@ -220,6 +227,7 @@ class CBuilder extends CTool implements Builder {
       // Note: We use a Set here to deduplicate the dependencies.
       ...sources,
       ...includeFiles,
+      ...forcedIncludes,
       ...dartBuildFiles,
     });
   }

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
@@ -28,6 +28,7 @@ class CLinker extends CTool implements Linker {
     required this.linkerOptions,
     super.sources = const [],
     super.includes = const [],
+    super.forcedIncludes = const [],
     super.frameworks = CTool.defaultFrameworks,
     super.libraries = const [],
     super.libraryDirectories = CTool.defaultLibraryDirectories,

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/ctool.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/ctool.dart
@@ -46,6 +46,14 @@ abstract class CTool {
   /// The sources will be reported as dependencies of the hook.
   final List<String> includes;
 
+  /// Files passed to the compiler that will be included before all source
+  /// files.
+  ///
+  /// Resolved against [LinkInput.packageRoot].
+  ///
+  /// The sources will be reported as dependencies of the hook.
+  final List<String> forcedIncludes;
+
   /// Frameworks to link.
   ///
   /// Only effective if [language] is [Language.objectiveC].
@@ -154,6 +162,7 @@ abstract class CTool {
     required this.assetName,
     required this.sources,
     required this.includes,
+    required this.forcedIncludes,
     required this.frameworks,
     required this.libraries,
     required this.libraryDirectories,

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/ctool.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/ctool.dart
@@ -52,6 +52,10 @@ abstract class CTool {
   /// Resolved against [LinkInput.packageRoot].
   ///
   /// The sources will be reported as dependencies of the hook.
+  /// For clang, each of the files are added as an `-include` flag.
+  /// see: https://gcc.gnu.org/onlinedocs/gcc-13.2.0/gcc/Preprocessor-Options.html#index-include
+  /// For MSVC, each of the files are added as an `/FI` flag.
+  /// see: https://learn.microsoft.com/en-us/cpp/build/reference/fi-name-forced-include-file
   final List<String> forcedIncludes;
 
   /// Frameworks to link.

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:math';
-import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:native_assets_cli/code_assets.dart';

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -115,13 +115,22 @@ void main() async {
             sources: [addCUri.toFilePath()],
             optimizationLevel: optimizationLevel,
             buildMode: buildMode,
+            defines: {'FOO': '"BAR"'},
           );
           await cbuilder.run(
             input: buildInput,
             output: buildOutput,
             logger: logger,
           );
+          if (compiler == msvc) {
+            // ensure that the nfi.txt file is created
+            final nfiFile = tempUri.resolve('nfi.txt');
+            expect(await File.fromUri(nfiFile).exists(), true);
 
+            // ensure that the nfi.txt file contains the correct content
+            final nfiContent = await File.fromUri(nfiFile).readAsString();
+            expect(nfiContent, contains('#define FOO "BAR"'));
+          }
           final libUri = tempUri.resolve(
             OS.windows.libraryFileName(name, linkMode),
           );

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -115,22 +115,12 @@ void main() async {
             sources: [addCUri.toFilePath()],
             optimizationLevel: optimizationLevel,
             buildMode: buildMode,
-            defines: {'FOO': '"BAR"'},
           );
           await cbuilder.run(
             input: buildInput,
             output: buildOutput,
             logger: logger,
           );
-          if (compiler == msvc) {
-            // ensure that the nfi.txt file is created
-            final nfiFile = tempUri.resolve('nfi.txt');
-            expect(await File.fromUri(nfiFile).exists(), true);
-
-            // ensure that the nfi.txt file contains the correct content
-            final nfiContent = await File.fromUri(nfiFile).readAsString();
-            expect(nfiContent, contains('#define FOO "BAR"'));
-          }
           final libUri = tempUri.resolve(
             OS.windows.libraryFileName(name, linkMode),
           );

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -121,6 +121,7 @@ void main() async {
             output: buildOutput,
             logger: logger,
           );
+
           final libUri = tempUri.resolve(
             OS.windows.libraryFileName(name, linkMode),
           );

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -233,6 +233,9 @@ void main() {
     if (!await File.fromUri(definesCUri).exists()) {
       throw Exception('Run the test from the root directory.');
     }
+    final forcedIncludeCUri = packageUri.resolve(
+      'test/cbuilder/testfiles/defines/src/forcedInclude.c',
+    );
     const name = 'defines';
 
     final logMessages = <String>[];
@@ -268,6 +271,7 @@ void main() {
     final cbuilder = CBuilder.executable(
       name: name,
       sources: [definesCUri.toFilePath()],
+      forcedIncludes: [forcedIncludeCUri.toFilePath()],
       flags: [flag],
       buildMode: BuildMode.release,
     );
@@ -278,6 +282,8 @@ void main() {
     final result = await runProcess(executable: executableUri, logger: logger);
     expect(result.exitCode, 0);
     expect(result.stdout, contains('Macro FOO is defined: USER_FLAG'));
+    // check the forced include is added
+    expect(result.stdout, contains('Macro FIFOO is defined: "QuotedFIFOO"'));
 
     final compilerInvocation = logMessages.singleWhere(
       (message) => message.contains(definesCUri.toFilePath()),

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -282,7 +282,7 @@ void main() {
     final result = await runProcess(executable: executableUri, logger: logger);
     expect(result.exitCode, 0);
     expect(result.stdout, contains('Macro FOO is defined: USER_FLAG'));
-    // check the forced include is added
+    // Check the forced include is added.
     expect(result.stdout, contains('Macro FIFOO is defined: "QuotedFIFOO"'));
 
     final compilerInvocation = logMessages.singleWhere(

--- a/pkgs/native_toolchain_c/test/cbuilder/testfiles/defines/src/defines.c
+++ b/pkgs/native_toolchain_c/test/cbuilder/testfiles/defines/src/defines.c
@@ -34,5 +34,11 @@ int main() {
   MACRO_IS_UNDEFINED(FOO);
 #endif
 
+#ifdef FIFOO
+  MACRO_IS_DEFINED(FIFOO);
+#else
+  MACRO_IS_UNDEFINED(FIFOO);
+#endif
+
   return 0;
 }

--- a/pkgs/native_toolchain_c/test/cbuilder/testfiles/defines/src/forcedInclude.c
+++ b/pkgs/native_toolchain_c/test/cbuilder/testfiles/defines/src/forcedInclude.c
@@ -1,0 +1,3 @@
+#ifndef FIFOO
+#define FIFOO "QuotedFIFOO"
+#endif


### PR DESCRIPTION
Fix #2095 

- This PR addresses the issue https://github.com/dart-lang/native/issues/2095 where defines that include double quotation marks would break the command-line execution using `CL.EXE`

**How it works**

`CBuilder.libaray` and `CBuilder.executable` take a new optional argument `forcedIncludes` which is a list of file paths to source files, these source files, if defined will be prepended by the compiler to each source.

In `clang`, this uses the `-include<file>` argument, in `CL.exe` this uses the `/FI<file>` argument. See the related issue: https://github.com/dart-lang/native/issues/2095

I'm currently on OSX so I haven't run the test on windows yet

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
