### PR TITLE
Add `web` OS and architectures

### DIFF
--- a/pkgs/code_assets/doc/schema/shared/shared_definitions.schema.json
+++ b/pkgs/code_assets/doc/schema/shared/shared_definitions.schema.json
@@ -33,6 +33,12 @@
           "const": "x64"
         },
         {
+          "const": "js"
+        },
+        {
+          "const": "wasm"
+        },
+        {
           "type": "string"
         }
       ]
@@ -369,6 +375,9 @@
         },
         {
           "const": "windows"
+        },
+        {
+          "const": "web"
         },
         {
           "type": "string"

--- a/pkgs/native_assets_cli/lib/src/code_assets/architecture.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/architecture.dart
@@ -35,6 +35,14 @@ final class Architecture {
   /// The [x86-64](https://en.wikipedia.org/wiki/X86-64) architecture.
   static const Architecture x64 = Architecture._('x64');
 
+  /// The artificial [JavaScript](https://en.wikipedia.org/wiki/JavaScript)
+  /// architecture.
+  static const Architecture js = Architecture._('js');
+
+  /// The artificial [WebAssembly](https://en.wikipedia.org/wiki/WebAssembly)
+  /// architecture.
+  static const Architecture wasm = Architecture._('wasm');
+
   /// Known values for [Architecture].
   static const List<Architecture> values = [
     arm,

--- a/pkgs/native_assets_cli/lib/src/code_assets/os.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/os.dart
@@ -36,8 +36,19 @@ final class OS {
   /// operating system.
   static const OS windows = OS._('windows');
 
+  /// The [web](https://en.wikipedia.org/wiki/Web) "operating system".
+  static const OS web = OS._('web');
+
   /// Known values for [OS].
-  static const List<OS> values = [android, fuchsia, iOS, linux, macOS, windows];
+  static const List<OS> values = [
+    android,
+    fuchsia,
+    iOS,
+    linux,
+    macOS,
+    windows,
+    web,
+  ];
 
   /// Typical cross compilation between OSes.
   static const osCrossCompilationDefault = {

--- a/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
@@ -43,9 +43,13 @@ class Architecture {
 
   static const ia32 = Architecture._('ia32');
 
+  static const js = Architecture._('js');
+
   static const riscv32 = Architecture._('riscv32');
 
   static const riscv64 = Architecture._('riscv64');
+
+  static const wasm = Architecture._('wasm');
 
   static const x64 = Architecture._('x64');
 
@@ -53,8 +57,10 @@ class Architecture {
     arm,
     arm64,
     ia32,
+    js,
     riscv32,
     riscv64,
+    wasm,
     x64,
   ];
 
@@ -699,9 +705,11 @@ class OS {
 
   static const macOS = OS._('macos');
 
+  static const web = OS._('web');
+
   static const windows = OS._('windows');
 
-  static const List<OS> values = [android, iOS, linux, macOS, windows];
+  static const List<OS> values = [android, iOS, linux, macOS, web, windows];
 
   static final Map<String, OS> _byName = {
     for (final value in values) value.name: value,


### PR DESCRIPTION
See the comment from @bkonyi at https://github.com/flutter/flutter/pull/164094#discussion_r1998980713.

Having to work around the web platform by having a `null` `OS` and `Architecture` is awkward, regardless of whether the web is actually an OS or not.

For the architecture, I don't really have a use case for separating into `js` and `wasm` at the moment, but could imagine this becoming relevant when running `dart compile wasm` vs `dart compile js` (vs `dart compile exe` on native).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
