### PR TITLE
check null instead of assert

### DIFF
--- a/pkgs/native_toolchain_c/lib/src/tool/tool_resolver.dart
+++ b/pkgs/native_toolchain_c/lib/src/tool/tool_resolver.dart
@@ -208,11 +208,12 @@ class InstallLocationResolver implements ToolResolver {
   Future<List<Uri>> tryResolvePath(String path) async {
     if (path.startsWith(home)) {
       final homeDir_ = homeDir;
-      assert(homeDir_ != null);
-      path = path.replaceAll(
-        '$home/',
-        homeDir!.toFilePath().replaceAll('\\', '/'),
-      );
+      if (homeDir_ != null) {
+        path = path.replaceAll(
+          '$home/',
+          homeDir!.toFilePath().replaceAll('\\', '/'),
+        );
+      }
     }
 
     final result = <Uri>[];


### PR DESCRIPTION
Given that there are multiple paths to resolve a tool, we should not assert if null, but instead avoid parsing the path if null.