### PR TITLE
[native_assets_cli] Validate assets for linking

### DIFF
--- a/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
@@ -80,7 +80,11 @@ Future<ValidationErrors> validateCodeAssetBuildOutput(
 ) => _validateCodeAssetBuildOrLinkOutput(
   input,
   input.config.code,
-  output.assets.encodedAssets,
+  [
+    ...output.assets.encodedAssets,
+    for (final assetList in output.assets.encodedAssetsForLinking.values)
+      ...assetList,
+  ],
   output,
   true,
 );

--- a/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
@@ -73,14 +73,11 @@ ValidationErrors _validateCodeConfig(String inputName, CodeConfig code) {
 
 Future<ValidationErrors> _validateCodeAssetLinkInput(
   List<EncodedAsset> encodedAssets,
-) async {
-  final errors = <String>[];
-  for (final asset in encodedAssets) {
-    if (asset.type != CodeAsset.type) continue;
-    _validateCodeAssetFile(CodeAsset.fromEncoded(asset), errors);
-  }
-  return errors;
-}
+) async => [
+  for (final asset in encodedAssets)
+    if (asset.type == CodeAsset.type)
+      ..._validateCodeAssetFile(CodeAsset.fromEncoded(asset)),
+];
 
 Future<ValidationErrors> validateCodeAssetBuildOutput(
   BuildInput input,
@@ -227,18 +224,17 @@ void _validateCodeAsset(
     );
   }
 
-  _validateCodeAssetFile(codeAsset, errors);
+  errors.addAll(_validateCodeAssetFile(codeAsset));
 }
 
-void _validateCodeAssetFile(CodeAsset codeAsset, List<String> errors) {
+List<String> _validateCodeAssetFile(CodeAsset codeAsset) {
   final id = codeAsset.id;
   final file = codeAsset.file;
-  if (file == null && _mustHaveFile(codeAsset.linkMode)) {
-    errors.add('CodeAsset "$id" has no file.');
-  }
-  if (file != null) {
-    errors.addAll(_validateFile('Code asset "$id" file', file));
-  }
+  return [
+    if (file == null && _mustHaveFile(codeAsset.linkMode))
+      'CodeAsset "$id" has no file.',
+    if (file != null) ..._validateFile('Code asset "$id" file', file),
+  ];
 }
 
 bool _mustHaveFile(LinkMode linkMode) => switch (linkMode) {

--- a/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
@@ -23,11 +23,11 @@ Future<ValidationErrors> validateDataAssetLinkInput(LinkInput input) async {
 Future<ValidationErrors> validateDataAssetBuildOutput(
   BuildInput input,
   BuildOutput output,
-) => _validateDataAssetBuildOrLinkOutput(
-  input,
-  output.assets.encodedAssets,
-  true,
-);
+) => _validateDataAssetBuildOrLinkOutput(input, [
+  ...output.assets.encodedAssets,
+  for (final assetList in output.assets.encodedAssetsForLinking.values)
+    ...assetList,
+], true);
 
 Future<ValidationErrors> validateDataAssetLinkOutput(
   LinkInput input,


### PR DESCRIPTION
We were missing some validation for assets for linking:

* `BuildOutput` both code and data assets.
* `LinkInput` for code assets.

Code assets for linking should not have their link mode checked.