### PR TITLE
[native_assets_cli] Syntax validation

### DIFF
--- a/pkgs/json_syntax_generator/lib/src/generator/helper_library.dart
+++ b/pkgs/json_syntax_generator/lib/src/generator/helper_library.dart
@@ -64,12 +64,10 @@ class JsonReader {
 
   /// [List.cast] but with [FormatException]s.
   List<T> _castList<T extends Object?>(List<Object?> list, String key) {
-    var index = 0;
-    for (final value in list) {
+    for (final (index, value) in list.indexed) {
       if (value is! T) {
         throwFormatException(value, T, [key, index]);
       }
-      index++;
     }
     return list.cast();
   }
@@ -78,24 +76,13 @@ class JsonReader {
     List<Object?> list,
     String key,
   ) {
-    var index = 0;
     final result = <String>[];
-    for (final value in list) {
+    for (final (index, value) in list.indexed) {
       if (value is! T) {
         result.add(errorString(value, T, [key, index]));
       }
-      index++;
     }
     return result;
-  }
-
-  List<T>? optionalListParsed<T extends Object?>(
-    String key,
-    T Function(Object?) elementParser,
-  ) {
-    final jsonValue = optionalList(key);
-    if (jsonValue == null) return null;
-    return [for (final element in jsonValue) elementParser(element)];
   }
 
   Map<String, T> map$<T extends Object?>(String key) =>

--- a/pkgs/json_syntax_generator/lib/src/generator/helper_library.dart
+++ b/pkgs/json_syntax_generator/lib/src/generator/helper_library.dart
@@ -22,21 +22,45 @@ class JsonReader {
   T get<T extends Object?>(String key) {
     final value = json[key];
     if (value is T) return value;
-    final pathString = _jsonPathToString([key]);
-    if (value == null) {
-      throw FormatException("No value was provided for '$pathString'.");
-    }
     throwFormatException(value, T, [key]);
+  }
+
+  List<String> validate<T extends Object?>(String key) {
+    final value = json[key];
+    if (value is T) return [];
+    return [
+      errorString(value, T, [key]),
+    ];
   }
 
   List<T> list<T extends Object?>(String key) =>
       _castList<T>(get<List<Object?>>(key), key);
+
+  List<String> validateList<T extends Object?>(String key) {
+    final listErrors = validate<List<Object?>>(key);
+    if (listErrors.isNotEmpty) {
+      return listErrors;
+    }
+    return _validateListElements(get<List<Object?>>(key), key);
+  }
 
   List<T>? optionalList<T extends Object?>(String key) =>
       switch (get<List<Object?>?>(key)?.cast<T>()) {
         null => null,
         final l => _castList<T>(l, key),
       };
+
+  List<String> validateOptionalList<T extends Object?>(String key) {
+    final listErrors = validate<List<Object?>?>(key);
+    if (listErrors.isNotEmpty) {
+      return listErrors;
+    }
+    final list = get<List<Object?>?>(key);
+    if (list == null) {
+      return [];
+    }
+    return _validateListElements(list, key);
+  }
 
   /// [List.cast] but with [FormatException]s.
   List<T> _castList<T extends Object?>(List<Object?> list, String key) {
@@ -48,6 +72,21 @@ class JsonReader {
       index++;
     }
     return list.cast();
+  }
+
+  List<String> _validateListElements<T extends Object?>(
+    List<Object?> list,
+    String key,
+  ) {
+    var index = 0;
+    final result = <String>[];
+    for (final value in list) {
+      if (value is! T) {
+        result.add(errorString(value, T, [key, index]));
+      }
+      index++;
+    }
+    return result;
   }
 
   List<T>? optionalListParsed<T extends Object?>(
@@ -62,11 +101,31 @@ class JsonReader {
   Map<String, T> map$<T extends Object?>(String key) =>
       _castMap<T>(get<Map<String, Object?>>(key), key);
 
+  List<String> validateMap<T extends Object?>(String key) {
+    final mapErrors = validate<Map<String, Object?>>(key);
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return _validateMapElements<T>(get<Map<String, Object?>>(key), key);
+  }
+
   Map<String, T>? optionalMap<T extends Object?>(String key) =>
       switch (get<Map<String, Object?>?>(key)) {
         null => null,
         final m => _castMap<T>(m, key),
       };
+
+  List<String> validateOptionalMap<T extends Object?>(String key) {
+    final mapErrors = validate<Map<String, Object?>?>(key);
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    final map = get<Map<String, Object?>?>(key);
+    if (map == null) {
+      return [];
+    }
+    return _validateMapElements<T>(map, key);
+  }
 
   /// [Map.cast] but with [FormatException]s.
   Map<String, T> _castMap<T extends Object?>(
@@ -81,17 +140,39 @@ class JsonReader {
     return map_.cast();
   }
 
+  List<String> _validateMapElements<T extends Object?>(
+    Map<String, Object?> map_,
+    String parentKey,
+  ) {
+    final result = <String>[];
+    for (final MapEntry(:key, :value) in map_.entries) {
+      if (value is! T) {
+        result.add(errorString(value, T, [parentKey, key]));
+      }
+    }
+    return result;
+  }
+
   List<String>? optionalStringList(String key) => optionalList<String>(key);
+
+  List<String> validateOptionalStringList(String key) =>
+      validateOptionalList<String>(key);
 
   List<String> stringList(String key) => list<String>(key);
 
+  List<String> validateStringList(String key) => validateList<String>(key);
+
   Uri path$(String key) => _fileSystemPathToUri(get<String>(key));
+
+  List<String> validatePath(String key) => validate<String>(key);
 
   Uri? optionalPath(String key) {
     final value = get<String?>(key);
     if (value == null) return null;
     return _fileSystemPathToUri(value);
   }
+
+  List<String> validateOptionalPath(String key) => validate<String?>(key);
 
   List<Uri>? optionalPathList(String key) {
     final strings = optionalStringList(key);
@@ -100,6 +181,9 @@ class JsonReader {
     }
     return [for (final string in strings) _fileSystemPathToUri(string)];
   }
+
+  List<String> validateOptionalPathList(String key) =>
+      validateOptionalStringList(key);
 
   static Uri _fileSystemPathToUri(String path) {
     if (path.endsWith(Platform.pathSeparator)) {
@@ -116,11 +200,21 @@ class JsonReader {
     Type expectedType,
     List<Object> pathExtension,
   ) {
+    throw FormatException(errorString(value, expectedType, pathExtension));
+  }
+
+  String errorString(
+    Object? value,
+    Type expectedType,
+    List<Object> pathExtension,
+  ) {
     final pathString = _jsonPathToString(pathExtension);
-    throw FormatException(
-      "Unexpected value '$value' (${value.runtimeType}) for '$pathString'. "
-      'Expected a $expectedType.',
-    );
+    if (value == null) {
+      return "No value was provided for '$pathString'."
+          ' Expected a $expectedType.';
+    }
+    return "Unexpected value '$value' (${value.runtimeType}) for '$pathString'."
+        ' Expected a $expectedType.';
   }
 }
 

--- a/pkgs/json_syntax_generator/lib/src/generator/normal_class_generator.dart
+++ b/pkgs/json_syntax_generator/lib/src/generator/normal_class_generator.dart
@@ -24,6 +24,7 @@ class ClassGenerator {
     final constructorSetterCalls = <String>[];
     final accessors = <String>[];
     final superParams = <String>[];
+    final validateCalls = <String>[];
 
     final propertyNames =
         {
@@ -62,6 +63,7 @@ class ClassGenerator {
       }
       if (thisClassProperty != null) {
         accessors.add(PropertyGenerator(thisClassProperty).generate());
+        validateCalls.add('...${property.validateName}()');
       }
     }
 
@@ -96,6 +98,12 @@ class $className extends $superclassName {
   ${accessors.join('\n')}
 
   @override
+  List<String> validate() => [
+    ...super.validate(),
+    ${validateCalls.join(',\n')}
+  ];
+
+  @override
   String toString() => '$className(\$json)';
 }
 ''');
@@ -121,6 +129,10 @@ class $className {
 
   ${accessors.join('\n')}
 
+  List<String> validate() => [
+    ${validateCalls.join(',\n')}
+  ];
+
   @override
   String toString() => '$className(\$json)';
 }
@@ -132,7 +144,7 @@ class $className {
 extension ${className}Extension on $superclassName {
   bool get is$className => type == '$identifyingSubtype';
 
-  $className get as$className => $className.fromJson(json);
+  $className get as$className => $className.fromJson(json, path: path);
 }
 ''');
     }

--- a/pkgs/json_syntax_generator/lib/src/generator/property_generator.dart
+++ b/pkgs/json_syntax_generator/lib/src/generator/property_generator.dart
@@ -218,12 +218,11 @@ $dartType get $fieldName {
   }
   final result = <String, List<Asset>>{};
   for (final MapEntry(:key, :value) in jsonValue.entries) {
-    var index = 0;
     result[key] = [
-      for (final item in value as List<Object?>)
+      for (final (index, item) in (value as List<Object?>).indexed)
         $typeName.fromJson(
           item as $jsonObjectDartType,
-          path: [...path, key, index++],
+          path: [...path, key, index],
         ),
     ];
   }
@@ -311,14 +310,15 @@ List<String> $validateName() => _reader.validateOptionalMap('$jsonKey');
         }
         buffer.writeln('''
 $dartType get $fieldName {
-  var index = 0;
-  return _reader.optionalListParsed(
-    '$jsonKey',
-    (e) => $typeName.fromJson(
-      e as Map<String, Object?>,
-      path: [...path, '$jsonKey', index++],
-    ),
-  );
+  final jsonValue = _reader.optionalList('$jsonKey');
+  if (jsonValue == null) return null;
+  return [
+    for (final (index, element) in jsonValue.indexed)
+      $typeName.fromJson(
+        element as Map<String, Object?>,
+        path: [...path, '$jsonKey', index],
+      ),
+  ];
 }
 
 set $setterName($dartType value) {

--- a/pkgs/json_syntax_generator/lib/src/model/property_info.dart
+++ b/pkgs/json_syntax_generator/lib/src/model/property_info.dart
@@ -9,6 +9,9 @@ class PropertyInfo {
   /// The Dart getter and setter name.
   final String name;
 
+  /// The Dart validate method name.
+  String get validateName => '_validate${_ucFirst(name)}';
+
   /// The key in the json object for this property.
   final String jsonKey;
 
@@ -52,4 +55,11 @@ PropertyInfo(
   setterPrivate: $setterPrivate,
   isRequired: $isRequired
 )''';
+}
+
+String _ucFirst(String str) {
+  if (str.isEmpty) {
+    return '';
+  }
+  return str[0].toUpperCase() + str.substring(1);
 }

--- a/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
@@ -28,6 +28,11 @@ class AndroidCodeConfig {
     json.setOrRemove('target_ndk_api', value);
   }
 
+  List<String> _validateTargetNdkApi() =>
+      _reader.validate<int?>('target_ndk_api');
+
+  List<String> validate() => [..._validateTargetNdkApi()];
+
   @override
   String toString() => 'AndroidCodeConfig($json)';
 }
@@ -98,6 +103,10 @@ class Asset {
     json.setOrRemove('type', value);
   }
 
+  List<String> _validateType() => _reader.validate<String?>('type');
+
+  List<String> validate() => [..._validateType()];
+
   @override
   String toString() => 'Asset($json)';
 }
@@ -147,17 +156,24 @@ class NativeCodeAsset extends Asset {
     json.setOrRemove('architecture', value?.name);
   }
 
+  List<String> _validateArchitecture() =>
+      _reader.validate<String?>('architecture');
+
   Uri? get file => _reader.optionalPath('file');
 
   set _file(Uri? value) {
     json.setOrRemove('file', value?.toFilePath());
   }
 
+  List<String> _validateFile() => _reader.validateOptionalPath('file');
+
   String get id => _reader.get<String>('id');
 
   set _id(String value) {
     json.setOrRemove('id', value);
   }
+
+  List<String> _validateId() => _reader.validate<String>('id');
 
   LinkMode get linkMode {
     final jsonValue = _reader.map$('link_mode');
@@ -166,6 +182,14 @@ class NativeCodeAsset extends Asset {
 
   set _linkMode(LinkMode value) {
     json['link_mode'] = value.json;
+  }
+
+  List<String> _validateLinkMode() {
+    final mapErrors = _reader.validate<Map<String, Object?>>('link_mode');
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return linkMode.validate();
   }
 
   OS get os {
@@ -177,6 +201,18 @@ class NativeCodeAsset extends Asset {
     json['os'] = value.name;
   }
 
+  List<String> _validateOs() => _reader.validate<String>('os');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateArchitecture(),
+    ..._validateFile(),
+    ..._validateId(),
+    ..._validateLinkMode(),
+    ..._validateOs(),
+  ];
+
   @override
   String toString() => 'NativeCodeAsset($json)';
 }
@@ -184,7 +220,8 @@ class NativeCodeAsset extends Asset {
 extension NativeCodeAssetExtension on Asset {
   bool get isNativeCodeAsset => type == 'native_code';
 
-  NativeCodeAsset get asNativeCodeAsset => NativeCodeAsset.fromJson(json);
+  NativeCodeAsset get asNativeCodeAsset =>
+      NativeCodeAsset.fromJson(json, path: path);
 }
 
 class CCompilerConfig {
@@ -220,17 +257,24 @@ class CCompilerConfig {
     json['ar'] = value.toFilePath();
   }
 
+  List<String> _validateAr() => _reader.validatePath('ar');
+
   Uri get cc => _reader.path$('cc');
 
   set _cc(Uri value) {
     json['cc'] = value.toFilePath();
   }
 
+  List<String> _validateCc() => _reader.validatePath('cc');
+
   Uri? get envScript => _reader.optionalPath('env_script');
 
   set _envScript(Uri? value) {
     json.setOrRemove('env_script', value?.toFilePath());
   }
+
+  List<String> _validateEnvScript() =>
+      _reader.validateOptionalPath('env_script');
 
   List<String>? get envScriptArguments =>
       _reader.optionalStringList('env_script_arguments');
@@ -239,11 +283,16 @@ class CCompilerConfig {
     json.setOrRemove('env_script_arguments', value);
   }
 
+  List<String> _validateEnvScriptArguments() =>
+      _reader.validateOptionalStringList('env_script_arguments');
+
   Uri get ld => _reader.path$('ld');
 
   set _ld(Uri value) {
     json['ld'] = value.toFilePath();
   }
+
+  List<String> _validateLd() => _reader.validatePath('ld');
 
   Windows? get windows {
     final jsonValue = _reader.optionalMap('windows');
@@ -254,6 +303,23 @@ class CCompilerConfig {
   set _windows(Windows? value) {
     json.setOrRemove('windows', value?.json);
   }
+
+  List<String> _validateWindows() {
+    final mapErrors = _reader.validate<Map<String, Object?>?>('windows');
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return windows?.validate() ?? [];
+  }
+
+  List<String> validate() => [
+    ..._validateAr(),
+    ..._validateCc(),
+    ..._validateEnvScript(),
+    ..._validateEnvScriptArguments(),
+    ..._validateLd(),
+    ..._validateWindows(),
+  ];
 
   @override
   String toString() => 'CCompilerConfig($json)';
@@ -288,6 +354,18 @@ class Windows {
     json.setOrRemove('developer_command_prompt', value?.json);
   }
 
+  List<String> _validateDeveloperCommandPrompt() {
+    final mapErrors = _reader.validate<Map<String, Object?>?>(
+      'developer_command_prompt',
+    );
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return developerCommandPrompt?.validate() ?? [];
+  }
+
+  List<String> validate() => [..._validateDeveloperCommandPrompt()];
+
   @override
   String toString() => 'Windows($json)';
 }
@@ -315,11 +393,17 @@ class DeveloperCommandPrompt {
     json['arguments'] = value;
   }
 
+  List<String> _validateArguments() => _reader.validateStringList('arguments');
+
   Uri get script => _reader.path$('script');
 
   set _script(Uri value) {
     json['script'] = value.toFilePath();
   }
+
+  List<String> _validateScript() => _reader.validatePath('script');
+
+  List<String> validate() => [..._validateArguments(), ..._validateScript()];
 
   @override
   String toString() => 'DeveloperCommandPrompt($json)';
@@ -364,6 +448,14 @@ class CodeConfig {
     json.setOrRemove('android', value?.json);
   }
 
+  List<String> _validateAndroid() {
+    final mapErrors = _reader.validate<Map<String, Object?>?>('android');
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return android?.validate() ?? [];
+  }
+
   CCompilerConfig? get cCompiler {
     final jsonValue = _reader.optionalMap('c_compiler');
     if (jsonValue == null) return null;
@@ -372,6 +464,14 @@ class CodeConfig {
 
   set _cCompiler(CCompilerConfig? value) {
     json.setOrRemove('c_compiler', value?.json);
+  }
+
+  List<String> _validateCCompiler() {
+    final mapErrors = _reader.validate<Map<String, Object?>?>('c_compiler');
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return cCompiler?.validate() ?? [];
   }
 
   IOSCodeConfig? get iOS {
@@ -384,6 +484,14 @@ class CodeConfig {
     json.setOrRemove('ios', value?.json);
   }
 
+  List<String> _validateIOS() {
+    final mapErrors = _reader.validate<Map<String, Object?>?>('ios');
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return iOS?.validate() ?? [];
+  }
+
   LinkModePreference get linkModePreference {
     final jsonValue = _reader.get<String>('link_mode_preference');
     return LinkModePreference.fromJson(jsonValue);
@@ -392,6 +500,9 @@ class CodeConfig {
   set _linkModePreference(LinkModePreference value) {
     json['link_mode_preference'] = value.name;
   }
+
+  List<String> _validateLinkModePreference() =>
+      _reader.validate<String>('link_mode_preference');
 
   MacOSCodeConfig? get macOS {
     final jsonValue = _reader.optionalMap('macos');
@@ -403,6 +514,14 @@ class CodeConfig {
     json.setOrRemove('macos', value?.json);
   }
 
+  List<String> _validateMacOS() {
+    final mapErrors = _reader.validate<Map<String, Object?>?>('macos');
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return macOS?.validate() ?? [];
+  }
+
   Architecture get targetArchitecture {
     final jsonValue = _reader.get<String>('target_architecture');
     return Architecture.fromJson(jsonValue);
@@ -412,6 +531,9 @@ class CodeConfig {
     json['target_architecture'] = value.name;
   }
 
+  List<String> _validateTargetArchitecture() =>
+      _reader.validate<String>('target_architecture');
+
   OS get targetOs {
     final jsonValue = _reader.get<String>('target_os');
     return OS.fromJson(jsonValue);
@@ -420,6 +542,18 @@ class CodeConfig {
   set _targetOs(OS value) {
     json['target_os'] = value.name;
   }
+
+  List<String> _validateTargetOs() => _reader.validate<String>('target_os');
+
+  List<String> validate() => [
+    ..._validateAndroid(),
+    ..._validateCCompiler(),
+    ..._validateIOS(),
+    ..._validateLinkModePreference(),
+    ..._validateMacOS(),
+    ..._validateTargetArchitecture(),
+    ..._validateTargetOs(),
+  ];
 
   @override
   String toString() => 'CodeConfig($json)';
@@ -450,6 +584,16 @@ class Config {
     json.sortOnKey();
   }
 
+  List<String> _validateCode() {
+    final mapErrors = _reader.validate<Map<String, Object?>?>('code');
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return code?.validate() ?? [];
+  }
+
+  List<String> validate() => [..._validateCode()];
+
   @override
   String toString() => 'Config($json)';
 }
@@ -477,11 +621,21 @@ class IOSCodeConfig {
     json.setOrRemove('target_sdk', value);
   }
 
+  List<String> _validateTargetSdk() => _reader.validate<String?>('target_sdk');
+
   int? get targetVersion => _reader.get<int?>('target_version');
 
   set _targetVersion(int? value) {
     json.setOrRemove('target_version', value);
   }
+
+  List<String> _validateTargetVersion() =>
+      _reader.validate<int?>('target_version');
+
+  List<String> validate() => [
+    ..._validateTargetSdk(),
+    ..._validateTargetVersion(),
+  ];
 
   @override
   String toString() => 'IOSCodeConfig($json)';
@@ -507,6 +661,10 @@ class LinkMode {
     json.setOrRemove('type', value);
   }
 
+  List<String> _validateType() => _reader.validate<String>('type');
+
+  List<String> validate() => [..._validateType()];
+
   @override
   String toString() => 'LinkMode($json)';
 }
@@ -518,6 +676,9 @@ class DynamicLoadingBundleLinkMode extends LinkMode {
   DynamicLoadingBundleLinkMode() : super(type: 'dynamic_loading_bundle');
 
   @override
+  List<String> validate() => [...super.validate()];
+
+  @override
   String toString() => 'DynamicLoadingBundleLinkMode($json)';
 }
 
@@ -525,7 +686,7 @@ extension DynamicLoadingBundleLinkModeExtension on LinkMode {
   bool get isDynamicLoadingBundleLinkMode => type == 'dynamic_loading_bundle';
 
   DynamicLoadingBundleLinkMode get asDynamicLoadingBundleLinkMode =>
-      DynamicLoadingBundleLinkMode.fromJson(json);
+      DynamicLoadingBundleLinkMode.fromJson(json, path: path);
 }
 
 class DynamicLoadingExecutableLinkMode extends LinkMode {
@@ -536,6 +697,9 @@ class DynamicLoadingExecutableLinkMode extends LinkMode {
     : super(type: 'dynamic_loading_executable');
 
   @override
+  List<String> validate() => [...super.validate()];
+
+  @override
   String toString() => 'DynamicLoadingExecutableLinkMode($json)';
 }
 
@@ -544,7 +708,7 @@ extension DynamicLoadingExecutableLinkModeExtension on LinkMode {
       type == 'dynamic_loading_executable';
 
   DynamicLoadingExecutableLinkMode get asDynamicLoadingExecutableLinkMode =>
-      DynamicLoadingExecutableLinkMode.fromJson(json);
+      DynamicLoadingExecutableLinkMode.fromJson(json, path: path);
 }
 
 class DynamicLoadingProcessLinkMode extends LinkMode {
@@ -554,6 +718,9 @@ class DynamicLoadingProcessLinkMode extends LinkMode {
   DynamicLoadingProcessLinkMode() : super(type: 'dynamic_loading_process');
 
   @override
+  List<String> validate() => [...super.validate()];
+
+  @override
   String toString() => 'DynamicLoadingProcessLinkMode($json)';
 }
 
@@ -561,7 +728,7 @@ extension DynamicLoadingProcessLinkModeExtension on LinkMode {
   bool get isDynamicLoadingProcessLinkMode => type == 'dynamic_loading_process';
 
   DynamicLoadingProcessLinkMode get asDynamicLoadingProcessLinkMode =>
-      DynamicLoadingProcessLinkMode.fromJson(json);
+      DynamicLoadingProcessLinkMode.fromJson(json, path: path);
 }
 
 class DynamicLoadingSystemLinkMode extends LinkMode {
@@ -587,6 +754,11 @@ class DynamicLoadingSystemLinkMode extends LinkMode {
     json['uri'] = value.toFilePath();
   }
 
+  List<String> _validateUri() => _reader.validatePath('uri');
+
+  @override
+  List<String> validate() => [...super.validate(), ..._validateUri()];
+
   @override
   String toString() => 'DynamicLoadingSystemLinkMode($json)';
 }
@@ -595,7 +767,7 @@ extension DynamicLoadingSystemLinkModeExtension on LinkMode {
   bool get isDynamicLoadingSystemLinkMode => type == 'dynamic_loading_system';
 
   DynamicLoadingSystemLinkMode get asDynamicLoadingSystemLinkMode =>
-      DynamicLoadingSystemLinkMode.fromJson(json);
+      DynamicLoadingSystemLinkMode.fromJson(json, path: path);
 }
 
 class StaticLinkMode extends LinkMode {
@@ -604,13 +776,17 @@ class StaticLinkMode extends LinkMode {
   StaticLinkMode() : super(type: 'static');
 
   @override
+  List<String> validate() => [...super.validate()];
+
+  @override
   String toString() => 'StaticLinkMode($json)';
 }
 
 extension StaticLinkModeExtension on LinkMode {
   bool get isStaticLinkMode => type == 'static';
 
-  StaticLinkMode get asStaticLinkMode => StaticLinkMode.fromJson(json);
+  StaticLinkMode get asStaticLinkMode =>
+      StaticLinkMode.fromJson(json, path: path);
 }
 
 class LinkModePreference {
@@ -673,6 +849,11 @@ class MacOSCodeConfig {
     json.setOrRemove('target_version', value);
   }
 
+  List<String> _validateTargetVersion() =>
+      _reader.validate<int?>('target_version');
+
+  List<String> validate() => [..._validateTargetVersion()];
+
   @override
   String toString() => 'MacOSCodeConfig($json)';
 }
@@ -730,21 +911,45 @@ class JsonReader {
   T get<T extends Object?>(String key) {
     final value = json[key];
     if (value is T) return value;
-    final pathString = _jsonPathToString([key]);
-    if (value == null) {
-      throw FormatException("No value was provided for '$pathString'.");
-    }
     throwFormatException(value, T, [key]);
+  }
+
+  List<String> validate<T extends Object?>(String key) {
+    final value = json[key];
+    if (value is T) return [];
+    return [
+      errorString(value, T, [key]),
+    ];
   }
 
   List<T> list<T extends Object?>(String key) =>
       _castList<T>(get<List<Object?>>(key), key);
+
+  List<String> validateList<T extends Object?>(String key) {
+    final listErrors = validate<List<Object?>>(key);
+    if (listErrors.isNotEmpty) {
+      return listErrors;
+    }
+    return _validateListElements(get<List<Object?>>(key), key);
+  }
 
   List<T>? optionalList<T extends Object?>(String key) =>
       switch (get<List<Object?>?>(key)?.cast<T>()) {
         null => null,
         final l => _castList<T>(l, key),
       };
+
+  List<String> validateOptionalList<T extends Object?>(String key) {
+    final listErrors = validate<List<Object?>?>(key);
+    if (listErrors.isNotEmpty) {
+      return listErrors;
+    }
+    final list = get<List<Object?>?>(key);
+    if (list == null) {
+      return [];
+    }
+    return _validateListElements(list, key);
+  }
 
   /// [List.cast] but with [FormatException]s.
   List<T> _castList<T extends Object?>(List<Object?> list, String key) {
@@ -756,6 +961,21 @@ class JsonReader {
       index++;
     }
     return list.cast();
+  }
+
+  List<String> _validateListElements<T extends Object?>(
+    List<Object?> list,
+    String key,
+  ) {
+    var index = 0;
+    final result = <String>[];
+    for (final value in list) {
+      if (value is! T) {
+        result.add(errorString(value, T, [key, index]));
+      }
+      index++;
+    }
+    return result;
   }
 
   List<T>? optionalListParsed<T extends Object?>(
@@ -770,11 +990,31 @@ class JsonReader {
   Map<String, T> map$<T extends Object?>(String key) =>
       _castMap<T>(get<Map<String, Object?>>(key), key);
 
+  List<String> validateMap<T extends Object?>(String key) {
+    final mapErrors = validate<Map<String, Object?>>(key);
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return _validateMapElements<T>(get<Map<String, Object?>>(key), key);
+  }
+
   Map<String, T>? optionalMap<T extends Object?>(String key) =>
       switch (get<Map<String, Object?>?>(key)) {
         null => null,
         final m => _castMap<T>(m, key),
       };
+
+  List<String> validateOptionalMap<T extends Object?>(String key) {
+    final mapErrors = validate<Map<String, Object?>?>(key);
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    final map = get<Map<String, Object?>?>(key);
+    if (map == null) {
+      return [];
+    }
+    return _validateMapElements<T>(map, key);
+  }
 
   /// [Map.cast] but with [FormatException]s.
   Map<String, T> _castMap<T extends Object?>(
@@ -789,17 +1029,39 @@ class JsonReader {
     return map_.cast();
   }
 
+  List<String> _validateMapElements<T extends Object?>(
+    Map<String, Object?> map_,
+    String parentKey,
+  ) {
+    final result = <String>[];
+    for (final MapEntry(:key, :value) in map_.entries) {
+      if (value is! T) {
+        result.add(errorString(value, T, [parentKey, key]));
+      }
+    }
+    return result;
+  }
+
   List<String>? optionalStringList(String key) => optionalList<String>(key);
+
+  List<String> validateOptionalStringList(String key) =>
+      validateOptionalList<String>(key);
 
   List<String> stringList(String key) => list<String>(key);
 
+  List<String> validateStringList(String key) => validateList<String>(key);
+
   Uri path$(String key) => _fileSystemPathToUri(get<String>(key));
+
+  List<String> validatePath(String key) => validate<String>(key);
 
   Uri? optionalPath(String key) {
     final value = get<String?>(key);
     if (value == null) return null;
     return _fileSystemPathToUri(value);
   }
+
+  List<String> validateOptionalPath(String key) => validate<String?>(key);
 
   List<Uri>? optionalPathList(String key) {
     final strings = optionalStringList(key);
@@ -808,6 +1070,9 @@ class JsonReader {
     }
     return [for (final string in strings) _fileSystemPathToUri(string)];
   }
+
+  List<String> validateOptionalPathList(String key) =>
+      validateOptionalStringList(key);
 
   static Uri _fileSystemPathToUri(String path) {
     if (path.endsWith(Platform.pathSeparator)) {
@@ -824,11 +1089,21 @@ class JsonReader {
     Type expectedType,
     List<Object> pathExtension,
   ) {
+    throw FormatException(errorString(value, expectedType, pathExtension));
+  }
+
+  String errorString(
+    Object? value,
+    Type expectedType,
+    List<Object> pathExtension,
+  ) {
     final pathString = _jsonPathToString(pathExtension);
-    throw FormatException(
-      "Unexpected value '$value' (${value.runtimeType}) for '$pathString'. "
-      'Expected a $expectedType.',
-    );
+    if (value == null) {
+      return "No value was provided for '$pathString'."
+          ' Expected a $expectedType.';
+    }
+    return "Unexpected value '$value' (${value.runtimeType}) for '$pathString'."
+        ' Expected a $expectedType.';
   }
 }
 

--- a/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
@@ -953,12 +953,10 @@ class JsonReader {
 
   /// [List.cast] but with [FormatException]s.
   List<T> _castList<T extends Object?>(List<Object?> list, String key) {
-    var index = 0;
-    for (final value in list) {
+    for (final (index, value) in list.indexed) {
       if (value is! T) {
         throwFormatException(value, T, [key, index]);
       }
-      index++;
     }
     return list.cast();
   }
@@ -967,24 +965,13 @@ class JsonReader {
     List<Object?> list,
     String key,
   ) {
-    var index = 0;
     final result = <String>[];
-    for (final value in list) {
+    for (final (index, value) in list.indexed) {
       if (value is! T) {
         result.add(errorString(value, T, [key, index]));
       }
-      index++;
     }
     return result;
-  }
-
-  List<T>? optionalListParsed<T extends Object?>(
-    String key,
-    T Function(Object?) elementParser,
-  ) {
-    final jsonValue = optionalList(key);
-    if (jsonValue == null) return null;
-    return [for (final element in jsonValue) elementParser(element)];
   }
 
   Map<String, T> map$<T extends Object?>(String key) =>

--- a/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
@@ -78,7 +78,7 @@ ValidationErrors _validateConfig(String inputName, HookConfig config) {
   return errors;
 }
 
-List<String> _validateConfigSyntax(HookConfig config) {
+ValidationErrors _validateConfigSyntax(HookConfig config) {
   final syntaxNode = syntax.Config.fromJson(config.json, path: config.path);
   final syntaxErrors = syntaxNode.validate();
   if (syntaxErrors.isEmpty) {
@@ -206,7 +206,7 @@ Future<ValidationErrors> _validateCodeAssetBuildOrLinkOutput(
   return errors;
 }
 
-List<String> _validateCodeAssetSyntax(EncodedAsset encodedAsset) {
+ValidationErrors _validateCodeAssetSyntax(EncodedAsset encodedAsset) {
   final syntaxNode = syntax.Asset.fromJson(
     encodedAsset.toJson(),
     path: encodedAsset.jsonPath ?? [],
@@ -230,7 +230,7 @@ void _validateCodeAsset(
   HookInput input,
   CodeConfig codeConfig,
   CodeAsset codeAsset,
-  List<String> errors,
+  ValidationErrors errors,
   Set<String> ids,
   bool validateAssetId,
   bool validateLinkMode,
@@ -281,7 +281,7 @@ void _validateCodeAsset(
   errors.addAll(_validateCodeAssetFile(codeAsset));
 }
 
-List<String> _validateCodeAssetFile(CodeAsset codeAsset) {
+ValidationErrors _validateCodeAssetFile(CodeAsset codeAsset) {
   final id = codeAsset.id;
   final file = codeAsset.file;
   return [
@@ -313,7 +313,7 @@ void _groupCodeAssetsByFilename(
 }
 
 void _validateNoDuplicateDylibNames(
-  List<String> errors,
+  ValidationErrors errors,
   Map<String, Set<String>> fileNameToEncodedAssetId,
 ) {
   for (final fileName in fileNameToEncodedAssetId.keys) {

--- a/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
@@ -28,6 +28,10 @@ class Asset {
     json.setOrRemove('type', value);
   }
 
+  List<String> _validateType() => _reader.validate<String?>('type');
+
+  List<String> validate() => [..._validateType()];
+
   @override
   String toString() => 'Asset($json)';
 }
@@ -62,17 +66,31 @@ class DataAsset extends Asset {
     json['file'] = value.toFilePath();
   }
 
+  List<String> _validateFile() => _reader.validatePath('file');
+
   String get name => _reader.get<String>('name');
 
   set _name(String value) {
     json.setOrRemove('name', value);
   }
 
+  List<String> _validateName() => _reader.validate<String>('name');
+
   String get package => _reader.get<String>('package');
 
   set _package(String value) {
     json.setOrRemove('package', value);
   }
+
+  List<String> _validatePackage() => _reader.validate<String>('package');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateFile(),
+    ..._validateName(),
+    ..._validatePackage(),
+  ];
 
   @override
   String toString() => 'DataAsset($json)';
@@ -81,7 +99,7 @@ class DataAsset extends Asset {
 extension DataAssetExtension on Asset {
   bool get isDataAsset => type == 'data';
 
-  DataAsset get asDataAsset => DataAsset.fromJson(json);
+  DataAsset get asDataAsset => DataAsset.fromJson(json, path: path);
 }
 
 class JsonReader {
@@ -100,21 +118,45 @@ class JsonReader {
   T get<T extends Object?>(String key) {
     final value = json[key];
     if (value is T) return value;
-    final pathString = _jsonPathToString([key]);
-    if (value == null) {
-      throw FormatException("No value was provided for '$pathString'.");
-    }
     throwFormatException(value, T, [key]);
+  }
+
+  List<String> validate<T extends Object?>(String key) {
+    final value = json[key];
+    if (value is T) return [];
+    return [
+      errorString(value, T, [key]),
+    ];
   }
 
   List<T> list<T extends Object?>(String key) =>
       _castList<T>(get<List<Object?>>(key), key);
+
+  List<String> validateList<T extends Object?>(String key) {
+    final listErrors = validate<List<Object?>>(key);
+    if (listErrors.isNotEmpty) {
+      return listErrors;
+    }
+    return _validateListElements(get<List<Object?>>(key), key);
+  }
 
   List<T>? optionalList<T extends Object?>(String key) =>
       switch (get<List<Object?>?>(key)?.cast<T>()) {
         null => null,
         final l => _castList<T>(l, key),
       };
+
+  List<String> validateOptionalList<T extends Object?>(String key) {
+    final listErrors = validate<List<Object?>?>(key);
+    if (listErrors.isNotEmpty) {
+      return listErrors;
+    }
+    final list = get<List<Object?>?>(key);
+    if (list == null) {
+      return [];
+    }
+    return _validateListElements(list, key);
+  }
 
   /// [List.cast] but with [FormatException]s.
   List<T> _castList<T extends Object?>(List<Object?> list, String key) {
@@ -126,6 +168,21 @@ class JsonReader {
       index++;
     }
     return list.cast();
+  }
+
+  List<String> _validateListElements<T extends Object?>(
+    List<Object?> list,
+    String key,
+  ) {
+    var index = 0;
+    final result = <String>[];
+    for (final value in list) {
+      if (value is! T) {
+        result.add(errorString(value, T, [key, index]));
+      }
+      index++;
+    }
+    return result;
   }
 
   List<T>? optionalListParsed<T extends Object?>(
@@ -140,11 +197,31 @@ class JsonReader {
   Map<String, T> map$<T extends Object?>(String key) =>
       _castMap<T>(get<Map<String, Object?>>(key), key);
 
+  List<String> validateMap<T extends Object?>(String key) {
+    final mapErrors = validate<Map<String, Object?>>(key);
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return _validateMapElements<T>(get<Map<String, Object?>>(key), key);
+  }
+
   Map<String, T>? optionalMap<T extends Object?>(String key) =>
       switch (get<Map<String, Object?>?>(key)) {
         null => null,
         final m => _castMap<T>(m, key),
       };
+
+  List<String> validateOptionalMap<T extends Object?>(String key) {
+    final mapErrors = validate<Map<String, Object?>?>(key);
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    final map = get<Map<String, Object?>?>(key);
+    if (map == null) {
+      return [];
+    }
+    return _validateMapElements<T>(map, key);
+  }
 
   /// [Map.cast] but with [FormatException]s.
   Map<String, T> _castMap<T extends Object?>(
@@ -159,17 +236,39 @@ class JsonReader {
     return map_.cast();
   }
 
+  List<String> _validateMapElements<T extends Object?>(
+    Map<String, Object?> map_,
+    String parentKey,
+  ) {
+    final result = <String>[];
+    for (final MapEntry(:key, :value) in map_.entries) {
+      if (value is! T) {
+        result.add(errorString(value, T, [parentKey, key]));
+      }
+    }
+    return result;
+  }
+
   List<String>? optionalStringList(String key) => optionalList<String>(key);
+
+  List<String> validateOptionalStringList(String key) =>
+      validateOptionalList<String>(key);
 
   List<String> stringList(String key) => list<String>(key);
 
+  List<String> validateStringList(String key) => validateList<String>(key);
+
   Uri path$(String key) => _fileSystemPathToUri(get<String>(key));
+
+  List<String> validatePath(String key) => validate<String>(key);
 
   Uri? optionalPath(String key) {
     final value = get<String?>(key);
     if (value == null) return null;
     return _fileSystemPathToUri(value);
   }
+
+  List<String> validateOptionalPath(String key) => validate<String?>(key);
 
   List<Uri>? optionalPathList(String key) {
     final strings = optionalStringList(key);
@@ -178,6 +277,9 @@ class JsonReader {
     }
     return [for (final string in strings) _fileSystemPathToUri(string)];
   }
+
+  List<String> validateOptionalPathList(String key) =>
+      validateOptionalStringList(key);
 
   static Uri _fileSystemPathToUri(String path) {
     if (path.endsWith(Platform.pathSeparator)) {
@@ -194,11 +296,21 @@ class JsonReader {
     Type expectedType,
     List<Object> pathExtension,
   ) {
+    throw FormatException(errorString(value, expectedType, pathExtension));
+  }
+
+  String errorString(
+    Object? value,
+    Type expectedType,
+    List<Object> pathExtension,
+  ) {
     final pathString = _jsonPathToString(pathExtension);
-    throw FormatException(
-      "Unexpected value '$value' (${value.runtimeType}) for '$pathString'. "
-      'Expected a $expectedType.',
-    );
+    if (value == null) {
+      return "No value was provided for '$pathString'."
+          ' Expected a $expectedType.';
+    }
+    return "Unexpected value '$value' (${value.runtimeType}) for '$pathString'."
+        ' Expected a $expectedType.';
   }
 }
 

--- a/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
@@ -160,12 +160,10 @@ class JsonReader {
 
   /// [List.cast] but with [FormatException]s.
   List<T> _castList<T extends Object?>(List<Object?> list, String key) {
-    var index = 0;
-    for (final value in list) {
+    for (final (index, value) in list.indexed) {
       if (value is! T) {
         throwFormatException(value, T, [key, index]);
       }
-      index++;
     }
     return list.cast();
   }
@@ -174,24 +172,13 @@ class JsonReader {
     List<Object?> list,
     String key,
   ) {
-    var index = 0;
     final result = <String>[];
-    for (final value in list) {
+    for (final (index, value) in list.indexed) {
       if (value is! T) {
         result.add(errorString(value, T, [key, index]));
       }
-      index++;
     }
     return result;
-  }
-
-  List<T>? optionalListParsed<T extends Object?>(
-    String key,
-    T Function(Object?) elementParser,
-  ) {
-    final jsonValue = optionalList(key);
-    if (jsonValue == null) return null;
-    return [for (final element in jsonValue) elementParser(element)];
   }
 
   Map<String, T> map$<T extends Object?>(String key) =>

--- a/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
@@ -5,18 +5,28 @@
 import 'dart:io';
 
 import '../../data_assets_builder.dart';
+import 'syntax.g.dart' as syntax;
 
 Future<ValidationErrors> validateDataAssetBuildInput(BuildInput input) async =>
     const [];
 
 Future<ValidationErrors> validateDataAssetLinkInput(LinkInput input) async {
-  final errors = <String>[
-    for (final asset in input.assets.data)
-      ..._validateFile(
-        'LinkInput.assets.data asset "${asset.id}" file',
-        asset.file,
+  final errors = <String>[];
+  for (final asset in input.assets.encodedAssets) {
+    final syntaxErrors = _validateDataAssetSyntax(asset);
+    if (asset.type != DataAsset.type) continue;
+    if (syntaxErrors.isNotEmpty) {
+      errors.addAll(syntaxErrors);
+      continue;
+    }
+    final dataAsset = DataAsset.fromEncoded(asset);
+    errors.addAll(
+      _validateFile(
+        'LinkInput.assets.data asset "${dataAsset.id}" file',
+        dataAsset.file,
       ),
-  ];
+    );
+  }
   return errors;
 }
 
@@ -48,6 +58,11 @@ Future<ValidationErrors> _validateDataAssetBuildOrLinkOutput(
 
   for (final asset in encodedAssets) {
     if (asset.type != DataAsset.type) continue;
+    final syntaxErrors = _validateDataAssetSyntax(asset);
+    if (syntaxErrors.isNotEmpty) {
+      errors.addAll(syntaxErrors);
+      continue;
+    }
     _validateDataAsset(
       input,
       DataAsset.fromEncoded(asset),
@@ -74,6 +89,26 @@ void _validateDataAsset(
   }
   final file = dataAsset.file;
   errors.addAll(_validateFile('Data asset ${dataAsset.name} file', file));
+}
+
+List<String> _validateDataAssetSyntax(EncodedAsset encodedAsset) {
+  final syntaxNode = syntax.Asset.fromJson(
+    encodedAsset.toJson(),
+    path: encodedAsset.jsonPath ?? [],
+  );
+  if (!syntaxNode.isDataAsset) {
+    return [];
+  }
+  final syntaxErrors = syntaxNode.asDataAsset.validate();
+  if (syntaxErrors.isEmpty) {
+    return [];
+  }
+  return [...syntaxErrors, semanticValidationSkippedMessage(syntaxNode.path)];
+}
+
+String semanticValidationSkippedMessage(List<Object> jsonPath) {
+  final pathString = jsonPath.join('.');
+  return "Syntax errors in '$pathString'. Semantic validation skipped.";
 }
 
 ValidationErrors _validateFile(

--- a/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
@@ -77,7 +77,7 @@ Future<ValidationErrors> _validateDataAssetBuildOrLinkOutput(
 void _validateDataAsset(
   HookInput input,
   DataAsset dataAsset,
-  List<String> errors,
+  ValidationErrors errors,
   Set<String> ids,
   bool isBuild,
 ) {
@@ -91,7 +91,7 @@ void _validateDataAsset(
   errors.addAll(_validateFile('Data asset ${dataAsset.name} file', file));
 }
 
-List<String> _validateDataAssetSyntax(EncodedAsset encodedAsset) {
+ValidationErrors _validateDataAssetSyntax(EncodedAsset encodedAsset) {
   final syntaxNode = syntax.Asset.fromJson(
     encodedAsset.toJson(),
     path: encodedAsset.jsonPath ?? [],

--- a/pkgs/native_assets_cli/lib/src/extension.dart
+++ b/pkgs/native_assets_cli/lib/src/extension.dart
@@ -14,7 +14,7 @@ typedef ValidationErrors = List<String>;
 ///
 /// The extension contains callbacks to
 /// 1. setup the input, and
-/// 2. validate semantic constraints.
+/// 2. validate syntactic and semantic constraints.
 abstract interface class ProtocolExtension {
   /// The [HookConfig.buildAssetTypes] this extension adds.
   List<String> get buildAssetTypes;
@@ -25,19 +25,19 @@ abstract interface class ProtocolExtension {
   /// Setup the [HookConfig] for this extension.
   void setupLinkInput(LinkInputBuilder input);
 
-  /// Reports semantic errors from this extension on the [BuildInput].
+  /// Reports errors from this extension on the [BuildInput].
   Future<ValidationErrors> validateBuildInput(BuildInput input);
 
-  /// Reports semantic errors from this extension on the [LinkInput].
+  /// Reports errors from this extension on the [LinkInput].
   Future<ValidationErrors> validateBuildOutput(
     BuildInput input,
     BuildOutput output,
   );
 
-  /// Reports semantic errors from this extension on the [LinkInput].
+  /// Reports errors from this extension on the [LinkInput].
   Future<ValidationErrors> validateLinkInput(LinkInput input);
 
-  /// Reports semantic errors from this extension on the [LinkOutput].
+  /// Reports errors from this extension on the [LinkOutput].
   Future<ValidationErrors> validateLinkOutput(
     LinkInput input,
     LinkOutput output,

--- a/pkgs/native_assets_cli/lib/src/hook/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/hook/syntax.g.dart
@@ -28,6 +28,10 @@ class Asset {
     json.setOrRemove('type', value);
   }
 
+  List<String> _validateType() => _reader.validate<String>('type');
+
+  List<String> validate() => [..._validateType()];
+
   @override
   String toString() => 'Asset($json)';
 }
@@ -53,6 +57,15 @@ class BuildConfig extends Config {
   set _linkingEnabled(bool value) {
     json.setOrRemove('linking_enabled', value);
   }
+
+  List<String> _validateLinkingEnabled() =>
+      _reader.validate<bool>('linking_enabled');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateLinkingEnabled(),
+  ];
 
   @override
   String toString() => 'BuildConfig($json)';
@@ -94,6 +107,16 @@ class BuildInput extends HookInput {
   set _dependencyMetadata(Map<String, Map<String, Object?>>? value) {
     json.setOrRemove('dependency_metadata', value);
   }
+
+  List<String> _validateDependencyMetadata() =>
+      _reader.validateOptionalMap<Map<String, Object?>>('dependency_metadata');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateConfig(),
+    ..._validateDependencyMetadata(),
+  ];
 
   @override
   String toString() => 'BuildInput($json)';
@@ -157,12 +180,39 @@ class BuildOutput extends HookOutput {
     json.sortOnKey();
   }
 
+  List<String> _validateAssetsForLinking() {
+    final mapErrors = _reader.validateOptionalMap('assetsForLinking');
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    final jsonValue = _reader.optionalMap('assetsForLinking');
+    if (jsonValue == null) {
+      return [];
+    }
+    final result = <String>[];
+    for (final list in assetsForLinking!.values) {
+      for (final element in list) {
+        result.addAll(element.validate());
+      }
+    }
+    return result;
+  }
+
   Map<String, Object?>? get metadata => _reader.optionalMap('metadata');
 
   set metadata(Map<String, Object?>? value) {
     json.setOrRemove('metadata', value);
     json.sortOnKey();
   }
+
+  List<String> _validateMetadata() => _reader.validateOptionalMap('metadata');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateAssetsForLinking(),
+    ..._validateMetadata(),
+  ];
 
   @override
   String toString() => 'BuildOutput($json)';
@@ -188,6 +238,11 @@ class Config {
     json['build_asset_types'] = value;
     json.sortOnKey();
   }
+
+  List<String> _validateBuildAssetTypes() =>
+      _reader.validateStringList('build_asset_types');
+
+  List<String> validate() => [..._validateBuildAssetTypes()];
 
   @override
   String toString() => 'Config($json)';
@@ -232,12 +287,22 @@ class HookInput {
     json.sortOnKey();
   }
 
+  List<String> _validateConfig() {
+    final mapErrors = _reader.validate<Map<String, Object?>>('config');
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return config.validate();
+  }
+
   Uri get outDir => _reader.path$('out_dir');
 
   set outDir(Uri value) {
     json['out_dir'] = value.toFilePath();
     json.sortOnKey();
   }
+
+  List<String> _validateOutDir() => _reader.validatePath('out_dir');
 
   Uri get outDirShared => _reader.path$('out_dir_shared');
 
@@ -246,12 +311,17 @@ class HookInput {
     json.sortOnKey();
   }
 
+  List<String> _validateOutDirShared() =>
+      _reader.validatePath('out_dir_shared');
+
   Uri? get outFile => _reader.optionalPath('out_file');
 
   set outFile(Uri? value) {
     json.setOrRemove('out_file', value?.toFilePath());
     json.sortOnKey();
   }
+
+  List<String> _validateOutFile() => _reader.validateOptionalPath('out_file');
 
   String get packageName => _reader.get<String>('package_name');
 
@@ -260,6 +330,9 @@ class HookInput {
     json.sortOnKey();
   }
 
+  List<String> _validatePackageName() =>
+      _reader.validate<String>('package_name');
+
   Uri get packageRoot => _reader.path$('package_root');
 
   set packageRoot(Uri value) {
@@ -267,12 +340,26 @@ class HookInput {
     json.sortOnKey();
   }
 
+  List<String> _validatePackageRoot() => _reader.validatePath('package_root');
+
   String get version => _reader.get<String>('version');
 
   set version(String value) {
     json.setOrRemove('version', value);
     json.sortOnKey();
   }
+
+  List<String> _validateVersion() => _reader.validate<String>('version');
+
+  List<String> validate() => [
+    ..._validateConfig(),
+    ..._validateOutDir(),
+    ..._validateOutDirShared(),
+    ..._validateOutFile(),
+    ..._validatePackageName(),
+    ..._validatePackageRoot(),
+    ..._validateVersion(),
+  ];
 
   @override
   String toString() => 'HookInput($json)';
@@ -321,12 +408,29 @@ class HookOutput {
     json.sortOnKey();
   }
 
+  List<String> _validateAssets() {
+    final listErrors = _reader.validateOptionalList<Map<String, Object?>>(
+      'assets',
+    );
+    if (listErrors.isNotEmpty) {
+      return listErrors;
+    }
+    final elements = assets;
+    if (elements == null) {
+      return [];
+    }
+    return [for (final element in elements) ...element.validate()];
+  }
+
   List<Uri>? get dependencies => _reader.optionalPathList('dependencies');
 
   set dependencies(List<Uri>? value) {
     json.setOrRemove('dependencies', value?.toJson());
     json.sortOnKey();
   }
+
+  List<String> _validateDependencies() =>
+      _reader.validateOptionalPathList('dependencies');
 
   String get timestamp => _reader.get<String>('timestamp');
 
@@ -335,12 +439,23 @@ class HookOutput {
     json.sortOnKey();
   }
 
+  List<String> _validateTimestamp() => _reader.validate<String>('timestamp');
+
   String get version => _reader.get<String>('version');
 
   set version(String value) {
     json.setOrRemove('version', value);
     json.sortOnKey();
   }
+
+  List<String> _validateVersion() => _reader.validate<String>('version');
+
+  List<String> validate() => [
+    ..._validateAssets(),
+    ..._validateDependencies(),
+    ..._validateTimestamp(),
+    ..._validateVersion(),
+  ];
 
   @override
   String toString() => 'HookOutput($json)';
@@ -392,11 +507,35 @@ class LinkInput extends HookInput {
     }
   }
 
+  List<String> _validateAssets() {
+    final listErrors = _reader.validateOptionalList<Map<String, Object?>>(
+      'assets',
+    );
+    if (listErrors.isNotEmpty) {
+      return listErrors;
+    }
+    final elements = assets;
+    if (elements == null) {
+      return [];
+    }
+    return [for (final element in elements) ...element.validate()];
+  }
+
   Uri? get resourceIdentifiers => _reader.optionalPath('resource_identifiers');
 
   set _resourceIdentifiers(Uri? value) {
     json.setOrRemove('resource_identifiers', value?.toFilePath());
   }
+
+  List<String> _validateResourceIdentifiers() =>
+      _reader.validateOptionalPath('resource_identifiers');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateAssets(),
+    ..._validateResourceIdentifiers(),
+  ];
 
   @override
   String toString() => 'LinkInput($json)';
@@ -411,6 +550,9 @@ class LinkOutput extends HookOutput {
     required super.timestamp,
     required super.version,
   }) : super();
+
+  @override
+  List<String> validate() => [...super.validate()];
 
   @override
   String toString() => 'LinkOutput($json)';
@@ -432,21 +574,45 @@ class JsonReader {
   T get<T extends Object?>(String key) {
     final value = json[key];
     if (value is T) return value;
-    final pathString = _jsonPathToString([key]);
-    if (value == null) {
-      throw FormatException("No value was provided for '$pathString'.");
-    }
     throwFormatException(value, T, [key]);
+  }
+
+  List<String> validate<T extends Object?>(String key) {
+    final value = json[key];
+    if (value is T) return [];
+    return [
+      errorString(value, T, [key]),
+    ];
   }
 
   List<T> list<T extends Object?>(String key) =>
       _castList<T>(get<List<Object?>>(key), key);
+
+  List<String> validateList<T extends Object?>(String key) {
+    final listErrors = validate<List<Object?>>(key);
+    if (listErrors.isNotEmpty) {
+      return listErrors;
+    }
+    return _validateListElements(get<List<Object?>>(key), key);
+  }
 
   List<T>? optionalList<T extends Object?>(String key) =>
       switch (get<List<Object?>?>(key)?.cast<T>()) {
         null => null,
         final l => _castList<T>(l, key),
       };
+
+  List<String> validateOptionalList<T extends Object?>(String key) {
+    final listErrors = validate<List<Object?>?>(key);
+    if (listErrors.isNotEmpty) {
+      return listErrors;
+    }
+    final list = get<List<Object?>?>(key);
+    if (list == null) {
+      return [];
+    }
+    return _validateListElements(list, key);
+  }
 
   /// [List.cast] but with [FormatException]s.
   List<T> _castList<T extends Object?>(List<Object?> list, String key) {
@@ -458,6 +624,21 @@ class JsonReader {
       index++;
     }
     return list.cast();
+  }
+
+  List<String> _validateListElements<T extends Object?>(
+    List<Object?> list,
+    String key,
+  ) {
+    var index = 0;
+    final result = <String>[];
+    for (final value in list) {
+      if (value is! T) {
+        result.add(errorString(value, T, [key, index]));
+      }
+      index++;
+    }
+    return result;
   }
 
   List<T>? optionalListParsed<T extends Object?>(
@@ -472,11 +653,31 @@ class JsonReader {
   Map<String, T> map$<T extends Object?>(String key) =>
       _castMap<T>(get<Map<String, Object?>>(key), key);
 
+  List<String> validateMap<T extends Object?>(String key) {
+    final mapErrors = validate<Map<String, Object?>>(key);
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return _validateMapElements<T>(get<Map<String, Object?>>(key), key);
+  }
+
   Map<String, T>? optionalMap<T extends Object?>(String key) =>
       switch (get<Map<String, Object?>?>(key)) {
         null => null,
         final m => _castMap<T>(m, key),
       };
+
+  List<String> validateOptionalMap<T extends Object?>(String key) {
+    final mapErrors = validate<Map<String, Object?>?>(key);
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    final map = get<Map<String, Object?>?>(key);
+    if (map == null) {
+      return [];
+    }
+    return _validateMapElements<T>(map, key);
+  }
 
   /// [Map.cast] but with [FormatException]s.
   Map<String, T> _castMap<T extends Object?>(
@@ -491,17 +692,39 @@ class JsonReader {
     return map_.cast();
   }
 
+  List<String> _validateMapElements<T extends Object?>(
+    Map<String, Object?> map_,
+    String parentKey,
+  ) {
+    final result = <String>[];
+    for (final MapEntry(:key, :value) in map_.entries) {
+      if (value is! T) {
+        result.add(errorString(value, T, [parentKey, key]));
+      }
+    }
+    return result;
+  }
+
   List<String>? optionalStringList(String key) => optionalList<String>(key);
+
+  List<String> validateOptionalStringList(String key) =>
+      validateOptionalList<String>(key);
 
   List<String> stringList(String key) => list<String>(key);
 
+  List<String> validateStringList(String key) => validateList<String>(key);
+
   Uri path$(String key) => _fileSystemPathToUri(get<String>(key));
+
+  List<String> validatePath(String key) => validate<String>(key);
 
   Uri? optionalPath(String key) {
     final value = get<String?>(key);
     if (value == null) return null;
     return _fileSystemPathToUri(value);
   }
+
+  List<String> validateOptionalPath(String key) => validate<String?>(key);
 
   List<Uri>? optionalPathList(String key) {
     final strings = optionalStringList(key);
@@ -510,6 +733,9 @@ class JsonReader {
     }
     return [for (final string in strings) _fileSystemPathToUri(string)];
   }
+
+  List<String> validateOptionalPathList(String key) =>
+      validateOptionalStringList(key);
 
   static Uri _fileSystemPathToUri(String path) {
     if (path.endsWith(Platform.pathSeparator)) {
@@ -526,11 +752,21 @@ class JsonReader {
     Type expectedType,
     List<Object> pathExtension,
   ) {
+    throw FormatException(errorString(value, expectedType, pathExtension));
+  }
+
+  String errorString(
+    Object? value,
+    Type expectedType,
+    List<Object> pathExtension,
+  ) {
     final pathString = _jsonPathToString(pathExtension);
-    throw FormatException(
-      "Unexpected value '$value' (${value.runtimeType}) for '$pathString'. "
-      'Expected a $expectedType.',
-    );
+    if (value == null) {
+      return "No value was provided for '$pathString'."
+          ' Expected a $expectedType.';
+    }
+    return "Unexpected value '$value' (${value.runtimeType}) for '$pathString'."
+        ' Expected a $expectedType.';
   }
 }
 

--- a/pkgs/native_assets_cli/lib/src/hook/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/hook/syntax.g.dart
@@ -156,12 +156,11 @@ class BuildOutput extends HookOutput {
     }
     final result = <String, List<Asset>>{};
     for (final MapEntry(:key, :value) in jsonValue.entries) {
-      var index = 0;
       result[key] = [
-        for (final item in value as List<Object?>)
+        for (final (index, item) in (value as List<Object?>).indexed)
           Asset.fromJson(
             item as Map<String, Object?>,
-            path: [...path, key, index++],
+            path: [...path, key, index],
           ),
       ];
     }
@@ -389,14 +388,15 @@ class HookOutput {
   }
 
   List<Asset>? get assets {
-    var index = 0;
-    return _reader.optionalListParsed(
-      'assets',
-      (e) => Asset.fromJson(
-        e as Map<String, Object?>,
-        path: [...path, 'assets', index++],
-      ),
-    );
+    final jsonValue = _reader.optionalList('assets');
+    if (jsonValue == null) return null;
+    return [
+      for (final (index, element) in jsonValue.indexed)
+        Asset.fromJson(
+          element as Map<String, Object?>,
+          path: [...path, 'assets', index],
+        ),
+    ];
   }
 
   set assets(List<Asset>? value) {
@@ -489,14 +489,15 @@ class LinkInput extends HookInput {
   }
 
   List<Asset>? get assets {
-    var index = 0;
-    return _reader.optionalListParsed(
-      'assets',
-      (e) => Asset.fromJson(
-        e as Map<String, Object?>,
-        path: [...path, 'assets', index++],
-      ),
-    );
+    final jsonValue = _reader.optionalList('assets');
+    if (jsonValue == null) return null;
+    return [
+      for (final (index, element) in jsonValue.indexed)
+        Asset.fromJson(
+          element as Map<String, Object?>,
+          path: [...path, 'assets', index],
+        ),
+    ];
   }
 
   set _assets(List<Asset>? value) {
@@ -616,12 +617,10 @@ class JsonReader {
 
   /// [List.cast] but with [FormatException]s.
   List<T> _castList<T extends Object?>(List<Object?> list, String key) {
-    var index = 0;
-    for (final value in list) {
+    for (final (index, value) in list.indexed) {
       if (value is! T) {
         throwFormatException(value, T, [key, index]);
       }
-      index++;
     }
     return list.cast();
   }
@@ -630,24 +629,13 @@ class JsonReader {
     List<Object?> list,
     String key,
   ) {
-    var index = 0;
     final result = <String>[];
-    for (final value in list) {
+    for (final (index, value) in list.indexed) {
       if (value is! T) {
         result.add(errorString(value, T, [key, index]));
       }
-      index++;
     }
     return result;
-  }
-
-  List<T>? optionalListParsed<T extends Object?>(
-    String key,
-    T Function(Object?) elementParser,
-  ) {
-    final jsonValue = optionalList(key);
-    if (jsonValue == null) return null;
-    return [for (final element in jsonValue) elementParser(element)];
   }
 
   Map<String, T> map$<T extends Object?>(String key) =>

--- a/pkgs/native_assets_cli/lib/src/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/validation.dart
@@ -107,7 +107,7 @@ Future<ValidationErrors> validateLinkOutput(
 }
 
 /// Only output asset types that are supported by the embedder.
-List<String> _validateOutputAssetTypes(
+ValidationErrors _validateOutputAssetTypes(
   HookInput input,
   Iterable<EncodedAsset> assets,
 ) {
@@ -130,7 +130,10 @@ List<String> _validateOutputAssetTypes(
 }
 
 /// EncodedAssetsForLinking should be empty if linking is not supported.
-List<String> _validateAssetsForLinking(BuildInput input, BuildOutput output) {
+ValidationErrors _validateAssetsForLinking(
+  BuildInput input,
+  BuildOutput output,
+) {
   final errors = <String>[];
   if (!input.config.linkingEnabled) {
     if (output.assets.encodedAssetsForLinking.isNotEmpty) {


### PR DESCRIPTION
Bug: https://github.com/dart-lang/native/issues/1826

This PR adds generated `validate` functions on the syntax classes that check the type and nullability of the required fields.

This PR does not separate syntax and semantic validation in the `ProtocolExtension` as proposed in https://github.com/dart-lang/native/issues/2088. The inputs/outputs classes expose the underlying JSON and are lazy. So, they don't fail on syntax errors unless traversed.

This PR does not yet address:

* https://github.com/dart-lang/native/issues/2039 (follow up PR)
* Non-local syntax (e.g. `file` is required if `link_mode` is x).

To prevent crashes in the semantic validation, the semantic validation is not run when when syntactic errors are found. To prevent confusion for users, an extra error message is added that semantic validation is not run if syntactic errors are found.

_We should consider also skipping extension validation if any errors occur in the base protocol, the validation code of extensions should be able to rely on that base protocol doesn't contain any errors._