### PR TITLE
[native_assets_cli] Make nullable fields required in syntax

### DIFF
--- a/pkgs/json_syntax_generator/lib/src/generator/normal_class_generator.dart
+++ b/pkgs/json_syntax_generator/lib/src/generator/normal_class_generator.dart
@@ -39,20 +39,14 @@ class ClassGenerator {
       final property = superClassProperty ?? thisClassProperty!;
       if (superClassProperty != null) {
         if (identifyingSubtype == null) {
-          constructorParams.add(
-            '${property.isRequired ? 'required ' : ''}super.${property.name}',
-          );
+          constructorParams.add('required super.${property.name}');
         } else {
           superParams.add("type: '$identifyingSubtype'");
         }
       } else {
         final dartType = property.type;
-        constructorParams.add(
-          '${property.isRequired ? 'required ' : ''}$dartType ${property.name}',
-        );
-        setupParams.add(
-          '${property.isRequired ? 'required' : ''} $dartType ${property.name}',
-        );
+        constructorParams.add('required $dartType ${property.name}');
+        setupParams.add('required $dartType ${property.name}');
         if (property.setterPrivate) {
           constructorSetterCalls.add('_${property.name} = ${property.name};');
         } else {

--- a/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
@@ -94,7 +94,7 @@ class Asset {
 
   Asset.fromJson(this.json, {this.path = const []});
 
-  Asset({String? type}) : json = {}, path = const [] {
+  Asset({required String? type}) : json = {}, path = const [] {
     _type = type;
     json.sortOnKey();
   }
@@ -118,7 +118,7 @@ class NativeCodeAsset extends Asset {
 
   NativeCodeAsset({
     required Architecture architecture,
-    Uri? file,
+    required Uri? file,
     required String id,
     required LinkMode linkMode,
     required OS os,
@@ -135,7 +135,7 @@ class NativeCodeAsset extends Asset {
   /// [Asset].
   void setup({
     required Architecture architecture,
-    Uri? file,
+    required Uri? file,
     required String id,
     required LinkMode linkMode,
     required OS os,
@@ -237,10 +237,10 @@ class CCompilerConfig {
   CCompilerConfig({
     required Uri ar,
     required Uri cc,
-    Uri? envScript,
-    List<String>? envScriptArguments,
+    required Uri? envScript,
+    required List<String>? envScriptArguments,
     required Uri ld,
-    Windows? windows,
+    required Windows? windows,
   }) : json = {},
        path = const [] {
     _ar = ar;
@@ -335,7 +335,7 @@ class Windows {
 
   Windows.fromJson(this.json, {this.path = const []});
 
-  Windows({DeveloperCommandPrompt? developerCommandPrompt})
+  Windows({required DeveloperCommandPrompt? developerCommandPrompt})
     : json = {},
       path = const [] {
     _developerCommandPrompt = developerCommandPrompt;
@@ -420,11 +420,11 @@ class CodeConfig {
   CodeConfig.fromJson(this.json, {this.path = const []});
 
   CodeConfig({
-    AndroidCodeConfig? android,
-    CCompilerConfig? cCompiler,
-    IOSCodeConfig? iOS,
+    required AndroidCodeConfig? android,
+    required CCompilerConfig? cCompiler,
+    required IOSCodeConfig? iOS,
     required LinkModePreference linkModePreference,
-    MacOSCodeConfig? macOS,
+    required MacOSCodeConfig? macOS,
     required Architecture targetArchitecture,
     required OS targetOs,
   }) : json = {},
@@ -569,7 +569,7 @@ class Config {
 
   Config.fromJson(this.json, {this.path = const []});
 
-  Config({CodeConfig? code}) : json = {}, path = const [] {
+  Config({required CodeConfig? code}) : json = {}, path = const [] {
     this.code = code;
     json.sortOnKey();
   }

--- a/pkgs/native_assets_cli/lib/src/config.dart
+++ b/pkgs/native_assets_cli/lib/src/config.dart
@@ -298,6 +298,8 @@ sealed class HookOutputBuilder {
   final _syntax = syntax.HookOutput(
     timestamp: DateTime.now().roundDownToSeconds().toString(),
     version: latestVersion.toString(),
+    assets: null,
+    dependencies: null,
   );
 
   Map<String, Object?> get json => _syntax.json;

--- a/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
@@ -19,7 +19,7 @@ class Asset {
 
   Asset.fromJson(this.json, {this.path = const []});
 
-  Asset({String? type}) : json = {}, path = const [] {
+  Asset({required String? type}) : json = {}, path = const [] {
     _type = type;
     json.sortOnKey();
   }

--- a/pkgs/native_assets_cli/lib/src/hook/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/hook/syntax.g.dart
@@ -78,10 +78,10 @@ class BuildInput extends HookInput {
 
   BuildInput({
     required super.config,
-    Map<String, Map<String, Object?>>? dependencyMetadata,
+    required Map<String, Map<String, Object?>>? dependencyMetadata,
     required super.outDir,
     required super.outDirShared,
-    super.outFile,
+    required super.outFile,
     required super.packageName,
     required super.packageRoot,
     required super.version,
@@ -92,7 +92,7 @@ class BuildInput extends HookInput {
 
   /// Setup all fields for [BuildInput] that are not in
   /// [HookInput].
-  void setup({Map<String, Map<String, Object?>>? dependencyMetadata}) {
+  void setup({required Map<String, Map<String, Object?>>? dependencyMetadata}) {
     _dependencyMetadata = dependencyMetadata;
     json.sortOnKey();
   }
@@ -128,10 +128,10 @@ class BuildOutput extends HookOutput {
   BuildOutput.fromJson(super.json, {super.path}) : super.fromJson();
 
   BuildOutput({
-    super.assets,
-    Map<String, List<Asset>>? assetsForLinking,
-    super.dependencies,
-    Map<String, Object?>? metadata,
+    required super.assets,
+    required Map<String, List<Asset>>? assetsForLinking,
+    required super.dependencies,
+    required Map<String, Object?>? metadata,
     required super.timestamp,
     required super.version,
   }) : super() {
@@ -143,8 +143,8 @@ class BuildOutput extends HookOutput {
   /// Setup all fields for [BuildOutput] that are not in
   /// [HookOutput].
   void setup({
-    Map<String, List<Asset>>? assetsForLinking,
-    Map<String, Object?>? metadata,
+    required Map<String, List<Asset>>? assetsForLinking,
+    required Map<String, Object?>? metadata,
   }) {
     this.assetsForLinking = assetsForLinking;
     this.metadata = metadata;
@@ -262,7 +262,7 @@ class HookInput {
     required Config config,
     required Uri outDir,
     required Uri outDirShared,
-    Uri? outFile,
+    required Uri? outFile,
     required String packageName,
     required Uri packageRoot,
     required String version,
@@ -376,8 +376,8 @@ class HookOutput {
   HookOutput.fromJson(this.json, {this.path = const []});
 
   HookOutput({
-    List<Asset>? assets,
-    List<Uri>? dependencies,
+    required List<Asset>? assets,
+    required List<Uri>? dependencies,
     required String timestamp,
     required String version,
   }) : json = {},
@@ -467,14 +467,14 @@ class LinkInput extends HookInput {
   LinkInput.fromJson(super.json, {super.path}) : super.fromJson();
 
   LinkInput({
-    List<Asset>? assets,
+    required List<Asset>? assets,
     required super.config,
     required super.outDir,
     required super.outDirShared,
-    super.outFile,
+    required super.outFile,
     required super.packageName,
     required super.packageRoot,
-    Uri? resourceIdentifiers,
+    required Uri? resourceIdentifiers,
     required super.version,
   }) : super() {
     _assets = assets;
@@ -484,7 +484,10 @@ class LinkInput extends HookInput {
 
   /// Setup all fields for [LinkInput] that are not in
   /// [HookInput].
-  void setup({List<Asset>? assets, Uri? resourceIdentifiers}) {
+  void setup({
+    required List<Asset>? assets,
+    required Uri? resourceIdentifiers,
+  }) {
     _assets = assets;
     _resourceIdentifiers = resourceIdentifiers;
     json.sortOnKey();
@@ -548,8 +551,8 @@ class LinkOutput extends HookOutput {
   LinkOutput.fromJson(super.json, {super.path}) : super.fromJson();
 
   LinkOutput({
-    super.assets,
-    super.dependencies,
+    required super.assets,
+    required super.dependencies,
     required super.timestamp,
     required super.version,
   }) : super();


### PR DESCRIPTION
The syntax `setup` methods remove fields from the underlying json if the values are null. That could lead to accidentally unsetting a value if omitted, which is not what is expected from the API.

To keep life consistent, also make the nullable fields for constructors required.

(There were only 2 syntax fields missing in our codebase, see diff. They were doing the right thing, but being explicit is good.)

Inspired by: https://github.com/dart-lang/native/pull/2116#discussion_r2005636511