### PR TITLE
[native_assets_cli] Validate tagged union syntax

### DIFF
--- a/pkgs/hook/tool/generate_syntax.dart
+++ b/pkgs/hook/tool/generate_syntax.dart
@@ -18,7 +18,7 @@ final rootSchemas = loadSchemas([
   packageUri.resolve('../data_assets/doc/schema/'),
 ]);
 
-void main() {
+void main(List<String> args) {
   for (final packageName in generateFor) {
     const schemaName = 'shared';
     final schemaUri = packageUri.resolve(
@@ -66,6 +66,16 @@ void main() {
                   ]
                   : null,
         ).analyze();
+    final textDumpFile = File.fromUri(
+      packageUri.resolve(
+        '../native_assets_cli/lib/src/$packageName/syntax.g.txt',
+      ),
+    );
+    if (args.contains('-d')) {
+      textDumpFile.writeAsStringSync(analyzedSchema.toString());
+    } else if (textDumpFile.existsSync()) {
+      textDumpFile.deleteSync();
+    }
     final output =
         SyntaxGenerator(
           analyzedSchema,

--- a/pkgs/json_syntax_generator/lib/src/model/property_info.dart
+++ b/pkgs/json_syntax_generator/lib/src/model/property_info.dart
@@ -53,7 +53,7 @@ PropertyInfo(
   type: $type,
   isOverride: $isOverride,
   setterPrivate: $setterPrivate,
-  isRequired: $isRequired
+  isRequired: $isRequired,
 )''';
 }
 

--- a/pkgs/json_syntax_generator/lib/src/parser/schema_analyzer.dart
+++ b/pkgs/json_syntax_generator/lib/src/parser/schema_analyzer.dart
@@ -102,8 +102,8 @@ class SchemaAnalyzer {
   void _analyzeClass(
     JsonSchemas schemas, {
     String? name,
-    ClassInfo? superclass,
-    String? identifyingSubtype,
+    NormalClassInfo? superclass,
+    String? taggedUnionValue,
   }) {
     var typeName = schemas.className;
     if (_classes[typeName] != null) return; // Already analyzed.
@@ -118,7 +118,7 @@ class SchemaAnalyzer {
       }
       final superClassName = schemas.superClassName;
       if (superClassName != null) {
-        superclass = _classes[superClassName]!;
+        superclass = _classes[superClassName] as NormalClassInfo;
       }
     }
     final superSchemas = schemas.superClassSchemas;
@@ -160,7 +160,9 @@ class SchemaAnalyzer {
       name: typeName,
       superclass: superclass,
       properties: properties,
-      taggedUnionKey: identifyingSubtype,
+      taggedUnionValue: taggedUnionValue,
+      taggedUnionProperty:
+          schemas.generateSubClasses ? properties.single.name : null,
     );
     _classes[typeName] = classInfo;
     if (schemas.generateSubClasses) {
@@ -172,7 +174,7 @@ class SchemaAnalyzer {
   void _analyzeSubClasses(
     JsonSchemas schemas, {
     String? name,
-    ClassInfo? superclass,
+    NormalClassInfo? superclass,
   }) {
     final typeName = schemas.className;
 
@@ -197,7 +199,7 @@ class SchemaAnalyzer {
           subtypeSchema,
           name: subTypeName,
           superclass: superclass,
-          identifyingSubtype: subType,
+          taggedUnionValue: subType,
         );
       } else {
         // This is a tagged union without any defined properties.
@@ -205,7 +207,7 @@ class SchemaAnalyzer {
           name: subTypeName,
           superclass: superclass,
           properties: [],
-          taggedUnionKey: subType,
+          taggedUnionValue: subType,
         );
       }
     }

--- a/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
@@ -92,7 +92,18 @@ class Asset {
 
   JsonReader get _reader => JsonReader(json, path);
 
-  Asset.fromJson(this.json, {this.path = const []});
+  factory Asset.fromJson(
+    Map<String, Object?> json, {
+    List<Object> path = const [],
+  }) {
+    final result = Asset._fromJson(json, path: path);
+    if (result.isNativeCodeAsset) {
+      return result.asNativeCodeAsset;
+    }
+    return result;
+  }
+
+  Asset._fromJson(this.json, {this.path = const []});
 
   Asset({required String? type}) : json = {}, path = const [] {
     _type = type;
@@ -114,7 +125,7 @@ class Asset {
 }
 
 class NativeCodeAsset extends Asset {
-  NativeCodeAsset.fromJson(super.json, {super.path}) : super.fromJson();
+  NativeCodeAsset.fromJson(super.json, {super.path}) : super._fromJson();
 
   NativeCodeAsset({
     required Architecture architecture,
@@ -649,7 +660,30 @@ class LinkMode {
 
   JsonReader get _reader => JsonReader(json, path);
 
-  LinkMode.fromJson(this.json, {this.path = const []});
+  factory LinkMode.fromJson(
+    Map<String, Object?> json, {
+    List<Object> path = const [],
+  }) {
+    final result = LinkMode._fromJson(json, path: path);
+    if (result.isDynamicLoadingBundleLinkMode) {
+      return result.asDynamicLoadingBundleLinkMode;
+    }
+    if (result.isDynamicLoadingExecutableLinkMode) {
+      return result.asDynamicLoadingExecutableLinkMode;
+    }
+    if (result.isDynamicLoadingProcessLinkMode) {
+      return result.asDynamicLoadingProcessLinkMode;
+    }
+    if (result.isDynamicLoadingSystemLinkMode) {
+      return result.asDynamicLoadingSystemLinkMode;
+    }
+    if (result.isStaticLinkMode) {
+      return result.asStaticLinkMode;
+    }
+    return result;
+  }
+
+  LinkMode._fromJson(this.json, {this.path = const []});
 
   LinkMode({required String type}) : json = {}, path = const [] {
     _type = type;
@@ -672,7 +706,7 @@ class LinkMode {
 
 class DynamicLoadingBundleLinkMode extends LinkMode {
   DynamicLoadingBundleLinkMode.fromJson(super.json, {super.path})
-    : super.fromJson();
+    : super._fromJson();
 
   DynamicLoadingBundleLinkMode() : super(type: 'dynamic_loading_bundle');
 
@@ -692,7 +726,7 @@ extension DynamicLoadingBundleLinkModeExtension on LinkMode {
 
 class DynamicLoadingExecutableLinkMode extends LinkMode {
   DynamicLoadingExecutableLinkMode.fromJson(super.json, {super.path})
-    : super.fromJson();
+    : super._fromJson();
 
   DynamicLoadingExecutableLinkMode()
     : super(type: 'dynamic_loading_executable');
@@ -714,7 +748,7 @@ extension DynamicLoadingExecutableLinkModeExtension on LinkMode {
 
 class DynamicLoadingProcessLinkMode extends LinkMode {
   DynamicLoadingProcessLinkMode.fromJson(super.json, {super.path})
-    : super.fromJson();
+    : super._fromJson();
 
   DynamicLoadingProcessLinkMode() : super(type: 'dynamic_loading_process');
 
@@ -734,7 +768,7 @@ extension DynamicLoadingProcessLinkModeExtension on LinkMode {
 
 class DynamicLoadingSystemLinkMode extends LinkMode {
   DynamicLoadingSystemLinkMode.fromJson(super.json, {super.path})
-    : super.fromJson();
+    : super._fromJson();
 
   DynamicLoadingSystemLinkMode({required Uri uri})
     : super(type: 'dynamic_loading_system') {
@@ -772,7 +806,7 @@ extension DynamicLoadingSystemLinkModeExtension on LinkMode {
 }
 
 class StaticLinkMode extends LinkMode {
-  StaticLinkMode.fromJson(super.json, {super.path}) : super.fromJson();
+  StaticLinkMode.fromJson(super.json, {super.path}) : super._fromJson();
 
   StaticLinkMode() : super(type: 'static');
 

--- a/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
@@ -17,7 +17,18 @@ class Asset {
 
   JsonReader get _reader => JsonReader(json, path);
 
-  Asset.fromJson(this.json, {this.path = const []});
+  factory Asset.fromJson(
+    Map<String, Object?> json, {
+    List<Object> path = const [],
+  }) {
+    final result = Asset._fromJson(json, path: path);
+    if (result.isDataAsset) {
+      return result.asDataAsset;
+    }
+    return result;
+  }
+
+  Asset._fromJson(this.json, {this.path = const []});
 
   Asset({required String? type}) : json = {}, path = const [] {
     _type = type;
@@ -39,7 +50,7 @@ class Asset {
 }
 
 class DataAsset extends Asset {
-  DataAsset.fromJson(super.json, {super.path}) : super.fromJson();
+  DataAsset.fromJson(super.json, {super.path}) : super._fromJson();
 
   DataAsset({required Uri file, required String name, required String package})
     : super(type: 'data') {


### PR DESCRIPTION
Bug: https://github.com/dart-lang/native/issues/1826

Changes the constructors of tagged union super classes to be factories and to branch on the known sub classes. This fixes the syntax validation for tagged unions.

This PR also:

1. splits the `ClassInfo` to only support subclassing in `NormalClassInfo` (the enum classes don't allow subclassing),and
2. refactors the `NormalClassGenerator` in multiple methods for better readability, and
3. adds a `-d` (dump) parameter to the generator to dump the representation halfway in the pipeline as a text file.