### PR TITLE
[native_assets_cli] Validate conditionally required fields

### DIFF
--- a/pkgs/json_syntax_generator/lib/src/generator/helper_library.dart
+++ b/pkgs/json_syntax_generator/lib/src/generator/helper_library.dart
@@ -203,6 +203,19 @@ class JsonReader {
     return "Unexpected value '$value' (${value.runtimeType}) for '$pathString'."
         ' Expected a $expectedType.';
   }
+
+  /// Traverses a JSON path, returns `null` if the path cannot be traversed.
+  Object? tryTraverse(List<String> path) {
+    Object? json = this.json;
+    while (path.isNotEmpty) {
+      final key = path.removeAt(0);
+      if (json is! Map<String, Object?>) {
+        return null;
+      }
+      json = json[key];
+    }
+    return json;
+  }
 }
 
 extension on Map<String, Object?> {

--- a/pkgs/json_syntax_generator/lib/src/generator/helper_library.dart
+++ b/pkgs/json_syntax_generator/lib/src/generator/helper_library.dart
@@ -207,8 +207,7 @@ class JsonReader {
   /// Traverses a JSON path, returns `null` if the path cannot be traversed.
   Object? tryTraverse(List<String> path) {
     Object? json = this.json;
-    while (path.isNotEmpty) {
-      final key = path.removeAt(0);
+    for (final key in path) {
       if (json is! Map<String, Object?>) {
         return null;
       }

--- a/pkgs/json_syntax_generator/lib/src/model/class_info.dart
+++ b/pkgs/json_syntax_generator/lib/src/model/class_info.dart
@@ -43,12 +43,15 @@ class NormalClassInfo extends ClassInfo {
   bool get isTaggedUnion =>
       taggedUnionProperty != null || taggedUnionValue != null;
 
+  final List<ConditionallyRequired> extraValidation;
+
   NormalClassInfo({
     required super.name,
     this.superclass,
     required this.properties,
     this.taggedUnionProperty,
     this.taggedUnionValue,
+    this.extraValidation = const [],
   }) : super() {
     superclass?.subclasses.add(this);
     if (taggedUnionValue != null) {
@@ -61,6 +64,9 @@ class NormalClassInfo extends ClassInfo {
     final propertiesString = properties
         .map((p) => indentLines(p.toString(), level: 2))
         .join(',\n');
+    final extraValidationString = extraValidation
+        .map((p) => indentLines(p.toString(), level: 2))
+        .join('\n');
     return '''
 $runtimeType(
   name: $name,
@@ -71,8 +77,37 @@ $propertiesString
   ],
   taggedUnionProperty: $taggedUnionProperty,
   taggedUnionValue: $taggedUnionValue,
+  extraValidation: [
+$extraValidationString
+  ],
 )''';
   }
+}
+
+/// The property [requiredPath] is required if some [conditionPath] has a value
+/// in [conditionValues].
+///
+/// This class is special cased to cover the uses cases seen so far. If
+/// different types of conditionals are needed, this class should probably be
+/// extended to cover some arbitrary expression.
+class ConditionallyRequired {
+  final List<String> conditionPath;
+  final List<String> conditionValues;
+  final List<String> requiredPath;
+
+  const ConditionallyRequired({
+    required this.conditionPath,
+    required this.conditionValues,
+    required this.requiredPath,
+  });
+
+  @override
+  String toString() => '''
+ConditionallyRequired(
+  path: $conditionPath,
+  values: $conditionValues,
+  required: $requiredPath,
+)''';
 }
 
 class EnumClassInfo extends ClassInfo {

--- a/pkgs/json_syntax_generator/lib/src/model/property_info.dart
+++ b/pkgs/json_syntax_generator/lib/src/model/property_info.dart
@@ -35,8 +35,6 @@ class PropertyInfo {
   /// meal. See [SchemaAnalyzer.publicSetters].
   final bool setterPrivate;
 
-  bool get isRequired => !type.isNullable;
-
   PropertyInfo({
     required this.name,
     required this.jsonKey,
@@ -53,7 +51,6 @@ PropertyInfo(
   type: $type,
   isOverride: $isOverride,
   setterPrivate: $setterPrivate,
-  isRequired: $isRequired,
 )''';
 }
 

--- a/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
@@ -1171,8 +1171,7 @@ class JsonReader {
   /// Traverses a JSON path, returns `null` if the path cannot be traversed.
   Object? tryTraverse(List<String> path) {
     Object? json = this.json;
-    while (path.isNotEmpty) {
-      final key = path.removeAt(0);
+    for (final key in path) {
       if (json is! Map<String, Object?>) {
         return null;
       }

--- a/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
@@ -223,7 +223,19 @@ class NativeCodeAsset extends Asset {
     ..._validateId(),
     ..._validateLinkMode(),
     ..._validateOs(),
+    ..._validateExtraRules(),
   ];
+
+  List<String> _validateExtraRules() {
+    final result = <String>[];
+    if ([
+      'dynamic_loading_bundle',
+      'static',
+    ].contains(_reader.tryTraverse(['link_mode', 'type']))) {
+      result.addAll(_reader.validate<Object>('file'));
+    }
+    return result;
+  }
 
   @override
   String toString() => 'NativeCodeAsset($json)';
@@ -565,7 +577,35 @@ class CodeConfig {
     ..._validateMacOS(),
     ..._validateTargetArchitecture(),
     ..._validateTargetOs(),
+    ..._validateExtraRules(),
   ];
+
+  List<String> _validateExtraRules() {
+    final result = <String>[];
+    if (_reader.tryTraverse(['target_os']) == 'macos') {
+      result.addAll(_reader.validate<Object>('macos'));
+    }
+    if (_reader.tryTraverse(['target_os']) == 'ios') {
+      result.addAll(_reader.validate<Object>('ios'));
+    }
+    if (_reader.tryTraverse(['target_os']) == 'android') {
+      result.addAll(_reader.validate<Object>('android'));
+    }
+    if (_reader.tryTraverse(['target_os']) == 'windows') {
+      final objectErrors = _reader.validate<Map<String, Object?>?>(
+        'c_compiler',
+      );
+      result.addAll(objectErrors);
+      if (objectErrors.isEmpty) {
+        final jsonValue = _reader.get<Map<String, Object?>?>('c_compiler');
+        if (jsonValue != null) {
+          final reader = JsonReader(jsonValue, [...path, 'c_compiler']);
+          result.addAll(reader.validate<Object>('windows'));
+        }
+      }
+    }
+    return result;
+  }
 
   @override
   String toString() => 'CodeConfig($json)';
@@ -1126,6 +1166,19 @@ class JsonReader {
     }
     return "Unexpected value '$value' (${value.runtimeType}) for '$pathString'."
         ' Expected a $expectedType.';
+  }
+
+  /// Traverses a JSON path, returns `null` if the path cannot be traversed.
+  Object? tryTraverse(List<String> path) {
+    Object? json = this.json;
+    while (path.isNotEmpty) {
+      final key = path.removeAt(0);
+      if (json is! Map<String, Object?>) {
+        return null;
+      }
+      json = json[key];
+    }
+    return json;
   }
 }
 

--- a/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
@@ -316,8 +316,7 @@ class JsonReader {
   /// Traverses a JSON path, returns `null` if the path cannot be traversed.
   Object? tryTraverse(List<String> path) {
     Object? json = this.json;
-    while (path.isNotEmpty) {
-      final key = path.removeAt(0);
+    for (final key in path) {
       if (json is! Map<String, Object?>) {
         return null;
       }

--- a/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
@@ -312,6 +312,19 @@ class JsonReader {
     return "Unexpected value '$value' (${value.runtimeType}) for '$pathString'."
         ' Expected a $expectedType.';
   }
+
+  /// Traverses a JSON path, returns `null` if the path cannot be traversed.
+  Object? tryTraverse(List<String> path) {
+    Object? json = this.json;
+    while (path.isNotEmpty) {
+      final key = path.removeAt(0);
+      if (json is! Map<String, Object?>) {
+        return null;
+      }
+      json = json[key];
+    }
+    return json;
+  }
 }
 
 extension on Map<String, Object?> {

--- a/pkgs/native_assets_cli/lib/src/hook/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/hook/syntax.g.dart
@@ -761,6 +761,19 @@ class JsonReader {
     return "Unexpected value '$value' (${value.runtimeType}) for '$pathString'."
         ' Expected a $expectedType.';
   }
+
+  /// Traverses a JSON path, returns `null` if the path cannot be traversed.
+  Object? tryTraverse(List<String> path) {
+    Object? json = this.json;
+    while (path.isNotEmpty) {
+      final key = path.removeAt(0);
+      if (json is! Map<String, Object?>) {
+        return null;
+      }
+      json = json[key];
+    }
+    return json;
+  }
 }
 
 extension on Map<String, Object?> {

--- a/pkgs/native_assets_cli/lib/src/hook/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/hook/syntax.g.dart
@@ -765,8 +765,7 @@ class JsonReader {
   /// Traverses a JSON path, returns `null` if the path cannot be traversed.
   Object? tryTraverse(List<String> path) {
     Object? json = this.json;
-    while (path.isNotEmpty) {
-      final key = path.removeAt(0);
+    for (final key in path) {
       if (json is! Map<String, Object?>) {
         return null;
       }


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/1826

This PR adds the final step to the generated syntax validation: conditionally required fields:

1. If target OS is `x`, then require `x` config in code config.
2. If target OS is `windows`, then require `windows` in the c compiler config (more info https://github.com/dart-lang/native/pull/1913).
3. If link mode is dynamic library bundled or static library, then require a file in a code asset.

We could consider trying to nest the fields under the condition, but that has other downsides:

RE 1: Then the OS is no longer an enum usable in the code-asset as OS field. (We could consider this if we remove the OS/arch from code asset outputs. We should be able to do this due to the code config always having a single OS and architecture anyway. https://github.com/dart-lang/native/issues/2127)
RE 2: That would mean the compiler config would be split over two places. `input.config.code.cCompiler` and `inputconfig.code.windows.cCompiler`. Maybe that's better? Maybe not?
RE 3: Treating a group of files in assets would then become `input.assets.code.switch( ... )` instead of simply `input.assets.code.map((a) => a.file)`. Maybe that's okay because we don't often use files in such way anyway?

WDYT @mosuem @HosseinYousefi?

(I'd probably do any of those refactorings in follow up PRs.)