### PR TITLE
[native_assets_cli] Fix snake casing in JSON

### DIFF
--- a/pkgs/code_assets/doc/schema/shared/shared_definitions.generated.schema.json
+++ b/pkgs/code_assets/doc/schema/shared/shared_definitions.generated.schema.json
@@ -31,6 +31,15 @@
                   "$ref": "shared_definitions.schema.json#/definitions/Asset"
                 }
               }
+            },
+            "assets_for_linking": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "$ref": "shared_definitions.schema.json#/definitions/Asset"
+                }
+              }
             }
           }
         }

--- a/pkgs/code_assets/doc/schema/shared/shared_definitions.schema.json
+++ b/pkgs/code_assets/doc/schema/shared/shared_definitions.schema.json
@@ -336,6 +336,12 @@
           "const": "dynamic"
         },
         {
+          "const": "prefer_dynamic"
+        },
+        {
+          "const": "prefer_static"
+        },
+        {
           "const": "prefer-dynamic"
         },
         {

--- a/pkgs/code_assets/test/data/build_output_macos.json
+++ b/pkgs/code_assets/test/data/build_output_macos.json
@@ -64,6 +64,20 @@
       }
     ]
   },
+  "assets_for_linking": {
+    "package_with_linker": [
+      {
+        "architecture": "arm64",
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/iv6i0d/native_add/.dart_tool/native_assets_builder/native_add/c6b312c90c95d2d98ffb6760a738fb36/out/libnative_add.a",
+        "id": "package:native_add/src/native_add_bindings_generated.dart",
+        "link_mode": {
+          "type": "static"
+        },
+        "os": "macos",
+        "type": "native_code"
+      }
+    ]
+  },
   "dependencies": [
     "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/ZnD2I3/native_add/src/native_add.c"
   ],

--- a/pkgs/code_assets/test/schema/schema_test.dart
+++ b/pkgs/code_assets/test/schema/schema_test.dart
@@ -116,10 +116,14 @@ FieldsFunction _codeFields(AllTestData allTestData) {
           (['assets', 0, ...field], expectRequiredFieldMissing),
         if (hook == Hook.build) ...[
           for (final field in requiredCodeAssetFields)
-            (
-              ['assetsForLinking', 'package_with_linker', 0, ...field],
-              expectRequiredFieldMissing,
-            ),
+            for (final assetsForLinking in [
+              'assetsForLinking',
+              'assets_for_linking',
+            ])
+              (
+                [assetsForLinking, 'package_with_linker', 0, ...field],
+                expectRequiredFieldMissing,
+              ),
         ],
         (['assets', staticIndex, 'file'], expectRequiredFieldMissing),
         (

--- a/pkgs/data_assets/doc/schema/shared/shared_definitions.generated.schema.json
+++ b/pkgs/data_assets/doc/schema/shared/shared_definitions.generated.schema.json
@@ -31,6 +31,15 @@
                   "$ref": "shared_definitions.schema.json#/definitions/Asset"
                 }
               }
+            },
+            "assets_for_linking": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "$ref": "shared_definitions.schema.json#/definitions/Asset"
+                }
+              }
             }
           }
         }

--- a/pkgs/data_assets/test/data/build_output.json
+++ b/pkgs/data_assets/test/data/build_output.json
@@ -30,6 +30,22 @@
       }
     ]
   },
+  "assets_for_linking": {
+    "package_with_linker": [
+      {
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_0.json",
+        "name": "assets/data_0.json",
+        "package": "simple_link",
+        "type": "data"
+      },
+      {
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_1.json",
+        "name": "assets/data_1.json",
+        "package": "simple_link",
+        "type": "data"
+      }
+    ]
+  },
   "dependencies": [
     "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_2.json",
     "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_3.json"

--- a/pkgs/data_assets/test/schema/schema_test.dart
+++ b/pkgs/data_assets/test/schema/schema_test.dart
@@ -50,10 +50,14 @@ List<(List<Object>, void Function(ValidationResults result))> _dataFields({
       (['assets', 0, field], expectRequiredFieldMissing),
     if (hook == Hook.build) ...[
       for (final field in _dataAssetFields)
-        (
-          ['assetsForLinking', 'package_with_linker', 0, field],
-          expectRequiredFieldMissing,
-        ),
+        for (final assetsForLinking in [
+          'assetsForLinking',
+          'assets_for_linking',
+        ])
+          (
+            [assetsForLinking, 'package_with_linker', 0, field],
+            expectRequiredFieldMissing,
+          ),
     ],
   ],
 ];

--- a/pkgs/hook/doc/schema/hook/shared_definitions.schema.json
+++ b/pkgs/hook/doc/schema/hook/shared_definitions.schema.json
@@ -5,6 +5,11 @@
     "BuildInput": {},
     "BuildOutput": {
       "$ref": "../shared/shared_definitions.schema.json#/definitions/BuildOutput",
+      "properties": {
+        "assets_for_linking": {
+          "$comment": "Older SDKs will only read 'assetsForLinking', so it must be emitted as well."
+        }
+      },
       "unevaluatedProperties": false
     },
     "HookInput": {

--- a/pkgs/hook/doc/schema/sdk/shared_definitions.schema.json
+++ b/pkgs/hook/doc/schema/sdk/shared_definitions.schema.json
@@ -6,7 +6,16 @@
       "$ref": "../shared/shared_definitions.schema.json#/definitions/BuildInput",
       "unevaluatedProperties": false
     },
-    "BuildOutput": {},
+    "BuildOutput": {
+      "properties": {
+        "assetsForLinking": {
+          "deprecated": true
+        },
+        "assets_for_linking": {
+          "$comment": "Older hooks will still emit 'assetsForLinking', so it must be read."
+        }
+      }
+    },
     "HookInput": {
       "properties": {
         "out_file": {

--- a/pkgs/hook/doc/schema/shared/shared_definitions.schema.json
+++ b/pkgs/hook/doc/schema/shared/shared_definitions.schema.json
@@ -61,6 +61,15 @@
             }
           }
         },
+        "assets_for_linking": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Asset"
+            }
+          }
+        },
         "metadata": {
           "type": "object",
           "additionalProperties": true

--- a/pkgs/hook/test/data/build_output.json
+++ b/pkgs/hook/test/data/build_output.json
@@ -22,6 +22,18 @@
       }
     ]
   },
+  "assets_for_linking": {
+    "package_with_linker": [
+      {
+        "some_key": "some_value",
+        "type": "some_asset_type"
+      },
+      {
+        "some_other_key": "some_value",
+        "type": "some_other_asset_type"
+      }
+    ]
+  },
   "dependencies": [
     "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_2.json",
     "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_3.json"

--- a/pkgs/hook/test/schema/helpers.dart
+++ b/pkgs/hook/test/schema/helpers.dart
@@ -340,19 +340,23 @@ FieldsReturn _hookFields({
       (['assets'], expectOptionalFieldMissing),
       (['assets', 0], expectOptionalFieldMissing),
       (['assets', 0, 'type'], expectRequiredFieldMissing),
-      if (hook == Hook.build) ...[
-        (['metadata'], expectOptionalFieldMissing),
-        (['assetsForLinking'], expectOptionalFieldMissing),
-        (
-          ['assetsForLinking', 'package_with_linker', 0],
-          expectOptionalFieldMissing,
-        ),
-        (['assetsForLinking'], expectOptionalFieldMissing),
-        (
-          ['assetsForLinking', 'package_with_linker', 0, 'type'],
-          expectRequiredFieldMissing,
-        ),
-      ],
+      if (hook == Hook.build)
+        for (final assetsForLinking in [
+          'assetsForLinking',
+          'assets_for_linking',
+        ]) ...[
+          (['metadata'], expectOptionalFieldMissing),
+          ([assetsForLinking], expectOptionalFieldMissing),
+          (
+            [assetsForLinking, 'package_with_linker', 0],
+            expectOptionalFieldMissing,
+          ),
+          ([assetsForLinking], expectOptionalFieldMissing),
+          (
+            [assetsForLinking, 'package_with_linker', 0, 'type'],
+            expectRequiredFieldMissing,
+          ),
+        ],
     ],
   ];
 }

--- a/pkgs/hook/tool/generate_schemas.dart
+++ b/pkgs/hook/tool/generate_schemas.dart
@@ -43,6 +43,15 @@ void generateSharedDefinitions() {
           },
         },
       },
+      'assets_for_linking': {
+        'type': 'object',
+        'additionalProperties': {
+          'type': 'array',
+          'items': {
+            r'$ref': 'shared_definitions.schema.json#/definitions/Asset',
+          },
+        },
+      },
     },
   };
   const linkInputAssetOverride = {

--- a/pkgs/hook/tool/generate_syntax.dart
+++ b/pkgs/hook/tool/generate_syntax.dart
@@ -33,6 +33,9 @@ void main(List<String> args) {
             'Ios': 'IOS',
             'macos': 'macOS',
             'Macos': 'MacOS',
+            'prefer-dynamic': 'preferDynamicOld',
+            'prefer-static': 'preferStaticOld',
+            'assetsForLinking': 'assetsForLinkingOld',
           },
           publicSetters: [
             'BuildOutput',

--- a/pkgs/json_syntax_generator/lib/src/parser/schema_analyzer.dart
+++ b/pkgs/json_syntax_generator/lib/src/parser/schema_analyzer.dart
@@ -398,7 +398,7 @@ class SchemaAnalyzer {
       return '';
     }
 
-    final parts = string.replaceAll('-', '_').split('_');
+    final parts = string.split('_');
 
     String remapCapitalization(String input) =>
         capitalizationOverrides[input] ?? input;

--- a/pkgs/native_assets_cli/lib/src/code_assets/link_mode_preference.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/link_mode_preference.dart
@@ -34,14 +34,14 @@ final class LinkModePreference {
   /// Provide native assets as dynamic libraries, if possible.
   ///
   /// Otherwise, build native assets as static libraries
-  static const preferDynamic = LinkModePreference('prefer-dynamic');
+  static const preferDynamic = LinkModePreference('prefer_dynamic');
 
   /// Provide native assets as static libraries, if possible.
   ///
   /// Otherwise, build native assets as dynamic libraries. Preferred for AOT
   /// compilation, if there are any native assets which can only be provided as
   /// dynamic libraries.
-  static const preferStatic = LinkModePreference('prefer-static');
+  static const preferStatic = LinkModePreference('prefer_static');
 
   static const values = [dynamic, static, preferDynamic, preferStatic];
 
@@ -50,13 +50,21 @@ final class LinkModePreference {
 }
 
 extension LinkModePreferenceSyntax on LinkModePreference {
-  static final _toSyntax = {
-    for (final item in LinkModePreference.values)
-      item: syntax.LinkModePreference.fromJson(item.name),
+  static const _toSyntax = {
+    LinkModePreference.dynamic: syntax.LinkModePreference.dynamic,
+    LinkModePreference.preferDynamic: syntax.LinkModePreference.preferDynamic,
+    LinkModePreference.preferStatic: syntax.LinkModePreference.preferStatic,
+    LinkModePreference.static: syntax.LinkModePreference.static,
   };
 
-  static final _fromSyntax = {
-    for (var entry in _toSyntax.entries) entry.value: entry.key,
+  static const _fromSyntax = {
+    syntax.LinkModePreference.dynamic: LinkModePreference.dynamic,
+    syntax.LinkModePreference.preferDynamic: LinkModePreference.preferDynamic,
+    syntax.LinkModePreference.preferDynamicOld:
+        LinkModePreference.preferDynamic,
+    syntax.LinkModePreference.preferStatic: LinkModePreference.preferStatic,
+    syntax.LinkModePreference.preferStaticOld: LinkModePreference.preferStatic,
+    syntax.LinkModePreference.static: LinkModePreference.static,
   };
 
   syntax.LinkModePreference toSyntax() => _toSyntax[this]!;

--- a/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
@@ -871,14 +871,20 @@ class LinkModePreference {
 
   static const dynamic = LinkModePreference._('dynamic');
 
-  static const preferDynamic = LinkModePreference._('prefer-dynamic');
+  static const preferDynamicOld = LinkModePreference._('prefer-dynamic');
 
-  static const preferStatic = LinkModePreference._('prefer-static');
+  static const preferStaticOld = LinkModePreference._('prefer-static');
+
+  static const preferDynamic = LinkModePreference._('prefer_dynamic');
+
+  static const preferStatic = LinkModePreference._('prefer_static');
 
   static const static = LinkModePreference._('static');
 
   static const List<LinkModePreference> values = [
     dynamic,
+    preferDynamicOld,
+    preferStaticOld,
     preferDynamic,
     preferStatic,
     static,

--- a/pkgs/native_assets_cli/lib/src/config.dart
+++ b/pkgs/native_assets_cli/lib/src/config.dart
@@ -335,7 +335,8 @@ class BuildOutput extends HookOutput {
   /// specified in the key, which can decide if they are bundled or not.
   Map<String, List<EncodedAsset>> get _encodedAssetsForLinking => {
     for (final MapEntry(:key, :value)
-        in (_syntax.assetsForLinking ?? {}).entries)
+        in (_syntax.assetsForLinking ?? _syntax.assetsForLinkingOld ?? {})
+            .entries)
       key: _parseAssets(value),
   };
 
@@ -435,6 +436,7 @@ extension type EncodedAssetBuildOutputBuilder._(BuildOutputBuilder _output) {
         syntax.Asset.fromJson(asset.toJson()),
       );
       _syntax.assetsForLinking = assetsForLinking;
+      _syntax.assetsForLinkingOld = assetsForLinking;
     } else {
       final assets = _syntax.assets ?? [];
       assets.add(syntax.Asset.fromJson(asset.toJson()));
@@ -465,12 +467,14 @@ extension type EncodedAssetBuildOutputBuilder._(BuildOutputBuilder _output) {
     String? linkInPackage,
   }) {
     if (linkInPackage != null) {
-      final assetsForLinking = _syntax.assetsForLinking ?? {};
+      final assetsForLinking =
+          _syntax.assetsForLinking ?? _syntax.assetsForLinkingOld ?? {};
       final list = assetsForLinking[linkInPackage] ??= [];
       for (final asset in assets) {
         list.add(syntax.Asset.fromJson(asset.toJson()));
       }
       _syntax.assetsForLinking = assetsForLinking;
+      _syntax.assetsForLinkingOld = assetsForLinking;
     } else {
       final list = _syntax.assets ?? [];
       for (final asset in assets) {

--- a/pkgs/native_assets_cli/lib/src/hook/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/hook/syntax.g.dart
@@ -130,11 +130,13 @@ class BuildOutput extends HookOutput {
   BuildOutput({
     required super.assets,
     required Map<String, List<Asset>>? assetsForLinking,
+    required Map<String, List<Asset>>? assetsForLinkingOld,
     required super.dependencies,
     required Map<String, Object?>? metadata,
     required super.timestamp,
     required super.version,
   }) : super() {
+    this.assetsForLinkingOld = assetsForLinkingOld;
     this.assetsForLinking = assetsForLinking;
     this.metadata = metadata;
     json.sortOnKey();
@@ -143,16 +145,66 @@ class BuildOutput extends HookOutput {
   /// Setup all fields for [BuildOutput] that are not in
   /// [HookOutput].
   void setup({
+    required Map<String, List<Asset>>? assetsForLinkingOld,
     required Map<String, List<Asset>>? assetsForLinking,
     required Map<String, Object?>? metadata,
   }) {
+    this.assetsForLinkingOld = assetsForLinkingOld;
     this.assetsForLinking = assetsForLinking;
     this.metadata = metadata;
     json.sortOnKey();
   }
 
-  Map<String, List<Asset>>? get assetsForLinking {
+  Map<String, List<Asset>>? get assetsForLinkingOld {
     final jsonValue = _reader.optionalMap('assetsForLinking');
+    if (jsonValue == null) {
+      return null;
+    }
+    final result = <String, List<Asset>>{};
+    for (final MapEntry(:key, :value) in jsonValue.entries) {
+      result[key] = [
+        for (final (index, item) in (value as List<Object?>).indexed)
+          Asset.fromJson(
+            item as Map<String, Object?>,
+            path: [...path, key, index],
+          ),
+      ];
+    }
+    return result;
+  }
+
+  set assetsForLinkingOld(Map<String, List<Asset>>? value) {
+    if (value == null) {
+      json.remove('assetsForLinking');
+    } else {
+      json['assetsForLinking'] = {
+        for (final MapEntry(:key, :value) in value.entries)
+          key: [for (final item in value) item.json],
+      };
+    }
+    json.sortOnKey();
+  }
+
+  List<String> _validateAssetsForLinkingOld() {
+    final mapErrors = _reader.validateOptionalMap('assetsForLinking');
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    final jsonValue = _reader.optionalMap('assetsForLinking');
+    if (jsonValue == null) {
+      return [];
+    }
+    final result = <String>[];
+    for (final list in assetsForLinkingOld!.values) {
+      for (final element in list) {
+        result.addAll(element.validate());
+      }
+    }
+    return result;
+  }
+
+  Map<String, List<Asset>>? get assetsForLinking {
+    final jsonValue = _reader.optionalMap('assets_for_linking');
     if (jsonValue == null) {
       return null;
     }
@@ -171,9 +223,9 @@ class BuildOutput extends HookOutput {
 
   set assetsForLinking(Map<String, List<Asset>>? value) {
     if (value == null) {
-      json.remove('assetsForLinking');
+      json.remove('assets_for_linking');
     } else {
-      json['assetsForLinking'] = {
+      json['assets_for_linking'] = {
         for (final MapEntry(:key, :value) in value.entries)
           key: [for (final item in value) item.json],
       };
@@ -182,11 +234,11 @@ class BuildOutput extends HookOutput {
   }
 
   List<String> _validateAssetsForLinking() {
-    final mapErrors = _reader.validateOptionalMap('assetsForLinking');
+    final mapErrors = _reader.validateOptionalMap('assets_for_linking');
     if (mapErrors.isNotEmpty) {
       return mapErrors;
     }
-    final jsonValue = _reader.optionalMap('assetsForLinking');
+    final jsonValue = _reader.optionalMap('assets_for_linking');
     if (jsonValue == null) {
       return [];
     }
@@ -211,6 +263,7 @@ class BuildOutput extends HookOutput {
   @override
   List<String> validate() => [
     ...super.validate(),
+    ..._validateAssetsForLinkingOld(),
     ..._validateAssetsForLinking(),
     ..._validateMetadata(),
   ];

--- a/pkgs/native_assets_cli/test/build_output_test.dart
+++ b/pkgs/native_assets_cli/test/build_output_test.dart
@@ -65,6 +65,12 @@ void main() {
         ],
         'package:linker2': <Object?>[],
       },
+      'assets_for_linking': {
+        'package:linker1': [
+          {'a-1': 'v-1', 'type': 'my-asset-type'},
+        ],
+        'package:linker2': <Object?>[],
+      },
     }.forEach((k, v) {
       expect(input.json[k], equals(v));
     });

--- a/pkgs/native_assets_cli/test/code_assets/config_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/config_test.dart
@@ -70,7 +70,7 @@ void main() async {
       'code': {
         'target_architecture': 'arm64',
         'target_os': targetOS.name,
-        'link_mode_preference': 'prefer-static',
+        'link_mode_preference': 'prefer_static',
         'c_compiler': {
           'ar': fakeAr.toFilePath(),
           'ld': fakeLd.toFilePath(),


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/2037
Closes: https://github.com/dart-lang/native/issues/2038

Fixes spelling in the JSON format:

* `prefer-dynamic` -> `prefer_dynamic`
* `prefer-static` -> `prefer_static`
* `assetsForLinking` -> `assets_for_linking`

### PR changes

* `pkgs/hook`, `pkgs/code_assets`, and `pkgs/data_assets`
  * Introduces new schemas in the non-generated `.schema.json` files
  * Updates the generated schemas to pick up on the new spelling for `assets_for_linking`.
  * Adds test data for the new spelling.
  * Added JSON schema tests for the new spelling.

* `package:native_assets_cli`
  * Generated the syntax classes
  * Deal with version skew in the mapping between syntax classes and semantic API

### Version skew between hooks and SDKs

* For https://github.com/dart-lang/native/issues/2037
  * Backwards compatibility older SDKs: Also still emit `assetsForLinking`, instead of only `assets_for_linking`.
  * Backwards compatibility older hooks: Also still read `assetsForLinking`, instead of only `assets_for_linking`.

* For https://github.com/dart-lang/native/issues/2038
  * Backwards compatibility older SDKs: Still read the casing with dashes.
  * Backwards compatibility older hooks: Irrelevant. Both Flutter and Dart only use `dynamic`.
