### PR TITLE
[native_assets_cli] Deprecate `output_directory`

### DIFF
--- a/pkgs/hook/doc/schema/hook/shared_definitions.schema.json
+++ b/pkgs/hook/doc/schema/hook/shared_definitions.schema.json
@@ -14,6 +14,10 @@
     },
     "HookInput": {
       "properties": {
+        "out_dir": {
+          "$comment": "Future SDKs will no longer provide 'out_dir'. Use a unique subdirectory of 'out_dir_shared' instead.",
+          "deprecated": true
+        },
         "out_file": {
           "$comment": "'out_file' is not provided by older SDKs. Then, it must be $out_dir/output.json."
         },

--- a/pkgs/hook/doc/schema/sdk/shared_definitions.schema.json
+++ b/pkgs/hook/doc/schema/sdk/shared_definitions.schema.json
@@ -18,6 +18,9 @@
     },
     "HookInput": {
       "properties": {
+        "out_dir": {
+          "$comment": "'out_dir' is read by older hooks, so it must still be emitted."
+        },
         "out_file": {
           "$comment": "'out_file' is not read by older hooks. If the file doesn't exist, then it must be $out_dir/output.json."
         },

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_caching_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_caching_test.dart
@@ -213,25 +213,30 @@ void main() async {
         await runPubGet(workingDirectory: packageUri, logger: logger);
         logMessages.clear();
 
-        final result =
-            (await build(
-              packageUri,
-              logger,
-              dartExecutable,
-              buildAssetTypes: [CodeAsset.type],
-              hookEnvironment:
-                  modifiedEnvKey == 'PATH'
-                      ? null
-                      : filteredEnvironment(
-                        NativeAssetsBuildRunner.hookEnvironmentVariablesFilter,
-                      ),
-            ))!;
+        (await build(
+          packageUri,
+          logger,
+          dartExecutable,
+          buildAssetTypes: [CodeAsset.type],
+          hookEnvironment:
+              modifiedEnvKey == 'PATH'
+                  ? null
+                  : filteredEnvironment(
+                    NativeAssetsBuildRunner.hookEnvironmentVariablesFilter,
+                  ),
+        ))!;
         logMessages.clear();
 
         // Simulate that the environment variables changed by augmenting the
         // persisted environment from the last invocation.
         final dependenciesHashFile = File.fromUri(
-          CodeAsset.fromEncoded(result.encodedAssets.single).file!.parent.parent
+          (Directory.fromUri(
+                    packageUri.resolve(
+                      '.dart_tool/native_assets_builder/native_add/',
+                    ),
+                  ).listSync().single
+                  as Directory)
+              .uri
               .resolve('dependencies.dependencies_hash_file.json'),
         );
         expect(await dependenciesHashFile.exists(), true);

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:file_testing/file_testing.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';
@@ -52,12 +53,13 @@ void main() async {
         final stderrFile = File.fromUri(
           buildDirectory.uri.resolve('stderr.txt'),
         );
-        expect(stdoutFile.existsSync(), true);
+
+        expect(stdoutFile, exists);
         expect(
           stdoutFile.readAsStringSync(encoding: systemEncoding),
           contains('Some stdout.'),
         );
-        expect(stderrFile.existsSync(), true);
+        expect(stderrFile, exists);
         expect(
           stderrFile.readAsStringSync(encoding: systemEncoding),
           contains('Some stderr.'),

--- a/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
@@ -20,7 +20,7 @@ void main() async {
     'native_dynamic_linking build',
     () => inTempDir((tempUri) async {
       final buildOutputUri = tempUri.resolve('build_output.json');
-      final outputDirectory = tempUri.resolve('out/');
+      var outputDirectory = tempUri.resolve('out/');
       await Directory.fromUri(outputDirectory).create();
       final outputDirectoryShared = tempUri.resolve('out_shared/');
       await Directory.fromUri(outputDirectoryShared).create();
@@ -56,6 +56,7 @@ void main() async {
       File.fromUri(
         buildInputUri,
       ).writeAsStringSync(jsonEncode(inputBuilder.json));
+      outputDirectory = BuildInput(inputBuilder.json).outputDirectory;
 
       await runPubGet(workingDirectory: testPackageUri, logger: logger);
 

--- a/pkgs/native_assets_cli/lib/src/config.dart
+++ b/pkgs/native_assets_cli/lib/src/config.dart
@@ -36,7 +36,22 @@ sealed class HookInput {
   ///
   /// The invoker of the the hook will ensure concurrent invocations wait on
   /// each other.
-  Uri get outputDirectory => _syntax.outDir;
+  Uri get outputDirectory {
+    if (_cachedOutputDirectory != null) {
+      return _cachedOutputDirectory!.uri;
+    }
+    final checksum = config.computeChecksum();
+    final directory = Directory.fromUri(
+      outputDirectoryShared.resolve('$checksum/'),
+    );
+    if (!directory.existsSync()) {
+      directory.createSync(recursive: true);
+    }
+    _cachedOutputDirectory = directory;
+    return directory.uri;
+  }
+
+  Directory? _cachedOutputDirectory;
 
   /// The directory in which shared output and intermediate artifacts can be
   /// placed.
@@ -110,21 +125,22 @@ sealed class HookInputBuilder {
   /// Constructs a checksum for a [BuildInput].
   ///
   /// This can be used to construct an output directory name specific to the
-  /// [BuildInput] being built with this [BuildInputBuilder]. It is therefore
-  /// assumed the output directory has not been set yet.
-  String computeChecksum() {
-    final config = _syntax.config.json;
-    final hash = sha256
-        .convert(const JsonEncoder().fuse(const Utf8Encoder()).convert(config))
-        .toString()
-        // 256 bit hashes lead to 64 hex character strings.
-        // To avoid overflowing file paths limits, only use 32.
-        // Using 16 hex characters would also be unlikely to have collisions.
-        .substring(0, 32);
-    return hash;
-  }
+  /// [HookConfig] being built with this builder. It is therefore assumed the
+  /// output directory has not been set yet.
+  String computeChecksum() => _jsonChecksum(_syntax.config.json);
 
   HookConfigBuilder get config => HookConfigBuilder._(this);
+}
+
+String _jsonChecksum(Map<String, Object?> json) {
+  final hash = sha256
+      .convert(const JsonEncoder().fuse(const Utf8Encoder()).convert(json))
+      .toString()
+      // 256 bit hashes lead to 64 hex character strings.
+      // To avoid overflowing file paths limits, only use 32.
+      // Using 16 hex characters would also be unlikely to have collisions.
+      .substring(0, 32);
+  return hash;
 }
 
 final class BuildInput extends HookInput {
@@ -618,6 +634,13 @@ final class HookConfig {
   List<String> get buildAssetTypes => _syntax.buildAssetTypes;
 
   HookConfig._(HookInput input) : _syntax = input._syntax.config;
+
+  /// Constructs a checksum for this hook config.
+  ///
+  /// This can be used to construct an output directory name specific to the
+  /// [HookConfig] being built with this builder. It is therefore assumed the
+  /// output directory has not been set yet.
+  String computeChecksum() => _jsonChecksum(_syntax.json);
 }
 
 final class BuildConfig extends HookConfig {

--- a/pkgs/native_assets_cli/lib/src/config.dart
+++ b/pkgs/native_assets_cli/lib/src/config.dart
@@ -110,6 +110,11 @@ sealed class HookInputBuilder {
   void setupShared({
     required Uri packageRoot,
     required String packageName,
+    @Deprecated(
+      'This parameter is not read in `HookInput`. '
+      'It must still be provided to accommodate `HookInput`s in hooks using an '
+      'older version of this package.',
+    )
     required Uri outputDirectory,
     required Uri outputDirectoryShared,
     required Uri outputFile,

--- a/pkgs/native_assets_cli/test/build_input_test.dart
+++ b/pkgs/native_assets_cli/test/build_input_test.dart
@@ -76,7 +76,10 @@ void main() async {
     expect(input.json, inputJson);
     expect(json.decode(input.toString()), inputJson);
 
-    expect(input.outputDirectory, outDirUri);
+    // The output_directory is deprecated, the hook makes a directory inside the
+    // shared output directory.
+    expect(input.outputDirectory, isNot(outDirUri));
+
     expect(input.outputDirectoryShared, outputDirectoryShared);
 
     expect(input.packageName, packageName);
@@ -105,21 +108,6 @@ void main() async {
         );
       });
     }
-
-    test('BuildInput FormatException out_dir', () {
-      final input = inputJson;
-      input.remove('out_dir');
-      expect(
-        () => BuildInput(input),
-        throwsA(
-          predicate(
-            (e) =>
-                e is FormatException &&
-                e.message.contains("No value was provided for 'out_dir'."),
-          ),
-        ),
-      );
-    });
 
     test('BuildInput FormatException dependency_metadata', () {
       final input = inputJson;

--- a/pkgs/native_assets_cli/test/code_assets/config_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/config_test.dart
@@ -158,7 +158,6 @@ void main() async {
       final input = BuildInput(inputJson(targetOS: targetOS));
       expect(input.packageName, packageName);
       expect(input.packageRoot, packageRootUri);
-      expect(input.outputDirectory, outDirUri);
       expect(input.outputDirectoryShared, outputDirectoryShared);
       expect(input.config.linkingEnabled, false);
       expect(input.config.buildAssetTypes, [CodeAsset.type]);
@@ -212,7 +211,6 @@ void main() async {
       );
       expect(input.packageName, packageName);
       expect(input.packageRoot, packageRootUri);
-      expect(input.outputDirectory, outDirUri);
       expect(input.outputDirectoryShared, outputDirectoryShared);
       expect(input.config.buildAssetTypes, [CodeAsset.type]);
       expectCorrectCodeConfig(input.config.code, targetOS: targetOS);

--- a/pkgs/native_assets_cli/test/link_input_test.dart
+++ b/pkgs/native_assets_cli/test/link_input_test.dart
@@ -63,7 +63,10 @@ void main() async {
     expect(input.json, inputJson);
     expect(json.decode(input.toString()), inputJson);
 
-    expect(input.outputDirectory, outDirUri);
+    // The output_directory is deprecated, the hook makes a directory inside the
+    // shared output directory.
+    expect(input.outputDirectory, isNot(outDirUri));
+
     expect(input.outputDirectoryShared, outputDirectoryShared);
 
     expect(input.packageName, packageName);
@@ -90,21 +93,6 @@ void main() async {
         );
       });
     }
-
-    test('LinkInput FormatException out_dir', () {
-      final input = inputJson;
-      input.remove('out_dir');
-      expect(
-        () => LinkInput(input),
-        throwsA(
-          predicate(
-            (e) =>
-                e is FormatException &&
-                e.message.contains("No value was provided for 'out_dir'."),
-          ),
-        ),
-      );
-    });
 
     test('LinkInput FormatExceptions', () {
       final input = inputJson;

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -177,6 +177,8 @@ Future<Uri> buildLib(
   );
   await cbuilder.run(input: buildInput, output: buildOutput, logger: logger);
 
-  final libUri = tempUri.resolve(OS.android.libraryFileName(name, linkMode));
+  final libUri = buildInput.outputDirectory.resolve(
+    OS.android.libraryFileName(name, linkMode),
+  );
   return libUri;
 }

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -114,7 +114,7 @@ void main() {
                   logger: logger,
                 );
 
-                final libUri = tempUri.resolve(libName);
+                final libUri = buildInput.outputDirectory.resolve(libName);
                 final objdumpResult = await runProcess(
                   executable: Uri.file('objdump'),
                   arguments: ['-t', libUri.path],
@@ -157,9 +157,8 @@ void main() {
                   );
                   if (installName == null) {
                     // If no install path is passed, we have an absolute path.
-                    final tempName = tempUri.pathSegments.lastWhere(
-                      (e) => e != '',
-                    );
+                    final tempName = buildInput.outputDirectory.pathSegments
+                        .lastWhere((e) => e != '');
                     final pathEnding =
                         Uri.directory(tempName).resolve(libName).toFilePath();
                     expect(Uri.file(libInstallName).isAbsolute, true);
@@ -270,6 +269,8 @@ Future<Uri> buildLib(
   );
   await cbuilder.run(input: buildInput, output: buildOutput, logger: logger);
 
-  final libUri = tempUri.resolve(OS.iOS.libraryFileName(name, linkMode));
+  final libUri = buildInput.outputDirectory.resolve(
+    OS.iOS.libraryFileName(name, linkMode),
+  );
   return libUri;
 }

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -80,7 +80,7 @@ void main() {
           logger: logger,
         );
 
-        final libUri = tempUri.resolve(
+        final libUri = buildInput.outputDirectory.resolve(
           OS.linux.libraryFileName(name, linkMode),
         );
         final machine = await readelfMachine(libUri.path);

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -93,7 +93,7 @@ void main() {
               logger: logger,
             );
 
-            final libUri = tempUri.resolve(
+            final libUri = buildInput.outputDirectory.resolve(
               OS.macOS.libraryFileName(name, linkMode),
             );
             final result = await runProcess(
@@ -190,6 +190,8 @@ Future<Uri> buildLib(
   );
   await cbuilder.run(input: buildInput, output: buildOutput, logger: logger);
 
-  final libUri = tempUri.resolve(OS.iOS.libraryFileName(name, linkMode));
+  final libUri = buildInput.outputDirectory.resolve(
+    OS.iOS.libraryFileName(name, linkMode),
+  );
   return libUri;
 }

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -122,7 +122,7 @@ void main() async {
             logger: logger,
           );
 
-          final libUri = tempUri.resolve(
+          final libUri = buildInput.outputDirectory.resolve(
             OS.windows.libraryFileName(name, linkMode),
           );
           expect(await File.fromUri(libUri).exists(), true);

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -84,7 +84,7 @@ void main() {
           logger: logger,
         );
 
-        final executableUri = tempUri.resolve(
+        final executableUri = buildInput.outputDirectory.resolve(
           OS.current.executableFileName(name),
         );
         expect(await File.fromUri(executableUri).exists(), true);
@@ -170,7 +170,9 @@ void main() {
           logger: logger,
         );
 
-        final dylibUri = tempUri.resolve(OS.current.dylibFileName(name));
+        final dylibUri = buildInput.outputDirectory.resolve(
+          OS.current.dylibFileName(name),
+        );
         expect(await File.fromUri(dylibUri).exists(), equals(buildCodeAssets));
         if (buildCodeAssets) {
           final dylib = openDynamicLibraryForTest(dylibUri.toFilePath());
@@ -277,7 +279,9 @@ void main() {
     );
     await cbuilder.run(input: buildInput, output: buildOutput, logger: logger);
 
-    final executableUri = tempUri.resolve(OS.current.executableFileName(name));
+    final executableUri = buildInput.outputDirectory.resolve(
+      OS.current.executableFileName(name),
+    );
     expect(await File.fromUri(executableUri).exists(), true);
     final result = await runProcess(executable: executableUri, logger: logger);
     expect(result.exitCode, 0);
@@ -344,7 +348,9 @@ void main() {
     final buildOutput = BuildOutput(buildOutputBuilder.json);
     expect(buildOutput.dependencies, contains(includesHUri));
 
-    final dylibUri = tempUri.resolve(OS.current.dylibFileName(name));
+    final dylibUri = buildInput.outputDirectory.resolve(
+      OS.current.dylibFileName(name),
+    );
     final dylib = openDynamicLibraryForTest(dylibUri.toFilePath());
     final x = dylib.lookup<Int>('x');
     expect(x.value, 42);
@@ -398,7 +404,9 @@ void main() {
     );
     await cbuilder.run(input: buildInput, output: buildOutput, logger: logger);
 
-    final dylibUri = tempUri.resolve(OS.current.dylibFileName(name));
+    final dylibUri = buildInput.outputDirectory.resolve(
+      OS.current.dylibFileName(name),
+    );
 
     final dylib = openDynamicLibraryForTest(dylibUri.toFilePath());
     final add = dylib
@@ -465,7 +473,9 @@ void main() {
     );
     await cbuilder.run(input: buildInput, output: buildOutput, logger: logger);
 
-    final executableUri = tempUri.resolve(OS.current.executableFileName(name));
+    final executableUri = buildInput.outputDirectory.resolve(
+      OS.current.executableFileName(name),
+    );
     expect(await File.fromUri(executableUri).exists(), true);
     final result = await runProcess(executable: executableUri, logger: logger);
     expect(result.exitCode, 0);
@@ -540,7 +550,7 @@ void main() {
         logger: logger,
       );
 
-      final executableUri = tempUri.resolve(
+      final executableUri = buildInput.outputDirectory.resolve(
         OS.current.executableFileName(name),
       );
       expect(await File.fromUri(executableUri).exists(), true);
@@ -617,10 +627,12 @@ void main() {
     );
 
     final debugLibraryFile = File.fromUri(
-      tempUri.resolve(OS.current.dylibFileName('debug')),
+      buildInput.outputDirectory.resolve(OS.current.dylibFileName('debug')),
     );
     final nestedDebugLibraryFile = File.fromUri(
-      tempUri.resolve('debug/').resolve(OS.current.dylibFileName('debug')),
+      buildInput.outputDirectory
+          .resolve('debug/')
+          .resolve(OS.current.dylibFileName('debug')),
     );
     await nestedDebugLibraryFile.parent.create(recursive: true);
     await debugLibraryFile.rename(nestedDebugLibraryFile.path);
@@ -655,7 +667,9 @@ void main() {
       logger: logger,
     );
 
-    final executableUri = tempUri.resolve(OS.current.executableFileName(name));
+    final executableUri = buildInput.outputDirectory.resolve(
+      OS.current.executableFileName(name),
+    );
     expect(await File.fromUri(executableUri).exists(), true);
     final result = await runProcess(executable: executableUri, logger: logger);
     expect(result.exitCode, 0);
@@ -718,7 +732,9 @@ Future<void> testDefines({
   );
   await cbuilder.run(input: buildInput, output: buildOutput, logger: logger);
 
-  final executableUri = tempUri.resolve(OS.current.executableFileName(name));
+  final executableUri = buildInput.outputDirectory.resolve(
+    OS.current.executableFileName(name),
+  );
   expect(await File.fromUri(executableUri).exists(), true);
   final result = await runProcess(executable: executableUri, logger: logger);
   expect(result.exitCode, 0);

--- a/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
@@ -68,7 +68,9 @@ void main() {
     );
     await cbuilder.run(input: buildInput, output: buildOutput, logger: logger);
 
-    final dylibUri = tempUri.resolve(OS.current.dylibFileName(name));
+    final dylibUri = buildInput.outputDirectory.resolve(
+      OS.current.dylibFileName(name),
+    );
     expect(await File.fromUri(dylibUri).exists(), true);
     final dylib = openDynamicLibraryForTest(dylibUri.toFilePath());
     final add = dylib


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/2058

Implements `input.outputDirectory` on top of `input.outputDirectoryShared` in the hook API.

### New directory structure

* `.dart_tool/`
  * `native_assets_builder/`
    * `<package_name>/`
      * `<config-checksum>/`
        * `input.json`
        * `output.json`
        * `dependencies.dependencies_hash_file.json`
        * `package_config_hashable.json`
        * `hook.dill`
        * `hook.dill.d`
        * `stderr.txt`
        * `stdout.txt`
        * `out/` <- old output directory, created by SDK (stays here for backwards compatibility purposes)
    * `shared/`
      * `<package_name>/`
        * `build/` (`input.outputDirectoryShared`)
          * `<config-checksum>/` <- new output directory, created by the hook
        * `link/` (`input.outputDirectoryShared`)
          * `<config-checksum>/` <- new output directory, created by the hook

### Version skew

The `out_dir` in the JSON is still emitted for the time being, until everyone has migrated.

### Fixes in this PR

The `native_toolchain_c` tests were not looking at what the `input.outputDirectory` was but assumed that the temp dir was that directory. These tests have been fixed.

The `NativeAssetsBuildRunner` was passing `HookInput` around instead of the `buildDir` and tried to reverse engineer the `buildDir` by doing `input.outputDirector.resolve('../')`. This has now been cleaned up.