### PR TITLE
[native_assets_cli] Prevent `EncodedAsset` and `Metadata` hashcode changing

### DIFF
--- a/pkgs/native_assets_cli/lib/src/config.dart
+++ b/pkgs/native_assets_cli/lib/src/config.dart
@@ -151,7 +151,7 @@ String _jsonChecksum(Map<String, Object?> json) {
 final class BuildInput extends HookInput {
   Map<String, Metadata> get metadata => {
     for (final entry in (_syntaxBuildInput.dependencyMetadata ?? {}).entries)
-      entry.key: Metadata.fromJson(entry.value),
+      entry.key: Metadata(entry.value),
   };
 
   @override

--- a/pkgs/native_assets_cli/lib/src/metadata.dart
+++ b/pkgs/native_assets_cli/lib/src/metadata.dart
@@ -5,12 +5,14 @@
 import 'package:collection/collection.dart';
 
 class Metadata {
-  final Map<String, Object?> metadata;
+  final UnmodifiableMapView<String, Object?> metadata;
 
-  const Metadata(this.metadata);
-
-  factory Metadata.fromJson(Map<String, Object?>? jsonMap) =>
-      Metadata(jsonMap ?? {});
+  Metadata(Map<String, Object?> metadata)
+    : metadata = UnmodifiableMapView(
+        // It would be better if `jsonMap` would be deep copied.
+        // https://github.com/dart-lang/native/issues/2045
+        Map.of(metadata),
+      );
 
   Map<String, Object?> toJson() => metadata;
 

--- a/pkgs/native_assets_cli/test/build_input_test.dart
+++ b/pkgs/native_assets_cli/test/build_input_test.dart
@@ -30,11 +30,11 @@ void main() async {
     packageName = 'my_package';
     packageRootUri = tempUri.resolve('$packageName/');
     metadata = {
-      'bar': const Metadata({
+      'bar': Metadata({
         'key': 'value',
         'foo': ['asdf', 'fdsa'],
       }),
-      'foo': const Metadata({'key': 321}),
+      'foo': Metadata({'key': 321}),
     };
 
     inputJson = {

--- a/pkgs/native_assets_cli/test/model/metadata_test.dart
+++ b/pkgs/native_assets_cli/test/model/metadata_test.dart
@@ -6,7 +6,7 @@ import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
 
 void main() {
-  const metadata = Metadata({
+  final metadata = Metadata({
     'key': 'value',
     'my_list': [1, 2, 3],
     'my_map': {3: 4, 'foo': 'bar'},


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/2045

We have two types of classes in the semantic API:

1. Pure views on top of a JSON.
   These classes are mirrored by a builder class.
   Objects from these classes cannot be passed from input to output in hooks.
   These classes do not override `hashCode` and `operator ==`.
   Examples: `CodeConfig`, `BuildInput`.
2. Data classes that eagerly copy all fields out of the JSON.
   These classes have a public constructor with it's constituent fields.
   Objects from these classes may be passed from input to output in hooks.
   These classes do override `hashCode` and `operator ==`.
   Examples: `CodeAsset`, `Architecture`, `OS`, `DataAsset`.

This changes `Metadata` and `EncodedAsset` to follow pattern 2 fully:

* All data is copied on construction.
* The map accessors do not allow modification.

This means the `hashCode` and `operator ==` are now correct.

We could consider changing `Metadata` and `EncodedAsset` to pattern 1, but I didn't want to refactor that code in this PR. For more details:

* https://github.com/dart-lang/native/issues/2045