### PR TITLE
[native_assets_cli] Nest `Asset` `encoding`s

### DIFF
--- a/pkgs/code_assets/doc/schema/shared/shared_definitions.schema.json
+++ b/pkgs/code_assets/doc/schema/shared/shared_definitions.schema.json
@@ -55,55 +55,16 @@
       },
       "then": {
         "properties": {
-          "architecture": {
-            "allOf": [
-              {
-                "$ref": "#/definitions/Architecture"
-              }
-            ]
-          },
-          "file": {
-            "$ref": "../../../../hooks/doc/schema/shared/shared_definitions.schema.json#/definitions/absolutePath"
-          },
-          "id": {
-            "type": "string"
-          },
-          "link_mode": {
-            "$ref": "#/definitions/LinkMode"
-          },
-          "os": {
-            "$ref": "#/definitions/OS"
+          "encoding": {
+            "$ref": "#/definitions/NativeCodeAssetEncoding"
           }
         },
-        "required": [
-          "architecture",
-          "id",
-          "link_mode",
-          "os"
-        ],
-        "if": {
-          "properties": {
-            "link_mode": {
-              "properties": {
-                "type": {
-                  "anyOf": [
-                    {
-                      "const": "dynamic_loading_bundle"
-                    },
-                    {
-                      "const": "static"
-                    }
-                  ]
-                }
-              }
-            }
+        "allOf": [
+          {
+            "$comment": "Also include the fields parent object for backwards compatibility.",
+            "$ref": "#/definitions/NativeCodeAssetEncoding"
           }
-        },
-        "then": {
-          "required": [
-            "file"
-          ]
-        }
+        ]
       }
     },
     "CCompilerConfig": {
@@ -192,13 +153,13 @@
           "if": {
             "properties": {
               "target_os": {
-                "const": "macos"
+                "const": "android"
               }
             }
           },
           "then": {
             "required": [
-              "macos"
+              "android"
             ]
           }
         },
@@ -220,13 +181,13 @@
           "if": {
             "properties": {
               "target_os": {
-                "const": "android"
+                "const": "macos"
               }
             }
           },
           "then": {
             "required": [
-              "android"
+              "macos"
             ]
           }
         },
@@ -332,10 +293,10 @@
         {
           "enum": [
             "dynamic",
-            "prefer_dynamic",
             "prefer-dynamic",
-            "prefer_static",
             "prefer-static",
+            "prefer_dynamic",
+            "prefer_static",
             "static"
           ]
         },
@@ -354,6 +315,59 @@
       "required": [
         "target_version"
       ]
+    },
+    "NativeCodeAssetEncoding": {
+      "type": "object",
+      "properties": {
+        "architecture": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Architecture"
+            }
+          ]
+        },
+        "file": {
+          "$ref": "../../../../hooks/doc/schema/shared/shared_definitions.schema.json#/definitions/absolutePath"
+        },
+        "id": {
+          "type": "string"
+        },
+        "link_mode": {
+          "$ref": "#/definitions/LinkMode"
+        },
+        "os": {
+          "$ref": "#/definitions/OS"
+        }
+      },
+      "required": [
+        "architecture",
+        "id",
+        "link_mode",
+        "os"
+      ],
+      "if": {
+        "properties": {
+          "link_mode": {
+            "properties": {
+              "type": {
+                "anyOf": [
+                  {
+                    "const": "dynamic_loading_bundle"
+                  },
+                  {
+                    "const": "static"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "file"
+        ]
+      }
     },
     "OS": {
       "type": "string",

--- a/pkgs/code_assets/test/data/build_output_android.json
+++ b/pkgs/code_assets/test/data/build_output_android.json
@@ -3,6 +3,15 @@
   "assets": [
     {
       "architecture": "arm",
+      "encoding": {
+        "architecture": "arm",
+        "file": "/Users/dacoharkes/src/dacoharkes/playground/my_package/example/.dart_tool/native_assets_builder/my_package/c540d75d10834674921701cd6c3c7c15/out/libmy_package.so",
+        "id": "package:my_package/my_package_bindings_generated.dart",
+        "link_mode": {
+          "type": "dynamic_loading_bundle"
+        },
+        "os": "android"
+      },
       "file": "/Users/dacoharkes/src/dacoharkes/playground/my_package/example/.dart_tool/native_assets_builder/my_package/c540d75d10834674921701cd6c3c7c15/out/libmy_package.so",
       "id": "package:my_package/my_package_bindings_generated.dart",
       "link_mode": {

--- a/pkgs/code_assets/test/data/build_output_linux.json
+++ b/pkgs/code_assets/test/data/build_output_linux.json
@@ -3,6 +3,15 @@
   "assets": [
     {
       "architecture": "x64",
+      "encoding": {
+        "architecture": "x64",
+        "file": "/usr/local/google/home/dacoharkes/src/dacoharkes/playground/my_package/example/.dart_tool/native_assets_builder/my_package/79cc7fbaec53b1465c3e388e6848234b/out/libmy_package.so",
+        "id": "package:my_package/my_package_bindings_generated.dart",
+        "link_mode": {
+          "type": "dynamic_loading_bundle"
+        },
+        "os": "linux"
+      },
       "file": "/usr/local/google/home/dacoharkes/src/dacoharkes/playground/my_package/example/.dart_tool/native_assets_builder/my_package/79cc7fbaec53b1465c3e388e6848234b/out/libmy_package.so",
       "id": "package:my_package/my_package_bindings_generated.dart",
       "link_mode": {

--- a/pkgs/code_assets/test/data/build_output_macos.json
+++ b/pkgs/code_assets/test/data/build_output_macos.json
@@ -3,6 +3,15 @@
   "assets": [
     {
       "architecture": "arm64",
+      "encoding": {
+        "architecture": "arm64",
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/ZnD2I3/native_add/.dart_tool/native_assets_builder/native_add/14857adfaff1b1829b79c612288f54d7/out/libnative_add.dylib",
+        "id": "package:native_add/src/native_add_bindings_generated.dart",
+        "link_mode": {
+          "type": "dynamic_loading_bundle"
+        },
+        "os": "macos"
+      },
       "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/ZnD2I3/native_add/.dart_tool/native_assets_builder/native_add/14857adfaff1b1829b79c612288f54d7/out/libnative_add.dylib",
       "id": "package:native_add/src/native_add_bindings_generated.dart",
       "link_mode": {
@@ -13,6 +22,15 @@
     },
     {
       "architecture": "arm64",
+      "encoding": {
+        "architecture": "arm64",
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/iv6i0d/native_add/.dart_tool/native_assets_builder/native_add/c6b312c90c95d2d98ffb6760a738fb36/out/libnative_add.a",
+        "id": "package:native_add/src/native_add_bindings_generated.dart",
+        "link_mode": {
+          "type": "static"
+        },
+        "os": "macos"
+      },
       "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/iv6i0d/native_add/.dart_tool/native_assets_builder/native_add/c6b312c90c95d2d98ffb6760a738fb36/out/libnative_add.a",
       "id": "package:native_add/src/native_add_bindings_generated.dart",
       "link_mode": {
@@ -23,6 +41,14 @@
     },
     {
       "architecture": "arm64",
+      "encoding": {
+        "architecture": "arm64",
+        "id": "package:system_library/memory_executable.dart",
+        "link_mode": {
+          "type": "dynamic_loading_executable"
+        },
+        "os": "macos"
+      },
       "id": "package:system_library/memory_executable.dart",
       "link_mode": {
         "type": "dynamic_loading_executable"
@@ -32,6 +58,14 @@
     },
     {
       "architecture": "arm64",
+      "encoding": {
+        "architecture": "arm64",
+        "id": "package:system_library/memory_process.dart",
+        "link_mode": {
+          "type": "dynamic_loading_process"
+        },
+        "os": "macos"
+      },
       "id": "package:system_library/memory_process.dart",
       "link_mode": {
         "type": "dynamic_loading_process"
@@ -41,6 +75,15 @@
     },
     {
       "architecture": "arm64",
+      "encoding": {
+        "architecture": "arm64",
+        "id": "package:system_library/memory_system.dart",
+        "link_mode": {
+          "type": "dynamic_loading_system",
+          "uri": "libc.dylib"
+        },
+        "os": "macos"
+      },
       "id": "package:system_library/memory_system.dart",
       "link_mode": {
         "type": "dynamic_loading_system",
@@ -54,6 +97,15 @@
     "package_with_linker": [
       {
         "architecture": "arm64",
+        "encoding": {
+          "architecture": "arm64",
+          "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/iv6i0d/native_add/.dart_tool/native_assets_builder/native_add/c6b312c90c95d2d98ffb6760a738fb36/out/libnative_add.a",
+          "id": "package:native_add/src/native_add_bindings_generated.dart",
+          "link_mode": {
+            "type": "static"
+          },
+          "os": "macos"
+        },
         "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/iv6i0d/native_add/.dart_tool/native_assets_builder/native_add/c6b312c90c95d2d98ffb6760a738fb36/out/libnative_add.a",
         "id": "package:native_add/src/native_add_bindings_generated.dart",
         "link_mode": {
@@ -68,6 +120,15 @@
     "package_with_linker": [
       {
         "architecture": "arm64",
+        "encoding": {
+          "architecture": "arm64",
+          "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/iv6i0d/native_add/.dart_tool/native_assets_builder/native_add/c6b312c90c95d2d98ffb6760a738fb36/out/libnative_add.a",
+          "id": "package:native_add/src/native_add_bindings_generated.dart",
+          "link_mode": {
+            "type": "static"
+          },
+          "os": "macos"
+        },
         "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/iv6i0d/native_add/.dart_tool/native_assets_builder/native_add/c6b312c90c95d2d98ffb6760a738fb36/out/libnative_add.a",
         "id": "package:native_add/src/native_add_bindings_generated.dart",
         "link_mode": {

--- a/pkgs/code_assets/test/data/build_output_windows.json
+++ b/pkgs/code_assets/test/data/build_output_windows.json
@@ -3,6 +3,15 @@
   "assets": [
     {
       "architecture": "x64",
+      "encoding": {
+        "architecture": "x64",
+        "file": "C:\\src\\dacoharkes\\playground\\my_package\\example\\.dart_tool\\native_assets_builder\\my_package\\190c04c47dc2f9eb26d2411b1968b2cf\\out\\my_package.dll",
+        "id": "package:my_package/my_package_bindings_generated.dart",
+        "link_mode": {
+          "type": "dynamic_loading_bundle"
+        },
+        "os": "windows"
+      },
       "file": "C:\\src\\dacoharkes\\playground\\my_package\\example\\.dart_tool\\native_assets_builder\\my_package\\190c04c47dc2f9eb26d2411b1968b2cf\\out\\my_package.dll",
       "id": "package:my_package/my_package_bindings_generated.dart",
       "link_mode": {

--- a/pkgs/code_assets/test/data/link_input_macos.json
+++ b/pkgs/code_assets/test/data/link_input_macos.json
@@ -3,6 +3,15 @@
   "assets": [
     {
       "architecture": "arm64",
+      "encoding": {
+        "architecture": "arm64",
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/iv6i0d/native_add/.dart_tool/native_assets_builder/native_add/c6b312c90c95d2d98ffb6760a738fb36/out/libnative_add.a",
+        "id": "package:native_add/src/native_add_bindings_generated.dart",
+        "link_mode": {
+          "type": "static"
+        },
+        "os": "macos"
+      },
       "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/iv6i0d/native_add/.dart_tool/native_assets_builder/native_add/c6b312c90c95d2d98ffb6760a738fb36/out/libnative_add.a",
       "id": "package:native_add/src/native_add_bindings_generated.dart",
       "link_mode": {

--- a/pkgs/code_assets/test/data/link_output_macos.json
+++ b/pkgs/code_assets/test/data/link_output_macos.json
@@ -3,6 +3,15 @@
   "assets": [
     {
       "architecture": "arm64",
+      "encoding": {
+        "architecture": "arm64",
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/ZnD2I3/native_add/.dart_tool/native_assets_builder/native_add/14857adfaff1b1829b79c612288f54d7/out/libnative_add.dylib",
+        "id": "package:native_add/src/native_add_bindings_generated.dart",
+        "link_mode": {
+          "type": "dynamic_loading_bundle"
+        },
+        "os": "macos"
+      },
       "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/ZnD2I3/native_add/.dart_tool/native_assets_builder/native_add/14857adfaff1b1829b79c612288f54d7/out/libnative_add.dylib",
       "id": "package:native_add/src/native_add_bindings_generated.dart",
       "link_mode": {
@@ -13,6 +22,15 @@
     },
     {
       "architecture": "arm64",
+      "encoding": {
+        "architecture": "arm64",
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/iv6i0d/native_add/.dart_tool/native_assets_builder/native_add/c6b312c90c95d2d98ffb6760a738fb36/out/libnative_add.a",
+        "id": "package:native_add/src/native_add_bindings_generated.dart",
+        "link_mode": {
+          "type": "static"
+        },
+        "os": "macos"
+      },
       "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/iv6i0d/native_add/.dart_tool/native_assets_builder/native_add/c6b312c90c95d2d98ffb6760a738fb36/out/libnative_add.a",
       "id": "package:native_add/src/native_add_bindings_generated.dart",
       "link_mode": {
@@ -23,6 +41,14 @@
     },
     {
       "architecture": "arm64",
+      "encoding": {
+        "architecture": "arm64",
+        "id": "package:system_library/memory_executable.dart",
+        "link_mode": {
+          "type": "dynamic_loading_executable"
+        },
+        "os": "macos"
+      },
       "id": "package:system_library/memory_executable.dart",
       "link_mode": {
         "type": "dynamic_loading_executable"
@@ -32,6 +58,14 @@
     },
     {
       "architecture": "arm64",
+      "encoding": {
+        "architecture": "arm64",
+        "id": "package:system_library/memory_process.dart",
+        "link_mode": {
+          "type": "dynamic_loading_process"
+        },
+        "os": "macos"
+      },
       "id": "package:system_library/memory_process.dart",
       "link_mode": {
         "type": "dynamic_loading_process"
@@ -41,6 +75,15 @@
     },
     {
       "architecture": "arm64",
+      "encoding": {
+        "architecture": "arm64",
+        "id": "package:system_library/memory_system.dart",
+        "link_mode": {
+          "type": "dynamic_loading_system",
+          "uri": "libc.dylib"
+        },
+        "os": "macos"
+      },
       "id": "package:system_library/memory_system.dart",
       "link_mode": {
         "type": "dynamic_loading_system",

--- a/pkgs/code_assets/test/schema/schema_test.dart
+++ b/pkgs/code_assets/test/schema/schema_test.dart
@@ -112,22 +112,34 @@ FieldsFunction _codeFields(AllTestData allTestData) {
           ),
           if (hook == Hook.link) ...[
             for (final field in requiredCodeAssetFields)
-              (['assets', 0, ...field], expectRequiredFieldMissing),
+              for (final encoding in _encoding)
+                (
+                  ['assets', 0, ...encoding, ...field],
+                  expectRequiredFieldMissing,
+                ),
           ],
         ],
       if (inputOrOutput == InputOrOutput.output) ...[
         for (final field in requiredCodeAssetFields)
-          (['assets', 0, ...field], expectRequiredFieldMissing),
+          for (final encoding in _encoding)
+            (['assets', 0, ...encoding, ...field], expectRequiredFieldMissing),
         if (hook == Hook.build) ...[
           for (final field in requiredCodeAssetFields)
-            for (final assetsForLinking in [
-              'assetsForLinking',
-              'assets_for_linking',
-            ])
-              (
-                [assetsForLinking, 'package_with_linker', 0, ...field],
-                expectRequiredFieldMissing,
-              ),
+            for (final encoding in _encoding)
+              for (final assetsForLinking in [
+                'assetsForLinking',
+                'assets_for_linking',
+              ])
+                (
+                  [
+                    assetsForLinking,
+                    'package_with_linker',
+                    0,
+                    ...encoding,
+                    ...field,
+                  ],
+                  expectRequiredFieldMissing,
+                ),
         ],
         (['assets', staticIndex, 'file'], expectRequiredFieldMissing),
         (
@@ -238,4 +250,9 @@ _codeFieldsAndroid({
         expectRequiredFieldMissing,
       ),
     ],
+];
+
+const _encoding = [
+  <String>[],
+  ['encoding'],
 ];

--- a/pkgs/data_assets/doc/schema/shared/shared_definitions.schema.json
+++ b/pkgs/data_assets/doc/schema/shared/shared_definitions.schema.json
@@ -26,22 +26,35 @@
       },
       "then": {
         "properties": {
-          "file": {
-            "$ref": "../../../../hooks/doc/schema/shared/shared_definitions.schema.json#/definitions/absolutePath"
-          },
-          "name": {
-            "type": "string"
-          },
-          "package": {
-            "type": "string"
+          "encoding": {
+            "$ref": "#/definitions/DataAssetEncoding"
           }
         },
-        "required": [
-          "file",
-          "name",
-          "package"
+        "allOf": [
+          {
+            "$ref": "#/definitions/DataAssetEncoding"
+          }
         ]
       }
+    },
+    "DataAssetEncoding": {
+      "type": "object",
+      "properties": {
+        "file": {
+          "$ref": "../../../../hooks/doc/schema/shared/shared_definitions.schema.json#/definitions/absolutePath"
+        },
+        "name": {
+          "type": "string"
+        },
+        "package": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "file",
+        "name",
+        "package"
+      ]
     }
   }
 }

--- a/pkgs/data_assets/test/data/build_output.json
+++ b/pkgs/data_assets/test/data/build_output.json
@@ -2,12 +2,22 @@
   "$schema": "../../doc/schema/hook/build_output.generated.schema.json",
   "assets": [
     {
+      "encoding": {
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_0.json",
+        "name": "assets/data_0.json",
+        "package": "simple_link"
+      },
       "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_0.json",
       "name": "assets/data_0.json",
       "package": "simple_link",
       "type": "data"
     },
     {
+      "encoding": {
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_1.json",
+        "name": "assets/data_1.json",
+        "package": "simple_link"
+      },
       "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_1.json",
       "name": "assets/data_1.json",
       "package": "simple_link",
@@ -17,12 +27,22 @@
   "assetsForLinking": {
     "package_with_linker": [
       {
+        "encoding": {
+          "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_0.json",
+          "name": "assets/data_0.json",
+          "package": "simple_link"
+        },
         "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_0.json",
         "name": "assets/data_0.json",
         "package": "simple_link",
         "type": "data"
       },
       {
+        "encoding": {
+          "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_1.json",
+          "name": "assets/data_1.json",
+          "package": "simple_link"
+        },
         "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_1.json",
         "name": "assets/data_1.json",
         "package": "simple_link",
@@ -33,12 +53,22 @@
   "assets_for_linking": {
     "package_with_linker": [
       {
+        "encoding": {
+          "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_0.json",
+          "name": "assets/data_0.json",
+          "package": "simple_link"
+        },
         "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_0.json",
         "name": "assets/data_0.json",
         "package": "simple_link",
         "type": "data"
       },
       {
+        "encoding": {
+          "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_1.json",
+          "name": "assets/data_1.json",
+          "package": "simple_link"
+        },
         "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_1.json",
         "name": "assets/data_1.json",
         "package": "simple_link",

--- a/pkgs/data_assets/test/data/link_input.json
+++ b/pkgs/data_assets/test/data/link_input.json
@@ -2,12 +2,22 @@
   "$schema": "../../doc/schema/sdk/link_input.generated.schema.json",
   "assets": [
     {
+      "encoding": {
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_0.json",
+        "name": "assets/data_0.json",
+        "package": "simple_link"
+      },
       "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_0.json",
       "name": "assets/data_0.json",
       "package": "simple_link",
       "type": "data"
     },
     {
+      "encoding": {
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_1.json",
+        "name": "assets/data_1.json",
+        "package": "simple_link"
+      },
       "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_1.json",
       "name": "assets/data_1.json",
       "package": "simple_link",

--- a/pkgs/data_assets/test/data/link_output.json
+++ b/pkgs/data_assets/test/data/link_output.json
@@ -2,12 +2,22 @@
   "$schema": "../../doc/schema/hook/link_output.generated.schema.json",
   "assets": [
     {
+      "encoding": {
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_0.json",
+        "name": "assets/data_0.json",
+        "package": "simple_link"
+      },
       "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_0.json",
       "name": "assets/data_0.json",
       "package": "simple_link",
       "type": "data"
     },
     {
+      "encoding": {
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_1.json",
+        "name": "assets/data_1.json",
+        "package": "simple_link"
+      },
       "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_1.json",
       "name": "assets/data_1.json",
       "package": "simple_link",

--- a/pkgs/data_assets/test/schema/schema_test.dart
+++ b/pkgs/data_assets/test/schema/schema_test.dart
@@ -33,6 +33,10 @@ void main() {
 Uri packageUri = findPackageRoot('data_assets');
 
 const _dataAssetFields = ['package', 'name', 'file'];
+const _encoding = [
+  <String>[],
+  ['encoding'],
+];
 
 List<(List<Object>, void Function(ValidationResults result))> _dataFields({
   required InputOrOutput inputOrOutput,
@@ -42,7 +46,8 @@ List<(List<Object>, void Function(ValidationResults result))> _dataFields({
   if (inputOrOutput == InputOrOutput.input) ...[
     if (hook == Hook.link) ...[
       for (final field in _dataAssetFields)
-        (['assets', 0, field], expectRequiredFieldMissing),
+        for (final encoding in _encoding)
+          (['assets', 0, ...encoding, field], expectRequiredFieldMissing),
     ],
   ],
   if (inputOrOutput == InputOrOutput.output) ...[
@@ -50,14 +55,15 @@ List<(List<Object>, void Function(ValidationResults result))> _dataFields({
       (['assets', 0, field], expectRequiredFieldMissing),
     if (hook == Hook.build) ...[
       for (final field in _dataAssetFields)
-        for (final assetsForLinking in [
-          'assetsForLinking',
-          'assets_for_linking',
-        ])
-          (
-            [assetsForLinking, 'package_with_linker', 0, field],
-            expectRequiredFieldMissing,
-          ),
+        for (final encoding in _encoding)
+          for (final assetsForLinking in [
+            'assetsForLinking',
+            'assets_for_linking',
+          ])
+            (
+              [assetsForLinking, 'package_with_linker', 0, ...encoding, field],
+              expectRequiredFieldMissing,
+            ),
     ],
   ],
 ];

--- a/pkgs/hooks/doc/schema/shared/shared_definitions.schema.json
+++ b/pkgs/hooks/doc/schema/shared/shared_definitions.schema.json
@@ -7,6 +7,10 @@
       "properties": {
         "type": {
           "type": "string"
+        },
+        "encoding": {
+          "type": "object",
+          "additionalProperties": true
         }
       },
       "required": [

--- a/pkgs/hooks/test/data/build_output.json
+++ b/pkgs/hooks/test/data/build_output.json
@@ -2,10 +2,16 @@
   "$schema": "../../doc/schema/hook/build_output.generated.schema.json",
   "assets": [
     {
+      "encoding": {
+        "some_key": "some_value"
+      },
       "some_key": "some_value",
       "type": "some_asset_type"
     },
     {
+      "encoding": {
+        "some_other_key": "some_value"
+      },
       "some_other_key": "some_value",
       "type": "some_other_asset_type"
     }
@@ -13,10 +19,16 @@
   "assetsForLinking": {
     "package_with_linker": [
       {
+        "encoding": {
+          "some_key": "some_value"
+        },
         "some_key": "some_value",
         "type": "some_asset_type"
       },
       {
+        "encoding": {
+          "some_other_key": "some_value"
+        },
         "some_other_key": "some_value",
         "type": "some_other_asset_type"
       }
@@ -25,10 +37,16 @@
   "assets_for_linking": {
     "package_with_linker": [
       {
+        "encoding": {
+          "some_key": "some_value"
+        },
         "some_key": "some_value",
         "type": "some_asset_type"
       },
       {
+        "encoding": {
+          "some_other_key": "some_value"
+        },
         "some_other_key": "some_value",
         "type": "some_other_asset_type"
       }

--- a/pkgs/hooks/test/data/build_output_windows.json
+++ b/pkgs/hooks/test/data/build_output_windows.json
@@ -2,14 +2,18 @@
   "$schema": "../../doc/schema/hook/build_output.generated.schema.json",
   "assets": [
     {
-      "architecture": "x64",
-      "file": "C:\\src\\dacoharkes\\playground\\my_package\\example\\.dart_tool\\native_assets_builder\\my_package\\190c04c47dc2f9eb26d2411b1968b2cf\\out\\my_package.dll",
-      "id": "package:my_package/my_package_bindings_generated.dart",
-      "link_mode": {
-        "type": "dynamic_loading_bundle"
+      "encoding": {
+        "some_key": "some_value"
       },
-      "os": "windows",
-      "type": "native_code"
+      "some_key": "some_value",
+      "type": "some_asset_type"
+    },
+    {
+      "encoding": {
+        "some_other_key": "some_value"
+      },
+      "some_other_key": "some_value",
+      "type": "some_other_asset_type"
     }
   ],
   "dependencies": [

--- a/pkgs/hooks/test/schema/helpers.dart
+++ b/pkgs/hooks/test/schema/helpers.dart
@@ -339,6 +339,7 @@ FieldsReturn _hookFields({
       (['dependencies', 0], expectOptionalFieldMissing),
       (['assets'], expectOptionalFieldMissing),
       (['assets', 0], expectOptionalFieldMissing),
+      (['assets', 0, 'encoding'], expectOptionalFieldMissing),
       (['assets', 0, 'type'], expectRequiredFieldMissing),
       if (hook == Hook.build)
         for (final assetsForLinking in [

--- a/pkgs/json_syntax_generator/lib/src/parser/schema_analyzer.dart
+++ b/pkgs/json_syntax_generator/lib/src/parser/schema_analyzer.dart
@@ -103,10 +103,10 @@ class SchemaAnalyzer {
     NormalClassInfo? superclass,
     String? taggedUnionValue,
   }) {
-    var typeName = schemas.className;
+    final typeName =
+        name != null ? _ucFirst(_snakeToCamelCase(name)) : schemas.className!;
     if (_classes[typeName] != null) return; // Already analyzed.
 
-    typeName ??= _ucFirst(_snakeToCamelCase(name!));
     final properties = <PropertyInfo>[];
 
     if (superclass == null) {

--- a/pkgs/native_assets_cli/lib/src/code_assets/code_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/code_asset.dart
@@ -106,9 +106,8 @@ final class CodeAsset {
 
   factory CodeAsset.fromEncoded(EncodedAsset asset) {
     assert(asset.type == CodeAsset.type);
-    final jsonMap = asset.encoding;
-    final syntaxNode = syntax.NativeCodeAsset.fromJson(
-      jsonMap,
+    final syntaxNode = syntax.NativeCodeAssetEncoding.fromJson(
+      asset.encoding,
       path: asset.jsonPath ?? [],
     );
     return CodeAsset._(
@@ -150,16 +149,14 @@ final class CodeAsset {
   int get hashCode => Object.hash(id, linkMode, architecture, os, file);
 
   EncodedAsset encode() {
-    final nativeCodeAsset = syntax.NativeCodeAsset.fromJson({});
-    nativeCodeAsset.setup(
+    final encoding = syntax.NativeCodeAssetEncoding(
       architecture: architecture.toSyntax(),
       file: file,
       id: id,
       linkMode: linkMode.toSyntax(),
       os: os.toSyntax(),
     );
-    final json = nativeCodeAsset.json;
-    return EncodedAsset(CodeAsset.type, json);
+    return EncodedAsset(CodeAsset.type, encoding.json);
   }
 
   static const String type = 'native_code';

--- a/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
@@ -374,14 +374,14 @@ class CodeConfig {
 
   List<String> _validateExtraRules() {
     final result = <String>[];
-    if (_reader.tryTraverse(['target_os']) == 'macos') {
-      result.addAll(_reader.validate<Object>('macos'));
+    if (_reader.tryTraverse(['target_os']) == 'android') {
+      result.addAll(_reader.validate<Object>('android'));
     }
     if (_reader.tryTraverse(['target_os']) == 'ios') {
       result.addAll(_reader.validate<Object>('ios'));
     }
-    if (_reader.tryTraverse(['target_os']) == 'android') {
-      result.addAll(_reader.validate<Object>('android'));
+    if (_reader.tryTraverse(['target_os']) == 'macos') {
+      result.addAll(_reader.validate<Object>('macos'));
     }
     if (_reader.tryTraverse(['target_os']) == 'windows') {
       final objectErrors = _reader.validate<Map<String, Object?>?>(
@@ -819,12 +819,14 @@ class NativeCodeAsset extends Asset {
 
   NativeCodeAsset({
     required Architecture architecture,
+    required NativeCodeAssetEncoding? encoding,
     required Uri? file,
     required String id,
     required LinkMode linkMode,
     required OS os,
   }) : super(type: 'native_code') {
     _architecture = architecture;
+    _encoding = encoding;
     _file = file;
     _id = id;
     _linkMode = linkMode;
@@ -836,11 +838,149 @@ class NativeCodeAsset extends Asset {
   /// [Asset].
   void setup({
     required Architecture architecture,
+    required NativeCodeAssetEncoding? encoding,
     required Uri? file,
     required String id,
     required LinkMode linkMode,
     required OS os,
   }) {
+    _architecture = architecture;
+    _encoding = encoding;
+    _file = file;
+    _id = id;
+    _linkMode = linkMode;
+    _os = os;
+    json.sortOnKey();
+  }
+
+  Architecture get architecture {
+    final jsonValue = _reader.get<String>('architecture');
+    return Architecture.fromJson(jsonValue);
+  }
+
+  set _architecture(Architecture value) {
+    json['architecture'] = value.name;
+  }
+
+  List<String> _validateArchitecture() =>
+      _reader.validate<String>('architecture');
+
+  NativeCodeAssetEncoding? get encoding {
+    final jsonValue = _reader.optionalMap('encoding');
+    if (jsonValue == null) return null;
+    return NativeCodeAssetEncoding.fromJson(
+      jsonValue,
+      path: [...path, 'encoding'],
+    );
+  }
+
+  set _encoding(NativeCodeAssetEncoding? value) {
+    json.setOrRemove('encoding', value?.json);
+  }
+
+  List<String> _validateEncoding() {
+    final mapErrors = _reader.validate<Map<String, Object?>?>('encoding');
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return encoding?.validate() ?? [];
+  }
+
+  Uri? get file => _reader.optionalPath('file');
+
+  set _file(Uri? value) {
+    json.setOrRemove('file', value?.toFilePath());
+  }
+
+  List<String> _validateFile() => _reader.validateOptionalPath('file');
+
+  String get id => _reader.get<String>('id');
+
+  set _id(String value) {
+    json.setOrRemove('id', value);
+  }
+
+  List<String> _validateId() => _reader.validate<String>('id');
+
+  LinkMode get linkMode {
+    final jsonValue = _reader.map$('link_mode');
+    return LinkMode.fromJson(jsonValue, path: [...path, 'link_mode']);
+  }
+
+  set _linkMode(LinkMode value) {
+    json['link_mode'] = value.json;
+  }
+
+  List<String> _validateLinkMode() {
+    final mapErrors = _reader.validate<Map<String, Object?>>('link_mode');
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return linkMode.validate();
+  }
+
+  OS get os {
+    final jsonValue = _reader.get<String>('os');
+    return OS.fromJson(jsonValue);
+  }
+
+  set _os(OS value) {
+    json['os'] = value.name;
+  }
+
+  List<String> _validateOs() => _reader.validate<String>('os');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateArchitecture(),
+    ..._validateEncoding(),
+    ..._validateFile(),
+    ..._validateId(),
+    ..._validateLinkMode(),
+    ..._validateOs(),
+    ..._validateExtraRules(),
+  ];
+
+  List<String> _validateExtraRules() {
+    final result = <String>[];
+    if ([
+      'dynamic_loading_bundle',
+      'static',
+    ].contains(_reader.tryTraverse(['link_mode', 'type']))) {
+      result.addAll(_reader.validate<Object>('file'));
+    }
+    return result;
+  }
+
+  @override
+  String toString() => 'NativeCodeAsset($json)';
+}
+
+extension NativeCodeAssetExtension on Asset {
+  bool get isNativeCodeAsset => type == 'native_code';
+
+  NativeCodeAsset get asNativeCodeAsset =>
+      NativeCodeAsset.fromJson(json, path: path);
+}
+
+class NativeCodeAssetEncoding {
+  final Map<String, Object?> json;
+
+  final List<Object> path;
+
+  JsonReader get _reader => JsonReader(json, path);
+
+  NativeCodeAssetEncoding.fromJson(this.json, {this.path = const []});
+
+  NativeCodeAssetEncoding({
+    required Architecture architecture,
+    required Uri? file,
+    required String id,
+    required LinkMode linkMode,
+    required OS os,
+  }) : json = {},
+       path = const [] {
     _architecture = architecture;
     _file = file;
     _id = id;
@@ -905,9 +1045,7 @@ class NativeCodeAsset extends Asset {
 
   List<String> _validateOs() => _reader.validate<String>('os');
 
-  @override
   List<String> validate() => [
-    ...super.validate(),
     ..._validateArchitecture(),
     ..._validateFile(),
     ..._validateId(),
@@ -928,14 +1066,7 @@ class NativeCodeAsset extends Asset {
   }
 
   @override
-  String toString() => 'NativeCodeAsset($json)';
-}
-
-extension NativeCodeAssetExtension on Asset {
-  bool get isNativeCodeAsset => type == 'native_code';
-
-  NativeCodeAsset get asNativeCodeAsset =>
-      NativeCodeAsset.fromJson(json, path: path);
+  String toString() => 'NativeCodeAssetEncoding($json)';
 }
 
 class OS {

--- a/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
@@ -173,14 +173,14 @@ Future<ValidationErrors> _validateCodeAssetBuildOrLinkOutput(
 }
 
 ValidationErrors _validateCodeAssetSyntax(EncodedAsset encodedAsset) {
-  final syntaxNode = syntax.Asset.fromJson(
-    encodedAsset.toJson(),
-    path: encodedAsset.jsonPath ?? [],
-  );
-  if (!syntaxNode.isNativeCodeAsset) {
+  if (encodedAsset.type != CodeAsset.type) {
     return [];
   }
-  final syntaxErrors = syntaxNode.asNativeCodeAsset.validate();
+  final syntaxNode = syntax.NativeCodeAssetEncoding.fromJson(
+    encodedAsset.encoding,
+    path: encodedAsset.jsonPath ?? [],
+  );
+  final syntaxErrors = syntaxNode.validate();
   if (syntaxErrors.isEmpty) {
     return [];
   }

--- a/pkgs/native_assets_cli/lib/src/data_assets/data_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/data_asset.dart
@@ -43,8 +43,10 @@ final class DataAsset {
   /// Constructs a [DataAsset] from an [EncodedAsset].
   factory DataAsset.fromEncoded(EncodedAsset asset) {
     assert(asset.type == DataAsset.type);
-    final jsonMap = asset.encoding;
-    final syntaxNode = syntax.DataAsset.fromJson(jsonMap);
+    final syntaxNode = syntax.DataAssetEncoding.fromJson(
+      asset.encoding,
+      path: asset.jsonPath ?? [],
+    );
     return DataAsset(
       file: syntaxNode.file,
       name: syntaxNode.name,
@@ -66,10 +68,12 @@ final class DataAsset {
   int get hashCode => Object.hash(package, name, file.toFilePath());
 
   EncodedAsset encode() {
-    final dataAsset = syntax.DataAsset.fromJson({});
-    dataAsset.setup(file: file, name: name, package: package);
-    final json = dataAsset.json;
-    return EncodedAsset(DataAsset.type, json);
+    final encoding = syntax.DataAssetEncoding(
+      file: file,
+      name: name,
+      package: package,
+    );
+    return EncodedAsset(DataAsset.type, encoding.json);
   }
 
   @override

--- a/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
@@ -52,8 +52,13 @@ class Asset {
 class DataAsset extends Asset {
   DataAsset.fromJson(super.json, {super.path}) : super._fromJson();
 
-  DataAsset({required Uri file, required String name, required String package})
-    : super(type: 'data') {
+  DataAsset({
+    required DataAssetEncoding? encoding,
+    required Uri file,
+    required String name,
+    required String package,
+  }) : super(type: 'data') {
+    _encoding = encoding;
     _file = file;
     _name = name;
     _package = package;
@@ -63,10 +68,94 @@ class DataAsset extends Asset {
   /// Setup all fields for [DataAsset] that are not in
   /// [Asset].
   void setup({
+    required DataAssetEncoding? encoding,
     required Uri file,
     required String name,
     required String package,
   }) {
+    _encoding = encoding;
+    _file = file;
+    _name = name;
+    _package = package;
+    json.sortOnKey();
+  }
+
+  DataAssetEncoding? get encoding {
+    final jsonValue = _reader.optionalMap('encoding');
+    if (jsonValue == null) return null;
+    return DataAssetEncoding.fromJson(jsonValue, path: [...path, 'encoding']);
+  }
+
+  set _encoding(DataAssetEncoding? value) {
+    json.setOrRemove('encoding', value?.json);
+  }
+
+  List<String> _validateEncoding() {
+    final mapErrors = _reader.validate<Map<String, Object?>?>('encoding');
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return encoding?.validate() ?? [];
+  }
+
+  Uri get file => _reader.path$('file');
+
+  set _file(Uri value) {
+    json['file'] = value.toFilePath();
+  }
+
+  List<String> _validateFile() => _reader.validatePath('file');
+
+  String get name => _reader.get<String>('name');
+
+  set _name(String value) {
+    json.setOrRemove('name', value);
+  }
+
+  List<String> _validateName() => _reader.validate<String>('name');
+
+  String get package => _reader.get<String>('package');
+
+  set _package(String value) {
+    json.setOrRemove('package', value);
+  }
+
+  List<String> _validatePackage() => _reader.validate<String>('package');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateEncoding(),
+    ..._validateFile(),
+    ..._validateName(),
+    ..._validatePackage(),
+  ];
+
+  @override
+  String toString() => 'DataAsset($json)';
+}
+
+extension DataAssetExtension on Asset {
+  bool get isDataAsset => type == 'data';
+
+  DataAsset get asDataAsset => DataAsset.fromJson(json, path: path);
+}
+
+class DataAssetEncoding {
+  final Map<String, Object?> json;
+
+  final List<Object> path;
+
+  JsonReader get _reader => JsonReader(json, path);
+
+  DataAssetEncoding.fromJson(this.json, {this.path = const []});
+
+  DataAssetEncoding({
+    required Uri file,
+    required String name,
+    required String package,
+  }) : json = {},
+       path = const [] {
     _file = file;
     _name = name;
     _package = package;
@@ -97,22 +186,14 @@ class DataAsset extends Asset {
 
   List<String> _validatePackage() => _reader.validate<String>('package');
 
-  @override
   List<String> validate() => [
-    ...super.validate(),
     ..._validateFile(),
     ..._validateName(),
     ..._validatePackage(),
   ];
 
   @override
-  String toString() => 'DataAsset($json)';
-}
-
-extension DataAssetExtension on Asset {
-  bool get isDataAsset => type == 'data';
-
-  DataAsset get asDataAsset => DataAsset.fromJson(json, path: path);
+  String toString() => 'DataAssetEncoding($json)';
 }
 
 class JsonReader {

--- a/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
@@ -92,14 +92,14 @@ void _validateDataAsset(
 }
 
 ValidationErrors _validateDataAssetSyntax(EncodedAsset encodedAsset) {
-  final syntaxNode = syntax.Asset.fromJson(
-    encodedAsset.toJson(),
-    path: encodedAsset.jsonPath ?? [],
-  );
-  if (!syntaxNode.isDataAsset) {
+  if (encodedAsset.type != DataAsset.type) {
     return [];
   }
-  final syntaxErrors = syntaxNode.asDataAsset.validate();
+  final syntaxNode = syntax.DataAssetEncoding.fromJson(
+    encodedAsset.encoding,
+    path: encodedAsset.jsonPath ?? [],
+  );
+  final syntaxErrors = syntaxNode.validate();
   if (syntaxErrors.isEmpty) {
     return [];
   }

--- a/pkgs/native_assets_cli/lib/src/hooks/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/hooks/syntax.g.dart
@@ -19,10 +19,21 @@ class Asset {
 
   Asset.fromJson(this.json, {this.path = const []});
 
-  Asset({required String type}) : json = {}, path = const [] {
+  Asset({required Map<String, Object?>? encoding, required String type})
+    : json = {},
+      path = const [] {
+    _encoding = encoding;
     _type = type;
     json.sortOnKey();
   }
+
+  Map<String, Object?>? get encoding => _reader.optionalMap('encoding');
+
+  set _encoding(Map<String, Object?>? value) {
+    json.setOrRemove('encoding', value);
+  }
+
+  List<String> _validateEncoding() => _reader.validateOptionalMap('encoding');
 
   String get type => _reader.get<String>('type');
 
@@ -32,7 +43,7 @@ class Asset {
 
   List<String> _validateType() => _reader.validate<String>('type');
 
-  List<String> validate() => [..._validateType()];
+  List<String> validate() => [..._validateEncoding(), ..._validateType()];
 
   @override
   String toString() => 'Asset($json)';

--- a/pkgs/native_assets_cli/test/build_output_test.dart
+++ b/pkgs/native_assets_cli/test/build_output_test.dart
@@ -56,18 +56,34 @@ void main() {
         'meta1': 'meta1-value',
       },
       'assets': [
-        {'a-0': 'v-0', 'type': 'my-asset-type'},
-        {'a-2': 'v-2', 'type': 'my-asset-type'},
+        {
+          'a-0': 'v-0',
+          'encoding': {'a-0': 'v-0'},
+          'type': 'my-asset-type',
+        },
+        {
+          'a-2': 'v-2',
+          'encoding': {'a-2': 'v-2'},
+          'type': 'my-asset-type',
+        },
       ],
       'assetsForLinking': {
         'package:linker1': [
-          {'a-1': 'v-1', 'type': 'my-asset-type'},
+          {
+            'a-1': 'v-1',
+            'encoding': {'a-1': 'v-1'},
+            'type': 'my-asset-type',
+          },
         ],
         'package:linker2': <Object?>[],
       },
       'assets_for_linking': {
         'package:linker1': [
-          {'a-1': 'v-1', 'type': 'my-asset-type'},
+          {
+            'a-1': 'v-1',
+            'encoding': {'a-1': 'v-1'},
+            'type': 'my-asset-type',
+          },
         ],
         'package:linker2': <Object?>[],
       },

--- a/pkgs/native_assets_cli/test/code_assets/code_asset_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/code_asset_test.dart
@@ -23,6 +23,13 @@ void main() async {
         'link_mode': {'type': 'dynamic_loading_bundle'},
         'os': 'android',
         'type': 'native_code',
+        'encoding': {
+          'architecture': 'riscv64',
+          'file': 'not there',
+          'id': 'package:my_package/name',
+          'link_mode': {'type': 'dynamic_loading_bundle'},
+          'os': 'android',
+        },
       },
     );
   });

--- a/pkgs/native_assets_cli/test/code_assets/config_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/config_test.dart
@@ -85,6 +85,13 @@ void main() async {
             'link_mode': {'type': 'dynamic_loading_bundle'},
             'os': 'android',
             'type': 'native_code',
+            'encoding': {
+              'architecture': 'riscv64',
+              'file': 'not there',
+              'id': 'package:my_package/name',
+              'link_mode': {'type': 'dynamic_loading_bundle'},
+              'os': 'android',
+            },
           },
         ],
       'config': {
@@ -326,6 +333,7 @@ void main() async {
     traverseJson<Map<String, Object?>>(input, [
       'assets',
       0,
+      'encoding',
     ]).remove('link_mode');
     expect(
       () => LinkInput(input).assets.code.first.linkMode,
@@ -334,7 +342,7 @@ void main() async {
           (e) =>
               e is FormatException &&
               e.message.contains(
-                "No value was provided for 'assets.0.link_mode'.",
+                "No value was provided for 'assets.0.encoding.link_mode'.",
               ),
         ),
       ),

--- a/pkgs/native_assets_cli/test/code_assets/validation_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/validation_test.dart
@@ -78,7 +78,7 @@ void main() {
     );
     expect(
       errors,
-      contains(contains("No value was provided for 'assets.0.file'.")),
+      contains(contains("No value was provided for 'assets.0.encoding.file'.")),
     );
   });
 
@@ -158,16 +158,38 @@ void main() {
       ),
       isEmpty,
     );
+
+    traverseJson<Map<String, Object?>>(outputBuilder.json, [
+      'assets',
+      0,
+      'encoding',
+    ]).remove('architecture');
+    expect(
+      await validateCodeAssetBuildOutput(
+        input,
+        BuildOutput(outputBuilder.json),
+      ),
+      contains(
+        contains(
+          'No value was provided for \'assets.0.encoding.architecture\'.'
+          ' Expected a String.',
+        ),
+      ),
+    );
+
+    traverseJson<Map<String, Object?>>(outputBuilder.json, [
+      'assets',
+      0,
+    ]).remove('encoding');
     traverseJson<Map<String, Object?>>(outputBuilder.json, [
       'assets',
       0,
     ]).remove('architecture');
-    final errors = await validateCodeAssetBuildOutput(
-      input,
-      BuildOutput(outputBuilder.json),
-    );
     expect(
-      errors,
+      await validateCodeAssetBuildOutput(
+        input,
+        BuildOutput(outputBuilder.json),
+      ),
       contains(
         contains(
           'No value was provided for \'assets.0.architecture\'.'
@@ -204,6 +226,7 @@ void main() {
     traverseJson<Map<String, Object?>>(outputBuilder.json, [
       'assets',
       0,
+      'encoding',
       'link_mode',
     ]).remove('uri');
     final errors = await validateCodeAssetBuildOutput(
@@ -214,7 +237,7 @@ void main() {
       errors,
       contains(
         contains(
-          'No value was provided for \'assets.0.link_mode.uri\'.'
+          'No value was provided for \'assets.0.encoding.link_mode.uri\'.'
           ' Expected a String.',
         ),
       ),

--- a/pkgs/native_assets_cli/test/data_assets/data_asset_test.dart
+++ b/pkgs/native_assets_cli/test/data_assets/data_asset_test.dart
@@ -18,6 +18,11 @@ void main() async {
         'package': 'my_package',
         'name': 'name',
         'type': 'data',
+        'encoding': {
+          'file': 'not there',
+          'name': 'name',
+          'package': 'my_package',
+        },
       },
     );
   });

--- a/pkgs/native_assets_cli/test/link_output_test.dart
+++ b/pkgs/native_assets_cli/test/link_output_test.dart
@@ -37,9 +37,21 @@ void main() {
       'version': '1.9.0',
       'dependencies': ['path0', 'path1', 'path2'],
       'assets': [
-        {'a-0': 'v-0', 'type': 'my-asset-type'},
-        {'a-1': 'v-1', 'type': 'my-asset-type'},
-        {'a-2': 'v-2', 'type': 'my-asset-type'},
+        {
+          'a-0': 'v-0',
+          'encoding': {'a-0': 'v-0'},
+          'type': 'my-asset-type',
+        },
+        {
+          'a-1': 'v-1',
+          'encoding': {'a-1': 'v-1'},
+          'type': 'my-asset-type',
+        },
+        {
+          'a-2': 'v-2',
+          'encoding': {'a-2': 'v-2'},
+          'type': 'my-asset-type',
+        },
       ],
     }.forEach((k, v) {
       expect(input.json[k], equals(v));

--- a/pkgs/native_assets_cli/test/model/asset_test.dart
+++ b/pkgs/native_assets_cli/test/model/asset_test.dart
@@ -78,6 +78,13 @@ void main() {
       'link_mode': {'type': 'dynamic_loading_bundle'},
       'os': 'android',
       'type': 'native_code',
+      'encoding': {
+        'architecture': 'x64',
+        'file': fooUri.toFilePath(),
+        'id': 'package:my_package/foo',
+        'link_mode': {'type': 'dynamic_loading_bundle'},
+        'os': 'android',
+      },
     },
     {
       'architecture': 'x64',
@@ -88,6 +95,15 @@ void main() {
       },
       'os': 'android',
       'type': 'native_code',
+      'encoding': {
+        'architecture': 'x64',
+        'id': 'package:my_package/foo3',
+        'link_mode': {
+          'type': 'dynamic_loading_system',
+          'uri': foo3Uri.toFilePath(),
+        },
+        'os': 'android',
+      },
     },
     {
       'architecture': 'x64',
@@ -95,6 +111,12 @@ void main() {
       'link_mode': {'type': 'dynamic_loading_executable'},
       'os': 'android',
       'type': 'native_code',
+      'encoding': {
+        'architecture': 'x64',
+        'id': 'package:my_package/foo4',
+        'link_mode': {'type': 'dynamic_loading_executable'},
+        'os': 'android',
+      },
     },
     {
       'architecture': 'x64',
@@ -102,6 +124,12 @@ void main() {
       'link_mode': {'type': 'dynamic_loading_process'},
       'os': 'android',
       'type': 'native_code',
+      'encoding': {
+        'architecture': 'x64',
+        'id': 'package:my_package/foo5',
+        'link_mode': {'type': 'dynamic_loading_process'},
+        'os': 'android',
+      },
     },
     {
       'architecture': 'arm64',
@@ -110,6 +138,13 @@ void main() {
       'link_mode': {'type': 'static'},
       'os': 'linux',
       'type': 'native_code',
+      'encoding': {
+        'architecture': 'arm64',
+        'file': barUri.toFilePath(),
+        'id': 'package:my_package/bar',
+        'link_mode': {'type': 'static'},
+        'os': 'linux',
+      },
     },
     {
       'architecture': 'x64',
@@ -118,18 +153,35 @@ void main() {
       'link_mode': {'type': 'dynamic_loading_bundle'},
       'os': 'windows',
       'type': 'native_code',
+      'encoding': {
+        'architecture': 'x64',
+        'file': blaUri.toFilePath(),
+        'id': 'package:my_package/bla',
+        'link_mode': {'type': 'dynamic_loading_bundle'},
+        'os': 'windows',
+      },
     },
     {
       'name': 'my_data_asset',
       'package': 'my_package',
       'file': Uri.file('path/to/data.txt').toFilePath(),
       'type': 'data',
+      'encoding': {
+        'name': 'my_data_asset',
+        'package': 'my_package',
+        'file': Uri.file('path/to/data.txt').toFilePath(),
+      },
     },
     {
       'name': 'my_data_asset2',
       'package': 'my_package',
       'file': Uri.file('path/to/data.json').toFilePath(),
       'type': 'data',
+      'encoding': {
+        'name': 'my_data_asset2',
+        'package': 'my_package',
+        'file': Uri.file('path/to/data.json').toFilePath(),
+      },
     },
   ];
 


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/2090

Nests the encoding of an asset under an `encoding` key:

```json
    {
      "type": "native_code",
      "encoding": { // new location
        "architecture": "x64",
        "file": "/usr/local/google/home/dacoharkes/src/dacoharkes/playground/my_package/example/.dart_tool/native_assets_builder/my_package/79cc7fbaec53b1465c3e388e6848234b/out/libmy_package.so",
        "id": "package:my_package/my_package_bindings_generated.dart",
        "link_mode": {
          "type": "dynamic_loading_bundle"
        },
        "os": "linux"
      },
      // old location: kept for backwards compatibility
      "architecture": "x64",
      "file": "/usr/local/google/home/dacoharkes/src/dacoharkes/playground/my_package/example/.dart_tool/native_assets_builder/my_package/79cc7fbaec53b1465c3e388e6848234b/out/libmy_package.so",
      "id": "package:my_package/my_package_bindings_generated.dart",
      "link_mode": {
        "type": "dynamic_loading_bundle"
      },
      "os": "linux",
    }
```

Having an explicit syntax node for `CodeAssetEncoding` and `DataAssetEncoding` simplifies accessing those fields and validating only the `EncodedAsset.encoding`. `EncodedAsset.encoding` always contains one of those two. (No more weird business with reasoning if the `type` field is there or not.) Note: as a consequence, the checks for if something is a data asset or code asset happens with `EncodedAsset.type == FooAsset.type` instead of via syntax.

### PR changes

* `pkgs/hooks`, `pkgs/code_assets`, and `pkgs/data_assets`
  * Introduces new schemas in the non-generated `.schema.json` files.
    * `pkgs/hooks` the `encoding` property as a `Map<String, Object?>` -> This makes the extension point explicit.
    * `pkgs/data_assets` and `pkgs/code_assets` the `DataAssetEncoding` and `NativeCodeAssetEncoding` for the fields in that encoding field.
  * Adds test data for the new location.
  * Added JSON schema tests for the new location

* `package:native_assets_cli`
  * Generated the syntax classes.
  * Deal with version skew in the mapping between syntax classes and semantic API.
    * Emit both when writing.
    * Read `encoding` first, and if it doesn't exist, the parent object.
  * Fix tests that deal with syntax errors.

### Version skew between hooks and SDKs

* Backwards compatibility older hooks & SDKs: Always emit both encodings.