### PR TITLE
[native_assets_cli] Remove `CodeAsset` `os` and `architecture` getters

### DIFF
--- a/pkgs/native_assets_builder/test_data/add_asset_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/add_asset_link/hook/link.dart
@@ -13,8 +13,8 @@ void main(List<String> arguments) async {
               package: 'add_asset_link',
               name: 'dylib_add_link',
               linkMode: builtDylib.linkMode,
-              os: builtDylib.os,
-              architecture: builtDylib.architecture,
+              os: input.config.code.targetOS,
+              architecture: input.config.code.targetArchitecture,
               file: builtDylib.file,
             ),
           )

--- a/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
@@ -4,8 +4,14 @@
 
 import 'dart:io';
 
-import '../../code_assets_builder.dart';
+import '../config.dart';
+import '../encoded_asset.dart';
+import '../validation.dart';
+import 'code_asset.dart';
+import 'config.dart';
 import 'link_mode.dart';
+import 'link_mode_preference.dart';
+import 'os.dart';
 import 'syntax.g.dart' as syntax;
 
 Future<ValidationErrors> validateCodeAssetBuildInput(BuildInput input) async =>


### PR DESCRIPTION
Bug: https://github.com/dart-lang/native/issues/2127

We want to remove these fields as they are redundant with the `CodeConfig`.

This PR does not yet change anything in the protocol, but removes all the uses of the fields.

When rolling this PR into Dart and Flutter, we'll need take the OS and architecture from the `CodeConfig` passed into a hook build.