### PR TITLE
[native_assets_cli] Hide `CodeAsset.type` and `DataAsset.type`

### DIFF
--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -106,9 +106,7 @@ class NativeAssetsBuildRunner {
       )?.forEach((key, value) => metadata[key] = value);
 
       final inputBuilder = BuildInputBuilder();
-      inputBuilder.config.setupShared(
-        buildAssetTypes: [for (final e in extensions) ...e.buildAssetTypes],
-      );
+
       for (final e in extensions) {
         e.setupBuildInput(inputBuilder);
       }
@@ -199,9 +197,6 @@ class NativeAssetsBuildRunner {
     var hookResult = HookResult(encodedAssets: buildResult.encodedAssets);
     for (final package in buildPlan) {
       final inputBuilder = LinkInputBuilder();
-      inputBuilder.config.setupShared(
-        buildAssetTypes: [for (final e in extensions) ...e.buildAssetTypes],
-      );
       for (final e in extensions) {
         e.setupLinkInput(inputBuilder);
       }

--- a/pkgs/native_assets_builder/test/build_runner/build_dependencies_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_dependencies_test.dart
@@ -29,7 +29,7 @@ void main() async {
               logger,
               dartExecutable,
               capturedLogs: logMessages,
-              buildAssetTypes: [CodeAsset.type],
+              buildAssetTypes: [BuildAssetType.code],
             ))!;
         expect(
           logMessages.join('\n'),

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_asset_id_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_asset_id_test.dart
@@ -24,7 +24,7 @@ void main() async {
           packageUri,
           createCapturingLogger(logMessages, level: Level.SEVERE),
           dartExecutable,
-          buildAssetTypes: [CodeAsset.type],
+          buildAssetTypes: [BuildAssetType.code],
         );
         final fullLog = logMessages.join('\n');
         expect(result, isNull);
@@ -52,7 +52,7 @@ void main() async {
           packageUri,
           logger,
           dartExecutable,
-          buildAssetTypes: [CodeAsset.type],
+          buildAssetTypes: [BuildAssetType.code],
         );
         expect(result, isNotNull);
       }

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_caching_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_caching_test.dart
@@ -29,7 +29,7 @@ void main() async {
               logger,
               dartExecutable,
               capturedLogs: logMessages,
-              buildAssetTypes: [CodeAsset.type],
+              buildAssetTypes: [BuildAssetType.code],
             ))!;
         expect(
           logMessages.join('\n'),
@@ -52,7 +52,7 @@ void main() async {
               logger,
               dartExecutable,
               capturedLogs: logMessages,
-              buildAssetTypes: [CodeAsset.type],
+              buildAssetTypes: [BuildAssetType.code],
             ))!;
         final hookUri = packageUri.resolve('hook/build.dart');
         expect(
@@ -97,7 +97,7 @@ void main() async {
               packageUri,
               logger,
               dartExecutable,
-              buildAssetTypes: [CodeAsset.type],
+              buildAssetTypes: [BuildAssetType.code],
             ))!;
         await expectSymbols(
           asset: CodeAsset.fromEncoded(result.encodedAssets.single),
@@ -117,7 +117,7 @@ void main() async {
               packageUri,
               logger,
               dartExecutable,
-              buildAssetTypes: [CodeAsset.type],
+              buildAssetTypes: [BuildAssetType.code],
             ))!;
 
         final cUri = packageUri.resolve('src/').resolve('native_add.c');
@@ -153,7 +153,7 @@ void main() async {
             packageUri,
             logger,
             dartExecutable,
-            buildAssetTypes: [CodeAsset.type],
+            buildAssetTypes: [BuildAssetType.code],
           ))!;
       {
         final compiledHook =
@@ -183,7 +183,7 @@ void main() async {
               packageUri,
               logger,
               dartExecutable,
-              buildAssetTypes: [CodeAsset.type],
+              buildAssetTypes: [BuildAssetType.code],
             ))!;
 
         final hookUri = packageUri.resolve('hook/build.dart');
@@ -217,7 +217,7 @@ void main() async {
           packageUri,
           logger,
           dartExecutable,
-          buildAssetTypes: [CodeAsset.type],
+          buildAssetTypes: [BuildAssetType.code],
           hookEnvironment:
               modifiedEnvKey == 'PATH'
                   ? null
@@ -255,7 +255,7 @@ void main() async {
           packageUri,
           logger,
           dartExecutable,
-          buildAssetTypes: [CodeAsset.type],
+          buildAssetTypes: [BuildAssetType.code],
         ))!;
         expect(logMessages.join('\n'), contains('hook.dill'));
         expect(

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_failure_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_failure_test.dart
@@ -26,7 +26,7 @@ void main() async {
               packageUri,
               logger,
               dartExecutable,
-              buildAssetTypes: [CodeAsset.type],
+              buildAssetTypes: [BuildAssetType.code],
             ))!;
         expect(result.encodedAssets.length, 1);
         await expectSymbols(
@@ -50,7 +50,7 @@ void main() async {
           packageUri,
           createCapturingLogger(logMessages, level: Level.SEVERE),
           dartExecutable,
-          buildAssetTypes: [CodeAsset.type],
+          buildAssetTypes: [BuildAssetType.code],
         );
         final fullLog = logMessages.join('\n');
         expect(result, isNull);
@@ -80,7 +80,7 @@ void main() async {
               packageUri,
               logger,
               dartExecutable,
-              buildAssetTypes: [CodeAsset.type],
+              buildAssetTypes: [BuildAssetType.code],
             ))!;
         expect(result.encodedAssets.length, 1);
         await expectSymbols(
@@ -111,7 +111,7 @@ void main() async {
           logger,
           capturedLogs: logMessages,
           dartExecutable,
-          buildAssetTypes: [CodeAsset.type],
+          buildAssetTypes: [BuildAssetType.code],
         );
         Matcher stringContainsBuildHookCompilation(String packageName) =>
             stringContainsInOrder([

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_non_root_package_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_non_root_package_test.dart
@@ -28,7 +28,7 @@ void main() async {
               dartExecutable,
               capturedLogs: logMessages,
               runPackageName: 'some_dev_dep',
-              buildAssetTypes: [CodeAsset.type],
+              buildAssetTypes: [BuildAssetType.code],
             ))!;
         expect(result.encodedAssets, isEmpty);
         expect(result.dependencies, isEmpty);
@@ -43,7 +43,7 @@ void main() async {
               dartExecutable,
               capturedLogs: logMessages,
               runPackageName: 'native_add',
-              buildAssetTypes: [CodeAsset.type],
+              buildAssetTypes: [BuildAssetType.code],
             ))!;
         expect(result.encodedAssets, isNotEmpty);
         expect(

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_test.dart
@@ -30,7 +30,7 @@ void main() async {
               logger,
               dartExecutable,
               capturedLogs: logMessages,
-              buildAssetTypes: [CodeAsset.type],
+              buildAssetTypes: [BuildAssetType.code],
             ))!;
         expect(
           logMessages.join('\n'),
@@ -74,7 +74,7 @@ void main() async {
             logger,
             dartExecutable,
             capturedLogs: logMessages,
-            buildAssetTypes: [CodeAsset.type],
+            buildAssetTypes: [BuildAssetType.code],
           ))!;
       expect(
         false,

--- a/pkgs/native_assets_builder/test/build_runner/conflicting_dylib_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/conflicting_dylib_test.dart
@@ -24,7 +24,7 @@ void main() async {
           packageUri,
           createCapturingLogger(logMessages, level: Level.SEVERE),
           dartExecutable,
-          buildAssetTypes: [CodeAsset.type],
+          buildAssetTypes: [BuildAssetType.code],
         );
         final fullLog = logMessages.join('\n');
         expect(result, isNull);
@@ -49,7 +49,7 @@ void main() async {
               logger,
               linkingEnabled: true,
               dartExecutable,
-              buildAssetTypes: [CodeAsset.type],
+              buildAssetTypes: [BuildAssetType.code],
             ))!;
 
         final linkResult = await link(
@@ -57,7 +57,7 @@ void main() async {
           logger,
           dartExecutable,
           buildResult: buildResult,
-          buildAssetTypes: [CodeAsset.type],
+          buildAssetTypes: [BuildAssetType.code],
         );
         // Application validation error due to conflicting dylib name.
         expect(linkResult, isNull);

--- a/pkgs/native_assets_builder/test/build_runner/fail_on_os_sdk_version_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/fail_on_os_sdk_version_test.dart
@@ -73,7 +73,7 @@ void main() async {
                   packageUri,
                   createCapturingLogger(logMessages, level: Level.SEVERE),
                   dartExecutable,
-                  buildAssetTypes: [CodeAsset.type, DataAsset.type],
+                  buildAssetTypes: [BuildAssetType.code, BuildAssetType.data],
                 );
                 final fullLog = logMessages.join('\n');
                 if (hook == 'build') {

--- a/pkgs/native_assets_builder/test/build_runner/helpers.dart
+++ b/pkgs/native_assets_builder/test/build_runner/helpers.dart
@@ -39,7 +39,7 @@ Future<BuildResult?> buildDataAssets(
   logger,
   dartExecutable,
   capturedLogs: capturedLogs,
-  buildAssetTypes: [DataAsset.type],
+  buildAssetTypes: [BuildAssetType.data],
   runPackageName: runPackageName,
   linkingEnabled: linkingEnabled,
 );
@@ -53,9 +53,11 @@ Future<BuildResult?> buildCodeAssets(
   logger,
   dartExecutable,
   capturedLogs: capturedLogs,
-  buildAssetTypes: [CodeAsset.type],
+  buildAssetTypes: [BuildAssetType.code],
   runPackageName: runPackageName,
 );
+
+enum BuildAssetType { code, data }
 
 Future<BuildResult?> build(
   Uri packageUri,
@@ -71,7 +73,7 @@ Future<BuildResult?> build(
   int? targetAndroidNdkApi,
   Target? target,
   bool linkingEnabled = false,
-  required List<String> buildAssetTypes,
+  required List<BuildAssetType> buildAssetTypes,
   Map<String, String>? hookEnvironment,
 }) async {
   final targetOS = target?.os ?? OS.current;
@@ -91,7 +93,7 @@ Future<BuildResult?> build(
       packageLayout: packageLayout,
     ).build(
       extensions: [
-        if (buildAssetTypes.contains(CodeAsset.type))
+        if (buildAssetTypes.contains(BuildAssetType.code))
           CodeAssetExtension(
             targetArchitecture: target?.architecture ?? Architecture.current,
             targetOS: targetOS,
@@ -115,7 +117,8 @@ Future<BuildResult?> build(
                     ? AndroidCodeConfig(targetNdkApi: targetAndroidNdkApi!)
                     : null,
           ),
-        if (buildAssetTypes.contains(DataAsset.type)) DataAssetsExtension(),
+        if (buildAssetTypes.contains(BuildAssetType.data))
+          DataAssetsExtension(),
       ],
       linkingEnabled: linkingEnabled,
     );
@@ -147,7 +150,7 @@ Future<LinkResult?> link(
   int? targetMacOSVersion,
   int? targetAndroidNdkApi,
   Target? target,
-  required List<String> buildAssetTypes,
+  required List<BuildAssetType> buildAssetTypes,
 }) async {
   final targetOS = target?.os ?? OS.current;
   final runPackageName_ =
@@ -165,7 +168,7 @@ Future<LinkResult?> link(
       packageLayout: packageLayout,
     ).link(
       extensions: [
-        if (buildAssetTypes.contains(CodeAsset.type))
+        if (buildAssetTypes.contains(BuildAssetType.code))
           CodeAssetExtension(
             targetArchitecture: target?.architecture ?? Architecture.current,
             targetOS: target?.os ?? OS.current,
@@ -189,7 +192,8 @@ Future<LinkResult?> link(
                     ? AndroidCodeConfig(targetNdkApi: targetAndroidNdkApi!)
                     : null,
           ),
-        if (buildAssetTypes.contains(DataAsset.type)) DataAssetsExtension(),
+        if (buildAssetTypes.contains(BuildAssetType.data))
+          DataAssetsExtension(),
       ],
       buildResult: buildResult,
       resourceIdentifiers: resourceIdentifiers,
@@ -218,7 +222,7 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
   int? targetAndroidNdkApi,
   Target? target,
   Uri? resourceIdentifiers,
-  required List<String> buildAssetTypes,
+  required List<BuildAssetType> buildAssetTypes,
 }) async => await runWithLog(capturedLogs, () async {
   final runPackageName_ =
       runPackageName ?? packageUri.pathSegments.lastWhere((e) => e.isNotEmpty);
@@ -236,7 +240,7 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
   final targetOS = target?.os ?? OS.current;
   final buildResult = await buildRunner.build(
     extensions: [
-      if (buildAssetTypes.contains(CodeAsset.type))
+      if (buildAssetTypes.contains(BuildAssetType.code))
         CodeAssetExtension(
           targetArchitecture: target?.architecture ?? Architecture.current,
           targetOS: target?.os ?? OS.current,
@@ -260,7 +264,7 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
                   ? AndroidCodeConfig(targetNdkApi: targetAndroidNdkApi!)
                   : null,
         ),
-      if (buildAssetTypes.contains(DataAsset.type)) DataAssetsExtension(),
+      if (buildAssetTypes.contains(BuildAssetType.data)) DataAssetsExtension(),
     ],
     linkingEnabled: true,
   );
@@ -277,7 +281,7 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
 
   final linkResult = await buildRunner.link(
     extensions: [
-      if (buildAssetTypes.contains(CodeAsset.type))
+      if (buildAssetTypes.contains(BuildAssetType.code))
         CodeAssetExtension(
           targetArchitecture: target?.architecture ?? Architecture.current,
           targetOS: target?.os ?? OS.current,
@@ -301,7 +305,7 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
                   ? AndroidCodeConfig(targetNdkApi: targetAndroidNdkApi!)
                   : null,
         ),
-      if (buildAssetTypes.contains(DataAsset.type)) DataAssetsExtension(),
+      if (buildAssetTypes.contains(BuildAssetType.data)) DataAssetsExtension(),
     ],
     buildResult: buildResult,
     resourceIdentifiers: resourceIdentifiers,

--- a/pkgs/native_assets_builder/test/build_runner/link_caching_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/link_caching_test.dart
@@ -42,7 +42,7 @@ void main() async {
               logger,
               dartExecutable,
               buildResult: buildResult,
-              buildAssetTypes: [DataAsset.type],
+              buildAssetTypes: [BuildAssetType.data],
               capturedLogs: logMessages,
             ))!;
       }

--- a/pkgs/native_assets_builder/test/build_runner/link_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/link_test.dart
@@ -30,7 +30,7 @@ void main() async {
             logger,
             dartExecutable,
             buildResult: buildResult,
-            buildAssetTypes: [DataAsset.type],
+            buildAssetTypes: [BuildAssetType.data],
           ))!;
       expect(linkResult.encodedAssets.length, 2);
 
@@ -84,7 +84,7 @@ void main() async {
         logger,
         dartExecutable,
         buildResult: buildResult,
-        buildAssetTypes: [DataAsset.type],
+        buildAssetTypes: [BuildAssetType.data],
       );
       expect(linkResult, isNotNull);
 
@@ -116,7 +116,7 @@ void main() async {
             dartExecutable,
             buildResult: buildResult,
             capturedLogs: logMessages,
-            buildAssetTypes: [DataAsset.type],
+            buildAssetTypes: [BuildAssetType.data],
           ))!;
       expect(linkResult.encodedAssets.length, 0);
       expect(
@@ -148,7 +148,7 @@ void main() async {
             logger,
             dartExecutable,
             linkingEnabled: true,
-            buildAssetTypes: [CodeAsset.type],
+            buildAssetTypes: [BuildAssetType.code],
           ))!;
       expect(buildResult.encodedAssets.length, 0);
       expect(buildResult.encodedAssetsForLinking.length, 1);
@@ -161,14 +161,13 @@ void main() async {
             dartExecutable,
             buildResult: buildResult,
             capturedLogs: logMessages,
-            buildAssetTypes: [CodeAsset.type],
+            buildAssetTypes: [BuildAssetType.code],
           ))!;
       expect(linkResult.encodedAssets.length, 1);
-      expect(linkResult.encodedAssets.first.type, CodeAsset.type);
+      expect(linkResult.encodedAssets.first.isCodeAsset, isTrue);
     });
   });
 }
 
-Iterable<String> _getNames(List<EncodedAsset> assets) => assets
-    .where((e) => e.type == DataAsset.type)
-    .map((e) => DataAsset.fromEncoded(e).name);
+Iterable<String> _getNames(List<EncodedAsset> assets) =>
+    assets.where((e) => e.isDataAsset).map((e) => e.asDataAsset.name);

--- a/pkgs/native_assets_builder/test/build_runner/metadata_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/metadata_test.dart
@@ -28,7 +28,7 @@ void main() async {
           logger,
           dartExecutable,
           capturedLogs: logMessages,
-          buildAssetTypes: ['foo'],
+          buildAssetTypes: [],
         );
         expect(
           logMessages.join('\n'),

--- a/pkgs/native_assets_builder/test/build_runner/packaging_preference_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/packaging_preference_test.dart
@@ -24,7 +24,7 @@ void main() async {
             logger,
             dartExecutable,
             linkModePreference: LinkModePreference.dynamic,
-            buildAssetTypes: [CodeAsset.type],
+            buildAssetTypes: [BuildAssetType.code],
           ))!;
 
       final resultPreferDynamic =
@@ -33,7 +33,7 @@ void main() async {
             logger,
             dartExecutable,
             linkModePreference: LinkModePreference.preferDynamic,
-            buildAssetTypes: [CodeAsset.type],
+            buildAssetTypes: [BuildAssetType.code],
           ))!;
 
       final resultStatic =
@@ -42,7 +42,7 @@ void main() async {
             logger,
             dartExecutable,
             linkModePreference: LinkModePreference.static,
-            buildAssetTypes: [CodeAsset.type],
+            buildAssetTypes: [BuildAssetType.code],
           ))!;
 
       final resultPreferStatic =
@@ -51,7 +51,7 @@ void main() async {
             logger,
             dartExecutable,
             linkModePreference: LinkModePreference.preferStatic,
-            buildAssetTypes: [CodeAsset.type],
+            buildAssetTypes: [BuildAssetType.code],
           ))!;
 
       // This package honors preferences.

--- a/pkgs/native_assets_builder/test/build_runner/resources_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/resources_test.dart
@@ -38,7 +38,7 @@ void main() async {
         dartExecutable,
         buildResult: buildResult,
         resourceIdentifiers: resourcesUri,
-        buildAssetTypes: [DataAsset.type],
+        buildAssetTypes: [BuildAssetType.data],
       );
       expect(buildFiles(), anyElement(endsWith('resources.json')));
     });

--- a/pkgs/native_assets_builder/test/build_runner/system_library_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/system_library_test.dart
@@ -24,7 +24,7 @@ void main() async {
             logger,
             dartExecutable,
             capturedLogs: logMessages,
-            buildAssetTypes: [CodeAsset.type],
+            buildAssetTypes: [BuildAssetType.code],
           ))!;
       expect(result.encodedAssets.length, 3);
     });

--- a/pkgs/native_assets_builder/test/build_runner/version_skew_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/version_skew_test.dart
@@ -26,7 +26,7 @@ void main() async {
             packageUri,
             logger,
             dartExecutable,
-            buildAssetTypes: [CodeAsset.type],
+            buildAssetTypes: [BuildAssetType.code],
           );
           expect(result?.encodedAssets.length, 1);
         }

--- a/pkgs/native_assets_builder/test/build_runner/wrong_linker_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/wrong_linker_test.dart
@@ -24,7 +24,7 @@ void main() async {
           packageUri,
           createCapturingLogger(logMessages, level: Level.SEVERE),
           dartExecutable,
-          buildAssetTypes: [CodeAsset.type],
+          buildAssetTypes: [BuildAssetType.code],
 
           linkingEnabled: true,
         );

--- a/pkgs/native_assets_builder/test/helpers.dart
+++ b/pkgs/native_assets_builder/test/helpers.dart
@@ -214,13 +214,13 @@ extension on String {
 extension AssetIterable on Iterable<EncodedAsset> {
   Future<bool> allExist() async {
     for (final encodedAsset in this) {
-      if (encodedAsset.type == DataAsset.type) {
-        final dataAsset = DataAsset.fromEncoded(encodedAsset);
+      if (encodedAsset.isDataAsset) {
+        final dataAsset = encodedAsset.asDataAsset;
         if (!await dataAsset.file.fileSystemEntity.exists()) {
           return false;
         }
-      } else if (encodedAsset.type == CodeAsset.type) {
-        final codeAsset = CodeAsset.fromEncoded(encodedAsset);
+      } else if (encodedAsset.isCodeAsset) {
+        final codeAsset = encodedAsset.asCodeAsset;
         if (!await (codeAsset.file?.fileSystemEntity.exists() ?? true)) {
           return false;
         }

--- a/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
@@ -40,16 +40,17 @@ void main() async {
               outputDirectoryShared: outputDirectoryShared,
             )
             ..config.setupBuild(linkingEnabled: false)
-            ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-            ..config.setupCode(
-              targetArchitecture: Architecture.current,
-              targetOS: targetOS,
-              macOS:
-                  targetOS == OS.macOS
-                      ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                      : null,
-              linkModePreference: LinkModePreference.dynamic,
-              cCompiler: cCompiler,
+            ..addExtension(
+              CodeAssetExtension(
+                targetArchitecture: Architecture.current,
+                targetOS: targetOS,
+                macOS:
+                    targetOS == OS.macOS
+                        ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+                        : null,
+                linkModePreference: LinkModePreference.dynamic,
+                cCompiler: cCompiler,
+              ),
             );
 
       final buildInputUri = testTempUri.resolve('build_input.json');
@@ -88,7 +89,7 @@ void main() async {
 
       final addLibraryPath =
           assets
-              .where((e) => e.type == CodeAsset.type)
+              .where((e) => e.isCodeAsset)
               .map(CodeAsset.fromEncoded)
               .firstWhere((asset) => asset.id.endsWith('add.dart'))
               .file!

--- a/pkgs/native_assets_builder/test/test_data/transformer_test.dart
+++ b/pkgs/native_assets_builder/test/test_data/transformer_test.dart
@@ -51,17 +51,17 @@ void main() async {
                 outputDirectoryShared: outputDirectoryShared,
               )
               ..config.setupBuild(linkingEnabled: false)
-              ..config.setupShared(
-                buildAssetTypes: [CodeAsset.type, DataAsset.type],
-              )
-              ..config.setupCode(
-                targetArchitecture: architecture,
-                targetOS: targetOS,
-                macOS:
-                    targetOS == OS.macOS
-                        ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                        : null,
-                linkModePreference: LinkModePreference.dynamic,
+              ..addExtension(DataAssetsExtension())
+              ..addExtension(
+                CodeAssetExtension(
+                  targetArchitecture: architecture,
+                  targetOS: targetOS,
+                  macOS:
+                      targetOS == OS.macOS
+                          ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+                          : null,
+                  linkModePreference: LinkModePreference.dynamic,
+                ),
               );
 
         final buildInputUri = testTempUri.resolve('build_input.json');

--- a/pkgs/native_assets_builder/test_data/no_hook/lib/no_hook.dart
+++ b/pkgs/native_assets_builder/test_data/no_hook/lib/no_hook.dart
@@ -4,4 +4,4 @@
 
 import 'package:native_assets_cli/code_assets.dart';
 
-String get useSomeNativeAssetsCli => CodeAsset.type;
+String get useSomeNativeAssetsCli => OS.android.name;

--- a/pkgs/native_assets_builder/test_data/relative_path/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/relative_path/hook/build.dart
@@ -8,7 +8,7 @@ import 'package:native_assets_cli/data_assets.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {
-    if (input.config.buildAssetTypes.contains(DataAsset.type)) {
+    if (input.config.buildDataAssets) {
       output.assets.data.add(
         DataAsset(
           package: input.packageName,

--- a/pkgs/native_assets_cli/example/build/download_asset/tool/build.dart
+++ b/pkgs/native_assets_cli/example/build/download_asset/tool/build.dart
@@ -82,24 +82,25 @@ BuildInput createBuildInput(
           outputDirectory: outputDirectory,
           outputDirectoryShared: outputDirectoryShared,
         )
-        ..config.setupShared(buildAssetTypes: [CodeAsset.type])
         ..config.setupBuild(linkingEnabled: false)
-        ..config.setupCode(
-          targetArchitecture: Architecture.fromString(architecture),
-          targetOS: os,
-          linkModePreference: LinkModePreference.dynamic,
-          android:
-              os != OS.android
-                  ? null
-                  : AndroidCodeConfig(targetNdkApi: androidTargetNdkApi),
-          iOS:
-              os != OS.iOS
-                  ? null
-                  : IOSCodeConfig(
-                    targetSdk: IOSSdk.fromString(iOSSdk!),
-                    targetVersion: iOSTargetVersion,
-                  ),
-          macOS: MacOSCodeConfig(targetVersion: macOSTargetVersion),
+        ..addExtension(
+          CodeAssetExtension(
+            targetArchitecture: Architecture.fromString(architecture),
+            targetOS: os,
+            linkModePreference: LinkModePreference.dynamic,
+            android:
+                os != OS.android
+                    ? null
+                    : AndroidCodeConfig(targetNdkApi: androidTargetNdkApi),
+            iOS:
+                os != OS.iOS
+                    ? null
+                    : IOSCodeConfig(
+                      targetSdk: IOSSdk.fromString(iOSSdk!),
+                      targetVersion: iOSTargetVersion,
+                    ),
+            macOS: MacOSCodeConfig(targetVersion: macOSTargetVersion),
+          ),
         );
   return BuildInput(inputBuilder.json);
 }

--- a/pkgs/native_assets_cli/lib/code_assets.dart
+++ b/pkgs/native_assets_cli/lib/code_assets.dart
@@ -13,7 +13,8 @@ export 'native_assets_cli.dart'
 export 'src/code_assets/architecture.dart' show Architecture;
 export 'src/code_assets/c_compiler_config.dart'
     show CCompilerConfig, DeveloperCommandPrompt, WindowsCCompilerConfig;
-export 'src/code_assets/code_asset.dart' show CodeAsset, OSLibraryNaming;
+export 'src/code_assets/code_asset.dart'
+    show CodeAsset, EncodedCodeAsset, OSLibraryNaming;
 export 'src/code_assets/config.dart'
     show
         AndroidCodeConfig,

--- a/pkgs/native_assets_cli/lib/data_assets.dart
+++ b/pkgs/native_assets_cli/lib/data_assets.dart
@@ -15,7 +15,8 @@ export 'src/data_assets/config.dart'
         AddDataAssetsDirectory,
         DataAssetBuildOutputBuilder,
         DataAssetBuildOutputBuilderAdd,
+        DataAssetHookConfig,
         DataAssetLinkInput,
         DataAssetLinkOutputBuilder,
         DataAssetLinkOutputBuilderAdd;
-export 'src/data_assets/data_asset.dart' show DataAsset;
+export 'src/data_assets/data_asset.dart' show DataAsset, EncodedDataAsset;

--- a/pkgs/native_assets_cli/lib/src/code_assets/code_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/code_asset.dart
@@ -106,7 +106,7 @@ final class CodeAsset {
        _os = os;
 
   factory CodeAsset.fromEncoded(EncodedAsset asset) {
-    assert(asset.type == CodeAsset.type);
+    assert(asset.isCodeAsset);
     final syntaxNode = syntax.NativeCodeAssetEncoding.fromJson(
       asset.encoding,
       path: asset.jsonPath ?? [],
@@ -163,10 +163,20 @@ final class CodeAsset {
       linkMode: linkMode.toSyntax(),
       os: _os?.toSyntax(),
     );
-    return EncodedAsset(CodeAsset.type, encoding.json);
+    return EncodedAsset(CodeAssetType.type, encoding.json);
   }
+}
 
+extension CodeAssetType on CodeAsset {
+  // TODO(https://github.com/dart-lang/native/issues/2132): Change to be
+  // namespaced by package name. (We'll temporarily need to support both the
+  // old a new type.)
   static const String type = 'native_code';
+}
+
+extension EncodedCodeAsset on EncodedAsset {
+  bool get isCodeAsset => type == CodeAssetType.type;
+  CodeAsset get asCodeAsset => CodeAsset.fromEncoded(this);
 }
 
 // These field will be removed in the future, prevent anyone from reading them.

--- a/pkgs/native_assets_cli/lib/src/code_assets/config.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/config.dart
@@ -18,7 +18,7 @@ extension CodeAssetHookConfig on HookConfig {
   /// Code asset specific configuration.
   CodeConfig get code => CodeConfig._fromJson(json, path);
 
-  bool get buildCodeAssets => buildAssetTypes.contains(CodeAsset.type);
+  bool get buildCodeAssets => buildAssetTypes.contains(CodeAssetType.type);
 }
 
 /// Extension to the [LinkInput] providing access to configuration specific to
@@ -32,9 +32,8 @@ extension CodeAssetLinkInput on LinkInputAssets {
   // linker script has to add those files as dependencies via
   // [LinkOutput.addDependency] to ensure the linker script will be re-run if
   // the content of the files changes.
-  Iterable<CodeAsset> get code => encodedAssets
-      .where((e) => e.type == CodeAsset.type)
-      .map(CodeAsset.fromEncoded);
+  Iterable<CodeAsset> get code =>
+      encodedAssets.where((e) => e.isCodeAsset).map(CodeAsset.fromEncoded);
 }
 
 /// Configuration for hook writers if code assets are supported.
@@ -184,6 +183,7 @@ extension type CodeAssetLinkOutputBuilderAdd._(
 
 /// Extension to initialize code specific configuration on link/build inputs.
 extension CodeAssetBuildInputBuilder on HookConfigBuilder {
+  @Deprecated('Prefer using input.addExtension(CodeExtension(...)).')
   void setupCode({
     required Architecture targetArchitecture,
     required OS targetOS,
@@ -215,7 +215,7 @@ extension CodeAssetBuildOutput on BuildOutputAssets {
   /// The code assets emitted by the build hook.
   List<CodeAsset> get code =>
       encodedAssets
-          .where((asset) => asset.type == CodeAsset.type)
+          .where((asset) => asset.isCodeAsset)
           .map(CodeAsset.fromEncoded)
           .toList();
 }
@@ -225,7 +225,7 @@ extension CodeAssetLinkOutput on LinkOutputAssets {
   /// The code assets emitted by the link hook.
   List<CodeAsset> get code =>
       encodedAssets
-          .where((asset) => asset.type == CodeAsset.type)
+          .where((asset) => asset.isCodeAsset)
           .map(CodeAsset.fromEncoded)
           .toList();
 }

--- a/pkgs/native_assets_cli/lib/src/code_assets/extension.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/extension.dart
@@ -2,7 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../../code_assets_builder.dart';
+import '../config.dart';
+import '../encoded_asset.dart';
+import '../extension.dart';
+import 'architecture.dart';
+import 'c_compiler_config.dart';
+import 'code_asset.dart';
+import 'config.dart';
+import 'link_mode_preference.dart';
+import 'os.dart';
 import 'validation.dart';
 
 /// The protocol extension for the `hook/build.dart` and `hook/link.dart`
@@ -26,8 +34,7 @@ final class CodeAssetExtension implements ProtocolExtension {
     this.macOS,
   });
 
-  @override
-  List<String> get buildAssetTypes => [CodeAsset.type];
+  static const List<String> _buildAssetTypes = [CodeAssetType.type];
 
   @override
   void setupBuildInput(BuildInputBuilder input) {
@@ -40,6 +47,8 @@ final class CodeAssetExtension implements ProtocolExtension {
   }
 
   void _setupConfig(HookInputBuilder input) {
+    input.config.addBuildAssetTypes(_buildAssetTypes);
+    // ignore: deprecated_member_use_from_same_package
     input.config.setupCode(
       targetArchitecture: targetArchitecture,
       targetOS: targetOS,

--- a/pkgs/native_assets_cli/lib/src/code_assets/testing.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/testing.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import '../../code_assets_builder.dart';
 import '../../test.dart';
 import '../validation.dart';
-import 'validation.dart';
 
 /// Validate a code build hook; this will throw an exception on validation
 /// errors.
@@ -35,34 +34,34 @@ Future<void> testCodeBuildHook({
   LinkModePreference? linkModePreference,
   bool? linkingEnabled,
 }) async {
+  final extension = CodeAssetExtension(
+    linkModePreference: linkModePreference ?? LinkModePreference.dynamic,
+    cCompiler: cCompiler,
+    targetArchitecture: targetArchitecture ?? Architecture.current,
+    targetOS: targetOS ?? OS.current,
+    iOS:
+        targetOS == OS.iOS
+            ? IOSCodeConfig(
+              targetSdk: targetIOSSdk!,
+              targetVersion: targetIOSVersion!,
+            )
+            : null,
+    macOS:
+        targetOS == OS.macOS
+            ? MacOSCodeConfig(targetVersion: targetMacOSVersion!)
+            : null,
+    android:
+        targetOS == OS.android
+            ? AndroidCodeConfig(targetNdkApi: targetAndroidNdkApi!)
+            : null,
+  );
   await testBuildHook(
     mainMethod: mainMethod,
     extraInputSetup: (input) {
-      input.config.setupShared(buildAssetTypes: [CodeAsset.type]);
-      input.config.setupCode(
-        linkModePreference: linkModePreference ?? LinkModePreference.dynamic,
-        cCompiler: cCompiler,
-        targetArchitecture: targetArchitecture ?? Architecture.current,
-        targetOS: targetOS ?? OS.current,
-        iOS:
-            targetOS == OS.iOS
-                ? IOSCodeConfig(
-                  targetSdk: targetIOSSdk!,
-                  targetVersion: targetIOSVersion!,
-                )
-                : null,
-        macOS:
-            targetOS == OS.macOS
-                ? MacOSCodeConfig(targetVersion: targetMacOSVersion!)
-                : null,
-        android:
-            targetOS == OS.android
-                ? AndroidCodeConfig(targetNdkApi: targetAndroidNdkApi!)
-                : null,
-      );
+      input.addExtension(extension);
     },
     check: (input, output) async {
-      final validationErrors = await validateCodeAssetBuildOutput(
+      final validationErrors = await extension.validateBuildOutput(
         input,
         output,
       );

--- a/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
@@ -64,7 +64,7 @@ Future<ValidationErrors> _validateCodeAssetLinkInput(
 ) async {
   final errors = <String>[];
   for (final asset in encodedAssets) {
-    if (asset.type != CodeAsset.type) continue;
+    if (!asset.isCodeAsset) continue;
     final syntaxErrors = _validateCodeAssetSyntax(asset);
     if (syntaxErrors.isNotEmpty) {
       errors.addAll(syntaxErrors);
@@ -112,7 +112,7 @@ Future<ValidationErrors> validateCodeAssetInApplication(
 ) async {
   final fileNameToEncodedAssetId = <String, Set<String>>{};
   for (final asset in assets) {
-    if (asset.type != CodeAsset.type) continue;
+    if (!asset.isCodeAsset) continue;
     _groupCodeAssetsByFilename(
       CodeAsset.fromEncoded(asset),
       fileNameToEncodedAssetId,
@@ -136,7 +136,7 @@ Future<ValidationErrors> _validateCodeAssetBuildOrLinkOutput(
   final fileNameToEncodedAssetId = <String, Set<String>>{};
 
   for (final asset in encodedAssets) {
-    if (asset.type != CodeAsset.type) continue;
+    if (!asset.isCodeAsset) continue;
     final syntaxErrors = _validateCodeAssetSyntax(asset);
     if (syntaxErrors.isNotEmpty) {
       errors.addAll(syntaxErrors);
@@ -158,7 +158,7 @@ Future<ValidationErrors> _validateCodeAssetBuildOrLinkOutput(
   }
 
   for (final asset in encodedAssetsForLinking) {
-    if (asset.type != CodeAsset.type) continue;
+    if (!asset.isCodeAsset) continue;
     final syntaxErrors = _validateCodeAssetSyntax(asset);
     if (syntaxErrors.isNotEmpty) {
       errors.addAll(syntaxErrors);
@@ -179,7 +179,7 @@ Future<ValidationErrors> _validateCodeAssetBuildOrLinkOutput(
 }
 
 ValidationErrors _validateCodeAssetSyntax(EncodedAsset encodedAsset) {
-  if (encodedAsset.type != CodeAsset.type) {
+  if (!encodedAsset.isCodeAsset) {
     return [];
   }
   final syntaxNode = syntax.NativeCodeAssetEncoding.fromJson(

--- a/pkgs/native_assets_cli/lib/src/data_assets/config.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/config.dart
@@ -80,8 +80,8 @@ extension AddDataAssetsDirectory on BuildOutputBuilder {
 
 /// Extension to the [HookConfig] providing access to configuration specific
 /// to data assets.
-extension CodeAssetHookConfig on HookConfig {
-  bool get buildDataAssets => buildAssetTypes.contains(DataAsset.type);
+extension DataAssetHookConfig on HookConfig {
+  bool get buildDataAssets => buildAssetTypes.contains(DataAssetType.type);
 }
 
 /// Extension to initialize data specific configuration on link/build inputs.
@@ -96,9 +96,8 @@ extension DataAssetLinkInput on LinkInputAssets {
   // then the linker script has to add those files as dependencies via
   // [LinkOutput.addDependency] to ensure the linker script will be re-run if
   // the content of the files changes.
-  Iterable<DataAsset> get data => encodedAssets
-      .where((e) => e.type == DataAsset.type)
-      .map(DataAsset.fromEncoded);
+  Iterable<DataAsset> get data =>
+      encodedAssets.where((e) => e.isDataAsset).map(DataAsset.fromEncoded);
 }
 
 /// Build output extension for data assets.
@@ -148,7 +147,7 @@ extension type DataAssetLinkOutputBuilderAdd(
 extension DataAssetBuildOutput on BuildOutputAssets {
   List<DataAsset> get data =>
       encodedAssets
-          .where((asset) => asset.type == DataAsset.type)
+          .where((asset) => asset.isDataAsset)
           .map<DataAsset>(DataAsset.fromEncoded)
           .toList();
 }
@@ -157,7 +156,7 @@ extension DataAssetBuildOutput on BuildOutputAssets {
 extension DataAssetLinkOutput on LinkOutputAssets {
   List<DataAsset> get data =>
       encodedAssets
-          .where((asset) => asset.type == DataAsset.type)
+          .where((asset) => asset.isDataAsset)
           .map<DataAsset>(DataAsset.fromEncoded)
           .toList();
 }

--- a/pkgs/native_assets_cli/lib/src/data_assets/data_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/data_asset.dart
@@ -42,7 +42,7 @@ final class DataAsset {
 
   /// Constructs a [DataAsset] from an [EncodedAsset].
   factory DataAsset.fromEncoded(EncodedAsset asset) {
-    assert(asset.type == DataAsset.type);
+    assert(asset.isDataAsset);
     final syntaxNode = syntax.DataAssetEncoding.fromJson(
       asset.encoding,
       path: asset.jsonPath ?? [],
@@ -73,11 +73,21 @@ final class DataAsset {
       name: name,
       package: package,
     );
-    return EncodedAsset(DataAsset.type, encoding.json);
+    return EncodedAsset(DataAssetType.type, encoding.json);
   }
 
   @override
   String toString() => 'DataAsset(${encode().encoding})';
+}
 
+extension DataAssetType on DataAsset {
+  // TODO(https://github.com/dart-lang/native/issues/2132): Change to be
+  // namespaced by package name. (We'll temporarily need to support both the
+  // old a new type.)
   static const String type = 'data';
+}
+
+extension EncodedDataAsset on EncodedAsset {
+  bool get isDataAsset => type == DataAssetType.type;
+  DataAsset get asDataAsset => DataAsset.fromEncoded(this);
 }

--- a/pkgs/native_assets_cli/lib/src/data_assets/extension.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/extension.dart
@@ -2,7 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../../data_assets_builder.dart';
+import '../config.dart';
+import '../encoded_asset.dart';
+import '../extension.dart';
+import 'data_asset.dart';
 import 'validation.dart';
 
 /// The protocol extension for the `hook/build.dart` and `hook/link.dart`
@@ -10,14 +13,21 @@ import 'validation.dart';
 final class DataAssetsExtension implements ProtocolExtension {
   DataAssetsExtension();
 
-  @override
-  List<String> get buildAssetTypes => [DataAsset.type];
+  static const List<String> _buildAssetTypes = [DataAssetType.type];
 
   @override
-  void setupBuildInput(BuildInputBuilder input) {}
+  void setupBuildInput(BuildInputBuilder input) {
+    _setupConfig(input);
+  }
 
   @override
-  void setupLinkInput(LinkInputBuilder input) {}
+  void setupLinkInput(LinkInputBuilder input) {
+    _setupConfig(input);
+  }
+
+  void _setupConfig(HookInputBuilder input) {
+    input.config.addBuildAssetTypes(_buildAssetTypes);
+  }
 
   @override
   Future<ValidationErrors> validateBuildInput(BuildInput input) =>

--- a/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
@@ -14,7 +14,7 @@ Future<ValidationErrors> validateDataAssetLinkInput(LinkInput input) async {
   final errors = <String>[];
   for (final asset in input.assets.encodedAssets) {
     final syntaxErrors = _validateDataAssetSyntax(asset);
-    if (asset.type != DataAsset.type) continue;
+    if (!asset.isDataAsset) continue;
     if (syntaxErrors.isNotEmpty) {
       errors.addAll(syntaxErrors);
       continue;
@@ -57,7 +57,7 @@ Future<ValidationErrors> _validateDataAssetBuildOrLinkOutput(
   final ids = <String>{};
 
   for (final asset in encodedAssets) {
-    if (asset.type != DataAsset.type) continue;
+    if (!asset.isDataAsset) continue;
     final syntaxErrors = _validateDataAssetSyntax(asset);
     if (syntaxErrors.isNotEmpty) {
       errors.addAll(syntaxErrors);
@@ -92,7 +92,7 @@ void _validateDataAsset(
 }
 
 ValidationErrors _validateDataAssetSyntax(EncodedAsset encodedAsset) {
-  if (encodedAsset.type != DataAsset.type) {
+  if (!encodedAsset.isDataAsset) {
     return [];
   }
   final syntaxNode = syntax.DataAssetEncoding.fromJson(

--- a/pkgs/native_assets_cli/lib/src/extension.dart
+++ b/pkgs/native_assets_cli/lib/src/extension.dart
@@ -17,7 +17,7 @@ typedef ValidationErrors = List<String>;
 /// 2. validate syntactic and semantic constraints.
 abstract interface class ProtocolExtension {
   /// The [HookConfig.buildAssetTypes] this extension adds.
-  List<String> get buildAssetTypes;
+  // List<String> get buildAssetTypes;
 
   /// Setup the [BuildConfig] for this extension.
   void setupBuildInput(BuildInputBuilder input);

--- a/pkgs/native_assets_cli/test/api/build_test.dart
+++ b/pkgs/native_assets_cli/test/api/build_test.dart
@@ -39,7 +39,6 @@ void main() async {
         outputDirectory: outDirUri,
         outputDirectoryShared: outputDirectoryShared,
       )
-      ..config.setupShared(buildAssetTypes: ['foo'])
       ..config.setupBuild(linkingEnabled: false);
     input = BuildInput(inputBuilder.json);
 

--- a/pkgs/native_assets_cli/test/build_input_test.dart
+++ b/pkgs/native_assets_cli/test/build_input_test.dart
@@ -68,7 +68,7 @@ void main() async {
             outputDirectory: outDirUri,
             outputDirectoryShared: outputDirectoryShared,
           )
-          ..config.setupShared(buildAssetTypes: ['my-asset-type'])
+          ..config.addBuildAssetTypes(['my-asset-type'])
           ..config.setupBuild(linkingEnabled: false)
           ..setupBuildInput(metadata: metadata);
     final input = BuildInput(inputBuilder.json);

--- a/pkgs/native_assets_cli/test/code_assets/config_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/config_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/src/code_assets/code_asset.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';
@@ -141,20 +142,21 @@ void main() async {
             outputDirectoryShared: outputDirectoryShared,
           )
           ..config.setupBuild(linkingEnabled: false)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: OS.android,
-            targetArchitecture: Architecture.arm64,
-            android: AndroidCodeConfig(targetNdkApi: 30),
-            linkModePreference: LinkModePreference.preferStatic,
-            cCompiler: CCompilerConfig(
-              compiler: fakeClang,
-              linker: fakeLd,
-              archiver: fakeAr,
-              windows: WindowsCCompilerConfig(
-                developerCommandPrompt: DeveloperCommandPrompt(
-                  script: fakeVcVars,
-                  arguments: ['arg0', 'arg1'],
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: OS.android,
+              targetArchitecture: Architecture.arm64,
+              android: AndroidCodeConfig(targetNdkApi: 30),
+              linkModePreference: LinkModePreference.preferStatic,
+              cCompiler: CCompilerConfig(
+                compiler: fakeClang,
+                linker: fakeLd,
+                archiver: fakeAr,
+                windows: WindowsCCompilerConfig(
+                  developerCommandPrompt: DeveloperCommandPrompt(
+                    script: fakeVcVars,
+                    arguments: ['arg0', 'arg1'],
+                  ),
                 ),
               ),
             ),
@@ -171,7 +173,7 @@ void main() async {
       expect(input.packageRoot, packageRootUri);
       expect(input.outputDirectoryShared, outputDirectoryShared);
       expect(input.config.linkingEnabled, false);
-      expect(input.config.buildAssetTypes, [CodeAsset.type]);
+      expect(input.config.buildAssetTypes, [CodeAssetType.type]);
       expectCorrectCodeConfig(input.config.code, targetOS: targetOS);
     }
   });
@@ -187,20 +189,21 @@ void main() async {
             outputDirectoryShared: outputDirectoryShared,
           )
           ..setupLink(assets: assets, recordedUsesFile: null)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: OS.android,
-            targetArchitecture: Architecture.arm64,
-            android: AndroidCodeConfig(targetNdkApi: 30),
-            linkModePreference: LinkModePreference.preferStatic,
-            cCompiler: CCompilerConfig(
-              compiler: fakeClang,
-              linker: fakeLd,
-              archiver: fakeAr,
-              windows: WindowsCCompilerConfig(
-                developerCommandPrompt: DeveloperCommandPrompt(
-                  script: fakeVcVars,
-                  arguments: ['arg0', 'arg1'],
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: OS.android,
+              targetArchitecture: Architecture.arm64,
+              android: AndroidCodeConfig(targetNdkApi: 30),
+              linkModePreference: LinkModePreference.preferStatic,
+              cCompiler: CCompilerConfig(
+                compiler: fakeClang,
+                linker: fakeLd,
+                archiver: fakeAr,
+                windows: WindowsCCompilerConfig(
+                  developerCommandPrompt: DeveloperCommandPrompt(
+                    script: fakeVcVars,
+                    arguments: ['arg0', 'arg1'],
+                  ),
                 ),
               ),
             ),
@@ -223,7 +226,7 @@ void main() async {
       expect(input.packageName, packageName);
       expect(input.packageRoot, packageRootUri);
       expect(input.outputDirectoryShared, outputDirectoryShared);
-      expect(input.config.buildAssetTypes, [CodeAsset.type]);
+      expect(input.config.buildAssetTypes, [CodeAssetType.type]);
       expectCorrectCodeConfig(input.config.code, targetOS: targetOS);
     }
   });

--- a/pkgs/native_assets_cli/test/code_assets/validation_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/validation_test.dart
@@ -50,13 +50,13 @@ void main() {
     LinkModePreference linkModePreference = LinkModePreference.dynamic,
   }) {
     final builder =
-        makeBuildInputBuilder()
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
+        makeBuildInputBuilder()..addExtension(
+          CodeAssetExtension(
             targetOS: OS.linux,
             targetArchitecture: Architecture.arm64,
             linkModePreference: linkModePreference,
-          );
+          ),
+        );
     return BuildInput(builder.json);
   }
 
@@ -262,9 +262,8 @@ void main() {
     for (final propertyKey in ['target_version', 'target_sdk']) {
       test('Missing targetIOSVersion', () async {
         final builder =
-            makeBuildInputBuilder()
-              ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-              ..config.setupCode(
+            makeBuildInputBuilder()..addExtension(
+              CodeAssetExtension(
                 targetOS: OS.iOS,
                 targetArchitecture: Architecture.arm64,
                 linkModePreference: LinkModePreference.dynamic,
@@ -272,7 +271,8 @@ void main() {
                   targetSdk: IOSSdk.iPhoneOS,
                   targetVersion: 123,
                 ),
-              );
+              ),
+            );
         traverseJson<Map<String, Object?>>(builder.json, [
           'config',
           'code',
@@ -295,14 +295,14 @@ void main() {
 
     test('Missing targetAndroidNdkApi', () async {
       final builder =
-          makeBuildInputBuilder()
-            ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-            ..config.setupCode(
+          makeBuildInputBuilder()..addExtension(
+            CodeAssetExtension(
               targetOS: OS.android,
               targetArchitecture: Architecture.arm64,
               linkModePreference: LinkModePreference.dynamic,
               android: AndroidCodeConfig(targetNdkApi: 123),
-            );
+            ),
+          );
       traverseJson<Map<String, Object?>>(builder.json, [
         'config',
         'code',
@@ -321,14 +321,14 @@ void main() {
 
     test('Missing config.code.macos', () async {
       final builder =
-          makeBuildInputBuilder()
-            ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-            ..config.setupCode(
+          makeBuildInputBuilder()..addExtension(
+            CodeAssetExtension(
               targetOS: OS.macOS,
               targetArchitecture: Architecture.arm64,
               linkModePreference: LinkModePreference.dynamic,
               macOS: MacOSCodeConfig(targetVersion: 123),
-            );
+            ),
+          );
 
       traverseJson<Map<String, Object?>>(builder.json, [
         'config',
@@ -358,9 +358,8 @@ void main() {
     test('CCompilerConfig validation', () async {
       final nonExistent = outDirUri.resolve('foo baz');
       final builder =
-          makeBuildInputBuilder()
-            ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-            ..config.setupCode(
+          makeBuildInputBuilder()..addExtension(
+            CodeAssetExtension(
               targetOS: OS.windows,
               targetArchitecture: Architecture.x64,
               linkModePreference: LinkModePreference.dynamic,
@@ -375,7 +374,8 @@ void main() {
                   ),
                 ),
               ),
-            );
+            ),
+          );
       final errors = await validateCodeAssetBuildInput(
         BuildInput(builder.json),
       );

--- a/pkgs/native_assets_cli/test/data_assets/validation_test.dart
+++ b/pkgs/native_assets_cli/test/data_assets/validation_test.dart
@@ -41,7 +41,7 @@ void main() {
             outputDirectoryShared: outDirSharedUri,
           )
           ..config.setupBuild(linkingEnabled: false)
-          ..config.setupShared(buildAssetTypes: [DataAsset.type]);
+          ..addExtension(DataAssetsExtension());
     return BuildInput(inputBuilder.json);
   }
 

--- a/pkgs/native_assets_cli/test/example/local_asset_test.dart
+++ b/pkgs/native_assets_cli/test/example/local_asset_test.dart
@@ -47,16 +47,17 @@ void main() async {
             outputDirectoryShared: outputDirectoryShared,
           )
           ..config.setupBuild(linkingEnabled: false)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: targetOS,
-            macOS:
-                targetOS == OS.macOS
-                    ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                    : null,
-            targetArchitecture: Architecture.current,
-            linkModePreference: LinkModePreference.dynamic,
-            cCompiler: cCompiler,
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: targetOS,
+              macOS:
+                  targetOS == OS.macOS
+                      ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+                      : null,
+              targetArchitecture: Architecture.current,
+              linkModePreference: LinkModePreference.dynamic,
+              cCompiler: cCompiler,
+            ),
           );
 
     final buildInputUri = testTempUri.resolve('build_input.json');

--- a/pkgs/native_assets_cli/test/example/native_add_library_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_library_test.dart
@@ -47,16 +47,17 @@ void main() async {
             outputDirectoryShared: outputDirectoryShared,
           )
           ..config.setupBuild(linkingEnabled: false)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: OS.current,
-            macOS:
-                targetOS == OS.macOS
-                    ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                    : null,
-            targetArchitecture: Architecture.current,
-            linkModePreference: LinkModePreference.dynamic,
-            cCompiler: cCompiler,
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: OS.current,
+              macOS:
+                  targetOS == OS.macOS
+                      ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+                      : null,
+              targetArchitecture: Architecture.current,
+              linkModePreference: LinkModePreference.dynamic,
+              cCompiler: cCompiler,
+            ),
           );
 
     final buildInputUri = testTempUri.resolve('build_input.json');

--- a/pkgs/native_assets_cli/test/example/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_dynamic_linking_test.dart
@@ -51,16 +51,17 @@ void main() async {
             outputDirectoryShared: outputDirectoryShared,
           )
           ..config.setupBuild(linkingEnabled: false)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: targetOS,
-            macOS:
-                targetOS == OS.macOS
-                    ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                    : null,
-            targetArchitecture: Architecture.current,
-            linkModePreference: LinkModePreference.dynamic,
-            cCompiler: cCompiler,
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: targetOS,
+              macOS:
+                  targetOS == OS.macOS
+                      ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+                      : null,
+              targetArchitecture: Architecture.current,
+              linkModePreference: LinkModePreference.dynamic,
+              cCompiler: cCompiler,
+            ),
           );
 
     final buildInputUri = testTempUri.resolve('build_input.json');

--- a/pkgs/native_assets_cli/test/helpers.dart
+++ b/pkgs/native_assets_cli/test/helpers.dart
@@ -144,13 +144,13 @@ extension on String {
 extension AssetIterable on Iterable<EncodedAsset> {
   Future<bool> allExist() async {
     for (final encodedAsset in this) {
-      if (encodedAsset.type == DataAsset.type) {
-        final dataAsset = DataAsset.fromEncoded(encodedAsset);
+      if (encodedAsset.isDataAsset) {
+        final dataAsset = encodedAsset.asDataAsset;
         if (!await dataAsset.file.fileSystemEntity.exists()) {
           return false;
         }
-      } else if (encodedAsset.type == CodeAsset.type) {
-        final codeAsset = CodeAsset.fromEncoded(encodedAsset);
+      } else if (encodedAsset.isCodeAsset) {
+        final codeAsset = encodedAsset.asCodeAsset;
         if (!await (codeAsset.file?.fileSystemEntity.exists() ?? true)) {
           return false;
         }

--- a/pkgs/native_assets_cli/test/link_input_test.dart
+++ b/pkgs/native_assets_cli/test/link_input_test.dart
@@ -54,9 +54,7 @@ void main() async {
             outputDirectory: outDirUri,
             outputDirectoryShared: outputDirectoryShared,
           )
-          ..config.setupShared(
-            buildAssetTypes: ['asset-type-1', 'asset-type-2'],
-          )
+          ..config.addBuildAssetTypes(['asset-type-1', 'asset-type-2'])
           ..setupLink(assets: assets, recordedUsesFile: null);
     final input = LinkInput(inputBuilder.json);
 

--- a/pkgs/native_assets_cli/test/validation_test.dart
+++ b/pkgs/native_assets_cli/test/validation_test.dart
@@ -39,7 +39,6 @@ void main() {
             outputDirectory: outDirUri,
             outputDirectoryShared: outDirSharedUri,
           )
-          ..config.setupShared(buildAssetTypes: ['my-asset-type'])
           ..config.setupBuild(linkingEnabled: false);
     return BuildInput(inputBuilder.json);
   }

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -121,7 +121,7 @@ class CBuilder extends CTool implements Builder {
   }) async {
     if (!input.config.buildCodeAssets) {
       logger?.info(
-        'buildAssetTypes did not contain "${CodeAsset.type}", '
+        'config.buildAssetTypes did not contain CodeAssets, '
         'skipping CodeAsset $assetName build.',
       );
       return;

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
@@ -40,16 +40,17 @@ void main() {
             outputDirectoryShared: tempUri2,
           )
           ..config.setupBuild(linkingEnabled: false)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: targetOS,
-            macOS:
-                targetOS == OS.macOS
-                    ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                    : null,
-            targetArchitecture: Architecture.current,
-            linkModePreference: LinkModePreference.dynamic,
-            cCompiler: cCompiler,
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: targetOS,
+              macOS:
+                  targetOS == OS.macOS
+                      ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+                      : null,
+              targetArchitecture: Architecture.current,
+              linkModePreference: LinkModePreference.dynamic,
+              cCompiler: cCompiler,
+            ),
           );
 
     final buildInput = BuildInput(buildInputBuilder.json);

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -153,16 +153,17 @@ Future<Uri> buildLib(
           outputDirectoryShared: tempUriShared,
         )
         ..config.setupBuild(linkingEnabled: false)
-        ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-        ..config.setupCode(
-          targetOS: OS.android,
-          targetArchitecture: targetArchitecture,
-          cCompiler: cCompiler,
-          android: AndroidCodeConfig(targetNdkApi: androidNdkApi),
-          linkModePreference:
-              linkMode == DynamicLoadingBundled()
-                  ? LinkModePreference.dynamic
-                  : LinkModePreference.static,
+        ..addExtension(
+          CodeAssetExtension(
+            targetOS: OS.android,
+            targetArchitecture: targetArchitecture,
+            cCompiler: cCompiler,
+            android: AndroidCodeConfig(targetNdkApi: androidNdkApi),
+            linkModePreference:
+                linkMode == DynamicLoadingBundled()
+                    ? LinkModePreference.dynamic
+                    : LinkModePreference.static,
+          ),
         );
 
   final buildInput = BuildInput(buildInputBuilder.json);

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -81,19 +81,20 @@ void main() {
                         outputDirectoryShared: tempUri2,
                       )
                       ..config.setupBuild(linkingEnabled: false)
-                      ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-                      ..config.setupCode(
-                        targetOS: OS.iOS,
-                        targetArchitecture: target,
-                        linkModePreference:
-                            linkMode == DynamicLoadingBundled()
-                                ? LinkModePreference.dynamic
-                                : LinkModePreference.static,
-                        iOS: IOSCodeConfig(
-                          targetSdk: targetIOSSdk,
-                          targetVersion: flutteriOSHighestBestEffort,
+                      ..addExtension(
+                        CodeAssetExtension(
+                          targetOS: OS.iOS,
+                          targetArchitecture: target,
+                          linkModePreference:
+                              linkMode == DynamicLoadingBundled()
+                                  ? LinkModePreference.dynamic
+                                  : LinkModePreference.static,
+                          iOS: IOSCodeConfig(
+                            targetSdk: targetIOSSdk,
+                            targetVersion: flutteriOSHighestBestEffort,
+                          ),
+                          cCompiler: cCompiler,
                         ),
-                        cCompiler: cCompiler,
                       );
 
                 final buildInput = BuildInput(buildInputBuilder.json);
@@ -243,19 +244,20 @@ Future<Uri> buildLib(
           outputDirectoryShared: tempUri2,
         )
         ..config.setupBuild(linkingEnabled: false)
-        ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-        ..config.setupCode(
-          targetOS: OS.iOS,
-          targetArchitecture: targetArchitecture,
-          linkModePreference:
-              linkMode == DynamicLoadingBundled()
-                  ? LinkModePreference.dynamic
-                  : LinkModePreference.static,
-          iOS: IOSCodeConfig(
-            targetSdk: IOSSdk.iPhoneOS,
-            targetVersion: targetIOSVersion,
+        ..addExtension(
+          CodeAssetExtension(
+            targetOS: OS.iOS,
+            targetArchitecture: targetArchitecture,
+            linkModePreference:
+                linkMode == DynamicLoadingBundled()
+                    ? LinkModePreference.dynamic
+                    : LinkModePreference.static,
+            iOS: IOSCodeConfig(
+              targetSdk: IOSSdk.iPhoneOS,
+              targetVersion: targetIOSVersion,
+            ),
+            cCompiler: cCompiler,
           ),
-          cCompiler: cCompiler,
         );
 
   final buildInput = BuildInput(buildInputBuilder.json);

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -53,15 +53,16 @@ void main() {
                 outputDirectoryShared: tempUri2,
               )
               ..config.setupBuild(linkingEnabled: false)
-              ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-              ..config.setupCode(
-                targetOS: OS.linux,
-                targetArchitecture: target,
-                linkModePreference:
-                    linkMode == DynamicLoadingBundled()
-                        ? LinkModePreference.dynamic
-                        : LinkModePreference.static,
-                cCompiler: cCompiler,
+              ..addExtension(
+                CodeAssetExtension(
+                  targetOS: OS.linux,
+                  targetArchitecture: target,
+                  linkModePreference:
+                      linkMode == DynamicLoadingBundled()
+                          ? LinkModePreference.dynamic
+                          : LinkModePreference.static,
+                  cCompiler: cCompiler,
+                ),
               );
 
         final buildInput = BuildInput(buildInputBuilder.json);

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -65,16 +65,19 @@ void main() {
                     outputDirectoryShared: tempUri2,
                   )
                   ..config.setupBuild(linkingEnabled: false)
-                  ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-                  ..config.setupCode(
-                    targetOS: OS.macOS,
-                    targetArchitecture: target,
-                    linkModePreference:
-                        linkMode == DynamicLoadingBundled()
-                            ? LinkModePreference.dynamic
-                            : LinkModePreference.static,
-                    cCompiler: cCompiler,
-                    macOS: MacOSCodeConfig(targetVersion: defaultMacOSVersion),
+                  ..addExtension(
+                    CodeAssetExtension(
+                      targetOS: OS.macOS,
+                      targetArchitecture: target,
+                      linkModePreference:
+                          linkMode == DynamicLoadingBundled()
+                              ? LinkModePreference.dynamic
+                              : LinkModePreference.static,
+                      cCompiler: cCompiler,
+                      macOS: MacOSCodeConfig(
+                        targetVersion: defaultMacOSVersion,
+                      ),
+                    ),
                   );
             final buildInput = BuildInput(buildInputBuilder.json);
             final buildOutput = BuildOutputBuilder();
@@ -167,16 +170,17 @@ Future<Uri> buildLib(
           outputDirectoryShared: tempUri2,
         )
         ..config.setupBuild(linkingEnabled: false)
-        ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-        ..config.setupCode(
-          targetOS: OS.macOS,
-          targetArchitecture: targetArchitecture,
-          linkModePreference:
-              linkMode == DynamicLoadingBundled()
-                  ? LinkModePreference.dynamic
-                  : LinkModePreference.static,
-          macOS: MacOSCodeConfig(targetVersion: targetMacOSVersion),
-          cCompiler: cCompiler,
+        ..addExtension(
+          CodeAssetExtension(
+            targetOS: OS.macOS,
+            targetArchitecture: targetArchitecture,
+            linkModePreference:
+                linkMode == DynamicLoadingBundled()
+                    ? LinkModePreference.dynamic
+                    : LinkModePreference.static,
+            macOS: MacOSCodeConfig(targetVersion: targetMacOSVersion),
+            cCompiler: cCompiler,
+          ),
         );
 
   final buildInput = BuildInput(buildInputBuilder.json);

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -95,15 +95,16 @@ void main() async {
                   outputDirectoryShared: tempUri2,
                 )
                 ..config.setupBuild(linkingEnabled: false)
-                ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-                ..config.setupCode(
-                  targetOS: OS.windows,
-                  targetArchitecture: target,
-                  linkModePreference:
-                      linkMode == DynamicLoadingBundled()
-                          ? LinkModePreference.dynamic
-                          : LinkModePreference.static,
-                  cCompiler: await (compilers[compiler]!)(),
+                ..addExtension(
+                  CodeAssetExtension(
+                    targetOS: OS.windows,
+                    targetArchitecture: target,
+                    linkModePreference:
+                        linkMode == DynamicLoadingBundled()
+                            ? LinkModePreference.dynamic
+                            : LinkModePreference.static,
+                    cCompiler: await (compilers[compiler]!)(),
+                  ),
                 );
 
           final buildInput = BuildInput(buildInputBuilder.json);

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -59,14 +59,15 @@ void main() {
                 outputDirectoryShared: tempUri2,
               )
               ..config.setupBuild(linkingEnabled: false)
-              ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-              ..config.setupCode(
-                targetOS: targetOS,
-                macOS: macOSConfig,
-                targetArchitecture: Architecture.current,
-                // Ignored by executables.
-                linkModePreference: LinkModePreference.dynamic,
-                cCompiler: cCompiler,
+              ..addExtension(
+                CodeAssetExtension(
+                  targetOS: targetOS,
+                  macOS: macOSConfig,
+                  targetArchitecture: Architecture.current,
+                  // Ignored by executables.
+                  linkModePreference: LinkModePreference.dynamic,
+                  cCompiler: cCompiler,
+                ),
               );
 
         final buildInput = BuildInput(buildInputBuilder.json);
@@ -141,16 +142,15 @@ void main() {
                 outputDirectoryShared: tempUri2,
               )
               ..config.setupBuild(linkingEnabled: false);
-        buildInputBuilder.config.setupShared(
-          buildAssetTypes: [if (buildCodeAssets) CodeAsset.type],
-        );
         if (buildCodeAssets) {
-          buildInputBuilder.config.setupCode(
-            targetOS: targetOS,
-            macOS: macOSConfig,
-            targetArchitecture: Architecture.current,
-            linkModePreference: LinkModePreference.dynamic,
-            cCompiler: cCompiler,
+          buildInputBuilder.addExtension(
+            CodeAssetExtension(
+              targetOS: targetOS,
+              macOS: macOSConfig,
+              targetArchitecture: Architecture.current,
+              linkModePreference: LinkModePreference.dynamic,
+              cCompiler: cCompiler,
+            ),
           );
         }
 
@@ -253,14 +253,15 @@ void main() {
             outputDirectoryShared: tempUri2,
           )
           ..config.setupBuild(linkingEnabled: false)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: targetOS,
-            macOS: macOSConfig,
-            targetArchitecture: Architecture.current,
-            // Ignored by executables.
-            linkModePreference: LinkModePreference.dynamic,
-            cCompiler: cCompiler,
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: targetOS,
+              macOS: macOSConfig,
+              targetArchitecture: Architecture.current,
+              // Ignored by executables.
+              linkModePreference: LinkModePreference.dynamic,
+              cCompiler: cCompiler,
+            ),
           );
     final buildInput = BuildInput(buildInputBuilder.json);
     final buildOutput = BuildOutputBuilder();
@@ -319,14 +320,15 @@ void main() {
             outputDirectoryShared: tempUri2,
           )
           ..config.setupBuild(linkingEnabled: false)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: targetOS,
-            macOS: macOSConfig,
-            targetArchitecture: Architecture.current,
-            // Ignored by executables.
-            linkModePreference: LinkModePreference.dynamic,
-            cCompiler: cCompiler,
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: targetOS,
+              macOS: macOSConfig,
+              targetArchitecture: Architecture.current,
+              // Ignored by executables.
+              linkModePreference: LinkModePreference.dynamic,
+              cCompiler: cCompiler,
+            ),
           );
 
     final buildInput = BuildInput(buildInputBuilder.json);
@@ -377,14 +379,15 @@ void main() {
             outputDirectoryShared: tempUri2,
           )
           ..config.setupBuild(linkingEnabled: false)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: targetOS,
-            macOS: macOSConfig,
-            targetArchitecture: Architecture.current,
-            // Ignored by executables.
-            linkModePreference: LinkModePreference.dynamic,
-            cCompiler: cCompiler,
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: targetOS,
+              macOS: macOSConfig,
+              targetArchitecture: Architecture.current,
+              // Ignored by executables.
+              linkModePreference: LinkModePreference.dynamic,
+              cCompiler: cCompiler,
+            ),
           );
 
     final buildInput = BuildInput(buildInputBuilder.json);
@@ -446,14 +449,15 @@ void main() {
             outputDirectoryShared: tempUri2,
           )
           ..config.setupBuild(linkingEnabled: false)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: targetOS,
-            macOS: macOSConfig,
-            targetArchitecture: Architecture.current,
-            // Ignored by executables.
-            linkModePreference: LinkModePreference.dynamic,
-            cCompiler: cCompiler,
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: targetOS,
+              macOS: macOSConfig,
+              targetArchitecture: Architecture.current,
+              // Ignored by executables.
+              linkModePreference: LinkModePreference.dynamic,
+              cCompiler: cCompiler,
+            ),
           );
     final buildInput = BuildInput(buildInputBuilder.json);
     final buildOutput = BuildOutputBuilder();
@@ -514,14 +518,15 @@ void main() {
             outputDirectoryShared: tempUri2,
           )
           ..config.setupBuild(linkingEnabled: false)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: targetOS,
-            macOS: macOSConfig,
-            targetArchitecture: Architecture.current,
-            // Ignored by executables.
-            linkModePreference: LinkModePreference.dynamic,
-            cCompiler: cCompiler,
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: targetOS,
+              macOS: macOSConfig,
+              targetArchitecture: Architecture.current,
+              // Ignored by executables.
+              linkModePreference: LinkModePreference.dynamic,
+              cCompiler: cCompiler,
+            ),
           );
     final buildInput = BuildInput(buildInputBuilder.json);
     final buildOutput = BuildOutputBuilder();
@@ -600,14 +605,15 @@ void main() {
             outputDirectoryShared: tempUri2,
           )
           ..config.setupBuild(linkingEnabled: false)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: targetOS,
-            macOS: macOSConfig,
-            targetArchitecture: Architecture.current,
-            // Ignored by executables.
-            linkModePreference: LinkModePreference.dynamic,
-            cCompiler: cCompiler,
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: targetOS,
+              macOS: macOSConfig,
+              targetArchitecture: Architecture.current,
+              // Ignored by executables.
+              linkModePreference: LinkModePreference.dynamic,
+              cCompiler: cCompiler,
+            ),
           );
     final buildInput = BuildInput(buildInputBuilder.json);
     final buildOutput = BuildOutputBuilder();
@@ -703,17 +709,18 @@ Future<void> testDefines({
           outputDirectoryShared: tempUri2,
         )
         ..config.setupBuild(linkingEnabled: false)
-        ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-        ..config.setupCode(
-          targetOS: targetOS,
-          macOS:
-              targetOS == OS.macOS
-                  ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                  : null,
-          targetArchitecture: Architecture.current,
-          // Ignored by executables.
-          linkModePreference: LinkModePreference.dynamic,
-          cCompiler: cCompiler,
+        ..addExtension(
+          CodeAssetExtension(
+            targetOS: targetOS,
+            macOS:
+                targetOS == OS.macOS
+                    ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+                    : null,
+            targetArchitecture: Architecture.current,
+            // Ignored by executables.
+            linkModePreference: LinkModePreference.dynamic,
+            cCompiler: cCompiler,
+          ),
         );
 
   final buildInput = BuildInput(buildInputBuilder.json);

--- a/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
@@ -53,28 +53,29 @@ void main() {
             outputDirectoryShared: tempUri2,
           )
           ..config.setupBuild(linkingEnabled: false)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: targetOS,
-            macOS:
-                targetOS == OS.macOS
-                    ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                    : null,
-            targetArchitecture: Architecture.current,
-            linkModePreference: LinkModePreference.dynamic,
-            cCompiler: CCompilerConfig(
-              archiver: ar,
-              compiler: cc,
-              linker: ld,
-              windows:
-                  targetOS == OS.windows
-                      ? WindowsCCompilerConfig(
-                        developerCommandPrompt: DeveloperCommandPrompt(
-                          script: envScript!,
-                          arguments: [],
-                        ),
-                      )
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: targetOS,
+              macOS:
+                  targetOS == OS.macOS
+                      ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
                       : null,
+              targetArchitecture: Architecture.current,
+              linkModePreference: LinkModePreference.dynamic,
+              cCompiler: CCompilerConfig(
+                archiver: ar,
+                compiler: cc,
+                linker: ld,
+                windows:
+                    targetOS == OS.windows
+                        ? WindowsCCompilerConfig(
+                          developerCommandPrompt: DeveloperCommandPrompt(
+                            script: envScript!,
+                            arguments: [],
+                          ),
+                        )
+                        : null,
+              ),
             ),
           );
     final buildInput = BuildInput(buildInputBuilder.json);
@@ -107,12 +108,13 @@ void main() {
             outputDirectory: tempUri,
           )
           ..config.setupBuild(linkingEnabled: false)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: OS.windows,
-            targetArchitecture: Architecture.arm64,
-            linkModePreference: LinkModePreference.dynamic,
-            cCompiler: cCompiler,
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: OS.windows,
+              targetArchitecture: Architecture.arm64,
+              linkModePreference: LinkModePreference.dynamic,
+              cCompiler: cCompiler,
+            ),
           );
 
     final buildInput = BuildInput(buildInputBuilder.json);

--- a/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
@@ -44,16 +44,17 @@ void main() {
             outputDirectoryShared: tempUri2,
           )
           ..config.setupBuild(linkingEnabled: false)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: targetOS,
-            macOS:
-                targetOS == OS.macOS
-                    ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                    : null,
-            targetArchitecture: Architecture.current,
-            linkModePreference: LinkModePreference.dynamic,
-            cCompiler: cCompiler,
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: targetOS,
+              macOS:
+                  targetOS == OS.macOS
+                      ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+                      : null,
+              targetArchitecture: Architecture.current,
+              linkModePreference: LinkModePreference.dynamic,
+              cCompiler: cCompiler,
+            ),
           );
 
     final buildInput = BuildInput(buildInputBuilder.json);

--- a/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
+++ b/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
@@ -36,12 +36,13 @@ Future<Uri> buildTestArchive(
           outputDirectoryShared: tempUri2,
         )
         ..config.setupBuild(linkingEnabled: false)
-        ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-        ..config.setupCode(
-          targetOS: os,
-          targetArchitecture: architecture,
-          linkModePreference: LinkModePreference.dynamic,
-          cCompiler: cCompiler,
+        ..addExtension(
+          CodeAssetExtension(
+            targetOS: os,
+            targetArchitecture: architecture,
+            linkModePreference: LinkModePreference.dynamic,
+            cCompiler: cCompiler,
+          ),
         );
 
   final buildInput = BuildInput(buildInputBuilder.json);

--- a/pkgs/native_toolchain_c/test/clinker/objects_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/objects_test.dart
@@ -41,12 +41,13 @@ Future<void> main() async {
             outputDirectoryShared: tempUri2,
           )
           ..setupLink(assets: [], recordedUsesFile: null)
-          ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-          ..config.setupCode(
-            targetOS: os,
-            targetArchitecture: architecture,
-            linkModePreference: LinkModePreference.dynamic,
-            cCompiler: cCompiler,
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: os,
+              targetArchitecture: architecture,
+              linkModePreference: LinkModePreference.dynamic,
+              cCompiler: cCompiler,
+            ),
           );
 
     final linkInput = LinkInput(linkInputBuilder.json);

--- a/pkgs/native_toolchain_c/test/clinker/throws_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/throws_test.dart
@@ -30,12 +30,13 @@ Future<void> main() async {
               outputDirectory: tempUri,
             )
             ..setupLink(assets: [], recordedUsesFile: null)
-            ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-            ..config.setupCode(
-              targetOS: os,
-              targetArchitecture: Architecture.x64,
-              linkModePreference: LinkModePreference.dynamic,
-              cCompiler: cCompiler,
+            ..addExtension(
+              CodeAssetExtension(
+                targetOS: os,
+                targetArchitecture: Architecture.x64,
+                linkModePreference: LinkModePreference.dynamic,
+                cCompiler: cCompiler,
+              ),
             );
 
       final linkHookInput = LinkInput(linkInputBuilder.json);

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
@@ -73,12 +73,13 @@ Future<void> runTests(List<Architecture> architectures) async {
                   outputDirectoryShared: tempUri2,
                 )
                 ..setupLink(assets: [], recordedUsesFile: null)
-                ..config.setupShared(buildAssetTypes: [CodeAsset.type])
-                ..config.setupCode(
-                  targetOS: os,
-                  targetArchitecture: architecture,
-                  linkModePreference: LinkModePreference.dynamic,
-                  cCompiler: cCompiler,
+                ..addExtension(
+                  CodeAssetExtension(
+                    targetOS: os,
+                    targetArchitecture: architecture,
+                    linkModePreference: LinkModePreference.dynamic,
+                    cCompiler: cCompiler,
+                  ),
                 );
 
           final linkInput = LinkInput(linkInputBuilder.json);


### PR DESCRIPTION
Bug: https://github.com/dart-lang/native/issues/2132

This PR hides the asset types inside the respective extensions:

* In hooks:
  * Add extensions on `EncodedAsset` such as `isCodeAsset` to check if something is a certain asset.
  * Use the `buildCodeAssets` and `buildDataAssets` extensions everywhere.
* For `BuildInput` builders:
  * Use `setupBuildInput` from the `ProtocolExtension`s. (`ProtocolExtension.buildAssetTypes` has been made private and folded into `setupBuildInput` and `setupLinkInput`.)

This enables two things:

* Having more than one asset type per protocol, and prevent SDKs from adding in a certain asset type to the build input. (If SDKs only want to use a subset of asset types of a protocol extension, such should be configured via the constructor of protocol extension.)
* Migrating asset types, asset types can have more than one type this way. (This enables addressing https://github.com/dart-lang/native/issues/2132)

Notable cleanups

* Some tests relied on passing around an identifier for which asset types to build, this is now addressed with `enum BuildAssetType { code, data }`.