### PR TITLE
[ffigen] Fix clang warning

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 18.1.0-wip
+
+- Fix a clang warning in ObjC protocol generated bindings.
+
 ## 18.0.0
 
 - Add variable substitutions that can be used in the `headers.entry-points` to

--- a/pkgs/ffigen/lib/src/code_generator/writer.dart
+++ b/pkgs/ffigen/lib/src/code_generator/writer.dart
@@ -422,6 +422,9 @@ class Writer {
 #error "This file must be compiled with ARC enabled"
 #endif
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+
 typedef struct {
   int64_t version;
   void* (*newWaiter)(void);
@@ -473,6 +476,8 @@ id objc_retainBlock(id);
 
     s.write('''
 #undef BLOCKING_BLOCK_IMPL
+
+#pragma clang diagnostic pop
 ''');
 
     return empty ? null : s.toString();

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 18.0.0
+version: 18.1.0-wip
 description: >
   Generator for FFI bindings, using LibClang to parse C, Objective-C, and Swift
   files.

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.1.0-wip
+
+- Use ffigen 18.1.0
+
 ## 7.0.0
 
 - Use ffigen 18.0.0

--- a/pkgs/objective_c/pubspec.yaml
+++ b/pkgs/objective_c/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: objective_c
 description: 'A library to access Objective C from Flutter that acts as a support library for package:ffigen.'
-version: 7.0.0
+version: 7.1.0-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/objective_c
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aobjective_c
 

--- a/pkgs/objective_c/src/objective_c_bindings_generated.m
+++ b/pkgs/objective_c/src/objective_c_bindings_generated.m
@@ -9,6 +9,9 @@
 #error "This file must be compiled with ARC enabled"
 #endif
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+
 typedef struct {
   int64_t version;
   void* (*newWaiter)(void);
@@ -283,3 +286,5 @@ id  _ObjectiveCBindings_protocolTrampoline_c7gk2u(id target, void * sel, struct 
   return ((ProtocolTrampoline_16)((id (*)(id, SEL, SEL))objc_msgSend)(target, @selector(getDOBJCDartProtocolMethodForSelector:), sel))(sel, arg1, arg2, arg3);
 }
 #undef BLOCKING_BLOCK_IMPL
+
+#pragma clang diagnostic pop


### PR DESCRIPTION
Disable the `undeclared-selector` warning in generated ObjC code. The warning is triggered by references to the `getDOBJCDartProtocolMethodForSelector:` method, which is defined in package:objective_c, and there's no good way of importing the header that defines it.

Another approach would be to change `@selector(getDOBJCDartProtocolMethodForSelector:)` to `sel_registerName("getDOBJCDartProtocolMethodForSelector:")`. But presumably clang is doing some sort of caching or compile time evaluation of `@selector`, so `sel_registerName` would be a slight performance regression.

Fixes https://github.com/dart-lang/native/issues/2094