### PR TITLE
[native_assets_cli] `code_assets` and `data_assets` packages

### DIFF
--- a/pkgs/code_assets/CHANGELOG.md
+++ b/pkgs/code_assets/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0-wip
+
+- Initial version.

--- a/pkgs/code_assets/LICENSE
+++ b/pkgs/code_assets/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2025, the Dart project authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pkgs/code_assets/README.md
+++ b/pkgs/code_assets/README.md
@@ -1,0 +1,33 @@
+[![package:code_assets](https://github.com/dart-lang/native/actions/workflows/native.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/native.yaml)
+[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
+[![pub package](https://img.shields.io/pub/v/code_assets.svg)](https://pub.dev/packages/code_assets)
+[![package publisher](https://img.shields.io/pub/publisher/code_assets.svg)](https://pub.dev/packages/code_assets/publisher)
+
+This library contains the hook protocol specification for bundling native code
+with Dart packages.
+
+## This package is documentation only for the moment.
+
+For using this feature, please refer to `package:native_assets_cli` for now.
+In the future, we'll split up that package into here.
+
+## Status: Experimental
+
+**NOTE**: This package is currently experimental and published under the
+[labs.dart.dev](https://dart.dev/dart-team-packages) pub publisher in order to
+solicit feedback. 
+
+For packages in the labs.dart.dev publisher we generally plan to either graduate
+the package into a supported publisher (dart.dev, tools.dart.dev) after a period
+of feedback and iteration, or discontinue the package. These packages have a
+much higher expected rate of API and breaking changes.
+
+Your feedback is valuable and will help us evolve this package. 
+For bugs, please file an issue in the 
+[bug tracker](https://github.com/dart-lang/native/issues).
+For general feedback and suggestions for the native assets feature in Dart and
+Flutter, please comment in [dart-lang#50565] or [flutter#129757].
+
+[dart-lang#50565]: https://github.com/dart-lang/sdk/issues/50565
+[flutter#129757]: https://github.com/flutter/flutter/issues/129757
+

--- a/pkgs/code_assets/pubspec.yaml
+++ b/pkgs/code_assets/pubspec.yaml
@@ -2,6 +2,10 @@ name: code_assets
 version: 0.1.0-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/code_assets
 
+description: >-
+  This library contains the hook protocol specification for bundling native code
+  with Dart packages.
+
 publish_to: none
 
 environment:

--- a/pkgs/data_assets/CHANGELOG.md
+++ b/pkgs/data_assets/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0-wip
+
+- Initial version.

--- a/pkgs/data_assets/LICENSE
+++ b/pkgs/data_assets/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2025, the Dart project authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pkgs/data_assets/README.md
+++ b/pkgs/data_assets/README.md
@@ -1,0 +1,28 @@
+[![package:data_assets](https://github.com/dart-lang/native/actions/workflows/native.yaml/badge.svg)](https://github.com/dart-lang/native/actions/workflows/native.yaml)
+[![Coverage Status](https://coveralls.io/repos/github/dart-lang/native/badge.svg?branch=main)](https://coveralls.io/github/dart-lang/native?branch=main)
+[![pub package](https://img.shields.io/pub/v/data_assets.svg)](https://pub.dev/packages/data_assets)
+[![package publisher](https://img.shields.io/pub/publisher/data_assets.svg)](https://pub.dev/packages/data_assets/publisher)
+
+This library contains the hook protocol specification for bundling data assets
+with Dart packages.
+
+## This package is documentation only for the moment.
+
+For using this feature, please refer to `package:native_assets_cli` for now.
+In the future, we'll split up that package into here.
+
+## Status: Experimental
+
+**NOTE**: This package is currently experimental and published under the
+[labs.dart.dev](https://dart.dev/dart-team-packages) pub publisher in order to
+solicit feedback. 
+
+For packages in the labs.dart.dev publisher we generally plan to either graduate
+the package into a supported publisher (dart.dev, tools.dart.dev) after a period
+of feedback and iteration, or discontinue the package. These packages have a
+much higher expected rate of API and breaking changes.
+
+Your feedback is valuable and will help us evolve this package. 
+For bugs, please file an issue in the 
+[bug tracker](https://github.com/dart-lang/native/issues).
+

--- a/pkgs/data_assets/pubspec.yaml
+++ b/pkgs/data_assets/pubspec.yaml
@@ -2,6 +2,10 @@ name: data_assets
 version: 0.1.0-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/data_assets
 
+description: >-
+  This library contains the hook protocol specification for bundling data assets
+  with Dart packages.
+
 publish_to: none
 
 environment:


### PR DESCRIPTION
Add the required files to publish packages on pub. (Validated with `dart pub publish --dry-run`.)