### PR TITLE
[native_assets_cli] Introduce `JsonObject` base class for syntax

### DIFF
--- a/pkgs/json_syntax_generator/lib/src/generator/helper_library.dart
+++ b/pkgs/json_syntax_generator/lib/src/generator/helper_library.dart
@@ -6,6 +6,20 @@
 ///
 /// This simplifies the code generator.
 const helperLib = r'''
+class JsonObject {
+  final Map<String, Object?> json;
+
+  final List<Object> path;
+
+  JsonReader get _reader => JsonReader(json, path);
+
+  JsonObject() : json = {}, path = const [];
+
+  JsonObject.fromJson(this.json, {this.path = const []});
+
+  List<String> validate() => [];
+}
+
 class JsonReader {
   /// The JSON Object this reader is reading.
   final Map<String, Object?> json;

--- a/pkgs/json_syntax_generator/lib/src/model/dart_type.dart
+++ b/pkgs/json_syntax_generator/lib/src/model/dart_type.dart
@@ -55,6 +55,9 @@ class ClassDartType extends DartType {
   String toNonNullableString() => classInfo.name;
 }
 
+/// The [ClassInfo] for the `JsonObject` base class.
+final jsonObjectClassInfo = NormalClassInfo(name: 'JsonObject', properties: []);
+
 class ListDartType extends DartType {
   final DartType itemType;
 

--- a/pkgs/json_syntax_generator/lib/src/parser/schema_analyzer.dart
+++ b/pkgs/json_syntax_generator/lib/src/parser/schema_analyzer.dart
@@ -365,8 +365,8 @@ class SchemaAnalyzer {
                   'Expected an object with arbitrary properties.',
                 );
               }
-              dartType = MapDartType(
-                valueType: const ObjectDartType(isNullable: true),
+              dartType = ClassDartType(
+                classInfo: jsonObjectClassInfo,
                 isNullable: !required,
               );
             default:

--- a/pkgs/native_assets_cli/lib/src/code_assets/config.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/config.dart
@@ -206,7 +206,7 @@ extension CodeAssetBuildInputBuilder on HookConfigBuilder {
       macOS: macOS?.toSyntax(),
     );
     final baseHookConfig = hook_syntax.HookInput.fromJson(builder.json).config;
-    baseHookConfig.extensions ??= {};
+    baseHookConfig.extensions ??= hook_syntax.JsonObject.fromJson({});
     final hookConfig = syntax.Config.fromJson(baseHookConfig.json);
     hookConfig.extensions!.codeAssets = codeConfig;
     hookConfig.code = codeConfig; // old location

--- a/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
@@ -10,16 +10,11 @@
 
 import 'dart:io';
 
-class AndroidCodeConfig {
-  final Map<String, Object?> json;
+class AndroidCodeConfig extends JsonObject {
+  AndroidCodeConfig.fromJson(super.json, {super.path = const []})
+    : super.fromJson();
 
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
-  AndroidCodeConfig.fromJson(this.json, {this.path = const []});
-
-  AndroidCodeConfig({required int targetNdkApi}) : json = {}, path = const [] {
+  AndroidCodeConfig({required int targetNdkApi}) : super() {
     _targetNdkApi = targetNdkApi;
     json.sortOnKey();
   }
@@ -33,7 +28,8 @@ class AndroidCodeConfig {
   List<String> _validateTargetNdkApi() =>
       _reader.validate<int>('target_ndk_api');
 
-  List<String> validate() => [..._validateTargetNdkApi()];
+  @override
+  List<String> validate() => [...super.validate(), ..._validateTargetNdkApi()];
 
   @override
   String toString() => 'AndroidCodeConfig($json)';
@@ -85,13 +81,7 @@ class Architecture {
   String toString() => name;
 }
 
-class Asset {
-  final Map<String, Object?> json;
-
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
+class Asset extends JsonObject {
   factory Asset.fromJson(
     Map<String, Object?> json, {
     List<Object> path = const [],
@@ -106,9 +96,9 @@ class Asset {
     return result;
   }
 
-  Asset._fromJson(this.json, {this.path = const []});
+  Asset._fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  Asset({required String? type}) : json = {}, path = const [] {
+  Asset({required String? type}) : super() {
     _type = type;
     json.sortOnKey();
   }
@@ -121,20 +111,16 @@ class Asset {
 
   List<String> _validateType() => _reader.validate<String?>('type');
 
-  List<String> validate() => [..._validateType()];
+  @override
+  List<String> validate() => [...super.validate(), ..._validateType()];
 
   @override
   String toString() => 'Asset($json)';
 }
 
-class CCompilerConfig {
-  final Map<String, Object?> json;
-
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
-  CCompilerConfig.fromJson(this.json, {this.path = const []});
+class CCompilerConfig extends JsonObject {
+  CCompilerConfig.fromJson(super.json, {super.path = const []})
+    : super.fromJson();
 
   CCompilerConfig({
     required Uri ar,
@@ -143,8 +129,7 @@ class CCompilerConfig {
     required List<String>? envScriptArguments,
     required Uri ld,
     required Windows? windows,
-  }) : json = {},
-       path = const [] {
+  }) : super() {
     _ar = ar;
     _cc = cc;
     _envScript = envScript;
@@ -215,7 +200,9 @@ class CCompilerConfig {
     return windows?.validate() ?? [];
   }
 
+  @override
   List<String> validate() => [
+    ...super.validate(),
     ..._validateAr(),
     ..._validateCc(),
     ..._validateEnvScript(),
@@ -228,14 +215,8 @@ class CCompilerConfig {
   String toString() => 'CCompilerConfig($json)';
 }
 
-class CodeConfig {
-  final Map<String, Object?> json;
-
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
-  CodeConfig.fromJson(this.json, {this.path = const []});
+class CodeConfig extends JsonObject {
+  CodeConfig.fromJson(super.json, {super.path = const []}) : super.fromJson();
 
   CodeConfig({
     required AndroidCodeConfig? android,
@@ -245,8 +226,7 @@ class CodeConfig {
     required MacOSCodeConfig? macOS,
     required Architecture targetArchitecture,
     required OS targetOs,
-  }) : json = {},
-       path = const [] {
+  }) : super() {
     _android = android;
     _cCompiler = cCompiler;
     _iOS = iOS;
@@ -364,7 +344,9 @@ class CodeConfig {
 
   List<String> _validateTargetOs() => _reader.validate<String>('target_os');
 
+  @override
   List<String> validate() => [
+    ...super.validate(),
     ..._validateAndroid(),
     ..._validateCCompiler(),
     ..._validateIOS(),
@@ -406,18 +388,11 @@ class CodeConfig {
   String toString() => 'CodeConfig($json)';
 }
 
-class Config {
-  final Map<String, Object?> json;
-
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
-  Config.fromJson(this.json, {this.path = const []});
+class Config extends JsonObject {
+  Config.fromJson(super.json, {super.path = const []}) : super.fromJson();
 
   Config({required CodeConfig? code, required ConfigExtensions? extensions})
-    : json = {},
-      path = const [] {
+    : super() {
     this.code = code;
     this.extensions = extensions;
     json.sortOnKey();
@@ -461,24 +436,22 @@ class Config {
     return extensions?.validate() ?? [];
   }
 
-  List<String> validate() => [..._validateCode(), ..._validateExtensions()];
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateCode(),
+    ..._validateExtensions(),
+  ];
 
   @override
   String toString() => 'Config($json)';
 }
 
-class ConfigExtensions {
-  final Map<String, Object?> json;
+class ConfigExtensions extends JsonObject {
+  ConfigExtensions.fromJson(super.json, {super.path = const []})
+    : super.fromJson();
 
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
-  ConfigExtensions.fromJson(this.json, {this.path = const []});
-
-  ConfigExtensions({required CodeConfig? codeAssets})
-    : json = {},
-      path = const [] {
+  ConfigExtensions({required CodeConfig? codeAssets}) : super() {
     this.codeAssets = codeAssets;
     json.sortOnKey();
   }
@@ -502,24 +475,19 @@ class ConfigExtensions {
     return codeAssets?.validate() ?? [];
   }
 
-  List<String> validate() => [..._validateCodeAssets()];
+  @override
+  List<String> validate() => [...super.validate(), ..._validateCodeAssets()];
 
   @override
   String toString() => 'ConfigExtensions($json)';
 }
 
-class DeveloperCommandPrompt {
-  final Map<String, Object?> json;
-
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
-  DeveloperCommandPrompt.fromJson(this.json, {this.path = const []});
+class DeveloperCommandPrompt extends JsonObject {
+  DeveloperCommandPrompt.fromJson(super.json, {super.path = const []})
+    : super.fromJson();
 
   DeveloperCommandPrompt({required List<String> arguments, required Uri script})
-    : json = {},
-      path = const [] {
+    : super() {
     _arguments = arguments;
     _script = script;
     json.sortOnKey();
@@ -541,7 +509,12 @@ class DeveloperCommandPrompt {
 
   List<String> _validateScript() => _reader.validatePath('script');
 
-  List<String> validate() => [..._validateArguments(), ..._validateScript()];
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateArguments(),
+    ..._validateScript(),
+  ];
 
   @override
   String toString() => 'DeveloperCommandPrompt($json)';
@@ -648,18 +621,12 @@ extension DynamicLoadingSystemLinkModeExtension on LinkMode {
       DynamicLoadingSystemLinkMode.fromJson(json, path: path);
 }
 
-class IOSCodeConfig {
-  final Map<String, Object?> json;
-
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
-  IOSCodeConfig.fromJson(this.json, {this.path = const []});
+class IOSCodeConfig extends JsonObject {
+  IOSCodeConfig.fromJson(super.json, {super.path = const []})
+    : super.fromJson();
 
   IOSCodeConfig({required String targetSdk, required int targetVersion})
-    : json = {},
-      path = const [] {
+    : super() {
     _targetSdk = targetSdk;
     _targetVersion = targetVersion;
     json.sortOnKey();
@@ -682,7 +649,9 @@ class IOSCodeConfig {
   List<String> _validateTargetVersion() =>
       _reader.validate<int>('target_version');
 
+  @override
   List<String> validate() => [
+    ...super.validate(),
     ..._validateTargetSdk(),
     ..._validateTargetVersion(),
   ];
@@ -691,13 +660,7 @@ class IOSCodeConfig {
   String toString() => 'IOSCodeConfig($json)';
 }
 
-class LinkMode {
-  final Map<String, Object?> json;
-
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
+class LinkMode extends JsonObject {
   factory LinkMode.fromJson(
     Map<String, Object?> json, {
     List<Object> path = const [],
@@ -721,9 +684,9 @@ class LinkMode {
     return result;
   }
 
-  LinkMode._fromJson(this.json, {this.path = const []});
+  LinkMode._fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  LinkMode({required String type}) : json = {}, path = const [] {
+  LinkMode({required String type}) : super() {
     _type = type;
     json.sortOnKey();
   }
@@ -736,7 +699,8 @@ class LinkMode {
 
   List<String> _validateType() => _reader.validate<String>('type');
 
-  List<String> validate() => [..._validateType()];
+  @override
+  List<String> validate() => [...super.validate(), ..._validateType()];
 
   @override
   String toString() => 'LinkMode($json)';
@@ -788,16 +752,11 @@ class LinkModePreference {
   String toString() => name;
 }
 
-class MacOSCodeConfig {
-  final Map<String, Object?> json;
+class MacOSCodeConfig extends JsonObject {
+  MacOSCodeConfig.fromJson(super.json, {super.path = const []})
+    : super.fromJson();
 
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
-  MacOSCodeConfig.fromJson(this.json, {this.path = const []});
-
-  MacOSCodeConfig({required int targetVersion}) : json = {}, path = const [] {
+  MacOSCodeConfig({required int targetVersion}) : super() {
     _targetVersion = targetVersion;
     json.sortOnKey();
   }
@@ -811,7 +770,8 @@ class MacOSCodeConfig {
   List<String> _validateTargetVersion() =>
       _reader.validate<int>('target_version');
 
-  List<String> validate() => [..._validateTargetVersion()];
+  @override
+  List<String> validate() => [...super.validate(), ..._validateTargetVersion()];
 
   @override
   String toString() => 'MacOSCodeConfig($json)';
@@ -971,14 +931,9 @@ extension NativeCodeAssetExtension on Asset {
       NativeCodeAsset.fromJson(json, path: path);
 }
 
-class NativeCodeAssetEncoding {
-  final Map<String, Object?> json;
-
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
-  NativeCodeAssetEncoding.fromJson(this.json, {this.path = const []});
+class NativeCodeAssetEncoding extends JsonObject {
+  NativeCodeAssetEncoding.fromJson(super.json, {super.path = const []})
+    : super.fromJson();
 
   NativeCodeAssetEncoding({
     required Architecture? architecture,
@@ -986,8 +941,7 @@ class NativeCodeAssetEncoding {
     required String id,
     required LinkMode linkMode,
     required OS? os,
-  }) : json = {},
-       path = const [] {
+  }) : super() {
     _architecture = architecture;
     _file = file;
     _id = id;
@@ -1054,7 +1008,9 @@ class NativeCodeAssetEncoding {
 
   List<String> _validateOs() => _reader.validate<String?>('os');
 
+  @override
   List<String> validate() => [
+    ...super.validate(),
     ..._validateArchitecture(),
     ..._validateFile(),
     ..._validateId(),
@@ -1187,18 +1143,10 @@ extension StaticLinkModeExtension on LinkMode {
       StaticLinkMode.fromJson(json, path: path);
 }
 
-class Windows {
-  final Map<String, Object?> json;
+class Windows extends JsonObject {
+  Windows.fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
-  Windows.fromJson(this.json, {this.path = const []});
-
-  Windows({required DeveloperCommandPrompt? developerCommandPrompt})
-    : json = {},
-      path = const [] {
+  Windows({required DeveloperCommandPrompt? developerCommandPrompt}) : super() {
     _developerCommandPrompt = developerCommandPrompt;
     json.sortOnKey();
   }
@@ -1226,10 +1174,28 @@ class Windows {
     return developerCommandPrompt?.validate() ?? [];
   }
 
-  List<String> validate() => [..._validateDeveloperCommandPrompt()];
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateDeveloperCommandPrompt(),
+  ];
 
   @override
   String toString() => 'Windows($json)';
+}
+
+class JsonObject {
+  final Map<String, Object?> json;
+
+  final List<Object> path;
+
+  JsonReader get _reader => JsonReader(json, path);
+
+  JsonObject() : json = {}, path = const [];
+
+  JsonObject.fromJson(this.json, {this.path = const []});
+
+  List<String> validate() => [];
 }
 
 class JsonReader {

--- a/pkgs/native_assets_cli/lib/src/config.dart
+++ b/pkgs/native_assets_cli/lib/src/config.dart
@@ -356,7 +356,7 @@ class BuildOutput extends HookOutput {
   };
 
   /// Metadata passed to dependent build hook invocations.
-  Metadata get metadata => Metadata(_syntax.metadata ?? {});
+  Metadata get metadata => Metadata(_syntax.metadata?.json ?? {});
 
   @override
   final syntax.BuildOutput _syntax;
@@ -401,20 +401,20 @@ class BuildOutputBuilder extends HookOutputBuilder {
   /// packages.
   @Deprecated(metadataDeprecation)
   void addMetadatum(String key, Object value) {
-    final metadata = _syntax.metadata ?? {};
+    final metadata = _syntax.metadata?.json ?? {};
     metadata[key] = value;
     metadata.sortOnKey();
-    _syntax.metadata = metadata;
+    _syntax.metadata = syntax.JsonObject.fromJson(metadata);
   }
 
   /// Adds metadata to be passed to build hook invocations of dependent
   /// packages.
   @Deprecated(metadataDeprecation)
   void addMetadata(Map<String, Object> metadata) {
-    final value = _syntax.metadata ?? {};
+    final value = _syntax.metadata?.json ?? {};
     value.addAll(metadata);
     value.sortOnKey();
-    _syntax.metadata = value;
+    _syntax.metadata = syntax.JsonObject.fromJson(value);
   }
 
   EncodedAssetBuildOutputBuilder get assets =>

--- a/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
@@ -10,13 +10,7 @@
 
 import 'dart:io';
 
-class Asset {
-  final Map<String, Object?> json;
-
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
+class Asset extends JsonObject {
   factory Asset.fromJson(
     Map<String, Object?> json, {
     List<Object> path = const [],
@@ -31,9 +25,9 @@ class Asset {
     return result;
   }
 
-  Asset._fromJson(this.json, {this.path = const []});
+  Asset._fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  Asset({required String? type}) : json = {}, path = const [] {
+  Asset({required String? type}) : super() {
     _type = type;
     json.sortOnKey();
   }
@@ -46,7 +40,8 @@ class Asset {
 
   List<String> _validateType() => _reader.validate<String?>('type');
 
-  List<String> validate() => [..._validateType()];
+  @override
+  List<String> validate() => [...super.validate(), ..._validateType()];
 
   @override
   String toString() => 'Asset($json)';
@@ -146,21 +141,15 @@ extension DataAssetExtension on Asset {
   DataAsset get asDataAsset => DataAsset.fromJson(json, path: path);
 }
 
-class DataAssetEncoding {
-  final Map<String, Object?> json;
-
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
-  DataAssetEncoding.fromJson(this.json, {this.path = const []});
+class DataAssetEncoding extends JsonObject {
+  DataAssetEncoding.fromJson(super.json, {super.path = const []})
+    : super.fromJson();
 
   DataAssetEncoding({
     required Uri file,
     required String name,
     required String package,
-  }) : json = {},
-       path = const [] {
+  }) : super() {
     _file = file;
     _name = name;
     _package = package;
@@ -191,7 +180,9 @@ class DataAssetEncoding {
 
   List<String> _validatePackage() => _reader.validate<String>('package');
 
+  @override
   List<String> validate() => [
+    ...super.validate(),
     ..._validateFile(),
     ..._validateName(),
     ..._validatePackage(),
@@ -248,6 +239,20 @@ extension DataAssetNewExtension on Asset {
   bool get isDataAssetNew => type == 'data_assets/data';
 
   DataAssetNew get asDataAssetNew => DataAssetNew.fromJson(json, path: path);
+}
+
+class JsonObject {
+  final Map<String, Object?> json;
+
+  final List<Object> path;
+
+  JsonReader get _reader => JsonReader(json, path);
+
+  JsonObject() : json = {}, path = const [];
+
+  JsonObject.fromJson(this.json, {this.path = const []});
+
+  List<String> validate() => [];
 }
 
 class JsonReader {

--- a/pkgs/native_assets_cli/lib/src/encoded_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/encoded_asset.dart
@@ -39,7 +39,7 @@ final class EncodedAsset {
     final encoding =
         encodingSyntax != null
             // If 'encoding' is provided, copy that.
-            ? Map.of(encodingSyntax)
+            ? Map.of(encodingSyntax.json)
             // Otherwise, fall back to copying the keys except for 'type'.
             : {
               for (final key in json.keys)

--- a/pkgs/native_assets_cli/lib/src/hooks/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/hooks/syntax.g.dart
@@ -10,30 +10,32 @@
 
 import 'dart:io';
 
-class Asset {
-  final Map<String, Object?> json;
+class Asset extends JsonObject {
+  Asset.fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
-  Asset.fromJson(this.json, {this.path = const []});
-
-  Asset({required Map<String, Object?>? encoding, required String type})
-    : json = {},
-      path = const [] {
+  Asset({required JsonObject? encoding, required String type}) : super() {
     _encoding = encoding;
     _type = type;
     json.sortOnKey();
   }
 
-  Map<String, Object?>? get encoding => _reader.optionalMap('encoding');
-
-  set _encoding(Map<String, Object?>? value) {
-    json.setOrRemove('encoding', value);
+  JsonObject? get encoding {
+    final jsonValue = _reader.optionalMap('encoding');
+    if (jsonValue == null) return null;
+    return JsonObject.fromJson(jsonValue, path: [...path, 'encoding']);
   }
 
-  List<String> _validateEncoding() => _reader.validateOptionalMap('encoding');
+  set _encoding(JsonObject? value) {
+    json.setOrRemove('encoding', value?.json);
+  }
+
+  List<String> _validateEncoding() {
+    final mapErrors = _reader.validate<Map<String, Object?>?>('encoding');
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return encoding?.validate() ?? [];
+  }
 
   String get type => _reader.get<String>('type');
 
@@ -43,7 +45,12 @@ class Asset {
 
   List<String> _validateType() => _reader.validate<String>('type');
 
-  List<String> validate() => [..._validateEncoding(), ..._validateType()];
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateEncoding(),
+    ..._validateType(),
+  ];
 
   @override
   String toString() => 'Asset($json)';
@@ -146,7 +153,7 @@ class BuildOutput extends HookOutput {
     required Map<String, List<Asset>>? assetsForLinking,
     required Map<String, List<Asset>>? assetsForLinkingOld,
     required super.dependencies,
-    required Map<String, Object?>? metadata,
+    required JsonObject? metadata,
     required super.timestamp,
     required super.version,
   }) : super() {
@@ -161,7 +168,7 @@ class BuildOutput extends HookOutput {
   void setup({
     required Map<String, List<Asset>>? assetsForLinkingOld,
     required Map<String, List<Asset>>? assetsForLinking,
-    required Map<String, Object?>? metadata,
+    required JsonObject? metadata,
   }) {
     this.assetsForLinkingOld = assetsForLinkingOld;
     this.assetsForLinking = assetsForLinking;
@@ -265,14 +272,24 @@ class BuildOutput extends HookOutput {
     return result;
   }
 
-  Map<String, Object?>? get metadata => _reader.optionalMap('metadata');
+  JsonObject? get metadata {
+    final jsonValue = _reader.optionalMap('metadata');
+    if (jsonValue == null) return null;
+    return JsonObject.fromJson(jsonValue, path: [...path, 'metadata']);
+  }
 
-  set metadata(Map<String, Object?>? value) {
-    json.setOrRemove('metadata', value);
+  set metadata(JsonObject? value) {
+    json.setOrRemove('metadata', value?.json);
     json.sortOnKey();
   }
 
-  List<String> _validateMetadata() => _reader.validateOptionalMap('metadata');
+  List<String> _validateMetadata() {
+    final mapErrors = _reader.validate<Map<String, Object?>?>('metadata');
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return metadata?.validate() ?? [];
+  }
 
   @override
   List<String> validate() => [
@@ -286,20 +303,13 @@ class BuildOutput extends HookOutput {
   String toString() => 'BuildOutput($json)';
 }
 
-class Config {
-  final Map<String, Object?> json;
-
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
-  Config.fromJson(this.json, {this.path = const []});
+class Config extends JsonObject {
+  Config.fromJson(super.json, {super.path = const []}) : super.fromJson();
 
   Config({
     required List<String> buildAssetTypes,
-    required Map<String, Object?>? extensions,
-  }) : json = {},
-       path = const [] {
+    required JsonObject? extensions,
+  }) : super() {
     this.buildAssetTypes = buildAssetTypes;
     this.extensions = extensions;
     json.sortOnKey();
@@ -315,17 +325,28 @@ class Config {
   List<String> _validateBuildAssetTypes() =>
       _reader.validateStringList('build_asset_types');
 
-  Map<String, Object?>? get extensions => _reader.optionalMap('extensions');
+  JsonObject? get extensions {
+    final jsonValue = _reader.optionalMap('extensions');
+    if (jsonValue == null) return null;
+    return JsonObject.fromJson(jsonValue, path: [...path, 'extensions']);
+  }
 
-  set extensions(Map<String, Object?>? value) {
-    json.setOrRemove('extensions', value);
+  set extensions(JsonObject? value) {
+    json.setOrRemove('extensions', value?.json);
     json.sortOnKey();
   }
 
-  List<String> _validateExtensions() =>
-      _reader.validateOptionalMap('extensions');
+  List<String> _validateExtensions() {
+    final mapErrors = _reader.validate<Map<String, Object?>?>('extensions');
+    if (mapErrors.isNotEmpty) {
+      return mapErrors;
+    }
+    return extensions?.validate() ?? [];
+  }
 
+  @override
   List<String> validate() => [
+    ...super.validate(),
     ..._validateBuildAssetTypes(),
     ..._validateExtensions(),
   ];
@@ -334,14 +355,8 @@ class Config {
   String toString() => 'Config($json)';
 }
 
-class HookInput {
-  final Map<String, Object?> json;
-
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
-  HookInput.fromJson(this.json, {this.path = const []});
+class HookInput extends JsonObject {
+  HookInput.fromJson(super.json, {super.path = const []}) : super.fromJson();
 
   HookInput({
     required Config config,
@@ -351,8 +366,7 @@ class HookInput {
     required String packageName,
     required Uri packageRoot,
     required String? version,
-  }) : json = {},
-       path = const [] {
+  }) : super() {
     this.config = config;
     this.outDir = outDir;
     this.outDirShared = outDirShared;
@@ -437,7 +451,9 @@ class HookInput {
 
   List<String> _validateVersion() => _reader.validate<String?>('version');
 
+  @override
   List<String> validate() => [
+    ...super.validate(),
     ..._validateConfig(),
     ..._validateOutDir(),
     ..._validateOutDirShared(),
@@ -451,22 +467,15 @@ class HookInput {
   String toString() => 'HookInput($json)';
 }
 
-class HookOutput {
-  final Map<String, Object?> json;
-
-  final List<Object> path;
-
-  JsonReader get _reader => JsonReader(json, path);
-
-  HookOutput.fromJson(this.json, {this.path = const []});
+class HookOutput extends JsonObject {
+  HookOutput.fromJson(super.json, {super.path = const []}) : super.fromJson();
 
   HookOutput({
     required List<Asset>? assets,
     required List<Uri>? dependencies,
     required String timestamp,
     required String? version,
-  }) : json = {},
-       path = const [] {
+  }) : super() {
     this.assets = assets;
     this.dependencies = dependencies;
     this.timestamp = timestamp;
@@ -537,7 +546,9 @@ class HookOutput {
 
   List<String> _validateVersion() => _reader.validate<String?>('version');
 
+  @override
   List<String> validate() => [
+    ...super.validate(),
     ..._validateAssets(),
     ..._validateDependencies(),
     ..._validateTimestamp(),
@@ -647,6 +658,20 @@ class LinkOutput extends HookOutput {
 
   @override
   String toString() => 'LinkOutput($json)';
+}
+
+class JsonObject {
+  final Map<String, Object?> json;
+
+  final List<Object> path;
+
+  JsonReader get _reader => JsonReader(json, path);
+
+  JsonObject() : json = {}, path = const [];
+
+  JsonObject.fromJson(this.json, {this.path = const []});
+
+  List<String> validate() => [];
 }
 
 class JsonReader {


### PR DESCRIPTION
This PR introduce a common base class for all `JsonObject`s. This reduces code size.

Moreover, the properties that are an JSON object are now exposed as such. This makes a generated class a valid override of such property.