### PR TITLE
[native_assets_cli] Refactor overrides in syntax classes

### DIFF
--- a/pkgs/json_syntax_generator/lib/src/model/dart_type.dart
+++ b/pkgs/json_syntax_generator/lib/src/model/dart_type.dart
@@ -15,6 +15,14 @@ sealed class DartType {
     return isNullable ? '$typeString?' : typeString;
   }
 
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DartType && isNullable == other.isNullable;
+
+  @override
+  int get hashCode => isNullable.hashCode;
+
   String toNonNullableString();
 }
 
@@ -28,22 +36,53 @@ sealed class SimpleDartType extends DartType {
 
   @override
   String toNonNullableString() => typeName;
+
+  @override
+  bool operator ==(Object other) =>
+      super == other && other is SimpleDartType && typeName == other.typeName;
+
+  @override
+  int get hashCode => Object.hash(super.hashCode, typeName);
 }
 
 class StringDartType extends SimpleDartType {
   const StringDartType({required super.isNullable}) : super(typeName: 'String');
+
+  @override
+  bool operator ==(Object other) => super == other && other is StringDartType;
+
+  @override
+  int get hashCode => Object.hash(super.hashCode, 'String');
 }
 
 class IntDartType extends SimpleDartType {
   const IntDartType({required super.isNullable}) : super(typeName: 'int');
+
+  @override
+  bool operator ==(Object other) => super == other && other is IntDartType;
+
+  @override
+  int get hashCode => Object.hash(super.hashCode, 'int');
 }
 
 class BoolDartType extends SimpleDartType {
   const BoolDartType({required super.isNullable}) : super(typeName: 'bool');
+
+  @override
+  bool operator ==(Object other) => super == other && other is BoolDartType;
+
+  @override
+  int get hashCode => Object.hash(super.hashCode, 'bool');
 }
 
 class ObjectDartType extends SimpleDartType {
   const ObjectDartType({required super.isNullable}) : super(typeName: 'Object');
+
+  @override
+  bool operator ==(Object other) => super == other && other is ObjectDartType;
+
+  @override
+  int get hashCode => Object.hash(super.hashCode, 'Object');
 }
 
 class ClassDartType extends DartType {
@@ -53,6 +92,13 @@ class ClassDartType extends DartType {
 
   @override
   String toNonNullableString() => classInfo.name;
+
+  @override
+  bool operator ==(Object other) =>
+      super == other && other is ClassDartType && classInfo == other.classInfo;
+
+  @override
+  int get hashCode => Object.hash(super.hashCode, classInfo);
 }
 
 /// The [ClassInfo] for the `JsonObject` base class.
@@ -65,6 +111,13 @@ class ListDartType extends DartType {
 
   @override
   String toNonNullableString() => 'List<$itemType>';
+
+  @override
+  bool operator ==(Object other) =>
+      super == other && other is ListDartType && itemType == other.itemType;
+
+  @override
+  int get hashCode => Object.hash(super.hashCode, itemType);
 }
 
 class MapDartType extends DartType {
@@ -79,6 +132,16 @@ class MapDartType extends DartType {
 
   @override
   String toNonNullableString() => 'Map<$keyType, $valueType>';
+
+  @override
+  bool operator ==(Object other) =>
+      super == other &&
+      other is MapDartType &&
+      keyType == other.keyType &&
+      valueType == other.valueType;
+
+  @override
+  int get hashCode => Object.hash(super.hashCode, keyType, valueType);
 }
 
 class UriDartType extends DartType {
@@ -86,4 +149,10 @@ class UriDartType extends DartType {
 
   @override
   String toNonNullableString() => 'Uri';
+
+  @override
+  bool operator ==(Object other) => super == other && other is UriDartType;
+
+  @override
+  int get hashCode => Object.hash(super.hashCode, 'Uri');
 }

--- a/pkgs/json_syntax_generator/lib/src/parser/schema_analyzer.dart
+++ b/pkgs/json_syntax_generator/lib/src/parser/schema_analyzer.dart
@@ -142,7 +142,6 @@ class SchemaAnalyzer {
         superclass = _classes[superClassName] as NormalClassInfo;
       }
     }
-    final superSchemas = schemas.superClassSchemas;
     final propertyKeys = schemas.propertyKeys;
     final settersPrivate = !publicSetters.contains(typeName);
 
@@ -151,7 +150,6 @@ class SchemaAnalyzer {
       final propertySchemas = schemas.property(propertyKey);
       final required = schemas.propertyRequired(propertyKey);
       final allowEnum = !schemas.generateSubClasses;
-      final parentPropertySchemas = superSchemas?.property(propertyKey);
       final dartType = _analyzeDartType(
         propertyKey,
         propertySchemas,
@@ -159,13 +157,9 @@ class SchemaAnalyzer {
         allowEnum: allowEnum,
       );
       final fieldName = _snakeToCamelCase(propertyKey);
-      final isOverride =
-          parentPropertySchemas != null &&
-          (parentPropertySchemas?.type != null ||
-              propertySchemas.className != null);
-      if (parentPropertySchemas == null ||
-          parentPropertySchemas.className != propertySchemas.className ||
-          propertySchemas.type != parentPropertySchemas.type) {
+      final parentDartType = superclass?.getProperty(fieldName)?.type;
+      final isOverride = parentDartType != null;
+      if (parentDartType == null || parentDartType != dartType) {
         properties.add(
           PropertyInfo(
             name: fieldName,

--- a/pkgs/native_assets_cli/lib/src/hooks/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/hooks/syntax.g.dart
@@ -98,7 +98,7 @@ class BuildInput extends HookInput {
   BuildInput.fromJson(super.json, {super.path}) : super.fromJson();
 
   BuildInput({
-    required super.config,
+    required BuildConfig config,
     required Map<String, Map<String, Object?>>? dependencyMetadata,
     required super.outDir,
     required super.outDirShared,
@@ -106,7 +106,7 @@ class BuildInput extends HookInput {
     required super.packageName,
     required super.packageRoot,
     required super.version,
-  }) : super() {
+  }) : super(config: config) {
     _dependencyMetadata = dependencyMetadata;
     json.sortOnKey();
   }


### PR DESCRIPTION
This PR refactors field overrides in the syntax generator.

The analysis of overrides is now done on the `PropertyInfo` and `DartType` rather than on the `JsonSchema`.

If a field is overridden with a more specific type, generate the more specific type in the default constructor and pass it to the more general parameter in the super constructor invocation. (See the single change in the generated file.)