### PR TITLE
[native_assets_cli] Syntax for `assets_for_build` and `hooks/metadata`

### DIFF
--- a/pkgs/code_assets/doc/schema/shared/shared_definitions.generated.schema.json
+++ b/pkgs/code_assets/doc/schema/shared/shared_definitions.generated.schema.json
@@ -10,6 +10,19 @@
         },
         {
           "$ref": "../../../../hooks/doc/schema/shared/shared_definitions.schema.json#/definitions/BuildInput"
+        },
+        {
+          "properties": {
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "$ref": "shared_definitions.schema.json#/definitions/Asset"
+                }
+              }
+            }
+          }
         }
       ]
     },
@@ -30,6 +43,12 @@
                 "items": {
                   "$ref": "shared_definitions.schema.json#/definitions/Asset"
                 }
+              }
+            },
+            "assets_for_build": {
+              "type": "array",
+              "items": {
+                "$ref": "shared_definitions.schema.json#/definitions/Asset"
               }
             },
             "assets_for_linking": {

--- a/pkgs/code_assets/doc/schema/shared/shared_definitions.schema.json
+++ b/pkgs/code_assets/doc/schema/shared/shared_definitions.schema.json
@@ -38,10 +38,10 @@
           "type": "string",
           "anyOf": [
             {
-              "const": "native_code"
+              "const": "code_assets/code"
             },
             {
-              "const": "code_assets/code"
+              "const": "native_code"
             },
             {
               "type": "string"
@@ -50,6 +50,22 @@
         }
       },
       "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "code_assets/code"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "encoding": {
+                "$ref": "#/definitions/NativeCodeAssetEncoding"
+              }
+            }
+          }
+        },
         {
           "if": {
             "properties": {
@@ -70,22 +86,6 @@
                 "$ref": "#/definitions/NativeCodeAssetEncoding"
               }
             ]
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "code_assets/code"
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "encoding": {
-                "$ref": "#/definitions/NativeCodeAssetEncoding"
-              }
-            }
           }
         }
       ]

--- a/pkgs/code_assets/test/data/build_input_macos.json
+++ b/pkgs/code_assets/test/data/build_input_macos.json
@@ -1,5 +1,28 @@
 {
   "$schema": "../../doc/schema/sdk/build_input.generated.schema.json",
+  "assets": {
+    "some_package": [
+      {
+        "architecture": "arm64",
+        "encoding": {
+          "architecture": "arm64",
+          "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/iv6i0d/native_add/.dart_tool/native_assets_builder/native_add/c6b312c90c95d2d98ffb6760a738fb36/out/libnative_add.a",
+          "id": "package:native_add/src/native_add_bindings_generated.dart",
+          "link_mode": {
+            "type": "static"
+          },
+          "os": "macos"
+        },
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/iv6i0d/native_add/.dart_tool/native_assets_builder/native_add/c6b312c90c95d2d98ffb6760a738fb36/out/libnative_add.a",
+        "id": "package:native_add/src/native_add_bindings_generated.dart",
+        "link_mode": {
+          "type": "static"
+        },
+        "os": "macos",
+        "type": "native_code"
+      }
+    ]
+  },
   "config": {
     "build_asset_types": [
       "native_code"

--- a/pkgs/code_assets/test/data/build_output_macos.json
+++ b/pkgs/code_assets/test/data/build_output_macos.json
@@ -116,6 +116,27 @@
       }
     ]
   },
+  "assets_for_build": [
+    {
+      "architecture": "arm64",
+      "encoding": {
+        "architecture": "arm64",
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/iv6i0d/native_add/.dart_tool/native_assets_builder/native_add/c6b312c90c95d2d98ffb6760a738fb36/out/libnative_add.a",
+        "id": "package:native_add/src/native_add_bindings_generated.dart",
+        "link_mode": {
+          "type": "static"
+        },
+        "os": "macos"
+      },
+      "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/iv6i0d/native_add/.dart_tool/native_assets_builder/native_add/c6b312c90c95d2d98ffb6760a738fb36/out/libnative_add.a",
+      "id": "package:native_add/src/native_add_bindings_generated.dart",
+      "link_mode": {
+        "type": "static"
+      },
+      "os": "macos",
+      "type": "native_code"
+    }
+  ],
   "assets_for_linking": {
     "package_with_linker": [
       {

--- a/pkgs/code_assets/test/schema/schema_test.dart
+++ b/pkgs/code_assets/test/schema/schema_test.dart
@@ -127,20 +127,12 @@ FieldsFunction _codeFields(AllTestData allTestData) {
         if (hook == Hook.build) ...[
           for (final (field, expect) in codeAssetFields)
             for (final encoding in _encoding)
-              for (final assetsForLinking in [
-                'assetsForLinking',
-                'assets_for_linking',
+              for (final path in [
+                ['assets_for_build'],
+                ['assetsForLinking', 'package_with_linker'],
+                ['assets_for_linking', 'package_with_linker'],
               ])
-                (
-                  [
-                    assetsForLinking,
-                    'package_with_linker',
-                    0,
-                    ...encoding,
-                    ...field,
-                  ],
-                  expect,
-                ),
+                ([...path, 0, ...encoding, ...field], expect),
         ],
         (['assets', staticIndex, 'file'], expectRequiredFieldMissing),
         (

--- a/pkgs/data_assets/doc/schema/shared/shared_definitions.generated.schema.json
+++ b/pkgs/data_assets/doc/schema/shared/shared_definitions.generated.schema.json
@@ -10,6 +10,19 @@
         },
         {
           "$ref": "../../../../hooks/doc/schema/shared/shared_definitions.schema.json#/definitions/BuildInput"
+        },
+        {
+          "properties": {
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "$ref": "shared_definitions.schema.json#/definitions/Asset"
+                }
+              }
+            }
+          }
         }
       ]
     },
@@ -30,6 +43,12 @@
                 "items": {
                   "$ref": "shared_definitions.schema.json#/definitions/Asset"
                 }
+              }
+            },
+            "assets_for_build": {
+              "type": "array",
+              "items": {
+                "$ref": "shared_definitions.schema.json#/definitions/Asset"
               }
             },
             "assets_for_linking": {

--- a/pkgs/data_assets/test/data/build_input.json
+++ b/pkgs/data_assets/test/data/build_input.json
@@ -1,5 +1,31 @@
 {
   "$schema": "../../doc/schema/sdk/build_input.generated.schema.json",
+  "assets": {
+    "some_package": [
+      {
+        "encoding": {
+          "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_0.json",
+          "name": "assets/data_0.json",
+          "package": "simple_link"
+        },
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_0.json",
+        "name": "assets/data_0.json",
+        "package": "simple_link",
+        "type": "data"
+      },
+      {
+        "encoding": {
+          "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_1.json",
+          "name": "assets/data_1.json",
+          "package": "simple_link"
+        },
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_1.json",
+        "name": "assets/data_1.json",
+        "package": "simple_link",
+        "type": "data"
+      }
+    ]
+  },
   "config": {
     "build_asset_types": [
       "data"

--- a/pkgs/data_assets/test/data/build_output.json
+++ b/pkgs/data_assets/test/data/build_output.json
@@ -50,6 +50,30 @@
       }
     ]
   },
+  "assets_for_build": [
+    {
+      "encoding": {
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_0.json",
+        "name": "assets/data_0.json",
+        "package": "simple_link"
+      },
+      "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_0.json",
+      "name": "assets/data_0.json",
+      "package": "simple_link",
+      "type": "data"
+    },
+    {
+      "encoding": {
+        "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_1.json",
+        "name": "assets/data_1.json",
+        "package": "simple_link"
+      },
+      "file": "/private/var/folders/2y/mngq9h194yzglt4kzttzfq6800klzg/T/0s5bKi/simple_link/assets/data_1.json",
+      "name": "assets/data_1.json",
+      "package": "simple_link",
+      "type": "data"
+    }
+  ],
   "assets_for_linking": {
     "package_with_linker": [
       {

--- a/pkgs/data_assets/test/schema/schema_test.dart
+++ b/pkgs/data_assets/test/schema/schema_test.dart
@@ -58,14 +58,12 @@ List<(List<Object>, void Function(ValidationResults result))> _dataFields({
     if (hook == Hook.build) ...[
       for (final field in _dataAssetFields)
         for (final encoding in _encoding)
-          for (final assetsForLinking in [
-            'assetsForLinking',
-            'assets_for_linking',
+          for (final path in [
+            ['assets_for_build'],
+            ['assetsForLinking', 'package_with_linker'],
+            ['assets_for_linking', 'package_with_linker'],
           ])
-            (
-              [assetsForLinking, 'package_with_linker', 0, ...encoding, field],
-              expectRequiredFieldMissing,
-            ),
+            ([...path, 0, ...encoding, field], expectRequiredFieldMissing),
     ],
   ],
 ];

--- a/pkgs/hooks/doc/schema/shared/shared_definitions.schema.json
+++ b/pkgs/hooks/doc/schema/shared/shared_definitions.schema.json
@@ -6,7 +6,15 @@
       "type": "object",
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "hooks/metadata"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "encoding": {
           "type": "object",
@@ -15,6 +23,27 @@
       },
       "required": [
         "type"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "hooks/metadata"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "encoding": {
+                "$ref": "#/definitions/MetadataAssetEncoding"
+              }
+            },
+            "required": [
+              "encoding"
+            ]
+          }
+        }
       ]
     },
     "BuildConfig": {
@@ -36,6 +65,15 @@
     },
     "BuildInput": {
       "properties": {
+        "assets": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Asset"
+            }
+          }
+        },
         "config": {
           "$ref": "#/definitions/BuildConfig"
         },
@@ -63,6 +101,12 @@
             "items": {
               "$ref": "#/definitions/Asset"
             }
+          }
+        },
+        "assets_for_build": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Asset"
           }
         },
         "assets_for_linking": {
@@ -194,6 +238,18 @@
         {
           "$ref": "#/definitions/HookOutput"
         }
+      ]
+    },
+    "MetadataAssetEncoding": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {}
+      },
+      "required": [
+        "key"
       ]
     },
     "absolutePath": {

--- a/pkgs/hooks/test/data/build_input.json
+++ b/pkgs/hooks/test/data/build_input.json
@@ -1,5 +1,20 @@
 {
   "$schema": "../../doc/schema/sdk/build_input.generated.schema.json",
+  "assets": {
+    "some_package": [
+      {
+        "encoding": {
+          "key": "foo",
+          "value": "bar"
+        },
+        "type": "hooks/metadata"
+      },
+      {
+        "some_key": "some_value",
+        "type": "some_asset_type"
+      }
+    ]
+  },
   "config": {
     "build_asset_types": [
       "my_asset_type"

--- a/pkgs/hooks/test/data/build_output.json
+++ b/pkgs/hooks/test/data/build_output.json
@@ -20,35 +20,51 @@
     "package_with_linker": [
       {
         "encoding": {
-          "some_key": "some_value"
+          "a_key": "some_value"
         },
         "some_key": "some_value",
         "type": "some_asset_type"
       },
       {
         "encoding": {
-          "some_other_key": "some_value"
+          "key": "foo",
+          "value": "bar"
         },
-        "some_other_key": "some_value",
-        "type": "some_other_asset_type"
+        "type": "hooks/metadata"
       }
     ]
   },
+  "assets_for_build": [
+    {
+      "encoding": {
+        "a_key": "some_value"
+      },
+      "some_key": "some_value",
+      "type": "some_asset_type"
+    },
+    {
+      "encoding": {
+        "key": "foo",
+        "value": "bar"
+      },
+      "type": "hooks/metadata"
+    }
+  ],
   "assets_for_linking": {
     "package_with_linker": [
       {
         "encoding": {
-          "some_key": "some_value"
+          "a_key": "some_value"
         },
         "some_key": "some_value",
         "type": "some_asset_type"
       },
       {
         "encoding": {
-          "some_other_key": "some_value"
+          "key": "foo",
+          "value": "bar"
         },
-        "some_other_key": "some_value",
-        "type": "some_other_asset_type"
+        "type": "hooks/metadata"
       }
     ]
   },

--- a/pkgs/hooks/test/data/link_input.json
+++ b/pkgs/hooks/test/data/link_input.json
@@ -2,12 +2,15 @@
   "$schema": "../../doc/schema/sdk/link_input.generated.schema.json",
   "assets": [
     {
-      "some_key": "some_value",
+      "a_key": "some_value",
       "type": "some_asset_type"
     },
     {
-      "some_other_key": "some_value",
-      "type": "some_other_asset_type"
+      "encoding": {
+        "key": "foo",
+        "value": "bar"
+      },
+      "type": "hooks/metadata"
     }
   ],
   "config": {

--- a/pkgs/hooks/test/schema/helpers.dart
+++ b/pkgs/hooks/test/schema/helpers.dart
@@ -159,13 +159,14 @@ void testAllTestData(AllSchemas allSchemas, AllTestData allTestData) {
 /// [missingExpectations].
 void testField({
   required Uri schemaUri,
+  required Uri dataUri,
   required JsonSchema schema,
   required String data,
   required List<Object> field,
   required void Function(ValidationResults result) missingExpectations,
 }) {
   final fieldPath = field.join('.');
-  test('$schemaUri $fieldPath missing', () {
+  test('$schemaUri $dataUri $fieldPath missing', () {
     final dataDecoded = jsonDecode(data);
     final dataToModify = _traverseJson(
       dataDecoded,
@@ -254,6 +255,7 @@ void testFields({
             field: field,
             schemaUri: schemaUri,
             schema: schema,
+            dataUri: dataUri,
             data: data,
             missingExpectations: missingExpectations,
           );
@@ -342,27 +344,34 @@ FieldsReturn _hookFields({
       (['timestamp'], expectRequiredFieldMissing),
       (['dependencies'], expectOptionalFieldMissing),
       (['dependencies', 0], expectOptionalFieldMissing),
-      (['assets'], expectOptionalFieldMissing),
-      (['assets', 0], expectOptionalFieldMissing),
-      (['assets', 0, 'encoding'], expectOptionalFieldMissing),
-      (['assets', 0, 'type'], expectRequiredFieldMissing),
-      if (hook == Hook.build)
-        for (final assetsForLinking in [
-          'assetsForLinking',
-          'assets_for_linking',
+
+      if (hook == Hook.build) ...[
+        (['metadata'], expectOptionalFieldMissing),
+        for (final path in [
+          ['assets_for_build'],
+          ['assetsForLinking', 'package_with_linker'],
+          ['assets_for_linking', 'package_with_linker'],
         ]) ...[
-          (['metadata'], expectOptionalFieldMissing),
-          ([assetsForLinking], expectOptionalFieldMissing),
-          (
-            [assetsForLinking, 'package_with_linker', 0],
-            expectOptionalFieldMissing,
-          ),
-          ([assetsForLinking], expectOptionalFieldMissing),
-          (
-            [assetsForLinking, 'package_with_linker', 0, 'type'],
-            expectRequiredFieldMissing,
-          ),
+          ([...path], expectOptionalFieldMissing),
+          ([...path, 0], expectOptionalFieldMissing),
+          ([...path, 0, 'type'], expectRequiredFieldMissing),
+          ([...path, 0, 'encoding'], expectOptionalFieldMissing),
         ],
+      ],
+    ],
+    for (final path in [
+      if (inputOrOutput == InputOrOutput.output || hook == Hook.link)
+        ['assets'],
+      if (inputOrOutput == InputOrOutput.output && hook == Hook.build) ...[
+        ['assets_for_build'],
+        ['assetsForLinking', 'package_with_linker'],
+        ['assets_for_linking', 'package_with_linker'],
+      ],
+    ]) ...[
+      ([...path], expectOptionalFieldMissing),
+      ([...path, 0], expectOptionalFieldMissing),
+      ([...path, 0, 'type'], expectRequiredFieldMissing),
+      ([...path, 0, 'encoding'], expectOptionalFieldMissing),
     ],
   ];
 }

--- a/pkgs/hooks/test/schema/schema_test.dart
+++ b/pkgs/hooks/test/schema/schema_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:json_schema/json_schema.dart';
+
 import 'helpers.dart';
 
 void main() {
@@ -19,6 +21,35 @@ void main() {
     allTestData: allTestData,
     packageUri: packageUri,
   );
+
+  testFields(
+    allSchemas: allSchemas,
+    allTestData: allTestData,
+    packageUri: packageUri,
+    fields: _metadataAssetFields,
+  );
 }
 
 Uri packageUri = findPackageRoot('hooks');
+
+List<(List<Object>, void Function(ValidationResults result))>
+_metadataAssetFields({
+  required InputOrOutput inputOrOutput,
+  required Hook hook,
+  required Party party,
+}) => <(List<Object>, void Function(ValidationResults result))>[
+  for (final path in [
+    if (inputOrOutput == InputOrOutput.input && hook == Hook.link) ['assets'],
+    if (inputOrOutput == InputOrOutput.output && hook == Hook.build) ...[
+      ['assets_for_build'],
+      ['assetsForLinking', 'package_with_linker'],
+      ['assets_for_linking', 'package_with_linker'],
+    ],
+  ]) ...[
+    ([...path, 1], expectOptionalFieldMissing),
+    ([...path, 1, 'type'], expectRequiredFieldMissing),
+    ([...path, 1, 'encoding'], expectRequiredFieldMissing),
+    ([...path, 1, 'encoding', 'key'], expectRequiredFieldMissing),
+    // Skip `encoding.value`, it's optional and may have any type.
+  ],
+];

--- a/pkgs/hooks/tool/generate_schemas.dart
+++ b/pkgs/hooks/tool/generate_schemas.dart
@@ -52,6 +52,23 @@ void generateSharedDefinitions() {
           },
         },
       },
+      'assets_for_build': {
+        'type': 'array',
+        'items': {r'$ref': 'shared_definitions.schema.json#/definitions/Asset'},
+      },
+    },
+  };
+  const buildInputAssetOverride = {
+    'properties': {
+      'assets': {
+        'type': 'object',
+        'additionalProperties': {
+          'type': 'array',
+          'items': {
+            r'$ref': 'shared_definitions.schema.json#/definitions/Asset',
+          },
+        },
+      },
     },
   };
   const linkInputAssetOverride = {
@@ -128,6 +145,10 @@ void generateSharedDefinitions() {
                       hook == Hook.hook &&
                       inputOrOutput == InputOrOutput.output)
                     hookOutputAssetOverride,
+                  if (party == Party.shared &&
+                      hook == Hook.build &&
+                      inputOrOutput == InputOrOutput.input)
+                    buildInputAssetOverride,
                   if (party == Party.shared &&
                       hook == Hook.link &&
                       inputOrOutput == InputOrOutput.input)

--- a/pkgs/native_assets_cli/lib/src/config.dart
+++ b/pkgs/native_assets_cli/lib/src/config.dart
@@ -183,6 +183,7 @@ final class BuildInputBuilder extends HookInputBuilder {
       dependencyMetadata: {
         for (final key in metadata.keys) key: metadata[key]!.toJson(),
       },
+      assets: null, // TODO: Implement this.
     );
   }
 


### PR DESCRIPTION
Bug: https://github.com/dart-lang/native/issues/1251

This PR contains the JSON spec for:

* https://github.com/dart-lang/native/pull/2164

For more details see that PR.

This PR adds the syntax for passing assets from build hooks to build hooks.

build output `assets_for_build`:

```json
{
  "assets": [],
  "assets_for_build": [
    {
      "encoding": {
        "a_key": "some_value"
      },
      "some_key": "some_value",
      "type": "some_asset_type"
    }
  ],
  "assets_for_linking": {},
}
```

build input `assets` per package name:

```json
{
  "assets": {
    "some_package": [
      {
        "some_key": "some_value",
        "type": "some_asset_type"
      }
    ]
  },
  "config": {},
}
```

Secondly, this PR adds a syntax for metadata assets (assets that cannot be bundled but just ferry information between different hooks).

```json
      {
        "encoding": {
          "key": "foo",
          "value": "bar"
        },
        "type": "hooks/metadata"
      },
```

The schemas now check these.

And this is covered by tests.

Changes to the generated schemas:

* Override the new build input `asset` and build output `assets_for_build` with the `CodeAsset` and `DataAsset` in the generated extension schemas.

Notable changes to the syntax generator:

* Enable generating tagged enum classes if there are two fields (a tag, and some `encoding`) in the super class.
* Support `Object` fields (used for `MetadataAsset.value`).

