### PR TITLE
[infra] Bump `ffigen` in `package:native_`

### DIFF
--- a/pkgs/native_assets_builder/test_data/depend_on_fail_build/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/depend_on_fail_build/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
     path: ../../../native_assets_cli/
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   test: ^1.23.1

--- a/pkgs/native_assets_builder/test_data/depend_on_fail_build_app/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/depend_on_fail_build_app/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
     path: ../../../native_assets_cli/
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   test: ^1.23.1

--- a/pkgs/native_assets_builder/test_data/fail_build/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_build/pubspec.yaml
@@ -13,6 +13,6 @@ dependencies:
     path: ../../../native_assets_cli/
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   test: ^1.23.1

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/pubspec.yaml
@@ -13,6 +13,6 @@ dependencies:
     path: ../../../native_assets_cli/
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   test: ^1.23.1

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
     path: ../../../native_assets_cli/
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   test: ^1.23.1

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/pubspec.yaml
@@ -13,6 +13,6 @@ dependencies:
     path: ../../../native_assets_cli/
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   test: ^1.23.1

--- a/pkgs/native_assets_builder/test_data/native_add/lib/src/native_add_bindings_generated.dart
+++ b/pkgs/native_assets_builder/test_data/native_add/lib/src/native_add_bindings_generated.dart
@@ -8,5 +8,5 @@
 // ignore_for_file: type=lint
 import 'dart:ffi' as ffi;
 
-@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>(symbol: 'add')
+@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>()
 external int add(int a, int b);

--- a/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     path: ../../../native_toolchain_c/
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   some_dev_dep:
     path: ../some_dev_dep/

--- a/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     path: ../../../native_toolchain_c/
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   some_dev_dep:
     path: ../some_dev_dep/

--- a/pkgs/native_assets_builder/test_data/native_add_duplicate/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_duplicate/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
     path: ../../../native_toolchain_c/
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   some_dev_dep:
     path: ../some_dev_dep/

--- a/pkgs/native_assets_builder/test_data/native_add_version_skew/lib/src/native_add_bindings_generated.dart
+++ b/pkgs/native_assets_builder/test_data/native_add_version_skew/lib/src/native_add_bindings_generated.dart
@@ -8,5 +8,5 @@
 // ignore_for_file: type=lint
 import 'dart:ffi' as ffi;
 
-@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>(symbol: 'add')
+@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>()
 external int add(int a, int b);

--- a/pkgs/native_assets_builder/test_data/native_add_version_skew/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_version_skew/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   native_toolchain_c: ^0.8.0
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   some_dev_dep:
     path: ../some_dev_dep/

--- a/pkgs/native_assets_builder/test_data/native_add_version_skew_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_version_skew_2/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   native_toolchain_c: ^0.5.0
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   some_dev_dep:
     path: ../some_dev_dep/

--- a/pkgs/native_assets_builder/test_data/native_dynamic_linking/lib/add.dart
+++ b/pkgs/native_assets_builder/test_data/native_dynamic_linking/lib/add.dart
@@ -8,5 +8,5 @@
 // ignore_for_file: type=lint
 import 'dart:ffi' as ffi;
 
-@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>(symbol: 'add')
+@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>()
 external int add(int a, int b);

--- a/pkgs/native_assets_builder/test_data/native_dynamic_linking/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_dynamic_linking/pubspec.yaml
@@ -18,6 +18,6 @@ dependencies:
     path: ../../../native_toolchain_c/
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   test: ^1.21.0

--- a/pkgs/native_assets_builder/test_data/native_subtract/lib/src/native_subtract_bindings_generated.dart
+++ b/pkgs/native_assets_builder/test_data/native_subtract/lib/src/native_subtract_bindings_generated.dart
@@ -8,5 +8,5 @@
 // ignore_for_file: type=lint
 import 'dart:ffi' as ffi;
 
-@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>(symbol: 'subtract')
+@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>()
 external int subtract(int a, int b);

--- a/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
@@ -17,6 +17,6 @@ dependencies:
     path: ../../../native_toolchain_c/
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   test: ^1.23.1

--- a/pkgs/native_assets_builder/test_data/no_hook/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/no_hook/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     path: ../../../native_toolchain_c/
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   some_dev_dep:
     path: ../some_dev_dep/

--- a/pkgs/native_assets_builder/test_data/reusable_dynamic_library/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/reusable_dynamic_library/pubspec.yaml
@@ -1,9 +1,10 @@
-publish_to: none
+name: reusable_dynamic_library
 
-name: native_dynamic_linking
 description: Dynamically link native libraries to each other.
 version: 0.1.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli/example/build/native_dynamic_linking
+
+publish_to: none
 
 environment:
   sdk: '>=3.7.0 <4.0.0'
@@ -12,10 +13,10 @@ dependencies:
   logging: ^1.1.1
   # native_assets_cli: ^0.13.0
   native_assets_cli:
-    path: ../../../../native_assets_cli/
+    path: ../../../native_assets_cli/
   # native_toolchain_c: ^0.10.0
   native_toolchain_c:
-    path: ../../../../native_toolchain_c/
+    path: ../../../native_toolchain_c/
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/reuse_dynamic_library/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/reuse_dynamic_library/pubspec.yaml
@@ -1,9 +1,9 @@
-publish_to: none
-
-name: native_dynamic_linking
+name: reuse_dynamic_library
 description: Dynamically link native libraries to each other.
 version: 0.1.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli/example/build/native_dynamic_linking
+
+publish_to: none
 
 environment:
   sdk: '>=3.7.0 <4.0.0'
@@ -12,10 +12,12 @@ dependencies:
   logging: ^1.1.1
   # native_assets_cli: ^0.13.0
   native_assets_cli:
-    path: ../../../../native_assets_cli/
+    path: ../../../native_assets_cli/
   # native_toolchain_c: ^0.10.0
   native_toolchain_c:
-    path: ../../../../native_toolchain_c/
+    path: ../../../native_toolchain_c/
+  reusable_dynamic_library:
+    path: ../reusable_dynamic_library/
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/system_library/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/system_library/pubspec.yaml
@@ -17,6 +17,6 @@ dependencies:
     path: ../../../native_toolchain_c/
 
 dev_dependencies:
-  ffigen: ^10.0.0
+  ffigen: ^18.0.0
   lints: ^5.1.1
   test: ^1.23.1

--- a/pkgs/native_assets_builder/test_data/treeshaking_native_libs/lib/src/treeshaking_native_libs_bindings_generated.dart
+++ b/pkgs/native_assets_builder/test_data/treeshaking_native_libs/lib/src/treeshaking_native_libs_bindings_generated.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -8,8 +8,8 @@
 // ignore_for_file: type=lint
 import 'dart:ffi' as ffi;
 
-@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>(symbol: 'add')
+@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>()
 external int add(int a, int b);
 
-@ffi.Native<ffi.IntPtr Function(ffi.IntPtr, ffi.IntPtr)>(symbol: 'multiply')
+@ffi.Native<ffi.IntPtr Function(ffi.IntPtr, ffi.IntPtr)>()
 external int multiply(int a, int b);

--- a/pkgs/native_assets_builder/test_data/treeshaking_native_libs/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/treeshaking_native_libs/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     path: ../../../native_toolchain_c/
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   some_dev_dep:
     path: ../some_dev_dep/

--- a/pkgs/native_assets_cli/example/build/download_asset/lib/native_add.dart
+++ b/pkgs/native_assets_cli/example/build/download_asset/lib/native_add.dart
@@ -8,5 +8,5 @@
 // ignore_for_file: type=lint
 import 'dart:ffi' as ffi;
 
-@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>(symbol: 'add')
+@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>()
 external int add(int a, int b);

--- a/pkgs/native_assets_cli/example/build/download_asset/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/download_asset/pubspec.yaml
@@ -20,6 +20,6 @@ dependencies:
 
 dev_dependencies:
   args: ^2.6.0
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   test: ^1.21.0

--- a/pkgs/native_assets_cli/example/build/local_asset/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/local_asset/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
     path: ../../../../native_assets_cli/
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   test: ^1.21.0

--- a/pkgs/native_assets_cli/example/build/native_add_library/lib/native_add_library.dart
+++ b/pkgs/native_assets_cli/example/build/native_add_library/lib/native_add_library.dart
@@ -8,5 +8,5 @@
 // ignore_for_file: type=lint
 import 'dart:ffi' as ffi;
 
-@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>(symbol: 'add')
+@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>()
 external int add(int a, int b);

--- a/pkgs/native_assets_cli/example/build/native_add_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/native_add_library/pubspec.yaml
@@ -18,6 +18,6 @@ dependencies:
     path: ../../../../native_toolchain_c/
 
 dev_dependencies:
-  ffigen: ^8.0.2
+  ffigen: ^18.0.0
   lints: ^5.1.1
   test: ^1.21.0

--- a/pkgs/native_assets_cli/example/build/native_dynamic_linking/lib/add.dart
+++ b/pkgs/native_assets_cli/example/build/native_dynamic_linking/lib/add.dart
@@ -8,5 +8,5 @@
 // ignore_for_file: type=lint
 import 'dart:ffi' as ffi;
 
-@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>(symbol: 'add')
+@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>()
 external int add(int a, int b);

--- a/pkgs/native_assets_cli/example/build/system_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/system_library/pubspec.yaml
@@ -17,6 +17,6 @@ dependencies:
     path: ../../../../native_toolchain_c/
 
 dev_dependencies:
-  ffigen: ^10.0.0
+  ffigen: ^18.0.0
   lints: ^5.1.1
   test: ^1.23.1

--- a/pkgs/native_assets_cli/example/build/use_dart_api/lib/src/use_dart_api_bindings_generated.dart
+++ b/pkgs/native_assets_cli/example/build/use_dart_api/lib/src/use_dart_api_bindings_generated.dart
@@ -8,20 +8,16 @@
 // ignore_for_file: type=lint
 import 'dart:ffi' as ffi;
 
-@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>(symbol: 'add')
+@ffi.Native<ffi.Int32 Function(ffi.Int32, ffi.Int32)>()
 external int add(int a, int b);
 
-@ffi.Native<ffi.IntPtr Function(ffi.Pointer<ffi.Void>)>(symbol: 'InitDartApiDL')
+@ffi.Native<ffi.IntPtr Function(ffi.Pointer<ffi.Void>)>()
 external int InitDartApiDL(ffi.Pointer<ffi.Void> data);
 
-@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Handle)>(
-  symbol: 'NewPersistentHandle',
-)
+@ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Handle)>()
 external ffi.Pointer<ffi.Void> NewPersistentHandle(
   Object non_persistent_handle,
 );
 
-@ffi.Native<ffi.Handle Function(ffi.Pointer<ffi.Void>)>(
-  symbol: 'HandleFromPersistent',
-)
+@ffi.Native<ffi.Handle Function(ffi.Pointer<ffi.Void>)>()
 external Object HandleFromPersistent(ffi.Pointer<ffi.Void> persistent_handle);

--- a/pkgs/native_assets_cli/example/build/use_dart_api/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/use_dart_api/pubspec.yaml
@@ -17,6 +17,6 @@ dependencies:
     path: ../../../../native_toolchain_c/
 
 dev_dependencies:
-  ffigen: ^10.0.0
+  ffigen: ^18.0.0
   lints: ^5.1.1
   test: ^1.23.1


### PR DESCRIPTION
We were using an ancient version. But it seems like the only change is the symbol being omitted if possible.