### PR TITLE
[native_assets_builder] Test project for user-defines in dartdev

### DIFF
--- a/pkgs/native_assets_builder/test_data/manifest.yaml
+++ b/pkgs/native_assets_builder/test_data/manifest.yaml
@@ -179,8 +179,10 @@
 - use_all_api/hook/build.dart
 - use_all_api/hook/link.dart
 - use_all_api/pubspec.yaml
+- user_defines/bin/user_defines.dart
 - user_defines/hook/build.dart
 - user_defines/pubspec.yaml
+- user_defines/test/user_defines_test.dart
 - wrong_build_output/hook/build.dart
 - wrong_build_output/pubspec.yaml
 - wrong_build_output_2/hook/build.dart

--- a/pkgs/native_assets_builder/test_data/user_defines/bin/user_defines.dart
+++ b/pkgs/native_assets_builder/test_data/user_defines/bin/user_defines.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+void main() {
+  print('Hello world!');
+}

--- a/pkgs/native_assets_builder/test_data/user_defines/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/user_defines/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
 
 dev_dependencies:
   lints: ^5.1.1
+  test: ^1.25.15
 
 hooks:
   user_defines:

--- a/pkgs/native_assets_builder/test_data/user_defines/test/user_defines_test.dart
+++ b/pkgs/native_assets_builder/test_data/user_defines/test/user_defines_test.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+void main() {
+  test('my test', () {
+    expect(1, equals(1));
+  });
+}


### PR DESCRIPTION
Making the test project have a `bin/` and `test/` file so we can test the dartdev commands.
https://dart-review.googlesource.com/c/sdk/+/420700

(The hook exits with non-0 exit code if the build fails. The assets are not used in the bin and test scripts.)
