### PR TITLE
[native_assets_cli] Publish 0.14.0

### DIFF
--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   graphs: ^2.3.2
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   package_config: ^2.1.0
   pub_semver: ^2.2.0
   yaml: ^3.1.3

--- a/pkgs/native_assets_builder/test_data/add_asset_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/add_asset_link/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/complex_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/complex_link/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   complex_link_helper:
     path: ../complex_link_helper/
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/complex_link_helper/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/complex_link_helper/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cli_config: ^0.2.0
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/cyclic_package_1/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/cyclic_package_1/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cyclic_package_2:
     path: ../cyclic_package_2
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/cyclic_package_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/cyclic_package_2/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cyclic_package_1:
     path: ../cyclic_package_1
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/depend_on_fail_build/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/depend_on_fail_build/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   fail_build:
     path: ../fail_build/
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/depend_on_fail_build_app/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/depend_on_fail_build_app/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   depend_on_fail_build:
     path: ../depend_on_fail_build/
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/drop_dylib_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/drop_dylib_link/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/fail_build/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_build/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   fail_on_os_sdk_version_linker:
     path: ../fail_on_os_sdk_version_linker/
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/native_add_duplicate/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_duplicate/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   logging: ^1.3.0
   native_add:
     path: ../native_add/
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/native_dynamic_linking/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_dynamic_linking/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/no_asset_for_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/no_asset_for_link/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/no_hook/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/no_hook/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/package_reading_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/package_reading_metadata/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   package_with_metadata:
     path: ../package_with_metadata/
 

--- a/pkgs/native_assets_builder/test_data/package_with_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/package_with_metadata/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/relative_path/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/relative_path/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/reusable_dynamic_library/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/reusable_dynamic_library/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/reuse_dynamic_library/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/reuse_dynamic_library/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
   reusable_dynamic_library:
     path: ../reusable_dynamic_library/

--- a/pkgs/native_assets_builder/test_data/simple_data_asset/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/simple_data_asset/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/simple_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/simple_link/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cli_config: ^0.2.0
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/system_library/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/system_library/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/transformer/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/transformer/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   crypto: ^3.0.6
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/treeshaking_native_libs/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/treeshaking_native_libs/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/use_all_api/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/use_all_api/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   cli_config: ^0.2.0
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/user_defines/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/user_defines/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_build_output/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_build_output_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output_2/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_build_output_3/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output_3/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_linker/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_linker/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_namespace_asset/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_namespace_asset/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.14.0-wip
+## 0.14.0
 
 - Added support for sending assets between build hooks via the `ToBuild`
   `Routing`. This replaces the deprecated `Metadata`.
+- Added support for user-defines.
 
 ## 0.13.0
 

--- a/pkgs/native_assets_cli/example/build/download_asset/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/download_asset/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   crypto: ^3.0.6
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/build/local_asset/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/local_asset/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_cli/example/build/native_add_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/native_add_library/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/build/native_dynamic_linking/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/native_dynamic_linking/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/build/system_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/system_library/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/build/use_dart_api/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/use_dart_api/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   native_toolchain_c: ^0.11.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/link/package_with_assets/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/link/package_with_assets/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   record_use: ^0.3.0
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -3,10 +3,10 @@ description: >-
   A library that contains the argument and file formats for implementing a
   native assets CLI.
 
-version: 0.14.0-wip
+version: 0.14.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
-publish_to: none
+# publish_to: none
 
 topics:
   - ffi

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   glob: ^2.1.1
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.14.0-wip
+  native_assets_cli: ^0.14.0
   pub_semver: ^2.2.0
 
 dev_dependencies:


### PR DESCRIPTION
New process!

Now that we have a pub workspace, we don't have to flip to published dependency anymore in a follow up commit. We simply update the version number everywhere in one commit.