### PR TITLE
[infra] Try using dart sdk dev release lowerbound

### DIFF
--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -31,11 +31,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        sdk: [stable, dev]
+        sdk: [dev]
         package: [native_assets_builder, native_assets_cli, native_toolchain_c]
         # Breaking changes temporarily break the example run on the Dart SDK until native_assets_builder is rolled into the Dart SDK dev build.
         breaking-change: [false]
-
 
     runs-on: ${{ matrix.os }}-latest
 

--- a/.github/workflows/native_toolchain_c.yaml
+++ b/.github/workflows/native_toolchain_c.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        sdk: [stable]
+        sdk: [dev]
         package: [native_toolchain_c]
 
     runs-on: ${{ matrix.os }}-latest
@@ -41,13 +41,11 @@ jobs:
       - uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
         with:
           ndk-version: r27
-        if: ${{ matrix.sdk == 'stable' }}
 
       - run: dart pub get
 
       - name: Install native toolchains
         run: sudo apt-get update && sudo apt-get install gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf gcc-riscv64-linux-gnu
-        if: ${{ matrix.sdk == 'stable' && matrix.os == 'ubuntu' }}
 
       - run: git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
       - run: echo "$PWD/depot_tools" >> $GITHUB_PATH
@@ -57,4 +55,3 @@ jobs:
       - run: clang --version
 
       - run: dart test
-        if: ${{ matrix.sdk == 'stable' }}

--- a/pkgs/native_assets_builder/CHANGELOG.md
+++ b/pkgs/native_assets_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.15.0-wip
+
+- Bump `package:native_assets_cli` to 0.15.0.
+
 ## 0.14.0
 
 - Bump `package:native_assets_cli` to 0.14.0.

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   graphs: ^2.3.2
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   package_config: ^2.1.0
   pub_semver: ^2.2.0
   yaml: ^3.1.3

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -1,10 +1,8 @@
 name: native_assets_builder
 description: >-
   This package is the backend that invokes build hooks.
-version: 0.14.0
+version: 0.15.0-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_builder
-
-# publish_to: none
 
 resolution: workspace
 
@@ -18,7 +16,7 @@ dependencies:
   graphs: ^2.3.2
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
   package_config: ^2.1.0
   pub_semver: ^2.2.0
   yaml: ^3.1.3

--- a/pkgs/native_assets_builder/pubspec.yaml
+++ b/pkgs/native_assets_builder/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   graphs: ^2.3.2
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   package_config: ^2.1.0
   pub_semver: ^2.2.0
   yaml: ^3.1.3

--- a/pkgs/native_assets_builder/test_data/add_asset_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/add_asset_link/pubspec.yaml
@@ -12,8 +12,8 @@ environment:
 dependencies:
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/add_asset_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/add_asset_link/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/add_asset_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/add_asset_link/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/complex_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/complex_link/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   complex_link_helper:
     path: ../complex_link_helper/
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/complex_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/complex_link/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   complex_link_helper:
     path: ../complex_link_helper/
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/complex_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/complex_link/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   complex_link_helper:
     path: ../complex_link_helper/
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/complex_link_helper/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/complex_link_helper/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cli_config: ^0.2.0
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/complex_link_helper/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/complex_link_helper/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cli_config: ^0.2.0
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/complex_link_helper/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/complex_link_helper/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cli_config: ^0.2.0
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/cyclic_package_1/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/cyclic_package_1/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cyclic_package_2:
     path: ../cyclic_package_2
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/cyclic_package_1/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/cyclic_package_1/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cyclic_package_2:
     path: ../cyclic_package_2
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/cyclic_package_1/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/cyclic_package_1/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cyclic_package_2:
     path: ../cyclic_package_2
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/cyclic_package_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/cyclic_package_2/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cyclic_package_1:
     path: ../cyclic_package_1
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/cyclic_package_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/cyclic_package_2/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cyclic_package_1:
     path: ../cyclic_package_1
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/cyclic_package_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/cyclic_package_2/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cyclic_package_1:
     path: ../cyclic_package_1
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/depend_on_fail_build/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/depend_on_fail_build/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   fail_build:
     path: ../fail_build/
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/depend_on_fail_build/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/depend_on_fail_build/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   fail_build:
     path: ../fail_build/
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/depend_on_fail_build/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/depend_on_fail_build/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   fail_build:
     path: ../fail_build/
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/depend_on_fail_build_app/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/depend_on_fail_build_app/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   depend_on_fail_build:
     path: ../depend_on_fail_build/
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/depend_on_fail_build_app/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/depend_on_fail_build_app/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   depend_on_fail_build:
     path: ../depend_on_fail_build/
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/depend_on_fail_build_app/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/depend_on_fail_build_app/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   depend_on_fail_build:
     path: ../depend_on_fail_build/
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/drop_dylib_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/drop_dylib_link/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/drop_dylib_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/drop_dylib_link/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/drop_dylib_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/drop_dylib_link/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/fail_build/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_build/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/fail_build/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_build/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/fail_build/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_build/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   fail_on_os_sdk_version_linker:
     path: ../fail_on_os_sdk_version_linker/
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   fail_on_os_sdk_version_linker:
     path: ../fail_on_os_sdk_version_linker/
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   fail_on_os_sdk_version_linker:
     path: ../fail_on_os_sdk_version_linker/
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_add_source/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/native_add_duplicate/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_duplicate/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   logging: ^1.3.0
   native_add:
     path: ../native_add/
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/native_add_duplicate/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_duplicate/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   logging: ^1.3.0
   native_add:
     path: ../native_add/
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/native_add_duplicate/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_add_duplicate/pubspec.yaml
@@ -13,8 +13,8 @@ dependencies:
   logging: ^1.3.0
   native_add:
     path: ../native_add/
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/native_dynamic_linking/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_dynamic_linking/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/native_dynamic_linking/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_dynamic_linking/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/native_dynamic_linking/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_dynamic_linking/pubspec.yaml
@@ -12,8 +12,8 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/native_subtract/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/no_asset_for_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/no_asset_for_link/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/no_asset_for_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/no_asset_for_link/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/no_asset_for_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/no_asset_for_link/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/no_hook/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/no_hook/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/no_hook/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/no_hook/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/no_hook/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/no_hook/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/package_reading_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/package_reading_metadata/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   package_with_metadata:
     path: ../package_with_metadata/
 

--- a/pkgs/native_assets_builder/test_data/package_reading_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/package_reading_metadata/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
   package_with_metadata:
     path: ../package_with_metadata/
 

--- a/pkgs/native_assets_builder/test_data/package_reading_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/package_reading_metadata/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   package_with_metadata:
     path: ../package_with_metadata/
 

--- a/pkgs/native_assets_builder/test_data/package_with_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/package_with_metadata/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/package_with_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/package_with_metadata/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/package_with_metadata/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/package_with_metadata/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/relative_path/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/relative_path/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/relative_path/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/relative_path/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/relative_path/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/relative_path/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/reusable_dynamic_library/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/reusable_dynamic_library/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/reusable_dynamic_library/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/reusable_dynamic_library/pubspec.yaml
@@ -13,8 +13,8 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/reusable_dynamic_library/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/reusable_dynamic_library/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/reuse_dynamic_library/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/reuse_dynamic_library/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
   reusable_dynamic_library:
     path: ../reusable_dynamic_library/

--- a/pkgs/native_assets_builder/test_data/reuse_dynamic_library/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/reuse_dynamic_library/pubspec.yaml
@@ -12,8 +12,8 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
   reusable_dynamic_library:
     path: ../reusable_dynamic_library/
 

--- a/pkgs/native_assets_builder/test_data/reuse_dynamic_library/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/reuse_dynamic_library/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.1.1
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
   reusable_dynamic_library:
     path: ../reusable_dynamic_library/

--- a/pkgs/native_assets_builder/test_data/simple_data_asset/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/simple_data_asset/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/simple_data_asset/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/simple_data_asset/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/simple_data_asset/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/simple_data_asset/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/simple_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/simple_link/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cli_config: ^0.2.0
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/simple_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/simple_link/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cli_config: ^0.2.0
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/simple_link/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/simple_link/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cli_config: ^0.2.0
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/system_library/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/system_library/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/system_library/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/system_library/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/system_library/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/system_library/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/transformer/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/transformer/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   crypto: ^3.0.6
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/transformer/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/transformer/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   crypto: ^3.0.6
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/transformer/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/transformer/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   crypto: ^3.0.6
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/treeshaking_native_libs/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/treeshaking_native_libs/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/treeshaking_native_libs/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/treeshaking_native_libs/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_builder/test_data/treeshaking_native_libs/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/treeshaking_native_libs/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_builder/test_data/use_all_api/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/use_all_api/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   cli_config: ^0.2.0
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/use_all_api/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/use_all_api/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   cli_config: ^0.2.0
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/use_all_api/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/use_all_api/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   cli_config: ^0.2.0
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/user_defines/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/user_defines/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/user_defines/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/user_defines/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/user_defines/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/user_defines/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_build_output/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_build_output/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_build_output/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_build_output_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output_2/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_build_output_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output_2/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_build_output_2/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output_2/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_build_output_3/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output_3/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_build_output_3/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output_3/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_build_output_3/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_build_output_3/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_linker/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_linker/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_linker/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_linker/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_linker/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_linker/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_namespace_asset/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_namespace_asset/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_namespace_asset/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_namespace_asset/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_builder/test_data/wrong_namespace_asset/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/wrong_namespace_asset/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.15.0-wip
+## 0.15.0
 
 - **Breaking change** JSON encoding migration: change written asset type to the
   namespaced one. Still keep reading the old one. (Old build hooks will keep

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.15.0
+## 0.15.0-0
 
 - **Breaking change** JSON encoding migration: change written asset type to the
   namespaced one. Still keep reading the old one. (Old build hooks will keep

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.15.0-wip
+
+- **Breaking change** JSON encoding migration: change written asset type to the
+  namespaced one. Still keep reading the old one. (Old build hooks will keep
+  working with new SDKs.)
+- Bump SDK lower bound to version that understands namespaced asset types.
+  (Version 3.8.0-260.0.dev)
+
 ## 0.14.0
 
 - Added support for sending assets between build hooks via the `ToBuild`

--- a/pkgs/native_assets_cli/example/build/download_asset/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/download_asset/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   crypto: ^3.0.6
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/build/download_asset/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/download_asset/pubspec.yaml
@@ -13,8 +13,8 @@ environment:
 dependencies:
   crypto: ^3.0.6
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:
   args: ^2.6.0

--- a/pkgs/native_assets_cli/example/build/download_asset/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/download_asset/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   crypto: ^3.0.6
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/build/local_asset/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/local_asset/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_cli/example/build/local_asset/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/local_asset/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_cli/example/build/local_asset/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/local_asset/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_cli/example/build/native_add_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/native_add_library/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/build/native_add_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/native_add_library/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/build/native_add_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/native_add_library/pubspec.yaml
@@ -12,8 +12,8 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_cli/example/build/native_dynamic_linking/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/native_dynamic_linking/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/build/native_dynamic_linking/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/native_dynamic_linking/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/build/native_dynamic_linking/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/native_dynamic_linking/pubspec.yaml
@@ -12,8 +12,8 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_cli/example/build/system_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/system_library/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/build/system_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/system_library/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/build/system_library/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/system_library/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_cli/example/build/use_dart_api/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/use_dart_api/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/build/use_dart_api/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/use_dart_api/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/build/use_dart_api/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/use_dart_api/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   logging: ^1.3.0
-  native_assets_cli: ^0.14.0
-  native_toolchain_c: ^0.11.0
+  native_assets_cli: ^0.15.0-wip
+  native_toolchain_c: ^0.12.0-wip
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/native_assets_cli/example/link/package_with_assets/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/link/package_with_assets/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
   record_use: ^0.3.0
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/link/package_with_assets/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/link/package_with_assets/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   record_use: ^0.3.0
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/example/link/package_with_assets/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/link/package_with_assets/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   record_use: ^0.3.0
 
 dev_dependencies:

--- a/pkgs/native_assets_cli/lib/native_assets_cli.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli.dart
@@ -24,6 +24,7 @@ export 'src/config.dart'
         HookInput,
         LinkInput,
         LinkOutputBuilder,
+        PackageMetadata,
         ToAppBundle,
         ToBuildHooks,
         ToLinkHook;

--- a/pkgs/native_assets_cli/lib/src/code_assets/code_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/code_asset.dart
@@ -179,7 +179,7 @@ extension CodeAssetType on CodeAsset {
   /// Write the old type to prevent old hooks and SDKs from failing.
   // TODO(https://github.com/dart-lang/native/issues/2132): Change this to the
   // new value after it has rolled.
-  static const String typeForAsset = syntax.NativeCodeAsset.typeValue;
+  static const String typeForAsset = syntax.NativeCodeAssetNew.typeValue;
 }
 
 extension EncodedCodeAsset on EncodedAsset {

--- a/pkgs/native_assets_cli/lib/src/data_assets/data_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/data_asset.dart
@@ -92,7 +92,7 @@ extension DataAssetType on DataAsset {
   /// Write the old type to prevent old hooks and SDKs from failing.
   // TODO(https://github.com/dart-lang/native/issues/2132): Change this to the
   // new value after it has rolled.
-  static const String typeForAssets = syntax.DataAsset.typeValue;
+  static const String typeForAssets = syntax.DataAssetNew.typeValue;
 }
 
 extension EncodedDataAsset on EncodedAsset {

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A library that contains the argument and file formats for implementing a
   native assets CLI.
 
-version: 0.15.0-wip
+version: 0.15.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
 topics:

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -3,10 +3,8 @@ description: >-
   A library that contains the argument and file formats for implementing a
   native assets CLI.
 
-version: 0.14.0
+version: 0.15.0-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
-
-# publish_to: none
 
 topics:
   - ffi
@@ -16,7 +14,7 @@ topics:
 resolution: workspace
 
 environment:
-  sdk: '>=3.7.0 <4.0.0'
+  sdk: '>=3.8.0-260.0.dev <4.0.0'
 
 dependencies:
   collection: ^1.19.1

--- a/pkgs/native_assets_cli/pubspec.yaml
+++ b/pkgs/native_assets_cli/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A library that contains the argument and file formats for implementing a
   native assets CLI.
 
-version: 0.15.0
+version: 0.15.0-0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_assets_cli
 
 topics:

--- a/pkgs/native_assets_cli/test/code_assets/code_asset_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/code_asset_test.dart
@@ -22,7 +22,7 @@ void main() async {
         'id': 'package:my_package/name',
         'link_mode': {'type': 'dynamic_loading_bundle'},
         'os': 'android',
-        'type': 'native_code',
+        'type': 'code_assets/code',
         'encoding': {
           'architecture': 'riscv64',
           'file': 'not there',

--- a/pkgs/native_assets_cli/test/code_assets/config_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/config_test.dart
@@ -85,7 +85,7 @@ void main() async {
             'id': 'package:my_package/name',
             'link_mode': {'type': 'dynamic_loading_bundle'},
             'os': 'android',
-            'type': 'native_code',
+            'type': 'code_assets/code',
             'encoding': {
               'architecture': 'riscv64',
               'file': 'not there',

--- a/pkgs/native_assets_cli/test/data_assets/data_asset_test.dart
+++ b/pkgs/native_assets_cli/test/data_assets/data_asset_test.dart
@@ -17,7 +17,7 @@ void main() async {
         'file': 'not there',
         'package': 'my_package',
         'name': 'name',
-        'type': 'data',
+        'type': 'data_assets/data',
         'encoding': {
           'file': 'not there',
           'name': 'name',

--- a/pkgs/native_assets_cli/test/model/asset_test.dart
+++ b/pkgs/native_assets_cli/test/model/asset_test.dart
@@ -77,7 +77,7 @@ void main() {
       'id': 'package:my_package/foo',
       'link_mode': {'type': 'dynamic_loading_bundle'},
       'os': 'android',
-      'type': 'native_code',
+      'type': 'code_assets/code',
       'encoding': {
         'architecture': 'x64',
         'file': fooUri.toFilePath(),
@@ -94,7 +94,7 @@ void main() {
         'uri': foo3Uri.toFilePath(),
       },
       'os': 'android',
-      'type': 'native_code',
+      'type': 'code_assets/code',
       'encoding': {
         'architecture': 'x64',
         'id': 'package:my_package/foo3',
@@ -110,7 +110,7 @@ void main() {
       'id': 'package:my_package/foo4',
       'link_mode': {'type': 'dynamic_loading_executable'},
       'os': 'android',
-      'type': 'native_code',
+      'type': 'code_assets/code',
       'encoding': {
         'architecture': 'x64',
         'id': 'package:my_package/foo4',
@@ -123,7 +123,7 @@ void main() {
       'id': 'package:my_package/foo5',
       'link_mode': {'type': 'dynamic_loading_process'},
       'os': 'android',
-      'type': 'native_code',
+      'type': 'code_assets/code',
       'encoding': {
         'architecture': 'x64',
         'id': 'package:my_package/foo5',
@@ -137,7 +137,7 @@ void main() {
       'id': 'package:my_package/bar',
       'link_mode': {'type': 'static'},
       'os': 'linux',
-      'type': 'native_code',
+      'type': 'code_assets/code',
       'encoding': {
         'architecture': 'arm64',
         'file': barUri.toFilePath(),
@@ -152,7 +152,7 @@ void main() {
       'id': 'package:my_package/bla',
       'link_mode': {'type': 'dynamic_loading_bundle'},
       'os': 'windows',
-      'type': 'native_code',
+      'type': 'code_assets/code',
       'encoding': {
         'architecture': 'x64',
         'file': blaUri.toFilePath(),
@@ -165,7 +165,7 @@ void main() {
       'name': 'my_data_asset',
       'package': 'my_package',
       'file': Uri.file('path/to/data.txt').toFilePath(),
-      'type': 'data',
+      'type': 'data_assets/data',
       'encoding': {
         'name': 'my_data_asset',
         'package': 'my_package',
@@ -176,7 +176,7 @@ void main() {
       'name': 'my_data_asset2',
       'package': 'my_package',
       'file': Uri.file('path/to/data.json').toFilePath(),
-      'type': 'data',
+      'type': 'data_assets/data',
       'encoding': {
         'name': 'my_data_asset2',
         'package': 'my_package',

--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.0-wip
+
+- Bump `package:native_assets_cli` to 0.15.0.
+
 ## 0.11.0
 
 - Replace `linkInPackage` with `Routing`.

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   glob: ^2.1.1
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.15.0
+  native_assets_cli: ^0.15.0-0
   pub_semver: ^2.2.0
 
 dev_dependencies:

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,10 +1,8 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.11.0
+version: 0.12.0-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
-
-# publish_to: none
 
 topics:
   - compiler
@@ -22,7 +20,7 @@ dependencies:
   glob: ^2.1.1
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.14.0
+  native_assets_cli: ^0.15.0-wip
   pub_semver: ^2.2.0
 
 dev_dependencies:

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   glob: ^2.1.1
   logging: ^1.3.0
   meta: ^1.16.0
-  native_assets_cli: ^0.15.0-wip
+  native_assets_cli: ^0.15.0
   pub_semver: ^2.2.0
 
 dev_dependencies:


### PR DESCRIPTION
Let's try the new workflow where we put the Dart SDK lower bound with the first version that supports the required syntax in both Dart and Flutter (https://github.com/dart-lang/native/issues/93).

Let's try to release this, and roll it into Dart and Flutter to see if the new workflow works.

This PR removes all the builders against stable now that we have a dependency on a Dart SDK dev release.

Breaking JSON change in this PR: Start emitting new asset types (namespaced per package). This is not compatible with older versions of the protocol.