### PR TITLE
[native_assets_builder] user-defines in workspace pubspec

### DIFF
--- a/pkgs/native_assets_builder/test_data/user_defines/pubspec.yaml
+++ b/pkgs/native_assets_builder/test_data/user_defines/pubspec.yaml
@@ -21,9 +21,9 @@ dev_dependencies:
 # removed. (The tests copy this project and remove `resolution: workspace`.)
 hooks:
   user_defines:
-    user_defines:
+    user_defines: # package name
       user_define_key: user_define_value
       user_define_key2:
         foo: bar
-    some_other_package:
+    some_other_package: # package name
       user_define_key3: user_define_value3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,9 +62,9 @@ workspace:
 # Hook user-defines are specified in the pub workspace.
 hooks:
   user_defines:
-    user_defines:
+    user_defines: # package name
       user_define_key: user_define_value
       user_define_key2:
         foo: bar
-    some_other_package:
+    some_other_package: # package name
       user_define_key3: user_define_value3


### PR DESCRIPTION
Changes the test-data to have user-defines in the workspace pubspec, such that `dart test` etc. work on that project.

Keep the (ineffective) user-defines in the project pubspec, because the integration tests copy that pubspec and remove the `resolution: workspace` entry.

* https://github.com/dart-lang/native/issues/39
* https://github.com/dart-lang/native/issues/2187