### PR TITLE
[native_assets_cli] Format with Dart 3.8

### DIFF
--- a/pkgs/native_assets_cli/lib/src/code_assets/architecture.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/architecture.dart
@@ -100,11 +100,11 @@ extension ArchitectureSyntax on Architecture {
 
   syntax.Architecture toSyntax() => _toSyntax[this]!;
 
-  static Architecture fromSyntax(
-    syntax.Architecture syntax,
-  ) => switch (_fromSyntax[syntax]) {
-    null =>
-      throw FormatException('The architecture "${syntax.name}" is not known'),
-    final arch => arch,
-  };
+  static Architecture fromSyntax(syntax.Architecture syntax) =>
+      switch (_fromSyntax[syntax]) {
+        null => throw FormatException(
+          'The architecture "${syntax.name}" is not known',
+        ),
+        final arch => arch,
+      };
 }

--- a/pkgs/native_assets_cli/lib/src/code_assets/c_compiler_config.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/c_compiler_config.dart
@@ -22,10 +22,9 @@ final class CCompilerConfig {
 
   /// Configuration provided when [CodeConfig.targetOS] is [OS.windows].
   WindowsCCompilerConfig get windows => switch (_windows) {
-    null =>
-      throw StateError(
-        'Cannot access windows if CodeConfig.targetOS is not Windows',
-      ),
+    null => throw StateError(
+      'Cannot access windows if CodeConfig.targetOS is not Windows',
+    ),
     final c => c,
   };
 

--- a/pkgs/native_assets_cli/lib/src/code_assets/config.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/config.dart
@@ -18,10 +18,9 @@ extension CodeAssetHookConfig on HookConfig {
   /// Code asset specific configuration.
   CodeConfig get code => CodeConfig._fromJson(json, path);
 
-  bool get buildCodeAssets =>
-      buildAssetTypes
-          .where((e) => CodeAssetType.typesForBuildAssetTypes.contains(e))
-          .isNotEmpty;
+  bool get buildCodeAssets => buildAssetTypes
+      .where((e) => CodeAssetType.typesForBuildAssetTypes.contains(e))
+      .isNotEmpty;
 }
 
 /// Extension to the [LinkInput] providing access to configuration specific to
@@ -78,17 +77,17 @@ class CodeConfig {
 
   /// Configuration provided when [CodeConfig.targetOS] is [OS.android].
   AndroidCodeConfig get android => switch (_syntax.android) {
-    null =>
-      throw StateError(
-        'Cannot access androidConfig if targetOS is not android.',
-      ),
+    null => throw StateError(
+      'Cannot access androidConfig if targetOS is not android.',
+    ),
     final c => AndroidCodeConfig._(c),
   };
 
   /// Configuration provided when [CodeConfig.targetOS] is [OS.macOS].
   MacOSCodeConfig get macOS => switch (_syntax.macOS) {
-    null =>
-      throw StateError('Cannot access macOSConfig if targetOS is not MacOS.'),
+    null => throw StateError(
+      'Cannot access macOSConfig if targetOS is not MacOS.',
+    ),
     final c => MacOSCodeConfig._(c),
   };
 }
@@ -217,21 +216,19 @@ extension CodeAssetBuildInputBuilder on HookConfigBuilder {
 /// Provides access to [CodeAsset]s from a build hook output.
 extension CodeAssetBuildOutput on BuildOutputAssets {
   /// The code assets emitted by the build hook.
-  List<CodeAsset> get code =>
-      encodedAssets
-          .where((asset) => asset.isCodeAsset)
-          .map(CodeAsset.fromEncoded)
-          .toList();
+  List<CodeAsset> get code => encodedAssets
+      .where((asset) => asset.isCodeAsset)
+      .map(CodeAsset.fromEncoded)
+      .toList();
 }
 
 /// Provides access to [CodeAsset]s from a link hook output.
 extension CodeAssetLinkOutput on LinkOutputAssets {
   /// The code assets emitted by the link hook.
-  List<CodeAsset> get code =>
-      encodedAssets
-          .where((asset) => asset.isCodeAsset)
-          .map(CodeAsset.fromEncoded)
-          .toList();
+  List<CodeAsset> get code => encodedAssets
+      .where((asset) => asset.isCodeAsset)
+      .map(CodeAsset.fromEncoded)
+      .toList();
 }
 
 extension MacOSCodeConfigSyntax on MacOSCodeConfig {

--- a/pkgs/native_assets_cli/lib/src/code_assets/testing.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/testing.dart
@@ -39,21 +39,18 @@ Future<void> testCodeBuildHook({
     cCompiler: cCompiler,
     targetArchitecture: targetArchitecture ?? Architecture.current,
     targetOS: targetOS ?? OS.current,
-    iOS:
-        targetOS == OS.iOS
-            ? IOSCodeConfig(
-              targetSdk: targetIOSSdk!,
-              targetVersion: targetIOSVersion!,
-            )
-            : null,
-    macOS:
-        targetOS == OS.macOS
-            ? MacOSCodeConfig(targetVersion: targetMacOSVersion!)
-            : null,
-    android:
-        targetOS == OS.android
-            ? AndroidCodeConfig(targetNdkApi: targetAndroidNdkApi!)
-            : null,
+    iOS: targetOS == OS.iOS
+        ? IOSCodeConfig(
+            targetSdk: targetIOSSdk!,
+            targetVersion: targetIOSVersion!,
+          )
+        : null,
+    macOS: targetOS == OS.macOS
+        ? MacOSCodeConfig(targetVersion: targetMacOSVersion!)
+        : null,
+    android: targetOS == OS.android
+        ? AndroidCodeConfig(targetNdkApi: targetAndroidNdkApi!)
+        : null,
   );
   await testBuildHook(
     mainMethod: mainMethod,

--- a/pkgs/native_assets_cli/lib/src/config.dart
+++ b/pkgs/native_assets_cli/lib/src/config.dart
@@ -103,10 +103,9 @@ extension type HookInputUserDefines._(HookInput _input) {
 }
 
 sealed class HookInputBuilder {
-  final _syntax =
-      syntax.HookInput.fromJson({})
-        ..version = latestVersion.toString()
-        ..config = syntax.Config(buildAssetTypes: [], extensions: null);
+  final _syntax = syntax.HookInput.fromJson({})
+    ..version = latestVersion.toString()
+    ..config = syntax.Config(buildAssetTypes: [], extensions: null);
 
   Map<String, Object?> get json => _syntax.json;
 
@@ -129,8 +128,9 @@ sealed class HookInputBuilder {
     _syntax.outDir = outputDirectory;
     _syntax.outDirShared = outputDirectoryShared;
     _syntax.outFile = outputFile;
-    _syntax.userDefines =
-        userDefines == null ? null : syntax.JsonObject.fromJson(userDefines);
+    _syntax.userDefines = userDefines == null
+        ? null
+        : syntax.JsonObject.fromJson(userDefines);
   }
 
   /// Constructs a checksum for a [BuildInput].
@@ -237,16 +237,15 @@ final class BuildInputBuilder extends HookInputBuilder {
       dependencyMetadata: {
         for (final key in metadata.keys) key: metadata[key]!.toJson(),
       },
-      assets:
-          assets == null
-              ? null
-              : {
-                for (final MapEntry(:key, :value) in assets.entries)
-                  key: [
-                    for (final asset in value)
-                      syntax.Asset.fromJson(asset.toJson()),
-                  ],
-              },
+      assets: assets == null
+          ? null
+          : {
+              for (final MapEntry(:key, :value) in assets.entries)
+                key: [
+                  for (final asset in value)
+                    syntax.Asset.fromJson(asset.toJson()),
+                ],
+            },
     );
   }
 
@@ -332,13 +331,12 @@ final class LinkInputBuilder extends HookInputBuilder {
       extension.setupLinkInput(this);
 }
 
-List<EncodedAsset> _parseAssets(List<syntax.Asset>? assets) =>
-    assets == null
-        ? []
-        : [
-          for (final asset in assets)
-            EncodedAsset.fromJson(asset.json, asset.path),
-        ];
+List<EncodedAsset> _parseAssets(List<syntax.Asset>? assets) => assets == null
+    ? []
+    : [
+        for (final asset in assets)
+          EncodedAsset.fromJson(asset.json, asset.path),
+      ];
 
 sealed class HookOutput {
   /// The underlying json configuration of this [HookOutput].

--- a/pkgs/native_assets_cli/lib/src/data_assets/config.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/config.dart
@@ -81,10 +81,9 @@ extension AddDataAssetsDirectory on BuildOutputBuilder {
 /// Extension to the [HookConfig] providing access to configuration specific
 /// to data assets.
 extension DataAssetHookConfig on HookConfig {
-  bool get buildDataAssets =>
-      buildAssetTypes
-          .where((e) => DataAssetType.typesForBuildAssetTypes.contains(e))
-          .isNotEmpty;
+  bool get buildDataAssets => buildAssetTypes
+      .where((e) => DataAssetType.typesForBuildAssetTypes.contains(e))
+      .isNotEmpty;
 }
 
 /// Extension to initialize data specific configuration on link/build inputs.
@@ -149,18 +148,16 @@ extension type DataAssetLinkOutputBuilderAdd(
 
 /// Provides access to [DataAsset]s from a build hook output.
 extension DataAssetBuildOutput on BuildOutputAssets {
-  List<DataAsset> get data =>
-      encodedAssets
-          .where((asset) => asset.isDataAsset)
-          .map<DataAsset>(DataAsset.fromEncoded)
-          .toList();
+  List<DataAsset> get data => encodedAssets
+      .where((asset) => asset.isDataAsset)
+      .map<DataAsset>(DataAsset.fromEncoded)
+      .toList();
 }
 
 /// Provides access to [DataAsset]s from a link hook output.
 extension DataAssetLinkOutput on LinkOutputAssets {
-  List<DataAsset> get data =>
-      encodedAssets
-          .where((asset) => asset.isDataAsset)
-          .map<DataAsset>(DataAsset.fromEncoded)
-          .toList();
+  List<DataAsset> get data => encodedAssets
+      .where((asset) => asset.isDataAsset)
+      .map<DataAsset>(DataAsset.fromEncoded)
+      .toList();
 }

--- a/pkgs/native_assets_cli/lib/src/encoded_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/encoded_asset.dart
@@ -36,15 +36,14 @@ final class EncodedAsset {
   ]) {
     final syntax_ = syntax.Asset.fromJson(json, path: path ?? []);
     final encodingSyntax = syntax_.encoding;
-    final encoding =
-        encodingSyntax != null
-            // If 'encoding' is provided, copy that.
-            ? Map.of(encodingSyntax.json)
-            // Otherwise, fall back to copying the keys except for 'type'.
-            : {
-              for (final key in json.keys)
-                if (key != _typeKey) key: json[key],
-            };
+    final encoding = encodingSyntax != null
+        // If 'encoding' is provided, copy that.
+        ? Map.of(encodingSyntax.json)
+        // Otherwise, fall back to copying the keys except for 'type'.
+        : {
+            for (final key in json.keys)
+              if (key != _typeKey) key: json[key],
+          };
     final path_ = encodingSyntax != null ? [...?path, 'encoding'] : path;
 
     return EncodedAsset._(

--- a/pkgs/native_assets_cli/lib/src/model/resource_identifiers.dart
+++ b/pkgs/native_assets_cli/lib/src/model/resource_identifiers.dart
@@ -20,11 +20,10 @@ class ResourceIdentifiers {
   factory ResourceIdentifiers.fromFileContents(String fileContents) {
     final fileJson = (jsonDecode(fileContents) as Map)['identifiers'] as List;
     return ResourceIdentifiers(
-      identifiers:
-          fileJson
-              .map((e) => e as Map<String, Object?>)
-              .map(Identifier.fromJson)
-              .toList(),
+      identifiers: fileJson
+          .map((e) => e as Map<String, Object?>)
+          .map(Identifier.fromJson)
+          .toList(),
     );
   }
 

--- a/pkgs/native_assets_cli/lib/src/target.dart
+++ b/pkgs/native_assets_cli/lib/src/target.dart
@@ -114,30 +114,29 @@ final class Target implements Comparable<Target> {
 
   Architecture get architecture => Architecture.fromAbi(abi);
 
-  OS get os =>
-      {
-        Abi.androidArm: OS.android,
-        Abi.androidArm64: OS.android,
-        Abi.androidIA32: OS.android,
-        Abi.androidX64: OS.android,
-        Abi.androidRiscv64: OS.android,
-        Abi.fuchsiaArm64: OS.fuchsia,
-        Abi.fuchsiaX64: OS.fuchsia,
-        Abi.iosArm: OS.iOS,
-        Abi.iosArm64: OS.iOS,
-        Abi.iosX64: OS.iOS,
-        Abi.linuxArm: OS.linux,
-        Abi.linuxArm64: OS.linux,
-        Abi.linuxIA32: OS.linux,
-        Abi.linuxRiscv32: OS.linux,
-        Abi.linuxRiscv64: OS.linux,
-        Abi.linuxX64: OS.linux,
-        Abi.macosArm64: OS.macOS,
-        Abi.macosX64: OS.macOS,
-        Abi.windowsArm64: OS.windows,
-        Abi.windowsIA32: OS.windows,
-        Abi.windowsX64: OS.windows,
-      }[abi]!;
+  OS get os => {
+    Abi.androidArm: OS.android,
+    Abi.androidArm64: OS.android,
+    Abi.androidIA32: OS.android,
+    Abi.androidX64: OS.android,
+    Abi.androidRiscv64: OS.android,
+    Abi.fuchsiaArm64: OS.fuchsia,
+    Abi.fuchsiaX64: OS.fuchsia,
+    Abi.iosArm: OS.iOS,
+    Abi.iosArm64: OS.iOS,
+    Abi.iosX64: OS.iOS,
+    Abi.linuxArm: OS.linux,
+    Abi.linuxArm64: OS.linux,
+    Abi.linuxIA32: OS.linux,
+    Abi.linuxRiscv32: OS.linux,
+    Abi.linuxRiscv64: OS.linux,
+    Abi.linuxX64: OS.linux,
+    Abi.macosArm64: OS.macOS,
+    Abi.macosX64: OS.macOS,
+    Abi.windowsArm64: OS.windows,
+    Abi.windowsIA32: OS.windows,
+    Abi.windowsX64: OS.windows,
+  }[abi]!;
 
   @override
   String toString() => dartVMToString();
@@ -154,16 +153,15 @@ final class Target implements Comparable<Target> {
   /// A list of supported target [Target]s from this host [os].
   List<Target> supportedTargetTargets({
     Map<OS, List<OS>> osCrossCompilation = OS.osCrossCompilationDefault,
-  }) =>
-      Target.values
-          .where(
-            (target) =>
-                // Only valid cross compilation.
-                osCrossCompilation[os]!.contains(target.os) &&
-                // And no deprecated architectures.
-                target != Target.iOSArm,
-          )
-          .sorted;
+  }) => Target.values
+      .where(
+        (target) =>
+            // Only valid cross compilation.
+            osCrossCompilation[os]!.contains(target.os) &&
+            // And no deprecated architectures.
+            target != Target.iOSArm,
+      )
+      .sorted;
 }
 
 /// Common methods for manipulating iterables of [Target]s.

--- a/pkgs/native_assets_cli/lib/test.dart
+++ b/pkgs/native_assets_cli/lib/test.dart
@@ -36,8 +36,9 @@ Future<void> testBuildHook({
 
   try {
     // Deal with Windows temp folder aliases.
-    final tempUri =
-        Directory(await tempDir.resolveSymbolicLinks()).uri.normalizePath();
+    final tempUri = Directory(
+      await tempDir.resolveSymbolicLinks(),
+    ).uri.normalizePath();
     final outputDirectory = tempUri.resolve('output/');
     final outputDirectoryShared = tempUri.resolve('output_shared/');
     final outputFile = tempUri.resolve('output.json');

--- a/pkgs/native_assets_cli/test/build_input_test.dart
+++ b/pkgs/native_assets_cli/test/build_input_test.dart
@@ -85,18 +85,17 @@ void main() async {
   });
 
   test('BuildInputBuilder->JSON->BuildInput', () {
-    final inputBuilder =
-        BuildInputBuilder()
-          ..setupShared(
-            packageName: packageName,
-            packageRoot: packageRootUri,
-            outputFile: outFile,
-            outputDirectory: outDirUri,
-            outputDirectoryShared: outputDirectoryShared,
-          )
-          ..config.addBuildAssetTypes(['my-asset-type'])
-          ..config.setupBuild(linkingEnabled: false)
-          ..setupBuildInput(metadata: metadata, assets: assets);
+    final inputBuilder = BuildInputBuilder()
+      ..setupShared(
+        packageName: packageName,
+        packageRoot: packageRootUri,
+        outputFile: outFile,
+        outputDirectory: outDirUri,
+        outputDirectoryShared: outputDirectoryShared,
+      )
+      ..config.addBuildAssetTypes(['my-asset-type'])
+      ..config.setupBuild(linkingEnabled: false)
+      ..setupBuildInput(metadata: metadata, assets: assets);
     final input = BuildInput(inputBuilder.json);
 
     expect(input.json, inputJson);

--- a/pkgs/native_assets_cli/test/checksum_test.dart
+++ b/pkgs/native_assets_cli/test/checksum_test.dart
@@ -51,21 +51,18 @@ void main() {
                       CodeAssetExtension(
                         targetArchitecture: architecture,
                         targetOS: os,
-                        android:
-                            os == OS.android
-                                ? AndroidCodeConfig(targetNdkApi: targetVersion)
-                                : null,
-                        macOS:
-                            os == OS.macOS
-                                ? MacOSCodeConfig(targetVersion: targetVersion)
-                                : null,
-                        iOS:
-                            os == OS.iOS
-                                ? IOSCodeConfig(
-                                  targetVersion: targetVersion,
-                                  targetSdk: iOSSdk,
-                                )
-                                : null,
+                        android: os == OS.android
+                            ? AndroidCodeConfig(targetNdkApi: targetVersion)
+                            : null,
+                        macOS: os == OS.macOS
+                            ? MacOSCodeConfig(targetVersion: targetVersion)
+                            : null,
+                        iOS: os == OS.iOS
+                            ? IOSCodeConfig(
+                                targetVersion: targetVersion,
+                                targetSdk: iOSSdk,
+                              )
+                            : null,
                         linkModePreference: LinkModePreference.dynamic,
                       ),
                     );

--- a/pkgs/native_assets_cli/test/code_assets/config_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/config_test.dart
@@ -132,35 +132,34 @@ void main() async {
   }
 
   test('BuildInput.config.code', () {
-    final inputBuilder =
-        BuildInputBuilder()
-          ..setupShared(
-            packageName: packageName,
-            packageRoot: packageRootUri,
-            outputFile: outFile,
-            outputDirectory: outDirUri,
-            outputDirectoryShared: outputDirectoryShared,
-          )
-          ..config.setupBuild(linkingEnabled: false)
-          ..addExtension(
-            CodeAssetExtension(
-              targetOS: OS.android,
-              targetArchitecture: Architecture.arm64,
-              android: AndroidCodeConfig(targetNdkApi: 30),
-              linkModePreference: LinkModePreference.preferStatic,
-              cCompiler: CCompilerConfig(
-                compiler: fakeClang,
-                linker: fakeLd,
-                archiver: fakeAr,
-                windows: WindowsCCompilerConfig(
-                  developerCommandPrompt: DeveloperCommandPrompt(
-                    script: fakeVcVars,
-                    arguments: ['arg0', 'arg1'],
-                  ),
-                ),
+    final inputBuilder = BuildInputBuilder()
+      ..setupShared(
+        packageName: packageName,
+        packageRoot: packageRootUri,
+        outputFile: outFile,
+        outputDirectory: outDirUri,
+        outputDirectoryShared: outputDirectoryShared,
+      )
+      ..config.setupBuild(linkingEnabled: false)
+      ..addExtension(
+        CodeAssetExtension(
+          targetOS: OS.android,
+          targetArchitecture: Architecture.arm64,
+          android: AndroidCodeConfig(targetNdkApi: 30),
+          linkModePreference: LinkModePreference.preferStatic,
+          cCompiler: CCompilerConfig(
+            compiler: fakeClang,
+            linker: fakeLd,
+            archiver: fakeAr,
+            windows: WindowsCCompilerConfig(
+              developerCommandPrompt: DeveloperCommandPrompt(
+                script: fakeVcVars,
+                arguments: ['arg0', 'arg1'],
               ),
             ),
-          );
+          ),
+        ),
+      );
     final input = BuildInput(inputBuilder.json);
     expect(input.json, inputJson(includeDeprecated: true));
     expectCorrectCodeConfig(input.config.code);
@@ -182,35 +181,34 @@ void main() async {
   });
 
   test('LinkInput.{code,codeAssets}', () {
-    final inputBuilder =
-        LinkInputBuilder()
-          ..setupShared(
-            packageName: packageName,
-            packageRoot: packageRootUri,
-            outputFile: outFile,
-            outputDirectory: outDirUri,
-            outputDirectoryShared: outputDirectoryShared,
-          )
-          ..setupLink(assets: assets, recordedUsesFile: null)
-          ..addExtension(
-            CodeAssetExtension(
-              targetOS: OS.android,
-              targetArchitecture: Architecture.arm64,
-              android: AndroidCodeConfig(targetNdkApi: 30),
-              linkModePreference: LinkModePreference.preferStatic,
-              cCompiler: CCompilerConfig(
-                compiler: fakeClang,
-                linker: fakeLd,
-                archiver: fakeAr,
-                windows: WindowsCCompilerConfig(
-                  developerCommandPrompt: DeveloperCommandPrompt(
-                    script: fakeVcVars,
-                    arguments: ['arg0', 'arg1'],
-                  ),
-                ),
+    final inputBuilder = LinkInputBuilder()
+      ..setupShared(
+        packageName: packageName,
+        packageRoot: packageRootUri,
+        outputFile: outFile,
+        outputDirectory: outDirUri,
+        outputDirectoryShared: outputDirectoryShared,
+      )
+      ..setupLink(assets: assets, recordedUsesFile: null)
+      ..addExtension(
+        CodeAssetExtension(
+          targetOS: OS.android,
+          targetArchitecture: Architecture.arm64,
+          android: AndroidCodeConfig(targetNdkApi: 30),
+          linkModePreference: LinkModePreference.preferStatic,
+          cCompiler: CCompilerConfig(
+            compiler: fakeClang,
+            linker: fakeLd,
+            archiver: fakeAr,
+            windows: WindowsCCompilerConfig(
+              developerCommandPrompt: DeveloperCommandPrompt(
+                script: fakeVcVars,
+                arguments: ['arg0', 'arg1'],
               ),
             ),
-          );
+          ),
+        ),
+      );
     final input = LinkInput(inputBuilder.json);
     expect(input.json, inputJson(hookType: 'link', includeDeprecated: true));
     expectCorrectCodeConfig(input.config.code);
@@ -240,10 +238,9 @@ void main() async {
   test('BuildInput.config.code: invalid architecture', () {
     final input = inputJson();
     traverseJson<Map<String, Object?>>(input, [
-          'config',
-          'code',
-        ])['target_architecture'] =
-        'invalid_architecture';
+      'config',
+      'code',
+    ])['target_architecture'] = 'invalid_architecture';
     expect(
       () => BuildInput(input).config.code.targetArchitecture,
       throwsFormatException,
@@ -260,11 +257,10 @@ void main() async {
   test('LinkInput.config.code.target_os invalid type', () {
     final input = inputJson(hookType: 'link');
     traverseJson<Map<String, Object?>>(input, [
-          'config',
-          'extensions',
-          'code_assets',
-        ])['target_os'] =
-        123;
+      'config',
+      'extensions',
+      'code_assets',
+    ])['target_os'] = 123;
     expect(
       () => LinkInput(input).config.code.targetOS,
       throwsA(

--- a/pkgs/native_assets_cli/test/code_assets/validation_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/validation_test.dart
@@ -33,30 +33,29 @@ void main() {
   });
 
   BuildInputBuilder makeBuildInputBuilder() {
-    final inputBuilder =
-        BuildInputBuilder()
-          ..setupShared(
-            packageName: packageName,
-            packageRoot: tempUri,
-            outputFile: tempUri.resolve('output.json'),
-            outputDirectory: outDirUri,
-            outputDirectoryShared: outDirSharedUri,
-          )
-          ..config.setupBuild(linkingEnabled: false);
+    final inputBuilder = BuildInputBuilder()
+      ..setupShared(
+        packageName: packageName,
+        packageRoot: tempUri,
+        outputFile: tempUri.resolve('output.json'),
+        outputDirectory: outDirUri,
+        outputDirectoryShared: outDirSharedUri,
+      )
+      ..config.setupBuild(linkingEnabled: false);
     return inputBuilder;
   }
 
   BuildInput makeCodeBuildInput({
     LinkModePreference linkModePreference = LinkModePreference.dynamic,
   }) {
-    final builder =
-        makeBuildInputBuilder()..addExtension(
-          CodeAssetExtension(
-            targetOS: OS.linux,
-            targetArchitecture: Architecture.arm64,
-            linkModePreference: linkModePreference,
-          ),
-        );
+    final builder = makeBuildInputBuilder()
+      ..addExtension(
+        CodeAssetExtension(
+          targetOS: OS.linux,
+          targetArchitecture: Architecture.arm64,
+          linkModePreference: linkModePreference,
+        ),
+      );
     return BuildInput(builder.json);
   }
 
@@ -261,18 +260,18 @@ void main() {
   group('BuildInput.config.code validation', () {
     for (final propertyKey in ['target_version', 'target_sdk']) {
       test('Missing targetIOSVersion', () async {
-        final builder =
-            makeBuildInputBuilder()..addExtension(
-              CodeAssetExtension(
-                targetOS: OS.iOS,
-                targetArchitecture: Architecture.arm64,
-                linkModePreference: LinkModePreference.dynamic,
-                iOS: IOSCodeConfig(
-                  targetSdk: IOSSdk.iPhoneOS,
-                  targetVersion: 123,
-                ),
+        final builder = makeBuildInputBuilder()
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: OS.iOS,
+              targetArchitecture: Architecture.arm64,
+              linkModePreference: LinkModePreference.dynamic,
+              iOS: IOSCodeConfig(
+                targetSdk: IOSSdk.iPhoneOS,
+                targetVersion: 123,
               ),
-            );
+            ),
+          );
         traverseJson<Map<String, Object?>>(builder.json, [
           'config',
           'code',
@@ -294,15 +293,15 @@ void main() {
     }
 
     test('Missing targetAndroidNdkApi', () async {
-      final builder =
-          makeBuildInputBuilder()..addExtension(
-            CodeAssetExtension(
-              targetOS: OS.android,
-              targetArchitecture: Architecture.arm64,
-              linkModePreference: LinkModePreference.dynamic,
-              android: AndroidCodeConfig(targetNdkApi: 123),
-            ),
-          );
+      final builder = makeBuildInputBuilder()
+        ..addExtension(
+          CodeAssetExtension(
+            targetOS: OS.android,
+            targetArchitecture: Architecture.arm64,
+            linkModePreference: LinkModePreference.dynamic,
+            android: AndroidCodeConfig(targetNdkApi: 123),
+          ),
+        );
       traverseJson<Map<String, Object?>>(builder.json, [
         'config',
         'code',
@@ -320,15 +319,15 @@ void main() {
     });
 
     test('Missing config.code.macos', () async {
-      final builder =
-          makeBuildInputBuilder()..addExtension(
-            CodeAssetExtension(
-              targetOS: OS.macOS,
-              targetArchitecture: Architecture.arm64,
-              linkModePreference: LinkModePreference.dynamic,
-              macOS: MacOSCodeConfig(targetVersion: 123),
-            ),
-          );
+      final builder = makeBuildInputBuilder()
+        ..addExtension(
+          CodeAssetExtension(
+            targetOS: OS.macOS,
+            targetArchitecture: Architecture.arm64,
+            linkModePreference: LinkModePreference.dynamic,
+            macOS: MacOSCodeConfig(targetVersion: 123),
+          ),
+        );
 
       traverseJson<Map<String, Object?>>(builder.json, [
         'config',
@@ -357,25 +356,25 @@ void main() {
 
     test('CCompilerConfig validation', () async {
       final nonExistent = outDirUri.resolve('foo baz');
-      final builder =
-          makeBuildInputBuilder()..addExtension(
-            CodeAssetExtension(
-              targetOS: OS.windows,
-              targetArchitecture: Architecture.x64,
-              linkModePreference: LinkModePreference.dynamic,
-              cCompiler: CCompilerConfig(
-                compiler: nonExistent,
-                linker: nonExistent,
-                archiver: nonExistent,
-                windows: WindowsCCompilerConfig(
-                  developerCommandPrompt: DeveloperCommandPrompt(
-                    script: nonExistent,
-                    arguments: [],
-                  ),
+      final builder = makeBuildInputBuilder()
+        ..addExtension(
+          CodeAssetExtension(
+            targetOS: OS.windows,
+            targetArchitecture: Architecture.x64,
+            linkModePreference: LinkModePreference.dynamic,
+            cCompiler: CCompilerConfig(
+              compiler: nonExistent,
+              linker: nonExistent,
+              archiver: nonExistent,
+              windows: WindowsCCompilerConfig(
+                developerCommandPrompt: DeveloperCommandPrompt(
+                  script: nonExistent,
+                  arguments: [],
                 ),
               ),
             ),
-          );
+          ),
+        );
       final errors = await validateCodeAssetBuildInput(
         BuildInput(builder.json),
       );

--- a/pkgs/native_assets_cli/test/data_assets/validation_test.dart
+++ b/pkgs/native_assets_cli/test/data_assets/validation_test.dart
@@ -31,17 +31,16 @@ void main() {
   });
 
   BuildInput makeDataBuildInput() {
-    final inputBuilder =
-        BuildInputBuilder()
-          ..setupShared(
-            packageName: packageName,
-            packageRoot: tempUri.resolve('$packageName/'),
-            outputFile: tempUri.resolve('output.json'),
-            outputDirectory: outDirUri,
-            outputDirectoryShared: outDirSharedUri,
-          )
-          ..config.setupBuild(linkingEnabled: false)
-          ..addExtension(DataAssetsExtension());
+    final inputBuilder = BuildInputBuilder()
+      ..setupShared(
+        packageName: packageName,
+        packageRoot: tempUri.resolve('$packageName/'),
+        outputFile: tempUri.resolve('output.json'),
+        outputDirectory: outDirUri,
+        outputDirectoryShared: outDirSharedUri,
+      )
+      ..config.setupBuild(linkingEnabled: false)
+      ..addExtension(DataAssetsExtension());
     return BuildInput(inputBuilder.json);
   }
 

--- a/pkgs/native_assets_cli/test/example/local_asset_test.dart
+++ b/pkgs/native_assets_cli/test/example/local_asset_test.dart
@@ -37,28 +37,26 @@ void main() async {
     final dartUri = Uri.file(Platform.resolvedExecutable);
 
     final targetOS = OS.current;
-    final inputBuilder =
-        BuildInputBuilder()
-          ..setupShared(
-            packageRoot: testPackageUri,
-            packageName: name,
-            outputFile: buildOutputUri,
-            outputDirectory: outputDirectory,
-            outputDirectoryShared: outputDirectoryShared,
-          )
-          ..config.setupBuild(linkingEnabled: false)
-          ..addExtension(
-            CodeAssetExtension(
-              targetOS: targetOS,
-              macOS:
-                  targetOS == OS.macOS
-                      ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                      : null,
-              targetArchitecture: Architecture.current,
-              linkModePreference: LinkModePreference.dynamic,
-              cCompiler: cCompiler,
-            ),
-          );
+    final inputBuilder = BuildInputBuilder()
+      ..setupShared(
+        packageRoot: testPackageUri,
+        packageName: name,
+        outputFile: buildOutputUri,
+        outputDirectory: outputDirectory,
+        outputDirectoryShared: outputDirectoryShared,
+      )
+      ..config.setupBuild(linkingEnabled: false)
+      ..addExtension(
+        CodeAssetExtension(
+          targetOS: targetOS,
+          macOS: targetOS == OS.macOS
+              ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+              : null,
+          targetArchitecture: Architecture.current,
+          linkModePreference: LinkModePreference.dynamic,
+          cCompiler: cCompiler,
+        ),
+      );
 
     final buildInputUri = testTempUri.resolve('build_input.json');
     await File.fromUri(

--- a/pkgs/native_assets_cli/test/example/native_add_library_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_library_test.dart
@@ -37,28 +37,26 @@ void main() async {
     final dartUri = Uri.file(Platform.resolvedExecutable);
 
     final targetOS = OS.current;
-    final inputBuilder =
-        BuildInputBuilder()
-          ..setupShared(
-            packageRoot: testPackageUri,
-            packageName: name,
-            outputFile: buildOutputUri,
-            outputDirectory: outputDirectory,
-            outputDirectoryShared: outputDirectoryShared,
-          )
-          ..config.setupBuild(linkingEnabled: false)
-          ..addExtension(
-            CodeAssetExtension(
-              targetOS: OS.current,
-              macOS:
-                  targetOS == OS.macOS
-                      ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                      : null,
-              targetArchitecture: Architecture.current,
-              linkModePreference: LinkModePreference.dynamic,
-              cCompiler: cCompiler,
-            ),
-          );
+    final inputBuilder = BuildInputBuilder()
+      ..setupShared(
+        packageRoot: testPackageUri,
+        packageName: name,
+        outputFile: buildOutputUri,
+        outputDirectory: outputDirectory,
+        outputDirectoryShared: outputDirectoryShared,
+      )
+      ..config.setupBuild(linkingEnabled: false)
+      ..addExtension(
+        CodeAssetExtension(
+          targetOS: OS.current,
+          macOS: targetOS == OS.macOS
+              ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+              : null,
+          targetArchitecture: Architecture.current,
+          linkModePreference: LinkModePreference.dynamic,
+          cCompiler: cCompiler,
+        ),
+      );
 
     final buildInputUri = testTempUri.resolve('build_input.json');
     await File.fromUri(

--- a/pkgs/native_assets_cli/test/example/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_dynamic_linking_test.dart
@@ -41,28 +41,26 @@ void main() async {
     final dartUri = Uri.file(Platform.resolvedExecutable);
 
     final targetOS = OS.current;
-    final inputBuilder =
-        BuildInputBuilder()
-          ..setupShared(
-            packageRoot: testPackageUri,
-            packageName: name,
-            outputFile: buildOutputUri,
-            outputDirectory: outputDirectory,
-            outputDirectoryShared: outputDirectoryShared,
-          )
-          ..config.setupBuild(linkingEnabled: false)
-          ..addExtension(
-            CodeAssetExtension(
-              targetOS: targetOS,
-              macOS:
-                  targetOS == OS.macOS
-                      ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
-                      : null,
-              targetArchitecture: Architecture.current,
-              linkModePreference: LinkModePreference.dynamic,
-              cCompiler: cCompiler,
-            ),
-          );
+    final inputBuilder = BuildInputBuilder()
+      ..setupShared(
+        packageRoot: testPackageUri,
+        packageName: name,
+        outputFile: buildOutputUri,
+        outputDirectory: outputDirectory,
+        outputDirectoryShared: outputDirectoryShared,
+      )
+      ..config.setupBuild(linkingEnabled: false)
+      ..addExtension(
+        CodeAssetExtension(
+          targetOS: targetOS,
+          macOS: targetOS == OS.macOS
+              ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
+              : null,
+          targetArchitecture: Architecture.current,
+          linkModePreference: LinkModePreference.dynamic,
+          cCompiler: cCompiler,
+        ),
+      );
 
     final buildInputUri = testTempUri.resolve('build_input.json');
     await File.fromUri(

--- a/pkgs/native_assets_cli/test/helpers.dart
+++ b/pkgs/native_assets_cli/test/helpers.dart
@@ -18,8 +18,9 @@ Future<void> inTempDir(
 }) async {
   final tempDir = await Directory.systemTemp.createTemp(prefix);
   // Deal with Windows temp folder aliases.
-  final tempUri =
-      Directory(await tempDir.resolveSymbolicLinks()).uri.normalizePath();
+  final tempUri = Directory(
+    await tempDir.resolveSymbolicLinks(),
+  ).uri.normalizePath();
   try {
     await fun(tempUri);
   } finally {
@@ -87,27 +88,27 @@ extension on Uri {
 /// Archiver provided by the environment.
 ///
 /// Provided on Dart CI.
-final Uri? _ar =
-    Platform.environment['DART_HOOK_TESTING_C_COMPILER__AR']?.asFileUri();
+final Uri? _ar = Platform.environment['DART_HOOK_TESTING_C_COMPILER__AR']
+    ?.asFileUri();
 
 /// Compiler provided by the environment.
 ///
 /// Provided on Dart CI.
-final Uri? _cc =
-    Platform.environment['DART_HOOK_TESTING_C_COMPILER__CC']?.asFileUri();
+final Uri? _cc = Platform.environment['DART_HOOK_TESTING_C_COMPILER__CC']
+    ?.asFileUri();
 
 /// Linker provided by the environment.
 ///
 /// Provided on Dart CI.
-final Uri? _ld =
-    Platform.environment['DART_HOOK_TESTING_C_COMPILER__LD']?.asFileUri();
+final Uri? _ld = Platform.environment['DART_HOOK_TESTING_C_COMPILER__LD']
+    ?.asFileUri();
 
 /// Path to script that sets environment variables for [_cc], [_ld], and [_ar].
 ///
 /// Provided on Dart CI.
-final Uri? _envScript =
-    Platform.environment['DART_HOOK_TESTING_C_COMPILER__ENV_SCRIPT']
-        ?.asFileUri();
+final Uri? _envScript = Platform
+    .environment['DART_HOOK_TESTING_C_COMPILER__ENV_SCRIPT']
+    ?.asFileUri();
 
 /// Arguments for [_envScript] provided by environment.
 ///
@@ -119,23 +120,21 @@ final List<String>? _envScriptArgs = Platform
 /// Configuration for the native toolchain.
 ///
 /// Provided on Dart CI.
-final cCompiler =
-    (_cc == null || _ar == null || _ld == null)
-        ? null
-        : CCompilerConfig(
-          compiler: _cc!,
-          archiver: _ar!,
-          linker: _ld!,
-          windows: WindowsCCompilerConfig(
-            developerCommandPrompt:
-                _envScript == null
-                    ? null
-                    : DeveloperCommandPrompt(
-                      script: _envScript!,
-                      arguments: _envScriptArgs ?? [],
-                    ),
-          ),
-        );
+final cCompiler = (_cc == null || _ar == null || _ld == null)
+    ? null
+    : CCompilerConfig(
+        compiler: _cc!,
+        archiver: _ar!,
+        linker: _ld!,
+        windows: WindowsCCompilerConfig(
+          developerCommandPrompt: _envScript == null
+              ? null
+              : DeveloperCommandPrompt(
+                  script: _envScript!,
+                  arguments: _envScriptArgs ?? [],
+                ),
+        ),
+      );
 
 extension on String {
   Uri asFileUri() => Uri.file(this);
@@ -176,28 +175,24 @@ extension UriExtension on Uri {
 }
 
 /// Logger that outputs the full trace when a test fails.
-Logger get logger =>
-    _logger ??= () {
-      // A new logger is lazily created for each test so that the messages
-      // captured by printOnFailure are scoped to the correct test.
-      addTearDown(() => _logger = null);
-      return _createTestLogger();
-    }();
+Logger get logger => _logger ??= () {
+  // A new logger is lazily created for each test so that the messages
+  // captured by printOnFailure are scoped to the correct test.
+  addTearDown(() => _logger = null);
+  return _createTestLogger();
+}();
 
 Logger? _logger;
 
 Logger _createTestLogger({
   List<String>? capturedMessages,
   Level level = Level.ALL,
-}) =>
-    Logger.detached('')
-      ..level = level
-      ..onRecord.listen((record) {
-        printOnFailure(
-          '${record.level.name}: ${record.time}: ${record.message}',
-        );
-        capturedMessages?.add(record.message);
-      });
+}) => Logger.detached('')
+  ..level = level
+  ..onRecord.listen((record) {
+    printOnFailure('${record.level.name}: ${record.time}: ${record.message}');
+    capturedMessages?.add(record.message);
+  });
 
 final dartExecutable = File(Platform.resolvedExecutable).uri;
 

--- a/pkgs/native_assets_cli/test/link_input_test.dart
+++ b/pkgs/native_assets_cli/test/link_input_test.dart
@@ -45,17 +45,16 @@ void main() async {
   });
 
   test('LinkInputBuilder->JSON->LinkInput', () {
-    final inputBuilder =
-        LinkInputBuilder()
-          ..setupShared(
-            packageName: packageName,
-            packageRoot: packageRootUri,
-            outputFile: outFile,
-            outputDirectory: outDirUri,
-            outputDirectoryShared: outputDirectoryShared,
-          )
-          ..config.addBuildAssetTypes(['asset-type-1', 'asset-type-2'])
-          ..setupLink(assets: assets, recordedUsesFile: null);
+    final inputBuilder = LinkInputBuilder()
+      ..setupShared(
+        packageName: packageName,
+        packageRoot: packageRootUri,
+        outputFile: outFile,
+        outputDirectory: outDirUri,
+        outputDirectoryShared: outputDirectoryShared,
+      )
+      ..config.addBuildAssetTypes(['asset-type-1', 'asset-type-2'])
+      ..setupLink(assets: assets, recordedUsesFile: null);
     final input = LinkInput(inputBuilder.json);
 
     expect(input.json, inputJson);

--- a/pkgs/native_assets_cli/test/model/dependencies_test.dart
+++ b/pkgs/native_assets_cli/test/model/dependencies_test.dart
@@ -11,12 +11,9 @@ void main() {
   late Uri tempUri;
 
   setUp(
-    () async =>
-        tempUri =
-            Directory(
-              await (await Directory.systemTemp.createTemp())
-                  .resolveSymbolicLinks(),
-            ).uri,
+    () async => tempUri = Directory(
+      await (await Directory.systemTemp.createTemp()).resolveSymbolicLinks(),
+    ).uri,
   );
 
   tearDown(

--- a/pkgs/native_assets_cli/test/validation_test.dart
+++ b/pkgs/native_assets_cli/test/validation_test.dart
@@ -30,16 +30,15 @@ void main() {
   });
 
   BuildInput makeBuildInput() {
-    final inputBuilder =
-        BuildInputBuilder()
-          ..setupShared(
-            packageName: packageName,
-            packageRoot: tempUri,
-            outputFile: tempUri.resolve('output.json'),
-            outputDirectory: outDirUri,
-            outputDirectoryShared: outDirSharedUri,
-          )
-          ..config.setupBuild(linkingEnabled: false);
+    final inputBuilder = BuildInputBuilder()
+      ..setupShared(
+        packageName: packageName,
+        packageRoot: tempUri,
+        outputFile: tempUri.resolve('output.json'),
+        outputDirectory: outDirUri,
+        outputDirectoryShared: outDirSharedUri,
+      )
+      ..config.setupBuild(linkingEnabled: false);
     return BuildInput(inputBuilder.json);
   }
 


### PR DESCRIPTION
The CI will be red soon because `package:native_assets_cli` is opted in to a Dart 3.8 dev release.

When the CI will be red, we should land this PR to make it green again.

The PR will be red before a new dart dev release is cut. (Tuesday?)

Bug: https://github.com/dart-lang/native/issues/2194