### PR TITLE
Fixed an issue with how java.io.File is created

### DIFF
--- a/pkgs/jnigen/example/pdfbox_plugin/example/README.md
+++ b/pkgs/jnigen/example/pdfbox_plugin/example/README.md
@@ -10,6 +10,7 @@ On a Linux machine, following commands can be used to run the example applicatio
 cd .. ## From this folder
 dart run jnigen --config jnigen.yaml ## Downloads PDFBox JARs and generates bindings.
 cd example/
+dart run jni:setup
 flutter run --release ## Opens the files list from home directory
 ```
 

--- a/pkgs/jnigen/example/pdfbox_plugin/example/lib/main.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/example/lib/main.dart
@@ -67,8 +67,6 @@ class PDFInfoAppState extends State<PDFInfoApp> {
       final isDir = (await item.stat()).type == FileSystemEntityType.directory;
       if (item.path.endsWith('.pdf') && !isDir) {
         pdfs.add(item.path);
-      } else if (isDir) {
-        dirs.add(item.path);
       }
     }
     setState(() {
@@ -158,9 +156,10 @@ class PDFFileInfo {
     // Since java.io is not directly available, use package:jni API to
     // create a java.io.File object.
     final fileClass = JClass.forName("java/io/File");
-    final inputFile = fileClass
-        .constructorId("(Ljava/lang/String;)V")
-        .call(fileClass, JObject.type, [filename]);
+    final fileConstructor = fileClass.constructorId("(Ljava/lang/String;)V");
+    final inputFile = fileConstructor(
+        fileClass, JObject.type, [JString.fromString(filename)]);
+
     // Static method call PDDocument.load -> PDDocument
     final pdf = PDDocument.load(inputFile)!;
     // Instance method call getNumberOfPages() -> int


### PR DESCRIPTION
### [ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: Unable to locate the helper library.
- `dart run jni:setup` at the example app is required
- `README.md` updated

### flutter: Unsupported operation: cannot convert String to jvalue

#### The issue

```
flutter: Unsupported operation: cannot convert String to jvalue
flutter: #0      _fillJValue (package:jni/src/jvalues.dart:47)
flutter: #1      toJValues (package:jni/src/jvalues.dart:62)
flutter: #2      JConstructorId.call.<anonymous closure> (package:jni/src/jclass.dart:164)
flutter: #3      using (package:ffi/src/arena.dart:127)
flutter: #4      JConstructorId.call (package:jni/src/jclass.dart:161)
flutter: #5      new PDFFileInfo.usingPDFBox (package:pdfbox_example/main.dart:163)
flutter: #6      PDFInfoAppState.build (package:pdfbox_example/main.dart:125)
flutter: #7      StatefulElement.build (package:flutter/src/widgets/framework.dart:5841)
flutter: #8      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:5733)
flutter: #9      StatefulElement.performRebuild (package:flutter/src/widgets/framework.dart:5892)
flutter: #10     Element.rebuild (package:flutter/src/widgets/framework.dart:5445)
flutter: #11     BuildScope._tryRebuild (package:flutter/src/widgets/framework.dart:2704)
flutter: #12     BuildScope._flushDirtyElements (package:flutter/src/widgets/framework.dart:2762)
flutter: #13     BuildOwner.buildScope (package:flutter/src/widgets/framework.dart:3066)
flutter: #14     WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:1229)
flutter: #15     RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:482)
flutter: #16     SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1442)
flutter: #17     SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1355)
flutter: #18     SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1208)
flutter: #19     _invoke (dart:ui/hooks.dart:316)
flutter: #20     PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:428)
flutter: #21     _drawFrame (dart:ui/hooks.dart:288)
```
#### Fixed and tested with a sample pdf that has a title.

![image](https://github.com/user-attachments/assets/212c2fdf-ec63-4671-ad86-49f8482304db)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
