### PR TITLE
[ffigen] Changes to support downstream clone

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 18.1.1-wip
+
+- Make it easier for a downstream clone to change behavior of certain utils.
+
 ## 18.1.0
 
 - Fix a clang warning in ObjC protocol generated bindings.

--- a/pkgs/ffigen/lib/src/config_provider/overrideable_utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/overrideable_utils.dart
@@ -42,3 +42,7 @@ final libclangOverridePaths = const <String>[];
 ///
 /// Note that `dart test` sets the current directory to the package root.
 final packagePathForTests = p.current;
+
+/// Returns a path to a config yaml in a unit test.
+String configPathForTest(String directory, String file) =>
+    p.join(directory, file);

--- a/pkgs/ffigen/lib/src/config_provider/overrideable_utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/overrideable_utils.dart
@@ -31,9 +31,9 @@ String normalizePath(String path, String? configFilename) {
 
 /// These locations are searched for clang dylibs before any others. Downstream
 /// clones can use a non-null value for this path to search here first.
-final List<String> libclangOverridePaths = const <String>[];
+final libclangOverridePaths = const <String>[];
 
 /// Returns the root path of the package, for use during tests.
 ///
 /// Note that `dart test` sets the current directory to the package root.
-final String packagePathForTests = p.current;
+final packagePathForTests = p.current;

--- a/pkgs/ffigen/lib/src/config_provider/overrideable_utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/overrideable_utils.dart
@@ -7,7 +7,8 @@
 
 // This file is exclusively imported by utils.dart, so that there's only one
 // line we have to patch in the downstream clones.
-@Deprecated('Import config_provider/utils.dart instead') library;
+@Deprecated('Import config_provider/utils.dart instead')
+library;
 
 import 'dart:io';
 

--- a/pkgs/ffigen/lib/src/config_provider/overrideable_utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/overrideable_utils.dart
@@ -5,6 +5,10 @@
 // This file contains utils that are intended to be overridden by downstream
 // clones. They're gathered into one file to make it easy to swap them out.
 
+// This file is exclusively imported by utils.dart, so that there's only one
+// line we have to patch in the downstream clones.
+@Deprecated('Import config_provider/utils.dart instead') library;
+
 import 'dart:io';
 
 import 'package:path/path.dart' as p;

--- a/pkgs/ffigen/lib/src/config_provider/overrideable_utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/overrideable_utils.dart
@@ -5,7 +5,18 @@
 // This file contains utils that are intended to be overridden by downstream
 // clones. They're gathered into one file to make it easy to swap them out.
 
+import 'dart:io';
+
 import 'package:path/path.dart' as p;
+
+// Replaces the path separators according to current platform.
+String _replaceSeparators(String path) {
+  if (Platform.isWindows) {
+    return path.replaceAll(p.posix.separator, p.windows.separator);
+  } else {
+    return path.replaceAll(p.windows.separator, p.posix.separator);
+  }
+}
 
 /// Replaces the path separators according to current platform, and normalizes .
 /// and .. in the path. If a relative path is passed in, it is resolved relative
@@ -18,9 +29,9 @@ String normalizePath(String path, String? configFilename) {
       : p.absolute(p.join(p.dirname(configFilename), path))));
 }
 
-/// This is the first location searched for the clang dylib. Downstream clones
-/// can use a non-null value for this path to search here first.
-final String? libclangOverridablePath = null;
+/// These locations are searched for clang dylibs before any others. Downstream
+/// clones can use a non-null value for this path to search here first.
+final List<String> libclangOverridePaths = const <String>[];
 
 /// Returns the root path of the package, for use during tests.
 ///

--- a/pkgs/ffigen/lib/src/config_provider/overrideable_utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/overrideable_utils.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// This file contains utils that are intended to be overridden by downstream
+// clones. They're gathered into one file to make it easy to swap them out.
+
+import 'package:path/path.dart' as p;
+
+/// Replaces the path separators according to current platform, and normalizes .
+/// and .. in the path. If a relative path is passed in, it is resolved relative
+/// to the config path, and the absolute path is returned.
+String normalizePath(String path, String? configFilename) {
+  final resolveInConfigDir =
+      (configFilename == null) || p.isAbsolute(path) || path.startsWith('**');
+  return _replaceSeparators(p.normalize(resolveInConfigDir
+      ? path
+      : p.absolute(p.join(p.dirname(configFilename), path))));
+}
+
+/// This is the first location searched for the clang dylib. Downstream clones
+/// can use a non-null value for this path to search here first.
+final String? libclangOverridablePath = null;
+
+/// Returns the root path of the package, for use during tests.
+///
+/// Note that `dart test` sets the current directory to the package root.
+final String packagePathForTests = p.current;

--- a/pkgs/ffigen/lib/src/config_provider/spec_utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/spec_utils.dart
@@ -308,8 +308,10 @@ String? _findLibInConda() {
 /// Returns location of dynamic library by searching default locations. Logs
 /// error and throws an Exception if not found.
 String findDylibAtDefaultLocations() {
-  final overridableLib = findLibclangDylib(libclangOverridablePath);
-  if (overridableLib != null) return overridableLib;
+  for (final libclangPath in libclangOverridePaths) {
+    final overridableLib = findLibclangDylib(libclangPath);
+    if (overridableLib != null) return overridableLib;
+  }
 
   // Assume clang in conda has a higher priority.
   final condaLib = _findLibInConda();

--- a/pkgs/ffigen/lib/src/config_provider/spec_utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/spec_utils.dart
@@ -308,13 +308,17 @@ String? _findLibInConda() {
 /// Returns location of dynamic library by searching default locations. Logs
 /// error and throws an Exception if not found.
 String findDylibAtDefaultLocations() {
+  final overridableLib = findLibclangDylib(libclangOverridablePath);
+  if (overridableLib != null) return overridableLib;
+
   // Assume clang in conda has a higher priority.
-  var k = _findLibInConda();
-  if (k != null) return k;
+  final condaLib = _findLibInConda();
+  if (condaLib != null) return condaLib;
+
   if (Platform.isLinux) {
     for (final l in strings.linuxDylibLocations) {
-      k = findLibclangDylib(l);
-      if (k != null) return k;
+      final linuxLib = findLibclangDylib(l);
+      if (linuxLib != null) return linuxLib;
     }
     Process.runSync('ldconfig', ['-p']);
     final ldConfigResult = Process.runSync('ldconfig', ['-p']);
@@ -338,13 +342,13 @@ String findDylibAtDefaultLocations() {
           .add(p.join(userHome, 'scoop', 'apps', 'llvm', 'current', 'bin'));
     }
     for (final l in dylibLocations) {
-      k = findLibclangDylib(l);
-      if (k != null) return k;
+      final winLib = findLibclangDylib(l);
+      if (winLib != null) return winLib;
     }
   } else if (Platform.isMacOS) {
     for (final l in strings.macOsDylibLocations) {
-      k = findLibclangDylib(l);
-      if (k != null) return k;
+      final macLib = findLibclangDylib(l);
+      if (macLib != null) return macLib;
     }
     final findLibraryResult =
         Process.runSync('xcodebuild', ['-find-library', 'libclang.dylib']);

--- a/pkgs/ffigen/lib/src/config_provider/utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/utils.dart
@@ -6,6 +6,8 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
+export 'overridable_utils.dart';
+
 // Replaces the path separators according to current platform.
 String _replaceSeparators(String path) {
   if (Platform.isWindows) {
@@ -13,17 +15,6 @@ String _replaceSeparators(String path) {
   } else {
     return path.replaceAll(p.windows.separator, p.posix.separator);
   }
-}
-
-/// Replaces the path separators according to current platform, and normalizes .
-/// and .. in the path. If a relative path is passed in, it is resolved relative
-/// to the config path, and the absolute path is returned.
-String normalizePath(String path, String? configFilename) {
-  final resolveInConfigDir =
-      (configFilename == null) || p.isAbsolute(path) || path.startsWith('**');
-  return _replaceSeparators(p.normalize(resolveInConfigDir
-      ? path
-      : p.absolute(p.join(p.dirname(configFilename), path))));
 }
 
 /// Replaces any variable names in the path with the corresponding value.

--- a/pkgs/ffigen/lib/src/config_provider/utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/utils.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+// ignore: deprecated_member_use_from_same_package
 export 'overrideable_utils.dart';
 
 /// Replaces any variable names in the path with the corresponding value.

--- a/pkgs/ffigen/lib/src/config_provider/utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/utils.dart
@@ -4,18 +4,7 @@
 
 import 'dart:io';
 
-import 'package:path/path.dart' as p;
-
-export 'overridable_utils.dart';
-
-// Replaces the path separators according to current platform.
-String _replaceSeparators(String path) {
-  if (Platform.isWindows) {
-    return path.replaceAll(p.posix.separator, p.windows.separator);
-  } else {
-    return path.replaceAll(p.windows.separator, p.posix.separator);
-  }
-}
+export 'overrideable_utils.dart';
 
 /// Replaces any variable names in the path with the corresponding value.
 String substituteVars(String path) {

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 18.1.0
+version: 18.1.1
 description: >
   Generator for FFI bindings, using LibClang to parse C, Objective-C, and Swift
   files.

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 18.1.1
+version: 18.1.1-wip
 description: >
   Generator for FFI bindings, using LibClang to parse C, Objective-C, and Swift
   files.

--- a/pkgs/ffigen/test/collision_tests/decl_type_name_collision_test.dart
+++ b/pkgs/ffigen/test/collision_tests/decl_type_name_collision_test.dart
@@ -22,7 +22,7 @@ ${strings.description}: 'Decl type name collision test'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/collision_tests/decl_type_name_collision.h'
+    - '${absPath('test/collision_tests/decl_type_name_collision.h')}'
 ${strings.preamble}: |
     // ignore_for_file: non_constant_identifier_names, 
         '''),

--- a/pkgs/ffigen/test/config_tests/compiler_opts_test.dart
+++ b/pkgs/ffigen/test/config_tests/compiler_opts_test.dart
@@ -34,7 +34,7 @@ ${strings.description}: 'Compiler Opts Test'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/comment_markup.h'
+    - '${absPath('test/header_parser_tests/comment_markup.h')}'
 ${strings.compilerOptsAuto}:
   ${strings.macos}:
     ${strings.includeCStdLib}: false

--- a/pkgs/ffigen/test/config_tests/deprecate_assetid_test.dart
+++ b/pkgs/ffigen/test/config_tests/deprecate_assetid_test.dart
@@ -21,7 +21,7 @@ ${strings.ffiNative}:
     assetId: 'myasset'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/comment_markup.h'
+    - '${absPath('test/header_parser_tests/comment_markup.h')}'
 ''');
     parse(config);
 

--- a/pkgs/ffigen/test/config_tests/exclude_all_by_default_test.dart
+++ b/pkgs/ffigen/test/config_tests/exclude_all_by_default_test.dart
@@ -19,7 +19,7 @@ ${strings.output}: 'unused'
 ${strings.excludeAllByDefault}: false
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/config_tests/exclude_all_by_default.h'
+    - '${absPath('test/config_tests/exclude_all_by_default.h')}'
 ''');
 
       final library = parse(config);
@@ -40,7 +40,7 @@ ${strings.output}: 'unused'
 ${strings.excludeAllByDefault}: true
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/config_tests/exclude_all_by_default.h'
+    - '${absPath('test/config_tests/exclude_all_by_default.h')}'
 ''');
 
       final library = parse(config);

--- a/pkgs/ffigen/test/config_tests/include_exclude_test.dart
+++ b/pkgs/ffigen/test/config_tests/include_exclude_test.dart
@@ -49,7 +49,7 @@ ${strings.description}: 'include_exclude test'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/config_tests/include_exclude.h'
+    - '${absPath('test/config_tests/include_exclude.h')}'
 ''';
   if (include != null || exclude != null) {
     templateString += '''

--- a/pkgs/ffigen/test/config_tests/no_cursor_definition_warn_test.dart
+++ b/pkgs/ffigen/test/config_tests/no_cursor_definition_warn_test.dart
@@ -21,7 +21,7 @@ ${strings.description}: 'Warn for no cursor definition.'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/opaque_dependencies.h'
+    - '${absPath('test/header_parser_tests/opaque_dependencies.h')}'
 ${strings.structs}:
   ${strings.dependencyOnly}: ${strings.opaqueCompoundDependencies}
   ${strings.include}:

--- a/pkgs/ffigen/test/config_tests/packed_struct_override_test.dart
+++ b/pkgs/ffigen/test/config_tests/packed_struct_override_test.dart
@@ -12,12 +12,12 @@ import '../test_utils.dart';
 void main() {
   group('packed_struct_override_test', () {
     test('Invalid Packed Config values', () {
-      const baseYaml = '''${strings.name}: 'NativeLibrary'
+      final baseYaml = '''${strings.name}: 'NativeLibrary'
 ${strings.description}: 'Packed Struct Override Test'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/packed_structs.h'
+    - '${absPath('test/header_parser_tests/packed_structs.h')}'
 ${strings.structs}:
   ${strings.structPack}:
     ''';
@@ -35,7 +35,7 @@ ${strings.description}: 'Packed Struct Override Test'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/packed_structs.h'
+    - '${absPath('test/header_parser_tests/packed_structs.h')}'
 ${strings.structs}:
   ${strings.structPack}:
     'Normal.*': 1

--- a/pkgs/ffigen/test/config_tests/unknown_keys_warn_test.dart
+++ b/pkgs/ffigen/test/config_tests/unknown_keys_warn_test.dart
@@ -20,7 +20,7 @@ ${strings.description}: 'Warn for unknown keys.'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/packed_structs.h'
+    - '${absPath('test/header_parser_tests/packed_structs.h')}'
 'warn-1': 'warn'
 ${strings.typeMap}:
   'warn-2': 'warn'

--- a/pkgs/ffigen/test/header_parser_tests/comment_markup_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/comment_markup_test.dart
@@ -22,7 +22,7 @@ ${strings.description}: 'Comment Markup Test'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/comment_markup.h'
+    - '${absPath('test/header_parser_tests/comment_markup.h')}'
 ${strings.comments}:
   ${strings.style}: ${strings.any}
   ${strings.length}: ${strings.full}

--- a/pkgs/ffigen/test/header_parser_tests/dart_handle_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/dart_handle_test.dart
@@ -26,7 +26,7 @@ ${strings.compilerOpts}: '-I${path.join(sdkPath, "include")}'
 
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/dart_handle.h'
+    - '${absPath('test/header_parser_tests/dart_handle.h')}'
   ${strings.includeDirectives}:
     - '**dart_handle.h'
         '''),

--- a/pkgs/ffigen/test/header_parser_tests/enum_int_mimic_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/enum_int_mimic_test.dart
@@ -22,7 +22,7 @@ ${strings.description}: 'Enum int mimic test'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/enum_int_mimic.h'
+    - '${absPath('test/header_parser_tests/enum_int_mimic.h')}'
   ${strings.includeDirectives}:
     - '**enum_int_mimic.h'
 ${strings.ignoreSourceErrors}: true

--- a/pkgs/ffigen/test/header_parser_tests/forward_decl_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/forward_decl_test.dart
@@ -22,7 +22,7 @@ ${strings.description}: 'Forward Declaration Test'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/forward_decl.h'
+    - '${absPath('test/header_parser_tests/forward_decl.h')}'
 ${strings.ignoreSourceErrors}: true
         '''),
       );

--- a/pkgs/ffigen/test/header_parser_tests/function_n_struct_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/function_n_struct_test.dart
@@ -25,7 +25,7 @@ ${strings.output}: 'unused'
 
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/function_n_struct.h'
+    - '${absPath('test/header_parser_tests/function_n_struct.h')}'
         '''),
       );
     });

--- a/pkgs/ffigen/test/header_parser_tests/functions_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/functions_test.dart
@@ -23,7 +23,7 @@ ${strings.output}: 'unused'
 
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/functions.h'
+    - '${absPath('test/header_parser_tests/functions.h')}'
   ${strings.includeDirectives}:
     - '**functions.h'
 

--- a/pkgs/ffigen/test/header_parser_tests/globals_config.yaml
+++ b/pkgs/ffigen/test/header_parser_tests/globals_config.yaml
@@ -1,0 +1,18 @@
+name: 'NativeLibrary'
+description: 'Globals Test'
+output: 'unused'
+headers:
+  entry-points:
+    - globals.h
+  include-directives:
+    - '**globals.h'
+globals:
+  exclude:
+    - GlobalIgnore
+  symbol-address:
+    include:
+      - myInt
+      - pointerToLongDouble
+      - globalStruct
+compiler-opts: '-Wno-nullability-completeness'
+ignore-source-errors: true

--- a/pkgs/ffigen/test/header_parser_tests/globals_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/globals_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:ffigen/src/code_generator.dart';
 import 'package:ffigen/src/header_parser.dart' as parser;
-import 'package:ffigen/src/strings.dart' as strings;
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 

--- a/pkgs/ffigen/test/header_parser_tests/globals_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/globals_test.dart
@@ -23,7 +23,7 @@ ${strings.description}: 'Globals Test'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/globals.h'
+    - '${absPath('test/header_parser_tests/globals.h')}'
   ${strings.includeDirectives}:
     - '**globals.h'
 ${strings.globals}:

--- a/pkgs/ffigen/test/header_parser_tests/globals_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/globals_test.dart
@@ -17,8 +17,8 @@ void main() {
       logWarnings();
       expected = expectedLibrary();
       actual = parser.parse(
-        testConfigFromPath(absPath(
-            path.join('test', 'header_parser_tests', 'globals_config.yaml'))),
+        testConfigFromPath(configPath(
+            path.join('test', 'header_parser_tests'), 'globals_config.yaml')),
       );
     });
 

--- a/pkgs/ffigen/test/header_parser_tests/globals_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/globals_test.dart
@@ -18,8 +18,8 @@ void main() {
       logWarnings();
       expected = expectedLibrary();
       actual = parser.parse(
-        testConfigFromPath(absPath(path.join(
-            'test', 'header_parser_tests', 'globals_config.yaml'))),
+        testConfigFromPath(absPath(
+            path.join('test', 'header_parser_tests', 'globals_config.yaml'))),
       );
     });
 

--- a/pkgs/ffigen/test/header_parser_tests/globals_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/globals_test.dart
@@ -5,6 +5,7 @@
 import 'package:ffigen/src/code_generator.dart';
 import 'package:ffigen/src/header_parser.dart' as parser;
 import 'package:ffigen/src/strings.dart' as strings;
+import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 import '../test_utils.dart';
@@ -17,26 +18,8 @@ void main() {
       logWarnings();
       expected = expectedLibrary();
       actual = parser.parse(
-        testConfig('''
-${strings.name}: 'NativeLibrary'
-${strings.description}: 'Globals Test'
-${strings.output}: 'unused'
-${strings.headers}:
-  ${strings.entryPoints}:
-    - '${absPath('test/header_parser_tests/globals.h')}'
-  ${strings.includeDirectives}:
-    - '**globals.h'
-${strings.globals}:
-  ${strings.exclude}:
-    - GlobalIgnore
-  ${strings.symbolAddress}:
-    ${strings.include}:
-      - myInt
-      - pointerToLongDouble
-      - globalStruct
-${strings.compilerOpts}: '-Wno-nullability-completeness'
-${strings.ignoreSourceErrors}: true
-        '''),
+        testConfigFromPath(absPath(path.join(
+            'test', 'header_parser_tests', 'globals_config.yaml'))),
       );
     });
 

--- a/pkgs/ffigen/test/header_parser_tests/imported_types_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/imported_types_test.dart
@@ -23,7 +23,7 @@ ${strings.output}: 'unused'
 
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/imported_types.h'
+    - '${absPath('test/header_parser_tests/imported_types.h')}'
   ${strings.includeDirectives}:
     - '**imported_types.h'
 

--- a/pkgs/ffigen/test/header_parser_tests/macros_config.yaml
+++ b/pkgs/ffigen/test/header_parser_tests/macros_config.yaml
@@ -1,0 +1,8 @@
+name: 'NativeLibrary'
+description: 'Macros Test'
+output: 'unused'
+headers:
+  entry-points:
+    - macros.h
+  include-directives:
+    - '**macros.h'

--- a/pkgs/ffigen/test/header_parser_tests/macros_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/macros_test.dart
@@ -19,8 +19,8 @@ void main() {
       logWarnings(Level.WARNING);
       expected = expectedLibrary();
       actual = parser.parse(
-        testConfigFromPath(absPath(path.join(
-            'test', 'header_parser_tests', 'macros_config.yaml'))),
+        testConfigFromPath(absPath(
+            path.join('test', 'header_parser_tests', 'macros_config.yaml'))),
       );
     });
     test('Total bindings count', () {

--- a/pkgs/ffigen/test/header_parser_tests/macros_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/macros_test.dart
@@ -24,7 +24,7 @@ ${strings.description}: 'Macros Test'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/macros.h'
+    - '${absPath('test/header_parser_tests/macros.h')}'
   ${strings.includeDirectives}:
     - '**macros.h'
         '''),

--- a/pkgs/ffigen/test/header_parser_tests/macros_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/macros_test.dart
@@ -19,8 +19,8 @@ void main() {
       logWarnings(Level.WARNING);
       expected = expectedLibrary();
       actual = parser.parse(
-        testConfigFromPath(absPath(
-            path.join('test', 'header_parser_tests', 'macros_config.yaml'))),
+        testConfigFromPath(configPath(
+            path.join('test', 'header_parser_tests'), 'macros_config.yaml')),
       );
     });
     test('Total bindings count', () {

--- a/pkgs/ffigen/test/header_parser_tests/macros_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/macros_test.dart
@@ -5,6 +5,7 @@
 import 'package:ffigen/src/code_generator.dart';
 import 'package:ffigen/src/header_parser.dart' as parser;
 import 'package:ffigen/src/strings.dart' as strings;
+import 'package:path/path.dart' as path;
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
@@ -18,16 +19,8 @@ void main() {
       logWarnings(Level.WARNING);
       expected = expectedLibrary();
       actual = parser.parse(
-        testConfig('''
-${strings.name}: 'NativeLibrary'
-${strings.description}: 'Macros Test'
-${strings.output}: 'unused'
-${strings.headers}:
-  ${strings.entryPoints}:
-    - '${absPath('test/header_parser_tests/macros.h')}'
-  ${strings.includeDirectives}:
-    - '**macros.h'
-        '''),
+        testConfigFromPath(absPath(path.join(
+            'test', 'header_parser_tests', 'macros_config.yaml'))),
       );
     });
     test('Total bindings count', () {

--- a/pkgs/ffigen/test/header_parser_tests/macros_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/macros_test.dart
@@ -5,8 +5,8 @@
 import 'package:ffigen/src/code_generator.dart';
 import 'package:ffigen/src/header_parser.dart' as parser;
 import 'package:ffigen/src/strings.dart' as strings;
-import 'package:path/path.dart' as path;
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 import '../test_utils.dart';

--- a/pkgs/ffigen/test/header_parser_tests/native_func_typedef_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/native_func_typedef_test.dart
@@ -22,7 +22,7 @@ ${strings.description}: 'Native Func Typedef Test.'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/native_func_typedef.h'
+    - '${absPath('test/header_parser_tests/native_func_typedef.h')}'
         '''),
       );
     });

--- a/pkgs/ffigen/test/header_parser_tests/nested_parsing_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/nested_parsing_test.dart
@@ -23,7 +23,7 @@ ${strings.description}: 'Nested Parsing Test'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/nested_parsing.h'
+    - '${absPath('test/header_parser_tests/nested_parsing.h')}'
 ${strings.structs}:
   ${strings.exclude}:
     - Struct2

--- a/pkgs/ffigen/test/header_parser_tests/opaque_dependencies_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/opaque_dependencies_test.dart
@@ -22,7 +22,7 @@ ${strings.description}: 'Opaque Dependencies Test'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/opaque_dependencies.h'
+    - '${absPath('test/header_parser_tests/opaque_dependencies.h')}'
 ${strings.structs}:
   ${strings.include}:
     - 'E'

--- a/pkgs/ffigen/test/header_parser_tests/packed_structs_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/packed_structs_test.dart
@@ -22,7 +22,7 @@ ${strings.description}: 'Packed Structs Test'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/packed_structs.h'
+    - '${absPath('test/header_parser_tests/packed_structs.h')}'
         '''),
       );
     });

--- a/pkgs/ffigen/test/header_parser_tests/regress_384_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/regress_384_test.dart
@@ -22,8 +22,8 @@ ${strings.description}: 'https://github.com/dart-lang/ffigen/issues/384'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/regress_384_header_1.h'
-    - 'test/header_parser_tests/regress_384_header_2.h'
+    - '${absPath('test/header_parser_tests/regress_384_header_1.h')}'
+    - '${absPath('test/header_parser_tests/regress_384_header_2.h')}'
         '''),
       );
     });

--- a/pkgs/ffigen/test/header_parser_tests/struct_fptr_fields_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/struct_fptr_fields_test.dart
@@ -24,7 +24,7 @@ ${strings.description}: 'Function pointer fields in structs Test'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/struct_fptr_fields.h'
+    - '${absPath('test/header_parser_tests/struct_fptr_fields.h')}'
         ''') as yaml.YamlMap),
       );
     });

--- a/pkgs/ffigen/test/header_parser_tests/typedef_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/typedef_test.dart
@@ -24,7 +24,7 @@ ${strings.output}: 'unused'
 
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/typedef.h'
+    - '${absPath('test/header_parser_tests/typedef.h')}'
   ${strings.includeDirectives}:
     - '**typedef.h'
 ${strings.structs}:

--- a/pkgs/ffigen/test/header_parser_tests/unions_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/unions_test.dart
@@ -22,7 +22,7 @@ ${strings.description}: 'Unions Test'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/unions.h'
+    - '${absPath('test/header_parser_tests/unions.h')}'
 ${strings.ignoreSourceErrors}: true
         '''),
       );

--- a/pkgs/ffigen/test/header_parser_tests/unnamed_enums_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/unnamed_enums_test.dart
@@ -23,7 +23,7 @@ ${strings.description}: 'Unnamed Enums Test'
 ${strings.output}: 'unused'
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/unnamed_enums.h'
+    - '${absPath('test/header_parser_tests/unnamed_enums.h')}'
 ${strings.enums}:
   ${strings.exclude}:
     - Named

--- a/pkgs/ffigen/test/header_parser_tests/varargs_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/varargs_test.dart
@@ -25,7 +25,7 @@ ${strings.output}: 'unused'
 
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/header_parser_tests/varargs.h'
+    - '${absPath('test/header_parser_tests/varargs.h')}'
 
 ${strings.functions}:
   ${strings.varArgFunctions}:

--- a/pkgs/ffigen/test/rename_tests/rename_test.dart
+++ b/pkgs/ffigen/test/rename_tests/rename_test.dart
@@ -27,7 +27,7 @@ ${strings.output}: 'unused'
 
 ${strings.headers}:
   ${strings.entryPoints}:
-    - 'test/rename_tests/rename.h'
+    - '${absPath('test/rename_tests/rename.h')}'
 
 ${strings.functions}:
   ${strings.rename}:

--- a/pkgs/ffigen/test/test_utils.dart
+++ b/pkgs/ffigen/test/test_utils.dart
@@ -81,6 +81,9 @@ void matchLibrarySymbolFileWithExpected(Library library, String pathForActual,
 
 const bool updateExpectations = false;
 
+/// Transforms a repo relative path to an absolute path.
+String absPath(String p) => path.join(packagePathForTests, p);
+
 /// Generates actual file using library and tests using [expect] with expected.
 ///
 /// This will not delete the actual debug file incase [expect] throws an error.

--- a/pkgs/ffigen/test/test_utils.dart
+++ b/pkgs/ffigen/test/test_utils.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:ffigen/src/code_generator.dart';
 import 'package:ffigen/src/config_provider/config.dart';
+import 'package:ffigen/src/config_provider/utils.dart';
 import 'package:ffigen/src/config_provider/yaml_config.dart';
 import 'package:ffigen/src/strings.dart' as strings;
 import 'package:logging/logging.dart';
@@ -91,7 +92,7 @@ void _matchFileWithExpected({
       fileWriter,
   String Function(String)? codeNormalizer,
 }) {
-  final expectedPath = path.joinAll(pathToExpected);
+  final expectedPath = path.joinAll([packagePathForTests, ...pathToExpected]);
   final file = File(
     path.join(strings.tmpDir, pathForActual),
   );
@@ -146,7 +147,8 @@ Config testConfig(String yamlBody, {String? filename}) {
     packageConfig: PackageConfig([
       Package(
         'shared_bindings',
-        Uri.file(path.join(path.current, 'example', 'shared_bindings', 'lib/')),
+        Uri.file(path.join(
+            packagePathForTests, 'example', 'shared_bindings', 'lib/')),
       ),
     ]),
   );

--- a/pkgs/ffigen/test/test_utils.dart
+++ b/pkgs/ffigen/test/test_utils.dart
@@ -84,6 +84,10 @@ const bool updateExpectations = false;
 /// Transforms a repo relative path to an absolute path.
 String absPath(String p) => path.join(packagePathForTests, p);
 
+/// Returns a path to a config yaml in a unit test.
+String configPath(String directory, String file) =>
+    absPath(configPathForTest(directory, file));
+
 /// Generates actual file using library and tests using [expect] with expected.
 ///
 /// This will not delete the actual debug file incase [expect] throws an error.


### PR DESCRIPTION
An internal downstream clone needs to change the behavior of a few functions. This PR moves them all to a single overrideable_utils.dart file so that the clone can just swap out that file, rather than modifying the functions in place.