### PR TITLE
[native_assets_cli] Add base path for user-defines - fix

### DIFF
--- a/pkgs/native_assets_cli/lib/src/user_defines.dart
+++ b/pkgs/native_assets_cli/lib/src/user_defines.dart
@@ -38,7 +38,9 @@ extension PackageUserDefinesSyntax on PackageUserDefines {
       workspacePubspec: workspacePubspec?.toSyntax(),
     );
     // Fallback behavior for old hooks: write user-defines here.
-    result.json.addAll(workspacePubspec!.defines);
+    if (workspacePubspec != null) {
+      result.json.addAll(workspacePubspec!.defines);
+    }
     return result;
   }
 }


### PR DESCRIPTION
Fix for https://dart-review.googlesource.com/c/sdk/+/422720 which actually runs tests without user-defines. 😄 