### PR TITLE
[native_assets_cli] Cleanup JSON: old user defines

### DIFF
--- a/pkgs/code_assets/test/data/build_input_macos.json
+++ b/pkgs/code_assets/test/data/build_input_macos.json
@@ -40,6 +40,11 @@
   "package_name": "my_package",
   "package_root": "/Users/dacoharkes/src/dacoharkes/playground/my_package/",
   "user_defines": {
-    "some_key": "some_value"
+    "workspace_pubspec": {
+      "base_path": "/Users/dacoharkes/src/dacoharkes/playground/my_package/pubspec.yaml",
+      "defines": {
+        "some_key": "some_value"
+      }
+    }
   }
 }

--- a/pkgs/code_assets/test/data/link_input_macos.json
+++ b/pkgs/code_assets/test/data/link_input_macos.json
@@ -47,6 +47,11 @@
   "package_name": "my_package",
   "package_root": "/Users/dacoharkes/src/dacoharkes/playground/my_package/",
   "user_defines": {
-    "some_key": "some_value"
+    "workspace_pubspec": {
+      "base_path": "/Users/dacoharkes/src/dacoharkes/playground/my_package/pubspec.yaml",
+      "defines": {
+        "some_key": "some_value"
+      }
+    }
   }
 }

--- a/pkgs/data_assets/test/data/build_input.json
+++ b/pkgs/data_assets/test/data/build_input.json
@@ -31,6 +31,11 @@
   "package_name": "my_package",
   "package_root": "/Users/dacoharkes/src/dacoharkes/playground/my_package/",
   "user_defines": {
-    "some_key": "some_value"
+    "workspace_pubspec": {
+      "base_path": "/Users/dacoharkes/src/dacoharkes/playground/my_package/pubspec.yaml",
+      "defines": {
+        "some_key": "some_value"
+      }
+    }
   }
 }

--- a/pkgs/data_assets/test/data/link_input.json
+++ b/pkgs/data_assets/test/data/link_input.json
@@ -29,6 +29,11 @@
   "package_name": "my_package",
   "package_root": "/Users/dacoharkes/src/dacoharkes/playground/my_package/",
   "user_defines": {
-    "some_key": "some_value"
+    "workspace_pubspec": {
+      "base_path": "/Users/dacoharkes/src/dacoharkes/playground/my_package/pubspec.yaml",
+      "defines": {
+        "some_key": "some_value"
+      }
+    }
   }
 }

--- a/pkgs/hooks/test/data/build_input.json
+++ b/pkgs/hooks/test/data/build_input.json
@@ -37,6 +37,11 @@
   "package_name": "my_package",
   "package_root": "/Users/dacoharkes/src/dacoharkes/playground/my_package/",
   "user_defines": {
-    "some_key": "some_value"
+    "workspace_pubspec": {
+      "base_path": "/Users/dacoharkes/src/dacoharkes/playground/my_package/pubspec.yaml",
+      "defines": {
+        "some_key": "some_value"
+      }
+    }
   }
 }

--- a/pkgs/hooks/test/data/link_input.json
+++ b/pkgs/hooks/test/data/link_input.json
@@ -24,6 +24,11 @@
   "package_name": "my_package",
   "package_root": "/Users/dacoharkes/src/dacoharkes/playground/my_package/",
   "user_defines": {
-    "some_key": "some_value"
+    "workspace_pubspec": {
+      "base_path": "/Users/dacoharkes/src/dacoharkes/playground/my_package/pubspec.yaml",
+      "defines": {
+        "some_key": "some_value"
+      }
+    }
   }
 }

--- a/pkgs/hooks/test/schema/helpers.dart
+++ b/pkgs/hooks/test/schema/helpers.dart
@@ -292,6 +292,15 @@ FieldsReturn _hookFields({
   ([r'$schema'], expectOptionalFieldMissing),
   if (inputOrOutput == InputOrOutput.input) ...[
     (['user_defines'], expectOptionalFieldMissing),
+    (['user_defines', 'workspace_pubspec'], expectOptionalFieldMissing),
+    (
+      ['user_defines', 'workspace_pubspec', 'base_path'],
+      expectRequiredFieldMissing,
+    ),
+    (
+      ['user_defines', 'workspace_pubspec', 'defines'],
+      expectRequiredFieldMissing,
+    ),
     (['out_dir_shared'], expectRequiredFieldMissing),
     (['package_name'], expectRequiredFieldMissing),
     (['package_root'], expectRequiredFieldMissing),

--- a/pkgs/native_assets_cli/lib/src/user_defines.dart
+++ b/pkgs/native_assets_cli/lib/src/user_defines.dart
@@ -23,12 +23,7 @@ extension PackageUserDefinesSyntax on PackageUserDefines {
   static PackageUserDefines fromSyntax(syntax.UserDefines syntaxNode) =>
       PackageUserDefines(
         workspacePubspec: switch (syntaxNode.workspacePubspec) {
-          null => PackageUserDefinesSource(
-            // Fallback behavior for old SDKs: read object as user-defines.
-            defines: syntaxNode.json,
-            // No known base path.
-            basePath: Uri.directory('/unknown/'),
-          ),
+          null => null,
           final o => PackageUserDefinesSourceSyntax.fromSyntax(o),
         },
       );
@@ -37,10 +32,7 @@ extension PackageUserDefinesSyntax on PackageUserDefines {
     final result = syntax.UserDefines(
       workspacePubspec: workspacePubspec?.toSyntax(),
     );
-    // Fallback behavior for old hooks: write user-defines here.
-    if (workspacePubspec != null) {
-      result.json.addAll(workspacePubspec!.defines);
-    }
+
     return result;
   }
 }


### PR DESCRIPTION
Bug:

* https://github.com/dart-lang/native/issues/2199

Cleanup of:

* https://github.com/dart-lang/native/issues/2187

The old JSON encoding was only replaced one week ago, but it was only in the SDK for a week. So remove the fallback encoding now anyways. If anyone adopted it last week, they know where to update it.

This PR also adds tests for the JSON schema, that were missing:

* `user_defines` is optional, there might not be any
  * `pub_workspace` is optional, there might be SDKs without a pubspec.
    * `base_path` is required. If there are any user-defines, they might have relative paths in them.
    * `defines` is required. If there are no defines, then the whole `pub_workspace` should be omitted. (Or simply add an empty map.)