### PR TITLE
[native_assets_builder] Cleanup old file fallbacks

### DIFF
--- a/pkgs/native_assets_builder/lib/src/build_runner/build_planner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_planner.dart
@@ -74,11 +74,6 @@ class NativeAssetsBuildPlanner {
   ///
   /// Whether a package has native assets is defined by whether it contains
   /// a `hook/build.dart` or `hook/link.dart`.
-  ///
-  /// For backwards compatibility, a toplevel `build.dart` is also supported.
-  // TODO(https://github.com/dart-lang/native/issues/823): Remove fallback when
-  // everyone has migrated. (Probably once we stop backwards compatibility of
-  // the protocol version pre 1.2.0 on some future version.)
   Future<List<Package>> packagesWithHook(Hook hook) async => switch (hook) {
     Hook.build => _packagesWithBuildHook ??= await _runPackagesWithHook(hook),
     Hook.link => _packagesWithLinkHook ??= await _runPackagesWithHook(hook),
@@ -97,11 +92,8 @@ class NativeAssetsBuildPlanner {
       final packageRoot = package.root;
       if (packageRoot.scheme == 'file') {
         if (await fileSystem
-                .file(packageRoot.resolve('hook/').resolve(hook.scriptName))
-                .exists() ||
-            await fileSystem
-                .file(packageRoot.resolve(hook.scriptName))
-                .exists()) {
+            .file(packageRoot.resolve('hook/').resolve(hook.scriptName))
+            .exists()) {
           result.add(package);
         }
       }

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -363,9 +363,6 @@ class NativeAssetsBuildRunner {
       final (hookKernelFile, hookHashes) = hookCompileResult;
 
       final buildOutputFile = _fileSystem.file(input.outputFile);
-      final buildOutputFileDeprecated = _fileSystem
-      // ignore: deprecated_member_use
-      .file(outputDirectory.resolve(hook.outputNameDeprecated));
 
       final dependenciesHashFile = buildDirUri.resolve(
         'dependencies.dependencies_hash_file.json',
@@ -375,16 +372,10 @@ class NativeAssetsBuildRunner {
         fileUri: dependenciesHashFile,
       );
       final lastModifiedCutoffTime = DateTime.now();
-      if ((buildOutputFile.existsSync() ||
-              buildOutputFileDeprecated.existsSync()) &&
-          await dependenciesHashes.exists()) {
+      if ((buildOutputFile.existsSync()) && await dependenciesHashes.exists()) {
         late final HookOutput output;
         try {
-          output = _readHookOutputFromUri(
-            hook,
-            buildOutputFile,
-            buildOutputFileDeprecated,
-          );
+          output = _readHookOutputFromUri(hook, buildOutputFile);
         } on FormatException catch (e) {
           logger.severe('''
 Building assets for package:${input.packageName} failed.
@@ -488,14 +479,6 @@ ${e.message}
       // Ensure we'll never read outdated build results.
       await hookOutputFile.delete();
     }
-    final hookOutputUriDeprecated =
-    // ignore: deprecated_member_use
-    outputDirectory.resolve(hook.outputNameDeprecated);
-    final hookOutputFileDeprecated = _fileSystem.file(hookOutputUriDeprecated);
-    if (await hookOutputFileDeprecated.exists()) {
-      // Ensure we'll never read outdated build results.
-      await hookOutputFileDeprecated.delete();
-    }
 
     final arguments = [
       '--packages=${packageLayout.packageConfigUri.toFilePath()}',
@@ -540,11 +523,7 @@ ${e.message}
         return null;
       }
 
-      final output = _readHookOutputFromUri(
-        hook,
-        hookOutputFile,
-        hookOutputFileDeprecated,
-      );
+      final output = _readHookOutputFromUri(hook, hookOutputFile);
       final errors = await _validate(input, output, validator);
       if (errors.isNotEmpty) {
         _printErrors(
@@ -852,14 +831,8 @@ ${compileResult.stdout}
     return (buildPlan, packageGraph);
   }
 
-  HookOutput _readHookOutputFromUri(
-    Hook hook,
-    File hookOutputFile,
-    // TODO(dcharkes): Remove when hooks with 1.7.0 are no longer supported.
-    File hookOutputFileDeprecated,
-  ) {
-    final file =
-        hookOutputFile.existsSync() ? hookOutputFile : hookOutputFileDeprecated;
+  HookOutput _readHookOutputFromUri(Hook hook, File hookOutputFile) {
+    final file = hookOutputFile;
     final fileContents = file.readAsStringSync();
     logger.info('output.json contents:\n$fileContents');
     final hookOutputJson = jsonDecode(fileContents) as Map<String, Object?>;

--- a/pkgs/native_assets_builder/test_data/use_all_api/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/use_all_api/hook/build.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: unnecessary_statements, deprecated_member_use
+// ignore_for_file: unnecessary_statements
 
 import 'package:native_assets_cli/code_assets.dart';
 import 'package:native_assets_cli/data_assets.dart';

--- a/pkgs/native_assets_cli/lib/src/model/hook.dart
+++ b/pkgs/native_assets_cli/lib/src/model/hook.dart
@@ -15,7 +15,4 @@ enum Hook {
   const Hook(this._scriptName);
 
   String get scriptName => '$_scriptName.dart';
-
-  @Deprecated('Use HookInput.outputFile instead.')
-  String get outputNameDeprecated => '${_scriptName}_output.json';
 }


### PR DESCRIPTION
* `$package/build.dart` has been migrated to `$package/hooks/build.dart` a long time ago, remove the fallback.
* `out_file` has been part of the protocol for a long time, remove the fallback.