### PR TITLE
[native_assets_cli] Cleanup TODOs

### DIFF
--- a/pkgs/json_syntax_generator/lib/src/generator/normal_class_generator.dart
+++ b/pkgs/json_syntax_generator/lib/src/generator/normal_class_generator.dart
@@ -210,8 +210,6 @@ static const ${tagProperty}Value = '$tagValue';
       final superClassProperty = superclass?.getProperty(property.name);
       if (superClassProperty != null) {
         // This property will be already set in the super constructor.
-        // TODO: The parameter in the constructor currently has the super class
-        // property type.
         continue;
       }
       if (property.setterPrivate) {

--- a/pkgs/native_assets_builder/test_data/complex_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/complex_link/hook/build.dart
@@ -32,8 +32,6 @@ void main(List<String> args) async {
                 ? ToLinkHook(packageName)
                 : const ToAppBundle(),
       );
-      // TODO(https://github.com/dart-lang/native/issues/1208): Report
-      // dependency on asset.
       output.addDependency(dataAsset.uri);
     }
   });

--- a/pkgs/native_assets_builder/test_data/complex_link_helper/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/complex_link_helper/hook/build.dart
@@ -33,8 +33,6 @@ void main(List<String> args) async {
                 ? const ToLinkHook('complex_link')
                 : const ToAppBundle(),
       );
-      // TODO(https://github.com/dart-lang/native/issues/1208): Report
-      // dependency on asset.
       output.addDependency(dataAsset.uri);
     }
   });

--- a/pkgs/native_assets_builder/test_data/simple_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/simple_link/hook/build.dart
@@ -32,8 +32,6 @@ void main(List<String> args) async {
                 ? ToLinkHook(packageName)
                 : const ToAppBundle(),
       );
-      // TODO(https://github.com/dart-lang/native/issues/1208): Report
-      // dependency on asset.
       output.addDependency(dataAsset.uri);
     }
   });

--- a/pkgs/native_assets_cli/example/build/download_asset/hook/build.dart
+++ b/pkgs/native_assets_cli/example/build/download_asset/hook/build.dart
@@ -11,12 +11,8 @@ import 'package:native_assets_cli/code_assets_builder.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> args) async {
-  // TODO(https://github.com/dart-lang/native/issues/39): Use user-defines to
-  // control this instead.
-  const localBuild = false;
-
   await build(args, (input, output) async {
-    // ignore: dead_code
+    final localBuild = input.userDefines['local_build'] as bool? ?? false;
     if (localBuild) {
       await runBuild(input, output);
     } else {

--- a/pkgs/native_assets_cli/example/build/download_asset/pubspec.yaml
+++ b/pkgs/native_assets_cli/example/build/download_asset/pubspec.yaml
@@ -21,3 +21,11 @@ dev_dependencies:
   ffigen: ^18.0.0
   lints: ^5.1.1
   test: ^1.25.15
+
+# Note: If pub workspaces are in use, the user-defines must be in the workspace
+# pub file. These defines are only in effect if `resolution: workspace` above is
+# removed.
+hooks:
+  user_defines:
+    download_asset: # package name
+      local_build: false

--- a/pkgs/native_assets_cli/example/link/package_with_assets/hook/build.dart
+++ b/pkgs/native_assets_cli/example/link/package_with_assets/hook/build.dart
@@ -32,8 +32,6 @@ void main(List<String> args) async {
                 ? ToLinkHook(packageName)
                 : const ToAppBundle(),
       );
-      // TODO(https://github.com/dart-lang/native/issues/1208): Report
-      // dependency on asset.
       output.addDependency(dataAsset.uri);
     }
   });

--- a/pkgs/native_assets_cli/lib/src/config.dart
+++ b/pkgs/native_assets_cli/lib/src/config.dart
@@ -127,7 +127,8 @@ extension type HookInputUserDefines._(HookInput _input) {
     if (pubspecSource != null) {
       sources.add(pubspecSource);
     }
-    // TODO: Add commandline arguments.
+    // TODO(https://github.com/dart-lang/native/issues/2215): Add commandline
+    // arguments.
     for (final source in sources) {
       final relativepath = source.defines[key];
       if (relativepath is String) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,8 @@ workspace:
 # Hook user-defines are specified in the pub workspace.
 hooks:
   user_defines:
+    download_asset:
+      local_build: false
     user_defines: # package name
       user_define_key: user_define_value
       user_define_key2:


### PR DESCRIPTION
* We now have user-defines, so use them in the example for downloading assets.
* Remove todos that we decided we're not going to address.