### PR TITLE
[native_assets_cli] Remove re-exporting

### DIFF
--- a/pkgs/native_assets_builder/lib/native_assets_builder.dart
+++ b/pkgs/native_assets_builder/lib/native_assets_builder.dart
@@ -2,16 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'package:native_assets_builder/src/build_runner/build_runner.dart'
+export 'src/build_runner/build_runner.dart'
     show
         BuildInputCreator,
         LinkInputCreator,
         NativeAssetsBuildRunner,
         UserDefines;
-export 'package:native_assets_builder/src/model/build_result.dart'
-    show BuildResult;
-export 'package:native_assets_builder/src/model/kernel_assets.dart';
-export 'package:native_assets_builder/src/model/link_result.dart'
-    show LinkResult;
-export 'package:native_assets_builder/src/package_layout/package_layout.dart'
-    show PackageLayout;
+export 'src/model/build_result.dart' show BuildResult;
+export 'src/model/kernel_assets.dart';
+export 'src/model/link_result.dart' show LinkResult;
+export 'src/package_layout/package_layout.dart' show PackageLayout;

--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -9,6 +9,7 @@ import 'dart:io' show Platform;
 import 'package:file/file.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:package_config/package_config.dart';
 import 'package:yaml/yaml.dart';

--- a/pkgs/native_assets_builder/lib/src/model/build_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/build_result.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:native_assets_cli/native_assets_cli_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 /// The result of executing build hooks from all packages in the dependency tree
 /// of the entry point application.

--- a/pkgs/native_assets_builder/lib/src/model/hook_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/hook_result.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:collection/collection.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_assets_cli/native_assets_cli_builder.dart';
 
 import '../../native_assets_builder.dart';

--- a/pkgs/native_assets_builder/lib/src/model/link_result.dart
+++ b/pkgs/native_assets_builder/lib/src/model/link_result.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:native_assets_cli/native_assets_cli_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 /// The result of executing the link hooks from all packages in the dependency
 /// tree of the entry point application.

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_caching_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_caching_test.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:native_assets_builder/src/build_runner/build_runner.dart';
+import 'package:native_assets_cli/code_assets.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_failure_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_failure_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:logging/logging.dart';
+import 'package:native_assets_cli/code_assets.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/build_runner_reusability_test.dart
@@ -5,6 +5,8 @@
 import 'package:file/local.dart';
 import 'package:native_assets_builder/src/build_runner/build_runner.dart';
 import 'package:native_assets_builder/src/package_layout/package_layout.dart';
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:native_assets_builder/src/utils/run_process.dart'
     show RunProcessResult;
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_shared_test_helper.dart
@@ -5,6 +5,10 @@
 import 'package:file/local.dart';
 import 'package:logging/logging.dart';
 import 'package:native_assets_builder/native_assets_builder.dart';
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/data_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 
 import '../helpers.dart';
 

--- a/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
+++ b/pkgs/native_assets_builder/test/build_runner/concurrency_test_helper.dart
@@ -5,6 +5,9 @@
 import 'package:file/local.dart';
 import 'package:logging/logging.dart';
 import 'package:native_assets_builder/native_assets_builder.dart';
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/data_assets_builder.dart';
 
 import '../helpers.dart';
 import 'helpers.dart';

--- a/pkgs/native_assets_builder/test/build_runner/fail_on_os_sdk_version_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/fail_on_os_sdk_version_test.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:logging/logging.dart';
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_builder/test/build_runner/helpers.dart
+++ b/pkgs/native_assets_builder/test/build_runner/helpers.dart
@@ -8,6 +8,10 @@ import 'dart:io';
 import 'package:file/local.dart';
 import 'package:logging/logging.dart';
 import 'package:native_assets_builder/native_assets_builder.dart';
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/data_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_builder/test/build_runner/link_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/link_test.dart
@@ -4,6 +4,9 @@
 
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart' hide build, link;
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_builder/test/build_runner/packaging_preference_test.dart
+++ b/pkgs/native_assets_builder/test/build_runner/packaging_preference_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:native_assets_cli/code_assets.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_builder/test/helpers.dart
+++ b/pkgs/native_assets_builder/test/helpers.dart
@@ -15,10 +15,6 @@ import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 
-export 'package:native_assets_cli/code_assets_builder.dart';
-export 'package:native_assets_cli/data_assets_builder.dart';
-export 'package:native_assets_cli/native_assets_cli_builder.dart';
-
 extension UriExtension on Uri {
   String get name => pathSegments.where((e) => e != '').last;
 

--- a/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_builder/test/test_data/native_dynamic_linking_test.dart
@@ -8,6 +8,10 @@ library;
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:test/test.dart';
 
 import '../build_runner/helpers.dart';

--- a/pkgs/native_assets_builder/test/test_data/transformer_test.dart
+++ b/pkgs/native_assets_builder/test/test_data/transformer_test.dart
@@ -8,6 +8,11 @@ library;
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/data_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:test/test.dart';
 
 import '../build_runner/helpers.dart';

--- a/pkgs/native_assets_builder/test/test_data/user_defines_test.dart
+++ b/pkgs/native_assets_builder/test/test_data/user_defines_test.dart
@@ -10,6 +10,7 @@ import 'dart:io';
 import 'package:file_testing/file_testing.dart';
 import 'package:native_assets_builder/native_assets_builder.dart';
 import 'package:native_assets_builder/src/build_runner/build_runner.dart';
+import 'package:native_assets_cli/data_assets.dart';
 import 'package:test/test.dart';
 
 import '../build_runner/helpers.dart';

--- a/pkgs/native_assets_builder/test_data/add_asset_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/add_asset_link/hook/build.dart
@@ -4,6 +4,7 @@
 
 import 'package:logging/logging.dart';
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
 void main(List<String> arguments) async {

--- a/pkgs/native_assets_builder/test_data/add_asset_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/add_asset_link/hook/link.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> arguments) async {
   await link(arguments, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/complex_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/complex_link/hook/build.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/complex_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/complex_link/hook/link.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> args) async {
   await link(

--- a/pkgs/native_assets_builder/test_data/complex_link_helper/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/complex_link_helper/hook/build.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/depend_on_fail_build/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/depend_on_fail_build/hook/build.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:fail_build/fail_build.dart';
-import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> arguments) async {
   await build(arguments, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/drop_dylib_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/drop_dylib_link/hook/build.dart
@@ -4,6 +4,7 @@
 
 import 'package:logging/logging.dart';
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
 void main(List<String> arguments) async {

--- a/pkgs/native_assets_builder/test_data/drop_dylib_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/drop_dylib_link/hook/link.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> arguments) async {
   await link(arguments, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version/hook/build.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 // Simulate needing some version of the API.
 //

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_link/hook/build.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> arguments) async {
   await build(arguments, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/fail_on_os_sdk_version_linker/hook/link.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 // Simulate needing some version of the API.
 //

--- a/pkgs/native_assets_builder/test_data/native_add_duplicate/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/native_add_duplicate/hook/build.dart
@@ -5,6 +5,8 @@
 import 'package:logging/logging.dart';
 import 'package:native_assets_cli/code_assets.dart';
 import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
 void main(List<String> arguments) async {

--- a/pkgs/native_assets_builder/test_data/native_add_duplicate/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/native_add_duplicate/hook/link.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> args) async {
   await link(args, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/no_asset_for_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/no_asset_for_link/hook/link.dart
@@ -4,6 +4,7 @@
 
 import 'package:native_assets_cli/code_assets.dart';
 import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> arguments) async {
   await link(arguments, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/relative_path/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/relative_path/hook/build.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/reusable_dynamic_library/lib/hook.dart
+++ b/pkgs/native_assets_builder/test_data/reusable_dynamic_library/lib/hook.dart
@@ -9,6 +9,7 @@ library;
 import 'dart:io';
 
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
 /// Helper class for populating a [CBuilder.library] call with the fields of

--- a/pkgs/native_assets_builder/test_data/simple_data_asset/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/simple_data_asset/hook/build.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/simple_link/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/simple_link/hook/build.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/simple_link/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/simple_link/hook/link.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> args) async {
   await link(args, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/system_library/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/system_library/hook/build.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> arguments) async {
   await build(arguments, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/transformer/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/transformer/hook/build.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:transformer/src/transform.dart';
 
 void main(List<String> arguments) async {

--- a/pkgs/native_assets_builder/test_data/treeshaking_native_libs/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/treeshaking_native_libs/hook/build.dart
@@ -4,6 +4,7 @@
 
 import 'package:logging/logging.dart';
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
 void main(List<String> arguments) async {

--- a/pkgs/native_assets_builder/test_data/treeshaking_native_libs/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/treeshaking_native_libs/hook/link.dart
@@ -4,6 +4,7 @@
 
 import 'package:logging/logging.dart';
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
 void main(List<String> arguments) async {

--- a/pkgs/native_assets_builder/test_data/use_all_api/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/use_all_api/hook/build.dart
@@ -6,6 +6,7 @@
 
 import 'package:native_assets_cli/code_assets.dart';
 import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/use_all_api/hook/link.dart
+++ b/pkgs/native_assets_builder/test_data/use_all_api/hook/link.dart
@@ -6,6 +6,7 @@
 
 import 'package:native_assets_cli/code_assets.dart';
 import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> args) async {
   await link(args, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/user_defines/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/user_defines/hook/build.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> arguments) async {
   await build(arguments, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/wrong_linker/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/wrong_linker/hook/build.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> arguments) async {
   await build(arguments, (input, output) async {

--- a/pkgs/native_assets_builder/test_data/wrong_namespace_asset/hook/build.dart
+++ b/pkgs/native_assets_builder/test_data/wrong_namespace_asset/hook/build.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> arguments) async {
   await build(arguments, (input, output) async {

--- a/pkgs/native_assets_cli/CHANGELOG.md
+++ b/pkgs/native_assets_cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.18.0-wip
 
-- Nothing yet.
+- **Breaking change** Reorganized the libraries structure. Classes are no longer
+  exported multiple times.
 
 ## 0.17.0
 

--- a/pkgs/native_assets_cli/example/build/download_asset/hook/build.dart
+++ b/pkgs/native_assets_cli/example/build/download_asset/hook/build.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 import 'package:download_asset/src/hook_helpers/c_build.dart';
 import 'package:download_asset/src/hook_helpers/download.dart';
 import 'package:download_asset/src/hook_helpers/hashes.dart';
-import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/code_assets.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> args) async {

--- a/pkgs/native_assets_cli/example/build/download_asset/lib/src/hook_helpers/c_build.dart
+++ b/pkgs/native_assets_cli/example/build/download_asset/lib/src/hook_helpers/c_build.dart
@@ -3,7 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:logging/logging.dart';
-import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
 Future<void> runBuild(BuildInput input, BuildOutputBuilder output) async {

--- a/pkgs/native_assets_cli/example/build/download_asset/lib/src/hook_helpers/download.dart
+++ b/pkgs/native_assets_cli/example/build/download_asset/lib/src/hook_helpers/download.dart
@@ -5,7 +5,7 @@
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
-import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/code_assets.dart';
 
 import 'c_build.dart';
 import 'version.dart';

--- a/pkgs/native_assets_cli/example/build/download_asset/lib/src/hook_helpers/targets.dart
+++ b/pkgs/native_assets_cli/example/build/download_asset/lib/src/hook_helpers/targets.dart
@@ -7,7 +7,7 @@
 //    dart --enable-experiment=native-assets tool/generate_asset_hashes.dart
 //
 
-import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/code_assets.dart';
 
 const supportedTargets = [
   (OS.android, Architecture.arm, null),

--- a/pkgs/native_assets_cli/example/build/download_asset/tool/build.dart
+++ b/pkgs/native_assets_cli/example/build/download_asset/tool/build.dart
@@ -7,7 +7,10 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:download_asset/src/hook_helpers/c_build.dart';
 import 'package:download_asset/src/hook_helpers/target_versions.dart';
+import 'package:native_assets_cli/code_assets.dart';
 import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 
 void main(List<String> args) async {
   final (os: os, architecture: architecture, iOSSdk: iOSSdk) = parseArguments(

--- a/pkgs/native_assets_cli/example/build/local_asset/hook/build.dart
+++ b/pkgs/native_assets_cli/example/build/local_asset/hook/build.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 const assetName = 'asset.txt';
 final packageAssetPath = Uri.file('assets/$assetName');

--- a/pkgs/native_assets_cli/example/build/local_asset/test/build_test.dart
+++ b/pkgs/native_assets_cli/example/build/local_asset/test/build_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:native_assets_cli/code_assets_builder.dart';
 import 'package:native_assets_cli/code_assets_testing.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/native_assets_cli/example/build/system_library/hook/build.dart
+++ b/pkgs/native_assets_cli/example/build/system_library/hook/build.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> arguments) async {
   await build(arguments, (input, output) async {

--- a/pkgs/native_assets_cli/example/link/package_with_assets/hook/build.dart
+++ b/pkgs/native_assets_cli/example/link/package_with_assets/hook/build.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {

--- a/pkgs/native_assets_cli/example/link/package_with_assets/hook/link.dart
+++ b/pkgs/native_assets_cli/example/link/package_with_assets/hook/link.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:record_use/record_use.dart';
 
 const multiplyIdentifier = Identifier(

--- a/pkgs/native_assets_cli/lib/code_assets.dart
+++ b/pkgs/native_assets_cli/lib/code_assets.dart
@@ -5,11 +5,6 @@
 /// Code asset support for hook authors.
 library;
 
-export 'native_assets_cli.dart'
-    hide
-        EncodedAsset,
-        EncodedAssetBuildOutputBuilder,
-        EncodedAssetLinkOutputBuilder;
 export 'src/code_assets/architecture.dart' show Architecture;
 export 'src/code_assets/c_compiler_config.dart'
     show CCompilerConfig, DeveloperCommandPrompt, WindowsCCompilerConfig;

--- a/pkgs/native_assets_cli/lib/code_assets_builder.dart
+++ b/pkgs/native_assets_cli/lib/code_assets_builder.dart
@@ -5,9 +5,6 @@
 /// Code asset support for hook invokers (e.g. building / bundling tools).
 library;
 
-export 'code_assets.dart' hide build, link;
-export 'native_assets_cli_builder.dart'
-    hide EncodedAssetBuildOutputBuilder, EncodedAssetLinkOutputBuilder;
 export 'src/code_assets/config.dart'
     show CodeAssetBuildInputBuilder, CodeAssetBuildOutput, CodeAssetLinkOutput;
 export 'src/code_assets/extension.dart';

--- a/pkgs/native_assets_cli/lib/code_assets_testing.dart
+++ b/pkgs/native_assets_cli/lib/code_assets_testing.dart
@@ -2,5 +2,4 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'code_assets_builder.dart';
 export 'src/code_assets/testing.dart' show testCodeBuildHook;

--- a/pkgs/native_assets_cli/lib/data_assets.dart
+++ b/pkgs/native_assets_cli/lib/data_assets.dart
@@ -5,11 +5,6 @@
 /// Data asset support for hook authors.
 library;
 
-export 'native_assets_cli.dart'
-    hide
-        EncodedAsset,
-        EncodedAssetBuildOutputBuilder,
-        EncodedAssetLinkOutputBuilder;
 export 'src/data_assets/config.dart'
     show
         AddDataAssetsDirectory,

--- a/pkgs/native_assets_cli/lib/data_assets_builder.dart
+++ b/pkgs/native_assets_cli/lib/data_assets_builder.dart
@@ -5,9 +5,6 @@
 /// Data asset support for hook invokers (e.g. building / bundling tools).
 library;
 
-export 'data_assets.dart' hide build, link;
-export 'native_assets_cli_builder.dart'
-    hide EncodedAssetBuildOutputBuilder, EncodedAssetLinkOutputBuilder;
 export 'src/data_assets/config.dart'
     show DataAssetBuildInputBuilder, DataAssetBuildOutput, DataAssetLinkOutput;
 export 'src/data_assets/extension.dart';

--- a/pkgs/native_assets_cli/lib/native_assets_cli_builder.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli_builder.dart
@@ -5,7 +5,6 @@
 /// Support for hook invokers (e.g. building / bundling tools).
 library;
 
-export 'native_assets_cli.dart' hide build, link;
 export 'src/config.dart'
     show
         BuildConfigBuilderSetup,

--- a/pkgs/native_assets_cli/lib/src/api/build.dart
+++ b/pkgs/native_assets_cli/lib/src/api/build.dart
@@ -50,6 +50,7 @@ import '../validation.dart';
 /// import 'dart:io';
 ///
 /// import 'package:native_assets_cli/code_assets.dart';
+/// import 'package:native_assets_cli/native_assets_cli.dart';
 ///
 /// const assetName = 'asset.txt';
 /// final packageAssetPath = Uri.file('data/$assetName');

--- a/pkgs/native_assets_cli/lib/src/code_assets/testing.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/testing.dart
@@ -4,7 +4,10 @@
 
 import 'dart:async';
 
+import '../../code_assets.dart';
 import '../../code_assets_builder.dart';
+import '../../native_assets_cli.dart';
+import '../../native_assets_cli_builder.dart';
 import '../../test.dart';
 import '../validation.dart';
 

--- a/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
@@ -4,7 +4,9 @@
 
 import 'dart:io';
 
-import '../../data_assets_builder.dart';
+import '../../data_assets.dart';
+import '../../native_assets_cli.dart';
+import '../../native_assets_cli_builder.dart';
 import 'syntax.g.dart' as syntax;
 
 Future<ValidationErrors> validateDataAssetBuildInput(BuildInput input) async =>

--- a/pkgs/native_assets_cli/lib/src/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/validation.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import '../native_assets_cli.dart';
 import '../native_assets_cli_builder.dart';
 import 'hooks/syntax.g.dart' as syntax;
 

--- a/pkgs/native_assets_cli/lib/test.dart
+++ b/pkgs/native_assets_cli/lib/test.dart
@@ -8,10 +8,9 @@ import 'dart:io';
 
 import 'package:yaml/yaml.dart';
 
+import 'native_assets_cli.dart';
 import 'native_assets_cli_builder.dart';
 import 'src/validation.dart';
-
-export 'native_assets_cli_builder.dart';
 
 /// Validate a build hook; this will throw an exception on validation errors.
 ///

--- a/pkgs/native_assets_cli/test/api/build_test.dart
+++ b/pkgs/native_assets_cli/test/api/build_test.dart
@@ -6,7 +6,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:file_testing/file_testing.dart';
-import 'package:native_assets_cli/native_assets_cli.dart' show build;
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/native_assets_cli/test/build_input_test.dart
+++ b/pkgs/native_assets_cli/test/build_input_test.dart
@@ -2,11 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/native_assets_cli/test/build_output_test.dart
+++ b/pkgs/native_assets_cli/test/build_output_test.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_assets_cli/src/utils/datetime.dart';
 import 'package:test/test.dart';

--- a/pkgs/native_assets_cli/test/checksum_test.dart
+++ b/pkgs/native_assets_cli/test/checksum_test.dart
@@ -2,8 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:native_assets_cli/code_assets.dart';
 import 'package:native_assets_cli/code_assets_builder.dart';
 import 'package:native_assets_cli/data_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:test/test.dart';
 
 import 'helpers.dart';

--- a/pkgs/native_assets_cli/test/code_assets/code_asset_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/code_asset_test.dart
@@ -2,7 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
 
 void main() async {

--- a/pkgs/native_assets_cli/test/code_assets/config_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/config_test.dart
@@ -4,7 +4,10 @@
 
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
 import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_assets_cli/src/code_assets/code_asset.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/native_assets_cli/test/code_assets/validation_test.dart
+++ b/pkgs/native_assets_cli/test/code_assets/validation_test.dart
@@ -4,7 +4,10 @@
 
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
 import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_assets_cli/src/code_assets/validation.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/native_assets_cli/test/data_assets/data_asset_test.dart
+++ b/pkgs/native_assets_cli/test/data_assets/data_asset_test.dart
@@ -2,7 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:native_assets_cli/data_assets_builder.dart';
+import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
 
 void main() async {

--- a/pkgs/native_assets_cli/test/data_assets/validation_test.dart
+++ b/pkgs/native_assets_cli/test/data_assets/validation_test.dart
@@ -4,7 +4,10 @@
 
 import 'dart:io';
 
+import 'package:native_assets_cli/data_assets.dart';
 import 'package:native_assets_cli/data_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_assets_cli/src/data_assets/validation.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/native_assets_cli/test/example/local_asset_test.dart
+++ b/pkgs/native_assets_cli/test/example/local_asset_test.dart
@@ -8,7 +8,9 @@ library;
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
 import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_cli/test/example/native_add_library_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_add_library_test.dart
@@ -8,7 +8,9 @@ library;
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
 import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_cli/test/example/native_dynamic_linking_test.dart
+++ b/pkgs/native_assets_cli/test/example/native_dynamic_linking_test.dart
@@ -12,7 +12,9 @@ library;
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
 import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_assets_cli/test/helpers.dart
+++ b/pkgs/native_assets_cli/test/helpers.dart
@@ -5,8 +5,9 @@
 import 'dart:io';
 
 import 'package:logging/logging.dart';
-import 'package:native_assets_cli/code_assets_builder.dart';
-import 'package:native_assets_cli/data_assets_builder.dart';
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
 
 const keepTempKey = 'KEEP_TEMPORARY_DIRECTORIES';

--- a/pkgs/native_assets_cli/test/link_input_test.dart
+++ b/pkgs/native_assets_cli/test/link_input_test.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/native_assets_cli/test/link_output_test.dart
+++ b/pkgs/native_assets_cli/test/link_output_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_assets_cli/src/utils/datetime.dart';
 import 'package:test/test.dart';

--- a/pkgs/native_assets_cli/test/model/asset_test.dart
+++ b/pkgs/native_assets_cli/test/model/asset_test.dart
@@ -3,8 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:collection/collection.dart';
-import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/code_assets.dart';
 import 'package:native_assets_cli/data_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/pkgs/native_assets_cli/test/model/target_test.dart
+++ b/pkgs/native_assets_cli/test/model/target_test.dart
@@ -5,7 +5,8 @@
 import 'dart:ffi';
 import 'dart:io';
 
-import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/pkgs/native_assets_cli/test/validation_test.dart
+++ b/pkgs/native_assets_cli/test/validation_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -6,7 +6,9 @@ import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
-import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 
 import 'build_mode.dart';
 import 'ctool.dart';

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 import 'ctool.dart';
 import 'language.dart';

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/ctool.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/ctool.dart
@@ -4,6 +4,7 @@
 
 import 'package:meta/meta.dart';
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 import 'cbuilder.dart';
 import 'clinker.dart';

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 
 import 'package:logging/logging.dart';
 import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
 
 import '../native_toolchain/msvc.dart';
 import '../native_toolchain/tool_likeness.dart';

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_build_failure_test.dart
@@ -7,6 +7,10 @@ library;
 
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -4,6 +4,10 @@
 
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:native_toolchain_c/src/utils/run_process.dart';
 import 'package:test/test.dart';

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -8,6 +8,10 @@ library;
 
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:native_toolchain_c/src/utils/run_process.dart';
 import 'package:test/test.dart';

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -7,6 +7,10 @@ library;
 
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -8,6 +8,10 @@ library;
 
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:native_toolchain_c/src/utils/run_process.dart';
 import 'package:test/test.dart';

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_windows_host_test.dart
@@ -8,6 +8,10 @@ library;
 
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:native_toolchain_c/src/native_toolchain/clang.dart';
 import 'package:native_toolchain_c/src/native_toolchain/msvc.dart';

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -8,6 +8,10 @@ library;
 import 'dart:ffi';
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:native_toolchain_c/src/utils/run_process.dart';
 import 'package:test/test.dart';

--- a/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/compiler_resolver_test.dart
@@ -6,6 +6,10 @@
 library;
 
 import 'package:collection/collection.dart';
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_toolchain_c/src/cbuilder/compiler_resolver.dart';
 import 'package:native_toolchain_c/src/native_toolchain/apple_clang.dart';
 import 'package:native_toolchain_c/src/native_toolchain/clang.dart';

--- a/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/objective_c_test.dart
@@ -8,6 +8,10 @@ library;
 import 'dart:ffi';
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
+++ b/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
@@ -4,6 +4,10 @@
 
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
 import '../helpers.dart';

--- a/pkgs/native_toolchain_c/test/clinker/objects_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/objects_test.dart
@@ -9,6 +9,10 @@ library;
 
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/native_toolchain_c/test/clinker/throws_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/throws_test.dart
@@ -4,6 +4,10 @@
 
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
@@ -9,6 +9,10 @@ library;
 
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
+import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_builder.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -7,12 +7,10 @@ import 'dart:ffi';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
-import 'package:native_assets_cli/code_assets_builder.dart';
+import 'package:native_assets_cli/code_assets.dart';
 import 'package:native_toolchain_c/src/native_toolchain/apple_clang.dart';
 import 'package:native_toolchain_c/src/utils/run_process.dart';
 import 'package:test/test.dart';
-
-export 'package:native_assets_cli/code_assets_builder.dart';
 
 /// Returns a suffix for a test that is parameterized.
 ///

--- a/pkgs/native_toolchain_c/test/tool/tool_resolver_test.dart
+++ b/pkgs/native_toolchain_c/test/tool/tool_resolver_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:native_assets_cli/code_assets.dart';
 import 'package:native_toolchain_c/src/native_toolchain/apple_clang.dart';
 import 'package:native_toolchain_c/src/native_toolchain/clang.dart';
 import 'package:native_toolchain_c/src/native_toolchain/msvc.dart';


### PR DESCRIPTION
This PR removes all `exports` that were not exporting a `src/` class. Classes are now only exported once in the `lib/xxx.dart`.

This cleans up ambiguity with imports:

1. It prevents importing a superset import (e.g. a bunch of `xx_builder.dart` imports changed to `xx.dart` imports because the builder facilities are not used).

```diff
- import 'package:native_assets_cli/native_assets_cli_builder.dart';
+ import 'package:native_assets_cli/native_assets_cli.dart';
```

2. It prevents the IDE from auto-selecting the wrong import on autocompleting.

As a side effect, now multiple imports might be needed for hooks:

```diff
import 'package:native_assets_cli/data_assets.dart';
+ import 'package:native_assets_cli/native_assets_cli.dart';
```

In a follow up PR I'll take a look at reducing the number of libraries (maybe we can merge the test/builder libraries with the other ones).

Bug:

* https://github.com/dart-lang/native/issues/1805

Before we can address https://github.com/dart-lang/native/issues/999, we need to have an idea what the import structure should look like.