### PR TITLE
[jnigen] Support `use` arenas on nullable JObjects

### DIFF
--- a/pkgs/jni/lib/src/jobject.dart
+++ b/pkgs/jni/lib/src/jobject.dart
@@ -219,7 +219,7 @@ class JObject {
   void releasedBy(Arena arena) => arena.onReleaseAll(release);
 }
 
-extension JObjectUseExtension<T extends JObject> on T {
+extension JObjectUseExtension<T extends JObject?> on T {
   /// Applies [callback] on this object and then delete the underlying JNI
   /// reference, returning the result of [callback].
   R use<R>(R Function(T) callback) {
@@ -227,7 +227,7 @@ extension JObjectUseExtension<T extends JObject> on T {
       final result = callback(this);
       return result;
     } finally {
-      release();
+      this?.release();
     }
   }
 }

--- a/pkgs/jni/test/jobject_test.dart
+++ b/pkgs/jni/test/jobject_test.dart
@@ -175,6 +175,8 @@ void run({required TestRunnerCallback testRunner}) {
       });
     });
     expect(randomInt, lessThan(15));
+    final JObject? nullableJObject = null;
+    expect(nullableJObject.use(() => 'foo'),equals('foo));
   });
 
   // The JObject and JClass have NativeFinalizer. However, it's possible to

--- a/pkgs/jni/test/jobject_test.dart
+++ b/pkgs/jni/test/jobject_test.dart
@@ -176,7 +176,7 @@ void run({required TestRunnerCallback testRunner}) {
     });
     expect(randomInt, lessThan(15));
     final JObject? nullableJObject = null;
-    expect(nullableJObject.use(() => 'foo'),equals('foo));
+    expect(nullableJObject.use((_) => 'foo'),equals('foo'));
   });
 
   // The JObject and JClass have NativeFinalizer. However, it's possible to

--- a/pkgs/jni/test/jobject_test.dart
+++ b/pkgs/jni/test/jobject_test.dart
@@ -176,7 +176,7 @@ void run({required TestRunnerCallback testRunner}) {
     });
     expect(randomInt, lessThan(15));
     final JObject? nullableJObject = null;
-    expect(nullableJObject.use((_) => 'foo'),equals('foo'));
+    expect(nullableJObject.use((_) => 'foo'), equals('foo'));
   });
 
   // The JObject and JClass have NativeFinalizer. However, it's possible to

--- a/pkgs/jni/test/jobject_test.dart
+++ b/pkgs/jni/test/jobject_test.dart
@@ -175,7 +175,7 @@ void run({required TestRunnerCallback testRunner}) {
       });
     });
     expect(randomInt, lessThan(15));
-    final JObject? nullableJObject = null;
+    const JObject? nullableJObject = null;
     expect(nullableJObject.use((_) => 'foo'), equals('foo'));
   });
 


### PR DESCRIPTION
The `use` method makes it really easy to use jni and not worry about memory management (even if the nesting get's ugly)

However this PR allows you to use `use` on nullable `JObject?`s too.
This is a very small pr which would allow you to do this.
```
someFunc(JObject? obj){
  obj.use(...);
}
```
The extension was only on `JObject` previosly.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
