### PR TITLE
[native_assets_cli] Rename syntax classes to `${name}Syntax`

### DIFF
--- a/pkgs/json_syntax_generator/lib/src/generator/enum_class_generator.dart
+++ b/pkgs/json_syntax_generator/lib/src/generator/enum_class_generator.dart
@@ -11,7 +11,7 @@ class EnumGenerator {
 
   String generate() {
     final buffer = StringBuffer();
-    final className = classInfo.name;
+    final className = classInfo.className;
     final enumValues = classInfo.enumValues;
 
     final staticFinals = <String>[];

--- a/pkgs/json_syntax_generator/lib/src/generator/helper_library.dart
+++ b/pkgs/json_syntax_generator/lib/src/generator/helper_library.dart
@@ -6,16 +6,16 @@
 ///
 /// This simplifies the code generator.
 const helperLib = r'''
-class JsonObject {
+class JsonObjectSyntax {
   final Map<String, Object?> json;
 
   final List<Object> path;
 
   JsonReader get _reader => JsonReader(json, path);
 
-  JsonObject() : json = {}, path = const [];
+  JsonObjectSyntax() : json = {}, path = const [];
 
-  JsonObject.fromJson(this.json, {this.path = const []});
+  JsonObjectSyntax.fromJson(this.json, {this.path = const []});
 
   List<String> validate() => [];
 }

--- a/pkgs/json_syntax_generator/lib/src/generator/normal_class_generator.dart
+++ b/pkgs/json_syntax_generator/lib/src/generator/normal_class_generator.dart
@@ -19,8 +19,9 @@ class ClassGenerator {
   }
 
   void _generateClass(StringBuffer buffer) {
-    final className = classInfo.name;
-    final superclassName = classInfo.superclass?.name ?? 'JsonObject';
+    final className = classInfo.className;
+    final superclassName =
+        classInfo.superclass?.className ?? 'JsonObjectSyntax';
 
     buffer.writeln('''
 class $className extends $superclassName {
@@ -57,7 +58,7 @@ static const ${tagProperty}Value = '$tagValue';
       return '';
     }
 
-    final className = classInfo.name;
+    final className = classInfo.className;
     final factorySubclassReturns = <String>[];
     for (final subclass in classInfo.subclasses) {
       if (subclass.taggedUnionValue != null) {
@@ -82,7 +83,7 @@ static const ${tagProperty}Value = '$tagValue';
   }
 
   String _generateJsonConstructor() {
-    final className = classInfo.name;
+    final className = classInfo.className;
 
     if (classInfo.superclass == null) {
       final constructorName =
@@ -107,7 +108,7 @@ static const ${tagProperty}Value = '$tagValue';
     final parameters = _generateDefaultConstructorParameters();
     final superArguments = _generateDefaultConstructorSuperArguments();
     final setterCalls = _generateSetterCalls();
-    final className = classInfo.name;
+    final className = classInfo.className;
     final parametersString = wrapBracesIfNotEmpty(parameters.join(', '));
     final superArgumentsString = superArguments.join(',');
     final body = wrapInBracesOrSemicolon(setterCalls.join('\n    '));
@@ -231,8 +232,8 @@ static const ${tagProperty}Value = '$tagValue';
 
     final parameters = _generateSetupParameters();
     final setterCalls = _generateSetterCalls();
-    final className = classInfo.name;
-    final superclassName = classInfo.superclass!.name;
+    final className = classInfo.className;
+    final superclassName = classInfo.superclass!.className;
     final parametersString = wrapBracesIfNotEmpty(parameters.join(', '));
     final setterCallsString = setterCalls.join('\n    ');
     return '''
@@ -343,7 +344,7 @@ static const ${tagProperty}Value = '$tagValue';
   }
 
   String _generateToString() {
-    final className = classInfo.name;
+    final className = classInfo.className;
     return '''
   @override
   String toString() => '$className(\$json)';
@@ -353,16 +354,17 @@ static const ${tagProperty}Value = '$tagValue';
   void _generateTaggedUnionExtension(StringBuffer buffer) {
     if (!classInfo.isTaggedUnion || classInfo.superclass == null) return;
 
-    final className = classInfo.name;
-    final superclassName = classInfo.superclass!.name;
+    final name = classInfo.name;
+    final className = classInfo.className;
+    final superclassName = classInfo.superclass!.className;
     final taggedUnionValue = classInfo.taggedUnionValue;
     final taggedUnionProperty = classInfo.superclass!.taggedUnionProperty;
 
     buffer.writeln('''
 extension ${className}Extension on $superclassName {
-  bool get is$className => $taggedUnionProperty == '$taggedUnionValue';
+  bool get is$name => $taggedUnionProperty == '$taggedUnionValue';
 
-  $className get as$className => $className.fromJson(json, path: path);
+  $className get as$name => $className.fromJson(json, path: path);
 }
 ''');
   }

--- a/pkgs/json_syntax_generator/lib/src/generator/property_generator.dart
+++ b/pkgs/json_syntax_generator/lib/src/generator/property_generator.dart
@@ -83,7 +83,7 @@ class PropertyGenerator {
     String sortOnKey,
   ) {
     final classInfo = dartType.classInfo;
-    final classType = classInfo.name;
+    final classType = classInfo.className;
     final fieldName = property.name;
     final validateName = property.validateName;
     final isNullable = property.type.isNullable;

--- a/pkgs/json_syntax_generator/lib/src/model/class_info.dart
+++ b/pkgs/json_syntax_generator/lib/src/model/class_info.dart
@@ -9,6 +9,8 @@ sealed class ClassInfo {
   /// The Dart class name.
   final String name;
 
+  String get className => '${name}Syntax';
+
   ClassInfo({required this.name});
 }
 

--- a/pkgs/json_syntax_generator/lib/src/model/dart_type.dart
+++ b/pkgs/json_syntax_generator/lib/src/model/dart_type.dart
@@ -91,7 +91,7 @@ class ClassDartType extends DartType {
   const ClassDartType({required this.classInfo, required super.isNullable});
 
   @override
-  String toNonNullableString() => classInfo.name;
+  String toNonNullableString() => classInfo.className;
 
   @override
   bool operator ==(Object other) =>

--- a/pkgs/native_assets_cli/lib/src/code_assets/architecture.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/architecture.dart
@@ -4,7 +4,7 @@
 
 import 'dart:ffi' show Abi;
 
-import 'syntax.g.dart' as syntax;
+import 'syntax.g.dart';
 
 /// A hardware architecture which the Dart VM can run on.
 final class Architecture {
@@ -82,25 +82,25 @@ final class Architecture {
   /// The name can be obtained from [Architecture.name] or
   /// [Architecture.toString].
   factory Architecture.fromString(String name) =>
-      ArchitectureSyntax.fromSyntax(syntax.Architecture.fromJson(name));
+      ArchitectureSyntaxExtension.fromSyntax(ArchitectureSyntax.fromJson(name));
 
   /// The current [Architecture].
   static final Architecture current = _abiToArch[Abi.current()]!;
 }
 
-extension ArchitectureSyntax on Architecture {
+extension ArchitectureSyntaxExtension on Architecture {
   static final _toSyntax = {
     for (final item in Architecture.values)
-      item: syntax.Architecture.fromJson(item.name),
+      item: ArchitectureSyntax.fromJson(item.name),
   };
 
   static final _fromSyntax = {
     for (var entry in _toSyntax.entries) entry.value: entry.key,
   };
 
-  syntax.Architecture toSyntax() => _toSyntax[this]!;
+  ArchitectureSyntax toSyntax() => _toSyntax[this]!;
 
-  static Architecture fromSyntax(syntax.Architecture syntax) =>
+  static Architecture fromSyntax(ArchitectureSyntax syntax) =>
       switch (_fromSyntax[syntax]) {
         null => throw FormatException(
           'The architecture "${syntax.name}" is not known',

--- a/pkgs/native_assets_cli/lib/src/code_assets/c_compiler_config.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/c_compiler_config.dart
@@ -6,7 +6,7 @@ import 'package:collection/collection.dart';
 
 import 'config.dart';
 import 'os.dart';
-import 'syntax.g.dart' as syntax;
+import 'syntax.g.dart';
 
 /// The configuration for a C toolchain.
 final class CCompilerConfig {
@@ -108,44 +108,45 @@ final class DeveloperCommandPrompt {
   DeveloperCommandPrompt({required this.script, required this.arguments});
 }
 
-extension CCompilerConfigSyntax on CCompilerConfig {
-  syntax.CCompilerConfig toSyntax() => syntax.CCompilerConfig(
+extension CCompilerConfigSyntaxExtension on CCompilerConfig {
+  CCompilerConfigSyntax toSyntax() => CCompilerConfigSyntax(
     ar: archiver,
     cc: compiler,
     ld: linker,
     windows: _windows?.toSyntax(),
   );
 
-  static CCompilerConfig fromSyntax(syntax.CCompilerConfig cCompiler) =>
+  static CCompilerConfig fromSyntax(CCompilerConfigSyntax cCompiler) =>
       CCompilerConfig(
         archiver: cCompiler.ar,
         compiler: cCompiler.cc,
         linker: cCompiler.ld,
         windows: switch (cCompiler.windows) {
           null => null,
-          final windows => WindowsCCompilerConfigSyntax.fromSyntax(windows),
+          final windows => WindowsCCompilerConfigSyntaxExtension.fromSyntax(
+            windows,
+          ),
         },
       );
 }
 
-extension WindowsCCompilerConfigSyntax on WindowsCCompilerConfig {
-  syntax.Windows toSyntax() => syntax.Windows(
-    developerCommandPrompt: developerCommandPrompt?.toSyntax(),
-  );
+extension WindowsCCompilerConfigSyntaxExtension on WindowsCCompilerConfig {
+  WindowsSyntax toSyntax() =>
+      WindowsSyntax(developerCommandPrompt: developerCommandPrompt?.toSyntax());
 
-  static WindowsCCompilerConfig fromSyntax(syntax.Windows windows) =>
+  static WindowsCCompilerConfig fromSyntax(WindowsSyntax windows) =>
       WindowsCCompilerConfig(
         developerCommandPrompt: switch (windows.developerCommandPrompt) {
           null => null,
-          final dcp => DeveloperCommandPromptSyntax.fromSyntax(dcp),
+          final dcp => DeveloperCommandPromptSyntaxExtension.fromSyntax(dcp),
         },
       );
 }
 
-extension DeveloperCommandPromptSyntax on DeveloperCommandPrompt {
-  syntax.DeveloperCommandPrompt toSyntax() =>
-      syntax.DeveloperCommandPrompt(script: script, arguments: arguments);
+extension DeveloperCommandPromptSyntaxExtension on DeveloperCommandPrompt {
+  DeveloperCommandPromptSyntax toSyntax() =>
+      DeveloperCommandPromptSyntax(script: script, arguments: arguments);
 
-  static DeveloperCommandPrompt fromSyntax(syntax.DeveloperCommandPrompt dcp) =>
+  static DeveloperCommandPrompt fromSyntax(DeveloperCommandPromptSyntax dcp) =>
       DeveloperCommandPrompt(script: dcp.script, arguments: dcp.arguments);
 }

--- a/pkgs/native_assets_cli/lib/src/code_assets/code_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/code_asset.dart
@@ -7,7 +7,7 @@ import '../encoded_asset.dart';
 import 'config.dart';
 import 'link_mode.dart';
 import 'os.dart';
-import 'syntax.g.dart' as syntax;
+import 'syntax.g.dart';
 
 /// A code asset which respects the native application binary interface (ABI).
 ///
@@ -85,13 +85,13 @@ final class CodeAsset {
 
   factory CodeAsset.fromEncoded(EncodedAsset asset) {
     assert(asset.isCodeAsset);
-    final syntaxNode = syntax.NativeCodeAssetEncoding.fromJson(
+    final syntaxNode = NativeCodeAssetEncodingSyntax.fromJson(
       asset.encoding,
       path: asset.jsonPath ?? [],
     );
     return CodeAsset._(
       id: syntaxNode.id,
-      linkMode: LinkModeSyntax.fromSyntax(syntaxNode.linkMode),
+      linkMode: LinkModeSyntaxExtension.fromSyntax(syntaxNode.linkMode),
       file: syntaxNode.file,
     );
   }
@@ -115,7 +115,7 @@ final class CodeAsset {
   int get hashCode => Object.hash(id, linkMode, file);
 
   EncodedAsset encode() {
-    final encoding = syntax.NativeCodeAssetEncoding(
+    final encoding = NativeCodeAssetEncodingSyntax(
       file: file,
       id: id,
       linkMode: linkMode.toSyntax(),
@@ -125,7 +125,7 @@ final class CodeAsset {
 }
 
 extension CodeAssetType on CodeAsset {
-  static const String type = syntax.NativeCodeAssetNew.typeValue;
+  static const String type = NativeCodeAssetNewSyntax.typeValue;
 }
 
 extension EncodedCodeAsset on EncodedAsset {

--- a/pkgs/native_assets_cli/lib/src/code_assets/config.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/config.dart
@@ -10,7 +10,7 @@ import 'code_asset.dart';
 import 'ios_sdk.dart';
 import 'link_mode_preference.dart';
 import 'os.dart';
-import 'syntax.g.dart' as syntax;
+import 'syntax.g.dart';
 
 /// Extension to the [HookConfig] providing access to configuration specific
 /// to code assets (only available if code assets are supported).
@@ -38,13 +38,10 @@ extension CodeAssetLinkInput on LinkInputAssets {
 
 /// Configuration for hook writers if code assets are supported.
 class CodeConfig {
-  final syntax.CodeConfig _syntax;
+  final CodeConfigSyntax _syntax;
 
   CodeConfig._fromJson(Map<String, Object?> json, List<Object> path)
-    : _syntax = syntax.Config.fromJson(
-        json,
-        path: path,
-      ).extensions!.codeAssets!;
+    : _syntax = ConfigSyntax.fromJson(json, path: path).extensions!.codeAssets!;
 
   /// The architecture the code code asset should be built for.
   ///
@@ -54,19 +51,19 @@ class CodeConfig {
   /// into a universal binary. So, the build and link hook implementations are
   /// not responsible for providing universal binaries.
   Architecture get targetArchitecture =>
-      ArchitectureSyntax.fromSyntax(_syntax.targetArchitecture);
+      ArchitectureSyntaxExtension.fromSyntax(_syntax.targetArchitecture);
 
   LinkModePreference get linkModePreference =>
-      LinkModePreferenceSyntax.fromSyntax(_syntax.linkModePreference);
+      LinkModePreferenceSyntaxExtension.fromSyntax(_syntax.linkModePreference);
 
   /// A compiler toolchain able to target [targetOS] with [targetArchitecture].
   CCompilerConfig? get cCompiler => switch (_syntax.cCompiler) {
     null => null,
-    final c => CCompilerConfigSyntax.fromSyntax(c),
+    final c => CCompilerConfigSyntaxExtension.fromSyntax(c),
   };
 
   /// The operating system being compiled for.
-  OS get targetOS => OSSyntax.fromSyntax(_syntax.targetOs);
+  OS get targetOS => OSSyntaxExtension.fromSyntax(_syntax.targetOs);
 
   /// Configuration provided when [CodeConfig.targetOS] is [OS.macOS].
   IOSCodeConfig get iOS => switch (_syntax.iOS) {
@@ -93,7 +90,7 @@ class CodeConfig {
 
 /// Configuration provided when [CodeConfig.targetOS] is [OS.iOS].
 class IOSCodeConfig {
-  final syntax.IOSCodeConfig _syntax;
+  final IOSCodeConfigSyntax _syntax;
 
   IOSCodeConfig._(this._syntax);
 
@@ -104,7 +101,7 @@ class IOSCodeConfig {
   int get targetVersion => _syntax.targetVersion;
 
   IOSCodeConfig({required IOSSdk targetSdk, required int targetVersion})
-    : _syntax = syntax.IOSCodeConfig(
+    : _syntax = IOSCodeConfigSyntax(
         targetSdk: targetSdk.type,
         targetVersion: targetVersion,
       );
@@ -112,7 +109,7 @@ class IOSCodeConfig {
 
 /// Configuration provided when [CodeConfig.targetOS] is [OS.macOS].
 class AndroidCodeConfig {
-  final syntax.AndroidCodeConfig _syntax;
+  final AndroidCodeConfigSyntax _syntax;
 
   AndroidCodeConfig._(this._syntax);
 
@@ -121,12 +118,12 @@ class AndroidCodeConfig {
   int get targetNdkApi => _syntax.targetNdkApi;
 
   AndroidCodeConfig({required int targetNdkApi})
-    : _syntax = syntax.AndroidCodeConfig(targetNdkApi: targetNdkApi);
+    : _syntax = AndroidCodeConfigSyntax(targetNdkApi: targetNdkApi);
 }
 
 //// Configuration provided when [CodeConfig.targetOS] is [OS.macOS].
 class MacOSCodeConfig {
-  final syntax.MacOSCodeConfig _syntax;
+  final MacOSCodeConfigSyntax _syntax;
 
   MacOSCodeConfig._(this._syntax);
 
@@ -134,7 +131,7 @@ class MacOSCodeConfig {
   int get targetVersion => _syntax.targetVersion;
 
   MacOSCodeConfig({required int targetVersion})
-    : _syntax = syntax.MacOSCodeConfig(targetVersion: targetVersion);
+    : _syntax = MacOSCodeConfigSyntax(targetVersion: targetVersion);
 }
 
 /// Extension to the [BuildOutputBuilder] providing access to emitting code
@@ -195,7 +192,7 @@ extension CodeAssetBuildInputBuilder on HookConfigBuilder {
     IOSCodeConfig? iOS,
     MacOSCodeConfig? macOS,
   }) {
-    final codeConfig = syntax.CodeConfig(
+    final codeConfig = CodeConfigSyntax(
       linkModePreference: linkModePreference.toSyntax(),
       targetArchitecture: targetArchitecture.toSyntax(),
       targetOs: targetOS.toSyntax(),
@@ -204,9 +201,11 @@ extension CodeAssetBuildInputBuilder on HookConfigBuilder {
       iOS: iOS?.toSyntax(),
       macOS: macOS?.toSyntax(),
     );
-    final baseHookConfig = hook_syntax.HookInput.fromJson(builder.json).config;
-    baseHookConfig.extensions ??= hook_syntax.JsonObject.fromJson({});
-    final hookConfig = syntax.Config.fromJson(baseHookConfig.json);
+    final baseHookConfig = hook_syntax.HookInputSyntax.fromJson(
+      builder.json,
+    ).config;
+    baseHookConfig.extensions ??= hook_syntax.JsonObjectSyntax.fromJson({});
+    final hookConfig = ConfigSyntax.fromJson(baseHookConfig.json);
     hookConfig.extensions!.codeAssets = codeConfig;
   }
 }
@@ -229,19 +228,19 @@ extension CodeAssetLinkOutput on LinkOutputAssets {
       .toList();
 }
 
-extension MacOSCodeConfigSyntax on MacOSCodeConfig {
-  syntax.MacOSCodeConfig toSyntax() =>
-      syntax.MacOSCodeConfig(targetVersion: targetVersion);
+extension MacOSCodeConfigSyntaxExtension on MacOSCodeConfig {
+  MacOSCodeConfigSyntax toSyntax() =>
+      MacOSCodeConfigSyntax(targetVersion: targetVersion);
 }
 
-extension IOSCodeConfigSyntax on IOSCodeConfig {
-  syntax.IOSCodeConfig toSyntax() => syntax.IOSCodeConfig(
+extension IOSCodeConfigSyntaxExtension on IOSCodeConfig {
+  IOSCodeConfigSyntax toSyntax() => IOSCodeConfigSyntax(
     targetSdk: targetSdk.type,
     targetVersion: targetVersion,
   );
 }
 
-extension AndroidCodeConfigSyntax on AndroidCodeConfig {
-  syntax.AndroidCodeConfig toSyntax() =>
-      syntax.AndroidCodeConfig(targetNdkApi: targetNdkApi);
+extension AndroidCodeConfigSyntaxExtension on AndroidCodeConfig {
+  AndroidCodeConfigSyntax toSyntax() =>
+      AndroidCodeConfigSyntax(targetNdkApi: targetNdkApi);
 }

--- a/pkgs/native_assets_cli/lib/src/code_assets/link_mode.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/link_mode.dart
@@ -4,7 +4,7 @@
 
 import 'code_asset.dart';
 
-import 'syntax.g.dart' as syntax;
+import 'syntax.g.dart';
 
 /// The link mode for a [CodeAsset].
 ///
@@ -25,7 +25,7 @@ abstract final class LinkMode {
   ///
   /// The json is expected to be valid encoding obtained via [LinkMode.toJson].
   factory LinkMode.fromJson(Map<String, Object?> json) =>
-      LinkModeSyntax.fromSyntax(syntax.LinkMode.fromJson(json));
+      LinkModeSyntaxExtension.fromSyntax(LinkModeSyntax.fromJson(json));
 
   /// The json representation of this [LinkMode].
   ///
@@ -34,19 +34,19 @@ abstract final class LinkMode {
   Map<String, Object?> toJson() => toSyntax().json;
 }
 
-extension LinkModeSyntax on LinkMode {
-  syntax.LinkMode toSyntax() => switch (this) {
-    StaticLinking() => syntax.StaticLinkMode(),
-    LookupInProcess() => syntax.DynamicLoadingProcessLinkMode(),
-    LookupInExecutable() => syntax.DynamicLoadingExecutableLinkMode(),
-    DynamicLoadingBundled() => syntax.DynamicLoadingBundleLinkMode(),
-    final DynamicLoadingSystem system => syntax.DynamicLoadingSystemLinkMode(
+extension LinkModeSyntaxExtension on LinkMode {
+  LinkModeSyntax toSyntax() => switch (this) {
+    StaticLinking() => StaticLinkModeSyntax(),
+    LookupInProcess() => DynamicLoadingProcessLinkModeSyntax(),
+    LookupInExecutable() => DynamicLoadingExecutableLinkModeSyntax(),
+    DynamicLoadingBundled() => DynamicLoadingBundleLinkModeSyntax(),
+    final DynamicLoadingSystem system => DynamicLoadingSystemLinkModeSyntax(
       uri: system.uri,
     ),
     _ => throw UnimplementedError('The link mode "$this" is not known'),
   };
 
-  static LinkMode fromSyntax(syntax.LinkMode linkMode) => switch (linkMode) {
+  static LinkMode fromSyntax(LinkModeSyntax linkMode) => switch (linkMode) {
     _ when linkMode.isStaticLinkMode => StaticLinking(),
     _ when linkMode.isDynamicLoadingProcessLinkMode => LookupInProcess(),
     _ when linkMode.isDynamicLoadingExecutableLinkMode => LookupInExecutable(),

--- a/pkgs/native_assets_cli/lib/src/code_assets/link_mode_preference.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/link_mode_preference.dart
@@ -4,7 +4,7 @@
 
 import 'code_asset.dart';
 
-import 'syntax.g.dart' as syntax;
+import 'syntax.g.dart';
 
 /// The preferred linkMode method for [CodeAsset]s.
 final class LinkModePreference {
@@ -14,8 +14,8 @@ final class LinkModePreference {
   const LinkModePreference(this.name);
 
   factory LinkModePreference.fromString(String name) =>
-      LinkModePreferenceSyntax.fromSyntax(
-        syntax.LinkModePreference.fromJson(name),
+      LinkModePreferenceSyntaxExtension.fromSyntax(
+        LinkModePreferenceSyntax.fromJson(name),
       );
 
   /// Provide native assets as dynamic libraries.
@@ -49,23 +49,23 @@ final class LinkModePreference {
   String toString() => name;
 }
 
-extension LinkModePreferenceSyntax on LinkModePreference {
+extension LinkModePreferenceSyntaxExtension on LinkModePreference {
   static const _toSyntax = {
-    LinkModePreference.dynamic: syntax.LinkModePreference.dynamic,
-    LinkModePreference.preferDynamic: syntax.LinkModePreference.preferDynamic,
-    LinkModePreference.preferStatic: syntax.LinkModePreference.preferStatic,
-    LinkModePreference.static: syntax.LinkModePreference.static,
+    LinkModePreference.dynamic: LinkModePreferenceSyntax.dynamic,
+    LinkModePreference.preferDynamic: LinkModePreferenceSyntax.preferDynamic,
+    LinkModePreference.preferStatic: LinkModePreferenceSyntax.preferStatic,
+    LinkModePreference.static: LinkModePreferenceSyntax.static,
   };
 
   static const _fromSyntax = {
-    syntax.LinkModePreference.dynamic: LinkModePreference.dynamic,
-    syntax.LinkModePreference.preferDynamic: LinkModePreference.preferDynamic,
-    syntax.LinkModePreference.preferStatic: LinkModePreference.preferStatic,
-    syntax.LinkModePreference.static: LinkModePreference.static,
+    LinkModePreferenceSyntax.dynamic: LinkModePreference.dynamic,
+    LinkModePreferenceSyntax.preferDynamic: LinkModePreference.preferDynamic,
+    LinkModePreferenceSyntax.preferStatic: LinkModePreference.preferStatic,
+    LinkModePreferenceSyntax.static: LinkModePreference.static,
   };
 
-  syntax.LinkModePreference toSyntax() => _toSyntax[this]!;
+  LinkModePreferenceSyntax toSyntax() => _toSyntax[this]!;
 
-  static LinkModePreference fromSyntax(syntax.LinkModePreference syntax) =>
+  static LinkModePreference fromSyntax(LinkModePreferenceSyntax syntax) =>
       _fromSyntax[syntax]!;
 }

--- a/pkgs/native_assets_cli/lib/src/code_assets/os.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/os.dart
@@ -4,7 +4,7 @@
 
 import 'dart:io';
 
-import 'syntax.g.dart' as syntax;
+import 'syntax.g.dart';
 
 /// An operating system the Dart VM runs on.
 final class OS {
@@ -57,7 +57,7 @@ final class OS {
   ///
   /// The name can be obtained from [OS.name] or [OS.toString].
   factory OS.fromString(String name) =>
-      OSSyntax.fromSyntax(syntax.OS.fromJson(name));
+      OSSyntaxExtension.fromSyntax(OSSyntax.fromJson(name));
 
   /// The current [OS].
   ///
@@ -65,18 +65,18 @@ final class OS {
   static final OS current = OS.fromString(Platform.operatingSystem);
 }
 
-extension OSSyntax on OS {
+extension OSSyntaxExtension on OS {
   static final _toSyntax = {
-    for (final item in OS.values) item: syntax.OS.fromJson(item.name),
+    for (final item in OS.values) item: OSSyntax.fromJson(item.name),
   };
 
   static final _fromSyntax = {
     for (var entry in _toSyntax.entries) entry.value: entry.key,
   };
 
-  syntax.OS toSyntax() => _toSyntax[this]!;
+  OSSyntax toSyntax() => _toSyntax[this]!;
 
-  static OS fromSyntax(syntax.OS syntax) => switch (_fromSyntax[syntax]) {
+  static OS fromSyntax(OSSyntax syntax) => switch (_fromSyntax[syntax]) {
     null => throw FormatException('The OS "${syntax.name}" is not known'),
     final e => e,
   };

--- a/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/syntax.g.dart
@@ -10,11 +10,11 @@
 
 import 'dart:io';
 
-class AndroidCodeConfig extends JsonObject {
-  AndroidCodeConfig.fromJson(super.json, {super.path = const []})
+class AndroidCodeConfigSyntax extends JsonObjectSyntax {
+  AndroidCodeConfigSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  AndroidCodeConfig({required int targetNdkApi}) : super() {
+  AndroidCodeConfigSyntax({required int targetNdkApi}) : super() {
     _targetNdkApi = targetNdkApi;
     json.sortOnKey();
   }
@@ -32,27 +32,27 @@ class AndroidCodeConfig extends JsonObject {
   List<String> validate() => [...super.validate(), ..._validateTargetNdkApi()];
 
   @override
-  String toString() => 'AndroidCodeConfig($json)';
+  String toString() => 'AndroidCodeConfigSyntax($json)';
 }
 
-class Architecture {
+class ArchitectureSyntax {
   final String name;
 
-  const Architecture._(this.name);
+  const ArchitectureSyntax._(this.name);
 
-  static const arm = Architecture._('arm');
+  static const arm = ArchitectureSyntax._('arm');
 
-  static const arm64 = Architecture._('arm64');
+  static const arm64 = ArchitectureSyntax._('arm64');
 
-  static const ia32 = Architecture._('ia32');
+  static const ia32 = ArchitectureSyntax._('ia32');
 
-  static const riscv32 = Architecture._('riscv32');
+  static const riscv32 = ArchitectureSyntax._('riscv32');
 
-  static const riscv64 = Architecture._('riscv64');
+  static const riscv64 = ArchitectureSyntax._('riscv64');
 
-  static const x64 = Architecture._('x64');
+  static const x64 = ArchitectureSyntax._('x64');
 
-  static const List<Architecture> values = [
+  static const List<ArchitectureSyntax> values = [
     arm,
     arm64,
     ia32,
@@ -61,18 +61,18 @@ class Architecture {
     x64,
   ];
 
-  static final Map<String, Architecture> _byName = {
+  static final Map<String, ArchitectureSyntax> _byName = {
     for (final value in values) value.name: value,
   };
 
-  Architecture.unknown(this.name) : assert(!_byName.keys.contains(name));
+  ArchitectureSyntax.unknown(this.name) : assert(!_byName.keys.contains(name));
 
-  factory Architecture.fromJson(String name) {
+  factory ArchitectureSyntax.fromJson(String name) {
     final knownValue = _byName[name];
     if (knownValue != null) {
       return knownValue;
     }
-    return Architecture.unknown(name);
+    return ArchitectureSyntax.unknown(name);
   }
 
   bool get isKnown => _byName[name] != null;
@@ -81,21 +81,21 @@ class Architecture {
   String toString() => name;
 }
 
-class Asset extends JsonObject {
-  factory Asset.fromJson(
+class AssetSyntax extends JsonObjectSyntax {
+  factory AssetSyntax.fromJson(
     Map<String, Object?> json, {
     List<Object> path = const [],
   }) {
-    final result = Asset._fromJson(json, path: path);
+    final result = AssetSyntax._fromJson(json, path: path);
     if (result.isNativeCodeAssetNew) {
       return result.asNativeCodeAssetNew;
     }
     return result;
   }
 
-  Asset._fromJson(super.json, {super.path = const []}) : super.fromJson();
+  AssetSyntax._fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  Asset({required String? type}) : super() {
+  AssetSyntax({required String? type}) : super() {
     _type = type;
     json.sortOnKey();
   }
@@ -112,18 +112,18 @@ class Asset extends JsonObject {
   List<String> validate() => [...super.validate(), ..._validateType()];
 
   @override
-  String toString() => 'Asset($json)';
+  String toString() => 'AssetSyntax($json)';
 }
 
-class CCompilerConfig extends JsonObject {
-  CCompilerConfig.fromJson(super.json, {super.path = const []})
+class CCompilerConfigSyntax extends JsonObjectSyntax {
+  CCompilerConfigSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  CCompilerConfig({
+  CCompilerConfigSyntax({
     required Uri ar,
     required Uri cc,
     required Uri ld,
-    required Windows? windows,
+    required WindowsSyntax? windows,
   }) : super() {
     _ar = ar;
     _cc = cc;
@@ -156,13 +156,13 @@ class CCompilerConfig extends JsonObject {
 
   List<String> _validateLd() => _reader.validatePath('ld');
 
-  Windows? get windows {
+  WindowsSyntax? get windows {
     final jsonValue = _reader.optionalMap('windows');
     if (jsonValue == null) return null;
-    return Windows.fromJson(jsonValue, path: [...path, 'windows']);
+    return WindowsSyntax.fromJson(jsonValue, path: [...path, 'windows']);
   }
 
-  set _windows(Windows? value) {
+  set _windows(WindowsSyntax? value) {
     json.setOrRemove('windows', value?.json);
   }
 
@@ -184,20 +184,21 @@ class CCompilerConfig extends JsonObject {
   ];
 
   @override
-  String toString() => 'CCompilerConfig($json)';
+  String toString() => 'CCompilerConfigSyntax($json)';
 }
 
-class CodeConfig extends JsonObject {
-  CodeConfig.fromJson(super.json, {super.path = const []}) : super.fromJson();
+class CodeConfigSyntax extends JsonObjectSyntax {
+  CodeConfigSyntax.fromJson(super.json, {super.path = const []})
+    : super.fromJson();
 
-  CodeConfig({
-    required AndroidCodeConfig? android,
-    required CCompilerConfig? cCompiler,
-    required IOSCodeConfig? iOS,
-    required LinkModePreference linkModePreference,
-    required MacOSCodeConfig? macOS,
-    required Architecture targetArchitecture,
-    required OS targetOs,
+  CodeConfigSyntax({
+    required AndroidCodeConfigSyntax? android,
+    required CCompilerConfigSyntax? cCompiler,
+    required IOSCodeConfigSyntax? iOS,
+    required LinkModePreferenceSyntax linkModePreference,
+    required MacOSCodeConfigSyntax? macOS,
+    required ArchitectureSyntax targetArchitecture,
+    required OSSyntax targetOs,
   }) : super() {
     _android = android;
     _cCompiler = cCompiler;
@@ -209,13 +210,16 @@ class CodeConfig extends JsonObject {
     json.sortOnKey();
   }
 
-  AndroidCodeConfig? get android {
+  AndroidCodeConfigSyntax? get android {
     final jsonValue = _reader.optionalMap('android');
     if (jsonValue == null) return null;
-    return AndroidCodeConfig.fromJson(jsonValue, path: [...path, 'android']);
+    return AndroidCodeConfigSyntax.fromJson(
+      jsonValue,
+      path: [...path, 'android'],
+    );
   }
 
-  set _android(AndroidCodeConfig? value) {
+  set _android(AndroidCodeConfigSyntax? value) {
     json.setOrRemove('android', value?.json);
   }
 
@@ -227,13 +231,16 @@ class CodeConfig extends JsonObject {
     return android?.validate() ?? [];
   }
 
-  CCompilerConfig? get cCompiler {
+  CCompilerConfigSyntax? get cCompiler {
     final jsonValue = _reader.optionalMap('c_compiler');
     if (jsonValue == null) return null;
-    return CCompilerConfig.fromJson(jsonValue, path: [...path, 'c_compiler']);
+    return CCompilerConfigSyntax.fromJson(
+      jsonValue,
+      path: [...path, 'c_compiler'],
+    );
   }
 
-  set _cCompiler(CCompilerConfig? value) {
+  set _cCompiler(CCompilerConfigSyntax? value) {
     json.setOrRemove('c_compiler', value?.json);
   }
 
@@ -245,13 +252,13 @@ class CodeConfig extends JsonObject {
     return cCompiler?.validate() ?? [];
   }
 
-  IOSCodeConfig? get iOS {
+  IOSCodeConfigSyntax? get iOS {
     final jsonValue = _reader.optionalMap('ios');
     if (jsonValue == null) return null;
-    return IOSCodeConfig.fromJson(jsonValue, path: [...path, 'ios']);
+    return IOSCodeConfigSyntax.fromJson(jsonValue, path: [...path, 'ios']);
   }
 
-  set _iOS(IOSCodeConfig? value) {
+  set _iOS(IOSCodeConfigSyntax? value) {
     json.setOrRemove('ios', value?.json);
   }
 
@@ -263,25 +270,25 @@ class CodeConfig extends JsonObject {
     return iOS?.validate() ?? [];
   }
 
-  LinkModePreference get linkModePreference {
+  LinkModePreferenceSyntax get linkModePreference {
     final jsonValue = _reader.get<String>('link_mode_preference');
-    return LinkModePreference.fromJson(jsonValue);
+    return LinkModePreferenceSyntax.fromJson(jsonValue);
   }
 
-  set _linkModePreference(LinkModePreference value) {
+  set _linkModePreference(LinkModePreferenceSyntax value) {
     json['link_mode_preference'] = value.name;
   }
 
   List<String> _validateLinkModePreference() =>
       _reader.validate<String>('link_mode_preference');
 
-  MacOSCodeConfig? get macOS {
+  MacOSCodeConfigSyntax? get macOS {
     final jsonValue = _reader.optionalMap('macos');
     if (jsonValue == null) return null;
-    return MacOSCodeConfig.fromJson(jsonValue, path: [...path, 'macos']);
+    return MacOSCodeConfigSyntax.fromJson(jsonValue, path: [...path, 'macos']);
   }
 
-  set _macOS(MacOSCodeConfig? value) {
+  set _macOS(MacOSCodeConfigSyntax? value) {
     json.setOrRemove('macos', value?.json);
   }
 
@@ -293,24 +300,24 @@ class CodeConfig extends JsonObject {
     return macOS?.validate() ?? [];
   }
 
-  Architecture get targetArchitecture {
+  ArchitectureSyntax get targetArchitecture {
     final jsonValue = _reader.get<String>('target_architecture');
-    return Architecture.fromJson(jsonValue);
+    return ArchitectureSyntax.fromJson(jsonValue);
   }
 
-  set _targetArchitecture(Architecture value) {
+  set _targetArchitecture(ArchitectureSyntax value) {
     json['target_architecture'] = value.name;
   }
 
   List<String> _validateTargetArchitecture() =>
       _reader.validate<String>('target_architecture');
 
-  OS get targetOs {
+  OSSyntax get targetOs {
     final jsonValue = _reader.get<String>('target_os');
-    return OS.fromJson(jsonValue);
+    return OSSyntax.fromJson(jsonValue);
   }
 
-  set _targetOs(OS value) {
+  set _targetOs(OSSyntax value) {
     json['target_os'] = value.name;
   }
 
@@ -357,24 +364,27 @@ class CodeConfig extends JsonObject {
   }
 
   @override
-  String toString() => 'CodeConfig($json)';
+  String toString() => 'CodeConfigSyntax($json)';
 }
 
-class Config extends JsonObject {
-  Config.fromJson(super.json, {super.path = const []}) : super.fromJson();
+class ConfigSyntax extends JsonObjectSyntax {
+  ConfigSyntax.fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  Config({required ConfigExtensions? extensions}) : super() {
+  ConfigSyntax({required ConfigExtensionsSyntax? extensions}) : super() {
     this.extensions = extensions;
     json.sortOnKey();
   }
 
-  ConfigExtensions? get extensions {
+  ConfigExtensionsSyntax? get extensions {
     final jsonValue = _reader.optionalMap('extensions');
     if (jsonValue == null) return null;
-    return ConfigExtensions.fromJson(jsonValue, path: [...path, 'extensions']);
+    return ConfigExtensionsSyntax.fromJson(
+      jsonValue,
+      path: [...path, 'extensions'],
+    );
   }
 
-  set extensions(ConfigExtensions? value) {
+  set extensions(ConfigExtensionsSyntax? value) {
     json.setOrRemove('extensions', value?.json);
     json.sortOnKey();
   }
@@ -391,25 +401,25 @@ class Config extends JsonObject {
   List<String> validate() => [...super.validate(), ..._validateExtensions()];
 
   @override
-  String toString() => 'Config($json)';
+  String toString() => 'ConfigSyntax($json)';
 }
 
-class ConfigExtensions extends JsonObject {
-  ConfigExtensions.fromJson(super.json, {super.path = const []})
+class ConfigExtensionsSyntax extends JsonObjectSyntax {
+  ConfigExtensionsSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  ConfigExtensions({required CodeConfig? codeAssets}) : super() {
+  ConfigExtensionsSyntax({required CodeConfigSyntax? codeAssets}) : super() {
     this.codeAssets = codeAssets;
     json.sortOnKey();
   }
 
-  CodeConfig? get codeAssets {
+  CodeConfigSyntax? get codeAssets {
     final jsonValue = _reader.optionalMap('code_assets');
     if (jsonValue == null) return null;
-    return CodeConfig.fromJson(jsonValue, path: [...path, 'code_assets']);
+    return CodeConfigSyntax.fromJson(jsonValue, path: [...path, 'code_assets']);
   }
 
-  set codeAssets(CodeConfig? value) {
+  set codeAssets(CodeConfigSyntax? value) {
     json.setOrRemove('code_assets', value?.json);
     json.sortOnKey();
   }
@@ -426,15 +436,17 @@ class ConfigExtensions extends JsonObject {
   List<String> validate() => [...super.validate(), ..._validateCodeAssets()];
 
   @override
-  String toString() => 'ConfigExtensions($json)';
+  String toString() => 'ConfigExtensionsSyntax($json)';
 }
 
-class DeveloperCommandPrompt extends JsonObject {
-  DeveloperCommandPrompt.fromJson(super.json, {super.path = const []})
+class DeveloperCommandPromptSyntax extends JsonObjectSyntax {
+  DeveloperCommandPromptSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  DeveloperCommandPrompt({required List<String> arguments, required Uri script})
-    : super() {
+  DeveloperCommandPromptSyntax({
+    required List<String> arguments,
+    required Uri script,
+  }) : super() {
     _arguments = arguments;
     _script = script;
     json.sortOnKey();
@@ -464,83 +476,85 @@ class DeveloperCommandPrompt extends JsonObject {
   ];
 
   @override
-  String toString() => 'DeveloperCommandPrompt($json)';
+  String toString() => 'DeveloperCommandPromptSyntax($json)';
 }
 
-class DynamicLoadingBundleLinkMode extends LinkMode {
-  DynamicLoadingBundleLinkMode.fromJson(super.json, {super.path})
+class DynamicLoadingBundleLinkModeSyntax extends LinkModeSyntax {
+  DynamicLoadingBundleLinkModeSyntax.fromJson(super.json, {super.path})
     : super._fromJson();
 
-  DynamicLoadingBundleLinkMode() : super(type: 'dynamic_loading_bundle');
+  DynamicLoadingBundleLinkModeSyntax() : super(type: 'dynamic_loading_bundle');
 
   @override
   List<String> validate() => [...super.validate()];
 
   @override
-  String toString() => 'DynamicLoadingBundleLinkMode($json)';
+  String toString() => 'DynamicLoadingBundleLinkModeSyntax($json)';
 }
 
-extension DynamicLoadingBundleLinkModeExtension on LinkMode {
+extension DynamicLoadingBundleLinkModeSyntaxExtension on LinkModeSyntax {
   bool get isDynamicLoadingBundleLinkMode => type == 'dynamic_loading_bundle';
 
-  DynamicLoadingBundleLinkMode get asDynamicLoadingBundleLinkMode =>
-      DynamicLoadingBundleLinkMode.fromJson(json, path: path);
+  DynamicLoadingBundleLinkModeSyntax get asDynamicLoadingBundleLinkMode =>
+      DynamicLoadingBundleLinkModeSyntax.fromJson(json, path: path);
 }
 
-class DynamicLoadingExecutableLinkMode extends LinkMode {
-  DynamicLoadingExecutableLinkMode.fromJson(super.json, {super.path})
+class DynamicLoadingExecutableLinkModeSyntax extends LinkModeSyntax {
+  DynamicLoadingExecutableLinkModeSyntax.fromJson(super.json, {super.path})
     : super._fromJson();
 
-  DynamicLoadingExecutableLinkMode()
+  DynamicLoadingExecutableLinkModeSyntax()
     : super(type: 'dynamic_loading_executable');
 
   @override
   List<String> validate() => [...super.validate()];
 
   @override
-  String toString() => 'DynamicLoadingExecutableLinkMode($json)';
+  String toString() => 'DynamicLoadingExecutableLinkModeSyntax($json)';
 }
 
-extension DynamicLoadingExecutableLinkModeExtension on LinkMode {
+extension DynamicLoadingExecutableLinkModeSyntaxExtension on LinkModeSyntax {
   bool get isDynamicLoadingExecutableLinkMode =>
       type == 'dynamic_loading_executable';
 
-  DynamicLoadingExecutableLinkMode get asDynamicLoadingExecutableLinkMode =>
-      DynamicLoadingExecutableLinkMode.fromJson(json, path: path);
+  DynamicLoadingExecutableLinkModeSyntax
+  get asDynamicLoadingExecutableLinkMode =>
+      DynamicLoadingExecutableLinkModeSyntax.fromJson(json, path: path);
 }
 
-class DynamicLoadingProcessLinkMode extends LinkMode {
-  DynamicLoadingProcessLinkMode.fromJson(super.json, {super.path})
+class DynamicLoadingProcessLinkModeSyntax extends LinkModeSyntax {
+  DynamicLoadingProcessLinkModeSyntax.fromJson(super.json, {super.path})
     : super._fromJson();
 
-  DynamicLoadingProcessLinkMode() : super(type: 'dynamic_loading_process');
+  DynamicLoadingProcessLinkModeSyntax()
+    : super(type: 'dynamic_loading_process');
 
   @override
   List<String> validate() => [...super.validate()];
 
   @override
-  String toString() => 'DynamicLoadingProcessLinkMode($json)';
+  String toString() => 'DynamicLoadingProcessLinkModeSyntax($json)';
 }
 
-extension DynamicLoadingProcessLinkModeExtension on LinkMode {
+extension DynamicLoadingProcessLinkModeSyntaxExtension on LinkModeSyntax {
   bool get isDynamicLoadingProcessLinkMode => type == 'dynamic_loading_process';
 
-  DynamicLoadingProcessLinkMode get asDynamicLoadingProcessLinkMode =>
-      DynamicLoadingProcessLinkMode.fromJson(json, path: path);
+  DynamicLoadingProcessLinkModeSyntax get asDynamicLoadingProcessLinkMode =>
+      DynamicLoadingProcessLinkModeSyntax.fromJson(json, path: path);
 }
 
-class DynamicLoadingSystemLinkMode extends LinkMode {
-  DynamicLoadingSystemLinkMode.fromJson(super.json, {super.path})
+class DynamicLoadingSystemLinkModeSyntax extends LinkModeSyntax {
+  DynamicLoadingSystemLinkModeSyntax.fromJson(super.json, {super.path})
     : super._fromJson();
 
-  DynamicLoadingSystemLinkMode({required Uri uri})
+  DynamicLoadingSystemLinkModeSyntax({required Uri uri})
     : super(type: 'dynamic_loading_system') {
     _uri = uri;
     json.sortOnKey();
   }
 
-  /// Setup all fields for [DynamicLoadingSystemLinkMode] that are not in
-  /// [LinkMode].
+  /// Setup all fields for [DynamicLoadingSystemLinkModeSyntax] that are not in
+  /// [LinkModeSyntax].
   void setup({required Uri uri}) {
     _uri = uri;
     json.sortOnKey();
@@ -558,21 +572,21 @@ class DynamicLoadingSystemLinkMode extends LinkMode {
   List<String> validate() => [...super.validate(), ..._validateUri()];
 
   @override
-  String toString() => 'DynamicLoadingSystemLinkMode($json)';
+  String toString() => 'DynamicLoadingSystemLinkModeSyntax($json)';
 }
 
-extension DynamicLoadingSystemLinkModeExtension on LinkMode {
+extension DynamicLoadingSystemLinkModeSyntaxExtension on LinkModeSyntax {
   bool get isDynamicLoadingSystemLinkMode => type == 'dynamic_loading_system';
 
-  DynamicLoadingSystemLinkMode get asDynamicLoadingSystemLinkMode =>
-      DynamicLoadingSystemLinkMode.fromJson(json, path: path);
+  DynamicLoadingSystemLinkModeSyntax get asDynamicLoadingSystemLinkMode =>
+      DynamicLoadingSystemLinkModeSyntax.fromJson(json, path: path);
 }
 
-class IOSCodeConfig extends JsonObject {
-  IOSCodeConfig.fromJson(super.json, {super.path = const []})
+class IOSCodeConfigSyntax extends JsonObjectSyntax {
+  IOSCodeConfigSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  IOSCodeConfig({required String targetSdk, required int targetVersion})
+  IOSCodeConfigSyntax({required String targetSdk, required int targetVersion})
     : super() {
     _targetSdk = targetSdk;
     _targetVersion = targetVersion;
@@ -604,15 +618,15 @@ class IOSCodeConfig extends JsonObject {
   ];
 
   @override
-  String toString() => 'IOSCodeConfig($json)';
+  String toString() => 'IOSCodeConfigSyntax($json)';
 }
 
-class LinkMode extends JsonObject {
-  factory LinkMode.fromJson(
+class LinkModeSyntax extends JsonObjectSyntax {
+  factory LinkModeSyntax.fromJson(
     Map<String, Object?> json, {
     List<Object> path = const [],
   }) {
-    final result = LinkMode._fromJson(json, path: path);
+    final result = LinkModeSyntax._fromJson(json, path: path);
     if (result.isDynamicLoadingBundleLinkMode) {
       return result.asDynamicLoadingBundleLinkMode;
     }
@@ -631,9 +645,10 @@ class LinkMode extends JsonObject {
     return result;
   }
 
-  LinkMode._fromJson(super.json, {super.path = const []}) : super.fromJson();
+  LinkModeSyntax._fromJson(super.json, {super.path = const []})
+    : super.fromJson();
 
-  LinkMode({required String type}) : super() {
+  LinkModeSyntax({required String type}) : super() {
     _type = type;
     json.sortOnKey();
   }
@@ -650,41 +665,42 @@ class LinkMode extends JsonObject {
   List<String> validate() => [...super.validate(), ..._validateType()];
 
   @override
-  String toString() => 'LinkMode($json)';
+  String toString() => 'LinkModeSyntax($json)';
 }
 
-class LinkModePreference {
+class LinkModePreferenceSyntax {
   final String name;
 
-  const LinkModePreference._(this.name);
+  const LinkModePreferenceSyntax._(this.name);
 
-  static const dynamic = LinkModePreference._('dynamic');
+  static const dynamic = LinkModePreferenceSyntax._('dynamic');
 
-  static const preferDynamic = LinkModePreference._('prefer_dynamic');
+  static const preferDynamic = LinkModePreferenceSyntax._('prefer_dynamic');
 
-  static const preferStatic = LinkModePreference._('prefer_static');
+  static const preferStatic = LinkModePreferenceSyntax._('prefer_static');
 
-  static const static = LinkModePreference._('static');
+  static const static = LinkModePreferenceSyntax._('static');
 
-  static const List<LinkModePreference> values = [
+  static const List<LinkModePreferenceSyntax> values = [
     dynamic,
     preferDynamic,
     preferStatic,
     static,
   ];
 
-  static final Map<String, LinkModePreference> _byName = {
+  static final Map<String, LinkModePreferenceSyntax> _byName = {
     for (final value in values) value.name: value,
   };
 
-  LinkModePreference.unknown(this.name) : assert(!_byName.keys.contains(name));
+  LinkModePreferenceSyntax.unknown(this.name)
+    : assert(!_byName.keys.contains(name));
 
-  factory LinkModePreference.fromJson(String name) {
+  factory LinkModePreferenceSyntax.fromJson(String name) {
     final knownValue = _byName[name];
     if (knownValue != null) {
       return knownValue;
     }
-    return LinkModePreference.unknown(name);
+    return LinkModePreferenceSyntax.unknown(name);
   }
 
   bool get isKnown => _byName[name] != null;
@@ -693,11 +709,11 @@ class LinkModePreference {
   String toString() => name;
 }
 
-class MacOSCodeConfig extends JsonObject {
-  MacOSCodeConfig.fromJson(super.json, {super.path = const []})
+class MacOSCodeConfigSyntax extends JsonObjectSyntax {
+  MacOSCodeConfigSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  MacOSCodeConfig({required int targetVersion}) : super() {
+  MacOSCodeConfigSyntax({required int targetVersion}) : super() {
     _targetVersion = targetVersion;
     json.sortOnKey();
   }
@@ -715,17 +731,17 @@ class MacOSCodeConfig extends JsonObject {
   List<String> validate() => [...super.validate(), ..._validateTargetVersion()];
 
   @override
-  String toString() => 'MacOSCodeConfig($json)';
+  String toString() => 'MacOSCodeConfigSyntax($json)';
 }
 
-class NativeCodeAssetEncoding extends JsonObject {
-  NativeCodeAssetEncoding.fromJson(super.json, {super.path = const []})
+class NativeCodeAssetEncodingSyntax extends JsonObjectSyntax {
+  NativeCodeAssetEncodingSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  NativeCodeAssetEncoding({
+  NativeCodeAssetEncodingSyntax({
     required Uri? file,
     required String id,
-    required LinkMode linkMode,
+    required LinkModeSyntax linkMode,
   }) : super() {
     _file = file;
     _id = id;
@@ -749,12 +765,12 @@ class NativeCodeAssetEncoding extends JsonObject {
 
   List<String> _validateId() => _reader.validate<String>('id');
 
-  LinkMode get linkMode {
+  LinkModeSyntax get linkMode {
     final jsonValue = _reader.map$('link_mode');
-    return LinkMode.fromJson(jsonValue, path: [...path, 'link_mode']);
+    return LinkModeSyntax.fromJson(jsonValue, path: [...path, 'link_mode']);
   }
 
-  set _linkMode(LinkMode value) {
+  set _linkMode(LinkModeSyntax value) {
     json['link_mode'] = value.json;
   }
 
@@ -787,37 +803,38 @@ class NativeCodeAssetEncoding extends JsonObject {
   }
 
   @override
-  String toString() => 'NativeCodeAssetEncoding($json)';
+  String toString() => 'NativeCodeAssetEncodingSyntax($json)';
 }
 
-class NativeCodeAssetNew extends Asset {
+class NativeCodeAssetNewSyntax extends AssetSyntax {
   static const typeValue = 'code_assets/code';
 
-  NativeCodeAssetNew.fromJson(super.json, {super.path}) : super._fromJson();
+  NativeCodeAssetNewSyntax.fromJson(super.json, {super.path})
+    : super._fromJson();
 
-  NativeCodeAssetNew({required NativeCodeAssetEncoding? encoding})
+  NativeCodeAssetNewSyntax({required NativeCodeAssetEncodingSyntax? encoding})
     : super(type: 'code_assets/code') {
     _encoding = encoding;
     json.sortOnKey();
   }
 
-  /// Setup all fields for [NativeCodeAssetNew] that are not in
-  /// [Asset].
-  void setup({required NativeCodeAssetEncoding? encoding}) {
+  /// Setup all fields for [NativeCodeAssetNewSyntax] that are not in
+  /// [AssetSyntax].
+  void setup({required NativeCodeAssetEncodingSyntax? encoding}) {
     _encoding = encoding;
     json.sortOnKey();
   }
 
-  NativeCodeAssetEncoding? get encoding {
+  NativeCodeAssetEncodingSyntax? get encoding {
     final jsonValue = _reader.optionalMap('encoding');
     if (jsonValue == null) return null;
-    return NativeCodeAssetEncoding.fromJson(
+    return NativeCodeAssetEncodingSyntax.fromJson(
       jsonValue,
       path: [...path, 'encoding'],
     );
   }
 
-  set _encoding(NativeCodeAssetEncoding? value) {
+  set _encoding(NativeCodeAssetEncodingSyntax? value) {
     json.setOrRemove('encoding', value?.json);
   }
 
@@ -833,45 +850,45 @@ class NativeCodeAssetNew extends Asset {
   List<String> validate() => [...super.validate(), ..._validateEncoding()];
 
   @override
-  String toString() => 'NativeCodeAssetNew($json)';
+  String toString() => 'NativeCodeAssetNewSyntax($json)';
 }
 
-extension NativeCodeAssetNewExtension on Asset {
+extension NativeCodeAssetNewSyntaxExtension on AssetSyntax {
   bool get isNativeCodeAssetNew => type == 'code_assets/code';
 
-  NativeCodeAssetNew get asNativeCodeAssetNew =>
-      NativeCodeAssetNew.fromJson(json, path: path);
+  NativeCodeAssetNewSyntax get asNativeCodeAssetNew =>
+      NativeCodeAssetNewSyntax.fromJson(json, path: path);
 }
 
-class OS {
+class OSSyntax {
   final String name;
 
-  const OS._(this.name);
+  const OSSyntax._(this.name);
 
-  static const android = OS._('android');
+  static const android = OSSyntax._('android');
 
-  static const iOS = OS._('ios');
+  static const iOS = OSSyntax._('ios');
 
-  static const linux = OS._('linux');
+  static const linux = OSSyntax._('linux');
 
-  static const macOS = OS._('macos');
+  static const macOS = OSSyntax._('macos');
 
-  static const windows = OS._('windows');
+  static const windows = OSSyntax._('windows');
 
-  static const List<OS> values = [android, iOS, linux, macOS, windows];
+  static const List<OSSyntax> values = [android, iOS, linux, macOS, windows];
 
-  static final Map<String, OS> _byName = {
+  static final Map<String, OSSyntax> _byName = {
     for (final value in values) value.name: value,
   };
 
-  OS.unknown(this.name) : assert(!_byName.keys.contains(name));
+  OSSyntax.unknown(this.name) : assert(!_byName.keys.contains(name));
 
-  factory OS.fromJson(String name) {
+  factory OSSyntax.fromJson(String name) {
     final knownValue = _byName[name];
     if (knownValue != null) {
       return knownValue;
     }
-    return OS.unknown(name);
+    return OSSyntax.unknown(name);
   }
 
   bool get isKnown => _byName[name] != null;
@@ -880,43 +897,45 @@ class OS {
   String toString() => name;
 }
 
-class StaticLinkMode extends LinkMode {
-  StaticLinkMode.fromJson(super.json, {super.path}) : super._fromJson();
+class StaticLinkModeSyntax extends LinkModeSyntax {
+  StaticLinkModeSyntax.fromJson(super.json, {super.path}) : super._fromJson();
 
-  StaticLinkMode() : super(type: 'static');
+  StaticLinkModeSyntax() : super(type: 'static');
 
   @override
   List<String> validate() => [...super.validate()];
 
   @override
-  String toString() => 'StaticLinkMode($json)';
+  String toString() => 'StaticLinkModeSyntax($json)';
 }
 
-extension StaticLinkModeExtension on LinkMode {
+extension StaticLinkModeSyntaxExtension on LinkModeSyntax {
   bool get isStaticLinkMode => type == 'static';
 
-  StaticLinkMode get asStaticLinkMode =>
-      StaticLinkMode.fromJson(json, path: path);
+  StaticLinkModeSyntax get asStaticLinkMode =>
+      StaticLinkModeSyntax.fromJson(json, path: path);
 }
 
-class Windows extends JsonObject {
-  Windows.fromJson(super.json, {super.path = const []}) : super.fromJson();
+class WindowsSyntax extends JsonObjectSyntax {
+  WindowsSyntax.fromJson(super.json, {super.path = const []})
+    : super.fromJson();
 
-  Windows({required DeveloperCommandPrompt? developerCommandPrompt}) : super() {
+  WindowsSyntax({required DeveloperCommandPromptSyntax? developerCommandPrompt})
+    : super() {
     _developerCommandPrompt = developerCommandPrompt;
     json.sortOnKey();
   }
 
-  DeveloperCommandPrompt? get developerCommandPrompt {
+  DeveloperCommandPromptSyntax? get developerCommandPrompt {
     final jsonValue = _reader.optionalMap('developer_command_prompt');
     if (jsonValue == null) return null;
-    return DeveloperCommandPrompt.fromJson(
+    return DeveloperCommandPromptSyntax.fromJson(
       jsonValue,
       path: [...path, 'developer_command_prompt'],
     );
   }
 
-  set _developerCommandPrompt(DeveloperCommandPrompt? value) {
+  set _developerCommandPrompt(DeveloperCommandPromptSyntax? value) {
     json.setOrRemove('developer_command_prompt', value?.json);
   }
 
@@ -937,19 +956,19 @@ class Windows extends JsonObject {
   ];
 
   @override
-  String toString() => 'Windows($json)';
+  String toString() => 'WindowsSyntax($json)';
 }
 
-class JsonObject {
+class JsonObjectSyntax {
   final Map<String, Object?> json;
 
   final List<Object> path;
 
   JsonReader get _reader => JsonReader(json, path);
 
-  JsonObject() : json = {}, path = const [];
+  JsonObjectSyntax() : json = {}, path = const [];
 
-  JsonObject.fromJson(this.json, {this.path = const []});
+  JsonObjectSyntax.fromJson(this.json, {this.path = const []});
 
   List<String> validate() => [];
 }

--- a/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/validation.dart
@@ -12,7 +12,7 @@ import 'config.dart';
 import 'link_mode.dart';
 import 'link_mode_preference.dart';
 import 'os.dart';
-import 'syntax.g.dart' as syntax;
+import 'syntax.g.dart';
 
 Future<ValidationErrors> validateCodeAssetBuildInput(BuildInput input) async =>
     [
@@ -56,7 +56,7 @@ ValidationErrors _validateConfig(String inputName, HookConfig config) {
 }
 
 ValidationErrors _validateConfigSyntax(HookConfig config) {
-  final syntaxNode = syntax.Config.fromJson(config.json, path: config.path);
+  final syntaxNode = ConfigSyntax.fromJson(config.json, path: config.path);
   final syntaxErrors = syntaxNode.validate();
   if (syntaxErrors.isEmpty) {
     return [];
@@ -189,7 +189,7 @@ ValidationErrors _validateCodeAssetSyntax(EncodedAsset encodedAsset) {
   if (!encodedAsset.isCodeAsset) {
     return [];
   }
-  final syntaxNode = syntax.NativeCodeAssetEncoding.fromJson(
+  final syntaxNode = NativeCodeAssetEncodingSyntax.fromJson(
     encodedAsset.encoding,
     path: encodedAsset.jsonPath ?? [],
   );

--- a/pkgs/native_assets_cli/lib/src/data_assets/data_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/data_asset.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../encoded_asset.dart';
-import 'syntax.g.dart' as syntax;
+import 'syntax.g.dart';
 
 /// Data bundled with a Dart or Flutter application.
 ///
@@ -43,7 +43,7 @@ final class DataAsset {
   /// Constructs a [DataAsset] from an [EncodedAsset].
   factory DataAsset.fromEncoded(EncodedAsset asset) {
     assert(asset.isDataAsset);
-    final syntaxNode = syntax.DataAssetEncoding.fromJson(
+    final syntaxNode = DataAssetEncodingSyntax.fromJson(
       asset.encoding,
       path: asset.jsonPath ?? [],
     );
@@ -68,7 +68,7 @@ final class DataAsset {
   int get hashCode => Object.hash(package, name, file.toFilePath());
 
   EncodedAsset encode() {
-    final encoding = syntax.DataAssetEncoding(
+    final encoding = DataAssetEncodingSyntax(
       file: file,
       name: name,
       package: package,
@@ -81,7 +81,7 @@ final class DataAsset {
 }
 
 extension DataAssetType on DataAsset {
-  static const String type = syntax.DataAssetNew.typeValue;
+  static const String type = DataAssetNewSyntax.typeValue;
 }
 
 extension EncodedDataAsset on EncodedAsset {

--- a/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/syntax.g.dart
@@ -10,21 +10,21 @@
 
 import 'dart:io';
 
-class Asset extends JsonObject {
-  factory Asset.fromJson(
+class AssetSyntax extends JsonObjectSyntax {
+  factory AssetSyntax.fromJson(
     Map<String, Object?> json, {
     List<Object> path = const [],
   }) {
-    final result = Asset._fromJson(json, path: path);
+    final result = AssetSyntax._fromJson(json, path: path);
     if (result.isDataAssetNew) {
       return result.asDataAssetNew;
     }
     return result;
   }
 
-  Asset._fromJson(super.json, {super.path = const []}) : super.fromJson();
+  AssetSyntax._fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  Asset({required String? type}) : super() {
+  AssetSyntax({required String? type}) : super() {
     _type = type;
     json.sortOnKey();
   }
@@ -41,14 +41,14 @@ class Asset extends JsonObject {
   List<String> validate() => [...super.validate(), ..._validateType()];
 
   @override
-  String toString() => 'Asset($json)';
+  String toString() => 'AssetSyntax($json)';
 }
 
-class DataAssetEncoding extends JsonObject {
-  DataAssetEncoding.fromJson(super.json, {super.path = const []})
+class DataAssetEncodingSyntax extends JsonObjectSyntax {
+  DataAssetEncodingSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  DataAssetEncoding({
+  DataAssetEncodingSyntax({
     required Uri file,
     required String name,
     required String package,
@@ -92,34 +92,37 @@ class DataAssetEncoding extends JsonObject {
   ];
 
   @override
-  String toString() => 'DataAssetEncoding($json)';
+  String toString() => 'DataAssetEncodingSyntax($json)';
 }
 
-class DataAssetNew extends Asset {
+class DataAssetNewSyntax extends AssetSyntax {
   static const typeValue = 'data_assets/data';
 
-  DataAssetNew.fromJson(super.json, {super.path}) : super._fromJson();
+  DataAssetNewSyntax.fromJson(super.json, {super.path}) : super._fromJson();
 
-  DataAssetNew({required DataAssetEncoding? encoding})
+  DataAssetNewSyntax({required DataAssetEncodingSyntax? encoding})
     : super(type: 'data_assets/data') {
     _encoding = encoding;
     json.sortOnKey();
   }
 
-  /// Setup all fields for [DataAssetNew] that are not in
-  /// [Asset].
-  void setup({required DataAssetEncoding? encoding}) {
+  /// Setup all fields for [DataAssetNewSyntax] that are not in
+  /// [AssetSyntax].
+  void setup({required DataAssetEncodingSyntax? encoding}) {
     _encoding = encoding;
     json.sortOnKey();
   }
 
-  DataAssetEncoding? get encoding {
+  DataAssetEncodingSyntax? get encoding {
     final jsonValue = _reader.optionalMap('encoding');
     if (jsonValue == null) return null;
-    return DataAssetEncoding.fromJson(jsonValue, path: [...path, 'encoding']);
+    return DataAssetEncodingSyntax.fromJson(
+      jsonValue,
+      path: [...path, 'encoding'],
+    );
   }
 
-  set _encoding(DataAssetEncoding? value) {
+  set _encoding(DataAssetEncodingSyntax? value) {
     json.setOrRemove('encoding', value?.json);
   }
 
@@ -135,25 +138,26 @@ class DataAssetNew extends Asset {
   List<String> validate() => [...super.validate(), ..._validateEncoding()];
 
   @override
-  String toString() => 'DataAssetNew($json)';
+  String toString() => 'DataAssetNewSyntax($json)';
 }
 
-extension DataAssetNewExtension on Asset {
+extension DataAssetNewSyntaxExtension on AssetSyntax {
   bool get isDataAssetNew => type == 'data_assets/data';
 
-  DataAssetNew get asDataAssetNew => DataAssetNew.fromJson(json, path: path);
+  DataAssetNewSyntax get asDataAssetNew =>
+      DataAssetNewSyntax.fromJson(json, path: path);
 }
 
-class JsonObject {
+class JsonObjectSyntax {
   final Map<String, Object?> json;
 
   final List<Object> path;
 
   JsonReader get _reader => JsonReader(json, path);
 
-  JsonObject() : json = {}, path = const [];
+  JsonObjectSyntax() : json = {}, path = const [];
 
-  JsonObject.fromJson(this.json, {this.path = const []});
+  JsonObjectSyntax.fromJson(this.json, {this.path = const []});
 
   List<String> validate() => [];
 }

--- a/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/validation.dart
@@ -8,7 +8,7 @@ import '../config.dart';
 import '../encoded_asset.dart';
 import '../extension.dart';
 import 'data_asset.dart';
-import 'syntax.g.dart' as syntax;
+import 'syntax.g.dart';
 
 Future<ValidationErrors> validateDataAssetBuildInput(BuildInput input) async =>
     [
@@ -106,7 +106,7 @@ ValidationErrors _validateDataAssetSyntax(EncodedAsset encodedAsset) {
   if (!encodedAsset.isDataAsset) {
     return [];
   }
-  final syntaxNode = syntax.DataAssetEncoding.fromJson(
+  final syntaxNode = DataAssetEncodingSyntax.fromJson(
     encodedAsset.encoding,
     path: encodedAsset.jsonPath ?? [],
   );

--- a/pkgs/native_assets_cli/lib/src/encoded_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/encoded_asset.dart
@@ -4,7 +4,7 @@
 
 import 'package:collection/collection.dart';
 
-import 'hooks/syntax.g.dart' as syntax;
+import 'hooks/syntax.g.dart';
 import 'utils/json.dart';
 
 /// An encoding of a particular asset type.
@@ -34,7 +34,7 @@ final class EncodedAsset {
     Map<String, Object?> json, [
     List<Object>? path,
   ]) {
-    final syntax_ = syntax.Asset.fromJson(json, path: path ?? []);
+    final syntax_ = AssetSyntax.fromJson(json, path: path ?? []);
     final encoding = Map<String, Object?>.of(syntax_.encoding?.json ?? {});
     final path_ = syntax_.encoding != null ? [...?path, 'encoding'] : path;
 

--- a/pkgs/native_assets_cli/lib/src/hooks/syntax.g.dart
+++ b/pkgs/native_assets_cli/lib/src/hooks/syntax.g.dart
@@ -10,33 +10,34 @@
 
 import 'dart:io';
 
-class Asset extends JsonObject {
-  factory Asset.fromJson(
+class AssetSyntax extends JsonObjectSyntax {
+  factory AssetSyntax.fromJson(
     Map<String, Object?> json, {
     List<Object> path = const [],
   }) {
-    final result = Asset._fromJson(json, path: path);
+    final result = AssetSyntax._fromJson(json, path: path);
     if (result.isHooksMetadataAsset) {
       return result.asHooksMetadataAsset;
     }
     return result;
   }
 
-  Asset._fromJson(super.json, {super.path = const []}) : super.fromJson();
+  AssetSyntax._fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  Asset({required JsonObject? encoding, required String type}) : super() {
+  AssetSyntax({required JsonObjectSyntax? encoding, required String type})
+    : super() {
     _encoding = encoding;
     _type = type;
     json.sortOnKey();
   }
 
-  JsonObject? get encoding {
+  JsonObjectSyntax? get encoding {
     final jsonValue = _reader.optionalMap('encoding');
     if (jsonValue == null) return null;
-    return JsonObject.fromJson(jsonValue, path: [...path, 'encoding']);
+    return JsonObjectSyntax.fromJson(jsonValue, path: [...path, 'encoding']);
   }
 
-  set _encoding(JsonObject? value) {
+  set _encoding(JsonObjectSyntax? value) {
     json.setOrRemove('encoding', value?.json);
   }
 
@@ -81,13 +82,13 @@ class Asset extends JsonObject {
   }
 
   @override
-  String toString() => 'Asset($json)';
+  String toString() => 'AssetSyntax($json)';
 }
 
-class BuildConfig extends Config {
-  BuildConfig.fromJson(super.json, {super.path}) : super.fromJson();
+class BuildConfigSyntax extends ConfigSyntax {
+  BuildConfigSyntax.fromJson(super.json, {super.path}) : super.fromJson();
 
-  BuildConfig({
+  BuildConfigSyntax({
     required super.buildAssetTypes,
     required super.extensions,
     required bool linkingEnabled,
@@ -96,8 +97,8 @@ class BuildConfig extends Config {
     json.sortOnKey();
   }
 
-  /// Setup all fields for [BuildConfig] that are not in
-  /// [Config].
+  /// Setup all fields for [BuildConfigSyntax] that are not in
+  /// [ConfigSyntax].
   void setup({required bool linkingEnabled}) {
     _linkingEnabled = linkingEnabled;
     json.sortOnKey();
@@ -119,15 +120,15 @@ class BuildConfig extends Config {
   ];
 
   @override
-  String toString() => 'BuildConfig($json)';
+  String toString() => 'BuildConfigSyntax($json)';
 }
 
-class BuildInput extends HookInput {
-  BuildInput.fromJson(super.json, {super.path}) : super.fromJson();
+class BuildInputSyntax extends HookInputSyntax {
+  BuildInputSyntax.fromJson(super.json, {super.path}) : super.fromJson();
 
-  BuildInput({
-    required Map<String, List<Asset>>? assets,
-    required BuildConfig config,
+  BuildInputSyntax({
+    required Map<String, List<AssetSyntax>>? assets,
+    required BuildConfigSyntax config,
     required super.outDirShared,
     required super.outFile,
     required super.packageName,
@@ -138,23 +139,23 @@ class BuildInput extends HookInput {
     json.sortOnKey();
   }
 
-  /// Setup all fields for [BuildInput] that are not in
-  /// [HookInput].
-  void setup({required Map<String, List<Asset>>? assets}) {
+  /// Setup all fields for [BuildInputSyntax] that are not in
+  /// [HookInputSyntax].
+  void setup({required Map<String, List<AssetSyntax>>? assets}) {
     _assets = assets;
     json.sortOnKey();
   }
 
-  Map<String, List<Asset>>? get assets {
+  Map<String, List<AssetSyntax>>? get assets {
     final jsonValue = _reader.optionalMap('assets');
     if (jsonValue == null) {
       return null;
     }
-    final result = <String, List<Asset>>{};
+    final result = <String, List<AssetSyntax>>{};
     for (final MapEntry(:key, :value) in jsonValue.entries) {
       result[key] = [
         for (final (index, item) in (value as List<Object?>).indexed)
-          Asset.fromJson(
+          AssetSyntax.fromJson(
             item as Map<String, Object?>,
             path: [...path, key, index],
           ),
@@ -163,7 +164,7 @@ class BuildInput extends HookInput {
     return result;
   }
 
-  set _assets(Map<String, List<Asset>>? value) {
+  set _assets(Map<String, List<AssetSyntax>>? value) {
     if (value == null) {
       json.remove('assets');
     } else {
@@ -193,9 +194,9 @@ class BuildInput extends HookInput {
   }
 
   @override
-  BuildConfig get config {
+  BuildConfigSyntax get config {
     final jsonValue = _reader.map$('config');
-    return BuildConfig.fromJson(jsonValue, path: [...path, 'config']);
+    return BuildConfigSyntax.fromJson(jsonValue, path: [...path, 'config']);
   }
 
   @override
@@ -206,16 +207,16 @@ class BuildInput extends HookInput {
   ];
 
   @override
-  String toString() => 'BuildInput($json)';
+  String toString() => 'BuildInputSyntax($json)';
 }
 
-class BuildOutput extends HookOutput {
-  BuildOutput.fromJson(super.json, {super.path}) : super.fromJson();
+class BuildOutputSyntax extends HookOutputSyntax {
+  BuildOutputSyntax.fromJson(super.json, {super.path}) : super.fromJson();
 
-  BuildOutput({
+  BuildOutputSyntax({
     required super.assets,
-    required List<Asset>? assetsForBuild,
-    required Map<String, List<Asset>>? assetsForLinking,
+    required List<AssetSyntax>? assetsForBuild,
+    required Map<String, List<AssetSyntax>>? assetsForLinking,
     required super.dependencies,
     required super.timestamp,
   }) : super() {
@@ -224,30 +225,30 @@ class BuildOutput extends HookOutput {
     json.sortOnKey();
   }
 
-  /// Setup all fields for [BuildOutput] that are not in
-  /// [HookOutput].
+  /// Setup all fields for [BuildOutputSyntax] that are not in
+  /// [HookOutputSyntax].
   void setup({
-    required List<Asset>? assetsForBuild,
-    required Map<String, List<Asset>>? assetsForLinking,
+    required List<AssetSyntax>? assetsForBuild,
+    required Map<String, List<AssetSyntax>>? assetsForLinking,
   }) {
     this.assetsForBuild = assetsForBuild;
     this.assetsForLinking = assetsForLinking;
     json.sortOnKey();
   }
 
-  List<Asset>? get assetsForBuild {
+  List<AssetSyntax>? get assetsForBuild {
     final jsonValue = _reader.optionalList('assets_for_build');
     if (jsonValue == null) return null;
     return [
       for (final (index, element) in jsonValue.indexed)
-        Asset.fromJson(
+        AssetSyntax.fromJson(
           element as Map<String, Object?>,
           path: [...path, 'assets_for_build', index],
         ),
     ];
   }
 
-  set assetsForBuild(List<Asset>? value) {
+  set assetsForBuild(List<AssetSyntax>? value) {
     if (value == null) {
       json.remove('assets_for_build');
     } else {
@@ -270,16 +271,16 @@ class BuildOutput extends HookOutput {
     return [for (final element in elements) ...element.validate()];
   }
 
-  Map<String, List<Asset>>? get assetsForLinking {
+  Map<String, List<AssetSyntax>>? get assetsForLinking {
     final jsonValue = _reader.optionalMap('assets_for_linking');
     if (jsonValue == null) {
       return null;
     }
-    final result = <String, List<Asset>>{};
+    final result = <String, List<AssetSyntax>>{};
     for (final MapEntry(:key, :value) in jsonValue.entries) {
       result[key] = [
         for (final (index, item) in (value as List<Object?>).indexed)
-          Asset.fromJson(
+          AssetSyntax.fromJson(
             item as Map<String, Object?>,
             path: [...path, key, index],
           ),
@@ -288,7 +289,7 @@ class BuildOutput extends HookOutput {
     return result;
   }
 
-  set assetsForLinking(Map<String, List<Asset>>? value) {
+  set assetsForLinking(Map<String, List<AssetSyntax>>? value) {
     if (value == null) {
       json.remove('assets_for_linking');
     } else {
@@ -326,15 +327,15 @@ class BuildOutput extends HookOutput {
   ];
 
   @override
-  String toString() => 'BuildOutput($json)';
+  String toString() => 'BuildOutputSyntax($json)';
 }
 
-class Config extends JsonObject {
-  Config.fromJson(super.json, {super.path = const []}) : super.fromJson();
+class ConfigSyntax extends JsonObjectSyntax {
+  ConfigSyntax.fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  Config({
+  ConfigSyntax({
     required List<String> buildAssetTypes,
-    required JsonObject? extensions,
+    required JsonObjectSyntax? extensions,
   }) : super() {
     this.buildAssetTypes = buildAssetTypes;
     this.extensions = extensions;
@@ -351,13 +352,13 @@ class Config extends JsonObject {
   List<String> _validateBuildAssetTypes() =>
       _reader.validateStringList('build_asset_types');
 
-  JsonObject? get extensions {
+  JsonObjectSyntax? get extensions {
     final jsonValue = _reader.optionalMap('extensions');
     if (jsonValue == null) return null;
-    return JsonObject.fromJson(jsonValue, path: [...path, 'extensions']);
+    return JsonObjectSyntax.fromJson(jsonValue, path: [...path, 'extensions']);
   }
 
-  set extensions(JsonObject? value) {
+  set extensions(JsonObjectSyntax? value) {
     json.setOrRemove('extensions', value?.json);
     json.sortOnKey();
   }
@@ -378,19 +379,20 @@ class Config extends JsonObject {
   ];
 
   @override
-  String toString() => 'Config($json)';
+  String toString() => 'ConfigSyntax($json)';
 }
 
-class HookInput extends JsonObject {
-  HookInput.fromJson(super.json, {super.path = const []}) : super.fromJson();
+class HookInputSyntax extends JsonObjectSyntax {
+  HookInputSyntax.fromJson(super.json, {super.path = const []})
+    : super.fromJson();
 
-  HookInput({
-    required Config config,
+  HookInputSyntax({
+    required ConfigSyntax config,
     required Uri outDirShared,
     required Uri outFile,
     required String packageName,
     required Uri packageRoot,
-    required UserDefines? userDefines,
+    required UserDefinesSyntax? userDefines,
   }) : super() {
     this.config = config;
     this.outDirShared = outDirShared;
@@ -401,12 +403,12 @@ class HookInput extends JsonObject {
     json.sortOnKey();
   }
 
-  Config get config {
+  ConfigSyntax get config {
     final jsonValue = _reader.map$('config');
-    return Config.fromJson(jsonValue, path: [...path, 'config']);
+    return ConfigSyntax.fromJson(jsonValue, path: [...path, 'config']);
   }
 
-  set config(Config value) {
+  set config(ConfigSyntax value) {
     json['config'] = value.json;
     json.sortOnKey();
   }
@@ -457,13 +459,16 @@ class HookInput extends JsonObject {
 
   List<String> _validatePackageRoot() => _reader.validatePath('package_root');
 
-  UserDefines? get userDefines {
+  UserDefinesSyntax? get userDefines {
     final jsonValue = _reader.optionalMap('user_defines');
     if (jsonValue == null) return null;
-    return UserDefines.fromJson(jsonValue, path: [...path, 'user_defines']);
+    return UserDefinesSyntax.fromJson(
+      jsonValue,
+      path: [...path, 'user_defines'],
+    );
   }
 
-  set userDefines(UserDefines? value) {
+  set userDefines(UserDefinesSyntax? value) {
     json.setOrRemove('user_defines', value?.json);
     json.sortOnKey();
   }
@@ -488,14 +493,15 @@ class HookInput extends JsonObject {
   ];
 
   @override
-  String toString() => 'HookInput($json)';
+  String toString() => 'HookInputSyntax($json)';
 }
 
-class HookOutput extends JsonObject {
-  HookOutput.fromJson(super.json, {super.path = const []}) : super.fromJson();
+class HookOutputSyntax extends JsonObjectSyntax {
+  HookOutputSyntax.fromJson(super.json, {super.path = const []})
+    : super.fromJson();
 
-  HookOutput({
-    required List<Asset>? assets,
+  HookOutputSyntax({
+    required List<AssetSyntax>? assets,
     required List<Uri>? dependencies,
     required String timestamp,
   }) : super() {
@@ -505,19 +511,19 @@ class HookOutput extends JsonObject {
     json.sortOnKey();
   }
 
-  List<Asset>? get assets {
+  List<AssetSyntax>? get assets {
     final jsonValue = _reader.optionalList('assets');
     if (jsonValue == null) return null;
     return [
       for (final (index, element) in jsonValue.indexed)
-        Asset.fromJson(
+        AssetSyntax.fromJson(
           element as Map<String, Object?>,
           path: [...path, 'assets', index],
         ),
     ];
   }
 
-  set assets(List<Asset>? value) {
+  set assets(List<AssetSyntax>? value) {
     if (value == null) {
       json.remove('assets');
     } else {
@@ -568,25 +574,26 @@ class HookOutput extends JsonObject {
   ];
 
   @override
-  String toString() => 'HookOutput($json)';
+  String toString() => 'HookOutputSyntax($json)';
 }
 
-class HooksMetadataAsset extends Asset {
+class HooksMetadataAssetSyntax extends AssetSyntax {
   static const typeValue = 'hooks/metadata';
 
-  HooksMetadataAsset.fromJson(super.json, {super.path}) : super._fromJson();
+  HooksMetadataAssetSyntax.fromJson(super.json, {super.path})
+    : super._fromJson();
 
-  HooksMetadataAsset({required MetadataAssetEncoding encoding})
+  HooksMetadataAssetSyntax({required MetadataAssetEncodingSyntax encoding})
     : super(type: 'hooks/metadata', encoding: encoding);
 
-  /// Setup all fields for [HooksMetadataAsset] that are not in
-  /// [Asset].
+  /// Setup all fields for [HooksMetadataAssetSyntax] that are not in
+  /// [AssetSyntax].
   void setup() {}
 
   @override
-  MetadataAssetEncoding get encoding {
+  MetadataAssetEncodingSyntax get encoding {
     final jsonValue = _reader.map$('encoding');
-    return MetadataAssetEncoding.fromJson(
+    return MetadataAssetEncodingSyntax.fromJson(
       jsonValue,
       path: [...path, 'encoding'],
     );
@@ -596,21 +603,21 @@ class HooksMetadataAsset extends Asset {
   List<String> validate() => [...super.validate(), ..._validateEncoding()];
 
   @override
-  String toString() => 'HooksMetadataAsset($json)';
+  String toString() => 'HooksMetadataAssetSyntax($json)';
 }
 
-extension HooksMetadataAssetExtension on Asset {
+extension HooksMetadataAssetSyntaxExtension on AssetSyntax {
   bool get isHooksMetadataAsset => type == 'hooks/metadata';
 
-  HooksMetadataAsset get asHooksMetadataAsset =>
-      HooksMetadataAsset.fromJson(json, path: path);
+  HooksMetadataAssetSyntax get asHooksMetadataAsset =>
+      HooksMetadataAssetSyntax.fromJson(json, path: path);
 }
 
-class LinkInput extends HookInput {
-  LinkInput.fromJson(super.json, {super.path}) : super.fromJson();
+class LinkInputSyntax extends HookInputSyntax {
+  LinkInputSyntax.fromJson(super.json, {super.path}) : super.fromJson();
 
-  LinkInput({
-    required List<Asset>? assets,
+  LinkInputSyntax({
+    required List<AssetSyntax>? assets,
     required super.config,
     required super.outDirShared,
     required super.outFile,
@@ -624,10 +631,10 @@ class LinkInput extends HookInput {
     json.sortOnKey();
   }
 
-  /// Setup all fields for [LinkInput] that are not in
-  /// [HookInput].
+  /// Setup all fields for [LinkInputSyntax] that are not in
+  /// [HookInputSyntax].
   void setup({
-    required List<Asset>? assets,
+    required List<AssetSyntax>? assets,
     required Uri? resourceIdentifiers,
   }) {
     _assets = assets;
@@ -635,19 +642,19 @@ class LinkInput extends HookInput {
     json.sortOnKey();
   }
 
-  List<Asset>? get assets {
+  List<AssetSyntax>? get assets {
     final jsonValue = _reader.optionalList('assets');
     if (jsonValue == null) return null;
     return [
       for (final (index, element) in jsonValue.indexed)
-        Asset.fromJson(
+        AssetSyntax.fromJson(
           element as Map<String, Object?>,
           path: [...path, 'assets', index],
         ),
     ];
   }
 
-  set _assets(List<Asset>? value) {
+  set _assets(List<AssetSyntax>? value) {
     if (value == null) {
       json.remove('assets');
     } else {
@@ -686,13 +693,13 @@ class LinkInput extends HookInput {
   ];
 
   @override
-  String toString() => 'LinkInput($json)';
+  String toString() => 'LinkInputSyntax($json)';
 }
 
-class LinkOutput extends HookOutput {
-  LinkOutput.fromJson(super.json, {super.path}) : super.fromJson();
+class LinkOutputSyntax extends HookOutputSyntax {
+  LinkOutputSyntax.fromJson(super.json, {super.path}) : super.fromJson();
 
-  LinkOutput({
+  LinkOutputSyntax({
     required super.assets,
     required super.dependencies,
     required super.timestamp,
@@ -702,14 +709,14 @@ class LinkOutput extends HookOutput {
   List<String> validate() => [...super.validate()];
 
   @override
-  String toString() => 'LinkOutput($json)';
+  String toString() => 'LinkOutputSyntax($json)';
 }
 
-class MetadataAssetEncoding extends JsonObject {
-  MetadataAssetEncoding.fromJson(super.json, {super.path = const []})
+class MetadataAssetEncodingSyntax extends JsonObjectSyntax {
+  MetadataAssetEncodingSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  MetadataAssetEncoding({required String key, required Object? value})
+  MetadataAssetEncodingSyntax({required String key, required Object? value})
     : super() {
     _key = key;
     _value = value;
@@ -740,27 +747,29 @@ class MetadataAssetEncoding extends JsonObject {
   ];
 
   @override
-  String toString() => 'MetadataAssetEncoding($json)';
+  String toString() => 'MetadataAssetEncodingSyntax($json)';
 }
 
-class UserDefines extends JsonObject {
-  UserDefines.fromJson(super.json, {super.path = const []}) : super.fromJson();
+class UserDefinesSyntax extends JsonObjectSyntax {
+  UserDefinesSyntax.fromJson(super.json, {super.path = const []})
+    : super.fromJson();
 
-  UserDefines({required UserDefinesSource? workspacePubspec}) : super() {
+  UserDefinesSyntax({required UserDefinesSourceSyntax? workspacePubspec})
+    : super() {
     _workspacePubspec = workspacePubspec;
     json.sortOnKey();
   }
 
-  UserDefinesSource? get workspacePubspec {
+  UserDefinesSourceSyntax? get workspacePubspec {
     final jsonValue = _reader.optionalMap('workspace_pubspec');
     if (jsonValue == null) return null;
-    return UserDefinesSource.fromJson(
+    return UserDefinesSourceSyntax.fromJson(
       jsonValue,
       path: [...path, 'workspace_pubspec'],
     );
   }
 
-  set _workspacePubspec(UserDefinesSource? value) {
+  set _workspacePubspec(UserDefinesSourceSyntax? value) {
     json.setOrRemove('workspace_pubspec', value?.json);
   }
 
@@ -781,15 +790,17 @@ class UserDefines extends JsonObject {
   ];
 
   @override
-  String toString() => 'UserDefines($json)';
+  String toString() => 'UserDefinesSyntax($json)';
 }
 
-class UserDefinesSource extends JsonObject {
-  UserDefinesSource.fromJson(super.json, {super.path = const []})
+class UserDefinesSourceSyntax extends JsonObjectSyntax {
+  UserDefinesSourceSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  UserDefinesSource({required Uri basePath, required JsonObject defines})
-    : super() {
+  UserDefinesSourceSyntax({
+    required Uri basePath,
+    required JsonObjectSyntax defines,
+  }) : super() {
     _basePath = basePath;
     _defines = defines;
     json.sortOnKey();
@@ -803,12 +814,12 @@ class UserDefinesSource extends JsonObject {
 
   List<String> _validateBasePath() => _reader.validatePath('base_path');
 
-  JsonObject get defines {
+  JsonObjectSyntax get defines {
     final jsonValue = _reader.map$('defines');
-    return JsonObject.fromJson(jsonValue, path: [...path, 'defines']);
+    return JsonObjectSyntax.fromJson(jsonValue, path: [...path, 'defines']);
   }
 
-  set _defines(JsonObject value) {
+  set _defines(JsonObjectSyntax value) {
     json['defines'] = value.json;
   }
 
@@ -828,19 +839,19 @@ class UserDefinesSource extends JsonObject {
   ];
 
   @override
-  String toString() => 'UserDefinesSource($json)';
+  String toString() => 'UserDefinesSourceSyntax($json)';
 }
 
-class JsonObject {
+class JsonObjectSyntax {
   final Map<String, Object?> json;
 
   final List<Object> path;
 
   JsonReader get _reader => JsonReader(json, path);
 
-  JsonObject() : json = {}, path = const [];
+  JsonObjectSyntax() : json = {}, path = const [];
 
-  JsonObject.fromJson(this.json, {this.path = const []});
+  JsonObjectSyntax.fromJson(this.json, {this.path = const []});
 
   List<String> validate() => [];
 }

--- a/pkgs/native_assets_cli/lib/src/metadata.dart
+++ b/pkgs/native_assets_cli/lib/src/metadata.dart
@@ -6,7 +6,7 @@ import 'package:collection/collection.dart';
 
 import 'config.dart';
 import 'encoded_asset.dart';
-import 'hooks/syntax.g.dart' as syntax;
+import 'hooks/syntax.g.dart';
 
 class Metadata {
   final UnmodifiableMapView<String, Object?> metadata;
@@ -50,7 +50,7 @@ final class MetadataAsset {
 
   factory MetadataAsset.fromEncoded(EncodedAsset asset) {
     assert(asset.type == _type);
-    final syntaxNode = syntax.MetadataAssetEncoding.fromJson(
+    final syntaxNode = MetadataAssetEncodingSyntax.fromJson(
       asset.encoding,
       path: asset.jsonPath ?? [],
     );

--- a/pkgs/native_assets_cli/lib/src/user_defines.dart
+++ b/pkgs/native_assets_cli/lib/src/user_defines.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'hooks/syntax.g.dart' as syntax;
+import 'hooks/syntax.g.dart';
 
 /// The user-defines for a single build hokok invocation
 ///
@@ -19,17 +19,17 @@ class PackageUserDefines {
       'PackageUserDefines(workspacePubspec: $workspacePubspec)';
 }
 
-extension PackageUserDefinesSyntax on PackageUserDefines {
-  static PackageUserDefines fromSyntax(syntax.UserDefines syntaxNode) =>
+extension PackageUserDefinesSyntaxExtension on PackageUserDefines {
+  static PackageUserDefines fromSyntax(UserDefinesSyntax syntaxNode) =>
       PackageUserDefines(
         workspacePubspec: switch (syntaxNode.workspacePubspec) {
           null => null,
-          final o => PackageUserDefinesSourceSyntax.fromSyntax(o),
+          final o => PackageUserDefinesSourceSyntaxExtension.fromSyntax(o),
         },
       );
 
-  syntax.UserDefines toSyntax() {
-    final result = syntax.UserDefines(
+  UserDefinesSyntax toSyntax() {
+    final result = UserDefinesSyntax(
       workspacePubspec: workspacePubspec?.toSyntax(),
     );
 
@@ -50,16 +50,16 @@ class PackageUserDefinesSource {
       'PackageUserDefinesSource(defines: $defines, basePath: $basePath)';
 }
 
-extension PackageUserDefinesSourceSyntax on PackageUserDefinesSource {
+extension PackageUserDefinesSourceSyntaxExtension on PackageUserDefinesSource {
   static PackageUserDefinesSource fromSyntax(
-    syntax.UserDefinesSource syntaxNode,
+    UserDefinesSourceSyntax syntaxNode,
   ) => PackageUserDefinesSource(
     defines: syntaxNode.defines.json,
     basePath: syntaxNode.basePath,
   );
 
-  syntax.UserDefinesSource toSyntax() => syntax.UserDefinesSource(
+  UserDefinesSourceSyntax toSyntax() => UserDefinesSourceSyntax(
     basePath: basePath,
-    defines: syntax.JsonObject.fromJson(defines),
+    defines: JsonObjectSyntax.fromJson(defines),
   );
 }

--- a/pkgs/native_assets_cli/lib/src/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/validation.dart
@@ -6,12 +6,12 @@ import 'dart:io';
 
 import 'config.dart';
 import 'encoded_asset.dart';
-import 'hooks/syntax.g.dart' as syntax;
+import 'hooks/syntax.g.dart';
 
 typedef ValidationErrors = List<String>;
 
 Future<ValidationErrors> validateBuildInput(BuildInput input) async {
-  final syntaxErrors = syntax.BuildInput.fromJson(input.json).validate();
+  final syntaxErrors = BuildInputSyntax.fromJson(input.json).validate();
   if (syntaxErrors.isNotEmpty) {
     return [...syntaxErrors, _semanticValidationSkippedMessage];
   }
@@ -20,7 +20,7 @@ Future<ValidationErrors> validateBuildInput(BuildInput input) async {
 }
 
 Future<ValidationErrors> validateLinkInput(LinkInput input) async {
-  final syntaxErrors = syntax.LinkInput.fromJson(input.json).validate();
+  final syntaxErrors = LinkInputSyntax.fromJson(input.json).validate();
   if (syntaxErrors.isNotEmpty) {
     return [...syntaxErrors, _semanticValidationSkippedMessage];
   }
@@ -74,7 +74,7 @@ Future<ValidationErrors> validateBuildOutput(
   BuildInput input,
   BuildOutput output,
 ) async {
-  final syntaxErrors = syntax.BuildOutput.fromJson(output.json).validate();
+  final syntaxErrors = BuildOutputSyntax.fromJson(output.json).validate();
   if (syntaxErrors.isNotEmpty) {
     return [...syntaxErrors, _semanticValidationSkippedMessage];
   }
@@ -96,7 +96,7 @@ Future<ValidationErrors> validateLinkOutput(
   LinkInput input,
   LinkOutput output,
 ) async {
-  final syntaxErrors = syntax.LinkOutput.fromJson(output.json).validate();
+  final syntaxErrors = LinkOutputSyntax.fromJson(output.json).validate();
   if (syntaxErrors.isNotEmpty) {
     return [...syntaxErrors, _semanticValidationSkippedMessage];
   }


### PR DESCRIPTION
Having classes with the same name makes autocomplete in the IDE annoying.

Instead of having `syntax.$name` with an import `as syntax`, use `${name}Syntax` as class name for the syntax classes.

Note, the extensions converting between semantic and syntax classes were called `${name}Syntax`. These have been renamed to `${name}SyntaxExtension`.