### PR TITLE
[ffigen] Fix #1268

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -1,6 +1,10 @@
-## 18.1.1-wip
+## 18.2.0-wip
 
+- Use package:objective_c 7.2.0.
 - Make it easier for a downstream clone to change behavior of certain utils.
+- Fix [a bug](https://github.com/dart-lang/native/issues/1268) where types could
+  occasionally show up as a generic ObjCObjectBase, when they were supposed to
+  be codegenned as a more specific interface types.
 
 ## 18.1.0
 
@@ -8,6 +12,7 @@
 
 ## 18.0.0
 
+- Use package:objective_c 7.0.0.
 - Add variable substitutions that can be used in the `headers.entry-points` to
   locate Apple APIs: `$XCODE`, `$IOS_SDK`, and `$MACOS_SDK`.
 - Add an empty constructor to all ObjC interfaces that have a `new` method,

--- a/pkgs/ffigen/lib/src/header_parser/type_extractor/extractor.dart
+++ b/pkgs/ffigen/lib/src/header_parser/type_extractor/extractor.dart
@@ -252,6 +252,7 @@ _CreateTypeFromCursorResult _createTypeFromCursor(clang_types.CXType cxtype,
         return _CreateTypeFromCursorResult(enumClass);
       }
     case clang_types.CXTypeKind.CXType_ObjCInterface:
+    case clang_types.CXTypeKind.CXType_ObjCObject:
       return _CreateTypeFromCursorResult(parseObjCInterfaceDeclaration(cursor));
     default:
       return _CreateTypeFromCursorResult(

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -41,7 +41,7 @@ dev_dependencies:
   dart_flutter_team_lints: ^2.0.0
   json_schema: ^5.1.1
   leak_tracker: ^10.0.7
-  objective_c: ^7.0.0
+  objective_c: ^7.2.0
   test: ^1.16.2
 
 dependency_overrides:

--- a/pkgs/ffigen/test/native_objc_test/property_config.yaml
+++ b/pkgs/ffigen/test/native_objc_test/property_config.yaml
@@ -8,6 +8,6 @@ objc-interfaces:
     - PropertyInterface
 headers:
   entry-points:
-    - 'property_test.m'
+    - 'property_test.h'
 preamble: |
   // ignore_for_file: camel_case_types, non_constant_identifier_names, unnecessary_non_null_assertion, unused_element, unused_field

--- a/pkgs/ffigen/test/native_objc_test/property_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/property_test.dart
@@ -9,6 +9,7 @@ import 'dart:ffi';
 import 'dart:io';
 
 import 'package:ffi/ffi.dart';
+import 'package:objective_c/objective_c.dart';
 import 'package:test/test.dart';
 import '../test_utils.dart';
 import 'property_bindings.dart';
@@ -50,7 +51,8 @@ void main() {
       });
     });
 
-    group('Regress #608', () {
+    group('Regress #209', () {
+      // Test for https://github.com/dart-lang/native/issues/209
       test('Structs', () {
         final inputPtr = calloc<Vec4>();
         final input = inputPtr.ref;
@@ -84,6 +86,13 @@ void main() {
       // Test for https://github.com/dart-lang/native/issues/1136
       expect(testInstance.instStaticSameName, 123);
       expect(PropertyInterface.getInstStaticSameName$1(), 456);
+    });
+
+    test('Regress #1268', () {
+      // Test for https://github.com/dart-lang/native/issues/1268
+      NSArray array = PropertyInterface.getRegressGH1268();
+      expect(array.length, 1);
+      expect(NSString.castFrom(array[0]).toDartString(), "hello");
     });
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/property_test.h
+++ b/pkgs/ffigen/test/native_objc_test/property_test.h
@@ -1,0 +1,32 @@
+#import <Foundation/NSObject.h>
+
+@class UndefinedTemplate<ObjectType>;
+@class NSString;
+@class NSArray<ObjectType>;
+
+typedef struct {
+  double x;
+  double y;
+  double z;
+  double w;
+} Vec4;
+
+@interface PropertyInterface : NSObject {
+}
+
+@property (readonly) int32_t readOnlyProperty;
+@property int32_t readWriteProperty;
+@property (class, readonly, copy) UndefinedTemplate<NSString *> *regressGH436;
+@property (class, readonly) int32_t classReadOnlyProperty;
+@property (class) int32_t classReadWriteProperty;
+@property float floatProperty;
+@property double doubleProperty;
+@property Vec4 structProperty;
+@property (class, readonly, copy) NSArray<NSString *> *regressGH1268;
+
+// An instance property and a static property with the same name.
+// https://github.com/dart-lang/native/issues/1136
+@property(readonly) int32_t instStaticSameName;
+@property(class, readonly) int32_t instStaticSameName;
+
+@end

--- a/pkgs/ffigen/test/native_objc_test/property_test.m
+++ b/pkgs/ffigen/test/native_objc_test/property_test.m
@@ -1,32 +1,7 @@
-#import <Foundation/NSObject.h>
+#import "property_test.h"
 
-@class UndefinedTemplate<ObjectType>;
-
-typedef struct {
-  double x;
-  double y;
-  double z;
-  double w;
-} Vec4;
-
-@interface PropertyInterface : NSObject {
-}
-
-@property (readonly) int32_t readOnlyProperty;
-@property int32_t readWriteProperty;
-@property (class, readonly, copy) UndefinedTemplate<NSString *> *regressGH436;
-@property (class, readonly) int32_t classReadOnlyProperty;
-@property (class) int32_t classReadWriteProperty;
-@property float floatProperty;
-@property double doubleProperty;
-@property Vec4 structProperty;
-
-// An instance property and a static property with the same name.
-// https://github.com/dart-lang/native/issues/1136
-@property(readonly) int32_t instStaticSameName;
-@property(class, readonly) int32_t instStaticSameName;
-
-@end
+#import <Foundation/NSString.h>
+#import <Foundation/NSArray.h>
 
 @implementation PropertyInterface
 
@@ -54,6 +29,10 @@ static int32_t _classReadWriteProperty = 0;
 
 + (int32_t)instStaticSameName {
   return 456;
+}
+
++ (NSArray<NSString *> *)regressGH1268 {
+  return @[@"hello"];
 }
 
 @end

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 7.2.0-wip
 
+- Use ffigen 18.2.0
 - NSArray is now a Dart Iterable and NSMutableArray is now a Dart List.
 
 ## 7.1.0

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -2333,7 +2333,7 @@ class NSError extends NSObject implements NSCopying, NSSecureCoding {
 
   /// errorWithDomain:code:userInfo:
   static NSError errorWithDomain_code_userInfo_(
-      NSString domain, int code, objc.ObjCObjectBase? dict) {
+      NSString domain, int code, NSDictionary? dict) {
     final _ret = _objc_msgSend_rc4ypv(
         _class_NSError,
         _sel_errorWithDomain_code_userInfo_,
@@ -2399,7 +2399,7 @@ class NSError extends NSObject implements NSCopying, NSSecureCoding {
 
   /// initWithDomain:code:userInfo:
   NSError initWithDomain_code_userInfo_(
-      NSString domain, int code, objc.ObjCObjectBase? dict) {
+      NSString domain, int code, NSDictionary? dict) {
     final _ret = _objc_msgSend_rc4ypv(
         this.ref.retainAndReturnPointer(),
         _sel_initWithDomain_code_userInfo_,
@@ -2462,9 +2462,9 @@ class NSError extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// userInfo
-  objc.ObjCObjectBase get userInfo {
+  NSDictionary get userInfo {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_userInfo);
-    return objc.ObjCObjectBase(_ret, retain: true, release: true);
+    return NSDictionary.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// Returns a new instance of NSError constructed with the default `new` method.
@@ -2987,9 +2987,9 @@ extension NSExtendedDictionary on NSDictionary {
 /// NSExtendedEnumerator
 extension NSExtendedEnumerator on NSEnumerator {
   /// allObjects
-  objc.ObjCObjectBase get allObjects {
+  NSArray get allObjects {
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_allObjects);
-    return objc.ObjCObjectBase(_ret, retain: true, release: true);
+    return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 }
 
@@ -3261,7 +3261,7 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
   }
 
   /// intersectSet:
-  void intersectSet_(objc.ObjCObjectBase other) {
+  void intersectSet_(NSSet other) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.intersectSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_xtuoz7(
@@ -3277,7 +3277,7 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
   }
 
   /// minusSet:
-  void minusSet_(objc.ObjCObjectBase other) {
+  void minusSet_(NSSet other) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.minusSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_xtuoz7(this.ref.pointer, _sel_minusSet_, other.ref.pointer);
@@ -3383,7 +3383,7 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
   }
 
   /// unionSet:
-  void unionSet_(objc.ObjCObjectBase other) {
+  void unionSet_(NSSet other) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.unionSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_xtuoz7(this.ref.pointer, _sel_unionSet_, other.ref.pointer);
@@ -3501,7 +3501,7 @@ extension NSExtendedOrderedSet on NSOrderedSet {
   }
 
   /// intersectsSet:
-  bool intersectsSet_(objc.ObjCObjectBase set) {
+  bool intersectsSet_(NSSet set) {
     objc.checkOsVersionInternal('NSOrderedSet.intersectsSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     return _objc_msgSend_19nvye5(
@@ -3525,7 +3525,7 @@ extension NSExtendedOrderedSet on NSOrderedSet {
   }
 
   /// isSubsetOfSet:
-  bool isSubsetOfSet_(objc.ObjCObjectBase set) {
+  bool isSubsetOfSet_(NSSet set) {
     objc.checkOsVersionInternal('NSOrderedSet.isSubsetOfSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     return _objc_msgSend_19nvye5(
@@ -3587,11 +3587,11 @@ extension NSExtendedOrderedSet on NSOrderedSet {
   }
 
   /// set
-  objc.ObjCObjectBase get set$ {
+  NSSet get set$ {
     objc.checkOsVersionInternal('NSOrderedSet.set',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_set);
-    return objc.ObjCObjectBase(_ret, retain: true, release: true);
+    return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 }
 
@@ -5853,7 +5853,7 @@ class NSMutableOrderedSet extends NSOrderedSet {
   }
 
   /// orderedSetWithSet:
-  static NSMutableOrderedSet orderedSetWithSet_(objc.ObjCObjectBase set) {
+  static NSMutableOrderedSet orderedSetWithSet_(NSSet set) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.orderedSetWithSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(
@@ -5864,7 +5864,7 @@ class NSMutableOrderedSet extends NSOrderedSet {
 
   /// orderedSetWithSet:copyItems:
   static NSMutableOrderedSet orderedSetWithSet_copyItems_(
-      objc.ObjCObjectBase set, bool flag) {
+      NSSet set, bool flag) {
     objc.checkOsVersionInternal(
         'NSMutableOrderedSet.orderedSetWithSet:copyItems:',
         iOS: (false, (5, 0, 0)),
@@ -6019,7 +6019,7 @@ class NSMutableOrderedSet extends NSOrderedSet {
   }
 
   /// initWithSet:
-  NSMutableOrderedSet initWithSet_(objc.ObjCObjectBase set) {
+  NSMutableOrderedSet initWithSet_(NSSet set) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.initWithSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(
@@ -6029,8 +6029,7 @@ class NSMutableOrderedSet extends NSOrderedSet {
   }
 
   /// initWithSet:copyItems:
-  NSMutableOrderedSet initWithSet_copyItems_(
-      objc.ObjCObjectBase set, bool flag) {
+  NSMutableOrderedSet initWithSet_copyItems_(NSSet set, bool flag) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.initWithSet:copyItems:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
@@ -8616,7 +8615,7 @@ class NSOrderedCollectionDifference extends NSObject
   ///
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
-  NSOrderedCollectionDifference initWithChanges_(objc.ObjCObjectBase changes) {
+  NSOrderedCollectionDifference initWithChanges_(NSArray changes) {
     objc.checkOsVersionInternal(
         'NSOrderedCollectionDifference.initWithChanges:',
         iOS: (false, (13, 0, 0)),
@@ -8634,9 +8633,9 @@ class NSOrderedCollectionDifference extends NSObject
   NSOrderedCollectionDifference
       initWithInsertIndexes_insertedObjects_removeIndexes_removedObjects_(
           NSIndexSet inserts,
-          objc.ObjCObjectBase? insertedObjects,
+          NSArray? insertedObjects,
           NSIndexSet removes,
-          objc.ObjCObjectBase? removedObjects) {
+          NSArray? removedObjects) {
     objc.checkOsVersionInternal(
         'NSOrderedCollectionDifference.initWithInsertIndexes:insertedObjects:removeIndexes:removedObjects:',
         iOS: (false, (13, 0, 0)),
@@ -8659,10 +8658,10 @@ class NSOrderedCollectionDifference extends NSObject
   NSOrderedCollectionDifference
       initWithInsertIndexes_insertedObjects_removeIndexes_removedObjects_additionalChanges_(
           NSIndexSet inserts,
-          objc.ObjCObjectBase? insertedObjects,
+          NSArray? insertedObjects,
           NSIndexSet removes,
-          objc.ObjCObjectBase? removedObjects,
-          objc.ObjCObjectBase changes) {
+          NSArray? removedObjects,
+          NSArray changes) {
     objc.checkOsVersionInternal(
         'NSOrderedCollectionDifference.initWithInsertIndexes:insertedObjects:removeIndexes:removedObjects:additionalChanges:',
         iOS: (false, (13, 0, 0)),
@@ -8681,11 +8680,11 @@ class NSOrderedCollectionDifference extends NSObject
 
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
-  objc.ObjCObjectBase get insertions {
+  NSArray get insertions {
     objc.checkOsVersionInternal('NSOrderedCollectionDifference.insertions',
         iOS: (false, (13, 0, 0)), macOS: (false, (10, 15, 0)));
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_insertions);
-    return objc.ObjCObjectBase(_ret, retain: true, release: true);
+    return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// inverseDifference
@@ -8705,11 +8704,11 @@ class NSOrderedCollectionDifference extends NSObject
 
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
-  objc.ObjCObjectBase get removals {
+  NSArray get removals {
     objc.checkOsVersionInternal('NSOrderedCollectionDifference.removals',
         iOS: (false, (13, 0, 0)), macOS: (false, (10, 15, 0)));
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_removals);
-    return objc.ObjCObjectBase(_ret, retain: true, release: true);
+    return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// Returns a new instance of NSOrderedCollectionDifference constructed with the default `new` method.
@@ -8867,7 +8866,7 @@ class NSOrderedSet extends NSObject
   }
 
   /// orderedSetWithSet:
-  static NSOrderedSet orderedSetWithSet_(objc.ObjCObjectBase set) {
+  static NSOrderedSet orderedSetWithSet_(NSSet set) {
     objc.checkOsVersionInternal('NSOrderedSet.orderedSetWithSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(
@@ -8876,8 +8875,7 @@ class NSOrderedSet extends NSObject
   }
 
   /// orderedSetWithSet:copyItems:
-  static NSOrderedSet orderedSetWithSet_copyItems_(
-      objc.ObjCObjectBase set, bool flag) {
+  static NSOrderedSet orderedSetWithSet_copyItems_(NSSet set, bool flag) {
     objc.checkOsVersionInternal('NSOrderedSet.orderedSetWithSet:copyItems:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_17amj0z(_class_NSOrderedSet,
@@ -9031,7 +9029,7 @@ class NSOrderedSet extends NSObject
   }
 
   /// initWithSet:
-  NSOrderedSet initWithSet_(objc.ObjCObjectBase set) {
+  NSOrderedSet initWithSet_(NSSet set) {
     objc.checkOsVersionInternal('NSOrderedSet.initWithSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(
@@ -9040,7 +9038,7 @@ class NSOrderedSet extends NSObject
   }
 
   /// initWithSet:copyItems:
-  NSOrderedSet initWithSet_copyItems_(objc.ObjCObjectBase set, bool flag) {
+  NSOrderedSet initWithSet_copyItems_(NSSet set, bool flag) {
     objc.checkOsVersionInternal('NSOrderedSet.initWithSet:copyItems:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
@@ -11540,7 +11538,7 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// resourceValuesForKeys:fromBookmarkData:
-  static objc.ObjCObjectBase? resourceValuesForKeys_fromBookmarkData_(
+  static NSDictionary? resourceValuesForKeys_fromBookmarkData_(
       NSArray keys, NSData bookmarkData) {
     objc.checkOsVersionInternal('NSURL.resourceValuesForKeys:fromBookmarkData:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
@@ -11551,7 +11549,7 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
         bookmarkData.ref.pointer);
     return _ret.address == 0
         ? null
-        : objc.ObjCObjectBase(_ret, retain: true, release: true);
+        : NSDictionary.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// supportsSecureCoding
@@ -11976,7 +11974,7 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// resourceValuesForKeys:error:
-  objc.ObjCObjectBase? resourceValuesForKeys_error_(
+  NSDictionary? resourceValuesForKeys_error_(
       NSArray keys, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     objc.checkOsVersionInternal('NSURL.resourceValuesForKeys:error:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
@@ -11984,7 +11982,7 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
         _sel_resourceValuesForKeys_error_, keys.ref.pointer, error);
     return _ret.address == 0
         ? null
-        : objc.ObjCObjectBase(_ret, retain: true, release: true);
+        : NSDictionary.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// scheme
@@ -12009,7 +12007,7 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// setResourceValues:error:
-  bool setResourceValues_error_(objc.ObjCObjectBase keyedValues,
+  bool setResourceValues_error_(NSDictionary keyedValues,
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
     objc.checkOsVersionInternal('NSURL.setResourceValues:error:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));

--- a/pkgs/objective_c/pubspec.yaml
+++ b/pkgs/objective_c/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
   args: ^2.6.0
   coverage: ^1.11.0
   dart_flutter_team_lints: ^2.0.0
-  ffigen: ^18.0.0
+  ffigen: ^18.2.0
   flutter_lints: ^3.0.0
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
There's a rareish bug where a specific interface type can be codegenned as a generic `ObjCObjectBase`. It can happen in methods or properties, in arguments or returns.

I'm not 100% sure what causes it, but it seems to happen when the interface has type params, and is forward declared. Eg, I was able to repro it in the test by writing a method that returns an `NSArray<NSString*>*`, and forward declaring `NSArray` and `NSString` instead of `#import`ing their headers.

The bug is that in the AST these types show up as a `CXType_ObjCObject` instead of a `CXType_ObjCInterface`. Their structure is exactly the same as any other interface, but the different kind enum value means that they fall through our parsing switch and default to the generic object type. So the fix is just to add this enum value to the switch.

Fixes #1268