### PR TITLE
[native_assets_cli] Curate public classes - part 2

### DIFF
--- a/pkgs/native_assets_cli/lib/src/code_assets/c_compiler_config.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/c_compiler_config.dart
@@ -8,7 +8,7 @@ import 'config.dart';
 import 'os.dart';
 import 'syntax.g.dart';
 
-/// The configuration for a C toolchain.
+/// The configuration for a C toolchain inside [CodeConfig.cCompiler].
 final class CCompilerConfig {
   /// Path to a C compiler.
   final Uri compiler;
@@ -70,14 +70,16 @@ final class CCompilerConfig {
   );
 }
 
-/// Configuration provided when [CodeConfig.targetOS] is [OS.windows].
+/// The configuration provided in [CCompilerConfig.windows] when
+/// [CodeConfig.targetOS] is [OS.windows].
 final class WindowsCCompilerConfig {
   final DeveloperCommandPrompt? developerCommandPrompt;
 
   WindowsCCompilerConfig({this.developerCommandPrompt});
 }
 
-/// The Windows Developer Command Prompt.
+/// The configuration for the Windows Developer Command Prompt in
+/// [WindowsCCompilerConfig.developerCommandPrompt].
 ///
 /// Sets up the environment variables for [CCompilerConfig.compiler],
 /// [CCompilerConfig.linker], and [CCompilerConfig.archiver] on Windows.

--- a/pkgs/native_assets_cli/lib/src/code_assets/code_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/code_asset.dart
@@ -9,7 +9,8 @@ import 'link_mode.dart';
 import 'os.dart';
 import 'syntax.g.dart';
 
-/// A code asset which respects the native application binary interface (ABI).
+/// An asset containing executable code which respects the native application
+/// binary interface (ABI).
 ///
 /// Typical languages which produce code assets that respect the native ABI
 /// include C, C++ (with `extern "C"`), Rust (with `extern "C"`), and a subset

--- a/pkgs/native_assets_cli/lib/src/code_assets/config.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/config.dart
@@ -36,8 +36,8 @@ extension CodeAssetLinkInput on LinkInputAssets {
       encodedAssets.where((e) => e.isCodeAsset).map(CodeAsset.fromEncoded);
 }
 
-/// Configuration for hook writers if code assets are supported.
-class CodeConfig {
+/// The configuration for [CodeAsset]s in [HookConfig].
+final class CodeConfig {
   final CodeConfigSyntax _syntax;
 
   CodeConfig._fromJson(Map<String, Object?> json, List<Object> path)
@@ -88,8 +88,9 @@ class CodeConfig {
   };
 }
 
-/// Configuration provided when [CodeConfig.targetOS] is [OS.iOS].
-class IOSCodeConfig {
+/// The configuration for [CodeAsset]s for target OS [OS.iOS] in
+/// [CodeConfig.iOS].
+final class IOSCodeConfig {
   final IOSCodeConfigSyntax _syntax;
 
   IOSCodeConfig._(this._syntax);
@@ -107,8 +108,9 @@ class IOSCodeConfig {
       );
 }
 
-/// Configuration provided when [CodeConfig.targetOS] is [OS.macOS].
-class AndroidCodeConfig {
+/// The configuration for [CodeAsset]s for target OS [OS.android] in
+/// [CodeConfig.android].
+final class AndroidCodeConfig {
   final AndroidCodeConfigSyntax _syntax;
 
   AndroidCodeConfig._(this._syntax);
@@ -121,8 +123,9 @@ class AndroidCodeConfig {
     : _syntax = AndroidCodeConfigSyntax(targetNdkApi: targetNdkApi);
 }
 
-//// Configuration provided when [CodeConfig.targetOS] is [OS.macOS].
-class MacOSCodeConfig {
+/// The configuration for [CodeAsset]s for target OS [OS.macOS] in
+/// [CodeConfig.macOS].
+final class MacOSCodeConfig {
   final MacOSCodeConfigSyntax _syntax;
 
   MacOSCodeConfig._(this._syntax);
@@ -134,15 +137,14 @@ class MacOSCodeConfig {
     : _syntax = MacOSCodeConfigSyntax(targetVersion: targetVersion);
 }
 
-/// Extension to the [BuildOutputBuilder] providing access to emitting code
-/// assets (only available if code assets are supported).
+/// Extension on [BuildOutputBuilder] to add [CodeAsset]s.
 extension CodeAssetBuildOutputBuilder on EncodedAssetBuildOutputBuilder {
   /// Provides access to emitting code assets.
   CodeAssetBuildOutputBuilderAdd get code =>
       CodeAssetBuildOutputBuilderAdd._(this);
 }
 
-/// Supports emitting code assets for build hooks.
+/// Extension on [BuildOutputBuilder] to add [CodeAsset]s.
 extension type CodeAssetBuildOutputBuilderAdd._(
   EncodedAssetBuildOutputBuilder _output
 ) {
@@ -161,15 +163,14 @@ extension type CodeAssetBuildOutputBuilderAdd._(
   }
 }
 
-/// Extension to the [LinkOutputBuilder] providing access to emitting code
-/// assets (only available if code assets are supported).
+/// Extension on [LinkOutputBuilder] to add [CodeAsset]s.
 extension CodeAssetLinkOutputBuilder on EncodedAssetLinkOutputBuilder {
   /// Provides access to emitting code assets.
   CodeAssetLinkOutputBuilderAdd get code =>
       CodeAssetLinkOutputBuilderAdd._(this);
 }
 
-/// Extension on [LinkOutputBuilder] to emit code assets.
+/// Extension on [LinkOutputBuilder] to add [CodeAsset]s.
 extension type CodeAssetLinkOutputBuilderAdd._(
   EncodedAssetLinkOutputBuilder _output
 ) {

--- a/pkgs/native_assets_cli/lib/src/code_assets/ios_sdk.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/ios_sdk.dart
@@ -2,7 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// For an iOS target, a build is either done for the device or the simulator.
+import 'config.dart';
+
+/// The iOS SDK (device or simulator) in [IOSCodeConfig.targetSdk].
 final class IOSSdk {
   final String type;
 

--- a/pkgs/native_assets_cli/lib/src/code_assets/link_mode.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/link_mode.dart
@@ -58,7 +58,7 @@ extension LinkModeSyntaxExtension on LinkMode {
   };
 }
 
-/// The [CodeAsset] will be loaded at runtime.
+/// [CodeAsset]s with this [LinkMode] will be loaded at runtime.
 ///
 /// Nothing happens at native code linking time.
 ///
@@ -71,14 +71,16 @@ abstract final class DynamicLoading extends LinkMode {
   DynamicLoading._() : super._();
 }
 
-/// The dynamic library is bundled by Dart/Flutter at build time.
+/// [CodeAsset]s with this [LinkMode] will be bundled as dynamic libraries by
+/// Dart/Flutter at build time.
 ///
 /// At runtime, the dynamic library will be loaded and the symbols will be
 /// looked up in this dynamic library.
 ///
-/// An asset with this dynamic loading method must provide a
-/// [CodeAsset.file]. The Dart and Flutter SDK will bundle this code in
-/// the final application.
+/// An asset with this link mode must provide a [CodeAsset.file] and it must be
+/// a dynamic library.
+///
+/// The Dart and Flutter SDK will bundle this code in the final application.
 final class DynamicLoadingBundled extends DynamicLoading {
   DynamicLoadingBundled._() : super._();
 
@@ -90,7 +92,8 @@ final class DynamicLoadingBundled extends DynamicLoading {
   String toString() => 'bundled';
 }
 
-/// The dynamic library is avaliable on the target system `PATH`.
+/// [CodeAsset]s with this [LinkMode] are expected to be available as dynamic
+/// library on the target system `PATH`.
 ///
 /// At buildtime, nothing happens.
 ///
@@ -115,8 +118,10 @@ final class DynamicLoadingSystem extends DynamicLoading {
   String toString() => _typeValue;
 }
 
-/// The native code is loaded in the process and symbols are available through
-/// `DynamicLibrary.process()`.
+/// [CodeAsset]s with this [LinkMode] are expected to have their symbols
+/// available through `DynamicLibrary.process()`.
+///
+/// At buildtime, nothing happens.
 final class LookupInProcess extends DynamicLoading {
   LookupInProcess._() : super._();
 
@@ -128,8 +133,10 @@ final class LookupInProcess extends DynamicLoading {
   String toString() => 'process';
 }
 
-/// The native code is embedded in executable and symbols are available through
-/// `DynamicLibrary.executable()`.
+/// [CodeAsset]s with this [LinkMode] are expected to have their symbols
+/// available through `DynamicLibrary.executable()`.
+///
+/// At buildtime, nothing happens.
 final class LookupInExecutable extends DynamicLoading {
   LookupInExecutable._() : super._();
 
@@ -141,7 +148,10 @@ final class LookupInExecutable extends DynamicLoading {
   String toString() => 'executable';
 }
 
-/// Static linking.
+/// [CodeAsset]s with this [LinkMode] are linked statically.
+///
+/// An asset with this link mode must provide a [CodeAsset.file] and it must be
+/// a static library.
 ///
 /// At native linking time, native function names will be resolved to static
 /// libraries.

--- a/pkgs/native_assets_cli/lib/src/code_assets/link_mode_preference.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/link_mode_preference.dart
@@ -4,9 +4,10 @@
 
 import 'code_asset.dart';
 
+import 'config.dart';
 import 'syntax.g.dart';
 
-/// The preferred linkMode method for [CodeAsset]s.
+/// The preferred link mode for [CodeAsset]s in [CodeConfig.linkModePreference].
 final class LinkModePreference {
   /// The name for this link mode.
   final String name;

--- a/pkgs/native_assets_cli/lib/src/code_assets/os.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/os.dart
@@ -6,7 +6,7 @@ import 'dart:io';
 
 import 'syntax.g.dart';
 
-/// An operating system the Dart VM runs on.
+/// An operating system which the Dart VM can run on.
 final class OS {
   /// The name of this operating system.
   final String name;

--- a/pkgs/native_assets_cli/lib/src/data_assets/config.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/config.dart
@@ -100,14 +100,14 @@ extension DataAssetLinkInput on LinkInputAssets {
       encodedAssets.where((e) => e.isDataAsset).map(DataAsset.fromEncoded);
 }
 
-/// Build output extension for data assets.
+/// Extension on [BuildOutputBuilder] to add [DataAsset]s.
 extension DataAssetBuildOutputBuilder on EncodedAssetBuildOutputBuilder {
   /// Provides access to emitting data assets.
   DataAssetBuildOutputBuilderAdd get data =>
       DataAssetBuildOutputBuilderAdd._(this);
 }
 
-/// Supports emitting code assets for build hooks.
+/// Extension on [BuildOutputBuilder] to add [DataAsset]s.
 extension type DataAssetBuildOutputBuilderAdd._(
   EncodedAssetBuildOutputBuilder _output
 ) {
@@ -126,14 +126,13 @@ extension type DataAssetBuildOutputBuilderAdd._(
   }
 }
 
-/// Extension to the [LinkOutputBuilder] providing access to emitting data
-/// assets (only available if data assets are supported).
+/// Extension on [LinkOutputBuilder] to add [DataAsset]s.
 extension DataAssetLinkOutputBuilder on EncodedAssetLinkOutputBuilder {
   /// Provides access to emitting data assets.
   DataAssetLinkOutputBuilderAdd get data => DataAssetLinkOutputBuilderAdd(this);
 }
 
-/// Extension on [LinkOutputBuilder] to emit data assets.
+/// Extension on [LinkOutputBuilder] to add [DataAsset]s.
 extension type DataAssetLinkOutputBuilderAdd(
   EncodedAssetLinkOutputBuilder _output
 ) {

--- a/pkgs/native_assets_cli/lib/src/data_assets/data_asset.dart
+++ b/pkgs/native_assets_cli/lib/src/data_assets/data_asset.dart
@@ -5,7 +5,8 @@
 import '../encoded_asset.dart';
 import 'syntax.g.dart';
 
-/// Data bundled with a Dart or Flutter application.
+/// An asset bundled as data (String or bytes) with a Dart or Flutter
+/// application.
 ///
 /// A data asset is accessible in a Dart or Flutter application. To retrieve an
 /// asset at runtime, the [id] is used. This enables access to the asset


### PR DESCRIPTION
This PR tries the curate the classes which are in the public API of what will be `package:code_assets` and `package:data_assets`.

The Dart docs can be inspected by `pkgs/native_assets_cli$ dart doc .`.

TODOs:

* This PR does not yet curate extension types, extensions, and top level functions.

Context:

* Work before splitting up the package: https://github.com/dart-lang/native/issues/999
