### PR TITLE
[native_assets_cli] Curate public toplevel functions

### DIFF
--- a/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
+++ b/pkgs/native_assets_builder/lib/src/build_runner/build_runner.dart
@@ -149,7 +149,7 @@ class NativeAssetsBuildRunner {
 
       final input = inputBuilder.build();
       final errors = [
-        ...await validateBuildInput(input),
+        ...await ProtocolBase.validateBuildInput(input),
         for (final e in extensions) ...await e.validateBuildInput(input),
       ];
       if (errors.isNotEmpty) {
@@ -255,7 +255,7 @@ class NativeAssetsBuildRunner {
 
       final input = inputBuilder.build();
       final errors = [
-        ...await validateLinkInput(input),
+        ...await ProtocolBase.validateLinkInput(input),
         for (final e in extensions) ...await e.validateLinkInput(input),
       ];
       if (errors.isNotEmpty) {
@@ -752,8 +752,11 @@ ${compileResult.stdout}
   ) async {
     final errors =
         input is BuildInput
-            ? await validateBuildOutput(input, output as BuildOutput)
-            : await validateLinkOutput(
+            ? await ProtocolBase.validateBuildOutput(
+              input,
+              output as BuildOutput,
+            )
+            : await ProtocolBase.validateLinkOutput(
               input as LinkInput,
               output as LinkOutput,
             );

--- a/pkgs/native_assets_cli/lib/native_assets_cli.dart
+++ b/pkgs/native_assets_cli/lib/native_assets_cli.dart
@@ -43,9 +43,4 @@ export 'src/extension.dart';
 export 'src/test.dart';
 export 'src/user_defines.dart'
     show PackageUserDefines, PackageUserDefinesSource;
-export 'src/validation.dart'
-    show
-        validateBuildInput,
-        validateBuildOutput,
-        validateLinkInput,
-        validateLinkOutput;
+export 'src/validation.dart' show ProtocolBase;

--- a/pkgs/native_assets_cli/lib/src/api/build.dart
+++ b/pkgs/native_assets_cli/lib/src/api/build.dart
@@ -9,7 +9,7 @@ import '../args_parser.dart';
 import '../config.dart';
 import '../validation.dart';
 
-/// Runs a native assets build.
+/// Builds assets in a `hook/build.dart`.
 ///
 /// Meant to be used in build hooks (`hook/build.dart`).
 ///
@@ -106,7 +106,10 @@ Future<void> build(
   final input = BuildInput(jsonInput);
   final output = BuildOutputBuilder();
   await builder(input, output);
-  final errors = await validateBuildOutput(input, BuildOutput(output.json));
+  final errors = await ProtocolBase.validateBuildOutput(
+    input,
+    BuildOutput(output.json),
+  );
   if (errors.isEmpty) {
     final jsonOutput = const JsonEncoder.withIndent(
       '  ',

--- a/pkgs/native_assets_cli/lib/src/api/link.dart
+++ b/pkgs/native_assets_cli/lib/src/api/link.dart
@@ -9,7 +9,7 @@ import '../args_parser.dart';
 import '../config.dart';
 import '../validation.dart';
 
-/// Runs a native assets link.
+/// Links assets in a `hook/link.dart`.
 ///
 /// Meant to be used in link hooks (`hook/link.dart`).
 ///
@@ -48,7 +48,10 @@ Future<void> link(
   final input = LinkInput(jsonInput);
   final output = LinkOutputBuilder();
   await linker(input, output);
-  final errors = await validateLinkOutput(input, LinkOutput(output.json));
+  final errors = await ProtocolBase.validateLinkOutput(
+    input,
+    LinkOutput(output.json),
+  );
   if (errors.isEmpty) {
     final jsonOutput = const JsonEncoder()
         .fuse(const Utf8Encoder())

--- a/pkgs/native_assets_cli/lib/src/code_assets/testing.dart
+++ b/pkgs/native_assets_cli/lib/src/code_assets/testing.dart
@@ -10,13 +10,14 @@ import '../test.dart';
 import '../user_defines.dart';
 import 'architecture.dart';
 import 'c_compiler_config.dart';
+import 'code_asset.dart';
 import 'config.dart';
 import 'extension.dart';
 import 'ios_sdk.dart';
 import 'link_mode_preference.dart';
 import 'os.dart';
 
-/// Validates a code build hook.
+/// Tests the main function of a `hook/build.dart` with [CodeAsset]s.
 ///
 /// This method will throw an exception on validation errors.
 ///

--- a/pkgs/native_assets_cli/lib/src/extension.dart
+++ b/pkgs/native_assets_cli/lib/src/extension.dart
@@ -6,10 +6,11 @@ import 'dart:async';
 
 import 'config.dart';
 import 'encoded_asset.dart';
+import 'validation.dart';
 
 typedef ValidationErrors = List<String>;
 
-/// An extension to the base protocol for `hook/build.dart` and
+/// An extension to the [ProtocolBase] for `hook/build.dart` and
 /// `hook/link.dart`.
 ///
 /// The extension contains callbacks to

--- a/pkgs/native_assets_cli/lib/src/test.dart
+++ b/pkgs/native_assets_cli/lib/src/test.dart
@@ -14,7 +14,7 @@ import 'extension.dart';
 import 'user_defines.dart';
 import 'validation.dart';
 
-/// Validates a build hook.
+/// Tests the main function of a `hook/build.dart`.
 ///
 /// This method will throw an exception on validation errors.
 ///
@@ -88,7 +88,7 @@ Future<void> testBuildHook({
     final output = BuildOutput(_readJsonFrom(input.outputFile));
 
     final outputErrors = [
-      ...await validateBuildOutput(input, output),
+      ...await ProtocolBase.validateBuildOutput(input, output),
       for (final extension in extensions) ...[
         ...await extension.validateBuildOutput(input, output),
         ...await extension.validateApplicationAssets(

--- a/pkgs/native_assets_cli/lib/src/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/validation.dart
@@ -14,8 +14,10 @@ typedef ValidationErrors = List<String>;
 /// The base protocol for `hook/build.dart` and `hook/link.dart` which can be
 /// extended with [ProtocolExtension]s.
 ///
-/// This class currently contains the logic of the protocol which is similar to
-/// the protocol extensions: validation rules.
+/// This class contains the [HookInput] and [HookOutput] validation rules for
+/// the base protocol. (In contrast to [ProtocolExtension]s, it does not contain
+/// setup methods for the [HookInput], the base protocol knows how to setup
+/// itself.)
 class ProtocolBase {
   static Future<ValidationErrors> validateBuildInput(BuildInput input) async {
     final syntaxErrors = BuildInputSyntax.fromJson(input.json).validate();

--- a/pkgs/native_assets_cli/lib/src/validation.dart
+++ b/pkgs/native_assets_cli/lib/src/validation.dart
@@ -6,149 +6,163 @@ import 'dart:io';
 
 import 'config.dart';
 import 'encoded_asset.dart';
+import 'extension.dart';
 import 'hooks/syntax.g.dart';
 
 typedef ValidationErrors = List<String>;
 
-Future<ValidationErrors> validateBuildInput(BuildInput input) async {
-  final syntaxErrors = BuildInputSyntax.fromJson(input.json).validate();
-  if (syntaxErrors.isNotEmpty) {
-    return [...syntaxErrors, _semanticValidationSkippedMessage];
+/// The base protocol for `hook/build.dart` and `hook/link.dart` which can be
+/// extended with [ProtocolExtension]s.
+///
+/// This class currently contains the logic of the protocol which is similar to
+/// the protocol extensions: validation rules.
+class ProtocolBase {
+  static Future<ValidationErrors> validateBuildInput(BuildInput input) async {
+    final syntaxErrors = BuildInputSyntax.fromJson(input.json).validate();
+    if (syntaxErrors.isNotEmpty) {
+      return [...syntaxErrors, _semanticValidationSkippedMessage];
+    }
+
+    return _validateHookInput('BuildInput', input);
   }
 
-  return _validateHookInput('BuildInput', input);
-}
+  static Future<ValidationErrors> validateLinkInput(LinkInput input) async {
+    final syntaxErrors = LinkInputSyntax.fromJson(input.json).validate();
+    if (syntaxErrors.isNotEmpty) {
+      return [...syntaxErrors, _semanticValidationSkippedMessage];
+    }
 
-Future<ValidationErrors> validateLinkInput(LinkInput input) async {
-  final syntaxErrors = LinkInputSyntax.fromJson(input.json).validate();
-  if (syntaxErrors.isNotEmpty) {
-    return [...syntaxErrors, _semanticValidationSkippedMessage];
+    final recordUses = input.recordedUsagesFile;
+    return <String>[
+      ..._validateHookInput('LinkInput', input),
+      if (recordUses != null)
+        ..._validateDirectory(
+          '$LinkInput.recordUses',
+          input.outputDirectoryShared,
+        ),
+    ];
   }
 
-  final recordUses = input.recordedUsagesFile;
-  return <String>[
-    ..._validateHookInput('LinkInput', input),
-    if (recordUses != null)
+  static ValidationErrors _validateHookInput(
+    String inputName,
+    HookInput input,
+  ) {
+    final errors = <String>[
+      ..._validateDirectory('$inputName.packageRoot', input.packageRoot),
       ..._validateDirectory(
-        '$LinkInput.recordUses',
+        '$inputName.outputDirectory',
+        input.outputDirectory,
+      ),
+      ..._validateDirectory(
+        '$inputName.outputDirectoryShared',
         input.outputDirectoryShared,
       ),
-  ];
-}
-
-ValidationErrors _validateHookInput(String inputName, HookInput input) {
-  final errors = <String>[
-    ..._validateDirectory('$inputName.packageRoot', input.packageRoot),
-    ..._validateDirectory('$inputName.outputDirectory', input.outputDirectory),
-    ..._validateDirectory(
-      '$inputName.outputDirectoryShared',
-      input.outputDirectoryShared,
-    ),
-    ..._validateDirectory(
-      '$inputName.outputFile',
-      input.outputFile,
-      mustExist: false,
-    ),
-  ];
-  return errors;
-}
-
-ValidationErrors _validateDirectory(
-  String name,
-  Uri uri, {
-  bool mustExist = true,
-  bool mustBeAbsolute = true,
-}) {
-  final errors = <String>[];
-  if (mustBeAbsolute && !uri.isAbsolute) {
-    errors.add('$name (${uri.toFilePath()}) must be an absolute path.');
-  }
-  if (mustExist && !Directory.fromUri(uri).existsSync()) {
-    errors.add('$name (${uri.toFilePath()}) does not exist as a directory.');
-  }
-  return errors;
-}
-
-/// Invoked by package:native_assets_builder
-Future<ValidationErrors> validateBuildOutput(
-  BuildInput input,
-  BuildOutput output,
-) async {
-  final syntaxErrors = BuildOutputSyntax.fromJson(output.json).validate();
-  if (syntaxErrors.isNotEmpty) {
-    return [...syntaxErrors, _semanticValidationSkippedMessage];
+      ..._validateDirectory(
+        '$inputName.outputFile',
+        input.outputFile,
+        mustExist: false,
+      ),
+    ];
+    return errors;
   }
 
-  final errors = [
-    ..._validateAssetsForLinking(input, output),
-    ..._validateOutputAssetTypes(input, output.assets.encodedAssets),
-  ];
-  if (input.config.linkingEnabled) {
-    for (final assets in output.assets.encodedAssetsForLinking.values) {
-      errors.addAll(_validateOutputAssetTypes(input, assets));
+  static ValidationErrors _validateDirectory(
+    String name,
+    Uri uri, {
+    bool mustExist = true,
+    bool mustBeAbsolute = true,
+  }) {
+    final errors = <String>[];
+    if (mustBeAbsolute && !uri.isAbsolute) {
+      errors.add('$name (${uri.toFilePath()}) must be an absolute path.');
     }
-  }
-  return errors;
-}
-
-/// Invoked by package:native_assets_builder
-Future<ValidationErrors> validateLinkOutput(
-  LinkInput input,
-  LinkOutput output,
-) async {
-  final syntaxErrors = LinkOutputSyntax.fromJson(output.json).validate();
-  if (syntaxErrors.isNotEmpty) {
-    return [...syntaxErrors, _semanticValidationSkippedMessage];
-  }
-
-  final errors = [
-    ..._validateOutputAssetTypes(input, output.assets.encodedAssets),
-  ];
-  return errors;
-}
-
-/// Only output asset types that are supported by the embedder.
-ValidationErrors _validateOutputAssetTypes(
-  HookInput input,
-  Iterable<EncodedAsset> assets,
-) {
-  final errors = <String>[];
-  final List<String> buildAssetTypes;
-  if (input is BuildInput) {
-    buildAssetTypes = input.config.buildAssetTypes;
-  } else {
-    buildAssetTypes = (input as LinkInput).config.buildAssetTypes;
-  }
-  for (final asset in assets) {
-    if (!buildAssetTypes.contains(asset.type)) {
-      final error =
-          'Asset with type "${asset.type}" is not a supported asset type '
-          '(${buildAssetTypes.join(' ')} are supported)';
-      errors.add(error);
+    if (mustExist && !Directory.fromUri(uri).existsSync()) {
+      errors.add('$name (${uri.toFilePath()}) does not exist as a directory.');
     }
+    return errors;
   }
-  return errors;
-}
 
-/// EncodedAssetsForLinking should be empty if linking is not supported.
-ValidationErrors _validateAssetsForLinking(
-  BuildInput input,
-  BuildOutput output,
-) {
-  final errors = <String>[];
-  if (!input.config.linkingEnabled) {
-    if (output.assets.encodedAssetsForLinking.isNotEmpty) {
-      const error =
-          'BuildOutput.assets_for_linking is not empty while '
-          'BuildInput.config.linkingEnabled is false';
-      errors.add(error);
+  /// Invoked by package:native_assets_builder
+  static Future<ValidationErrors> validateBuildOutput(
+    BuildInput input,
+    BuildOutput output,
+  ) async {
+    final syntaxErrors = BuildOutputSyntax.fromJson(output.json).validate();
+    if (syntaxErrors.isNotEmpty) {
+      return [...syntaxErrors, _semanticValidationSkippedMessage];
     }
-  }
-  return errors;
-}
 
-const _semanticValidationSkippedMessage =
-    'Syntax errors. Semantic validation skipped.';
+    final errors = [
+      ..._validateAssetsForLinking(input, output),
+      ..._validateOutputAssetTypes(input, output.assets.encodedAssets),
+    ];
+    if (input.config.linkingEnabled) {
+      for (final assets in output.assets.encodedAssetsForLinking.values) {
+        errors.addAll(_validateOutputAssetTypes(input, assets));
+      }
+    }
+    return errors;
+  }
+
+  /// Invoked by package:native_assets_builder
+  static Future<ValidationErrors> validateLinkOutput(
+    LinkInput input,
+    LinkOutput output,
+  ) async {
+    final syntaxErrors = LinkOutputSyntax.fromJson(output.json).validate();
+    if (syntaxErrors.isNotEmpty) {
+      return [...syntaxErrors, _semanticValidationSkippedMessage];
+    }
+
+    final errors = [
+      ..._validateOutputAssetTypes(input, output.assets.encodedAssets),
+    ];
+    return errors;
+  }
+
+  /// Only output asset types that are supported by the embedder.
+  static ValidationErrors _validateOutputAssetTypes(
+    HookInput input,
+    Iterable<EncodedAsset> assets,
+  ) {
+    final errors = <String>[];
+    final List<String> buildAssetTypes;
+    if (input is BuildInput) {
+      buildAssetTypes = input.config.buildAssetTypes;
+    } else {
+      buildAssetTypes = (input as LinkInput).config.buildAssetTypes;
+    }
+    for (final asset in assets) {
+      if (!buildAssetTypes.contains(asset.type)) {
+        final error =
+            'Asset with type "${asset.type}" is not a supported asset type '
+            '(${buildAssetTypes.join(' ')} are supported)';
+        errors.add(error);
+      }
+    }
+    return errors;
+  }
+
+  /// EncodedAssetsForLinking should be empty if linking is not supported.
+  static ValidationErrors _validateAssetsForLinking(
+    BuildInput input,
+    BuildOutput output,
+  ) {
+    final errors = <String>[];
+    if (!input.config.linkingEnabled) {
+      if (output.assets.encodedAssetsForLinking.isNotEmpty) {
+        const error =
+            'BuildOutput.assets_for_linking is not empty while '
+            'BuildInput.config.linkingEnabled is false';
+        errors.add(error);
+      }
+    }
+    return errors;
+  }
+
+  static const _semanticValidationSkippedMessage =
+      'Syntax errors. Semantic validation skipped.';
+}
 
 /// A test failure.
 ///

--- a/pkgs/native_assets_cli/test/validation_test.dart
+++ b/pkgs/native_assets_cli/test/validation_test.dart
@@ -50,7 +50,10 @@ void main() {
       EncodedAsset('my-asset-type', {}),
       routing: const ToLinkHook('bar'),
     );
-    final errors = await validateBuildOutput(input, outputBuilder.build());
+    final errors = await ProtocolBase.validateBuildOutput(
+      input,
+      outputBuilder.build(),
+    );
     expect(errors, contains(contains('linkingEnabled is false')));
   });
 
@@ -60,7 +63,10 @@ void main() {
     final assetFile = File.fromUri(outDirUri.resolve('foo.dylib'));
     await assetFile.writeAsBytes([1, 2, 3]);
     outputBuilder.assets.addEncodedAsset(EncodedAsset('baz', {}));
-    final errors = await validateBuildOutput(input, outputBuilder.build());
+    final errors = await ProtocolBase.validateBuildOutput(
+      input,
+      outputBuilder.build(),
+    );
     expect(errors, contains(contains('"baz" is not a supported asset type')));
   });
 }


### PR DESCRIPTION
This PR tries the curate the toplevel functions which are in the public API of what will be `package:hooks`,   `package:code_assets` and `package:data_assets`.

The validate functions for the base protocol are moved into a `ProtocolBase` class. (These need to be public because `package:native_assets_builder` uses them. And these need to be in `package:native_assets_cli` because the `test` methods use them.)

The Dart docs can be inspected by `pkgs/native_assets_cli$ dart doc .`.

TODOs:

* This PR does not yet curate extension types, and extensions.

Context:

* Work before splitting up the package: https://github.com/dart-lang/native/issues/999
