### PR TITLE
[ffi] Set default parameter name in using callback

### DIFF
--- a/pkgs/ffi/lib/src/arena.dart
+++ b/pkgs/ffi/lib/src/arena.dart
@@ -118,7 +118,7 @@ class Arena implements Allocator {
 /// If the isolate is shut down, through `Isolate.kill()`, resources are _not_
 /// cleaned up.
 R using<R>(
-  R Function(Arena) computation, [
+  R Function(Arena arena) computation, [
   Allocator wrappedAllocator = calloc,
 ]) {
   final arena = Arena(wrappedAllocator);


### PR DESCRIPTION
This is an extremely minor change. Providing a argument name makes auto complete better.

Before:


https://github.com/user-attachments/assets/b7b7a80f-23e6-469c-ac1b-e4b0ad8de781


After:

https://github.com/user-attachments/assets/6daa21c4-8248-487c-ac60-c565964ba868


---


- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
