### PR TITLE
[infra] Fix package_download_asset workflow

### DIFF
--- a/.github/workflows/package_download_asset.yaml
+++ b/.github/workflows/package_download_asset.yaml
@@ -34,7 +34,7 @@ jobs:
 
     - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
       with:
-        sdk: stable
+        sdk: dev
 
     - uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410
       with:

--- a/.github/workflows/package_download_asset.yaml
+++ b/.github/workflows/package_download_asset.yaml
@@ -1,5 +1,5 @@
 # A workflow that goes together with the example package:download_asset inside
-# package:native_assets_cli.
+# package:hooks.
 name: package_download_asset
 
 permissions:
@@ -10,7 +10,7 @@ on:
     branches: [ main ]
     paths:
       - .github/workflows/package_download_asset.yaml
-      - pkgs/native_assets_cli/example/build/download_asset/
+      - pkgs/hooks/example/build/download_asset/
   push:
     tags:
       - 'download_asset-prebuild-assets-*'
@@ -27,7 +27,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: pkgs/native_assets_cli/example/build/download_asset/
+        working-directory: pkgs/hooks/example/build/download_asset/
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -47,7 +47,7 @@ jobs:
 
     - run: dart pub get
 
-    # Keep this list consistent with pkgs/native_assets_cli/example/build/download_asset/lib/src/hook_helpers/target_versions.dart
+    # Keep this list consistent with pkgs/hooks/example/build/download_asset/lib/src/hook_helpers/target_versions.dart
     - name: Build Linux host
       if: matrix.os == 'ubuntu'
       run: |
@@ -84,9 +84,9 @@ jobs:
       with:
         name: ${{ matrix.os }}-host
         path: |
-          pkgs/native_assets_cli/example/build/download_asset/.dart_tool/download_asset/**/*.dll
-          pkgs/native_assets_cli/example/build/download_asset/.dart_tool/download_asset/**/*.dylib
-          pkgs/native_assets_cli/example/build/download_asset/.dart_tool/download_asset/**/*.so
+          pkgs/hooks/example/build/download_asset/.dart_tool/download_asset/**/*.dll
+          pkgs/hooks/example/build/download_asset/.dart_tool/download_asset/**/*.dylib
+          pkgs/hooks/example/build/download_asset/.dart_tool/download_asset/**/*.so
         if-no-files-found: error
 
   release:
@@ -95,7 +95,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: pkgs/native_assets_cli/example/build/download_asset/
+        working-directory: pkgs/hooks/example/build/download_asset/
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -106,7 +106,7 @@ jobs:
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
           merge-multiple: true
-          path: pkgs/native_assets_cli/example/build/download_asset/.dart_tool/download_asset/
+          path: pkgs/hooks/example/build/download_asset/.dart_tool/download_asset/
 
       - name: Display structure of downloaded assets
         run: ls -R .dart_tool/download_asset/
@@ -115,5 +115,5 @@ jobs:
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda
         if: startsWith(github.ref, 'refs/tags/download_asset-prebuild-assets')
         with:
-          files: 'pkgs/native_assets_cli/example/build/download_asset/.dart_tool/download_asset/**'
+          files: 'pkgs/hooks/example/build/download_asset/.dart_tool/download_asset/**'
           fail_on_unmatched_files: true


### PR DESCRIPTION
`package:native_assets_cli` was renamed to `package:hook`. So the example was moved.