### PR TITLE
[hooks_runner] Remove `package_graph.json` fallback

### DIFF
--- a/pkgs/code_assets/pubspec.yaml
+++ b/pkgs/code_assets/pubspec.yaml
@@ -27,6 +27,5 @@ dev_dependencies:
   custom_lint: ^0.7.5
   dart_flutter_team_lints: ^3.5.1
   json_schema: ^5.2.0
-  repo_lint_rules:
-    path: ../repo_lint_rules/
+  repo_lint_rules: 0.1.0-wip
   test: ^1.25.15

--- a/pkgs/data_assets/pubspec.yaml
+++ b/pkgs/data_assets/pubspec.yaml
@@ -23,6 +23,5 @@ dev_dependencies:
   custom_lint: ^0.7.5
   dart_flutter_team_lints: ^3.5.1
   json_schema: ^5.2.0
-  repo_lint_rules:
-    path: ../repo_lint_rules/
+  repo_lint_rules: 0.1.0-wip
   test: ^1.25.15

--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -38,6 +38,5 @@ dev_dependencies:
   json_syntax_generator:
     path: ../json_syntax_generator/
   path: ^1.9.1
-  repo_lint_rules:
-    path: ../repo_lint_rules/
+  repo_lint_rules: 0.1.0-wip
   test: ^1.25.15

--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.19.1-wip
+
+- Remove `package_graph.json` fallback.
+
 ## 0.19.0
 
 - Renamed package from `native_assets_builder` to `hooks_runner`.

--- a/pkgs/hooks_runner/lib/src/build_runner/build_planner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_planner.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:io' show Process;
 
 import 'package:file/file.dart';
 import 'package:graphs/graphs.dart' as graphs;
@@ -39,21 +38,8 @@ class NativeAssetsBuildPlanner {
     final packageGraphJsonFile = fileSystem.file(
       packageConfigUri.resolve('package_graph.json'),
     );
-    final String packageGraphJson;
-    if (packageGraphJsonFile.existsSync()) {
-      packageGraphJson = await packageGraphJsonFile.readAsString();
-    } else {
-      // TODO: Either bump SDK constraint to dev release (but we can't while
-      // flutter_tools requires published stable packages). Or wait for Dart 3.8
-      // to be released to remove this fallback.
-      final workingDirectory = packageConfigUri.resolve('../');
-      final result = await Process.run(
-        dartExecutable.toFilePath(),
-        ['pub', 'deps', '--json'],
-        workingDirectory: workingDirectory.toFilePath(),
-      );
-      packageGraphJson = result.stdout as String;
-    }
+    assert(packageGraphJsonFile.existsSync());
+    final packageGraphJson = await packageGraphJsonFile.readAsString();
     final packageGraph = PackageGraph.fromPackageGraphJsonString(
       packageGraphJson,
     );

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 0.19.0
+version: 0.19.1-wip
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -30,6 +30,5 @@ dev_dependencies:
   dart_flutter_team_lints: ^3.5.1
   data_assets: ^0.19.0 # Used in tests.
   file_testing: ^3.0.2
-  repo_lint_rules:
-    path: ../repo_lint_rules/
+  repo_lint_rules: 0.1.0-wip
   test: ^1.25.15

--- a/pkgs/json_syntax_generator/pubspec.yaml
+++ b/pkgs/json_syntax_generator/pubspec.yaml
@@ -21,6 +21,5 @@ dev_dependencies:
   custom_lint: ^0.7.5
   dart_flutter_team_lints: ^3.5.1
   path: ^1.9.1
-  repo_lint_rules:
-    path: ../repo_lint_rules/
+  repo_lint_rules: 0.1.0-wip
   test: ^1.25.15

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -28,6 +28,5 @@ dev_dependencies:
   collection: ^1.19.1
   custom_lint: ^0.7.5
   dart_flutter_team_lints: ^3.5.1
-  repo_lint_rules:
-    path: ../repo_lint_rules/
+  repo_lint_rules: 0.1.0-wip
   test: ^1.25.15


### PR DESCRIPTION
Both Dart and Flutter using this are on a version of pub that emits the `package_graph.json`.