### PR TITLE
[hooks_runner] Fix analysis in test projects

### DIFF
--- a/pkgs/hooks_runner/test_data/native_add_version_skew/analysis_options.yaml
+++ b/pkgs/hooks_runner/test_data/native_add_version_skew/analysis_options.yaml
@@ -1,0 +1,17 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml
+
+analyzer:
+  errors:
+    todo: ignore
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+
+linter:
+  rules:
+    - dangling_library_doc_comments
+    - prefer_const_declarations
+    - prefer_expression_function_bodies
+    - prefer_final_in_for_each
+    - prefer_final_locals

--- a/pkgs/hooks_runner/test_data/native_add_version_skew/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/native_add_version_skew/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   native_toolchain_c: ^0.12.0
 
 dev_dependencies:
+  dart_flutter_team_lints: ^3.5.1
   ffigen: ^18.0.0
   lints: ^5.1.1
   some_dev_dep:

--- a/pkgs/hooks_runner/test_data/native_add_version_skew_2/analysis_options.yaml
+++ b/pkgs/hooks_runner/test_data/native_add_version_skew_2/analysis_options.yaml
@@ -1,0 +1,17 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml
+
+analyzer:
+  errors:
+    todo: ignore
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+
+linter:
+  rules:
+    - dangling_library_doc_comments
+    - prefer_const_declarations
+    - prefer_expression_function_bodies
+    - prefer_final_in_for_each
+    - prefer_final_locals

--- a/pkgs/hooks_runner/test_data/native_add_version_skew_2/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/native_add_version_skew_2/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   native_toolchain_c: ^0.5.0
 
 dev_dependencies:
+  dart_flutter_team_lints: ^3.5.1
   ffigen: ^18.0.0
   lints: ^5.1.1
   some_dev_dep:


### PR DESCRIPTION
If no analysis options exist in a project the ancestor directories are checked.

However, then the packages referred to in the analysis options must actually be dependencies in the pubspec.

This makes the two projects that are _not_ part of the workspace have valid `analysis_options.yaml`.

These fixes make the following commands succeed:

```
$ dart format --output=none --set-exit-if-changed pkgs/code_assets pkgs/data_assets pkgs/hooks pkgs/hooks_runner 
$ dart analyze --fatal-infos pkgs/code_assets pkgs/data_assets pkgs/hooks pkgs/hooks_runner pkgs/json_syntax_generator pkgs/native_toolchain_c pkgs/repo_lint_rules
```