### PR TITLE
[infra] Enable running tests from root

### DIFF
--- a/pkgs/hooks/test/helpers.dart
+++ b/pkgs/hooks/test/helpers.dart
@@ -53,8 +53,8 @@ Future<void> inTempDir(
 Uri findPackageRoot(String packageName) {
   final script = Platform.script;
   final fileName = script.name;
-  if (fileName.endsWith('_test.dart')) {
-    // We're likely running from source.
+  if (fileName.endsWith('.dart')) {
+    // We're likely running from source in the package somewhere.
     var directory = script.resolve('.');
     while (true) {
       final dirName = directory.name;
@@ -66,11 +66,18 @@ Uri findPackageRoot(String packageName) {
       directory = parent;
     }
   } else if (fileName.endsWith('.dill')) {
+    // Probably from the package root.
     final cwd = Directory.current.uri;
     final dirName = cwd.name;
     if (dirName == packageName) {
       return cwd;
     }
+  }
+  // Or the workspace root.
+  final cwd = Directory.current.uri;
+  final candidate = cwd.resolve('pkgs/$packageName/');
+  if (Directory.fromUri(candidate).existsSync()) {
+    return candidate;
   }
   throw StateError(
     "Could not find package root for package '$packageName'. "

--- a/pkgs/hooks/test/schema/helpers.dart
+++ b/pkgs/hooks/test/schema/helpers.dart
@@ -10,48 +10,7 @@ import 'dart:io';
 import 'package:json_schema/json_schema.dart';
 import 'package:test/test.dart';
 
-/// Test files are run in a variety of ways, find this package root in all.
-///
-/// Test files can be run from source from any working directory. The Dart SDK
-/// `tools/test.py` runs them from the root of the SDK for example.
-///
-/// Test files can be run from dill from the root of package. `package:test`
-/// does this.
-///
-/// https://github.com/dart-lang/test/issues/110
-Uri findPackageRoot(String packageName) {
-  final script = Platform.script;
-  final fileName = script.name;
-  if (fileName.endsWith('.dart')) {
-    // We're likely running from source.
-    var directory = script.resolve('.');
-    while (true) {
-      final dirName = directory.name;
-      if (dirName == packageName) {
-        return directory;
-      }
-      final parent = directory.resolve('..');
-      if (parent == directory) break;
-      directory = parent;
-    }
-  } else if (fileName.endsWith('.dill')) {
-    final cwd = Directory.current.uri;
-    final dirName = cwd.name;
-    if (dirName == packageName) {
-      return cwd;
-    }
-  }
-  throw StateError(
-    "Could not find package root for package '$packageName'. "
-    'Tried finding the package root via Platform.script '
-    "'${Platform.script.toFilePath()}' and Directory.current "
-    "'${Directory.current.uri.toFilePath()}'.",
-  );
-}
-
-extension on Uri {
-  String get name => pathSegments.where((e) => e != '').last;
-}
+export '../helpers.dart' show findPackageRoot;
 
 typedef AllSchemas = Map<Uri, JsonSchema>;
 

--- a/pkgs/hooks_runner/test/helpers.dart
+++ b/pkgs/hooks_runner/test/helpers.dart
@@ -118,8 +118,8 @@ Future<run_process.RunProcessResult> runProcess({
 Uri findPackageRoot(String packageName) {
   final script = Platform.script;
   final fileName = script.name;
-  if (fileName.endsWith('_test.dart')) {
-    // We're likely running from source.
+  if (fileName.endsWith('.dart')) {
+    // We're likely running from source in the package somewhere.
     var directory = script.resolve('.');
     while (true) {
       final dirName = directory.name;
@@ -131,11 +131,18 @@ Uri findPackageRoot(String packageName) {
       directory = parent;
     }
   } else if (fileName.endsWith('.dill')) {
+    // Probably from the package root.
     final cwd = Directory.current.uri;
     final dirName = cwd.name;
     if (dirName == packageName) {
       return cwd;
     }
+  }
+  // Or the workspace root.
+  final cwd = Directory.current.uri;
+  final candidate = cwd.resolve('pkgs/$packageName/');
+  if (Directory.fromUri(candidate).existsSync()) {
+    return candidate;
   }
   throw StateError(
     "Could not find package root for package '$packageName'. "

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -91,8 +91,8 @@ Logger _createTestLogger({List<String>? capturedMessages}) =>
 Uri findPackageRoot(String packageName) {
   final script = Platform.script;
   final fileName = script.name;
-  if (fileName.endsWith('_test.dart')) {
-    // We're likely running from source.
+  if (fileName.endsWith('.dart')) {
+    // We're likely running from source in the package somewhere.
     var directory = script.resolve('.');
     while (true) {
       final dirName = directory.name;
@@ -104,11 +104,18 @@ Uri findPackageRoot(String packageName) {
       directory = parent;
     }
   } else if (fileName.endsWith('.dill')) {
+    // Probably from the package root.
     final cwd = Directory.current.uri;
     final dirName = cwd.name;
     if (dirName == packageName) {
       return cwd;
     }
+  }
+  // Or the workspace root.
+  final cwd = Directory.current.uri;
+  final candidate = cwd.resolve('pkgs/$packageName/');
+  if (Directory.fromUri(candidate).existsSync()) {
+    return candidate;
   }
   throw StateError(
     "Could not find package root for package '$packageName'. "


### PR DESCRIPTION
This enables running tests with `dart test` from the workspace root.

```
$ dart test pkgs/code_assets/test/ pkgs/data_assets/test/ pkgs/hooks/test/ pkgs/hooks_runner/test/ pkgs/native_toolchain_c/test/
```

This is significantly faster than running multiple `dart test` commands in each package in sequence.

(I'll attempt to make the CI use this afterwards.)