### PR TITLE
[infra] Enable running CI checks locally

### DIFF
--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -14,8 +14,10 @@ on:
       - "pkgs/data_assets/**"
       - "pkgs/hooks_runner/**"
       - "pkgs/hooks/**"
+      - "pkgs/json_syntax_generator/**"
       - "pkgs/native_toolchain_c/**"
-      - "tools/**"
+      - "pkgs/repo_lint_rules/**"
+      - "tool/**"
   push:
     branches: [main]
     paths:
@@ -24,8 +26,10 @@ on:
       - "pkgs/data_assets/**"
       - "pkgs/hooks_runner/**"
       - "pkgs/hooks/**"
+      - "pkgs/json_syntax_generator/**"
       - "pkgs/native_toolchain_c/**"
-      - "tools/**"
+      - "pkgs/repo_lint_rules/**"
+      - "tool/**"
   schedule:
     - cron: "0 0 * * 0" # weekly
 
@@ -37,13 +41,12 @@ jobs:
         os: [ubuntu, macos, windows]
         sdk: [dev]
         package:
-          - code_assets
+          # TODO(https://github.com/dart-lang/tools/issues/2083): Remove running coverage per package.
+          - code_assets # currently dubs as place where all packages are run
           - data_assets
           - hooks
           - hooks_runner
           - native_toolchain_c
-        # Breaking changes temporarily break the example run on the Dart SDK until hooks_runner is rolled into the Dart SDK dev build.
-        breaking-change: [false]
 
     runs-on: ${{ matrix.os }}-latest
 
@@ -63,65 +66,18 @@ jobs:
           ndk-version: r27
         if: ${{ matrix.os != 'macos' }}
 
-      - run: dart pub get
-
-      - run: dart pub get -C test_data/native_add_version_skew/
-        if: ${{ matrix.package == 'hooks_runner' }}
-
-      - run: dart pub get -C test_data/native_add_version_skew_2/
-        if: ${{ matrix.package == 'hooks_runner' }}
-
-      - run: dart analyze --fatal-infos
-        # Run on dev to ensure we're not depending on deprecated SDK things.
-
-      - run: dart format --output=none --set-exit-if-changed .
-
       - name: Install native toolchains
         run: sudo apt-get update && sudo apt-get install clang-15 gcc-i686-linux-gnu gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf gcc-riscv64-linux-gnu
         if: ${{ matrix.os == 'ubuntu' }}
 
-      - run: dart test
+      - run: dart pub get
 
-      - run: dart --enable-experiment=native-assets test
-        working-directory: pkgs/${{ matrix.package }}/example/build/native_dynamic_linking/
-        if: ${{ matrix.package == 'hooks' && matrix.sdk == 'dev' && !matrix.breaking-change }}
-      
-      - run: dart --enable-experiment=native-assets test
-        working-directory: pkgs/${{ matrix.package }}/example/build/native_add_app/
-        if: ${{ matrix.package == 'hooks' && matrix.sdk == 'dev' && !matrix.breaking-change }}
+      - name: Run pub get, analysis, formatting, generators, tests, and examples.
+        run: dart tool/ci.dart --pub
+        working-directory: .
+        if: ${{ matrix.package == 'code_assets' }}
 
-      - run: dart --enable-experiment=native-assets run
-        working-directory: pkgs/${{ matrix.package }}/example/build/native_add_app/
-        if: ${{ matrix.package == 'hooks' && matrix.sdk == 'dev' && !matrix.breaking-change }}
-
-      - run: dart --enable-experiment=native-assets build bin/native_add_app.dart
-        working-directory: pkgs/${{ matrix.package }}/example/build/native_add_app/
-        if: ${{ matrix.package == 'hooks' && matrix.sdk == 'dev' && !matrix.breaking-change }}
-
-      - run: ./native_add_app.exe
-        working-directory: pkgs/${{ matrix.package }}/example/build/native_add_app/bin/native_add_app/
-        if: ${{ matrix.package == 'hooks' && matrix.sdk == 'dev' && !matrix.breaking-change }}
-
-      - run: dart --enable-experiment=native-assets test
-        working-directory: pkgs/${{ matrix.package }}/example/build/use_dart_api/
-        if: ${{ matrix.package == 'hooks' && matrix.sdk == 'dev' && !matrix.breaking-change }}
-      
-      - run: dart --enable-experiment=native-assets test
-        working-directory: pkgs/${{ matrix.package }}/example/build/download_asset/
-        if: ${{ matrix.package == 'hooks' && matrix.sdk == 'dev' && !matrix.breaking-change }}
-      
-      - run: dart --enable-experiment=native-assets test
-        working-directory: pkgs/${{ matrix.package }}/example/build/system_library/
-        if: ${{ matrix.package == 'hooks' && matrix.sdk == 'dev' && !matrix.breaking-change }}
-
-      - run: |
-          dart tool/generate_schemas.dart
-          dart tool/generate_syntax.dart
-          dart tool/normalize.dart
-          git diff --exit-code
-        working-directory: pkgs/${{ matrix.package }}
-        if: ${{ matrix.package == 'hooks' && matrix.sdk == 'dev' }}
-
+      # TODO(https://github.com/dart-lang/tools/issues/2083): Remove running coverage per package.
       - name: Install coverage
         run: dart pub global activate coverage
 

--- a/pkgs/code_assets/pubspec.yaml
+++ b/pkgs/code_assets/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.19.0
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/code_assets
 
-topics: 
+topics:
   - assets
   - ffi
   - hooks
@@ -27,5 +27,6 @@ dev_dependencies:
   custom_lint: ^0.7.5
   dart_flutter_team_lints: ^3.5.1
   json_schema: ^5.2.0
-  repo_lint_rules: 0.1.0-wip
+  repo_lint_rules:
+    path: ../repo_lint_rules/
   test: ^1.25.15

--- a/pkgs/data_assets/pubspec.yaml
+++ b/pkgs/data_assets/pubspec.yaml
@@ -23,5 +23,6 @@ dev_dependencies:
   custom_lint: ^0.7.5
   dart_flutter_team_lints: ^3.5.1
   json_schema: ^5.2.0
-  repo_lint_rules: 0.1.0-wip
+  repo_lint_rules:
+    path: ../repo_lint_rules/
   test: ^1.25.15

--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -39,5 +39,6 @@ dev_dependencies:
   json_syntax_generator:
     path: ../json_syntax_generator/
   path: ^1.9.1
-  repo_lint_rules: 0.1.0-wip
+  repo_lint_rules:
+    path: ../repo_lint_rules/
   test: ^1.25.15

--- a/pkgs/hooks/tool/generate_schemas.dart
+++ b/pkgs/hooks/tool/generate_schemas.dart
@@ -197,7 +197,9 @@ void generateSharedDefinitions(Counts counts) {
         oldContent = file.readAsStringSync();
       }
 
-      if (jsonString != oldContent) {
+      final newContentNormalized = jsonString.replaceAll('\r\n', '\n');
+      final oldContentNormalized = oldContent.replaceAll('\r\n', '\n');
+      if (newContentNormalized != oldContentNormalized) {
         file.writeAsStringSync(jsonString);
         print('Generated $schemaUri (content changed)');
         counts.changed++;
@@ -244,7 +246,9 @@ void generateEntryPoints(Counts counts) {
             oldContent = file.readAsStringSync();
           }
 
-          if (jsonString != oldContent) {
+          final newContentNormalized = jsonString.replaceAll('\r\n', '\n');
+          final oldContentNormalized = oldContent.replaceAll('\r\n', '\n');
+          if (newContentNormalized != oldContentNormalized) {
             file.writeAsStringSync(jsonString);
             print('Generated $schemaUri (content changed)');
             counts.changed++;

--- a/pkgs/hooks/tool/generate_syntax.dart
+++ b/pkgs/hooks/tool/generate_syntax.dart
@@ -113,7 +113,9 @@ void main(List<String> args) {
 
     final newOutputContent = outputFile.readAsStringSync();
 
-    if (newOutputContent != oldOutputContent) {
+    final newContentNormalized = newOutputContent.replaceAll('\r\n', '\n');
+    final oldContentNormalized = oldOutputContent.replaceAll('\r\n', '\n');
+    if (newContentNormalized != oldContentNormalized) {
       print('Generated $outputUri');
       changedCount += 1;
     }

--- a/pkgs/hooks/tool/normalize.dart
+++ b/pkgs/hooks/tool/normalize.dart
@@ -81,7 +81,9 @@ bool processFile(File file) {
   final sortedJson = encoder.convert(sorted); // Already has no trailing newline
   final newContents = '$sortedJson\n';
 
-  if (contents == newContents) {
+  final newContentNormalized = newContents.replaceAll('\r\n', '\n');
+  final oldContentNormalized = contents.replaceAll('\r\n', '\n');
+  if (newContentNormalized == oldContentNormalized) {
     return false;
   }
 

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -30,5 +30,6 @@ dev_dependencies:
   dart_flutter_team_lints: ^3.5.1
   data_assets: ^0.19.0 # Used in tests.
   file_testing: ^3.0.2
-  repo_lint_rules: 0.1.0-wip
+  repo_lint_rules:
+    path: ../repo_lint_rules/
   test: ^1.25.15

--- a/pkgs/hooks_runner/test/helpers.dart
+++ b/pkgs/hooks_runner/test/helpers.dart
@@ -137,6 +137,11 @@ Uri findPackageRoot(String packageName) {
     if (dirName == packageName) {
       return cwd;
     }
+    // Or the workspace root.
+    final candidate = cwd.resolve('pkgs/$packageName/');
+    if (Directory.fromUri(candidate).existsSync()) {
+      return candidate;
+    }
   }
   // Or the workspace root.
   final cwd = Directory.current.uri;

--- a/pkgs/json_syntax_generator/pubspec.yaml
+++ b/pkgs/json_syntax_generator/pubspec.yaml
@@ -21,5 +21,6 @@ dev_dependencies:
   custom_lint: ^0.7.5
   dart_flutter_team_lints: ^3.5.1
   path: ^1.9.1
-  repo_lint_rules: 0.1.0-wip
+  repo_lint_rules:
+    path: ../repo_lint_rules/
   test: ^1.25.15

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -28,5 +28,6 @@ dev_dependencies:
   collection: ^1.19.1
   custom_lint: ^0.7.5
   dart_flutter_team_lints: ^3.5.1
-  repo_lint_rules: 0.1.0-wip
+  repo_lint_rules:
+    path: ../repo_lint_rules/
   test: ^1.25.15

--- a/tool/ci.dart
+++ b/tool/ci.dart
@@ -1,0 +1,214 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:yaml/yaml.dart';
+
+void main(List<String> arguments) async {
+  final parser = makeArgParser();
+
+  final ArgResults argResults = parser.parse(arguments);
+
+  final packages = loadPackagesFromPubspec();
+
+  if (argResults['help'] as bool) {
+    print('A command-line tool for running CI checks on the CI or locally.');
+    print('');
+    print('Applies to the following packages:');
+    for (final package in packages) {
+      print('  - $package');
+    }
+    print('');
+    print('Usage:');
+    print(parser.usage);
+    return;
+  }
+
+  if (argResults['pub'] as bool) {
+    const paths = [
+      '.',
+      'pkgs/hooks_runner/test_data/native_add_version_skew/',
+      'pkgs/hooks_runner/test_data/native_add_version_skew_2/',
+    ];
+    for (final path in paths) {
+      _runProcess('dart', ['pub', 'get', '--directory', path]);
+    }
+  }
+
+  if (argResults['analyze'] as bool) {
+    _runProcess('dart', ['analyze', '--fatal-infos', ...packages]);
+  }
+
+  if (argResults['format'] as bool) {
+    _runProcess('dart', [
+      'format',
+      '--output=none',
+      '--set-exit-if-changed',
+      ...packages,
+    ]);
+  }
+
+  if (argResults['generate'] as bool) {
+    const generators = [
+      'pkgs/hooks/tool/generate_schemas.dart',
+      'pkgs/hooks/tool/generate_syntax.dart',
+      'pkgs/hooks/tool/normalize.dart',
+    ];
+    for (final generator in generators) {
+      _runProcess('dart', [generator, '--set-exit-if-changed']);
+    }
+  }
+
+  if (argResults['test'] as bool) {
+    final testUris = <String>[];
+    for (final package in packages) {
+      final packageTestDirectory = Directory.fromUri(
+        repositoryRoot.resolve(package /*might end without slash*/),
+      ).uri.resolve('test/');
+      if (Directory.fromUri(packageTestDirectory).existsSync()) {
+        final relativePath = packageTestDirectory.toFilePath().replaceAll(
+          repositoryRoot.toFilePath(),
+          '',
+        );
+        testUris.add(relativePath);
+      }
+    }
+    _runProcess('dart', ['test', ...testUris]);
+  }
+
+  if (argResults['example'] as bool) {
+    const examplesWithTest = [
+      'native_dynamic_linking',
+      'native_add_app',
+      'use_dart_api',
+      'download_asset',
+      'system_library',
+    ];
+    for (final exampleWithTest in examplesWithTest) {
+      _runProcess(
+        workingDirectory: repositoryRoot.resolve(
+          'pkgs/hooks/example/build/$exampleWithTest/',
+        ),
+        'dart',
+        ['--enable-experiment=native-assets', 'test'],
+      );
+    }
+
+    _runProcess(
+      workingDirectory: repositoryRoot.resolve(
+        'pkgs/hooks/example/build/native_add_app/',
+      ),
+      'dart',
+      ['--enable-experiment=native-assets', 'run'],
+    );
+    _runProcess(
+      workingDirectory: repositoryRoot.resolve(
+        'pkgs/hooks/example/build/native_add_app/',
+      ),
+      'dart',
+      ['--enable-experiment=native-assets', 'build', 'bin/native_add_app.dart'],
+    );
+    _runProcess(
+      repositoryRoot
+          .resolve(
+            'pkgs/hooks/example/build/native_add_app/bin/native_add_app/native_add_app.exe',
+          )
+          .toFilePath(),
+      [],
+    );
+  }
+}
+
+ArgParser makeArgParser() {
+  final parser =
+      ArgParser()
+        ..addFlag(
+          'help',
+          abbr: 'h',
+          negatable: false,
+          help: 'Prints this help message.',
+        )
+        ..addFlag(
+          'analyze',
+          defaultsTo: true,
+          help: 'Run `dart analyze` on the packages.',
+        )
+        ..addFlag(
+          'example',
+          defaultsTo: true,
+          help: 'Run tests and executables for examples.',
+        )
+        ..addFlag(
+          'format',
+          defaultsTo: true,
+          help: 'Run `dart format` on the packages.',
+        )
+        ..addFlag(
+          'generate',
+          defaultsTo: true,
+          help: 'Run code generation scripts.',
+        )
+        ..addFlag(
+          'pub',
+          defaultsTo: false,
+          help: 'Run `dart pub get` on the root and non-workspace packages.',
+        )
+        ..addFlag(
+          'test',
+          defaultsTo: true,
+          help: 'Run `dart test` on the packages.',
+        );
+  return parser;
+}
+
+final Uri repositoryRoot = Platform.script.resolve('../');
+
+/// Load the root packages from the workspace. Omit nested test/example packages.
+List<String> loadPackagesFromPubspec() {
+  final pubspecYaml = loadYaml(
+    File.fromUri(repositoryRoot.resolve('pubspec.yaml')).readAsStringSync(),
+  );
+  final workspace = (pubspecYaml['workspace'] as List).cast<String>();
+  final packages =
+      workspace
+          .where(
+            (package) =>
+                !package.contains('test_data') && !package.contains('example'),
+          )
+          .toList();
+  return packages;
+}
+
+void _runProcess(
+  String executable,
+  List<String> arguments, {
+  Uri? workingDirectory,
+}) {
+  var commandString = '$executable ${arguments.join(' ')}';
+  if (workingDirectory != null) {
+    commandString = 'cd ${workingDirectory.toFilePath()} && $commandString';
+  }
+  print('+$commandString');
+  final result = Process.runSync(
+    executable,
+    arguments,
+    workingDirectory: workingDirectory?.toFilePath(),
+    stderrEncoding: utf8, // Make ✓ from `dart test` show up on GitHub UI.
+    stdoutEncoding: utf8,
+  );
+
+  if (result.stdout.toString().isNotEmpty) {
+    print(result.stdout);
+  }
+  if (result.stderr.toString().isNotEmpty) {
+    print(result.stderr);
+  }
+  if (result.exitCode != 0) {
+    print('+$commandString failed with exitCode ${result.exitCode}.');
+    exit(result.exitCode);
+  }
+}


### PR DESCRIPTION
Move a bunch of CI checks into `tool/ci.dart` to enable running them locally.

Currently missing to run locally:

* Health checks: `dart pub global run firehose:health` cannot run locally at the moment due to a missing `GITHUB_TOKEN`.
* Coverage: We need to be able to get coverage and upload coverage for multiple packages at the same time (https://github.com/dart-lang/tools/issues/2083).

Other fixes:

* `dart analyze` with custom lints currently requires to use path dependencies in pub workspaces (https://github.com/invertase/dart_custom_lint/issues/329).
* Ignore line endings when checking diffs for code generators.