### PR TITLE
[hooks_runner] Refactor failure handling

### DIFF
--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 0.19.1-wip
+## 0.20.0-wip
 
+- **Breaking change** Refactored error handling to use a `Result` type for more
+  explicit success/failure states.
 - Remove `package_graph.json` fallback.
 
 ## 0.19.0

--- a/pkgs/hooks_runner/lib/hooks_runner.dart
+++ b/pkgs/hooks_runner/lib/hooks_runner.dart
@@ -8,6 +8,8 @@ export 'src/build_runner/build_runner.dart'
         LinkInputCreator,
         NativeAssetsBuildRunner,
         UserDefines;
+export 'src/build_runner/failure.dart' show HooksRunnerFailure;
+export 'src/build_runner/result.dart' show Failure, Result, Success;
 export 'src/model/build_result.dart' show BuildResult;
 export 'src/model/kernel_assets.dart';
 export 'src/model/link_result.dart' show LinkResult;

--- a/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
@@ -21,6 +21,8 @@ import '../model/link_result.dart';
 import '../package_layout/package_layout.dart';
 import '../utils/run_process.dart';
 import 'build_planner.dart';
+import 'failure.dart';
+import 'result.dart';
 
 typedef InputCreator = HookInputBuilder Function();
 
@@ -72,7 +74,7 @@ class NativeAssetsBuildRunner {
     return packagesWithHook.map((e) => e.name).toList();
   }
 
-  Future<HookResult?> _checkUserDefines(
+  Future<Result<HookResult, HooksRunnerFailure>> _checkUserDefines(
     LoadedUserDefines? loadedUserDefines,
   ) async {
     if (loadedUserDefines?.pubspecErrors.isNotEmpty ?? false) {
@@ -80,13 +82,15 @@ class NativeAssetsBuildRunner {
       for (final error in loadedUserDefines!.pubspecErrors) {
         logger.severe(error);
       }
-      return null;
+      return const Failure(HooksRunnerFailure.projectConfig);
     }
-    return HookResult(
-      dependencies: switch (userDefines?.workspacePubspec) {
-        null => [],
-        final pubspec => [pubspec],
-      },
+    return Success(
+      HookResult(
+        dependencies: switch (userDefines?.workspacePubspec) {
+          null => [],
+          final pubspec => [pubspec],
+        },
+      ),
     );
   }
 
@@ -99,22 +103,22 @@ class NativeAssetsBuildRunner {
   ///
   /// The base protocol can be extended with [extensions]. See
   /// [ProtocolExtension] for more documentation.
-  Future<BuildResult?> build({
+  Future<Result<BuildResult, HooksRunnerFailure>> build({
     required List<ProtocolExtension> extensions,
     required bool linkingEnabled,
   }) async {
     final loadedUserDefines = await _loadedUserDefines;
     final hookResultUserDefines = await _checkUserDefines(loadedUserDefines);
-    if (hookResultUserDefines == null) {
-      return null;
+    if (hookResultUserDefines.isFailure) {
+      return hookResultUserDefines;
     }
-    var hookResult = hookResultUserDefines;
+    var hookResult = hookResultUserDefines.success;
 
-    final (buildPlan, packageGraph) = await _makePlan(
-      hook: Hook.build,
-      buildResult: null,
-    );
-    if (buildPlan == null) return null;
+    final planResult = await _makePlan(hook: Hook.build, buildResult: null);
+    if (planResult.isFailure) {
+      return planResult.asFailure;
+    }
+    final (buildPlan, packageGraph) = planResult.success;
 
     /// Key is packageName.
     final globalAssetsForBuild = <String, List<EncodedAsset>>{};
@@ -153,10 +157,8 @@ class NativeAssetsBuildRunner {
         for (final e in extensions) ...await e.validateBuildInput(input),
       ];
       if (errors.isNotEmpty) {
-        return _printErrors(
-          'Build input for ${package.name} contains errors',
-          errors,
-        );
+        _printErrors('Build input for ${package.name} contains errors', errors);
+        return const Failure(HooksRunnerFailure.internal);
       }
 
       final result = await _runHookForPackageCached(
@@ -173,8 +175,10 @@ class NativeAssetsBuildRunner {
         buildDirUri,
         outDirUri,
       );
-      if (result == null) return null;
-      final (hookOutput, hookDeps) = result;
+      if (result.isFailure) {
+        return result.asFailure;
+      }
+      final (hookOutput, hookDeps) = result.success;
       hookResult = hookResult.copyAdd(hookOutput, hookDeps);
       globalAssetsForBuild[package.name] =
           (hookOutput as BuildOutput).assets.encodedAssetsForBuild;
@@ -183,16 +187,16 @@ class NativeAssetsBuildRunner {
     // We only perform application wide validation in the final result of
     // building all assets (i.e. in the build step if linking is not enabled or
     // in the link step if linking is enableD).
-    if (linkingEnabled) return hookResult;
+    if (linkingEnabled) return Success(hookResult);
 
     final errors = [
       for (final e in extensions)
         ...await e.validateApplicationAssets(hookResult.encodedAssets),
     ];
-    if (errors.isEmpty) return hookResult;
+    if (errors.isEmpty) return Success(hookResult);
 
     _printErrors('Application asset verification failed', errors);
-    return null;
+    return const Failure(HooksRunnerFailure.hookRun);
   }
 
   /// This method is invoked by launchers such as dartdev (for `dart run`) and
@@ -204,23 +208,24 @@ class NativeAssetsBuildRunner {
   ///
   /// The base protocol can be extended with [extensions]. See
   /// [ProtocolExtension] for more documentation.
-  Future<LinkResult?> link({
+  Future<Result<LinkResult, HooksRunnerFailure>> link({
     required List<ProtocolExtension> extensions,
     Uri? resourceIdentifiers,
     required BuildResult buildResult,
   }) async {
     final loadedUserDefines = await _loadedUserDefines;
     final hookResultUserDefines = await _checkUserDefines(loadedUserDefines);
-    if (hookResultUserDefines == null) {
-      return null;
+    if (hookResultUserDefines.isFailure) {
+      return hookResultUserDefines;
     }
-    var linkResult = hookResultUserDefines;
+    var linkResult = hookResultUserDefines.success;
 
-    final (buildPlan, packageGraph) = await _makePlan(
+    final planResult = await _makePlan(
       hook: Hook.link,
       buildResult: buildResult,
     );
-    if (buildPlan == null) return null;
+    if (planResult.isFailure) return planResult.asFailure;
+    final (buildPlan, packageGraph) = planResult.success;
 
     for (final package in buildPlan) {
       final inputBuilder = LinkInputBuilder();
@@ -260,10 +265,8 @@ class NativeAssetsBuildRunner {
       ];
       if (errors.isNotEmpty) {
         print(input.assets.encodedAssets);
-        return _printErrors(
-          'Link input for ${package.name} contains errors',
-          errors,
-        );
+        _printErrors('Link input for ${package.name} contains errors', errors);
+        return const Failure(HooksRunnerFailure.internal);
       }
 
       final result = await _runHookForPackageCached(
@@ -280,8 +283,8 @@ class NativeAssetsBuildRunner {
         buildDirUri,
         outDirUri,
       );
-      if (result == null) return null;
-      final (hookOutput, hookDeps) = result;
+      if (result.isFailure) return result.asFailure;
+      final (hookOutput, hookDeps) = result.success;
       linkResult = linkResult.copyAdd(hookOutput, hookDeps);
     }
 
@@ -292,19 +295,18 @@ class NativeAssetsBuildRunner {
           ...linkResult.encodedAssets,
         ]),
     ];
-    if (errors.isEmpty) return linkResult;
+    if (errors.isEmpty) return Success(linkResult);
 
     _printErrors('Application asset verification failed', errors);
-    return null;
+    return const Failure(HooksRunnerFailure.hookRun);
   }
 
-  Null _printErrors(String message, ValidationErrors errors) {
+  void _printErrors(String message, ValidationErrors errors) {
     assert(errors.isNotEmpty);
     logger.severe(message);
     for (final error in errors) {
       logger.severe('- $error');
     }
-    return null;
   }
 
   Future<(Uri, Uri, Uri)> _setupDirectories(
@@ -334,7 +336,8 @@ class NativeAssetsBuildRunner {
     return (buildDirUri, outDirUri, outDirSharedUri);
   }
 
-  Future<(HookOutput, List<Uri>)?> _runHookForPackageCached(
+  Future<Result<(HookOutput, List<Uri>), HooksRunnerFailure>>
+  _runHookForPackageCached(
     Hook hook,
     HookInput input,
     _HookValidator validator,
@@ -355,10 +358,8 @@ class NativeAssetsBuildRunner {
         buildDirUri,
         input.packageRoot.resolve('hook/${hook.scriptName}'),
       );
-      if (hookCompileResult == null) {
-        return null;
-      }
-      final (hookKernelFile, hookHashes) = hookCompileResult;
+      if (hookCompileResult.isFailure) return hookCompileResult.asFailure;
+      final (hookKernelFile, hookHashes) = hookCompileResult.success;
 
       final buildOutputFile = _fileSystem.file(input.outputFile);
 
@@ -371,19 +372,15 @@ class NativeAssetsBuildRunner {
       );
       final lastModifiedCutoffTime = DateTime.now();
       if ((buildOutputFile.existsSync()) && await dependenciesHashes.exists()) {
-        late final HookOutput output;
-        try {
-          output = _readHookOutputFromUri(hook, buildOutputFile);
-        } on FormatException catch (e) {
-          logger.severe('''
-Building assets for package:${input.packageName} failed.
-${input.outputFile.toFilePath()} contained a format error.
-
-Contents: ${buildOutputFile.readAsStringSync()}.
-${e.message}
-        ''');
-          return null;
+        final outputResult = _readHookOutputFromUri(
+          hook,
+          buildOutputFile,
+          input.packageName,
+        );
+        if (outputResult.isFailure) {
+          return const Failure(HooksRunnerFailure.hookRun);
         }
+        final output = outputResult.success;
 
         final outdatedDependency = await dependenciesHashes
             .findOutdatedDependency(hookEnvironment);
@@ -395,7 +392,7 @@ ${e.message}
           );
           // All build flags go into [outDir]. Therefore we do not have to
           // check here whether the input is equal.
-          return (output, hookHashes.fileSystemEntities);
+          return Success((output, hookHashes.fileSystemEntities));
         }
         logger.info(
           'Rerunning ${hook.name} for ${input.packageName}'
@@ -413,15 +410,16 @@ ${e.message}
         buildDirUri,
         outputDirectory,
       );
-      if (result == null) {
+      if (result.isFailure) {
         if (await dependenciesHashes.exists()) {
           await dependenciesHashes.delete();
         }
-        return null;
+        return result.asFailure;
       } else {
+        final success = result.success;
         final modifiedDuringBuild = await dependenciesHashes.hashDependencies(
           [
-            ...result.dependencies,
+            ...success.dependencies,
             // Also depend on the compiled hook. Don't depend on the sources,
             // if only whitespace changes, we don't need to rerun the hook.
             hookKernelFile.uri,
@@ -432,8 +430,8 @@ ${e.message}
         if (modifiedDuringBuild != null) {
           logger.severe('File modified during build. Build must be rerun.');
         }
+        return Success((success, hookHashes.fileSystemEntities));
       }
-      return (result, hookHashes.fileSystemEntities);
     },
   );
 
@@ -455,7 +453,7 @@ ${e.message}
     'WINDIR', // Needed for CMake.
   };
 
-  Future<HookOutput?> _runHookForPackage(
+  Future<Result<HookOutput, HooksRunnerFailure>> _runHookForPackage(
     Hook hook,
     HookInput input,
     _HookValidator validator,
@@ -518,10 +516,18 @@ ${e.message}
   ${result.stdout}
           ''');
         deleteOutputIfExists = true;
-        return null;
+        return const Failure(HooksRunnerFailure.hookRun);
       }
 
-      final output = _readHookOutputFromUri(hook, hookOutputFile);
+      final outputResult = _readHookOutputFromUri(
+        hook,
+        hookOutputFile,
+        input.packageName,
+      );
+      if (outputResult.isFailure) {
+        return outputResult.asFailure;
+      }
+      final output = outputResult.success;
       final errors = await _validate(input, output, validator);
       if (errors.isNotEmpty) {
         _printErrors(
@@ -529,18 +535,9 @@ ${e.message}
           errors,
         );
         deleteOutputIfExists = true;
-        return null;
+        return const Failure(HooksRunnerFailure.hookRun);
       }
-      return output;
-    } on FormatException catch (e) {
-      logger.severe('''
-Building assets for package:${input.packageName} failed.
-${input.outputFile.toFilePath()} contained a format error.
-
-Contents: ${hookOutputFile.readAsStringSync()}.
-${e.message}
-        ''');
-      return null;
+      return Success(output);
     } finally {
       if (deleteOutputIfExists) {
         if (await hookOutputFile.exists()) {
@@ -594,7 +591,12 @@ ${e.message}
   ///
   /// TODO(https://github.com/dart-lang/native/issues/1578): Compile only once
   /// instead of per input. This requires more locking.
-  Future<(File kernelFile, DependenciesHashFile cacheFile)?>
+  Future<
+    Result<
+      (File kernelFile, DependenciesHashFile cacheFile),
+      HooksRunnerFailure
+    >
+  >
   _compileHookForPackageCached(
     String packageName,
     Uri buildDirUri,
@@ -631,17 +633,17 @@ ${e.message}
     }
 
     if (!mustCompile) {
-      return (kernelFile, dependenciesHashes);
+      return Success((kernelFile, dependenciesHashes));
     }
 
-    final success = await _compileHookForPackage(
+    final compileResult = await _compileHookForPackage(
       packageName,
       scriptUri,
       kernelFile,
       depFile,
     );
-    if (!success) {
-      return null;
+    if (compileResult.isFailure) {
+      return compileResult.asFailure;
     }
 
     final dartSources = await _readDepFile(depFile);
@@ -659,8 +661,7 @@ ${e.message}
     if (modifiedDuringBuild != null) {
       logger.severe('File modified during build. Build must be rerun.');
     }
-
-    return (kernelFile, dependenciesHashes);
+    return Success((kernelFile, dependenciesHashes));
   }
 
   Future<void> _makeHashablePackageConfig(Uri uri) async {
@@ -674,7 +675,7 @@ ${e.message}
     await _fileSystem.file(uri).writeAsString(contentsSanitized);
   }
 
-  Future<bool> _compileHookForPackage(
+  Future<Result<void, HooksRunnerFailure>> _compileHookForPackage(
     String packageName,
     Uri scriptUri,
     File kernelFile,
@@ -697,7 +698,6 @@ ${e.message}
       logger: logger,
       includeParentEnvironment: true,
     );
-    var success = true;
     if (compileResult.exitCode != 0) {
       final printWorkingDir =
           workingDirectory != _fileSystem.currentDirectory.uri;
@@ -717,15 +717,15 @@ ${compileResult.stderr}
 stdout:
 ${compileResult.stdout}
         ''');
-      success = false;
       if (await depFile.exists()) {
         await depFile.delete();
       }
       if (await kernelFile.exists()) {
         await kernelFile.delete();
       }
+      return const Failure(HooksRunnerFailure.hookRun);
     }
-    return success;
+    return const Success(null);
   }
 
   /// Returns only the assets output as assetForBuild by the packages that are
@@ -794,22 +794,26 @@ ${compileResult.stdout}
     return planner;
   }();
 
-  Future<(List<Package>? plan, PackageGraph? dependencyGraph)> _makePlan({
+  Future<
+    Result<(BuildPlan plan, PackageGraph? dependencyGraph), HooksRunnerFailure>
+  >
+  _makePlan({
     required Hook hook,
     // TODO(dacoharkes): How to share these two? Make them extend each other?
     BuildResult? buildResult,
   }) async {
-    final List<Package> buildPlan;
-    final PackageGraph? packageGraph;
     switch (hook) {
       case Hook.build:
         final planner = await _planner;
-        final plan = await planner.makeBuildHookPlan();
-        return (plan, planner.packageGraph);
+        final planResult = await planner.makeBuildHookPlan();
+        if (planResult.isFailure) {
+          return planResult.asFailure;
+        }
+        return Success((planResult.success, planner.packageGraph));
       case Hook.link:
         // Link hooks are not run in any particular order.
         // Link hooks are skipped if no assets for linking are provided.
-        buildPlan = [];
+        final buildPlan = <Package>[];
         final skipped = <String>[];
         final encodedAssetsForLinking = buildResult!.encodedAssetsForLinking;
         final planner = await _planner;
@@ -827,19 +831,34 @@ ${compileResult.stdout}
             ' due to no assets provided to link for these link hooks.',
           );
         }
-        packageGraph = null;
+        return Success((buildPlan, null));
     }
-    return (buildPlan, packageGraph);
   }
 
-  HookOutput _readHookOutputFromUri(Hook hook, File hookOutputFile) {
+  Result<HookOutput, HooksRunnerFailure> _readHookOutputFromUri(
+    Hook hook,
+    File hookOutputFile,
+    String packageName,
+  ) {
     final file = hookOutputFile;
     final fileContents = file.readAsStringSync();
     logger.info('output.json contents:\n$fileContents');
-    final hookOutputJson = jsonDecode(fileContents) as Map<String, Object?>;
-    return hook == Hook.build
-        ? BuildOutput(hookOutputJson)
-        : LinkOutput(hookOutputJson);
+    try {
+      final hookOutputJson = jsonDecode(fileContents) as Map<String, Object?>;
+      final output = switch (hook) {
+        Hook.build => BuildOutput(hookOutputJson),
+        Hook.link => LinkOutput(hookOutputJson),
+      };
+      return Success(output);
+    } on FormatException catch (e) {
+      logger.severe('''
+Building assets for package:$packageName failed.
+${hookOutputFile.uri.toFilePath()} contained a format error.
+
+Contents: $fileContents.
+${e.message}''');
+      return const Failure(HooksRunnerFailure.hookRun);
+    }
   }
 
   /// Returns a list of errors for [_readHooksUserDefinesFromPubspec].

--- a/pkgs/hooks_runner/lib/src/build_runner/failure.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/failure.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'build_runner.dart';
+
+/// A failure that occurred during a [NativeAssetsBuildRunner] `build` or
+/// `link`.
+enum HooksRunnerFailure {
+  /// Issues related to the execution of a build/link hook or its output.
+  ///
+  /// Typically fixed by the hook author or end-user adjusting
+  /// dependencies/assets.
+  hookRun,
+
+  /// Issues related to the Dart project's configuration.
+  ///
+  /// Typically fixed by the end-user in the `pubspec.yaml`.
+  projectConfig,
+
+  /// Internal errors within the build runner itself.
+  ///
+  /// These might indicate a bug in the Dart/Flutter SDK.
+  internal,
+}

--- a/pkgs/hooks_runner/lib/src/build_runner/result.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/result.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// The outcome of an operation that can either succeed with a value of type [T]
+/// or fail with an error of type [E].
+///
+/// This is a sealed class, meaning its implementations are fixed: [Success] and
+/// [Failure].
+///
+/// Modeled after the Rust `Result` type.
+sealed class Result<T, E> {
+  /// Private constructor to prevent direct instantiation.
+  const Result._();
+
+  /// Returns `true` if this is a [Success] instance.
+  bool get isSuccess => this is Success<T>;
+
+  /// Returns `true` if this is a [Failure] instance.
+  bool get isFailure => this is Failure<E>;
+
+  /// Returns this result as a [Success] instance.
+  ///
+  /// Throws if this is a [Failure].
+  Success<T> get asSuccess;
+
+  /// Returns this result as a [Failure] instance.
+  ///
+  /// Throws if this is a [Success].
+  Failure<E> get asFailure;
+
+  /// The success value if this is a [Success].
+  ///
+  /// Throws if this is a [Failure].
+  T get success;
+
+  /// The failure value if this is a [Failure].
+  ///
+  /// Throws if this is a [Success].
+  E get failure;
+}
+
+/// The successful outcome of an operation, containing the [value].
+class Success<S> extends Result<S, Never> {
+  /// The value of this [Success].
+  final S value;
+
+  /// Creates a [Success] instance with the given [value].
+  const Success(this.value) : super._();
+
+  @override
+  S get success => value;
+
+  @override
+  Never get failure => throw StateError('Is not a Failure.');
+
+  @override
+  Success<S> get asSuccess => this;
+
+  @override
+  Failure<Never> get asFailure => throw StateError('Is not a Failure.');
+}
+
+/// The failed outcome of an operation, containing the error [value].
+class Failure<E> extends Result<Never, E> {
+  /// The value of this [Failure].
+  final E value;
+
+  /// Creates a [Failure] instance with the given error [value].
+  const Failure(this.value) : super._();
+
+  @override
+  Never get success => throw StateError('Is not a Success.');
+
+  @override
+  E get failure => value;
+
+  @override
+  Success<Never> get asSuccess => throw StateError('Is not a Success.');
+
+  @override
+  Failure<E> get asFailure => this;
+}

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 0.19.1-wip
+version: 0.20.0-wip
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 

--- a/pkgs/hooks_runner/test/build_runner/build_planner_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/build_planner_test.dart
@@ -37,8 +37,8 @@ void main() async {
             fileSystem: const LocalFileSystem(),
           );
       final buildPlan = await nativeAssetsBuildPlanner.makeBuildHookPlan();
-      expect(buildPlan!.length, 1);
-      expect(buildPlan.single.name, 'native_add');
+      expect(buildPlan.success.length, 1);
+      expect(buildPlan.success.single.name, 'native_add');
     });
   });
 
@@ -68,7 +68,7 @@ void main() async {
               fileSystem: const LocalFileSystem(),
             );
         final buildPlan = await nativeAssetsBuildPlanner.makeBuildHookPlan();
-        expect(buildPlan!.length, 0);
+        expect(buildPlan.success.length, 0);
       });
     });
   }

--- a/pkgs/hooks_runner/test/build_runner/concurrency_shared_test_helper.dart
+++ b/pkgs/hooks_runner/test/build_runner/concurrency_shared_test_helper.dart
@@ -51,7 +51,7 @@ void main(List<String> args) async {
     ],
     linkingEnabled: false,
   );
-  if (result == null) {
+  if (result.isFailure) {
     throw Error();
   }
   print('done');

--- a/pkgs/hooks_runner/test/build_runner/concurrency_test_helper.dart
+++ b/pkgs/hooks_runner/test/build_runner/concurrency_test_helper.dart
@@ -53,7 +53,7 @@ void main(List<String> args) async {
     ],
     linkingEnabled: false,
   );
-  if (result == null) {
+  if (result.isFailure) {
     throw Error();
   }
   print('done');

--- a/pkgs/hooks_runner/test/build_runner/helpers.dart
+++ b/pkgs/hooks_runner/test/build_runner/helpers.dart
@@ -127,15 +127,16 @@ Future<BuildResult?> build(
       linkingEnabled: linkingEnabled,
     );
 
-    if (result != null) {
-      expect(await result.encodedAssets.allExist(), true);
-      for (final encodedAssetsForLinking
-          in result.encodedAssetsForLinking.values) {
-        expect(await encodedAssetsForLinking.allExist(), true);
-      }
+    if (result.isFailure) return null;
+    final buildResult = result.success;
+
+    expect(await buildResult.encodedAssets.allExist(), true);
+    for (final encodedAssetsForLinking
+        in buildResult.encodedAssetsForLinking.values) {
+      expect(await encodedAssetsForLinking.allExist(), true);
     }
 
-    return result;
+    return buildResult;
   });
 }
 
@@ -203,11 +204,11 @@ Future<LinkResult?> link(
       resourceIdentifiers: resourceIdentifiers,
     );
 
-    if (result != null) {
-      expect(await result.encodedAssets.allExist(), true);
-    }
+    if (result.isFailure) return null;
 
-    return result;
+    expect(await result.success.encodedAssets.allExist(), true);
+
+    return result.success;
   });
 }
 
@@ -273,13 +274,11 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
     linkingEnabled: true,
   );
 
-  if (buildResult == null) {
-    return (null, null);
-  }
+  if (buildResult.isFailure) return (null, null);
 
-  expect(await buildResult.encodedAssets.allExist(), true);
+  expect(await buildResult.success.encodedAssets.allExist(), true);
   for (final encodedAssetsForLinking
-      in buildResult.encodedAssetsForLinking.values) {
+      in buildResult.success.encodedAssetsForLinking.values) {
     expect(await encodedAssetsForLinking.allExist(), true);
   }
 
@@ -311,15 +310,15 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
         ),
       if (buildAssetTypes.contains(BuildAssetType.data)) DataAssetsExtension(),
     ],
-    buildResult: buildResult,
+    buildResult: buildResult.success,
     resourceIdentifiers: resourceIdentifiers,
   );
 
-  if (linkResult != null) {
-    expect(await linkResult.encodedAssets.allExist(), true);
-  }
+  if (linkResult.isFailure) return (buildResult.success, null);
 
-  return (buildResult, linkResult);
+  expect(await linkResult.success.encodedAssets.allExist(), true);
+
+  return (buildResult.success, linkResult.success);
 });
 
 Future<T> runWithLog<T>(


### PR DESCRIPTION
Bug: https://github.com/dart-lang/native/issues/2265

This PR introduces a `Result` type (similar to Rust's) to handle success and failure states more explicitly, improving error propagation.

Having error types in the build runner is a prerequisite for adding error types to hook outputs (https://github.com/dart-lang/native/issues/2265).

### Error types in build runner

*  **hook run error**: Issues related to the execution of a build/link hook, its output, or asset validation.
    *   *Typically fixed by the hook author or end-user adjusting dependencies/assets.*
*   **project config error**: Issues related to the Dart project's configuration, such as errors in `pubspec.yaml` or user-provided definitions.
    *   *Typically fixed by the end-user fixing their pubspec.*
*   **internal error**: Internal errors within the build runner itself, such as inability to create a build plan, invalid inputs, or failures in compiling hook scripts.
    *   *These might indicate a bug in the Dart/Flutter SDK's native assets tooling.*

Once we add infra errors to hooks (https://github.com/dart-lang/native/issues/2265), we will add that as a 4th type here.

### Chosen Approach: Rust-style `Result` Type

We opted for a Rust-inspired `Result<SuccessType, FailureType>` because:

* Explicit types for both result and error.
* Explicit handling at the call site.

### Alternative Implementations Considered

1.  **Go-style Tuples `(value?, error?)`:** Simpler, but less type-safe and relies on convention. (Closest to the state before this PR, where error means null for for the value.)
2.  **`Result` on package boundaries with `Exception`s internally:** Would be less verbose internally, but easier to get wrong. Would be more Dart-y.
3.  **`Result` with monads:** While powerful (e.g., with `map`/`then`), it can increase debugging complexity due to closures. Less-Dart-y.
4.  **`Result` with exhaustive `switch`es:** Leads to too deep nesting.
