### PR TITLE
[objective_c] CFString conversions

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/objc_built_in_functions.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_built_in_functions.dart
@@ -99,6 +99,7 @@ class ObjCBuiltInFunctions {
   static const builtInCompounds = {
     'AEDesc': 'AEDesc',
     '__CFRunLoop': 'CFRunLoop',
+    '__CFString': 'CFString',
     'CGPoint': 'CGPoint',
     'CGRect': 'CGRect',
     'CGSize': 'CGSize',

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -6,7 +6,7 @@
 - `NSSet` and `NSMutableSet` are now Dart `Set`s.
 - Add `.toNSNumber()` extension method to `int`, `double`, and `num`.
 - Add `DateTime.toNSDate()` and `NSDate.toDateTime()` extension methods.
-- Add `CFStringRef.toDartString()`.
+- Add `CFStringRef.toDartString()` and `CFStringRef.toNSString()`.
 - Add `toObjCObject` and `toDartObject` that automatically convert between
   supported Objective C and Dart types.
 - Added various interfaces, protocols, categories etc to the built ins, such as

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `NSSet` and `NSMutableSet` are now Dart `Set`s.
 - Add `.toNSNumber()` extension method to `int`, `double`, and `num`.
 - Add `DateTime.toNSDate()` and `NSDate.toDateTime()` extension methods.
+- Add `CFStringRef.toDartString()`.
 - Add `toObjCObject` and `toDartObject` that automatically convert between
   supported Objective C and Dart types.
 - Added various interfaces, protocols, categories etc to the built ins, such as

--- a/pkgs/objective_c/ffigen_objc.yaml
+++ b/pkgs/objective_c/ffigen_objc.yaml
@@ -106,6 +106,7 @@ structs:
   include:
     - AEDesc
     - __CFRunLoop
+    - __CFString
     - CGPoint
     - CGRect
     - CGSize
@@ -116,6 +117,7 @@ structs:
     - OpaqueAEDataStorageType
   rename:
     __CFRunLoop: CFRunLoop
+    __CFString: CFString
     _NSRange: NSRange
     _NSZone: NSZone
 enums:
@@ -153,6 +155,9 @@ enums:
 globals:
   include:
     - NSLocalizedDescriptionKey
+typedefs:
+  include:
+    - 'CFStringRef'
 preamble: |
   // Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
   // for details. All rights reserved. Use of this source code is governed by a

--- a/pkgs/objective_c/lib/objective_c.dart
+++ b/pkgs/objective_c/lib/objective_c.dart
@@ -18,6 +18,7 @@ export 'src/c_bindings_generated.dart'
         objectRelease,
         objectRetain,
         signalWaiter;
+export 'src/cf_string.dart';
 export 'src/converter.dart';
 export 'src/internal.dart'
     hide blockHasRegisteredClosure, isValidBlock, isValidClass, isValidObject;
@@ -32,6 +33,8 @@ export 'src/objective_c_bindings_generated.dart'
     show
         AEDesc,
         CFRunLoop,
+        CFString,
+        CFStringRef,
         CGPoint,
         CGRect,
         CGSize,

--- a/pkgs/objective_c/lib/src/cf_string.dart
+++ b/pkgs/objective_c/lib/src/cf_string.dart
@@ -2,9 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:ffi/ffi.dart';
-import 'objective_c_bindings_generated.dart';
 import 'ns_string.dart';
+import 'objective_c_bindings_generated.dart';
 
 extension CFStringRefConversions on CFStringRef {
   NSString toNSString() =>

--- a/pkgs/objective_c/lib/src/cf_string.dart
+++ b/pkgs/objective_c/lib/src/cf_string.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:ffi/ffi.dart';
+import 'objective_c_bindings_generated.dart';
+import 'ns_string.dart';
+
+extension CFStringRefConversions on CFStringRef {
+  NSString toNSString() =>
+      NSString.castFromPointer(cast(), retain: true, release: true);
+
+  String toDartString() => NSString.castFromPointer(cast()).toDartString();
+}

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -321,6 +321,10 @@ final class AEDesc extends ffi.Struct {
 
 final class CFRunLoop extends ffi.Opaque {}
 
+final class CFString extends ffi.Opaque {}
+
+typedef CFStringRef = ffi.Pointer<CFString>;
+
 final class CGPoint extends ffi.Struct {
   @ffi.Double()
   external double x;

--- a/pkgs/objective_c/test/cf_string_test.dart
+++ b/pkgs/objective_c/test/cf_string_test.dart
@@ -20,7 +20,8 @@ void main() {
 
     for (final s in ['Hello', '🇵🇬', 'Embedded\u0000Null']) {
       test('CFString conversions [$s]', () {
-        final cfString = s.toNSString().ref.retainAndAutorelease().cast<CFString>();
+        final cfString =
+            s.toNSString().ref.retainAndAutorelease().cast<CFString>();
         expect(cfString.toDartString(), s);
         expect(cfString.toNSString().toDartString(), s);
       });

--- a/pkgs/objective_c/test/cf_string_test.dart
+++ b/pkgs/objective_c/test/cf_string_test.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Objective C support is only available on mac.
+@TestOn('mac-os')
+library;
+
+import 'dart:ffi';
+
+import 'package:objective_c/objective_c.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CFString', () {
+    setUpAll(() {
+      // TODO(https://github.com/dart-lang/native/issues/1068): Remove this.
+      DynamicLibrary.open('test/objective_c.dylib');
+    });
+
+    for (final s in ['Hello', '🇵🇬', 'Embedded\u0000Null']) {
+      test('CFString conversions [$s]', () {
+        final cfString = s.toNSString().ref.retainAndAutorelease().cast<CFString>();
+        expect(cfString.toDartString(), s);
+        expect(cfString.toNSString().toDartString(), s);
+      });
+    }
+  });
+}


### PR DESCRIPTION
Toll-free bridging means we can directly cast `CFString*` to `NSString*`.

Fixes #1547
Fixes #1548