### PR TITLE
[hooks_runner] No hooks performance trace

### DIFF
--- a/pkgs/hooks_runner/lib/src/build_runner/build_planner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_planner.dart
@@ -75,12 +75,15 @@ class NativeAssetsBuildPlanner {
   Future<List<Package>> _runPackagesWithHook(Hook hook) async {
     final packageNamesInDependencies = packageGraph.vertices.toSet();
     final result = <Package>[];
+    final watch = Stopwatch()..start();
+    var length = 0;
     for (final package in packageLayout.packageConfig.packages) {
       if (!packageNamesInDependencies.contains(package.name)) {
         continue;
       }
       final packageRoot = package.root;
       if (packageRoot.scheme == 'file') {
+        length++;
         if (await fileSystem
             .file(packageRoot.resolve('hook/').resolve(hook.scriptName))
             .exists()) {
@@ -88,6 +91,11 @@ class NativeAssetsBuildPlanner {
         }
       }
     }
+    watch.stop();
+    logger.finest(
+      'Checking $length packages for hook/${hook.scriptName} '
+      'took ${watch.elapsedMilliseconds} ms.',
+    );
     return result;
   }
 

--- a/pkgs/hooks_runner/test/build_runner/build_planner_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/build_planner_test.dart
@@ -36,6 +36,10 @@ void main() async {
             packageLayout: packageLayout,
             fileSystem: const LocalFileSystem(),
           );
+      final packagesWithHook = await nativeAssetsBuildPlanner.packagesWithHook(
+        Hook.build,
+      );
+      expect(packagesWithHook.length, 1);
       final buildPlan = await nativeAssetsBuildPlanner.makeBuildHookPlan();
       expect(buildPlan.success.length, 1);
       expect(buildPlan.success.single.name, 'native_add');


### PR DESCRIPTION
> If there are no hooks at all in the package graph, do [...] flutter commands not regress.

Bug: https://github.com/dart-lang/native/issues/2236

When there are no hooks, all packages in the dependencies must be checked for `hook/build.dart`.

This check for Flutter's `hello_world` takes 1 ms in isolation:

`INFO: 2025-05-14 08:30:08.854304: _runPackagesWithHook took 850 us. Checked 8 packages.`

Inside Flutter this check (in `dart_build`) happens concurrently with other code, so it shows up as taking longer:

```
[        ] [   +1 ms] gen_dart_plugin_registrant: Starting due to {InvalidatedReasonKind.inputChanged: The following inputs have updated contents: /Users/dacoharkes/flt/flutter/examples/hello_world/.dart_tool/package_config_subset} <-- does sync IO
[        ] [   +2 ms] dart_build: Starting due to {}
[        ] [   +1 ms] release_unpack_macos: Starting due to {InvalidatedReasonKind.inputChanged: The following inputs have updated contents: /Users/dacoharkes/flt/flutter/packages/flutter_tools/lib/src/build_system/targets/macos.dart,/Users/dacoharkes/flt/flutter/bin/cache/engine.stamp}
[        ] [   +3 ms] check_dev_dependencies_macos: Complete
[        ] [  +11 ms] executing: [/Users/dacoharkes/flt/flutter/examples/hello_world/] /Users/dacoharkes/flt/flutter/bin/cache/dart-sdk/bin/dart pub --suppress-analytics deps --json
[        ] [  +28 ms] No packages with native assets. Skipping native assets compilation.
[        ] [   +2 ms] dart_build: Complete
```

Because it takes 1 ms, removing the experimental flag in Flutter should not regress `flutter run` / `flutter build`.

Alternatives tried but not chosen:

* We could do sync IO in the hooks_runner, that would make it slightly faster (600 us instead of 800 us for 8 packages), but block anything else happening concurrently.
* We could do `Future.wait` for all exists checks concurrently, but this leads to a slowdown for <20 packages when tested locally.