### PR TITLE
[ffigen] Switch to named params for ObjC methods

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## 19.0.0-wip
 
 - Use package:objective_c 8.0.0.
+- __Breaking change__: Major change to the way ObjC methods are code-genned.
+  Methods now use named parameters, making them more readable and closer to how
+  they're written in ObjC. For example, the `NSData` method
+  `dataWithBytes:length:` used to be gnerated as
+  `dataWithBytes_length_(Pointer<Void> bytes, int length)`, but is now generated
+  as `dataWithBytes(ffi.Pointer<ffi.Void> bytes, {required int length})`.
+  Protocol methods are not affected.
 - Make it easier for a downstream clone to change behavior of certain utils.
 - Fix [a bug](https://github.com/dart-lang/native/issues/1268) where types could
   occasionally show up as a generic ObjCObjectBase, when they were supposed to

--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -6,8 +6,8 @@
   they're written in ObjC. For example, the `NSData` method
   `dataWithBytes:length:` used to be gnerated as
   `dataWithBytes_length_(Pointer<Void> bytes, int length)`, but is now generated
-  as `dataWithBytes(ffi.Pointer<ffi.Void> bytes, {required int length})`.
-  Protocol methods are not affected.
+  as `dataWithBytes(Pointer<Void> bytes, {required int length})`. Protocol
+  methods are not affected.
 - Make it easier for a downstream clone to change behavior of certain utils.
 - Fix [a bug](https://github.com/dart-lang/native/issues/1268) where types could
   occasionally show up as a generic ObjCObjectBase, when they were supposed to

--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 19.0.0-wip
+## 19.0.0
 
 - Use package:objective_c 8.0.0.
 - __Breaking change__: Major change to the way ObjC methods are code-genned.

--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -4,10 +4,11 @@
 - __Breaking change__: Major change to the way ObjC methods are code-genned.
   Methods now use named parameters, making them more readable and closer to how
   they're written in ObjC. For example, the `NSData` method
-  `dataWithBytes:length:` used to be gnerated as
+  `dataWithBytes:length:` used to be generated as
   `dataWithBytes_length_(Pointer<Void> bytes, int length)`, but is now generated
   as `dataWithBytes(Pointer<Void> bytes, {required int length})`. Protocol
   methods are not affected.
+  - Migration tip: A quick way to find affected methods is to search for `_(`.
 - Make it easier for a downstream clone to change behavior of certain utils.
 - Fix [a bug](https://github.com/dart-lang/native/issues/1268) where types could
   occasionally show up as a generic ObjCObjectBase, when they were supposed to

--- a/pkgs/ffigen/example/objective_c/avf_audio_bindings.dart
+++ b/pkgs/ffigen/example/objective_c/avf_audio_bindings.dart
@@ -207,7 +207,7 @@ class AVAudioFormat extends objc.NSObject implements objc.NSSecureCoding {
   AVAudioFormat._(ffi.Pointer<objc.ObjCObject> pointer,
       {bool retain = false, bool release = false})
       : super.castFromPointer(pointer, retain: retain, release: release) {
-    objc.checkOsVersion('AVAudioFormat',
+    objc.checkOsVersionInternal('AVAudioFormat',
         iOS: (false, (8, 0, 0)), macOS: (false, (10, 10, 0)));
   }
 
@@ -601,7 +601,7 @@ class AVAudioPlayer extends objc.NSObject {
   AVAudioPlayer._(ffi.Pointer<objc.ObjCObject> pointer,
       {bool retain = false, bool release = false})
       : super.castFromPointer(pointer, retain: retain, release: release) {
-    objc.checkOsVersion('AVAudioPlayer',
+    objc.checkOsVersionInternal('AVAudioPlayer',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
   }
 
@@ -621,35 +621,34 @@ class AVAudioPlayer extends objc.NSObject {
   }
 
   /// initWithContentsOfURL:error:
-  AVAudioPlayer? initWithContentsOfURL_error_(
-      objc.NSURL url, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> outError) {
-    objc.checkOsVersion('AVAudioPlayer.initWithContentsOfURL:error:',
+  AVAudioPlayer? initWithContentsOfURL(objc.NSURL url,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
+    objc.checkOsVersionInternal('AVAudioPlayer.initWithContentsOfURL:error:',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1lhpu4m(this.ref.retainAndReturnPointer(),
-        _sel_initWithContentsOfURL_error_, url.ref.pointer, outError);
+        _sel_initWithContentsOfURL_error_, url.ref.pointer, error);
     return _ret.address == 0
         ? null
         : AVAudioPlayer.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithData:error:
-  AVAudioPlayer? initWithData_error_(
-      objc.NSData data, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> outError) {
-    objc.checkOsVersion('AVAudioPlayer.initWithData:error:',
+  AVAudioPlayer? initWithData(objc.NSData data,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
+    objc.checkOsVersionInternal('AVAudioPlayer.initWithData:error:',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1lhpu4m(this.ref.retainAndReturnPointer(),
-        _sel_initWithData_error_, data.ref.pointer, outError);
+        _sel_initWithData_error_, data.ref.pointer, error);
     return _ret.address == 0
         ? null
         : AVAudioPlayer.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfURL:fileTypeHint:error:
-  AVAudioPlayer? initWithContentsOfURL_fileTypeHint_error_(
-      objc.NSURL url,
-      objc.NSString? utiString,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> outError) {
-    objc.checkOsVersion(
+  AVAudioPlayer? initWithContentsOfURL$1(objc.NSURL url,
+      {objc.NSString? fileTypeHint,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
+    objc.checkOsVersionInternal(
         'AVAudioPlayer.initWithContentsOfURL:fileTypeHint:error:',
         iOS: (false, (7, 0, 0)),
         macOS: (false, (10, 9, 0)));
@@ -657,26 +656,27 @@ class AVAudioPlayer extends objc.NSObject {
         this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_fileTypeHint_error_,
         url.ref.pointer,
-        utiString?.ref.pointer ?? ffi.nullptr,
-        outError);
+        fileTypeHint?.ref.pointer ?? ffi.nullptr,
+        error);
     return _ret.address == 0
         ? null
         : AVAudioPlayer.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithData:fileTypeHint:error:
-  AVAudioPlayer? initWithData_fileTypeHint_error_(
-      objc.NSData data,
-      objc.NSString? utiString,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> outError) {
-    objc.checkOsVersion('AVAudioPlayer.initWithData:fileTypeHint:error:',
-        iOS: (false, (7, 0, 0)), macOS: (false, (10, 9, 0)));
+  AVAudioPlayer? initWithData$1(objc.NSData data,
+      {objc.NSString? fileTypeHint,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
+    objc.checkOsVersionInternal(
+        'AVAudioPlayer.initWithData:fileTypeHint:error:',
+        iOS: (false, (7, 0, 0)),
+        macOS: (false, (10, 9, 0)));
     final _ret = _objc_msgSend_1pnyuds(
         this.ref.retainAndReturnPointer(),
         _sel_initWithData_fileTypeHint_error_,
         data.ref.pointer,
-        utiString?.ref.pointer ?? ffi.nullptr,
-        outError);
+        fileTypeHint?.ref.pointer ?? ffi.nullptr,
+        error);
     return _ret.address == 0
         ? null
         : AVAudioPlayer.castFromPointer(_ret, retain: false, release: true);
@@ -684,56 +684,56 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// prepareToPlay
   bool prepareToPlay() {
-    objc.checkOsVersion('AVAudioPlayer.prepareToPlay',
+    objc.checkOsVersionInternal('AVAudioPlayer.prepareToPlay',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     return _objc_msgSend_91o635(this.ref.pointer, _sel_prepareToPlay);
   }
 
   /// play
   bool play() {
-    objc.checkOsVersion('AVAudioPlayer.play',
+    objc.checkOsVersionInternal('AVAudioPlayer.play',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     return _objc_msgSend_91o635(this.ref.pointer, _sel_play);
   }
 
   /// playAtTime:
-  bool playAtTime_(double time) {
-    objc.checkOsVersion('AVAudioPlayer.playAtTime:',
+  bool playAtTime(double time) {
+    objc.checkOsVersionInternal('AVAudioPlayer.playAtTime:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 7, 0)));
     return _objc_msgSend_18chyc(this.ref.pointer, _sel_playAtTime_, time);
   }
 
   /// pause
   void pause() {
-    objc.checkOsVersion('AVAudioPlayer.pause',
+    objc.checkOsVersionInternal('AVAudioPlayer.pause',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_1pl9qdv(this.ref.pointer, _sel_pause);
   }
 
   /// stop
   void stop() {
-    objc.checkOsVersion('AVAudioPlayer.stop',
+    objc.checkOsVersionInternal('AVAudioPlayer.stop',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_1pl9qdv(this.ref.pointer, _sel_stop);
   }
 
   /// isPlaying
   bool get playing {
-    objc.checkOsVersion('AVAudioPlayer.isPlaying',
+    objc.checkOsVersionInternal('AVAudioPlayer.isPlaying',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     return _objc_msgSend_91o635(this.ref.pointer, _sel_isPlaying);
   }
 
   /// numberOfChannels
   int get numberOfChannels {
-    objc.checkOsVersion('AVAudioPlayer.numberOfChannels',
+    objc.checkOsVersionInternal('AVAudioPlayer.numberOfChannels',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     return _objc_msgSend_xw2lbc(this.ref.pointer, _sel_numberOfChannels);
   }
 
   /// duration
   double get duration {
-    objc.checkOsVersion('AVAudioPlayer.duration',
+    objc.checkOsVersionInternal('AVAudioPlayer.duration',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     return objc.useMsgSendVariants
         ? _objc_msgSend_1ukqyt8Fpret(this.ref.pointer, _sel_duration)
@@ -742,7 +742,7 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// currentDevice
   objc.NSString? get currentDevice {
-    objc.checkOsVersion('AVAudioPlayer.currentDevice',
+    objc.checkOsVersionInternal('AVAudioPlayer.currentDevice',
         iOS: (true, null), macOS: (false, (10, 13, 0)));
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_currentDevice);
     return _ret.address == 0
@@ -752,7 +752,7 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// setCurrentDevice:
   set currentDevice(objc.NSString? value) {
-    objc.checkOsVersion('AVAudioPlayer.setCurrentDevice:',
+    objc.checkOsVersionInternal('AVAudioPlayer.setCurrentDevice:',
         iOS: (true, null), macOS: (false, (10, 13, 0)));
     _objc_msgSend_xtuoz7(this.ref.pointer, _sel_setCurrentDevice_,
         value?.ref.pointer ?? ffi.nullptr);
@@ -760,7 +760,7 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// delegate
   AVAudioPlayerDelegate? get delegate {
-    objc.checkOsVersion('AVAudioPlayer.delegate',
+    objc.checkOsVersionInternal('AVAudioPlayer.delegate',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_delegate);
     return _ret.address == 0
@@ -771,7 +771,7 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// setDelegate:
   set delegate(AVAudioPlayerDelegate? value) {
-    objc.checkOsVersion('AVAudioPlayer.setDelegate:',
+    objc.checkOsVersionInternal('AVAudioPlayer.setDelegate:',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_setDelegate_, value?.ref.pointer ?? ffi.nullptr);
@@ -779,7 +779,7 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// url
   objc.NSURL? get url {
-    objc.checkOsVersion('AVAudioPlayer.url',
+    objc.checkOsVersionInternal('AVAudioPlayer.url',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_url);
     return _ret.address == 0
@@ -789,7 +789,7 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// data
   objc.NSData? get data {
-    objc.checkOsVersion('AVAudioPlayer.data',
+    objc.checkOsVersionInternal('AVAudioPlayer.data',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_data);
     return _ret.address == 0
@@ -799,7 +799,7 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// pan
   double get pan {
-    objc.checkOsVersion('AVAudioPlayer.pan',
+    objc.checkOsVersionInternal('AVAudioPlayer.pan',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 7, 0)));
     return objc.useMsgSendVariants
         ? _objc_msgSend_2cgrxlFpret(this.ref.pointer, _sel_pan)
@@ -808,14 +808,14 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// setPan:
   set pan(double value) {
-    objc.checkOsVersion('AVAudioPlayer.setPan:',
+    objc.checkOsVersionInternal('AVAudioPlayer.setPan:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_v5hmet(this.ref.pointer, _sel_setPan_, value);
   }
 
   /// volume
   double get volume {
-    objc.checkOsVersion('AVAudioPlayer.volume',
+    objc.checkOsVersionInternal('AVAudioPlayer.volume',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     return objc.useMsgSendVariants
         ? _objc_msgSend_2cgrxlFpret(this.ref.pointer, _sel_volume)
@@ -824,36 +824,36 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// setVolume:
   set volume(double value) {
-    objc.checkOsVersion('AVAudioPlayer.setVolume:',
+    objc.checkOsVersionInternal('AVAudioPlayer.setVolume:',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_v5hmet(this.ref.pointer, _sel_setVolume_, value);
   }
 
   /// setVolume:fadeDuration:
-  void setVolume_fadeDuration_(double volume, double duration) {
-    objc.checkOsVersion('AVAudioPlayer.setVolume:fadeDuration:',
+  void setVolume(double volume$1, {required double fadeDuration}) {
+    objc.checkOsVersionInternal('AVAudioPlayer.setVolume:fadeDuration:',
         iOS: (false, (10, 0, 0)), macOS: (false, (10, 12, 0)));
     _objc_msgSend_1p4uk9e(
-        this.ref.pointer, _sel_setVolume_fadeDuration_, volume, duration);
+        this.ref.pointer, _sel_setVolume_fadeDuration_, volume$1, fadeDuration);
   }
 
   /// enableRate
   bool get enableRate {
-    objc.checkOsVersion('AVAudioPlayer.enableRate',
+    objc.checkOsVersionInternal('AVAudioPlayer.enableRate',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 8, 0)));
     return _objc_msgSend_91o635(this.ref.pointer, _sel_enableRate);
   }
 
   /// setEnableRate:
   set enableRate(bool value) {
-    objc.checkOsVersion('AVAudioPlayer.setEnableRate:',
+    objc.checkOsVersionInternal('AVAudioPlayer.setEnableRate:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 8, 0)));
     _objc_msgSend_1s56lr9(this.ref.pointer, _sel_setEnableRate_, value);
   }
 
   /// rate
   double get rate {
-    objc.checkOsVersion('AVAudioPlayer.rate',
+    objc.checkOsVersionInternal('AVAudioPlayer.rate',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 8, 0)));
     return objc.useMsgSendVariants
         ? _objc_msgSend_2cgrxlFpret(this.ref.pointer, _sel_rate)
@@ -862,14 +862,14 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// setRate:
   set rate(double value) {
-    objc.checkOsVersion('AVAudioPlayer.setRate:',
+    objc.checkOsVersionInternal('AVAudioPlayer.setRate:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 8, 0)));
     _objc_msgSend_v5hmet(this.ref.pointer, _sel_setRate_, value);
   }
 
   /// currentTime
   double get currentTime {
-    objc.checkOsVersion('AVAudioPlayer.currentTime',
+    objc.checkOsVersionInternal('AVAudioPlayer.currentTime',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     return objc.useMsgSendVariants
         ? _objc_msgSend_1ukqyt8Fpret(this.ref.pointer, _sel_currentTime)
@@ -878,14 +878,14 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// setCurrentTime:
   set currentTime(double value) {
-    objc.checkOsVersion('AVAudioPlayer.setCurrentTime:',
+    objc.checkOsVersionInternal('AVAudioPlayer.setCurrentTime:',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_hwm8nu(this.ref.pointer, _sel_setCurrentTime_, value);
   }
 
   /// deviceCurrentTime
   double get deviceCurrentTime {
-    objc.checkOsVersion('AVAudioPlayer.deviceCurrentTime',
+    objc.checkOsVersionInternal('AVAudioPlayer.deviceCurrentTime',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 7, 0)));
     return objc.useMsgSendVariants
         ? _objc_msgSend_1ukqyt8Fpret(this.ref.pointer, _sel_deviceCurrentTime)
@@ -894,21 +894,21 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// numberOfLoops
   int get numberOfLoops {
-    objc.checkOsVersion('AVAudioPlayer.numberOfLoops',
+    objc.checkOsVersionInternal('AVAudioPlayer.numberOfLoops',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     return _objc_msgSend_1hz7y9r(this.ref.pointer, _sel_numberOfLoops);
   }
 
   /// setNumberOfLoops:
   set numberOfLoops(int value) {
-    objc.checkOsVersion('AVAudioPlayer.setNumberOfLoops:',
+    objc.checkOsVersionInternal('AVAudioPlayer.setNumberOfLoops:',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_4sp4xj(this.ref.pointer, _sel_setNumberOfLoops_, value);
   }
 
   /// settings
   objc.NSDictionary get settings {
-    objc.checkOsVersion('AVAudioPlayer.settings',
+    objc.checkOsVersionInternal('AVAudioPlayer.settings',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_settings);
     return objc.NSDictionary.castFromPointer(_ret, retain: true, release: true);
@@ -916,7 +916,7 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// format
   AVAudioFormat get format {
-    objc.checkOsVersion('AVAudioPlayer.format',
+    objc.checkOsVersionInternal('AVAudioPlayer.format',
         iOS: (false, (10, 0, 0)), macOS: (false, (10, 12, 0)));
     final _ret = _objc_msgSend_151sglz(this.ref.pointer, _sel_format);
     return AVAudioFormat.castFromPointer(_ret, retain: true, release: true);
@@ -924,28 +924,28 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// isMeteringEnabled
   bool get meteringEnabled {
-    objc.checkOsVersion('AVAudioPlayer.isMeteringEnabled',
+    objc.checkOsVersionInternal('AVAudioPlayer.isMeteringEnabled',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     return _objc_msgSend_91o635(this.ref.pointer, _sel_isMeteringEnabled);
   }
 
   /// setMeteringEnabled:
   set meteringEnabled(bool value) {
-    objc.checkOsVersion('AVAudioPlayer.setMeteringEnabled:',
+    objc.checkOsVersionInternal('AVAudioPlayer.setMeteringEnabled:',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_1s56lr9(this.ref.pointer, _sel_setMeteringEnabled_, value);
   }
 
   /// updateMeters
   void updateMeters() {
-    objc.checkOsVersion('AVAudioPlayer.updateMeters',
+    objc.checkOsVersionInternal('AVAudioPlayer.updateMeters',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_1pl9qdv(this.ref.pointer, _sel_updateMeters);
   }
 
   /// peakPowerForChannel:
-  double peakPowerForChannel_(int channelNumber) {
-    objc.checkOsVersion('AVAudioPlayer.peakPowerForChannel:',
+  double peakPowerForChannel(int channelNumber) {
+    objc.checkOsVersionInternal('AVAudioPlayer.peakPowerForChannel:',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     return objc.useMsgSendVariants
         ? _objc_msgSend_65s5ywFpret(
@@ -955,8 +955,8 @@ class AVAudioPlayer extends objc.NSObject {
   }
 
   /// averagePowerForChannel:
-  double averagePowerForChannel_(int channelNumber) {
-    objc.checkOsVersion('AVAudioPlayer.averagePowerForChannel:',
+  double averagePowerForChannel(int channelNumber) {
+    objc.checkOsVersionInternal('AVAudioPlayer.averagePowerForChannel:',
         iOS: (false, (2, 2, 0)), macOS: (false, (10, 7, 0)));
     return objc.useMsgSendVariants
         ? _objc_msgSend_65s5ywFpret(
@@ -967,7 +967,7 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// channelAssignments
   objc.NSArray? get channelAssignments {
-    objc.checkOsVersion('AVAudioPlayer.channelAssignments',
+    objc.checkOsVersionInternal('AVAudioPlayer.channelAssignments',
         iOS: (false, (7, 0, 0)), macOS: (true, null));
     final _ret =
         _objc_msgSend_151sglz(this.ref.pointer, _sel_channelAssignments);
@@ -978,7 +978,7 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// setChannelAssignments:
   set channelAssignments(objc.NSArray? value) {
-    objc.checkOsVersion('AVAudioPlayer.setChannelAssignments:',
+    objc.checkOsVersionInternal('AVAudioPlayer.setChannelAssignments:',
         iOS: (false, (7, 0, 0)), macOS: (true, null));
     _objc_msgSend_xtuoz7(this.ref.pointer, _sel_setChannelAssignments_,
         value?.ref.pointer ?? ffi.nullptr);
@@ -986,7 +986,7 @@ class AVAudioPlayer extends objc.NSObject {
 
   /// init
   AVAudioPlayer init() {
-    objc.checkOsVersion('AVAudioPlayer.init',
+    objc.checkOsVersionInternal('AVAudioPlayer.init',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
     final _ret =
         _objc_msgSend_151sglz(this.ref.retainAndReturnPointer(), _sel_init);
@@ -1000,7 +1000,7 @@ class AVAudioPlayer extends objc.NSObject {
   }
 
   /// allocWithZone:
-  static AVAudioPlayer allocWithZone_(ffi.Pointer<objc.NSZone> zone) {
+  static AVAudioPlayer allocWithZone(ffi.Pointer<objc.NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_AVAudioPlayer, _sel_allocWithZone_, zone);
     return AVAudioPlayer.castFromPointer(_ret, retain: false, release: true);

--- a/pkgs/ffigen/example/objective_c/avf_audio_bindings.dart.m
+++ b/pkgs/ffigen/example/objective_c/avf_audio_bindings.dart.m
@@ -7,7 +7,47 @@
 #error "This file must be compiled with ARC enabled"
 #endif
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+
+typedef struct {
+  int64_t version;
+  void* (*newWaiter)(void);
+  void (*awaitWaiter)(void*);
+  void* (*currentIsolate)(void);
+  void (*enterIsolate)(void*);
+  void (*exitIsolate)(void);
+  int64_t (*getMainPortId)(void);
+  bool (*getCurrentThreadOwnsIsolate)(int64_t);
+} DOBJC_Context;
+
 id objc_retainBlock(id);
+
+#define BLOCKING_BLOCK_IMPL(ctx, BLOCK_SIG, INVOKE_DIRECT, INVOKE_LISTENER)    \
+  assert(ctx->version >= 1);                                                   \
+  void* targetIsolate = ctx->currentIsolate();                                 \
+  int64_t targetPort = ctx->getMainPortId == NULL ? 0 : ctx->getMainPortId();  \
+  return BLOCK_SIG {                                                           \
+    void* currentIsolate = ctx->currentIsolate();                              \
+    bool mayEnterIsolate =                                                     \
+        currentIsolate == NULL &&                                              \
+        ctx->getCurrentThreadOwnsIsolate != NULL &&                            \
+        ctx->getCurrentThreadOwnsIsolate(targetPort);                          \
+    if (currentIsolate == targetIsolate || mayEnterIsolate) {                  \
+      if (mayEnterIsolate) {                                                   \
+        ctx->enterIsolate(targetIsolate);                                      \
+      }                                                                        \
+      INVOKE_DIRECT;                                                           \
+      if (mayEnterIsolate) {                                                   \
+        ctx->exitIsolate();                                                    \
+      }                                                                        \
+    } else {                                                                   \
+      void* waiter = ctx->newWaiter();                                         \
+      INVOKE_LISTENER;                                                         \
+      ctx->awaitWaiter(waiter);                                                \
+    }                                                                          \
+  };
+
 
 Protocol* _AVFAudio_AVAudioPlayerDelegate(void) { return @protocol(AVAudioPlayerDelegate); }
 
@@ -16,3 +56,6 @@ __attribute__((visibility("default"))) __attribute__((used))
 id  _AVFAudio_protocolTrampoline_1mbt9g9(id target, void * sel) {
   return ((ProtocolTrampoline)((id (*)(id, SEL, SEL))objc_msgSend)(target, @selector(getDOBJCDartProtocolMethodForSelector:), sel))(sel);
 }
+#undef BLOCKING_BLOCK_IMPL
+
+#pragma clang diagnostic pop

--- a/pkgs/ffigen/example/objective_c/play_audio.dart
+++ b/pkgs/ffigen/example/objective_c/play_audio.dart
@@ -18,9 +18,9 @@ void main(List<String> args) async {
   for (final file in args) {
     final fileStr = NSString(file);
     print('Loading $file');
-    final fileUrl = NSURL.fileURLWithPath_(fileStr);
+    final fileUrl = NSURL.fileURLWithPath(fileStr);
     final player =
-        AVAudioPlayer.alloc().initWithContentsOfURL_error_(fileUrl, nullptr);
+        AVAudioPlayer.alloc().initWithContentsOfURL(fileUrl, error: nullptr);
     if (player == null) {
       print('Failed to load audio');
       continue;

--- a/pkgs/ffigen/example/swift/example.dart
+++ b/pkgs/ffigen/example/swift/example.dart
@@ -14,7 +14,7 @@ void main() {
 
   // TODO(https://github.com/dart-lang/ffigen/issues/443): Add a test for this.
   DynamicLibrary.open('libswiftapi.dylib');
-  final object = SwiftClass.new1();
+  final object = SwiftClass();
   print(object.sayHello().toDartString());
   print('field = ${object.someField}');
   object.someField = 456;

--- a/pkgs/ffigen/example/swift/swift_api_bindings.dart
+++ b/pkgs/ffigen/example/swift/swift_api_bindings.dart
@@ -219,7 +219,7 @@ class SwiftClass extends objc.NSObject {
 
   /// init
   SwiftClass init() {
-    objc.checkOsVersion('SwiftClass.init',
+    objc.checkOsVersionInternal('SwiftClass.init',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
     final _ret =
         _objc_msgSend_151sglz(this.ref.retainAndReturnPointer(), _sel_init);
@@ -233,7 +233,7 @@ class SwiftClass extends objc.NSObject {
   }
 
   /// allocWithZone:
-  static SwiftClass allocWithZone_(ffi.Pointer<objc.NSZone> zone) {
+  static SwiftClass allocWithZone(ffi.Pointer<objc.NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_SwiftClass, _sel_allocWithZone_, zone);
     return SwiftClass.castFromPointer(_ret, retain: false, release: true);

--- a/pkgs/ffigen/example/swift/swift_api_bindings.dart.m
+++ b/pkgs/ffigen/example/swift/swift_api_bindings.dart.m
@@ -7,10 +7,53 @@
 #error "This file must be compiled with ARC enabled"
 #endif
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+
+typedef struct {
+  int64_t version;
+  void* (*newWaiter)(void);
+  void (*awaitWaiter)(void*);
+  void* (*currentIsolate)(void);
+  void (*enterIsolate)(void*);
+  void (*exitIsolate)(void);
+  int64_t (*getMainPortId)(void);
+  bool (*getCurrentThreadOwnsIsolate)(int64_t);
+} DOBJC_Context;
+
 id objc_retainBlock(id);
+
+#define BLOCKING_BLOCK_IMPL(ctx, BLOCK_SIG, INVOKE_DIRECT, INVOKE_LISTENER)    \
+  assert(ctx->version >= 1);                                                   \
+  void* targetIsolate = ctx->currentIsolate();                                 \
+  int64_t targetPort = ctx->getMainPortId == NULL ? 0 : ctx->getMainPortId();  \
+  return BLOCK_SIG {                                                           \
+    void* currentIsolate = ctx->currentIsolate();                              \
+    bool mayEnterIsolate =                                                     \
+        currentIsolate == NULL &&                                              \
+        ctx->getCurrentThreadOwnsIsolate != NULL &&                            \
+        ctx->getCurrentThreadOwnsIsolate(targetPort);                          \
+    if (currentIsolate == targetIsolate || mayEnterIsolate) {                  \
+      if (mayEnterIsolate) {                                                   \
+        ctx->enterIsolate(targetIsolate);                                      \
+      }                                                                        \
+      INVOKE_DIRECT;                                                           \
+      if (mayEnterIsolate) {                                                   \
+        ctx->exitIsolate();                                                    \
+      }                                                                        \
+    } else {                                                                   \
+      void* waiter = ctx->newWaiter();                                         \
+      INVOKE_LISTENER;                                                         \
+      ctx->awaitWaiter(waiter);                                                \
+    }                                                                          \
+  };
+
 
 typedef id  (^ProtocolTrampoline)(void * sel);
 __attribute__((visibility("default"))) __attribute__((used))
 id  _SwiftLibrary_protocolTrampoline_1mbt9g9(id target, void * sel) {
   return ((ProtocolTrampoline)((id (*)(id, SEL, SEL))objc_msgSend)(target, @selector(getDOBJCDartProtocolMethodForSelector:), sel))(sel);
 }
+#undef BLOCKING_BLOCK_IMPL
+
+#pragma clang diagnostic pop

--- a/pkgs/ffigen/lib/src/code_generator/func.dart
+++ b/pkgs/ffigen/lib/src/code_generator/func.dart
@@ -259,4 +259,6 @@ class Parameter extends AstNode {
     super.visitChildren(visitor);
     visitor.visit(type);
   }
+
+  bool get isNullable => type.typealiasType is ObjCNullable;
 }

--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -112,8 +112,7 @@ interface class $name extends $protocolBase $impls{
 
       var anyListeners = false;
       for (final method in methods) {
-        final methodName =
-            method.getDartMethodName(methodNamer, usePropertyNaming: false);
+        final methodName = method.getDartProtocolMethodName(methodNamer);
         final fieldName = methodName;
         final argName = methodName;
         final block = method.protocolBlock!;

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objcinterfacedecl_parser.dart
@@ -159,7 +159,7 @@ void _parseSuperType(clang_types.CXCursor cursor, ObjCInterface itf) {
     returnType: fieldType,
     family: null,
     apiAvailability: apiAvailability,
-  );
+  )..finalizeParams();
 
   ObjCMethod? setter;
   if (!isReadOnly) {
@@ -181,6 +181,7 @@ void _parseSuperType(clang_types.CXCursor cursor, ObjCInterface itf) {
     );
     setter.params
         .add(Parameter(name: 'value', type: fieldType, objCConsumed: false));
+    setter.finalizeParams();
   }
   return (getter, setter);
 }
@@ -244,6 +245,7 @@ ObjCMethod? parseObjCMethod(clang_types.CXCursor cursor, Declaration itfDecl,
       default:
     }
   });
+  method.finalizeParams();
   return hasError ? null : method;
 }
 

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 19.0.0-wip
+version: 19.0.0
 description: >
   Generator for FFI bindings, using LibClang to parse C, Objective-C, and Swift
   files.

--- a/pkgs/ffigen/test/example_tests/objective_c_example_test.dart
+++ b/pkgs/ffigen/test/example_tests/objective_c_example_test.dart
@@ -30,8 +30,8 @@ void main() {
       expect(
           output,
           contains(
-              'AVAudioPlayer? initWithContentsOfURL_error_(objc.NSURL url, '
-              'ffi.Pointer<ffi.Pointer<objc.ObjCObject>> outError) {'));
+              'AVAudioPlayer? initWithContentsOfURL(objc.NSURL url, '
+              '{required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {'));
       expect(output, contains('double get duration {'));
       expect(output, contains('bool play() {'));
     });

--- a/pkgs/ffigen/test/example_tests/objective_c_example_test.dart
+++ b/pkgs/ffigen/test/example_tests/objective_c_example_test.dart
@@ -29,8 +29,7 @@ void main() {
       expect(output, contains('class AVAudioPlayer extends objc.NSObject {'));
       expect(
           output,
-          contains(
-              'AVAudioPlayer? initWithContentsOfURL(objc.NSURL url, '
+          contains('AVAudioPlayer? initWithContentsOfURL(objc.NSURL url, '
               '{required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {'));
       expect(output, contains('double get duration {'));
       expect(output, contains('bool play() {'));

--- a/pkgs/ffigen/test/native_objc_test/arc_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/arc_test.dart
@@ -482,8 +482,8 @@ void main() {
       final dtorOnMainThreadCounter = calloc<Int32>();
       final objects = <ArcDtorTestObject>[];
       for (var i = 0; i < numTestObjects; ++i) {
-        objects.add(ArcDtorTestObject.alloc().initWithCounters(
-            dtorCounter, onMainThread: dtorOnMainThreadCounter));
+        objects.add(ArcDtorTestObject.alloc().initWithCounters(dtorCounter,
+            onMainThread: dtorOnMainThreadCounter));
       }
       objects.clear();
 

--- a/pkgs/ffigen/test/native_objc_test/arc_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/arc_test.dart
@@ -39,9 +39,9 @@ void main() {
     (Pointer<ObjCObject>, Pointer<ObjCObject>) newMethodsInner(
         Pointer<Int32> counter) {
       final obj1 = ArcTestObject();
-      obj1.setCounter_(counter);
+      obj1.setCounter(counter);
       expect(counter.value, 1);
-      final obj2 = ArcTestObject.newWithCounter_(counter);
+      final obj2 = ArcTestObject.newWithCounter(counter);
       expect(counter.value, 2);
 
       final obj1raw = obj1.ref.pointer;
@@ -76,12 +76,12 @@ void main() {
 
     (Pointer<ObjCObject>, Pointer<ObjCObject>, Pointer<ObjCObject>)
         allocMethodsInner(Pointer<Int32> counter) {
-      final obj1 = ArcTestObject.alloc().initWithCounter_(counter);
+      final obj1 = ArcTestObject.alloc().initWithCounter(counter);
       expect(counter.value, 1);
       final obj2 = ArcTestObject.castFrom(ArcTestObject.alloc().init());
-      obj2.setCounter_(counter);
+      obj2.setCounter(counter);
       expect(counter.value, 2);
-      final obj3 = ArcTestObject.allocTheThing().initWithCounter_(counter);
+      final obj3 = ArcTestObject.allocTheThing().initWithCounter(counter);
       expect(counter.value, 3);
 
       final obj1raw = obj1.ref.pointer;
@@ -123,13 +123,13 @@ void main() {
       Pointer<ObjCObject>
     ) copyMethodsInner(Pointer<Int32> counter) {
       final pool = lib.objc_autoreleasePoolPush();
-      final obj1 = ArcTestObject.newWithCounter_(counter);
+      final obj1 = ArcTestObject.newWithCounter(counter);
       expect(counter.value, 1);
       final obj2 = obj1.copyMe();
       expect(counter.value, 2);
       final obj3 = obj1.mutableCopyMe();
       expect(counter.value, 3);
-      final obj4 = obj1.copyWithZone_(nullptr);
+      final obj4 = obj1.copyWithZone(nullptr);
       expect(counter.value, 4);
       final obj5 = obj1.copy();
       expect(counter.value, 5);
@@ -215,7 +215,7 @@ void main() {
     }, skip: !canDoGC);
 
     Pointer<ObjCObject> autoreleaseMethodsInner(Pointer<Int32> counter) {
-      final obj1 = ArcTestObject.makeAndAutorelease_(counter);
+      final obj1 = ArcTestObject.makeAndAutorelease(counter);
       expect(counter.value, 1);
 
       final obj1raw = obj1.ref.pointer;
@@ -238,7 +238,7 @@ void main() {
       expect(objectRetainCount(obj1raw), 0);
 
       final pool2 = lib.objc_autoreleasePoolPush();
-      final obj2 = ArcTestObject.makeAndAutorelease_(counter);
+      final obj2 = ArcTestObject.makeAndAutorelease(counter);
       final obj2raw = obj2.ref.pointer;
       expect(counter.value, 1);
       expect(objectRetainCount(obj2raw), 2);
@@ -258,7 +258,7 @@ void main() {
 
     Pointer<ObjCObject> assignPropertiesInnerInner(
         Pointer<Int32> counter, ArcTestObject outerObj) {
-      final assignObj = ArcTestObject.newWithCounter_(counter);
+      final assignObj = ArcTestObject.newWithCounter(counter);
       expect(counter.value, 2);
       final assignObjRaw = assignObj.ref.pointer;
       expect(objectRetainCount(assignObjRaw), 1);
@@ -275,7 +275,7 @@ void main() {
 
     (Pointer<ObjCObject>, Pointer<ObjCObject>) assignPropertiesInner(
         Pointer<Int32> counter) {
-      final outerObj = ArcTestObject.newWithCounter_(counter);
+      final outerObj = ArcTestObject.newWithCounter(counter);
       expect(counter.value, 1);
       final outerObjRaw = outerObj.ref.pointer;
       expect(objectRetainCount(outerObjRaw), 1);
@@ -302,7 +302,7 @@ void main() {
 
     Pointer<ObjCObject> retainPropertiesInnerInner(
         Pointer<Int32> counter, ArcTestObject outerObj) {
-      final retainObj = ArcTestObject.newWithCounter_(counter);
+      final retainObj = ArcTestObject.newWithCounter(counter);
       expect(counter.value, 2);
       final retainObjRaw = retainObj.ref.pointer;
       expect(objectRetainCount(retainObjRaw), 1);
@@ -315,7 +315,7 @@ void main() {
 
     (Pointer<ObjCObject>, Pointer<ObjCObject>) retainPropertiesInner(
         Pointer<Int32> counter) {
-      final outerObj = ArcTestObject.newWithCounter_(counter);
+      final outerObj = ArcTestObject.newWithCounter(counter);
       expect(counter.value, 1);
       final outerObjRaw = outerObj.ref.pointer;
       expect(objectRetainCount(outerObjRaw), 1);
@@ -349,10 +349,10 @@ void main() {
 
     (Pointer<ObjCObject>, Pointer<ObjCObject>, Pointer<ObjCObject>)
         copyPropertiesInner(Pointer<Int32> counter) {
-      final outerObj = ArcTestObject.newWithCounter_(counter);
+      final outerObj = ArcTestObject.newWithCounter(counter);
       expect(counter.value, 1);
 
-      final copyObj = ArcTestObject.newWithCounter_(counter);
+      final copyObj = ArcTestObject.newWithCounter(counter);
       expect(counter.value, 2);
       outerObj.copiedProperty = copyObj;
       // Copy properties make a copy of the object, so now we have 3 objects.
@@ -398,11 +398,11 @@ void main() {
 
     test('Manual release', () {
       final counter = calloc<Int32>();
-      final obj1 = ArcTestObject.newWithCounter_(counter);
+      final obj1 = ArcTestObject.newWithCounter(counter);
       expect(counter.value, 1);
-      final obj2 = ArcTestObject.newWithCounter_(counter);
+      final obj2 = ArcTestObject.newWithCounter(counter);
       expect(counter.value, 2);
-      final obj3 = ArcTestObject.newWithCounter_(counter);
+      final obj3 = ArcTestObject.newWithCounter(counter);
       expect(counter.value, 3);
 
       final obj1raw = obj1.ref.pointer;
@@ -429,7 +429,7 @@ void main() {
     });
 
     void largeRefCountInner(Pointer<Int32> counter) {
-      final obj = ArcTestObject.newWithCounter_(counter);
+      final obj = ArcTestObject.newWithCounter(counter);
       expect(counter.value, 1);
       final objRefs = <ArcTestObject>[];
       for (int i = 1; i < 1000; ++i) {
@@ -443,13 +443,13 @@ void main() {
 
     test('Consumed arguments', () {
       final counter = calloc<Int32>();
-      ArcTestObject? obj1 = ArcTestObject.newWithCounter_(counter);
+      ArcTestObject? obj1 = ArcTestObject.newWithCounter(counter);
       final obj1raw = obj1.ref.pointer;
 
       expect(objectRetainCount(obj1raw), 1);
       expect(counter.value, 1);
 
-      ArcTestObject.consumeArg_(obj1);
+      ArcTestObject.consumeArg(obj1);
 
       expect(objectRetainCount(obj1raw), 1);
       expect(counter.value, 1);
@@ -482,8 +482,8 @@ void main() {
       final dtorOnMainThreadCounter = calloc<Int32>();
       final objects = <ArcDtorTestObject>[];
       for (var i = 0; i < numTestObjects; ++i) {
-        objects.add(ArcDtorTestObject.alloc().initWithCounters_onMainThread_(
-            dtorCounter, dtorOnMainThreadCounter));
+        objects.add(ArcDtorTestObject.alloc().initWithCounters(
+            dtorCounter, onMainThread: dtorOnMainThreadCounter));
       }
       objects.clear();
 

--- a/pkgs/ffigen/test/native_objc_test/bad_method_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/bad_method_test.dart
@@ -28,14 +28,14 @@ void main() {
       final obj = BadMethodTestObject();
       final structPtr = obj.incompletePointerReturn();
       expect(structPtr.address, 1234);
-      expect(obj.incompletePointerParam_(structPtr), 1234);
+      expect(obj.incompletePointerParam(structPtr), 1234);
     });
 
     test("Test bit field methods that weren't skipped", () {
       final obj = BadMethodTestObject();
       final bitFieldPtr = obj.bitFieldPointerReturn();
       expect(bitFieldPtr.address, 5678);
-      expect(obj.bitFieldPointerParam_(bitFieldPtr), 5678);
+      expect(obj.bitFieldPointerParam(bitFieldPtr), 5678);
     });
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/bad_override_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/bad_override_test.dart
@@ -68,13 +68,13 @@ void main() {
       final triangle = Triangle();
 
       var parent = BadOverrideParent();
-      expect(parent.covariantArg_(square).toDartString(), 'Polygon: Square');
+      expect(parent.covariantArg(square).toDartString(), 'Polygon: Square');
       expect(
-          parent.covariantArg_(triangle).toDartString(), 'Polygon: Triangle');
+          parent.covariantArg(triangle).toDartString(), 'Polygon: Triangle');
 
       parent = BadOverrideChild();
-      expect(parent.covariantArg_(square).toDartString(), 'Rectangle: Square');
-      expect(() => parent.covariantArg_(triangle), throwsA(isA<TypeError>()));
+      expect(parent.covariantArg(square).toDartString(), 'Rectangle: Square');
+      expect(() => parent.covariantArg(triangle), throwsA(isA<TypeError>()));
     });
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/bad_override_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/bad_override_test.dart
@@ -69,8 +69,7 @@ void main() {
 
       var parent = BadOverrideParent();
       expect(parent.covariantArg(square).toDartString(), 'Polygon: Square');
-      expect(
-          parent.covariantArg(triangle).toDartString(), 'Polygon: Triangle');
+      expect(parent.covariantArg(triangle).toDartString(), 'Polygon: Triangle');
 
       parent = BadOverrideChild();
       expect(parent.covariantArg(square).toDartString(), 'Rectangle: Square');

--- a/pkgs/ffigen/test/native_objc_test/block_annotation_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_annotation_test.dart
@@ -81,7 +81,7 @@ void main() {
         ObjCBlock<EmptyObject Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyObject_ffiVoid.fromFunction(
                 (Pointer<Void> _) => EmptyObject.alloc().init());
-        return BlockAnnotationTest.invokeObjectProducer_(blk);
+        return BlockAnnotationTest.invokeObjectProducer(blk);
       });
     }, skip: !canDoGC);
 
@@ -110,7 +110,7 @@ void main() {
         ObjCBlock<Retained<EmptyObject> Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyObject_ffiVoid$1.fromFunction(
                 (Pointer<Void> _) => EmptyObject.alloc().init());
-        return BlockAnnotationTest.invokeRetainedObjectProducer_(
+        return BlockAnnotationTest.invokeRetainedObjectProducer(
             ObjCBlock<EmptyObject Function(Pointer<Void>)>(blk.ref.pointer,
                 retain: true, release: true));
       });
@@ -138,7 +138,7 @@ void main() {
         ObjCBlock<EmptyObject Function(Pointer<Void>, EmptyObject)> blk =
             ObjCBlock_EmptyObject_ffiVoid_EmptyObject.fromFunction(
                 (Pointer<Void> _, EmptyObject obj) => obj);
-        return BlockAnnotationTest.invokeObjectReceiver_(blk);
+        return BlockAnnotationTest.invokeObjectReceiver(blk);
       });
     }, skip: !canDoGC);
 
@@ -168,7 +168,7 @@ void main() {
         ObjCBlock<EmptyObject Function(Pointer<Void>, Consumed<EmptyObject>)>
             blk = ObjCBlock_EmptyObject_ffiVoid_EmptyObject$1.fromFunction(
                 (Pointer<Void> _, EmptyObject obj) => obj);
-        return BlockAnnotationTest.invokeConsumedObjectReceiver_(
+        return BlockAnnotationTest.invokeConsumedObjectReceiver(
             ObjCBlock<EmptyObject Function(Pointer<Void>, EmptyObject)>(
                 blk.ref.pointer,
                 retain: true,
@@ -209,7 +209,7 @@ void main() {
         ObjCBlock<Void Function(Pointer<Void>, EmptyObject)> blk =
             ObjCBlock_ffiVoid_ffiVoid_EmptyObject.listener(
                 (Pointer<Void> _, EmptyObject obj) => completer.complete(obj));
-        BlockAnnotationTest.invokeObjectListenerSync_(blk);
+        BlockAnnotationTest.invokeObjectListenerSync(blk);
       });
     }, skip: !canDoGC);
 
@@ -218,7 +218,7 @@ void main() {
         ObjCBlock<Void Function(Pointer<Void>, EmptyObject)> blk =
             ObjCBlock_ffiVoid_ffiVoid_EmptyObject.listener(
                 (Pointer<Void> _, EmptyObject obj) => completer.complete(obj));
-        final thread = BlockAnnotationTest.invokeObjectListenerAsync_(blk);
+        final thread = BlockAnnotationTest.invokeObjectListenerAsync(blk);
         thread.start();
       });
     }, skip: !canDoGC);
@@ -238,7 +238,7 @@ void main() {
         ObjCBlock<Void Function(Pointer<Void>, Consumed<EmptyObject>)> blk =
             ObjCBlock_ffiVoid_ffiVoid_EmptyObject$1.listener(
                 (Pointer<Void> _, EmptyObject obj) => completer.complete(obj));
-        BlockAnnotationTest.invokeObjectListenerSync_(
+        BlockAnnotationTest.invokeObjectListenerSync(
             ObjCBlock<Void Function(Pointer<Void>, EmptyObject)>(
                 blk.ref.pointer,
                 retain: true,
@@ -251,7 +251,7 @@ void main() {
         ObjCBlock<Void Function(Pointer<Void>, Consumed<EmptyObject>)> blk =
             ObjCBlock_ffiVoid_ffiVoid_EmptyObject$1.listener(
                 (Pointer<Void> _, EmptyObject obj) => completer.complete(obj));
-        final thread = BlockAnnotationTest.invokeObjectListenerAsync_(
+        final thread = BlockAnnotationTest.invokeObjectListenerAsync(
             ObjCBlock<Void Function(Pointer<Void>, EmptyObject)>(
                 blk.ref.pointer,
                 retain: true,
@@ -295,7 +295,7 @@ void main() {
         ObjCBlock<DartEmptyBlock Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyBlock_ffiVoid.fromFunction(
                 (Pointer<Void> _) => ObjCBlock_ffiVoid.fromFunction(() {}));
-        return BlockAnnotationTest.invokeBlockProducer_(blk);
+        return BlockAnnotationTest.invokeBlockProducer(blk);
       });
     }, skip: !canDoGC);
 
@@ -324,7 +324,7 @@ void main() {
         ObjCBlock<Retained<DartEmptyBlock> Function(Pointer<Void>)> blk =
             ObjCBlock_EmptyBlock_ffiVoid$1.fromFunction(
                 (Pointer<Void> _) => ObjCBlock_ffiVoid.fromFunction(() {}));
-        return BlockAnnotationTest.invokeRetainedBlockProducer_(
+        return BlockAnnotationTest.invokeRetainedBlockProducer(
             ObjCBlock<DartEmptyBlock Function(Pointer<Void>)>(blk.ref.pointer,
                 retain: true, release: true));
       });

--- a/pkgs/ffigen/test/native_objc_test/block_inherit_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_inherit_test.dart
@@ -33,7 +33,7 @@ void main() {
     test('BlockInheritTestBase', () {
       final BlockInheritTestBase baseObj = BlockInheritTestBase();
       expect(baseObj.getAnimal().laysEggs(), false);
-      expect(baseObj.acceptAnimal_(Platypus()), true);
+      expect(baseObj.acceptAnimal(Platypus()), true);
 
       final ObjCBlock<Mammal Function()> returner = baseObj.getReturner();
       final Mammal returnerResult = returner();
@@ -45,20 +45,20 @@ void main() {
       final platypus = Platypus();
       final ObjCBlock<Platypus Function()> platypusReturner =
           ObjCBlock_Platypus.fromFunction(() => platypus);
-      expect(baseObj.invokeReturner_(platypusReturner).laysEggs(), true);
+      expect(baseObj.invokeReturner(platypusReturner).laysEggs(), true);
 
       final ObjCBlock<Bool Function(Mammal)> mammalAccepter =
           ObjCBlock_bool_Mammal.fromFunction(
               (Mammal mammal) => mammal.laysEggs());
-      expect(baseObj.invokeAccepter_(mammalAccepter), false);
+      expect(baseObj.invokeAccepter(mammalAccepter), false);
     });
 
     test('BlockInheritTestChild', () {
       final BlockInheritTestChild childObj = BlockInheritTestChild();
       final BlockInheritTestBase baseObj = childObj;
       expect(baseObj.getAnimal().laysEggs(), true);
-      expect(baseObj.acceptAnimal_(Platypus()), true);
-      expect(childObj.acceptAnimal_(Mammal()), false);
+      expect(baseObj.acceptAnimal(Platypus()), true);
+      expect(childObj.acceptAnimal(Mammal()), false);
 
       final ObjCBlock<Mammal Function()> baseReturner = baseObj.getReturner();
       final Mammal baseReturnerResult = baseReturner();
@@ -81,24 +81,24 @@ void main() {
       final platypus = Platypus();
       final ObjCBlock<Platypus Function()> platypusReturner =
           ObjCBlock_Platypus.fromFunction(() => platypus);
-      expect(baseObj.invokeReturner_(platypusReturner).laysEggs(), true);
+      expect(baseObj.invokeReturner(platypusReturner).laysEggs(), true);
 
       final mammal = Mammal();
       final ObjCBlock<Mammal Function()> mammalReturner =
           ObjCBlock_Mammal.fromFunction(() => mammal);
-      expect(childObj.invokeReturner_(mammalReturner).laysEggs(), false);
-      expect(childObj.invokeReturner_(platypusReturner).laysEggs(), true);
+      expect(childObj.invokeReturner(mammalReturner).laysEggs(), false);
+      expect(childObj.invokeReturner(platypusReturner).laysEggs(), true);
 
       final ObjCBlock<Bool Function(Mammal)> mammalAccepter =
           ObjCBlock_bool_Mammal.fromFunction(
               (Mammal mammal) => mammal.laysEggs());
-      expect(baseObj.invokeAccepter_(mammalAccepter), true);
+      expect(baseObj.invokeAccepter(mammalAccepter), true);
 
       final ObjCBlock<Bool Function(Platypus)> platypusAccepter =
           ObjCBlock_bool_Platypus.fromFunction(
               (Platypus platypus) => platypus.laysEggs());
-      expect(childObj.invokeAccepter_(platypusAccepter), true);
-      expect(childObj.invokeAccepter_(mammalAccepter), true);
+      expect(childObj.invokeAccepter(platypusAccepter), true);
+      expect(childObj.invokeAccepter(mammalAccepter), true);
     });
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/block_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/block_test.dart
@@ -58,28 +58,28 @@ void main() {
       verifySetupFile(dylib);
       lib = BlockTestObjCLibrary(DynamicLibrary.open(dylib.absolute.path));
 
-      // generateBindingsForCoverage('block');
+      generateBindingsForCoverage('block');
 
-      BlockTester.setup_(NativeApi.initializeApiDLData);
+      BlockTester.setup(NativeApi.initializeApiDLData);
     });
 
     test('BlockTester is working', () {
       // This doesn't test any Block functionality, just that the BlockTester
       // itself is working correctly.
-      final blockTester = BlockTester.newFromMultiplier_(10);
-      expect(blockTester.call_(123), 1230);
+      final blockTester = BlockTester.newFromMultiplier(10);
+      expect(blockTester.call(123), 1230);
       final intBlock = blockTester.getBlock();
-      final blockTester2 = BlockTester.newFromBlock_(intBlock);
+      final blockTester2 = BlockTester.newFromBlock(intBlock);
       blockTester2.pokeBlock();
-      expect(blockTester2.call_(456), 4560);
+      expect(blockTester2.call(456), 4560);
     });
 
     test('Block from function pointer', () {
       final block =
           IntBlock.fromFunctionPointer(Pointer.fromFunction(_add100, 999));
-      final blockTester = BlockTester.newFromBlock_(block);
+      final blockTester = BlockTester.newFromBlock(block);
       blockTester.pokeBlock();
-      expect(blockTester.call_(123), 223);
+      expect(blockTester.call(123), 223);
       expect(block(123), 223);
     });
 
@@ -89,9 +89,9 @@ void main() {
 
     test('Block from function', () {
       final block = IntBlock.fromFunction(makeAdder(4000));
-      final blockTester = BlockTester.newFromBlock_(block);
+      final blockTester = BlockTester.newFromBlock(block);
       blockTester.pokeBlock();
-      expect(blockTester.call_(123), 4123);
+      expect(blockTester.call(123), 4123);
       expect(block(123), 4123);
     });
 
@@ -103,7 +103,7 @@ void main() {
         hasRun.complete();
       });
 
-      BlockTester.callOnSameThread_(block);
+      BlockTester.callOnSameThread(block);
 
       await hasRun.future;
       expect(value, 123);
@@ -117,7 +117,7 @@ void main() {
         hasRun.complete();
       });
 
-      final thread = BlockTester.callOnNewThread_(block);
+      final thread = BlockTester.callOnNewThread(block);
       thread.start();
 
       await hasRun.future;
@@ -138,7 +138,7 @@ void main() {
         waitSync(Duration(milliseconds: 100));
         value = 123;
       });
-      BlockTester.callOnSameThread_(block);
+      BlockTester.callOnSameThread(block);
       expect(value, 123);
     });
 
@@ -151,7 +151,7 @@ void main() {
       final resultBlock = ResultBlock.listener((int result) {
         resultCompleter.complete(result);
       });
-      BlockTester.blockingBlockTest_resultBlock_(block, resultBlock);
+      BlockTester.blockingBlockTest(block, resultBlock: resultBlock);
       expect(await resultCompleter.future, 123456);
     });
 
@@ -161,7 +161,7 @@ void main() {
         value = 123;
         throw "Hello";
       });
-      BlockTester.callOnSameThread_(block);
+      BlockTester.callOnSameThread(block);
       expect(value, 123);
     });
 
@@ -174,7 +174,7 @@ void main() {
       final resultBlock = ResultBlock.listener((int result) {
         resultCompleter.complete(result);
       });
-      BlockTester.blockingBlockTest_resultBlock_(block, resultBlock);
+      BlockTester.blockingBlockTest(block, resultBlock: resultBlock);
       expect(await resultCompleter.future, 123456);
     });
 
@@ -193,7 +193,7 @@ void main() {
         return x + 4.56;
       });
       expect(block(1.23), closeTo(5.79, 1e-6));
-      expect(BlockTester.callFloatBlock_(block), closeTo(5.79, 1e-6));
+      expect(BlockTester.callFloatBlock(block), closeTo(5.79, 1e-6));
     });
 
     test('Double block', () {
@@ -201,7 +201,7 @@ void main() {
         return x + 4.56;
       });
       expect(block(1.23), closeTo(5.79, 1e-6));
-      expect(BlockTester.callDoubleBlock_(block), closeTo(5.79, 1e-6));
+      expect(BlockTester.callDoubleBlock(block), closeTo(5.79, 1e-6));
     });
 
     test('Struct block', () {
@@ -230,7 +230,7 @@ void main() {
         expect(result1.z, 7.8);
         expect(result1.w, 1.2);
 
-        final result2 = BlockTester.callVec4Block_(block);
+        final result2 = BlockTester.callVec4Block(block);
         expect(result2.x, 3.4);
         expect(result2.y, 5.6);
         expect(result2.z, 7.8);
@@ -247,7 +247,7 @@ void main() {
       block('Hello'.toSelector());
       expect(sel, 'Hello');
 
-      BlockTester.callSelectorBlock_(block);
+      BlockTester.callSelectorBlock(block);
       expect(sel, 'Select');
     });
 
@@ -264,7 +264,7 @@ void main() {
       expect(isCalled, isTrue);
 
       isCalled = false;
-      final result2 = BlockTester.callObjectBlock_(block);
+      final result2 = BlockTester.callObjectBlock(block);
       expect(result2, isNot(obj));
       expect(result2.ref.pointer, isNot(nullptr));
       expect(isCalled, isTrue);
@@ -288,7 +288,7 @@ void main() {
       expect(isCalled, isTrue);
 
       isCalled = false;
-      final result3 = BlockTester.callNullableObjectBlock_(block);
+      final result3 = BlockTester.callNullableObjectBlock(block);
       expect(result3, isNull);
       expect(isCalled, isTrue);
     });
@@ -304,7 +304,7 @@ void main() {
       final result2 = block(null);
       expect(result2?.toDartString(), 'null Cat');
 
-      final result3 = BlockTester.callNullableStringBlock_(block);
+      final result3 = BlockTester.callNullableStringBlock(block);
       expect(result3?.toDartString(), 'Lizard Cat');
     });
 
@@ -315,7 +315,7 @@ void main() {
         hasRun.complete();
       });
 
-      BlockTester.callObjectListener_(block);
+      BlockTester.callObjectListener(block);
       await hasRun.future;
     });
 
@@ -326,7 +326,7 @@ void main() {
         hasRun.complete();
       });
 
-      BlockTester.callNullableListener_(block);
+      BlockTester.callNullableListener(block);
       await hasRun.future;
     });
 
@@ -347,7 +347,7 @@ void main() {
         hasRun.complete();
       });
 
-      BlockTester.callStructListener_(block);
+      BlockTester.callStructListener(block);
       await hasRun.future;
     });
 
@@ -358,7 +358,7 @@ void main() {
         hasRun.complete();
       });
 
-      BlockTester.callNSStringListener_x_(block, 123);
+      BlockTester.callNSStringListener(block, x: 123);
       await hasRun.future;
     });
 
@@ -378,7 +378,7 @@ void main() {
         hasRun.complete();
       });
 
-      BlockTester.callNoTrampolineListener_(block);
+      BlockTester.callNoTrampolineListener(block);
       await hasRun.future;
     });
 
@@ -396,12 +396,12 @@ void main() {
       final result1 = blockBlock(intBlock);
       expect(result1(1), 15);
 
-      final result2 = BlockTester.newBlock_withMult_(blockBlock, 2);
+      final result2 = BlockTester.newBlock(blockBlock, withMult: 2);
       expect(result2(1), 6);
     });
 
     test('Native block block', () {
-      final blockBlock = BlockTester.newBlockBlock_(7);
+      final blockBlock = BlockTester.newBlockBlock(7);
 
       final intBlock = IntBlock.fromFunction((int x) {
         return 5 * x;
@@ -409,7 +409,7 @@ void main() {
       final result1 = blockBlock(intBlock);
       expect(result1(1), 35);
 
-      final result2 = BlockTester.newBlock_withMult_(blockBlock, 2);
+      final result2 = BlockTester.newBlock(blockBlock, withMult: 2);
       expect(result2(1), 14);
     });
 
@@ -545,7 +545,7 @@ void main() {
           return 3 * intBlock(x);
         });
       });
-      final outputBlock = BlockTester.newBlock_withMult_(blockBlock, 2);
+      final outputBlock = BlockTester.newBlock(blockBlock, withMult: 2);
       expect(outputBlock(1), 6);
       lib.objc_autoreleasePoolPop(pool);
       doGC();
@@ -591,7 +591,7 @@ void main() {
       final inputBlock = IntBlock.fromFunction((int x) {
         return 5 * x;
       });
-      final blockBlock = BlockTester.newBlockBlock_(7);
+      final blockBlock = BlockTester.newBlockBlock(7);
       final outputBlock = blockBlock(inputBlock);
       expect(outputBlock(1), 35);
       lib.objc_autoreleasePoolPop(pool);
@@ -621,8 +621,8 @@ void main() {
 
     (Pointer<ObjCBlockImpl>, Pointer<ObjCBlockImpl>)
         nativeBlockBlockObjCCallRefCountTest() {
-      final blockBlock = BlockTester.newBlockBlock_(7);
-      final outputBlock = BlockTester.newBlock_withMult_(blockBlock, 2);
+      final blockBlock = BlockTester.newBlockBlock(7);
+      final outputBlock = BlockTester.newBlock(blockBlock, withMult: 2);
       expect(outputBlock(1), 14);
       doGC();
 
@@ -646,10 +646,10 @@ void main() {
       outputCounter.value = 0;
 
       final block = ObjectBlock.fromFunction((DummyObject x) {
-        return DummyObject.newWithCounter_(outputCounter);
+        return DummyObject.newWithCounter(outputCounter);
       });
 
-      final inputObj = DummyObject.newWithCounter_(inputCounter);
+      final inputObj = DummyObject.newWithCounter(inputCounter);
       final outputObj = block(inputObj);
       expect(inputCounter.value, 1);
       expect(outputCounter.value, 1);
@@ -676,11 +676,11 @@ void main() {
       outputCounter.value = 0;
 
       final block = ObjectBlock.fromFunction((DummyObject x) {
-        x.setCounter_(inputCounter);
-        return DummyObject.newWithCounter_(outputCounter);
+        x.setCounter(inputCounter);
+        return DummyObject.newWithCounter(outputCounter);
       });
 
-      final outputObj = BlockTester.callObjectBlock_(block);
+      final outputObj = BlockTester.callObjectBlock(block);
       expect(inputCounter.value, 1);
       expect(outputCounter.value, 1);
 
@@ -714,7 +714,7 @@ void main() {
         hasRun.complete();
       });
 
-      final thread = BlockTester.callWithBlockOnNewThread_(blockBlock);
+      final thread = BlockTester.callWithBlockOnNewThread(blockBlock);
       thread.start();
 
       await hasRun.future;
@@ -750,7 +750,7 @@ void main() {
         expect(dummyObject, isNotNull);
       });
 
-      final tester = BlockTester.newFromListener_(block);
+      final tester = BlockTester.newFromListener(block);
       final rawBlock = block!.ref.pointer;
       expect(blockRetainCount(rawBlock), 2);
 
@@ -759,7 +759,7 @@ void main() {
 
       dummyObject = null;
       block = null;
-      tester.invokeAndReleaseListener_(null);
+      tester.invokeAndReleaseListener(null);
       doGC();
       await Future<void>.delayed(Duration.zero); // Let dispose message arrive.
       doGC();
@@ -782,7 +782,7 @@ void main() {
         completer.complete();
       });
 
-      final tester = BlockTester.newFromListener_(block);
+      final tester = BlockTester.newFromListener(block);
       final rawBlock = block!.ref.pointer;
       expect(blockRetainCount(rawBlock), 2);
 
@@ -843,7 +843,7 @@ void main() {
         completer.complete();
         expect(dummyObject, isNotNull);
       });
-      final tester = BlockTester.newFromListener_(block);
+      final tester = BlockTester.newFromListener(block);
       expect(blockRetainCount(block.ref.pointer), 2);
       expect(objectRetainCount(dummyObject.ref.pointer), 1);
       return (tester, block.ref.pointer, dummyObject.ref.pointer);
@@ -1070,7 +1070,7 @@ void main() {
         final block = VoidBlock.blocking(() {
           innerValue = 123;
         });
-        BlockTester.callOnSameThreadOutsideIsolate_(block);
+        BlockTester.callOnSameThreadOutsideIsolate(block);
         return innerValue;
       });
       expect(value, 123);

--- a/pkgs/ffigen/test/native_objc_test/category_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/category_test.dart
@@ -28,9 +28,9 @@ void main() {
 
     test('Category methods', () {
       final thing = Thing();
-      expect(thing.add_Y_(1000, 234), 1234);
-      expect(thing.sub_Y_(1234, 1000), 234);
-      expect(thing.mul_Y_(1234, 1000), 1234000);
+      expect(thing.add(1000, Y: 234), 1234);
+      expect(thing.sub(1234, Y: 1000), 234);
+      expect(thing.mul(1234, Y: 1000), 1234000);
       expect(thing.someProperty, 456);
       expect(thing.anonymousCategoryMethod(), 404);
       expect(Thing.anonymousCategoryStaticMethod(), 128);

--- a/pkgs/ffigen/test/native_objc_test/method_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/method_test.dart
@@ -34,15 +34,15 @@ void main() {
       });
 
       test('One argument', () {
-        expect(testInstance.add_(23), 23);
+        expect(testInstance.add$1(23), 23);
       });
 
       test('Two arguments', () {
-        expect(testInstance.add_Y_(23, 17), 40);
+        expect(testInstance.add$2(23, Y: 17), 40);
       });
 
       test('Three arguments', () {
-        expect(testInstance.add_Y_Z_(23, 17, 60), 100);
+        expect(testInstance.add$3(23, Y: 17, Z: 60), 100);
       });
     });
 
@@ -52,15 +52,15 @@ void main() {
       });
 
       test('One argument', () {
-        expect(MethodInterface.sub_(7), -7);
+        expect(MethodInterface.sub$1(7), -7);
       });
 
       test('Two arguments', () {
-        expect(MethodInterface.sub_Y_(7, 3), -10);
+        expect(MethodInterface.sub$2(7, Y: 3), -10);
       });
 
       test('Three arguments', () {
-        expect(MethodInterface.sub_Y_Z_(10, 7, 3), -20);
+        expect(MethodInterface.sub$3(10, Y: 7, Z: 3), -20);
       });
     });
 
@@ -73,7 +73,7 @@ void main() {
         input.z = 5.6;
         input.w = 7.8;
 
-        final result = testInstance.twiddleVec4Components_(input);
+        final result = testInstance.twiddleVec4Components(input);
         expect(result.x, 3.4);
         expect(result.y, 5.6);
         expect(result.z, 7.8);
@@ -83,11 +83,11 @@ void main() {
       });
 
       test('Floats', () {
-        expect(testInstance.addFloats_Y_(1.23, 4.56), closeTo(5.79, 1e-6));
+        expect(testInstance.addFloats(1.23, Y: 4.56), closeTo(5.79, 1e-6));
       });
 
       test('Doubles', () {
-        expect(testInstance.addDoubles_Y_(1.23, 4.56), closeTo(5.79, 1e-6));
+        expect(testInstance.addDoubles(1.23, Y: 4.56), closeTo(5.79, 1e-6));
       });
 
       test('Method with same name as a type', () {

--- a/pkgs/ffigen/test/native_objc_test/native_objc_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/native_objc_test.dart
@@ -46,22 +46,22 @@ void main() {
     });
 
     test('Interface basics, with Foo', () {
-      final foo1 = Foo.makeFoo_(3.14159);
-      final foo2 = Foo.makeFoo_(2.71828);
+      final foo1 = Foo.makeFoo(3.14159);
+      final foo2 = Foo.makeFoo(2.71828);
 
       expect(foo1.intVal, 3);
       expect(foo2.intVal, 2);
 
-      expect(foo1.multiply_withOtherFoo_(false, foo2), 8);
-      expect(foo1.multiply_withOtherFoo_(true, foo2), 6);
+      expect(foo1.multiply(false, withOtherFoo: foo2), 8);
+      expect(foo1.multiply(true, withOtherFoo: foo2), 6);
 
       foo1.intVal = 100;
-      expect(foo1.multiply_withOtherFoo_(false, foo2), 8);
-      expect(foo1.multiply_withOtherFoo_(true, foo2), 200);
+      expect(foo1.multiply(false, withOtherFoo: foo2), 8);
+      expect(foo1.multiply(true, withOtherFoo: foo2), 200);
 
-      foo2.setDoubleVal_(1.61803);
-      expect(foo1.multiply_withOtherFoo_(false, foo2), 5);
-      expect(foo1.multiply_withOtherFoo_(true, foo2), 200);
+      foo2.setDoubleVal(1.61803);
+      expect(foo1.multiply(false, withOtherFoo: foo2), 5);
+      expect(foo1.multiply(true, withOtherFoo: foo2), 200);
     });
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/nullable_inheritance_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/nullable_inheritance_test.dart
@@ -34,17 +34,17 @@ void main() {
 
     group('Base', () {
       test('Nullable arguments', () {
-        expect(nullableBase.nullableArg_(obj), false);
-        expect(nullableBase.nullableArg_(null), true);
+        expect(nullableBase.nullableArg(obj), false);
+        expect(nullableBase.nullableArg(null), true);
       });
 
       test('Non-null arguments', () {
-        expect(nullableBase.nonNullArg_(obj), false);
+        expect(nullableBase.nonNullArg(obj), false);
       });
 
       test('Nullable return', () {
-        expect(nullableBase.nullableReturn_(false), isA<NSObject>());
-        expect(nullableBase.nullableReturn_(true), null);
+        expect(nullableBase.nullableReturn(false), isA<NSObject>());
+        expect(nullableBase.nullableReturn(true), null);
       });
 
       test('Non-null return', () {
@@ -54,16 +54,16 @@ void main() {
 
     group('Child', () {
       test('Nullable arguments, changed to non-null', () {
-        expect(nullableChild.nullableArg_(obj), false);
+        expect(nullableChild.nullableArg(obj), false);
       });
 
       test('Non-null arguments, changed to nullable', () {
-        expect(nullableChild.nonNullArg_(obj), false);
-        expect(nullableChild.nonNullArg_(null), true);
+        expect(nullableChild.nonNullArg(obj), false);
+        expect(nullableChild.nonNullArg(null), true);
       });
 
       test('Nullable return, changed to non-null', () {
-        expect(nullableChild.nullableReturn_(false), isA<NSObject>());
+        expect(nullableChild.nullableReturn(false), isA<NSObject>());
       });
 
       test('Non-null return, changed to nullable', () {

--- a/pkgs/ffigen/test/native_objc_test/nullable_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/nullable_test.dart
@@ -78,5 +78,22 @@ void main() {
       expect(
           NullableInterface.returnNullableAlias(false)?.toDartString(), "Hi");
     });
+
+    test('Multiple nullable args', () {
+      final x = NSObject();
+      final y = NSObject();
+      final z = NSObject();
+
+      expect(NullableInterface.multipleNullableArgs(x, y: y, z: z), x);
+      expect(NullableInterface.multipleNullableArgs(null, y: y, z: z), y);
+      expect(NullableInterface.multipleNullableArgs(null, y: null, z: z), z);
+      expect(
+          NullableInterface.multipleNullableArgs(null, y: null, z: null), null);
+
+      // Nullable named args are optional.
+      expect(NullableInterface.multipleNullableArgs(null, z: z), z);
+      expect(NullableInterface.multipleNullableArgs(null, y: y), y);
+      expect(NullableInterface.multipleNullableArgs(null), null);
+    });
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/nullable_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/nullable_test.dart
@@ -43,40 +43,40 @@ void main() {
 
     group('Nullable return', () {
       test('Not null', () {
-        expect(NullableInterface.returnNil_(false), isA<NSObject>());
+        expect(NullableInterface.returnNil(false), isA<NSObject>());
       });
       test('Null', () {
-        expect(NullableInterface.returnNil_(true), null);
+        expect(NullableInterface.returnNil(true), null);
       });
     });
 
     group('Nullable arguments', () {
       test('Not null', () {
-        expect(NullableInterface.isNullWithNullableNSObjectArg_(obj), false);
+        expect(NullableInterface.isNullWithNullableNSObjectArg(obj), false);
       });
       test('Null', () {
-        expect(NullableInterface.isNullWithNullableNSObjectArg_(null), true);
+        expect(NullableInterface.isNullWithNullableNSObjectArg(null), true);
       });
     });
 
     group('Not-nullable arguments', () {
       test('Not null', () {
         expect(
-            NullableInterface.isNullWithNotNullableNSObjectPtrArg_(obj), false);
+            NullableInterface.isNullWithNotNullableNSObjectPtrArg(obj), false);
       });
 
       test('Explicit non null', () {
         expect(
-            NullableInterface.isNullWithExplicitNonNullableNSObjectPtrArg_(obj),
+            NullableInterface.isNullWithExplicitNonNullableNSObjectPtrArg(obj),
             false);
       });
     });
 
     test('Nullable typealias', () {
       // Regression test for https://github.com/dart-lang/native/issues/1701
-      expect(NullableInterface.returnNullableAlias_(true), isNull);
+      expect(NullableInterface.returnNullableAlias(true), isNull);
       expect(
-          NullableInterface.returnNullableAlias_(false)?.toDartString(), "Hi");
+          NullableInterface.returnNullableAlias(false)?.toDartString(), "Hi");
     });
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/nullable_test.m
+++ b/pkgs/ffigen/test/native_objc_test/nullable_test.m
@@ -10,6 +10,8 @@ typedef NSString* MyString;
 +(BOOL) isNullWithExplicitNonNullableNSObjectPtrArg:(nonnull NSObject *)x;
 +(nullable NSObject *) returnNil:(BOOL)r;
 +(nullable MyString) returnNullableAlias:(BOOL)r;
++(nullable NSObject *) multipleNullableArgs:(nullable NSObject *)x
+    y:(nullable NSObject *)y z:(nullable NSObject *)z;
 
 @property (nullable, retain) NSObject *nullableObjectProperty;
 
@@ -43,6 +45,13 @@ typedef NSString* MyString;
   } else {
     return @"Hi";
   }
+}
+
++(nullable NSObject *) multipleNullableArgs:(nullable NSObject *)x
+    y:(nullable NSObject *)y z:(nullable NSObject *)z {
+  if (x != nil) return x;
+  if (y != nil) return y;
+  return z;
 }
 
 @end

--- a/pkgs/ffigen/test/native_objc_test/protocol_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/protocol_test.dart
@@ -46,20 +46,20 @@ void main() {
         final consumer = ProtocolConsumer();
 
         // Required instance method.
-        final result = consumer.callInstanceMethod_(asMyProtocol);
+        final result = consumer.callInstanceMethod(asMyProtocol);
         expect(
             result.toDartString(), 'ObjCProtocolImpl: Hello from ObjC: 3.14');
 
         // Optional instance method.
-        final intResult = consumer.callOptionalMethod_(asMyProtocol);
+        final intResult = consumer.callOptionalMethod(asMyProtocol);
         expect(intResult, 579);
 
         // Required instance method from secondary protocol.
-        final otherIntResult = consumer.callOtherMethod_(asSecondaryProtocol);
+        final otherIntResult = consumer.callOtherMethod(asSecondaryProtocol);
         expect(otherIntResult, 10);
 
         // Method using two protocols.
-        final twoMethodResult = consumer.callTwoMethods_(asMyProtocol);
+        final twoMethodResult = consumer.callTwoMethods(asMyProtocol);
         expect(twoMethodResult, 579);
       });
 
@@ -68,19 +68,19 @@ void main() {
 
         // Required instance method.
         final result =
-            protocolImpl.instanceMethod_withDouble_("abc".toNSString(), 123);
+            protocolImpl.instanceMethod("abc".toNSString(), withDouble: 123);
         expect(result.toDartString(), 'ObjCProtocolImpl: abc: 123.00');
 
         // Optional instance method.
         final structPtr = calloc<SomeStruct>();
         structPtr.ref.x = 12;
         structPtr.ref.y = 34;
-        final intResult = protocolImpl.optionalMethod_(structPtr.ref);
+        final intResult = protocolImpl.optionalMethod(structPtr.ref);
         expect(intResult, 46);
         calloc.free(structPtr);
 
         // Required instance method from secondary protocol.
-        final otherIntResult = protocolImpl.otherMethod_b_c_d_(2, 4, 6, 8);
+        final otherIntResult = protocolImpl.otherMethod(2, b: 4, c: 6, d: 8);
         expect(otherIntResult, 20);
 
         // Method from a protocol that isn't included by the filters.
@@ -96,7 +96,7 @@ void main() {
         final consumer = ProtocolConsumer();
 
         // Optional instance method, not implemented.
-        final intResult = consumer.callOptionalMethod_(protocolImpl);
+        final intResult = consumer.callOptionalMethod(protocolImpl);
         expect(intResult, -999);
       });
 
@@ -107,7 +107,7 @@ void main() {
         final structPtr = calloc<SomeStruct>();
         structPtr.ref.x = 12;
         structPtr.ref.y = 34;
-        expect(() => protocolImpl.optionalMethod_(structPtr.ref),
+        expect(() => protocolImpl.optionalMethod(structPtr.ref),
             throwsA(isA<UnimplementedOptionalMethodException>()));
         calloc.free(structPtr);
 
@@ -133,11 +133,11 @@ void main() {
         expect(SecondaryProtocol.conformsTo(myProtocol), isFalse);
 
         // Required instance method.
-        final result = consumer.callInstanceMethod_(myProtocol);
+        final result = consumer.callInstanceMethod(myProtocol);
         expect(result.toDartString(), 'MyProtocol: Hello from ObjC: 3.14');
 
         // Optional instance method.
-        final intResult = consumer.callOptionalMethod_(myProtocol);
+        final intResult = consumer.callOptionalMethod(myProtocol);
         expect(intResult, 333);
       });
 
@@ -167,15 +167,15 @@ void main() {
         expect(SecondaryProtocol.conformsTo(protocolImpl), isTrue);
 
         // Required instance method.
-        final result = consumer.callInstanceMethod_(asMyProtocol);
+        final result = consumer.callInstanceMethod(asMyProtocol);
         expect(result.toDartString(), 'ProtocolBuilder: Hello from ObjC: 3.14');
 
         // Required instance method from secondary protocol.
-        final otherIntResult = consumer.callOtherMethod_(asSecondaryProtocol);
+        final otherIntResult = consumer.callOtherMethod(asSecondaryProtocol);
         expect(otherIntResult, 24);
 
         // Method using two protocols.
-        final twoMethodResult = consumer.callTwoMethods_(asMyProtocol);
+        final twoMethodResult = consumer.callTwoMethods(asMyProtocol);
         expect(twoMethodResult, 222000);
       });
 
@@ -197,11 +197,11 @@ void main() {
             SecondaryProtocol.castFrom(protocolImpl);
 
         // Required instance method.
-        final result = consumer.callInstanceMethod_(asMyProtocol);
+        final result = consumer.callInstanceMethod(asMyProtocol);
         expect(result.toDartString(), 'ProtocolBuilder: Hello from ObjC: 3.14');
 
         // Required instance method from secondary protocol.
-        final otherIntResult = consumer.callOtherMethod_(asSecondaryProtocol);
+        final otherIntResult = consumer.callOtherMethod(asSecondaryProtocol);
         expect(otherIntResult, 24);
       });
 
@@ -215,7 +215,7 @@ void main() {
         );
 
         // Optional instance method, not implemented.
-        final intResult = consumer.callOptionalMethod_(myProtocol);
+        final intResult = consumer.callOptionalMethod(myProtocol);
         expect(intResult, -999);
       });
 
@@ -236,15 +236,15 @@ void main() {
         );
 
         // Required instance method.
-        final result = consumer.callInstanceMethod_(myProtocol);
+        final result = consumer.callInstanceMethod(myProtocol);
         expect(result.toDartString(), 'MyProtocol: Hello from ObjC: 3.14');
 
         // Optional instance method.
-        final intResult = consumer.callOptionalMethod_(myProtocol);
+        final intResult = consumer.callOptionalMethod(myProtocol);
         expect(intResult, 333);
 
         // Listener method.
-        consumer.callMethodOnRandomThread_(myProtocol);
+        consumer.callMethodOnRandomThread(myProtocol);
         expect(await listenerCompleter.future, 123);
       });
 
@@ -272,15 +272,15 @@ void main() {
             SecondaryProtocol.castFrom(protocolImpl);
 
         // Required instance method.
-        final result = consumer.callInstanceMethod_(asMyProtocol);
+        final result = consumer.callInstanceMethod(asMyProtocol);
         expect(result.toDartString(), 'ProtocolBuilder: Hello from ObjC: 3.14');
 
         // Required instance method from secondary protocol.
-        final otherIntResult = consumer.callOtherMethod_(asSecondaryProtocol);
+        final otherIntResult = consumer.callOtherMethod(asSecondaryProtocol);
         expect(otherIntResult, 24);
 
         // Listener method.
-        consumer.callMethodOnRandomThread_(asMyProtocol);
+        consumer.callMethodOnRandomThread(asMyProtocol);
         expect(await listenerCompleter.future, 123);
       });
 
@@ -310,7 +310,7 @@ void main() {
         );
 
         // Blocking method.
-        consumer.callBlockingMethodOnRandomThread_(myProtocol);
+        consumer.callBlockingMethodOnRandomThread(myProtocol);
         expect(await listenerCompleter.future, 123456);
       });
 
@@ -342,11 +342,11 @@ void main() {
             SecondaryProtocol.castFrom(protocolImpl);
 
         // Required instance method from secondary protocol.
-        final otherIntResult = consumer.callOtherMethod_(asSecondaryProtocol);
+        final otherIntResult = consumer.callOtherMethod(asSecondaryProtocol);
         expect(otherIntResult, 24);
 
         // Blocking method.
-        consumer.callBlockingMethodOnRandomThread_(asMyProtocol);
+        consumer.callBlockingMethodOnRandomThread(asMyProtocol);
         expect(await listenerCompleter.future, 98765);
       });
 
@@ -362,7 +362,7 @@ void main() {
         final myProtocol = MyProtocol.castFrom(builder.build());
 
         // Required instance method.
-        final result = consumer.callInstanceMethod_(myProtocol);
+        final result = consumer.callInstanceMethod(myProtocol);
         expect(result.toDartString(), 'DirectImpl: Hello from ObjC: 3.14');
       });
     });
@@ -438,7 +438,7 @@ void main() {
       final MyProtocol asMyProtocol = MyProtocol.castFrom(protocol);
 
       for (int i = 0; i < 1000; ++i) {
-        consumer.callMethodOnRandomThread_(asMyProtocol);
+        consumer.callMethodOnRandomThread(asMyProtocol);
       }
       await completer.future;
       expect(count, 1000);

--- a/pkgs/ffigen/test/native_objc_test/ref_count_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/ref_count_test.dart
@@ -39,9 +39,9 @@ void main() {
     (Pointer<ObjCObject>, Pointer<ObjCObject>) newMethodsInner(
         Pointer<Int32> counter) {
       final obj1 = RefCountTestObject();
-      obj1.setCounter_(counter);
+      obj1.setCounter(counter);
       expect(counter.value, 1);
-      final obj2 = RefCountTestObject.newWithCounter_(counter);
+      final obj2 = RefCountTestObject.newWithCounter(counter);
       expect(counter.value, 2);
 
       final obj1raw = obj1.ref.pointer;
@@ -76,13 +76,13 @@ void main() {
 
     (Pointer<ObjCObject>, Pointer<ObjCObject>, Pointer<ObjCObject>)
         allocMethodsInner(Pointer<Int32> counter) {
-      final obj1 = RefCountTestObject.alloc().initWithCounter_(counter);
+      final obj1 = RefCountTestObject.alloc().initWithCounter(counter);
       expect(counter.value, 1);
       final obj2 =
           RefCountTestObject.castFrom(RefCountTestObject.alloc().init());
-      obj2.setCounter_(counter);
+      obj2.setCounter(counter);
       expect(counter.value, 2);
-      final obj3 = RefCountTestObject.allocTheThing().initWithCounter_(counter);
+      final obj3 = RefCountTestObject.allocTheThing().initWithCounter(counter);
       expect(counter.value, 3);
 
       final obj1raw = obj1.ref.pointer;
@@ -124,13 +124,13 @@ void main() {
       Pointer<ObjCObject>
     ) copyMethodsInner(Pointer<Int32> counter) {
       final pool = lib.objc_autoreleasePoolPush();
-      final obj1 = RefCountTestObject.newWithCounter_(counter);
+      final obj1 = RefCountTestObject.newWithCounter(counter);
       expect(counter.value, 1);
       final obj2 = obj1.copyMe();
       expect(counter.value, 2);
       final obj3 = obj1.mutableCopyMe();
       expect(counter.value, 3);
-      final obj4 = obj1.copyWithZone_(nullptr);
+      final obj4 = obj1.copyWithZone(nullptr);
       expect(counter.value, 4);
       final obj5 = obj1.copy();
       expect(counter.value, 5);
@@ -216,7 +216,7 @@ void main() {
     }, skip: !canDoGC);
 
     Pointer<ObjCObject> autoreleaseMethodsInner(Pointer<Int32> counter) {
-      final obj1 = RefCountTestObject.makeAndAutorelease_(counter);
+      final obj1 = RefCountTestObject.makeAndAutorelease(counter);
       expect(counter.value, 1);
 
       final obj1raw = obj1.ref.pointer;
@@ -239,7 +239,7 @@ void main() {
       expect(objectRetainCount(obj1raw), 0);
 
       final pool2 = lib.objc_autoreleasePoolPush();
-      final obj2 = RefCountTestObject.makeAndAutorelease_(counter);
+      final obj2 = RefCountTestObject.makeAndAutorelease(counter);
       final obj2raw = obj2.ref.pointer;
       expect(counter.value, 1);
       expect(objectRetainCount(obj2raw), 2);
@@ -259,7 +259,7 @@ void main() {
 
     Pointer<ObjCObject> assignPropertiesInnerInner(
         Pointer<Int32> counter, RefCountTestObject outerObj) {
-      final assignObj = RefCountTestObject.newWithCounter_(counter);
+      final assignObj = RefCountTestObject.newWithCounter(counter);
       expect(counter.value, 2);
       final assignObjRaw = assignObj.ref.pointer;
       expect(objectRetainCount(assignObjRaw), 1);
@@ -276,7 +276,7 @@ void main() {
 
     (Pointer<ObjCObject>, Pointer<ObjCObject>) assignPropertiesInner(
         Pointer<Int32> counter) {
-      final outerObj = RefCountTestObject.newWithCounter_(counter);
+      final outerObj = RefCountTestObject.newWithCounter(counter);
       expect(counter.value, 1);
       final outerObjRaw = outerObj.ref.pointer;
       expect(objectRetainCount(outerObjRaw), 1);
@@ -303,7 +303,7 @@ void main() {
 
     Pointer<ObjCObject> retainPropertiesInnerInner(
         Pointer<Int32> counter, RefCountTestObject outerObj) {
-      final retainObj = RefCountTestObject.newWithCounter_(counter);
+      final retainObj = RefCountTestObject.newWithCounter(counter);
       expect(counter.value, 2);
       final retainObjRaw = retainObj.ref.pointer;
       expect(objectRetainCount(retainObjRaw), 1);
@@ -316,7 +316,7 @@ void main() {
 
     (Pointer<ObjCObject>, Pointer<ObjCObject>) retainPropertiesInner(
         Pointer<Int32> counter) {
-      final outerObj = RefCountTestObject.newWithCounter_(counter);
+      final outerObj = RefCountTestObject.newWithCounter(counter);
       expect(counter.value, 1);
       final outerObjRaw = outerObj.ref.pointer;
       expect(objectRetainCount(outerObjRaw), 1);
@@ -350,10 +350,10 @@ void main() {
 
     (Pointer<ObjCObject>, Pointer<ObjCObject>, Pointer<ObjCObject>)
         copyPropertiesInner(Pointer<Int32> counter) {
-      final outerObj = RefCountTestObject.newWithCounter_(counter);
+      final outerObj = RefCountTestObject.newWithCounter(counter);
       expect(counter.value, 1);
 
-      final copyObj = RefCountTestObject.newWithCounter_(counter);
+      final copyObj = RefCountTestObject.newWithCounter(counter);
       expect(counter.value, 2);
       outerObj.copiedProperty = copyObj;
       // Copy properties make a copy of the object, so now we have 3 objects.
@@ -433,11 +433,11 @@ void main() {
 
     test('Manual release', () {
       final counter = calloc<Int32>();
-      final obj1 = RefCountTestObject.newWithCounter_(counter);
+      final obj1 = RefCountTestObject.newWithCounter(counter);
       expect(counter.value, 1);
-      final obj2 = RefCountTestObject.newWithCounter_(counter);
+      final obj2 = RefCountTestObject.newWithCounter(counter);
       expect(counter.value, 2);
-      final obj3 = RefCountTestObject.newWithCounter_(counter);
+      final obj3 = RefCountTestObject.newWithCounter(counter);
       expect(counter.value, 3);
 
       final obj1raw = obj1.ref.pointer;
@@ -464,7 +464,7 @@ void main() {
     });
 
     Pointer<ObjCObject> manualRetainInner(Pointer<Int32> counter) {
-      final obj = RefCountTestObject.newWithCounter_(counter);
+      final obj = RefCountTestObject.newWithCounter(counter);
       expect(counter.value, 1);
       final objRaw = obj.ref.retainAndReturnPointer();
       expect(objectRetainCount(objRaw), 2);
@@ -495,7 +495,7 @@ void main() {
 
     RefCountTestObject unownedReferenceInner2(Pointer<Int32> counter) {
       final obj1 = RefCountTestObject();
-      obj1.setCounter_(counter);
+      obj1.setCounter(counter);
       expect(counter.value, 1);
       expect(objectRetainCount(obj1.ref.pointer), 1);
       final obj1b = obj1.unownedReference();
@@ -506,7 +506,7 @@ void main() {
       // sees some sort of change. Otherwise this test could pass just by the GC
       // not working correctly.
       final obj2 = RefCountTestObject();
-      obj2.setCounter_(counter);
+      obj2.setCounter(counter);
       expect(counter.value, 2);
       expect(objectRetainCount(obj2.ref.pointer), 1);
 
@@ -538,7 +538,7 @@ void main() {
     }, skip: !canDoGC);
 
     void largeRefCountInner(Pointer<Int32> counter) {
-      final obj = RefCountTestObject.newWithCounter_(counter);
+      final obj = RefCountTestObject.newWithCounter(counter);
       expect(counter.value, 1);
       final objRefs = <RefCountTestObject>[];
       for (int i = 1; i < 1000; ++i) {
@@ -552,13 +552,13 @@ void main() {
 
     test('Consumed arguments', () {
       final counter = calloc<Int32>();
-      RefCountTestObject? obj1 = RefCountTestObject.newWithCounter_(counter);
+      RefCountTestObject? obj1 = RefCountTestObject.newWithCounter(counter);
       final obj1raw = obj1.ref.pointer;
 
       expect(objectRetainCount(obj1raw), 1);
       expect(counter.value, 1);
 
-      RefCountTestObject.consumeArg_(obj1);
+      RefCountTestObject.consumeArg(obj1);
 
       expect(objectRetainCount(obj1raw), 1);
       expect(counter.value, 1);

--- a/pkgs/ffigen/test/native_objc_test/rename_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/rename_test.dart
@@ -49,7 +49,7 @@ void main() {
     test('Renamed method', () {
       final renamed = Renamed();
 
-      expect(renamed.fooBarBaz(123, 456), 579);
+      expect(renamed.fooBarBaz(123, y: 456), 579);
     });
 
     test('Renamed property', () {

--- a/pkgs/ffigen/test/native_objc_test/static_func_native_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_native_test.dart
@@ -39,7 +39,7 @@ void main() {
       final counter = alloc<Int32>();
       counter.value = 0;
 
-      final obj = StaticFuncTestObj.newWithCounter_(counter);
+      final obj = StaticFuncTestObj.newWithCounter(counter);
       expect(counter.value, 1);
 
       final pool = objc_autoreleasePoolPush();
@@ -63,7 +63,7 @@ void main() {
       final counter = alloc<Int32>();
       counter.value = 0;
 
-      final obj = StaticFuncTestObj.newWithCounter_(counter);
+      final obj = StaticFuncTestObj.newWithCounter(counter);
       expect(counter.value, 1);
 
       final pool = objc_autoreleasePoolPush();
@@ -130,7 +130,7 @@ void main() {
       final counter = alloc<Int32>();
       counter.value = 0;
 
-      final obj = StaticFuncTestObj.newWithCounter_(counter);
+      final obj = StaticFuncTestObj.newWithCounter(counter);
       expect(counter.value, 1);
 
       final outputObj = staticFuncReturnsRetainedArg(obj);
@@ -154,7 +154,7 @@ void main() {
         'Objects passed to static functions that consume them '
         'have correct ref counts', () {
       final counter = calloc<Int32>();
-      StaticFuncTestObj? obj1 = StaticFuncTestObj.newWithCounter_(counter);
+      StaticFuncTestObj? obj1 = StaticFuncTestObj.newWithCounter(counter);
       final obj1raw = obj1.ref.pointer;
 
       expect(objectRetainCount(obj1raw), 1);

--- a/pkgs/ffigen/test/native_objc_test/static_func_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/static_func_test.dart
@@ -41,7 +41,7 @@ void main() {
       final counter = alloc<Int32>();
       counter.value = 0;
 
-      final obj = StaticFuncTestObj.newWithCounter_(counter);
+      final obj = StaticFuncTestObj.newWithCounter(counter);
       expect(counter.value, 1);
 
       final pool = lib.objc_autoreleasePoolPush();
@@ -65,7 +65,7 @@ void main() {
       final counter = alloc<Int32>();
       counter.value = 0;
 
-      final obj = StaticFuncTestObj.newWithCounter_(counter);
+      final obj = StaticFuncTestObj.newWithCounter(counter);
       expect(counter.value, 1);
 
       final pool = lib.objc_autoreleasePoolPush();
@@ -132,7 +132,7 @@ void main() {
       final counter = alloc<Int32>();
       counter.value = 0;
 
-      final obj = StaticFuncTestObj.newWithCounter_(counter);
+      final obj = StaticFuncTestObj.newWithCounter(counter);
       expect(counter.value, 1);
 
       final outputObj = lib.staticFuncReturnsRetainedArg(obj);
@@ -156,7 +156,7 @@ void main() {
         'Objects passed to static functions that consume them '
         'have correct ref counts', () {
       final counter = calloc<Int32>();
-      StaticFuncTestObj? obj1 = StaticFuncTestObj.newWithCounter_(counter);
+      StaticFuncTestObj? obj1 = StaticFuncTestObj.newWithCounter(counter);
       final obj1raw = obj1.ref.pointer;
 
       expect(objectRetainCount(obj1raw), 1);

--- a/pkgs/ffigen/test/native_objc_test/string_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/string_test.dart
@@ -44,7 +44,7 @@ void main() {
       final str1 = 'Hello'.toNSString();
       final str2 = 'World!'.toNSString();
 
-      final str3 = StringUtil.strConcat_with_(str1, str2);
+      final str3 = StringUtil.strConcat(str1, with$: str2);
       expect(str3.length, 11);
       expect(str3.toDartString(), "HelloWorld!");
     });

--- a/pkgs/ffigen/test/native_objc_test/swift_class_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/swift_class_test.dart
@@ -27,7 +27,7 @@ void main() {
     test('Renamed class', () {
       final swiftObject = MySwiftClass();
       expect(swiftObject.getValue(), 123);
-      swiftObject.setValueWithX_(456);
+      swiftObject.setValueWithX(456);
       expect(swiftObject.getValue(), 456);
     });
   });

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 8.0.0-wip
+## 8.0.0
 
 - Use ffigen 19.0.0
 - `NSArray` is now a Dart `Iterable` and `NSMutableArray` is now a Dart `List`.

--- a/pkgs/objective_c/lib/src/ns_data.dart
+++ b/pkgs/objective_c/lib/src/ns_data.dart
@@ -42,7 +42,7 @@ extension NSDataListExtension on List<int> {
     final buffer = malloc<Uint8>(length);
     buffer.asTypedList(length).setAll(0, this);
 
-    final nsData = NSData.dataWithBytes_length_(buffer.cast(), length);
+    final nsData = NSData.dataWithBytes(buffer.cast(), length: length);
     malloc.free(buffer);
 
     return nsData;

--- a/pkgs/objective_c/lib/src/ns_date.dart
+++ b/pkgs/objective_c/lib/src/ns_date.dart
@@ -5,7 +5,7 @@
 import 'objective_c_bindings_generated.dart';
 
 extension DateTimeToNSDate on DateTime {
-  NSDate toNSDate() => NSDate.dateWithTimeIntervalSince1970_(
+  NSDate toNSDate() => NSDate.dateWithTimeIntervalSince1970(
       millisecondsSinceEpoch / Duration.millisecondsPerSecond);
 }
 

--- a/pkgs/objective_c/lib/src/ns_input_stream.dart
+++ b/pkgs/objective_c/lib/src/ns_input_stream.dart
@@ -11,10 +11,10 @@ extension NSInputStreamStreamExtension on Stream<List<int>> {
   /// the [Stream].
   ///
   /// > [!IMPORTANT]
-  /// > [NSInputStream.read_maxLength_] must be called from a different thread
-  /// > or [Isolate] than the one that calls [toNSInputStream]. Otherwise,
-  /// > [NSInputStream.read_maxLength_] will deadlock waiting for data to be
-  /// > added from the [Stream].
+  /// > [NSInputStream.read] must be called from a different thread or [Isolate]
+  /// > than the one that calls [toNSInputStream]. Otherwise,
+  /// > [NSInputStream.read] will deadlock waiting for data to be added from the
+  /// > [Stream].
   NSInputStream toNSInputStream() {
     // Eagerly add data until `maxReadAheadSize` is buffered.
     const maxReadAheadSize = 4096;

--- a/pkgs/objective_c/lib/src/ns_input_stream.dart
+++ b/pkgs/objective_c/lib/src/ns_input_stream.dart
@@ -31,8 +31,8 @@ extension NSInputStreamStreamExtension on Stream<List<int>> {
     }, onError: (Object e) {
       final d = NSMutableDictionary();
       d[NSLocalizedDescriptionKey] = e.toString().toNSString();
-      inputStream.setError(NSError.errorWithDomain(
-          'DartError'.toNSString(), code: 0, userInfo: d));
+      inputStream.setError(NSError.errorWithDomain('DartError'.toNSString(),
+          code: 0, userInfo: d));
       port.close();
     }, onDone: () {
       inputStream.setDone();

--- a/pkgs/objective_c/lib/src/ns_input_stream.dart
+++ b/pkgs/objective_c/lib/src/ns_input_stream.dart
@@ -44,7 +44,7 @@ extension NSInputStreamStreamExtension on Stream<List<int>> {
       // -1 indicates that the `NSInputStream` is closed. All other values
       // indicate that the `NSInputStream` needs more data.
       //
-      // If [DartInputStreamAdapter.setError_] or
+      // If [DartInputStreamAdapter.setError] or
       // [DartInputStreamAdapter.setDone] is called then the close message (-1)
       // will not be sent when the input stream is closed.
       if (count == -1) {

--- a/pkgs/objective_c/lib/src/ns_input_stream.dart
+++ b/pkgs/objective_c/lib/src/ns_input_stream.dart
@@ -21,18 +21,18 @@ extension NSInputStreamStreamExtension on Stream<List<int>> {
 
     final port = ReceivePort();
     final inputStream =
-        DartInputStreamAdapter.inputStreamWithPort_(port.sendPort.nativePort);
+        DartInputStreamAdapter.inputStreamWithPort(port.sendPort.nativePort);
     late final StreamSubscription<dynamic> dataSubscription;
 
     dataSubscription = listen((data) {
-      if (inputStream.addData_(data.toNSData()) > maxReadAheadSize) {
+      if (inputStream.addData(data.toNSData()) > maxReadAheadSize) {
         dataSubscription.pause();
       }
     }, onError: (Object e) {
       final d = NSMutableDictionary();
-      d.setObject_forKey_(e.toString().toNSString(), NSLocalizedDescriptionKey);
-      inputStream.setError_(NSError.errorWithDomain_code_userInfo_(
-          'DartError'.toNSString(), 0, d));
+      d[NSLocalizedDescriptionKey] = e.toString().toNSString();
+      inputStream.setError(NSError.errorWithDomain(
+          'DartError'.toNSString(), code: 0, userInfo: d));
       port.close();
     }, onDone: () {
       inputStream.setDone();

--- a/pkgs/objective_c/lib/src/ns_mutable_data.dart
+++ b/pkgs/objective_c/lib/src/ns_mutable_data.dart
@@ -35,7 +35,7 @@ extension NSMutableDataExtensions on NSMutableData {
     final f = malloc<Uint8>(iterable.length);
     try {
       f.asTypedList(iterable.length).setAll(0, iterable);
-      appendBytes_length_(f.cast(), iterable.length);
+      appendBytes(f.cast(), length: iterable.length);
     } finally {
       malloc.free(f);
     }
@@ -56,7 +56,7 @@ extension NSMutableDataListExtension on List<int> {
     final buffer = malloc<Uint8>(length);
     buffer.asTypedList(length).setAll(0, this);
 
-    final data = NSMutableData.dataWithBytes_length_(buffer.cast(), length);
+    final data = NSMutableData.dataWithBytes(buffer.cast(), length: length);
     malloc.free(buffer);
 
     return data;

--- a/pkgs/objective_c/lib/src/ns_number.dart
+++ b/pkgs/objective_c/lib/src/ns_number.dart
@@ -5,19 +5,19 @@
 import 'objective_c_bindings_generated.dart';
 
 extension IntToNSNumber on int {
-  NSNumber toNSNumber() => NSNumberCreation.numberWithLongLong_(this);
+  NSNumber toNSNumber() => NSNumberCreation.numberWithLongLong(this);
 }
 
 extension DoubleToNSNumber on double {
-  NSNumber toNSNumber() => NSNumberCreation.numberWithDouble_(this);
+  NSNumber toNSNumber() => NSNumberCreation.numberWithDouble(this);
 }
 
 extension NumToNSNumber on num {
   NSNumber toNSNumber() {
     final value = this;
     return switch (value) {
-      int() => NSNumberCreation.numberWithLongLong_(value),
-      double() => NSNumberCreation.numberWithDouble_(value),
+      int() => NSNumberCreation.numberWithLongLong(value),
+      double() => NSNumberCreation.numberWithDouble(value),
     };
   }
 }

--- a/pkgs/objective_c/lib/src/ns_string.dart
+++ b/pkgs/objective_c/lib/src/ns_string.dart
@@ -11,8 +11,8 @@ extension StringToNSString on String {
 
 extension NSStringToString on NSString {
   String toDartString() {
-    final data =
-        dataUsingEncoding_(0x94000100 /* NSUTF16LittleEndianStringEncoding */);
+    const nsUTF16LittleEndianStringEncoding = 0x94000100;
+    final data = dataUsingEncoding(nsUTF16LittleEndianStringEncoding);
     return data!.bytes.cast<Utf16>().toDartString(length: length);
   }
 }

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -369,7 +369,7 @@ class DartInputStreamAdapter extends NSInputStream implements NSStreamDelegate {
   }
 
   /// inputStreamWithData:
-  static DartInputStreamAdapter? inputStreamWithData_(NSData data) {
+  static DartInputStreamAdapter? inputStreamWithData(NSData data) {
     final _ret = _objc_msgSend_1sotr3r(_class_DOBJCDartInputStreamAdapter,
         _sel_inputStreamWithData_, data.ref.pointer);
     return _ret.address == 0
@@ -379,7 +379,7 @@ class DartInputStreamAdapter extends NSInputStream implements NSStreamDelegate {
   }
 
   /// inputStreamWithFileAtPath:
-  static DartInputStreamAdapter? inputStreamWithFileAtPath_(NSString path) {
+  static DartInputStreamAdapter? inputStreamWithFileAtPath(NSString path) {
     final _ret = _objc_msgSend_1sotr3r(_class_DOBJCDartInputStreamAdapter,
         _sel_inputStreamWithFileAtPath_, path.ref.pointer);
     return _ret.address == 0
@@ -392,7 +392,7 @@ class DartInputStreamAdapter extends NSInputStream implements NSStreamDelegate {
   /// @param sendPort A port to that is will receive two types of messages:
   /// -1 => The `NSInputStream` has been closed and the port can be closed.
   /// _  => The number of types being required in a `read:maxLength` call.
-  static DartInputStreamAdapter inputStreamWithPort_(int sendPort) {
+  static DartInputStreamAdapter inputStreamWithPort(int sendPort) {
     final _ret = _objc_msgSend_1ya1kjn(_class_DOBJCDartInputStreamAdapter,
         _sel_inputStreamWithPort_, sendPort);
     return DartInputStreamAdapter.castFromPointer(_ret,
@@ -400,7 +400,7 @@ class DartInputStreamAdapter extends NSInputStream implements NSStreamDelegate {
   }
 
   /// inputStreamWithURL:
-  static DartInputStreamAdapter? inputStreamWithURL_(NSURL url) {
+  static DartInputStreamAdapter? inputStreamWithURL(NSURL url) {
     objc.checkOsVersionInternal(
         'DOBJCDartInputStreamAdapter.inputStreamWithURL:',
         iOS: (false, (4, 0, 0)),
@@ -414,13 +414,13 @@ class DartInputStreamAdapter extends NSInputStream implements NSStreamDelegate {
   }
 
   /// addData:
-  int addData_(NSData data) {
+  int addData(NSData data) {
     return _objc_msgSend_1vd1c5m(
         this.ref.pointer, _sel_addData_, data.ref.pointer);
   }
 
   /// initWithData:
-  DartInputStreamAdapter initWithData_(NSData data) {
+  DartInputStreamAdapter initWithData(NSData data) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithData_, data.ref.pointer);
     return DartInputStreamAdapter.castFromPointer(_ret,
@@ -428,7 +428,7 @@ class DartInputStreamAdapter extends NSInputStream implements NSStreamDelegate {
   }
 
   /// initWithFileAtPath:
-  DartInputStreamAdapter? initWithFileAtPath_(NSString path) {
+  DartInputStreamAdapter? initWithFileAtPath(NSString path) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithFileAtPath_, path.ref.pointer);
     return _ret.address == 0
@@ -438,7 +438,7 @@ class DartInputStreamAdapter extends NSInputStream implements NSStreamDelegate {
   }
 
   /// initWithURL:
-  DartInputStreamAdapter? initWithURL_(NSURL url) {
+  DartInputStreamAdapter? initWithURL(NSURL url) {
     objc.checkOsVersionInternal('DOBJCDartInputStreamAdapter.initWithURL:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
     final _ret = _objc_msgSend_1sotr3r(
@@ -455,18 +455,18 @@ class DartInputStreamAdapter extends NSInputStream implements NSStreamDelegate {
   }
 
   /// setError:
-  void setError_(NSError error) {
+  void setError(NSError error) {
     _objc_msgSend_xtuoz7(this.ref.pointer, _sel_setError_, error.ref.pointer);
   }
 
   /// stream:handleEvent:
-  void stream_handleEvent_(NSStream aStream, NSStreamEvent eventCode) {
+  void stream(NSStream aStream, {required NSStreamEvent handleEvent}) {
     if (!objc.respondsToSelector(this.ref.pointer, _sel_stream_handleEvent_)) {
       throw objc.UnimplementedOptionalMethodException(
           'DOBJCDartInputStreamAdapter', 'stream:handleEvent:');
     }
     _objc_msgSend_3l8zum(this.ref.pointer, _sel_stream_handleEvent_,
-        aStream.ref.pointer, eventCode.value);
+        aStream.ref.pointer, handleEvent.value);
   }
 }
 
@@ -498,7 +498,7 @@ class DartProtocol extends NSObject {
   }
 
   /// allocWithZone:
-  static DartProtocol allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static DartProtocol allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret = _objc_msgSend_1cwp428(
         _class_DOBJCDartProtocol, _sel_allocWithZone_, zone);
     return DartProtocol.castFromPointer(_ret, retain: false, release: true);
@@ -522,7 +522,7 @@ class DartProtocol extends NSObject {
   }
 
   /// getDOBJCDartProtocolMethodForSelector:
-  objc.ObjCObjectBase getDOBJCDartProtocolMethodForSelector_(
+  objc.ObjCObjectBase getDOBJCDartProtocolMethodForSelector(
       ffi.Pointer<objc.ObjCSelector> sel) {
     final _ret = _objc_msgSend_3ctkt6(
         this.ref.pointer, _sel_getDOBJCDartProtocolMethodForSelector_, sel);
@@ -539,13 +539,14 @@ class DartProtocol extends NSObject {
   }
 
   /// initDOBJCDartProtocolFromDartProtocolBuilder:withDisposePort:
-  DartProtocol initDOBJCDartProtocolFromDartProtocolBuilder_withDisposePort_(
-      DartProtocolBuilder builder, int port) {
+  DartProtocol initDOBJCDartProtocolFromDartProtocolBuilder(
+      DartProtocolBuilder builder,
+      {required int withDisposePort}) {
     final _ret = _objc_msgSend_dbvvll(
         this.ref.retainAndReturnPointer(),
         _sel_initDOBJCDartProtocolFromDartProtocolBuilder_withDisposePort_,
         builder.ref.pointer,
-        port);
+        withDisposePort);
     return DartProtocol.castFromPointer(_ret, retain: false, release: true);
   }
 
@@ -596,7 +597,7 @@ class DartProtocolBuilder extends NSObject {
   }
 
   /// allocWithZone:
-  static DartProtocolBuilder allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static DartProtocolBuilder allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret = _objc_msgSend_1cwp428(
         _class_DOBJCDartProtocolBuilder, _sel_allocWithZone_, zone);
     return DartProtocolBuilder.castFromPointer(_ret,
@@ -612,7 +613,7 @@ class DartProtocolBuilder extends NSObject {
   }
 
   /// addProtocol:
-  void addProtocol_(Protocol protocol) {
+  void addProtocol(Protocol protocol) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_addProtocol_, protocol.ref.pointer);
   }
@@ -625,25 +626,24 @@ class DartProtocolBuilder extends NSObject {
   }
 
   /// buildInstance:
-  DartProtocol buildInstance_(int port) {
+  DartProtocol buildInstance(int port) {
     final _ret =
         _objc_msgSend_1ya1kjn(this.ref.pointer, _sel_buildInstance_, port);
     return DartProtocol.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// implementMethod:withBlock:withTrampoline:withSignature:
-  void implementMethod_withBlock_withTrampoline_withSignature_(
-      ffi.Pointer<objc.ObjCSelector> sel,
-      ffi.Pointer<ffi.Void> block,
-      ffi.Pointer<ffi.Void> trampoline,
-      ffi.Pointer<ffi.Char> signature) {
+  void implementMethod(ffi.Pointer<objc.ObjCSelector> sel,
+      {required ffi.Pointer<ffi.Void> withBlock,
+      required ffi.Pointer<ffi.Void> withTrampoline,
+      required ffi.Pointer<ffi.Char> withSignature}) {
     _objc_msgSend_1s2gdyk(
         this.ref.pointer,
         _sel_implementMethod_withBlock_withTrampoline_withSignature_,
         sel,
-        block,
-        trampoline,
-        signature);
+        withBlock,
+        withTrampoline,
+        withSignature);
   }
 
   /// init
@@ -657,7 +657,7 @@ class DartProtocolBuilder extends NSObject {
   }
 
   /// initWithClassName:
-  DartProtocolBuilder initWithClassName_(ffi.Pointer<ffi.Char> name) {
+  DartProtocolBuilder initWithClassName(ffi.Pointer<ffi.Char> name) {
     final _ret = _objc_msgSend_56zxyn(
         this.ref.retainAndReturnPointer(), _sel_initWithClassName_, name);
     return DartProtocolBuilder.castFromPointer(_ret,
@@ -740,12 +740,12 @@ class NSArray extends NSObject
   int get length => count;
 
   @override
-  objc.ObjCObjectBase elementAt(int index) => objectAtIndex_(index);
+  objc.ObjCObjectBase elementAt(int index) => objectAtIndex(index);
 
   @override
   Iterator<objc.ObjCObjectBase> get iterator => _NSArrayIterator(this);
 
-  objc.ObjCObjectBase operator [](int index) => objectAtIndex_(index);
+  objc.ObjCObjectBase operator [](int index) => objectAtIndex(index);
 
   NSArray._(ffi.Pointer<objc.ObjCObject> pointer,
       {bool retain = false, bool release = false})
@@ -773,7 +773,7 @@ class NSArray extends NSObject
   }
 
   /// allocWithZone:
-  static NSArray allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSArray allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSArray, _sel_allocWithZone_, zone);
     return NSArray.castFromPointer(_ret, retain: false, release: true);
@@ -786,31 +786,32 @@ class NSArray extends NSObject
   }
 
   /// arrayWithArray:
-  static NSArray arrayWithArray_(NSArray array) {
+  static NSArray arrayWithArray(NSArray array$1) {
     final _ret = _objc_msgSend_1sotr3r(
-        _class_NSArray, _sel_arrayWithArray_, array.ref.pointer);
+        _class_NSArray, _sel_arrayWithArray_, array$1.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// arrayWithObject:
-  static NSArray arrayWithObject_(objc.ObjCObjectBase anObject) {
+  static NSArray arrayWithObject(objc.ObjCObjectBase anObject) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSArray, _sel_arrayWithObject_, anObject.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// arrayWithObjects:
-  static NSArray arrayWithObjects_(objc.ObjCObjectBase firstObj) {
+  static NSArray arrayWithObjects(objc.ObjCObjectBase firstObj) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSArray, _sel_arrayWithObjects_, firstObj.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// arrayWithObjects:count:
-  static NSArray arrayWithObjects_count_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
+  static NSArray arrayWithObjects$1(
+      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      {required int count}) {
     final _ret = _objc_msgSend_zmbtbd(
-        _class_NSArray, _sel_arrayWithObjects_count_, objects, cnt);
+        _class_NSArray, _sel_arrayWithObjects_count_, objects, count);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -831,16 +832,19 @@ class NSArray extends NSObject
   }
 
   /// countByEnumeratingWithState:objects:count:
-  int countByEnumeratingWithState_objects_count_(
-      ffi.Pointer<NSFastEnumerationState> state,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> buffer,
-      int len) {
-    return _objc_msgSend_1b5ysjl(this.ref.pointer,
-        _sel_countByEnumeratingWithState_objects_count_, state, buffer, len);
+  int countByEnumeratingWithState(ffi.Pointer<NSFastEnumerationState> state,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      required int count$1}) {
+    return _objc_msgSend_1b5ysjl(
+        this.ref.pointer,
+        _sel_countByEnumeratingWithState_objects_count_,
+        state,
+        objects,
+        count$1);
   }
 
   /// encodeWithCoder:
-  void encodeWithCoder_(NSCoder coder) {
+  void encodeWithCoder(NSCoder coder) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_encodeWithCoder_, coder.ref.pointer);
   }
@@ -855,21 +859,21 @@ class NSArray extends NSObject
   }
 
   /// initWithArray:
-  NSArray initWithArray_(NSArray array) {
+  NSArray initWithArray(NSArray array$1) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
-        _sel_initWithArray_, array.ref.pointer);
+        _sel_initWithArray_, array$1.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithArray:copyItems:
-  NSArray initWithArray_copyItems_(NSArray array, bool flag) {
+  NSArray initWithArray$1(NSArray array$1, {required bool copyItems}) {
     final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
-        _sel_initWithArray_copyItems_, array.ref.pointer, flag);
+        _sel_initWithArray_copyItems_, array$1.ref.pointer, copyItems);
     return NSArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
-  NSArray? initWithCoder_(NSCoder coder) {
+  NSArray? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -878,22 +882,22 @@ class NSArray extends NSObject
   }
 
   /// initWithObjects:
-  NSArray initWithObjects_(objc.ObjCObjectBase firstObj) {
+  NSArray initWithObjects(objc.ObjCObjectBase firstObj) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithObjects_, firstObj.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithObjects:count:
-  NSArray initWithObjects_count_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
+  NSArray initWithObjects$1(ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      {required int count$1}) {
     final _ret = _objc_msgSend_zmbtbd(this.ref.retainAndReturnPointer(),
-        _sel_initWithObjects_count_, objects, cnt);
+        _sel_initWithObjects_count_, objects, count$1);
     return NSArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// objectAtIndex:
-  objc.ObjCObjectBase objectAtIndex_(int index) {
+  objc.ObjCObjectBase objectAtIndex(int index) {
     final _ret =
         _objc_msgSend_14hpxwa(this.ref.pointer, _sel_objectAtIndex_, index);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
@@ -949,7 +953,7 @@ class NSCharacterSet extends NSObject
   }
 
   /// allocWithZone:
-  static NSCharacterSet allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSCharacterSet allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSCharacterSet, _sel_allocWithZone_, zone);
     return NSCharacterSet.castFromPointer(_ret, retain: false, release: true);
@@ -970,21 +974,21 @@ class NSCharacterSet extends NSObject
   }
 
   /// characterSetWithBitmapRepresentation:
-  static NSCharacterSet characterSetWithBitmapRepresentation_(NSData data) {
+  static NSCharacterSet characterSetWithBitmapRepresentation(NSData data) {
     final _ret = _objc_msgSend_1sotr3r(_class_NSCharacterSet,
         _sel_characterSetWithBitmapRepresentation_, data.ref.pointer);
     return NSCharacterSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// characterSetWithCharactersInString:
-  static NSCharacterSet characterSetWithCharactersInString_(NSString aString) {
+  static NSCharacterSet characterSetWithCharactersInString(NSString aString) {
     final _ret = _objc_msgSend_1sotr3r(_class_NSCharacterSet,
         _sel_characterSetWithCharactersInString_, aString.ref.pointer);
     return NSCharacterSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// characterSetWithContentsOfFile:
-  static NSCharacterSet? characterSetWithContentsOfFile_(NSString fName) {
+  static NSCharacterSet? characterSetWithContentsOfFile(NSString fName) {
     final _ret = _objc_msgSend_1sotr3r(_class_NSCharacterSet,
         _sel_characterSetWithContentsOfFile_, fName.ref.pointer);
     return _ret.address == 0
@@ -993,7 +997,7 @@ class NSCharacterSet extends NSObject
   }
 
   /// characterSetWithRange:
-  static NSCharacterSet characterSetWithRange_(NSRange aRange) {
+  static NSCharacterSet characterSetWithRange(NSRange aRange) {
     final _ret = _objc_msgSend_1k1o1s7(
         _class_NSCharacterSet, _sel_characterSetWithRange_, aRange);
     return NSCharacterSet.castFromPointer(_ret, retain: true, release: true);
@@ -1118,19 +1122,19 @@ class NSCharacterSet extends NSObject
   }
 
   /// characterIsMember:
-  bool characterIsMember_(int aCharacter) {
+  bool characterIsMember(int aCharacter) {
     return _objc_msgSend_1co9mn4(
         this.ref.pointer, _sel_characterIsMember_, aCharacter);
   }
 
   /// encodeWithCoder:
-  void encodeWithCoder_(NSCoder coder) {
+  void encodeWithCoder(NSCoder coder) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_encodeWithCoder_, coder.ref.pointer);
   }
 
   /// hasMemberInPlane:
-  bool hasMemberInPlane_(int thePlane) {
+  bool hasMemberInPlane(int thePlane) {
     return _objc_msgSend_gerswc(
         this.ref.pointer, _sel_hasMemberInPlane_, thePlane);
   }
@@ -1145,7 +1149,7 @@ class NSCharacterSet extends NSObject
   }
 
   /// initWithCoder:
-  NSCharacterSet? initWithCoder_(NSCoder coder) {
+  NSCharacterSet? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -1160,13 +1164,13 @@ class NSCharacterSet extends NSObject
   }
 
   /// isSupersetOfSet:
-  bool isSupersetOfSet_(NSCharacterSet theOtherSet) {
+  bool isSupersetOfSet(NSCharacterSet theOtherSet) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_isSupersetOfSet_, theOtherSet.ref.pointer);
   }
 
   /// longCharacterIsMember:
-  bool longCharacterIsMember_(int theLongChar) {
+  bool longCharacterIsMember(int theLongChar) {
     return _objc_msgSend_jsclrq(
         this.ref.pointer, _sel_longCharacterIsMember_, theLongChar);
   }
@@ -1215,7 +1219,7 @@ class NSCoder extends NSObject {
   }
 
   /// allocWithZone:
-  static NSCoder allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSCoder allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSCoder, _sel_allocWithZone_, zone);
     return NSCoder.castFromPointer(_ret, retain: false, release: true);
@@ -1236,25 +1240,25 @@ class NSCoder extends NSObject {
   }
 
   /// decodeValueOfObjCType:at:size:
-  void decodeValueOfObjCType_at_size_(
-      ffi.Pointer<ffi.Char> type, ffi.Pointer<ffi.Void> data, int size) {
+  void decodeValueOfObjCType(ffi.Pointer<ffi.Char> type,
+      {required ffi.Pointer<ffi.Void> at, required int size}) {
     objc.checkOsVersionInternal('NSCoder.decodeValueOfObjCType:at:size:',
         iOS: (false, (11, 0, 0)), macOS: (false, (10, 13, 0)));
-    _objc_msgSend_nc6uds(this.ref.pointer, _sel_decodeValueOfObjCType_at_size_,
-        type, data, size);
+    _objc_msgSend_nc6uds(
+        this.ref.pointer, _sel_decodeValueOfObjCType_at_size_, type, at, size);
   }
 
   /// encodeDataObject:
-  void encodeDataObject_(NSData data) {
+  void encodeDataObject(NSData data) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_encodeDataObject_, data.ref.pointer);
   }
 
   /// encodeValueOfObjCType:at:
-  void encodeValueOfObjCType_at_(
-      ffi.Pointer<ffi.Char> type, ffi.Pointer<ffi.Void> addr) {
+  void encodeValueOfObjCType(ffi.Pointer<ffi.Char> type,
+      {required ffi.Pointer<ffi.Void> at}) {
     _objc_msgSend_1flkydz(
-        this.ref.pointer, _sel_encodeValueOfObjCType_at_, type, addr);
+        this.ref.pointer, _sel_encodeValueOfObjCType_at_, type, at);
   }
 
   /// init
@@ -1267,7 +1271,7 @@ class NSCoder extends NSObject {
   }
 
   /// versionForClassName:
-  int versionForClassName_(NSString className) {
+  int versionForClassName(NSString className) {
     return _objc_msgSend_1r6ymhb(
         this.ref.pointer, _sel_versionForClassName_, className.ref.pointer);
   }
@@ -1566,7 +1570,7 @@ class NSData extends NSObject
   }
 
   /// allocWithZone:
-  static NSData allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSData allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSData, _sel_allocWithZone_, zone);
     return NSData.castFromPointer(_ret, retain: false, release: true);
@@ -1579,30 +1583,35 @@ class NSData extends NSObject
   }
 
   /// dataWithBytes:length:
-  static NSData dataWithBytes_length_(ffi.Pointer<ffi.Void> bytes, int length) {
+  static NSData dataWithBytes(ffi.Pointer<ffi.Void> bytes,
+      {required int length}) {
     final _ret = _objc_msgSend_3nbx5e(
         _class_NSData, _sel_dataWithBytes_length_, bytes, length);
     return NSData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dataWithBytesNoCopy:length:
-  static NSData dataWithBytesNoCopy_length_(
-      ffi.Pointer<ffi.Void> bytes, int length) {
+  static NSData dataWithBytesNoCopy(ffi.Pointer<ffi.Void> bytes,
+      {required int length}) {
     final _ret = _objc_msgSend_3nbx5e(
         _class_NSData, _sel_dataWithBytesNoCopy_length_, bytes, length);
     return NSData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dataWithBytesNoCopy:length:freeWhenDone:
-  static NSData dataWithBytesNoCopy_length_freeWhenDone_(
-      ffi.Pointer<ffi.Void> bytes, int length, bool b) {
-    final _ret = _objc_msgSend_161ne8y(_class_NSData,
-        _sel_dataWithBytesNoCopy_length_freeWhenDone_, bytes, length, b);
+  static NSData dataWithBytesNoCopy$1(ffi.Pointer<ffi.Void> bytes,
+      {required int length, required bool freeWhenDone}) {
+    final _ret = _objc_msgSend_161ne8y(
+        _class_NSData,
+        _sel_dataWithBytesNoCopy_length_freeWhenDone_,
+        bytes,
+        length,
+        freeWhenDone);
     return NSData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dataWithContentsOfFile:
-  static NSData? dataWithContentsOfFile_(NSString path) {
+  static NSData? dataWithContentsOfFile(NSString path) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSData, _sel_dataWithContentsOfFile_, path.ref.pointer);
     return _ret.address == 0
@@ -1611,23 +1620,22 @@ class NSData extends NSObject
   }
 
   /// dataWithContentsOfFile:options:error:
-  static NSData? dataWithContentsOfFile_options_error_(
-      NSString path,
-      NSDataReadingOptions readOptionsMask,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> errorPtr) {
+  static NSData? dataWithContentsOfFile$1(NSString path,
+      {required NSDataReadingOptions options,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_8321cp(
         _class_NSData,
         _sel_dataWithContentsOfFile_options_error_,
         path.ref.pointer,
-        readOptionsMask.value,
-        errorPtr);
+        options.value,
+        error);
     return _ret.address == 0
         ? null
         : NSData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dataWithContentsOfURL:
-  static NSData? dataWithContentsOfURL_(NSURL url) {
+  static NSData? dataWithContentsOfURL(NSURL url) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSData, _sel_dataWithContentsOfURL_, url.ref.pointer);
     return _ret.address == 0
@@ -1636,25 +1644,24 @@ class NSData extends NSObject
   }
 
   /// dataWithContentsOfURL:options:error:
-  static NSData? dataWithContentsOfURL_options_error_(
-      NSURL url,
-      NSDataReadingOptions readOptionsMask,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> errorPtr) {
+  static NSData? dataWithContentsOfURL$1(NSURL url,
+      {required NSDataReadingOptions options,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_8321cp(
         _class_NSData,
         _sel_dataWithContentsOfURL_options_error_,
         url.ref.pointer,
-        readOptionsMask.value,
-        errorPtr);
+        options.value,
+        error);
     return _ret.address == 0
         ? null
         : NSData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dataWithData:
-  static NSData dataWithData_(NSData data) {
+  static NSData dataWithData(NSData data$1) {
     final _ret = _objc_msgSend_1sotr3r(
-        _class_NSData, _sel_dataWithData_, data.ref.pointer);
+        _class_NSData, _sel_dataWithData_, data$1.ref.pointer);
     return NSData.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -1678,9 +1685,8 @@ class NSData extends NSObject
   ///
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
-  NSData? compressedDataUsingAlgorithm_error_(
-      NSDataCompressionAlgorithm algorithm,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  NSData? compressedDataUsingAlgorithm(NSDataCompressionAlgorithm algorithm,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal('NSData.compressedDataUsingAlgorithm:error:',
         iOS: (false, (13, 0, 0)), macOS: (false, (10, 15, 0)));
     final _ret = _objc_msgSend_1vnlaqg(this.ref.pointer,
@@ -1694,9 +1700,8 @@ class NSData extends NSObject
   ///
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
-  NSData? decompressedDataUsingAlgorithm_error_(
-      NSDataCompressionAlgorithm algorithm,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  NSData? decompressedDataUsingAlgorithm(NSDataCompressionAlgorithm algorithm,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal('NSData.decompressedDataUsingAlgorithm:error:',
         iOS: (false, (13, 0, 0)), macOS: (false, (10, 15, 0)));
     final _ret = _objc_msgSend_1vnlaqg(this.ref.pointer,
@@ -1707,7 +1712,7 @@ class NSData extends NSObject
   }
 
   /// encodeWithCoder:
-  void encodeWithCoder_(NSCoder coder) {
+  void encodeWithCoder(NSCoder coder) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_encodeWithCoder_, coder.ref.pointer);
   }
@@ -1722,8 +1727,8 @@ class NSData extends NSObject
   }
 
   /// initWithBase64EncodedData:options:
-  NSData? initWithBase64EncodedData_options_(
-      NSData base64Data, NSDataBase64DecodingOptions options) {
+  NSData? initWithBase64EncodedData(NSData base64Data,
+      {required NSDataBase64DecodingOptions options}) {
     objc.checkOsVersionInternal('NSData.initWithBase64EncodedData:options:',
         iOS: (false, (7, 0, 0)), macOS: (false, (10, 9, 0)));
     final _ret = _objc_msgSend_7kpg7m(
@@ -1737,8 +1742,8 @@ class NSData extends NSObject
   }
 
   /// initWithBase64EncodedString:options:
-  NSData? initWithBase64EncodedString_options_(
-      NSString base64String, NSDataBase64DecodingOptions options) {
+  NSData? initWithBase64EncodedString(NSString base64String,
+      {required NSDataBase64DecodingOptions options}) {
     objc.checkOsVersionInternal('NSData.initWithBase64EncodedString:options:',
         iOS: (false, (7, 0, 0)), macOS: (false, (10, 9, 0)));
     final _ret = _objc_msgSend_7kpg7m(
@@ -1752,29 +1757,34 @@ class NSData extends NSObject
   }
 
   /// initWithBytes:length:
-  NSData initWithBytes_length_(ffi.Pointer<ffi.Void> bytes, int length) {
+  NSData initWithBytes(ffi.Pointer<ffi.Void> bytes$1, {required int length}) {
     final _ret = _objc_msgSend_3nbx5e(this.ref.retainAndReturnPointer(),
-        _sel_initWithBytes_length_, bytes, length);
+        _sel_initWithBytes_length_, bytes$1, length);
     return NSData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBytesNoCopy:length:
-  NSData initWithBytesNoCopy_length_(ffi.Pointer<ffi.Void> bytes, int length) {
+  NSData initWithBytesNoCopy(ffi.Pointer<ffi.Void> bytes$1,
+      {required int length}) {
     final _ret = _objc_msgSend_3nbx5e(this.ref.retainAndReturnPointer(),
-        _sel_initWithBytesNoCopy_length_, bytes, length);
+        _sel_initWithBytesNoCopy_length_, bytes$1, length);
     return NSData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBytesNoCopy:length:freeWhenDone:
-  NSData initWithBytesNoCopy_length_freeWhenDone_(
-      ffi.Pointer<ffi.Void> bytes, int length, bool b) {
-    final _ret = _objc_msgSend_161ne8y(this.ref.retainAndReturnPointer(),
-        _sel_initWithBytesNoCopy_length_freeWhenDone_, bytes, length, b);
+  NSData initWithBytesNoCopy$1(ffi.Pointer<ffi.Void> bytes$1,
+      {required int length, required bool freeWhenDone}) {
+    final _ret = _objc_msgSend_161ne8y(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithBytesNoCopy_length_freeWhenDone_,
+        bytes$1,
+        length,
+        freeWhenDone);
     return NSData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
-  NSData? initWithCoder_(NSCoder coder) {
+  NSData? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -1783,7 +1793,7 @@ class NSData extends NSObject
   }
 
   /// initWithContentsOfFile:
-  NSData? initWithContentsOfFile_(NSString path) {
+  NSData? initWithContentsOfFile(NSString path) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfFile_, path.ref.pointer);
     return _ret.address == 0
@@ -1792,23 +1802,22 @@ class NSData extends NSObject
   }
 
   /// initWithContentsOfFile:options:error:
-  NSData? initWithContentsOfFile_options_error_(
-      NSString path,
-      NSDataReadingOptions readOptionsMask,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> errorPtr) {
+  NSData? initWithContentsOfFile$1(NSString path,
+      {required NSDataReadingOptions options,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_8321cp(
         this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfFile_options_error_,
         path.ref.pointer,
-        readOptionsMask.value,
-        errorPtr);
+        options.value,
+        error);
     return _ret.address == 0
         ? null
         : NSData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfURL:
-  NSData? initWithContentsOfURL_(NSURL url) {
+  NSData? initWithContentsOfURL(NSURL url) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_, url.ref.pointer);
     return _ret.address == 0
@@ -1817,25 +1826,24 @@ class NSData extends NSObject
   }
 
   /// initWithContentsOfURL:options:error:
-  NSData? initWithContentsOfURL_options_error_(
-      NSURL url,
-      NSDataReadingOptions readOptionsMask,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> errorPtr) {
+  NSData? initWithContentsOfURL$1(NSURL url,
+      {required NSDataReadingOptions options,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_8321cp(
         this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_options_error_,
         url.ref.pointer,
-        readOptionsMask.value,
-        errorPtr);
+        options.value,
+        error);
     return _ret.address == 0
         ? null
         : NSData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithData:
-  NSData initWithData_(NSData data) {
+  NSData initWithData(NSData data$1) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
-        _sel_initWithData_, data.ref.pointer);
+        _sel_initWithData_, data$1.ref.pointer);
     return NSData.castFromPointer(_ret, retain: false, release: true);
   }
 
@@ -2014,7 +2022,7 @@ class NSDate extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// allocWithZone:
-  static NSDate allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSDate allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSDate, _sel_allocWithZone_, zone);
     return NSDate.castFromPointer(_ret, retain: false, release: true);
@@ -2027,29 +2035,32 @@ class NSDate extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// dateWithTimeInterval:sinceDate:
-  static NSDate dateWithTimeInterval_sinceDate_(
-      double secsToBeAdded, NSDate date) {
-    final _ret = _objc_msgSend_1ozwf6k(_class_NSDate,
-        _sel_dateWithTimeInterval_sinceDate_, secsToBeAdded, date.ref.pointer);
+  static NSDate dateWithTimeInterval(double secsToBeAdded,
+      {required NSDate sinceDate}) {
+    final _ret = _objc_msgSend_1ozwf6k(
+        _class_NSDate,
+        _sel_dateWithTimeInterval_sinceDate_,
+        secsToBeAdded,
+        sinceDate.ref.pointer);
     return NSDate.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dateWithTimeIntervalSince1970:
-  static NSDate dateWithTimeIntervalSince1970_(double secs) {
+  static NSDate dateWithTimeIntervalSince1970(double secs) {
     final _ret = _objc_msgSend_oa8mke(
         _class_NSDate, _sel_dateWithTimeIntervalSince1970_, secs);
     return NSDate.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dateWithTimeIntervalSinceNow:
-  static NSDate dateWithTimeIntervalSinceNow_(double secs) {
+  static NSDate dateWithTimeIntervalSinceNow(double secs) {
     final _ret = _objc_msgSend_oa8mke(
         _class_NSDate, _sel_dateWithTimeIntervalSinceNow_, secs);
     return NSDate.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dateWithTimeIntervalSinceReferenceDate:
-  static NSDate dateWithTimeIntervalSinceReferenceDate_(double ti) {
+  static NSDate dateWithTimeIntervalSinceReferenceDate(double ti) {
     final _ret = _objc_msgSend_oa8mke(
         _class_NSDate, _sel_dateWithTimeIntervalSinceReferenceDate_, ti);
     return NSDate.castFromPointer(_ret, retain: true, release: true);
@@ -2067,7 +2078,7 @@ class NSDate extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// dateByAddingTimeInterval:
-  NSDate dateByAddingTimeInterval_(double ti) {
+  NSDate dateByAddingTimeInterval(double ti) {
     objc.checkOsVersionInternal('NSDate.dateByAddingTimeInterval:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 6, 0)));
     final _ret = _objc_msgSend_oa8mke(
@@ -2076,7 +2087,7 @@ class NSDate extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// encodeWithCoder:
-  void encodeWithCoder_(NSCoder coder) {
+  void encodeWithCoder(NSCoder coder) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_encodeWithCoder_, coder.ref.pointer);
   }
@@ -2091,7 +2102,7 @@ class NSDate extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// initWithCoder:
-  NSDate? initWithCoder_(NSCoder coder) {
+  NSDate? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -2100,28 +2111,32 @@ class NSDate extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// initWithTimeInterval:sinceDate:
-  NSDate initWithTimeInterval_sinceDate_(double secsToBeAdded, NSDate date) {
-    final _ret = _objc_msgSend_1ozwf6k(this.ref.retainAndReturnPointer(),
-        _sel_initWithTimeInterval_sinceDate_, secsToBeAdded, date.ref.pointer);
+  NSDate initWithTimeInterval(double secsToBeAdded,
+      {required NSDate sinceDate}) {
+    final _ret = _objc_msgSend_1ozwf6k(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithTimeInterval_sinceDate_,
+        secsToBeAdded,
+        sinceDate.ref.pointer);
     return NSDate.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithTimeIntervalSince1970:
-  NSDate initWithTimeIntervalSince1970_(double secs) {
+  NSDate initWithTimeIntervalSince1970(double secs) {
     final _ret = _objc_msgSend_oa8mke(this.ref.retainAndReturnPointer(),
         _sel_initWithTimeIntervalSince1970_, secs);
     return NSDate.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithTimeIntervalSinceNow:
-  NSDate initWithTimeIntervalSinceNow_(double secs) {
+  NSDate initWithTimeIntervalSinceNow(double secs) {
     final _ret = _objc_msgSend_oa8mke(this.ref.retainAndReturnPointer(),
         _sel_initWithTimeIntervalSinceNow_, secs);
     return NSDate.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithTimeIntervalSinceReferenceDate:
-  NSDate initWithTimeIntervalSinceReferenceDate_(double ti) {
+  NSDate initWithTimeIntervalSinceReferenceDate(double ti) {
     final _ret = _objc_msgSend_oa8mke(this.ref.retainAndReturnPointer(),
         _sel_initWithTimeIntervalSinceReferenceDate_, ti);
     return NSDate.castFromPointer(_ret, retain: false, release: true);
@@ -2173,7 +2188,7 @@ class NSDictionary extends NSObject
 
   @override
   objc.ObjCObjectBase? operator [](Object? key) =>
-      key is NSCopying ? objectForKey_(key) : null;
+      key is NSCopying ? objectForKey(key) : null;
 
   @override
   Iterable<NSCopying> get keys => _NSDictionaryKeyIterable(this);
@@ -2221,7 +2236,7 @@ class NSDictionary extends NSObject
   }
 
   /// allocWithZone:
-  static NSDictionary allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSDictionary allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSDictionary, _sel_allocWithZone_, zone);
     return NSDictionary.castFromPointer(_ret, retain: false, release: true);
@@ -2234,43 +2249,46 @@ class NSDictionary extends NSObject
   }
 
   /// dictionaryWithDictionary:
-  static NSDictionary dictionaryWithDictionary_(NSDictionary dict) {
+  static NSDictionary dictionaryWithDictionary(NSDictionary dict) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSDictionary, _sel_dictionaryWithDictionary_, dict.ref.pointer);
     return NSDictionary.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dictionaryWithObject:forKey:
-  static NSDictionary dictionaryWithObject_forKey_(
-      objc.ObjCObjectBase object, NSCopying key) {
-    final _ret = _objc_msgSend_15qeuct(_class_NSDictionary,
-        _sel_dictionaryWithObject_forKey_, object.ref.pointer, key.ref.pointer);
+  static NSDictionary dictionaryWithObject(objc.ObjCObjectBase object,
+      {required NSCopying forKey}) {
+    final _ret = _objc_msgSend_15qeuct(
+        _class_NSDictionary,
+        _sel_dictionaryWithObject_forKey_,
+        object.ref.pointer,
+        forKey.ref.pointer);
     return NSDictionary.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dictionaryWithObjects:forKeys:
-  static NSDictionary dictionaryWithObjects_forKeys_(
-      NSArray objects, NSArray keys) {
+  static NSDictionary dictionaryWithObjects(NSArray objects,
+      {required NSArray forKeys}) {
     final _ret = _objc_msgSend_15qeuct(
         _class_NSDictionary,
         _sel_dictionaryWithObjects_forKeys_,
         objects.ref.pointer,
-        keys.ref.pointer);
+        forKeys.ref.pointer);
     return NSDictionary.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dictionaryWithObjects:forKeys:count:
-  static NSDictionary dictionaryWithObjects_forKeys_count_(
+  static NSDictionary dictionaryWithObjects$1(
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> keys,
-      int cnt) {
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> forKeys,
+      required int count}) {
     final _ret = _objc_msgSend_1dydpdi(_class_NSDictionary,
-        _sel_dictionaryWithObjects_forKeys_count_, objects, keys, cnt);
+        _sel_dictionaryWithObjects_forKeys_count_, objects, forKeys, count);
     return NSDictionary.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dictionaryWithObjectsAndKeys:
-  static NSDictionary dictionaryWithObjectsAndKeys_(
+  static NSDictionary dictionaryWithObjectsAndKeys(
       objc.ObjCObjectBase firstObject) {
     final _ret = _objc_msgSend_1sotr3r(_class_NSDictionary,
         _sel_dictionaryWithObjectsAndKeys_, firstObject.ref.pointer);
@@ -2294,16 +2312,19 @@ class NSDictionary extends NSObject
   }
 
   /// countByEnumeratingWithState:objects:count:
-  int countByEnumeratingWithState_objects_count_(
-      ffi.Pointer<NSFastEnumerationState> state,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> buffer,
-      int len) {
-    return _objc_msgSend_1b5ysjl(this.ref.pointer,
-        _sel_countByEnumeratingWithState_objects_count_, state, buffer, len);
+  int countByEnumeratingWithState(ffi.Pointer<NSFastEnumerationState> state,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      required int count$1}) {
+    return _objc_msgSend_1b5ysjl(
+        this.ref.pointer,
+        _sel_countByEnumeratingWithState_objects_count_,
+        state,
+        objects,
+        count$1);
   }
 
   /// encodeWithCoder:
-  void encodeWithCoder_(NSCoder coder) {
+  void encodeWithCoder(NSCoder coder) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_encodeWithCoder_, coder.ref.pointer);
   }
@@ -2318,7 +2339,7 @@ class NSDictionary extends NSObject
   }
 
   /// initWithCoder:
-  NSDictionary? initWithCoder_(NSCoder coder) {
+  NSDictionary? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -2327,39 +2348,45 @@ class NSDictionary extends NSObject
   }
 
   /// initWithDictionary:
-  NSDictionary initWithDictionary_(NSDictionary otherDictionary) {
+  NSDictionary initWithDictionary(NSDictionary otherDictionary) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithDictionary_, otherDictionary.ref.pointer);
     return NSDictionary.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithDictionary:copyItems:
-  NSDictionary initWithDictionary_copyItems_(
-      NSDictionary otherDictionary, bool flag) {
-    final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
-        _sel_initWithDictionary_copyItems_, otherDictionary.ref.pointer, flag);
+  NSDictionary initWithDictionary$1(NSDictionary otherDictionary,
+      {required bool copyItems}) {
+    final _ret = _objc_msgSend_17amj0z(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithDictionary_copyItems_,
+        otherDictionary.ref.pointer,
+        copyItems);
     return NSDictionary.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithObjects:forKeys:
-  NSDictionary initWithObjects_forKeys_(NSArray objects, NSArray keys) {
-    final _ret = _objc_msgSend_15qeuct(this.ref.retainAndReturnPointer(),
-        _sel_initWithObjects_forKeys_, objects.ref.pointer, keys.ref.pointer);
+  NSDictionary initWithObjects(NSArray objects, {required NSArray forKeys}) {
+    final _ret = _objc_msgSend_15qeuct(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_forKeys_,
+        objects.ref.pointer,
+        forKeys.ref.pointer);
     return NSDictionary.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithObjects:forKeys:count:
-  NSDictionary initWithObjects_forKeys_count_(
+  NSDictionary initWithObjects$1(
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> keys,
-      int cnt) {
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> forKeys,
+      required int count$1}) {
     final _ret = _objc_msgSend_1dydpdi(this.ref.retainAndReturnPointer(),
-        _sel_initWithObjects_forKeys_count_, objects, keys, cnt);
+        _sel_initWithObjects_forKeys_count_, objects, forKeys, count$1);
     return NSDictionary.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithObjectsAndKeys:
-  NSDictionary initWithObjectsAndKeys_(objc.ObjCObjectBase firstObject) {
+  NSDictionary initWithObjectsAndKeys(objc.ObjCObjectBase firstObject) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithObjectsAndKeys_, firstObject.ref.pointer);
     return NSDictionary.castFromPointer(_ret, retain: false, release: true);
@@ -2372,7 +2399,7 @@ class NSDictionary extends NSObject
   }
 
   /// objectForKey:
-  objc.ObjCObjectBase? objectForKey_(objc.ObjCObjectBase aKey) {
+  objc.ObjCObjectBase? objectForKey(objc.ObjCObjectBase aKey) {
     final _ret = _objc_msgSend_1sotr3r(
         this.ref.pointer, _sel_objectForKey_, aKey.ref.pointer);
     return _ret.address == 0
@@ -2454,7 +2481,7 @@ class NSEnumerator extends NSObject
   }
 
   /// allocWithZone:
-  static NSEnumerator allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSEnumerator allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSEnumerator, _sel_allocWithZone_, zone);
     return NSEnumerator.castFromPointer(_ret, retain: false, release: true);
@@ -2467,12 +2494,15 @@ class NSEnumerator extends NSObject
   }
 
   /// countByEnumeratingWithState:objects:count:
-  int countByEnumeratingWithState_objects_count_(
-      ffi.Pointer<NSFastEnumerationState> state,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> buffer,
-      int len) {
-    return _objc_msgSend_1b5ysjl(this.ref.pointer,
-        _sel_countByEnumeratingWithState_objects_count_, state, buffer, len);
+  int countByEnumeratingWithState(ffi.Pointer<NSFastEnumerationState> state,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      required int count$1}) {
+    return _objc_msgSend_1b5ysjl(
+        this.ref.pointer,
+        _sel_countByEnumeratingWithState_objects_count_,
+        state,
+        objects,
+        count$1);
   }
 
   /// init
@@ -2524,21 +2554,21 @@ class NSError extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// allocWithZone:
-  static NSError allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSError allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSError, _sel_allocWithZone_, zone);
     return NSError.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// errorWithDomain:code:userInfo:
-  static NSError errorWithDomain_code_userInfo_(
-      NSString domain, int code, NSDictionary? dict) {
+  static NSError errorWithDomain(NSString domain,
+      {required int code, NSDictionary? userInfo}) {
     final _ret = _objc_msgSend_rc4ypv(
         _class_NSError,
         _sel_errorWithDomain_code_userInfo_,
         domain.ref.pointer,
         code,
-        dict?.ref.pointer ?? ffi.nullptr);
+        userInfo?.ref.pointer ?? ffi.nullptr);
     return NSError.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -2565,7 +2595,7 @@ class NSError extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// encodeWithCoder:
-  void encodeWithCoder_(NSCoder coder) {
+  void encodeWithCoder(NSCoder coder) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_encodeWithCoder_, coder.ref.pointer);
   }
@@ -2588,7 +2618,7 @@ class NSError extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// initWithCoder:
-  NSError? initWithCoder_(NSCoder coder) {
+  NSError? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -2597,14 +2627,14 @@ class NSError extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// initWithDomain:code:userInfo:
-  NSError initWithDomain_code_userInfo_(
-      NSString domain, int code, NSDictionary? dict) {
+  NSError initWithDomain(NSString domain$1,
+      {required int code$1, NSDictionary? userInfo}) {
     final _ret = _objc_msgSend_rc4ypv(
         this.ref.retainAndReturnPointer(),
         _sel_initWithDomain_code_userInfo_,
-        domain.ref.pointer,
-        code,
-        dict?.ref.pointer ?? ffi.nullptr);
+        domain$1.ref.pointer,
+        code$1,
+        userInfo?.ref.pointer ?? ffi.nullptr);
     return NSError.castFromPointer(_ret, retain: false, release: true);
   }
 
@@ -2673,28 +2703,28 @@ class NSError extends NSObject implements NSCopying, NSSecureCoding {
 /// NSExtendedArray
 extension NSExtendedArray on NSArray {
   /// arrayByAddingObject:
-  NSArray arrayByAddingObject_(objc.ObjCObjectBase anObject) {
+  NSArray arrayByAddingObject(objc.ObjCObjectBase anObject) {
     final _ret = _objc_msgSend_1sotr3r(
         this.ref.pointer, _sel_arrayByAddingObject_, anObject.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// arrayByAddingObjectsFromArray:
-  NSArray arrayByAddingObjectsFromArray_(NSArray otherArray) {
+  NSArray arrayByAddingObjectsFromArray(NSArray otherArray) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.pointer,
         _sel_arrayByAddingObjectsFromArray_, otherArray.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// componentsJoinedByString:
-  NSString componentsJoinedByString_(NSString separator) {
+  NSString componentsJoinedByString(NSString separator) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.pointer,
         _sel_componentsJoinedByString_, separator.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// containsObject:
-  bool containsObject_(objc.ObjCObjectBase anObject) {
+  bool containsObject(objc.ObjCObjectBase anObject) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_containsObject_, anObject.ref.pointer);
   }
@@ -2706,20 +2736,20 @@ extension NSExtendedArray on NSArray {
   }
 
   /// descriptionWithLocale:
-  NSString descriptionWithLocale_(objc.ObjCObjectBase? locale) {
+  NSString descriptionWithLocale(objc.ObjCObjectBase? locale) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.pointer,
         _sel_descriptionWithLocale_, locale?.ref.pointer ?? ffi.nullptr);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// descriptionWithLocale:indent:
-  NSString descriptionWithLocale_indent_(
-      objc.ObjCObjectBase? locale, int level) {
+  NSString descriptionWithLocale$1(objc.ObjCObjectBase? locale,
+      {required int indent}) {
     final _ret = _objc_msgSend_1k4kd9s(
         this.ref.pointer,
         _sel_descriptionWithLocale_indent_,
         locale?.ref.pointer ?? ffi.nullptr,
-        level);
+        indent);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -2734,7 +2764,7 @@ extension NSExtendedArray on NSArray {
   }
 
   /// firstObjectCommonWithArray:
-  objc.ObjCObjectBase? firstObjectCommonWithArray_(NSArray otherArray) {
+  objc.ObjCObjectBase? firstObjectCommonWithArray(NSArray otherArray) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.pointer,
         _sel_firstObjectCommonWithArray_, otherArray.ref.pointer);
     return _ret.address == 0
@@ -2743,39 +2773,40 @@ extension NSExtendedArray on NSArray {
   }
 
   /// getObjects:range:
-  void getObjects_range_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, NSRange range) {
+  void getObjects(ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      {required NSRange range}) {
     _objc_msgSend_o16d3k(
         this.ref.pointer, _sel_getObjects_range_, objects, range);
   }
 
   /// indexOfObject:
-  int indexOfObject_(objc.ObjCObjectBase anObject) {
+  int indexOfObject(objc.ObjCObjectBase anObject) {
     return _objc_msgSend_1vd1c5m(
         this.ref.pointer, _sel_indexOfObject_, anObject.ref.pointer);
   }
 
   /// indexOfObject:inRange:
-  int indexOfObject_inRange_(objc.ObjCObjectBase anObject, NSRange range) {
+  int indexOfObject$1(objc.ObjCObjectBase anObject,
+      {required NSRange inRange}) {
     return _objc_msgSend_zug4wi(this.ref.pointer, _sel_indexOfObject_inRange_,
-        anObject.ref.pointer, range);
+        anObject.ref.pointer, inRange);
   }
 
   /// indexOfObjectIdenticalTo:
-  int indexOfObjectIdenticalTo_(objc.ObjCObjectBase anObject) {
+  int indexOfObjectIdenticalTo(objc.ObjCObjectBase anObject) {
     return _objc_msgSend_1vd1c5m(
         this.ref.pointer, _sel_indexOfObjectIdenticalTo_, anObject.ref.pointer);
   }
 
   /// indexOfObjectIdenticalTo:inRange:
-  int indexOfObjectIdenticalTo_inRange_(
-      objc.ObjCObjectBase anObject, NSRange range) {
+  int indexOfObjectIdenticalTo$1(objc.ObjCObjectBase anObject,
+      {required NSRange inRange}) {
     return _objc_msgSend_zug4wi(this.ref.pointer,
-        _sel_indexOfObjectIdenticalTo_inRange_, anObject.ref.pointer, range);
+        _sel_indexOfObjectIdenticalTo_inRange_, anObject.ref.pointer, inRange);
   }
 
   /// isEqualToArray:
-  bool isEqualToArray_(NSArray otherArray) {
+  bool isEqualToArray(NSArray otherArray) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_isEqualToArray_, otherArray.ref.pointer);
   }
@@ -2789,23 +2820,23 @@ extension NSExtendedArray on NSArray {
   }
 
   /// makeObjectsPerformSelector:
-  void makeObjectsPerformSelector_(ffi.Pointer<objc.ObjCSelector> aSelector) {
+  void makeObjectsPerformSelector(ffi.Pointer<objc.ObjCSelector> aSelector) {
     _objc_msgSend_1d9e4oe(
         this.ref.pointer, _sel_makeObjectsPerformSelector_, aSelector);
   }
 
   /// makeObjectsPerformSelector:withObject:
-  void makeObjectsPerformSelector_withObject_(
-      ffi.Pointer<objc.ObjCSelector> aSelector, objc.ObjCObjectBase? argument) {
+  void makeObjectsPerformSelector$1(ffi.Pointer<objc.ObjCSelector> aSelector,
+      {objc.ObjCObjectBase? withObject}) {
     _objc_msgSend_1qv0eq4(
         this.ref.pointer,
         _sel_makeObjectsPerformSelector_withObject_,
         aSelector,
-        argument?.ref.pointer ?? ffi.nullptr);
+        withObject?.ref.pointer ?? ffi.nullptr);
   }
 
   /// objectAtIndexedSubscript:
-  objc.ObjCObjectBase objectAtIndexedSubscript_(int idx) {
+  objc.ObjCObjectBase objectAtIndexedSubscript(int idx) {
     objc.checkOsVersionInternal('NSArray.objectAtIndexedSubscript:',
         iOS: (false, (6, 0, 0)), macOS: (false, (10, 8, 0)));
     final _ret = _objc_msgSend_14hpxwa(
@@ -2820,7 +2851,7 @@ extension NSExtendedArray on NSArray {
   }
 
   /// objectsAtIndexes:
-  NSArray objectsAtIndexes_(NSIndexSet indexes) {
+  NSArray objectsAtIndexes(NSIndexSet indexes) {
     final _ret = _objc_msgSend_1sotr3r(
         this.ref.pointer, _sel_objectsAtIndexes_, indexes.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
@@ -2840,27 +2871,27 @@ extension NSExtendedArray on NSArray {
   }
 
   /// sortedArrayUsingFunction:context:
-  NSArray sortedArrayUsingFunction_context_(
+  NSArray sortedArrayUsingFunction(
       ffi.Pointer<
               ffi.NativeFunction<
                   ffi.Long Function(ffi.Pointer<objc.ObjCObject>,
                       ffi.Pointer<objc.ObjCObject>, ffi.Pointer<ffi.Void>)>>
           comparator,
-      ffi.Pointer<ffi.Void> context) {
+      {required ffi.Pointer<ffi.Void> context}) {
     final _ret = _objc_msgSend_1ffoev1(this.ref.pointer,
         _sel_sortedArrayUsingFunction_context_, comparator, context);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// sortedArrayUsingFunction:context:hint:
-  NSArray sortedArrayUsingFunction_context_hint_(
+  NSArray sortedArrayUsingFunction$1(
       ffi.Pointer<
               ffi.NativeFunction<
                   ffi.Long Function(ffi.Pointer<objc.ObjCObject>,
                       ffi.Pointer<objc.ObjCObject>, ffi.Pointer<ffi.Void>)>>
           comparator,
-      ffi.Pointer<ffi.Void> context,
-      NSData? hint) {
+      {required ffi.Pointer<ffi.Void> context,
+      NSData? hint}) {
     final _ret = _objc_msgSend_1i2r70j(
         this.ref.pointer,
         _sel_sortedArrayUsingFunction_context_hint_,
@@ -2871,22 +2902,22 @@ extension NSExtendedArray on NSArray {
   }
 
   /// sortedArrayUsingSelector:
-  NSArray sortedArrayUsingSelector_(ffi.Pointer<objc.ObjCSelector> comparator) {
+  NSArray sortedArrayUsingSelector(ffi.Pointer<objc.ObjCSelector> comparator) {
     final _ret = _objc_msgSend_3ctkt6(
         this.ref.pointer, _sel_sortedArrayUsingSelector_, comparator);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// subarrayWithRange:
-  NSArray subarrayWithRange_(NSRange range) {
+  NSArray subarrayWithRange(NSRange range) {
     final _ret =
         _objc_msgSend_1k1o1s7(this.ref.pointer, _sel_subarrayWithRange_, range);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// writeToURL:error:
-  bool writeToURL_error_(
-      NSURL url, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  bool writeToURL(NSURL url,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal('NSArray.writeToURL:error:',
         iOS: (false, (11, 0, 0)), macOS: (false, (10, 13, 0)));
     return _objc_msgSend_l9p60w(
@@ -2903,25 +2934,25 @@ extension NSExtendedData on NSData {
   }
 
   /// getBytes:length:
-  void getBytes_length_(ffi.Pointer<ffi.Void> buffer, int length) {
+  void getBytes(ffi.Pointer<ffi.Void> buffer, {required int length}) {
     _objc_msgSend_zuf90e(
         this.ref.pointer, _sel_getBytes_length_, buffer, length);
   }
 
   /// getBytes:range:
-  void getBytes_range_(ffi.Pointer<ffi.Void> buffer, NSRange range) {
+  void getBytes$1(ffi.Pointer<ffi.Void> buffer, {required NSRange range}) {
     _objc_msgSend_xpqfd7(this.ref.pointer, _sel_getBytes_range_, buffer, range);
   }
 
   /// isEqualToData:
-  bool isEqualToData_(NSData other) {
+  bool isEqualToData(NSData other) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_isEqualToData_, other.ref.pointer);
   }
 
   /// rangeOfData:options:range:
-  NSRange rangeOfData_options_range_(
-      NSData dataToFind, NSDataSearchOptions mask, NSRange searchRange) {
+  NSRange rangeOfData(NSData dataToFind,
+      {required NSDataSearchOptions options, required NSRange range}) {
     objc.checkOsVersionInternal('NSData.rangeOfData:options:range:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
     final _ptr = pkg_ffi.calloc<NSRange>();
@@ -2931,14 +2962,14 @@ extension NSExtendedData on NSData {
             this.ref.pointer,
             _sel_rangeOfData_options_range_,
             dataToFind.ref.pointer,
-            mask.value,
-            searchRange)
+            options.value,
+            range)
         : _ptr.ref = _objc_msgSend_1d8s65w(
             this.ref.pointer,
             _sel_rangeOfData_options_range_,
             dataToFind.ref.pointer,
-            mask.value,
-            searchRange);
+            options.value,
+            range);
     final _finalizable = _ptr.cast<ffi.Uint8>().asTypedList(
         ffi.sizeOf<NSRange>(),
         finalizer: pkg_ffi.calloc.nativeFree);
@@ -2946,48 +2977,42 @@ extension NSExtendedData on NSData {
   }
 
   /// subdataWithRange:
-  NSData subdataWithRange_(NSRange range) {
+  NSData subdataWithRange(NSRange range) {
     final _ret =
         _objc_msgSend_1k1o1s7(this.ref.pointer, _sel_subdataWithRange_, range);
     return NSData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// writeToFile:atomically:
-  bool writeToFile_atomically_(NSString path, bool useAuxiliaryFile) {
+  bool writeToFile(NSString path, {required bool atomically}) {
     return _objc_msgSend_1iyq28l(this.ref.pointer, _sel_writeToFile_atomically_,
-        path.ref.pointer, useAuxiliaryFile);
+        path.ref.pointer, atomically);
   }
 
   /// writeToFile:options:error:
-  bool writeToFile_options_error_(
-      NSString path,
-      NSDataWritingOptions writeOptionsMask,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> errorPtr) {
+  bool writeToFile$1(NSString path,
+      {required NSDataWritingOptions options,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     return _objc_msgSend_1xi08ar(
         this.ref.pointer,
         _sel_writeToFile_options_error_,
         path.ref.pointer,
-        writeOptionsMask.value,
-        errorPtr);
+        options.value,
+        error);
   }
 
   /// writeToURL:atomically:
-  bool writeToURL_atomically_(NSURL url, bool atomically) {
+  bool writeToURL(NSURL url, {required bool atomically}) {
     return _objc_msgSend_1iyq28l(this.ref.pointer, _sel_writeToURL_atomically_,
         url.ref.pointer, atomically);
   }
 
   /// writeToURL:options:error:
-  bool writeToURL_options_error_(
-      NSURL url,
-      NSDataWritingOptions writeOptionsMask,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> errorPtr) {
-    return _objc_msgSend_1xi08ar(
-        this.ref.pointer,
-        _sel_writeToURL_options_error_,
-        url.ref.pointer,
-        writeOptionsMask.value,
-        errorPtr);
+  bool writeToURL$1(NSURL url,
+      {required NSDataWritingOptions options,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
+    return _objc_msgSend_1xi08ar(this.ref.pointer,
+        _sel_writeToURL_options_error_, url.ref.pointer, options.value, error);
   }
 }
 
@@ -3003,7 +3028,7 @@ extension NSExtendedDate on NSDate {
   }
 
   /// compare:
-  NSComparisonResult compare_(NSDate other) {
+  NSComparisonResult compare(NSDate other) {
     final _ret = _objc_msgSend_1ym6zyw(
         this.ref.pointer, _sel_compare_, other.ref.pointer);
     return NSComparisonResult.fromValue(_ret);
@@ -3016,27 +3041,27 @@ extension NSExtendedDate on NSDate {
   }
 
   /// descriptionWithLocale:
-  NSString descriptionWithLocale_(objc.ObjCObjectBase? locale) {
+  NSString descriptionWithLocale(objc.ObjCObjectBase? locale) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.pointer,
         _sel_descriptionWithLocale_, locale?.ref.pointer ?? ffi.nullptr);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// earlierDate:
-  NSDate earlierDate_(NSDate anotherDate) {
+  NSDate earlierDate(NSDate anotherDate) {
     final _ret = _objc_msgSend_1sotr3r(
         this.ref.pointer, _sel_earlierDate_, anotherDate.ref.pointer);
     return NSDate.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// isEqualToDate:
-  bool isEqualToDate_(NSDate otherDate) {
+  bool isEqualToDate(NSDate otherDate) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_isEqualToDate_, otherDate.ref.pointer);
   }
 
   /// laterDate:
-  NSDate laterDate_(NSDate anotherDate) {
+  NSDate laterDate(NSDate anotherDate) {
     final _ret = _objc_msgSend_1sotr3r(
         this.ref.pointer, _sel_laterDate_, anotherDate.ref.pointer);
     return NSDate.castFromPointer(_ret, retain: true, release: true);
@@ -3051,7 +3076,7 @@ extension NSExtendedDate on NSDate {
   }
 
   /// timeIntervalSinceDate:
-  double timeIntervalSinceDate_(NSDate anotherDate) {
+  double timeIntervalSinceDate(NSDate anotherDate) {
     return objc.useMsgSendVariants
         ? _objc_msgSend_mabicuFpret(this.ref.pointer,
             _sel_timeIntervalSinceDate_, anotherDate.ref.pointer)
@@ -3077,7 +3102,7 @@ extension NSExtendedDictionary on NSDictionary {
   }
 
   /// allKeysForObject:
-  NSArray allKeysForObject_(objc.ObjCObjectBase anObject) {
+  NSArray allKeysForObject(objc.ObjCObjectBase anObject) {
     final _ret = _objc_msgSend_1sotr3r(
         this.ref.pointer, _sel_allKeysForObject_, anObject.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
@@ -3103,42 +3128,41 @@ extension NSExtendedDictionary on NSDictionary {
   }
 
   /// descriptionWithLocale:
-  NSString descriptionWithLocale_(objc.ObjCObjectBase? locale) {
+  NSString descriptionWithLocale(objc.ObjCObjectBase? locale) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.pointer,
         _sel_descriptionWithLocale_, locale?.ref.pointer ?? ffi.nullptr);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// descriptionWithLocale:indent:
-  NSString descriptionWithLocale_indent_(
-      objc.ObjCObjectBase? locale, int level) {
+  NSString descriptionWithLocale$1(objc.ObjCObjectBase? locale,
+      {required int indent}) {
     final _ret = _objc_msgSend_1k4kd9s(
         this.ref.pointer,
         _sel_descriptionWithLocale_indent_,
         locale?.ref.pointer ?? ffi.nullptr,
-        level);
+        indent);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// getObjects:andKeys:count:
-  void getObjects_andKeys_count_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> keys,
-      int count) {
+  void getObjects(ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> andKeys,
+      required int count}) {
     objc.checkOsVersionInternal('NSDictionary.getObjects:andKeys:count:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
-    _objc_msgSend_n2svg2(
-        this.ref.pointer, _sel_getObjects_andKeys_count_, objects, keys, count);
+    _objc_msgSend_n2svg2(this.ref.pointer, _sel_getObjects_andKeys_count_,
+        objects, andKeys, count);
   }
 
   /// isEqualToDictionary:
-  bool isEqualToDictionary_(NSDictionary otherDictionary) {
+  bool isEqualToDictionary(NSDictionary otherDictionary) {
     return _objc_msgSend_19nvye5(this.ref.pointer, _sel_isEqualToDictionary_,
         otherDictionary.ref.pointer);
   }
 
   /// keysSortedByValueUsingSelector:
-  NSArray keysSortedByValueUsingSelector_(
+  NSArray keysSortedByValueUsingSelector(
       ffi.Pointer<objc.ObjCSelector> comparator) {
     final _ret = _objc_msgSend_3ctkt6(
         this.ref.pointer, _sel_keysSortedByValueUsingSelector_, comparator);
@@ -3152,7 +3176,7 @@ extension NSExtendedDictionary on NSDictionary {
   }
 
   /// objectForKeyedSubscript:
-  objc.ObjCObjectBase? objectForKeyedSubscript_(objc.ObjCObjectBase key) {
+  objc.ObjCObjectBase? objectForKeyedSubscript(objc.ObjCObjectBase key) {
     objc.checkOsVersionInternal('NSDictionary.objectForKeyedSubscript:',
         iOS: (false, (6, 0, 0)), macOS: (false, (10, 8, 0)));
     final _ret = _objc_msgSend_1sotr3r(
@@ -3163,19 +3187,19 @@ extension NSExtendedDictionary on NSDictionary {
   }
 
   /// objectsForKeys:notFoundMarker:
-  NSArray objectsForKeys_notFoundMarker_(
-      NSArray keys, objc.ObjCObjectBase marker) {
+  NSArray objectsForKeys(NSArray keys,
+      {required objc.ObjCObjectBase notFoundMarker}) {
     final _ret = _objc_msgSend_15qeuct(
         this.ref.pointer,
         _sel_objectsForKeys_notFoundMarker_,
         keys.ref.pointer,
-        marker.ref.pointer);
+        notFoundMarker.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// writeToURL:error:
-  bool writeToURL_error_(
-      NSURL url, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  bool writeToURL(NSURL url,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal('NSDictionary.writeToURL:error:',
         iOS: (false, (11, 0, 0)), macOS: (false, (10, 13, 0)));
     return _objc_msgSend_l9p60w(
@@ -3195,21 +3219,21 @@ extension NSExtendedEnumerator on NSEnumerator {
 /// NSExtendedMutableArray
 extension NSExtendedMutableArray on NSMutableArray {
   /// addObjectsFromArray:
-  void addObjectsFromArray_(NSArray otherArray) {
+  void addObjectsFromArray(NSArray otherArray) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_addObjectsFromArray_, otherArray.ref.pointer);
   }
 
   /// exchangeObjectAtIndex:withObjectAtIndex:
-  void exchangeObjectAtIndex_withObjectAtIndex_(int idx1, int idx2) {
+  void exchangeObjectAtIndex(int idx1, {required int withObjectAtIndex}) {
     _objc_msgSend_bfp043(this.ref.pointer,
-        _sel_exchangeObjectAtIndex_withObjectAtIndex_, idx1, idx2);
+        _sel_exchangeObjectAtIndex_withObjectAtIndex_, idx1, withObjectAtIndex);
   }
 
   /// insertObjects:atIndexes:
-  void insertObjects_atIndexes_(NSArray objects, NSIndexSet indexes) {
+  void insertObjects(NSArray objects, {required NSIndexSet atIndexes}) {
     _objc_msgSend_pfv6jd(this.ref.pointer, _sel_insertObjects_atIndexes_,
-        objects.ref.pointer, indexes.ref.pointer);
+        objects.ref.pointer, atIndexes.ref.pointer);
   }
 
   /// removeAllObjects
@@ -3218,106 +3242,107 @@ extension NSExtendedMutableArray on NSMutableArray {
   }
 
   /// removeObject:
-  void removeObject_(objc.ObjCObjectBase anObject) {
+  void removeObject(objc.ObjCObjectBase anObject) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_removeObject_, anObject.ref.pointer);
   }
 
   /// removeObject:inRange:
-  void removeObject_inRange_(objc.ObjCObjectBase anObject, NSRange range) {
+  void removeObject$1(objc.ObjCObjectBase anObject,
+      {required NSRange inRange}) {
     _objc_msgSend_1oteutl(this.ref.pointer, _sel_removeObject_inRange_,
-        anObject.ref.pointer, range);
+        anObject.ref.pointer, inRange);
   }
 
   /// removeObjectIdenticalTo:
-  void removeObjectIdenticalTo_(objc.ObjCObjectBase anObject) {
+  void removeObjectIdenticalTo(objc.ObjCObjectBase anObject) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_removeObjectIdenticalTo_, anObject.ref.pointer);
   }
 
   /// removeObjectIdenticalTo:inRange:
-  void removeObjectIdenticalTo_inRange_(
-      objc.ObjCObjectBase anObject, NSRange range) {
+  void removeObjectIdenticalTo$1(objc.ObjCObjectBase anObject,
+      {required NSRange inRange}) {
     _objc_msgSend_1oteutl(this.ref.pointer,
-        _sel_removeObjectIdenticalTo_inRange_, anObject.ref.pointer, range);
+        _sel_removeObjectIdenticalTo_inRange_, anObject.ref.pointer, inRange);
   }
 
   /// removeObjectsAtIndexes:
-  void removeObjectsAtIndexes_(NSIndexSet indexes) {
+  void removeObjectsAtIndexes(NSIndexSet indexes) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_removeObjectsAtIndexes_, indexes.ref.pointer);
   }
 
   /// removeObjectsInArray:
-  void removeObjectsInArray_(NSArray otherArray) {
+  void removeObjectsInArray(NSArray otherArray) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_removeObjectsInArray_, otherArray.ref.pointer);
   }
 
   /// removeObjectsInRange:
-  void removeObjectsInRange_(NSRange range) {
+  void removeObjectsInRange(NSRange range) {
     _objc_msgSend_1e3pm0z(this.ref.pointer, _sel_removeObjectsInRange_, range);
   }
 
   /// replaceObjectsAtIndexes:withObjects:
-  void replaceObjectsAtIndexes_withObjects_(
-      NSIndexSet indexes, NSArray objects) {
+  void replaceObjectsAtIndexes(NSIndexSet indexes,
+      {required NSArray withObjects}) {
     _objc_msgSend_pfv6jd(
         this.ref.pointer,
         _sel_replaceObjectsAtIndexes_withObjects_,
         indexes.ref.pointer,
-        objects.ref.pointer);
+        withObjects.ref.pointer);
   }
 
   /// replaceObjectsInRange:withObjectsFromArray:
-  void replaceObjectsInRange_withObjectsFromArray_(
-      NSRange range, NSArray otherArray) {
+  void replaceObjectsInRange(NSRange range,
+      {required NSArray withObjectsFromArray}) {
     _objc_msgSend_1tv4uax(
         this.ref.pointer,
         _sel_replaceObjectsInRange_withObjectsFromArray_,
         range,
-        otherArray.ref.pointer);
+        withObjectsFromArray.ref.pointer);
   }
 
   /// replaceObjectsInRange:withObjectsFromArray:range:
-  void replaceObjectsInRange_withObjectsFromArray_range_(
-      NSRange range, NSArray otherArray, NSRange otherRange) {
+  void replaceObjectsInRange$1(NSRange range,
+      {required NSArray withObjectsFromArray, required NSRange range$1}) {
     _objc_msgSend_15bolr3(
         this.ref.pointer,
         _sel_replaceObjectsInRange_withObjectsFromArray_range_,
         range,
-        otherArray.ref.pointer,
-        otherRange);
+        withObjectsFromArray.ref.pointer,
+        range$1);
   }
 
   /// setArray:
-  void setArray_(NSArray otherArray) {
+  void setArray(NSArray otherArray) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_setArray_, otherArray.ref.pointer);
   }
 
   /// setObject:atIndexedSubscript:
-  void setObject_atIndexedSubscript_(objc.ObjCObjectBase obj, int idx) {
+  void setObject(objc.ObjCObjectBase obj, {required int atIndexedSubscript}) {
     objc.checkOsVersionInternal('NSMutableArray.setObject:atIndexedSubscript:',
         iOS: (false, (6, 0, 0)), macOS: (false, (10, 8, 0)));
     _objc_msgSend_djsa9o(this.ref.pointer, _sel_setObject_atIndexedSubscript_,
-        obj.ref.pointer, idx);
+        obj.ref.pointer, atIndexedSubscript);
   }
 
   /// sortUsingFunction:context:
-  void sortUsingFunction_context_(
+  void sortUsingFunction(
       ffi.Pointer<
               ffi.NativeFunction<
                   ffi.Long Function(ffi.Pointer<objc.ObjCObject>,
                       ffi.Pointer<objc.ObjCObject>, ffi.Pointer<ffi.Void>)>>
           compare,
-      ffi.Pointer<ffi.Void> context) {
+      {required ffi.Pointer<ffi.Void> context}) {
     _objc_msgSend_1bvics1(
         this.ref.pointer, _sel_sortUsingFunction_context_, compare, context);
   }
 
   /// sortUsingSelector:
-  void sortUsingSelector_(ffi.Pointer<objc.ObjCSelector> comparator) {
+  void sortUsingSelector(ffi.Pointer<objc.ObjCSelector> comparator) {
     _objc_msgSend_1d9e4oe(
         this.ref.pointer, _sel_sortUsingSelector_, comparator);
   }
@@ -3326,47 +3351,43 @@ extension NSExtendedMutableArray on NSMutableArray {
 /// NSExtendedMutableData
 extension NSExtendedMutableData on NSMutableData {
   /// appendBytes:length:
-  void appendBytes_length_(ffi.Pointer<ffi.Void> bytes, int length) {
+  void appendBytes(ffi.Pointer<ffi.Void> bytes, {required int length}) {
     _objc_msgSend_zuf90e(
         this.ref.pointer, _sel_appendBytes_length_, bytes, length);
   }
 
   /// appendData:
-  void appendData_(NSData other) {
+  void appendData(NSData other) {
     _objc_msgSend_xtuoz7(this.ref.pointer, _sel_appendData_, other.ref.pointer);
   }
 
   /// increaseLengthBy:
-  void increaseLengthBy_(int extraLength) {
+  void increaseLengthBy(int extraLength) {
     _objc_msgSend_1i9r4xy(
         this.ref.pointer, _sel_increaseLengthBy_, extraLength);
   }
 
   /// replaceBytesInRange:withBytes:
-  void replaceBytesInRange_withBytes_(
-      NSRange range, ffi.Pointer<ffi.Void> bytes) {
-    _objc_msgSend_eh32gn(
-        this.ref.pointer, _sel_replaceBytesInRange_withBytes_, range, bytes);
+  void replaceBytesInRange(NSRange range,
+      {required ffi.Pointer<ffi.Void> withBytes}) {
+    _objc_msgSend_eh32gn(this.ref.pointer, _sel_replaceBytesInRange_withBytes_,
+        range, withBytes);
   }
 
   /// replaceBytesInRange:withBytes:length:
-  void replaceBytesInRange_withBytes_length_(NSRange range,
-      ffi.Pointer<ffi.Void> replacementBytes, int replacementLength) {
-    _objc_msgSend_c0vg4w(
-        this.ref.pointer,
-        _sel_replaceBytesInRange_withBytes_length_,
-        range,
-        replacementBytes,
-        replacementLength);
+  void replaceBytesInRange$1(NSRange range,
+      {required ffi.Pointer<ffi.Void> withBytes, required int length}) {
+    _objc_msgSend_c0vg4w(this.ref.pointer,
+        _sel_replaceBytesInRange_withBytes_length_, range, withBytes, length);
   }
 
   /// resetBytesInRange:
-  void resetBytesInRange_(NSRange range) {
+  void resetBytesInRange(NSRange range) {
     _objc_msgSend_1e3pm0z(this.ref.pointer, _sel_resetBytesInRange_, range);
   }
 
   /// setData:
-  void setData_(NSData data) {
+  void setData(NSData data) {
     _objc_msgSend_xtuoz7(this.ref.pointer, _sel_setData_, data.ref.pointer);
   }
 }
@@ -3374,7 +3395,7 @@ extension NSExtendedMutableData on NSMutableData {
 /// NSExtendedMutableDictionary
 extension NSExtendedMutableDictionary on NSMutableDictionary {
   /// addEntriesFromDictionary:
-  void addEntriesFromDictionary_(NSDictionary otherDictionary) {
+  void addEntriesFromDictionary(NSDictionary otherDictionary) {
     _objc_msgSend_xtuoz7(this.ref.pointer, _sel_addEntriesFromDictionary_,
         otherDictionary.ref.pointer);
   }
@@ -3385,40 +3406,41 @@ extension NSExtendedMutableDictionary on NSMutableDictionary {
   }
 
   /// removeObjectsForKeys:
-  void removeObjectsForKeys_(NSArray keyArray) {
+  void removeObjectsForKeys(NSArray keyArray) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_removeObjectsForKeys_, keyArray.ref.pointer);
   }
 
   /// setDictionary:
-  void setDictionary_(NSDictionary otherDictionary) {
+  void setDictionary(NSDictionary otherDictionary) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_setDictionary_, otherDictionary.ref.pointer);
   }
 
   /// setObject:forKeyedSubscript:
-  void setObject_forKeyedSubscript_(objc.ObjCObjectBase? obj, NSCopying key) {
+  void setObject(objc.ObjCObjectBase? obj,
+      {required NSCopying forKeyedSubscript}) {
     objc.checkOsVersionInternal(
         'NSMutableDictionary.setObject:forKeyedSubscript:',
         iOS: (false, (6, 0, 0)),
         macOS: (false, (10, 8, 0)));
     _objc_msgSend_pfv6jd(this.ref.pointer, _sel_setObject_forKeyedSubscript_,
-        obj?.ref.pointer ?? ffi.nullptr, key.ref.pointer);
+        obj?.ref.pointer ?? ffi.nullptr, forKeyedSubscript.ref.pointer);
   }
 }
 
 /// NSExtendedMutableOrderedSet
 extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
   /// addObject:
-  void addObject_(objc.ObjCObjectBase object) {
+  void addObject(objc.ObjCObjectBase object) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.addObject:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_xtuoz7(this.ref.pointer, _sel_addObject_, object.ref.pointer);
   }
 
   /// addObjects:count:
-  void addObjects_count_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int count) {
+  void addObjects(ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      {required int count}) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.addObjects:count:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_gcjqkl(
@@ -3426,7 +3448,7 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
   }
 
   /// addObjectsFromArray:
-  void addObjectsFromArray_(NSArray array) {
+  void addObjectsFromArray(NSArray array) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.addObjectsFromArray:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_xtuoz7(
@@ -3434,25 +3456,25 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
   }
 
   /// exchangeObjectAtIndex:withObjectAtIndex:
-  void exchangeObjectAtIndex_withObjectAtIndex_(int idx1, int idx2) {
+  void exchangeObjectAtIndex(int idx1, {required int withObjectAtIndex}) {
     objc.checkOsVersionInternal(
         'NSMutableOrderedSet.exchangeObjectAtIndex:withObjectAtIndex:',
         iOS: (false, (5, 0, 0)),
         macOS: (false, (10, 7, 0)));
     _objc_msgSend_bfp043(this.ref.pointer,
-        _sel_exchangeObjectAtIndex_withObjectAtIndex_, idx1, idx2);
+        _sel_exchangeObjectAtIndex_withObjectAtIndex_, idx1, withObjectAtIndex);
   }
 
   /// insertObjects:atIndexes:
-  void insertObjects_atIndexes_(NSArray objects, NSIndexSet indexes) {
+  void insertObjects(NSArray objects, {required NSIndexSet atIndexes}) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.insertObjects:atIndexes:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_pfv6jd(this.ref.pointer, _sel_insertObjects_atIndexes_,
-        objects.ref.pointer, indexes.ref.pointer);
+        objects.ref.pointer, atIndexes.ref.pointer);
   }
 
   /// intersectOrderedSet:
-  void intersectOrderedSet_(NSOrderedSet other) {
+  void intersectOrderedSet(NSOrderedSet other) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.intersectOrderedSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_xtuoz7(
@@ -3460,7 +3482,7 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
   }
 
   /// intersectSet:
-  void intersectSet_(NSSet other) {
+  void intersectSet(NSSet other) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.intersectSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_xtuoz7(
@@ -3468,7 +3490,7 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
   }
 
   /// minusOrderedSet:
-  void minusOrderedSet_(NSOrderedSet other) {
+  void minusOrderedSet(NSOrderedSet other) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.minusOrderedSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_xtuoz7(
@@ -3476,20 +3498,20 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
   }
 
   /// minusSet:
-  void minusSet_(NSSet other) {
+  void minusSet(NSSet other) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.minusSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_xtuoz7(this.ref.pointer, _sel_minusSet_, other.ref.pointer);
   }
 
   /// moveObjectsAtIndexes:toIndex:
-  void moveObjectsAtIndexes_toIndex_(NSIndexSet indexes, int idx) {
+  void moveObjectsAtIndexes(NSIndexSet indexes, {required int toIndex}) {
     objc.checkOsVersionInternal(
         'NSMutableOrderedSet.moveObjectsAtIndexes:toIndex:',
         iOS: (false, (5, 0, 0)),
         macOS: (false, (10, 7, 0)));
     _objc_msgSend_djsa9o(this.ref.pointer, _sel_moveObjectsAtIndexes_toIndex_,
-        indexes.ref.pointer, idx);
+        indexes.ref.pointer, toIndex);
   }
 
   /// removeAllObjects
@@ -3500,7 +3522,7 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
   }
 
   /// removeObject:
-  void removeObject_(objc.ObjCObjectBase object) {
+  void removeObject(objc.ObjCObjectBase object) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.removeObject:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_xtuoz7(
@@ -3508,7 +3530,7 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
   }
 
   /// removeObjectsAtIndexes:
-  void removeObjectsAtIndexes_(NSIndexSet indexes) {
+  void removeObjectsAtIndexes(NSIndexSet indexes) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.removeObjectsAtIndexes:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_xtuoz7(
@@ -3516,7 +3538,7 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
   }
 
   /// removeObjectsInArray:
-  void removeObjectsInArray_(NSArray array) {
+  void removeObjectsInArray(NSArray array) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.removeObjectsInArray:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_xtuoz7(
@@ -3524,15 +3546,15 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
   }
 
   /// removeObjectsInRange:
-  void removeObjectsInRange_(NSRange range) {
+  void removeObjectsInRange(NSRange range) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.removeObjectsInRange:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_1e3pm0z(this.ref.pointer, _sel_removeObjectsInRange_, range);
   }
 
   /// replaceObjectsAtIndexes:withObjects:
-  void replaceObjectsAtIndexes_withObjects_(
-      NSIndexSet indexes, NSArray objects) {
+  void replaceObjectsAtIndexes(NSIndexSet indexes,
+      {required NSArray withObjects}) {
     objc.checkOsVersionInternal(
         'NSMutableOrderedSet.replaceObjectsAtIndexes:withObjects:',
         iOS: (false, (5, 0, 0)),
@@ -3541,40 +3563,45 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
         this.ref.pointer,
         _sel_replaceObjectsAtIndexes_withObjects_,
         indexes.ref.pointer,
-        objects.ref.pointer);
+        withObjects.ref.pointer);
   }
 
   /// replaceObjectsInRange:withObjects:count:
-  void replaceObjectsInRange_withObjects_count_(NSRange range,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int count) {
+  void replaceObjectsInRange(NSRange range,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> withObjects,
+      required int count}) {
     objc.checkOsVersionInternal(
         'NSMutableOrderedSet.replaceObjectsInRange:withObjects:count:',
         iOS: (false, (5, 0, 0)),
         macOS: (false, (10, 7, 0)));
-    _objc_msgSend_122v0cv(this.ref.pointer,
-        _sel_replaceObjectsInRange_withObjects_count_, range, objects, count);
+    _objc_msgSend_122v0cv(
+        this.ref.pointer,
+        _sel_replaceObjectsInRange_withObjects_count_,
+        range,
+        withObjects,
+        count);
   }
 
   /// setObject:atIndex:
-  void setObject_atIndex_(objc.ObjCObjectBase obj, int idx) {
+  void setObject(objc.ObjCObjectBase obj, {required int atIndex}) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.setObject:atIndex:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_djsa9o(
-        this.ref.pointer, _sel_setObject_atIndex_, obj.ref.pointer, idx);
+        this.ref.pointer, _sel_setObject_atIndex_, obj.ref.pointer, atIndex);
   }
 
   /// setObject:atIndexedSubscript:
-  void setObject_atIndexedSubscript_(objc.ObjCObjectBase obj, int idx) {
+  void setObject$1(objc.ObjCObjectBase obj, {required int atIndexedSubscript}) {
     objc.checkOsVersionInternal(
         'NSMutableOrderedSet.setObject:atIndexedSubscript:',
         iOS: (false, (6, 0, 0)),
         macOS: (false, (10, 8, 0)));
     _objc_msgSend_djsa9o(this.ref.pointer, _sel_setObject_atIndexedSubscript_,
-        obj.ref.pointer, idx);
+        obj.ref.pointer, atIndexedSubscript);
   }
 
   /// unionOrderedSet:
-  void unionOrderedSet_(NSOrderedSet other) {
+  void unionOrderedSet(NSOrderedSet other) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.unionOrderedSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_xtuoz7(
@@ -3582,7 +3609,7 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
   }
 
   /// unionSet:
-  void unionSet_(NSSet other) {
+  void unionSet(NSSet other) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.unionSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_xtuoz7(this.ref.pointer, _sel_unionSet_, other.ref.pointer);
@@ -3592,19 +3619,19 @@ extension NSExtendedMutableOrderedSet on NSMutableOrderedSet {
 /// NSExtendedMutableSet
 extension NSExtendedMutableSet on NSMutableSet {
   /// addObjectsFromArray:
-  void addObjectsFromArray_(NSArray array) {
+  void addObjectsFromArray(NSArray array) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_addObjectsFromArray_, array.ref.pointer);
   }
 
   /// intersectSet:
-  void intersectSet_(NSSet otherSet) {
+  void intersectSet(NSSet otherSet) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_intersectSet_, otherSet.ref.pointer);
   }
 
   /// minusSet:
-  void minusSet_(NSSet otherSet) {
+  void minusSet(NSSet otherSet) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_minusSet_, otherSet.ref.pointer);
   }
@@ -3615,12 +3642,12 @@ extension NSExtendedMutableSet on NSMutableSet {
   }
 
   /// setSet:
-  void setSet_(NSSet otherSet) {
+  void setSet(NSSet otherSet) {
     _objc_msgSend_xtuoz7(this.ref.pointer, _sel_setSet_, otherSet.ref.pointer);
   }
 
   /// unionSet:
-  void unionSet_(NSSet otherSet) {
+  void unionSet(NSSet otherSet) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_unionSet_, otherSet.ref.pointer);
   }
@@ -3637,7 +3664,7 @@ extension NSExtendedOrderedSet on NSOrderedSet {
   }
 
   /// containsObject:
-  bool containsObject_(objc.ObjCObjectBase object) {
+  bool containsObject(objc.ObjCObjectBase object) {
     objc.checkOsVersionInternal('NSOrderedSet.containsObject:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     return _objc_msgSend_19nvye5(
@@ -3653,7 +3680,7 @@ extension NSExtendedOrderedSet on NSOrderedSet {
   }
 
   /// descriptionWithLocale:
-  NSString descriptionWithLocale_(objc.ObjCObjectBase? locale) {
+  NSString descriptionWithLocale(objc.ObjCObjectBase? locale) {
     objc.checkOsVersionInternal('NSOrderedSet.descriptionWithLocale:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(this.ref.pointer,
@@ -3662,15 +3689,15 @@ extension NSExtendedOrderedSet on NSOrderedSet {
   }
 
   /// descriptionWithLocale:indent:
-  NSString descriptionWithLocale_indent_(
-      objc.ObjCObjectBase? locale, int level) {
+  NSString descriptionWithLocale$1(objc.ObjCObjectBase? locale,
+      {required int indent}) {
     objc.checkOsVersionInternal('NSOrderedSet.descriptionWithLocale:indent:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1k4kd9s(
         this.ref.pointer,
         _sel_descriptionWithLocale_indent_,
         locale?.ref.pointer ?? ffi.nullptr,
-        level);
+        indent);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -3685,14 +3712,14 @@ extension NSExtendedOrderedSet on NSOrderedSet {
   }
 
   /// getObjects:range:
-  void getObjects_range_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, NSRange range) {
+  void getObjects(ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      {required NSRange range}) {
     _objc_msgSend_o16d3k(
         this.ref.pointer, _sel_getObjects_range_, objects, range);
   }
 
   /// intersectsOrderedSet:
-  bool intersectsOrderedSet_(NSOrderedSet other) {
+  bool intersectsOrderedSet(NSOrderedSet other) {
     objc.checkOsVersionInternal('NSOrderedSet.intersectsOrderedSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     return _objc_msgSend_19nvye5(
@@ -3700,15 +3727,15 @@ extension NSExtendedOrderedSet on NSOrderedSet {
   }
 
   /// intersectsSet:
-  bool intersectsSet_(NSSet set) {
+  bool intersectsSet(NSSet set$) {
     objc.checkOsVersionInternal('NSOrderedSet.intersectsSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     return _objc_msgSend_19nvye5(
-        this.ref.pointer, _sel_intersectsSet_, set.ref.pointer);
+        this.ref.pointer, _sel_intersectsSet_, set$.ref.pointer);
   }
 
   /// isEqualToOrderedSet:
-  bool isEqualToOrderedSet_(NSOrderedSet other) {
+  bool isEqualToOrderedSet(NSOrderedSet other) {
     objc.checkOsVersionInternal('NSOrderedSet.isEqualToOrderedSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     return _objc_msgSend_19nvye5(
@@ -3716,7 +3743,7 @@ extension NSExtendedOrderedSet on NSOrderedSet {
   }
 
   /// isSubsetOfOrderedSet:
-  bool isSubsetOfOrderedSet_(NSOrderedSet other) {
+  bool isSubsetOfOrderedSet(NSOrderedSet other) {
     objc.checkOsVersionInternal('NSOrderedSet.isSubsetOfOrderedSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     return _objc_msgSend_19nvye5(
@@ -3724,11 +3751,11 @@ extension NSExtendedOrderedSet on NSOrderedSet {
   }
 
   /// isSubsetOfSet:
-  bool isSubsetOfSet_(NSSet set) {
+  bool isSubsetOfSet(NSSet set$) {
     objc.checkOsVersionInternal('NSOrderedSet.isSubsetOfSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     return _objc_msgSend_19nvye5(
-        this.ref.pointer, _sel_isSubsetOfSet_, set.ref.pointer);
+        this.ref.pointer, _sel_isSubsetOfSet_, set$.ref.pointer);
   }
 
   /// lastObject
@@ -3742,7 +3769,7 @@ extension NSExtendedOrderedSet on NSOrderedSet {
   }
 
   /// objectAtIndexedSubscript:
-  objc.ObjCObjectBase objectAtIndexedSubscript_(int idx) {
+  objc.ObjCObjectBase objectAtIndexedSubscript(int idx) {
     objc.checkOsVersionInternal('NSOrderedSet.objectAtIndexedSubscript:',
         iOS: (false, (6, 0, 0)), macOS: (false, (10, 8, 0)));
     final _ret = _objc_msgSend_14hpxwa(
@@ -3759,7 +3786,7 @@ extension NSExtendedOrderedSet on NSOrderedSet {
   }
 
   /// objectsAtIndexes:
-  NSArray objectsAtIndexes_(NSIndexSet indexes) {
+  NSArray objectsAtIndexes(NSIndexSet indexes) {
     objc.checkOsVersionInternal('NSOrderedSet.objectsAtIndexes:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(
@@ -3811,7 +3838,7 @@ extension NSExtendedSet on NSSet {
   }
 
   /// containsObject:
-  bool containsObject_(objc.ObjCObjectBase anObject) {
+  bool containsObject(objc.ObjCObjectBase anObject) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_containsObject_, anObject.ref.pointer);
   }
@@ -3823,48 +3850,48 @@ extension NSExtendedSet on NSSet {
   }
 
   /// descriptionWithLocale:
-  NSString descriptionWithLocale_(objc.ObjCObjectBase? locale) {
+  NSString descriptionWithLocale(objc.ObjCObjectBase? locale) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.pointer,
         _sel_descriptionWithLocale_, locale?.ref.pointer ?? ffi.nullptr);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// intersectsSet:
-  bool intersectsSet_(NSSet otherSet) {
+  bool intersectsSet(NSSet otherSet) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_intersectsSet_, otherSet.ref.pointer);
   }
 
   /// isEqualToSet:
-  bool isEqualToSet_(NSSet otherSet) {
+  bool isEqualToSet(NSSet otherSet) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_isEqualToSet_, otherSet.ref.pointer);
   }
 
   /// isSubsetOfSet:
-  bool isSubsetOfSet_(NSSet otherSet) {
+  bool isSubsetOfSet(NSSet otherSet) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_isSubsetOfSet_, otherSet.ref.pointer);
   }
 
   /// makeObjectsPerformSelector:
-  void makeObjectsPerformSelector_(ffi.Pointer<objc.ObjCSelector> aSelector) {
+  void makeObjectsPerformSelector(ffi.Pointer<objc.ObjCSelector> aSelector) {
     _objc_msgSend_1d9e4oe(
         this.ref.pointer, _sel_makeObjectsPerformSelector_, aSelector);
   }
 
   /// makeObjectsPerformSelector:withObject:
-  void makeObjectsPerformSelector_withObject_(
-      ffi.Pointer<objc.ObjCSelector> aSelector, objc.ObjCObjectBase? argument) {
+  void makeObjectsPerformSelector$1(ffi.Pointer<objc.ObjCSelector> aSelector,
+      {objc.ObjCObjectBase? withObject}) {
     _objc_msgSend_1qv0eq4(
         this.ref.pointer,
         _sel_makeObjectsPerformSelector_withObject_,
         aSelector,
-        argument?.ref.pointer ?? ffi.nullptr);
+        withObject?.ref.pointer ?? ffi.nullptr);
   }
 
   /// setByAddingObject:
-  NSSet setByAddingObject_(objc.ObjCObjectBase anObject) {
+  NSSet setByAddingObject(objc.ObjCObjectBase anObject) {
     objc.checkOsVersionInternal('NSSet.setByAddingObject:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 5, 0)));
     final _ret = _objc_msgSend_1sotr3r(
@@ -3873,7 +3900,7 @@ extension NSExtendedSet on NSSet {
   }
 
   /// setByAddingObjectsFromArray:
-  NSSet setByAddingObjectsFromArray_(NSArray other) {
+  NSSet setByAddingObjectsFromArray(NSArray other) {
     objc.checkOsVersionInternal('NSSet.setByAddingObjectsFromArray:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 5, 0)));
     final _ret = _objc_msgSend_1sotr3r(
@@ -3882,7 +3909,7 @@ extension NSExtendedSet on NSSet {
   }
 
   /// setByAddingObjectsFromSet:
-  NSSet setByAddingObjectsFromSet_(NSSet other) {
+  NSSet setByAddingObjectsFromSet(NSSet other) {
     objc.checkOsVersionInternal('NSSet.setByAddingObjectsFromSet:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 5, 0)));
     final _ret = _objc_msgSend_1sotr3r(
@@ -4024,7 +4051,7 @@ class NSIndexSet extends NSObject
   }
 
   /// allocWithZone:
-  static NSIndexSet allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSIndexSet allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSIndexSet, _sel_allocWithZone_, zone);
     return NSIndexSet.castFromPointer(_ret, retain: false, release: true);
@@ -4037,14 +4064,14 @@ class NSIndexSet extends NSObject
   }
 
   /// indexSetWithIndex:
-  static NSIndexSet indexSetWithIndex_(int value) {
+  static NSIndexSet indexSetWithIndex(int value) {
     final _ret = _objc_msgSend_14hpxwa(
         _class_NSIndexSet, _sel_indexSetWithIndex_, value);
     return NSIndexSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// indexSetWithIndexesInRange:
-  static NSIndexSet indexSetWithIndexesInRange_(NSRange range) {
+  static NSIndexSet indexSetWithIndexesInRange(NSRange range) {
     final _ret = _objc_msgSend_1k1o1s7(
         _class_NSIndexSet, _sel_indexSetWithIndexesInRange_, range);
     return NSIndexSet.castFromPointer(_ret, retain: true, release: true);
@@ -4062,18 +4089,18 @@ class NSIndexSet extends NSObject
   }
 
   /// containsIndex:
-  bool containsIndex_(int value) {
+  bool containsIndex(int value) {
     return _objc_msgSend_6peh6o(this.ref.pointer, _sel_containsIndex_, value);
   }
 
   /// containsIndexes:
-  bool containsIndexes_(NSIndexSet indexSet) {
+  bool containsIndexes(NSIndexSet indexSet$1) {
     return _objc_msgSend_19nvye5(
-        this.ref.pointer, _sel_containsIndexes_, indexSet.ref.pointer);
+        this.ref.pointer, _sel_containsIndexes_, indexSet$1.ref.pointer);
   }
 
   /// containsIndexesInRange:
-  bool containsIndexesInRange_(NSRange range) {
+  bool containsIndexesInRange(NSRange range) {
     return _objc_msgSend_p4nurx(
         this.ref.pointer, _sel_containsIndexesInRange_, range);
   }
@@ -4084,7 +4111,7 @@ class NSIndexSet extends NSObject
   }
 
   /// countOfIndexesInRange:
-  int countOfIndexesInRange_(NSRange range) {
+  int countOfIndexesInRange(NSRange range) {
     objc.checkOsVersionInternal('NSIndexSet.countOfIndexesInRange:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 5, 0)));
     return _objc_msgSend_qm9f5w(
@@ -4092,7 +4119,7 @@ class NSIndexSet extends NSObject
   }
 
   /// encodeWithCoder:
-  void encodeWithCoder_(NSCoder coder) {
+  void encodeWithCoder(NSCoder coder) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_encodeWithCoder_, coder.ref.pointer);
   }
@@ -4103,34 +4130,36 @@ class NSIndexSet extends NSObject
   }
 
   /// getIndexes:maxCount:inIndexRange:
-  int getIndexes_maxCount_inIndexRange_(
-      ffi.Pointer<ffi.UnsignedLong> indexBuffer,
-      int bufferSize,
-      ffi.Pointer<NSRange> range) {
-    return _objc_msgSend_89xgla(this.ref.pointer,
-        _sel_getIndexes_maxCount_inIndexRange_, indexBuffer, bufferSize, range);
+  int getIndexes(ffi.Pointer<ffi.UnsignedLong> indexBuffer,
+      {required int maxCount, required ffi.Pointer<NSRange> inIndexRange}) {
+    return _objc_msgSend_89xgla(
+        this.ref.pointer,
+        _sel_getIndexes_maxCount_inIndexRange_,
+        indexBuffer,
+        maxCount,
+        inIndexRange);
   }
 
   /// indexGreaterThanIndex:
-  int indexGreaterThanIndex_(int value) {
+  int indexGreaterThanIndex(int value) {
     return _objc_msgSend_12py2ux(
         this.ref.pointer, _sel_indexGreaterThanIndex_, value);
   }
 
   /// indexGreaterThanOrEqualToIndex:
-  int indexGreaterThanOrEqualToIndex_(int value) {
+  int indexGreaterThanOrEqualToIndex(int value) {
     return _objc_msgSend_12py2ux(
         this.ref.pointer, _sel_indexGreaterThanOrEqualToIndex_, value);
   }
 
   /// indexLessThanIndex:
-  int indexLessThanIndex_(int value) {
+  int indexLessThanIndex(int value) {
     return _objc_msgSend_12py2ux(
         this.ref.pointer, _sel_indexLessThanIndex_, value);
   }
 
   /// indexLessThanOrEqualToIndex:
-  int indexLessThanOrEqualToIndex_(int value) {
+  int indexLessThanOrEqualToIndex(int value) {
     return _objc_msgSend_12py2ux(
         this.ref.pointer, _sel_indexLessThanOrEqualToIndex_, value);
   }
@@ -4145,7 +4174,7 @@ class NSIndexSet extends NSObject
   }
 
   /// initWithCoder:
-  NSIndexSet? initWithCoder_(NSCoder coder) {
+  NSIndexSet? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -4154,36 +4183,36 @@ class NSIndexSet extends NSObject
   }
 
   /// initWithIndex:
-  NSIndexSet initWithIndex_(int value) {
+  NSIndexSet initWithIndex(int value) {
     final _ret = _objc_msgSend_14hpxwa(
         this.ref.retainAndReturnPointer(), _sel_initWithIndex_, value);
     return NSIndexSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithIndexSet:
-  NSIndexSet initWithIndexSet_(NSIndexSet indexSet) {
+  NSIndexSet initWithIndexSet(NSIndexSet indexSet$1) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
-        _sel_initWithIndexSet_, indexSet.ref.pointer);
+        _sel_initWithIndexSet_, indexSet$1.ref.pointer);
     return NSIndexSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithIndexesInRange:
-  NSIndexSet initWithIndexesInRange_(NSRange range) {
+  NSIndexSet initWithIndexesInRange(NSRange range) {
     final _ret = _objc_msgSend_1k1o1s7(
         this.ref.retainAndReturnPointer(), _sel_initWithIndexesInRange_, range);
     return NSIndexSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// intersectsIndexesInRange:
-  bool intersectsIndexesInRange_(NSRange range) {
+  bool intersectsIndexesInRange(NSRange range) {
     return _objc_msgSend_p4nurx(
         this.ref.pointer, _sel_intersectsIndexesInRange_, range);
   }
 
   /// isEqualToIndexSet:
-  bool isEqualToIndexSet_(NSIndexSet indexSet) {
+  bool isEqualToIndexSet(NSIndexSet indexSet$1) {
     return _objc_msgSend_19nvye5(
-        this.ref.pointer, _sel_isEqualToIndexSet_, indexSet.ref.pointer);
+        this.ref.pointer, _sel_isEqualToIndexSet_, indexSet$1.ref.pointer);
   }
 
   /// lastIndex
@@ -4217,7 +4246,7 @@ class NSInputStream extends NSStream {
   }
 
   /// inputStreamWithData:
-  static NSInputStream? inputStreamWithData_(NSData data) {
+  static NSInputStream? inputStreamWithData(NSData data) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSInputStream, _sel_inputStreamWithData_, data.ref.pointer);
     return _ret.address == 0
@@ -4226,7 +4255,7 @@ class NSInputStream extends NSStream {
   }
 
   /// inputStreamWithFileAtPath:
-  static NSInputStream? inputStreamWithFileAtPath_(NSString path) {
+  static NSInputStream? inputStreamWithFileAtPath(NSString path) {
     final _ret = _objc_msgSend_1sotr3r(_class_NSInputStream,
         _sel_inputStreamWithFileAtPath_, path.ref.pointer);
     return _ret.address == 0
@@ -4235,7 +4264,7 @@ class NSInputStream extends NSStream {
   }
 
   /// inputStreamWithURL:
-  static NSInputStream? inputStreamWithURL_(NSURL url) {
+  static NSInputStream? inputStreamWithURL(NSURL url) {
     objc.checkOsVersionInternal('NSInputStream.inputStreamWithURL:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
     final _ret = _objc_msgSend_1sotr3r(
@@ -4246,10 +4275,10 @@ class NSInputStream extends NSStream {
   }
 
   /// getBuffer:length:
-  bool getBuffer_length_(ffi.Pointer<ffi.Pointer<ffi.Uint8>> buffer,
-      ffi.Pointer<ffi.UnsignedLong> len) {
+  bool getBuffer(ffi.Pointer<ffi.Pointer<ffi.Uint8>> buffer,
+      {required ffi.Pointer<ffi.UnsignedLong> length}) {
     return _objc_msgSend_19lrthf(
-        this.ref.pointer, _sel_getBuffer_length_, buffer, len);
+        this.ref.pointer, _sel_getBuffer_length_, buffer, length);
   }
 
   /// hasBytesAvailable
@@ -4258,14 +4287,14 @@ class NSInputStream extends NSStream {
   }
 
   /// initWithData:
-  NSInputStream initWithData_(NSData data) {
+  NSInputStream initWithData(NSData data) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithData_, data.ref.pointer);
     return NSInputStream.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithFileAtPath:
-  NSInputStream? initWithFileAtPath_(NSString path) {
+  NSInputStream? initWithFileAtPath(NSString path) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithFileAtPath_, path.ref.pointer);
     return _ret.address == 0
@@ -4274,7 +4303,7 @@ class NSInputStream extends NSStream {
   }
 
   /// initWithURL:
-  NSInputStream? initWithURL_(NSURL url) {
+  NSInputStream? initWithURL(NSURL url) {
     objc.checkOsVersionInternal('NSInputStream.initWithURL:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
     final _ret = _objc_msgSend_1sotr3r(
@@ -4285,9 +4314,9 @@ class NSInputStream extends NSStream {
   }
 
   /// read:maxLength:
-  int read_maxLength_(ffi.Pointer<ffi.Uint8> buffer, int len) {
+  int read(ffi.Pointer<ffi.Uint8> buffer, {required int maxLength}) {
     return _objc_msgSend_11e9f5x(
-        this.ref.pointer, _sel_read_maxLength_, buffer, len);
+        this.ref.pointer, _sel_read_maxLength_, buffer, maxLength);
   }
 }
 
@@ -4319,14 +4348,14 @@ class NSInvocation extends NSObject {
   }
 
   /// allocWithZone:
-  static NSInvocation allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSInvocation allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSInvocation, _sel_allocWithZone_, zone);
     return NSInvocation.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// invocationWithMethodSignature:
-  static NSInvocation invocationWithMethodSignature_(NSMethodSignature sig) {
+  static NSInvocation invocationWithMethodSignature(NSMethodSignature sig) {
     final _ret = _objc_msgSend_1sotr3r(_class_NSInvocation,
         _sel_invocationWithMethodSignature_, sig.ref.pointer);
     return NSInvocation.castFromPointer(_ret, retain: true, release: true);
@@ -4344,13 +4373,14 @@ class NSInvocation extends NSObject {
   }
 
   /// getArgument:atIndex:
-  void getArgument_atIndex_(ffi.Pointer<ffi.Void> argumentLocation, int idx) {
+  void getArgument(ffi.Pointer<ffi.Void> argumentLocation,
+      {required int atIndex}) {
     _objc_msgSend_unr2j3(
-        this.ref.pointer, _sel_getArgument_atIndex_, argumentLocation, idx);
+        this.ref.pointer, _sel_getArgument_atIndex_, argumentLocation, atIndex);
   }
 
   /// getReturnValue:
-  void getReturnValue_(ffi.Pointer<ffi.Void> retLoc) {
+  void getReturnValue(ffi.Pointer<ffi.Void> retLoc) {
     _objc_msgSend_ovsamd(this.ref.pointer, _sel_getReturnValue_, retLoc);
   }
 
@@ -4369,13 +4399,13 @@ class NSInvocation extends NSObject {
   }
 
   /// invokeUsingIMP:
-  void invokeUsingIMP_(
+  void invokeUsingIMP(
       ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> imp) {
     _objc_msgSend_hk6irj(this.ref.pointer, _sel_invokeUsingIMP_, imp);
   }
 
   /// invokeWithTarget:
-  void invokeWithTarget_(objc.ObjCObjectBase target) {
+  void invokeWithTarget(objc.ObjCObjectBase target) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_invokeWithTarget_, target.ref.pointer);
   }
@@ -4397,13 +4427,14 @@ class NSInvocation extends NSObject {
   }
 
   /// setArgument:atIndex:
-  void setArgument_atIndex_(ffi.Pointer<ffi.Void> argumentLocation, int idx) {
+  void setArgument(ffi.Pointer<ffi.Void> argumentLocation,
+      {required int atIndex}) {
     _objc_msgSend_unr2j3(
-        this.ref.pointer, _sel_setArgument_atIndex_, argumentLocation, idx);
+        this.ref.pointer, _sel_setArgument_atIndex_, argumentLocation, atIndex);
   }
 
   /// setReturnValue:
-  void setReturnValue_(ffi.Pointer<ffi.Void> retLoc) {
+  void setReturnValue(ffi.Pointer<ffi.Void> retLoc) {
     _objc_msgSend_ovsamd(this.ref.pointer, _sel_setReturnValue_, retLoc);
   }
 
@@ -4461,7 +4492,7 @@ class NSItemProvider extends NSObject implements NSCopying {
   }
 
   /// allocWithZone:
-  static NSItemProvider allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSItemProvider allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSItemProvider, _sel_allocWithZone_, zone);
     return NSItemProvider.castFromPointer(_ret, retain: false, release: true);
@@ -4480,7 +4511,7 @@ class NSItemProvider extends NSObject implements NSCopying {
   }
 
   /// canLoadObjectOfClass:
-  bool canLoadObjectOfClass_(NSItemProviderReading aClass) {
+  bool canLoadObjectOfClass(NSItemProviderReading aClass) {
     objc.checkOsVersionInternal('NSItemProvider.canLoadObjectOfClass:',
         iOS: (false, (11, 0, 0)), macOS: (false, (10, 13, 0)));
     return _objc_msgSend_19nvye5(
@@ -4488,7 +4519,7 @@ class NSItemProvider extends NSObject implements NSCopying {
   }
 
   /// hasItemConformingToTypeIdentifier:
-  bool hasItemConformingToTypeIdentifier_(NSString typeIdentifier) {
+  bool hasItemConformingToTypeIdentifier(NSString typeIdentifier) {
     objc.checkOsVersionInternal(
         'NSItemProvider.hasItemConformingToTypeIdentifier:',
         iOS: (false, (8, 0, 0)),
@@ -4498,8 +4529,8 @@ class NSItemProvider extends NSObject implements NSCopying {
   }
 
   /// hasRepresentationConformingToTypeIdentifier:fileOptions:
-  bool hasRepresentationConformingToTypeIdentifier_fileOptions_(
-      NSString typeIdentifier, NSItemProviderFileOptions fileOptions) {
+  bool hasRepresentationConformingToTypeIdentifier(NSString typeIdentifier,
+      {required NSItemProviderFileOptions fileOptions}) {
     objc.checkOsVersionInternal(
         'NSItemProvider.hasRepresentationConformingToTypeIdentifier:fileOptions:',
         iOS: (false, (11, 0, 0)),
@@ -4521,7 +4552,7 @@ class NSItemProvider extends NSObject implements NSCopying {
   }
 
   /// initWithContentsOfURL:
-  NSItemProvider? initWithContentsOfURL_(NSURL fileURL) {
+  NSItemProvider? initWithContentsOfURL(NSURL fileURL) {
     objc.checkOsVersionInternal('NSItemProvider.initWithContentsOfURL:',
         iOS: (false, (8, 0, 0)), macOS: (false, (10, 10, 0)));
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
@@ -4532,8 +4563,8 @@ class NSItemProvider extends NSObject implements NSCopying {
   }
 
   /// initWithItem:typeIdentifier:
-  NSItemProvider initWithItem_typeIdentifier_(
-      NSSecureCoding? item, NSString? typeIdentifier) {
+  NSItemProvider initWithItem(NSSecureCoding? item,
+      {NSString? typeIdentifier}) {
     objc.checkOsVersionInternal('NSItemProvider.initWithItem:typeIdentifier:',
         iOS: (false, (8, 0, 0)), macOS: (false, (10, 10, 0)));
     final _ret = _objc_msgSend_15qeuct(
@@ -4545,7 +4576,7 @@ class NSItemProvider extends NSObject implements NSCopying {
   }
 
   /// initWithObject:
-  NSItemProvider initWithObject_(NSItemProviderWriting object) {
+  NSItemProvider initWithObject(NSItemProviderWriting object) {
     objc.checkOsVersionInternal('NSItemProvider.initWithObject:',
         iOS: (false, (11, 0, 0)), macOS: (false, (10, 13, 0)));
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
@@ -4554,11 +4585,10 @@ class NSItemProvider extends NSObject implements NSCopying {
   }
 
   /// loadItemForTypeIdentifier:options:completionHandler:
-  void loadItemForTypeIdentifier_options_completionHandler_(
-      NSString typeIdentifier,
-      NSDictionary? options,
+  void loadItemForTypeIdentifier(NSString typeIdentifier,
+      {NSDictionary? options,
       objc.ObjCBlock<ffi.Void Function(ffi.Pointer<objc.ObjCObject>?, NSError)>?
-          completionHandler) {
+          completionHandler}) {
     objc.checkOsVersionInternal(
         'NSItemProvider.loadItemForTypeIdentifier:options:completionHandler:',
         iOS: (false, (8, 0, 0)),
@@ -4572,8 +4602,8 @@ class NSItemProvider extends NSObject implements NSCopying {
   }
 
   /// registerObject:visibility:
-  void registerObject_visibility_(NSItemProviderWriting object,
-      NSItemProviderRepresentationVisibility visibility) {
+  void registerObject(NSItemProviderWriting object,
+      {required NSItemProviderRepresentationVisibility visibility}) {
     objc.checkOsVersionInternal('NSItemProvider.registerObject:visibility:',
         iOS: (false, (11, 0, 0)), macOS: (false, (10, 13, 0)));
     _objc_msgSend_1k745tv(this.ref.pointer, _sel_registerObject_visibility_,
@@ -4590,7 +4620,7 @@ class NSItemProvider extends NSObject implements NSCopying {
   }
 
   /// registeredTypeIdentifiersWithFileOptions:
-  NSArray registeredTypeIdentifiersWithFileOptions_(
+  NSArray registeredTypeIdentifiersWithFileOptions(
       NSItemProviderFileOptions fileOptions) {
     objc.checkOsVersionInternal(
         'NSItemProvider.registeredTypeIdentifiersWithFileOptions:',
@@ -4938,14 +4968,14 @@ class NSLocale extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// allocWithZone:
-  static NSLocale allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSLocale allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSLocale, _sel_allocWithZone_, zone);
     return NSLocale.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// localeWithLocaleIdentifier:
-  static NSLocale localeWithLocaleIdentifier_(NSString ident) {
+  static NSLocale localeWithLocaleIdentifier(NSString ident) {
     objc.checkOsVersionInternal('NSLocale.localeWithLocaleIdentifier:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
     final _ret = _objc_msgSend_1sotr3r(
@@ -4971,7 +5001,8 @@ class NSLocale extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// displayNameForKey:value:
-  NSString? displayNameForKey_value_(NSString key, objc.ObjCObjectBase value) {
+  NSString? displayNameForKey(NSString key,
+      {required objc.ObjCObjectBase value}) {
     final _ret = _objc_msgSend_15qeuct(this.ref.pointer,
         _sel_displayNameForKey_value_, key.ref.pointer, value.ref.pointer);
     return _ret.address == 0
@@ -4980,7 +5011,7 @@ class NSLocale extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// encodeWithCoder:
-  void encodeWithCoder_(NSCoder coder) {
+  void encodeWithCoder(NSCoder coder) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_encodeWithCoder_, coder.ref.pointer);
   }
@@ -4995,7 +5026,7 @@ class NSLocale extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// initWithCoder:
-  NSLocale? initWithCoder_(NSCoder coder) {
+  NSLocale? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -5004,14 +5035,14 @@ class NSLocale extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// initWithLocaleIdentifier:
-  NSLocale initWithLocaleIdentifier_(NSString string) {
+  NSLocale initWithLocaleIdentifier(NSString string) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithLocaleIdentifier_, string.ref.pointer);
     return NSLocale.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// objectForKey:
-  objc.ObjCObjectBase? objectForKey_(NSString key) {
+  objc.ObjCObjectBase? objectForKey(NSString key) {
     final _ret = _objc_msgSend_1sotr3r(
         this.ref.pointer, _sel_objectForKey_, key.ref.pointer);
     return _ret.address == 0
@@ -5085,7 +5116,7 @@ class NSMethodSignature extends NSObject {
   }
 
   /// allocWithZone:
-  static NSMethodSignature allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSMethodSignature allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret = _objc_msgSend_1cwp428(
         _class_NSMethodSignature, _sel_allocWithZone_, zone);
     return NSMethodSignature.castFromPointer(_ret,
@@ -5100,7 +5131,7 @@ class NSMethodSignature extends NSObject {
   }
 
   /// signatureWithObjCTypes:
-  static NSMethodSignature? signatureWithObjCTypes_(
+  static NSMethodSignature? signatureWithObjCTypes(
       ffi.Pointer<ffi.Char> types) {
     final _ret = _objc_msgSend_56zxyn(
         _class_NSMethodSignature, _sel_signatureWithObjCTypes_, types);
@@ -5115,7 +5146,7 @@ class NSMethodSignature extends NSObject {
   }
 
   /// getArgumentTypeAtIndex:
-  ffi.Pointer<ffi.Char> getArgumentTypeAtIndex_(int idx) {
+  ffi.Pointer<ffi.Char> getArgumentTypeAtIndex(int idx) {
     return _objc_msgSend_1jtxufi(
         this.ref.pointer, _sel_getArgumentTypeAtIndex_, idx);
   }
@@ -5161,14 +5192,14 @@ class NSMutableArray extends NSArray with ListBase<objc.ObjCObjectBase> {
   ///
   /// The [length] must be a non-negative integer.
   static NSMutableArray filled(int length, objc.ObjCObjectBase fill) {
-    final a = arrayWithCapacity_(length);
+    final a = arrayWithCapacity(length);
     for (var i = 0; i < length; ++i) a.add(fill);
     return a;
   }
 
   /// Creates a [NSMutableArray] from [elements].
   static NSMutableArray of(Iterable<objc.ObjCObjectBase> elements) =>
-      arrayWithCapacity_(elements.length)..addAll(elements);
+      arrayWithCapacity(elements.length)..addAll(elements);
 
   @override
   set length(int newLength) {
@@ -5181,14 +5212,14 @@ class NSMutableArray extends NSArray with ListBase<objc.ObjCObjectBase> {
   Iterator<objc.ObjCObjectBase> get iterator => _NSArrayIterator(this);
 
   @override
-  objc.ObjCObjectBase operator [](int index) => objectAtIndex_(index);
+  objc.ObjCObjectBase operator [](int index) => objectAtIndex(index);
 
   @override
   void operator []=(int index, objc.ObjCObjectBase value) =>
-      replaceObjectAtIndex_withObject_(index, value);
+      replaceObjectAtIndex(index, withObject: value);
 
   @override
-  void add(objc.ObjCObjectBase value) => addObject_(value);
+  void add(objc.ObjCObjectBase value) => addObject(value);
 
   NSMutableArray._(ffi.Pointer<objc.ObjCObject> pointer,
       {bool retain = false, bool release = false})
@@ -5216,7 +5247,7 @@ class NSMutableArray extends NSArray with ListBase<objc.ObjCObjectBase> {
   }
 
   /// allocWithZone:
-  static NSMutableArray allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSMutableArray allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSMutableArray, _sel_allocWithZone_, zone);
     return NSMutableArray.castFromPointer(_ret, retain: false, release: true);
@@ -5229,38 +5260,39 @@ class NSMutableArray extends NSArray with ListBase<objc.ObjCObjectBase> {
   }
 
   /// arrayWithArray:
-  static NSMutableArray arrayWithArray_(NSArray array) {
+  static NSMutableArray arrayWithArray(NSArray array$1) {
     final _ret = _objc_msgSend_1sotr3r(
-        _class_NSMutableArray, _sel_arrayWithArray_, array.ref.pointer);
+        _class_NSMutableArray, _sel_arrayWithArray_, array$1.ref.pointer);
     return NSMutableArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// arrayWithCapacity:
-  static NSMutableArray arrayWithCapacity_(int numItems) {
+  static NSMutableArray arrayWithCapacity(int numItems) {
     final _ret = _objc_msgSend_14hpxwa(
         _class_NSMutableArray, _sel_arrayWithCapacity_, numItems);
     return NSMutableArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// arrayWithObject:
-  static NSMutableArray arrayWithObject_(objc.ObjCObjectBase anObject) {
+  static NSMutableArray arrayWithObject(objc.ObjCObjectBase anObject) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSMutableArray, _sel_arrayWithObject_, anObject.ref.pointer);
     return NSMutableArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// arrayWithObjects:
-  static NSMutableArray arrayWithObjects_(objc.ObjCObjectBase firstObj) {
+  static NSMutableArray arrayWithObjects(objc.ObjCObjectBase firstObj) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSMutableArray, _sel_arrayWithObjects_, firstObj.ref.pointer);
     return NSMutableArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// arrayWithObjects:count:
-  static NSMutableArray arrayWithObjects_count_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
+  static NSMutableArray arrayWithObjects$1(
+      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      {required int count}) {
     final _ret = _objc_msgSend_zmbtbd(
-        _class_NSMutableArray, _sel_arrayWithObjects_count_, objects, cnt);
+        _class_NSMutableArray, _sel_arrayWithObjects_count_, objects, count);
     return NSMutableArray.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -5277,7 +5309,7 @@ class NSMutableArray extends NSArray with ListBase<objc.ObjCObjectBase> {
   }
 
   /// addObject:
-  void addObject_(objc.ObjCObjectBase anObject) {
+  void addObject(objc.ObjCObjectBase anObject) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_addObject_, anObject.ref.pointer);
   }
@@ -5292,28 +5324,28 @@ class NSMutableArray extends NSArray with ListBase<objc.ObjCObjectBase> {
   }
 
   /// initWithArray:
-  NSMutableArray initWithArray_(NSArray array) {
+  NSMutableArray initWithArray(NSArray array$1) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
-        _sel_initWithArray_, array.ref.pointer);
+        _sel_initWithArray_, array$1.ref.pointer);
     return NSMutableArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithArray:copyItems:
-  NSMutableArray initWithArray_copyItems_(NSArray array, bool flag) {
+  NSMutableArray initWithArray$1(NSArray array$1, {required bool copyItems}) {
     final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
-        _sel_initWithArray_copyItems_, array.ref.pointer, flag);
+        _sel_initWithArray_copyItems_, array$1.ref.pointer, copyItems);
     return NSMutableArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCapacity:
-  NSMutableArray initWithCapacity_(int numItems) {
+  NSMutableArray initWithCapacity(int numItems) {
     final _ret = _objc_msgSend_14hpxwa(
         this.ref.retainAndReturnPointer(), _sel_initWithCapacity_, numItems);
     return NSMutableArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
-  NSMutableArray? initWithCoder_(NSCoder coder) {
+  NSMutableArray? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -5322,24 +5354,25 @@ class NSMutableArray extends NSArray with ListBase<objc.ObjCObjectBase> {
   }
 
   /// initWithObjects:
-  NSMutableArray initWithObjects_(objc.ObjCObjectBase firstObj) {
+  NSMutableArray initWithObjects(objc.ObjCObjectBase firstObj) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithObjects_, firstObj.ref.pointer);
     return NSMutableArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithObjects:count:
-  NSMutableArray initWithObjects_count_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
+  NSMutableArray initWithObjects$1(
+      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      {required int count$1}) {
     final _ret = _objc_msgSend_zmbtbd(this.ref.retainAndReturnPointer(),
-        _sel_initWithObjects_count_, objects, cnt);
+        _sel_initWithObjects_count_, objects, count$1);
     return NSMutableArray.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// insertObject:atIndex:
-  void insertObject_atIndex_(objc.ObjCObjectBase anObject, int index) {
+  void insertObject(objc.ObjCObjectBase anObject, {required int atIndex}) {
     _objc_msgSend_djsa9o(this.ref.pointer, _sel_insertObject_atIndex_,
-        anObject.ref.pointer, index);
+        anObject.ref.pointer, atIndex);
   }
 
   /// removeLastObject
@@ -5348,15 +5381,15 @@ class NSMutableArray extends NSArray with ListBase<objc.ObjCObjectBase> {
   }
 
   /// removeObjectAtIndex:
-  void removeObjectAtIndex_(int index) {
+  void removeObjectAtIndex(int index) {
     _objc_msgSend_1i9r4xy(this.ref.pointer, _sel_removeObjectAtIndex_, index);
   }
 
   /// replaceObjectAtIndex:withObject:
-  void replaceObjectAtIndex_withObject_(
-      int index, objc.ObjCObjectBase anObject) {
+  void replaceObjectAtIndex(int index,
+      {required objc.ObjCObjectBase withObject}) {
     _objc_msgSend_1gypgok(this.ref.pointer,
-        _sel_replaceObjectAtIndex_withObject_, index, anObject.ref.pointer);
+        _sel_replaceObjectAtIndex_withObject_, index, withObject.ref.pointer);
   }
 
   /// Returns a new instance of NSMutableArray constructed with the default `new` method.
@@ -5471,7 +5504,7 @@ class NSMutableData extends NSData {
   }
 
   /// allocWithZone:
-  static NSMutableData allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSMutableData allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSMutableData, _sel_allocWithZone_, zone);
     return NSMutableData.castFromPointer(_ret, retain: false, release: true);
@@ -5484,31 +5517,35 @@ class NSMutableData extends NSData {
   }
 
   /// dataWithBytes:length:
-  static NSMutableData dataWithBytes_length_(
-      ffi.Pointer<ffi.Void> bytes, int length) {
+  static NSMutableData dataWithBytes(ffi.Pointer<ffi.Void> bytes,
+      {required int length}) {
     final _ret = _objc_msgSend_3nbx5e(
         _class_NSMutableData, _sel_dataWithBytes_length_, bytes, length);
     return NSMutableData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dataWithBytesNoCopy:length:
-  static NSMutableData dataWithBytesNoCopy_length_(
-      ffi.Pointer<ffi.Void> bytes, int length) {
+  static NSMutableData dataWithBytesNoCopy(ffi.Pointer<ffi.Void> bytes,
+      {required int length}) {
     final _ret = _objc_msgSend_3nbx5e(
         _class_NSMutableData, _sel_dataWithBytesNoCopy_length_, bytes, length);
     return NSMutableData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dataWithBytesNoCopy:length:freeWhenDone:
-  static NSMutableData dataWithBytesNoCopy_length_freeWhenDone_(
-      ffi.Pointer<ffi.Void> bytes, int length, bool b) {
-    final _ret = _objc_msgSend_161ne8y(_class_NSMutableData,
-        _sel_dataWithBytesNoCopy_length_freeWhenDone_, bytes, length, b);
+  static NSMutableData dataWithBytesNoCopy$1(ffi.Pointer<ffi.Void> bytes,
+      {required int length, required bool freeWhenDone}) {
+    final _ret = _objc_msgSend_161ne8y(
+        _class_NSMutableData,
+        _sel_dataWithBytesNoCopy_length_freeWhenDone_,
+        bytes,
+        length,
+        freeWhenDone);
     return NSMutableData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dataWithCapacity:
-  static NSMutableData? dataWithCapacity_(int aNumItems) {
+  static NSMutableData? dataWithCapacity(int aNumItems) {
     final _ret = _objc_msgSend_14hpxwa(
         _class_NSMutableData, _sel_dataWithCapacity_, aNumItems);
     return _ret.address == 0
@@ -5517,7 +5554,7 @@ class NSMutableData extends NSData {
   }
 
   /// dataWithContentsOfFile:
-  static NSMutableData? dataWithContentsOfFile_(NSString path) {
+  static NSMutableData? dataWithContentsOfFile(NSString path) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSMutableData, _sel_dataWithContentsOfFile_, path.ref.pointer);
     return _ret.address == 0
@@ -5526,23 +5563,22 @@ class NSMutableData extends NSData {
   }
 
   /// dataWithContentsOfFile:options:error:
-  static NSMutableData? dataWithContentsOfFile_options_error_(
-      NSString path,
-      NSDataReadingOptions readOptionsMask,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> errorPtr) {
+  static NSMutableData? dataWithContentsOfFile$1(NSString path,
+      {required NSDataReadingOptions options,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_8321cp(
         _class_NSMutableData,
         _sel_dataWithContentsOfFile_options_error_,
         path.ref.pointer,
-        readOptionsMask.value,
-        errorPtr);
+        options.value,
+        error);
     return _ret.address == 0
         ? null
         : NSMutableData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dataWithContentsOfURL:
-  static NSMutableData? dataWithContentsOfURL_(NSURL url) {
+  static NSMutableData? dataWithContentsOfURL(NSURL url) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSMutableData, _sel_dataWithContentsOfURL_, url.ref.pointer);
     return _ret.address == 0
@@ -5551,30 +5587,29 @@ class NSMutableData extends NSData {
   }
 
   /// dataWithContentsOfURL:options:error:
-  static NSMutableData? dataWithContentsOfURL_options_error_(
-      NSURL url,
-      NSDataReadingOptions readOptionsMask,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> errorPtr) {
+  static NSMutableData? dataWithContentsOfURL$1(NSURL url,
+      {required NSDataReadingOptions options,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_8321cp(
         _class_NSMutableData,
         _sel_dataWithContentsOfURL_options_error_,
         url.ref.pointer,
-        readOptionsMask.value,
-        errorPtr);
+        options.value,
+        error);
     return _ret.address == 0
         ? null
         : NSMutableData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dataWithData:
-  static NSMutableData dataWithData_(NSData data) {
+  static NSMutableData dataWithData(NSData data$1) {
     final _ret = _objc_msgSend_1sotr3r(
-        _class_NSMutableData, _sel_dataWithData_, data.ref.pointer);
+        _class_NSMutableData, _sel_dataWithData_, data$1.ref.pointer);
     return NSMutableData.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// dataWithLength:
-  static NSMutableData? dataWithLength_(int length) {
+  static NSMutableData? dataWithLength(int length) {
     final _ret = _objc_msgSend_14hpxwa(
         _class_NSMutableData, _sel_dataWithLength_, length);
     return _ret.address == 0
@@ -5598,9 +5633,9 @@ class NSMutableData extends NSData {
   ///
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
-  NSMutableData? compressedDataUsingAlgorithm_error_(
+  NSMutableData? compressedDataUsingAlgorithm(
       NSDataCompressionAlgorithm algorithm,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSMutableData.compressedDataUsingAlgorithm:error:',
         iOS: (false, (13, 0, 0)),
@@ -5616,9 +5651,9 @@ class NSMutableData extends NSData {
   ///
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
-  NSMutableData? decompressedDataUsingAlgorithm_error_(
+  NSMutableData? decompressedDataUsingAlgorithm(
       NSDataCompressionAlgorithm algorithm,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSMutableData.decompressedDataUsingAlgorithm:error:',
         iOS: (false, (13, 0, 0)),
@@ -5640,8 +5675,8 @@ class NSMutableData extends NSData {
   }
 
   /// initWithBase64EncodedData:options:
-  NSMutableData? initWithBase64EncodedData_options_(
-      NSData base64Data, NSDataBase64DecodingOptions options) {
+  NSMutableData? initWithBase64EncodedData(NSData base64Data,
+      {required NSDataBase64DecodingOptions options}) {
     objc.checkOsVersionInternal(
         'NSMutableData.initWithBase64EncodedData:options:',
         iOS: (false, (7, 0, 0)),
@@ -5657,8 +5692,8 @@ class NSMutableData extends NSData {
   }
 
   /// initWithBase64EncodedString:options:
-  NSMutableData? initWithBase64EncodedString_options_(
-      NSString base64String, NSDataBase64DecodingOptions options) {
+  NSMutableData? initWithBase64EncodedString(NSString base64String,
+      {required NSDataBase64DecodingOptions options}) {
     objc.checkOsVersionInternal(
         'NSMutableData.initWithBase64EncodedString:options:',
         iOS: (false, (7, 0, 0)),
@@ -5674,30 +5709,35 @@ class NSMutableData extends NSData {
   }
 
   /// initWithBytes:length:
-  NSMutableData initWithBytes_length_(ffi.Pointer<ffi.Void> bytes, int length) {
+  NSMutableData initWithBytes(ffi.Pointer<ffi.Void> bytes$1,
+      {required int length}) {
     final _ret = _objc_msgSend_3nbx5e(this.ref.retainAndReturnPointer(),
-        _sel_initWithBytes_length_, bytes, length);
+        _sel_initWithBytes_length_, bytes$1, length);
     return NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBytesNoCopy:length:
-  NSMutableData initWithBytesNoCopy_length_(
-      ffi.Pointer<ffi.Void> bytes, int length) {
+  NSMutableData initWithBytesNoCopy(ffi.Pointer<ffi.Void> bytes$1,
+      {required int length}) {
     final _ret = _objc_msgSend_3nbx5e(this.ref.retainAndReturnPointer(),
-        _sel_initWithBytesNoCopy_length_, bytes, length);
+        _sel_initWithBytesNoCopy_length_, bytes$1, length);
     return NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBytesNoCopy:length:freeWhenDone:
-  NSMutableData initWithBytesNoCopy_length_freeWhenDone_(
-      ffi.Pointer<ffi.Void> bytes, int length, bool b) {
-    final _ret = _objc_msgSend_161ne8y(this.ref.retainAndReturnPointer(),
-        _sel_initWithBytesNoCopy_length_freeWhenDone_, bytes, length, b);
+  NSMutableData initWithBytesNoCopy$1(ffi.Pointer<ffi.Void> bytes$1,
+      {required int length, required bool freeWhenDone}) {
+    final _ret = _objc_msgSend_161ne8y(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithBytesNoCopy_length_freeWhenDone_,
+        bytes$1,
+        length,
+        freeWhenDone);
     return NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCapacity:
-  NSMutableData? initWithCapacity_(int capacity) {
+  NSMutableData? initWithCapacity(int capacity) {
     final _ret = _objc_msgSend_14hpxwa(
         this.ref.retainAndReturnPointer(), _sel_initWithCapacity_, capacity);
     return _ret.address == 0
@@ -5706,7 +5746,7 @@ class NSMutableData extends NSData {
   }
 
   /// initWithCoder:
-  NSMutableData? initWithCoder_(NSCoder coder) {
+  NSMutableData? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -5715,7 +5755,7 @@ class NSMutableData extends NSData {
   }
 
   /// initWithContentsOfFile:
-  NSMutableData? initWithContentsOfFile_(NSString path) {
+  NSMutableData? initWithContentsOfFile(NSString path) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfFile_, path.ref.pointer);
     return _ret.address == 0
@@ -5724,23 +5764,22 @@ class NSMutableData extends NSData {
   }
 
   /// initWithContentsOfFile:options:error:
-  NSMutableData? initWithContentsOfFile_options_error_(
-      NSString path,
-      NSDataReadingOptions readOptionsMask,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> errorPtr) {
+  NSMutableData? initWithContentsOfFile$1(NSString path,
+      {required NSDataReadingOptions options,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_8321cp(
         this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfFile_options_error_,
         path.ref.pointer,
-        readOptionsMask.value,
-        errorPtr);
+        options.value,
+        error);
     return _ret.address == 0
         ? null
         : NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithContentsOfURL:
-  NSMutableData? initWithContentsOfURL_(NSURL url) {
+  NSMutableData? initWithContentsOfURL(NSURL url) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_, url.ref.pointer);
     return _ret.address == 0
@@ -5749,30 +5788,29 @@ class NSMutableData extends NSData {
   }
 
   /// initWithContentsOfURL:options:error:
-  NSMutableData? initWithContentsOfURL_options_error_(
-      NSURL url,
-      NSDataReadingOptions readOptionsMask,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> errorPtr) {
+  NSMutableData? initWithContentsOfURL$1(NSURL url,
+      {required NSDataReadingOptions options,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_8321cp(
         this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_options_error_,
         url.ref.pointer,
-        readOptionsMask.value,
-        errorPtr);
+        options.value,
+        error);
     return _ret.address == 0
         ? null
         : NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithData:
-  NSMutableData initWithData_(NSData data) {
+  NSMutableData initWithData(NSData data$1) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
-        _sel_initWithData_, data.ref.pointer);
+        _sel_initWithData_, data$1.ref.pointer);
     return NSMutableData.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithLength:
-  NSMutableData? initWithLength_(int length) {
+  NSMutableData? initWithLength(int length) {
     final _ret = _objc_msgSend_14hpxwa(
         this.ref.retainAndReturnPointer(), _sel_initWithLength_, length);
     return _ret.address == 0
@@ -5803,12 +5841,12 @@ class NSMutableData extends NSData {
 class NSMutableDictionary extends NSDictionary {
   /// Creates a [NSMutableDictionary] from [other].
   static NSDictionary of(Map<NSCopying, objc.ObjCObjectBase> other) =>
-      NSMutableDictionary.dictionaryWithCapacity_(other.length)..addAll(other);
+      NSMutableDictionary.dictionaryWithCapacity(other.length)..addAll(other);
 
   /// Creates a [NSMutableDictionary] from [entries].
   static NSMutableDictionary fromEntries(
           Iterable<MapEntry<NSCopying, objc.ObjCObjectBase>> entries) =>
-      NSMutableDictionary.dictionaryWithCapacity_(entries.length)
+      NSMutableDictionary.dictionaryWithCapacity(entries.length)
         ..addEntries(entries);
 
   @override
@@ -5818,13 +5856,13 @@ class NSMutableDictionary extends NSDictionary {
   objc.ObjCObjectBase? remove(Object? key) {
     if (key is! NSCopying) return null;
     final old = this[key];
-    removeObjectForKey_(key);
+    removeObjectForKey(key);
     return old;
   }
 
   @override
   void operator []=(NSCopying key, objc.ObjCObjectBase value) =>
-      setObject_forKey_(value, NSCopying.castFrom(key));
+      setObject(value, forKey: NSCopying.castFrom(key));
 
   NSMutableDictionary._(ffi.Pointer<objc.ObjCObject> pointer,
       {bool retain = false, bool release = false})
@@ -5853,7 +5891,7 @@ class NSMutableDictionary extends NSDictionary {
   }
 
   /// allocWithZone:
-  static NSMutableDictionary allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSMutableDictionary allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret = _objc_msgSend_1cwp428(
         _class_NSMutableDictionary, _sel_allocWithZone_, zone);
     return NSMutableDictionary.castFromPointer(_ret,
@@ -5869,7 +5907,7 @@ class NSMutableDictionary extends NSDictionary {
   }
 
   /// dictionaryWithCapacity:
-  static NSMutableDictionary dictionaryWithCapacity_(int numItems) {
+  static NSMutableDictionary dictionaryWithCapacity(int numItems) {
     final _ret = _objc_msgSend_14hpxwa(
         _class_NSMutableDictionary, _sel_dictionaryWithCapacity_, numItems);
     return NSMutableDictionary.castFromPointer(_ret,
@@ -5877,7 +5915,7 @@ class NSMutableDictionary extends NSDictionary {
   }
 
   /// dictionaryWithDictionary:
-  static NSMutableDictionary dictionaryWithDictionary_(NSDictionary dict) {
+  static NSMutableDictionary dictionaryWithDictionary(NSDictionary dict) {
     final _ret = _objc_msgSend_1sotr3r(_class_NSMutableDictionary,
         _sel_dictionaryWithDictionary_, dict.ref.pointer);
     return NSMutableDictionary.castFromPointer(_ret,
@@ -5885,39 +5923,42 @@ class NSMutableDictionary extends NSDictionary {
   }
 
   /// dictionaryWithObject:forKey:
-  static NSMutableDictionary dictionaryWithObject_forKey_(
-      objc.ObjCObjectBase object, NSCopying key) {
-    final _ret = _objc_msgSend_15qeuct(_class_NSMutableDictionary,
-        _sel_dictionaryWithObject_forKey_, object.ref.pointer, key.ref.pointer);
+  static NSMutableDictionary dictionaryWithObject(objc.ObjCObjectBase object,
+      {required NSCopying forKey}) {
+    final _ret = _objc_msgSend_15qeuct(
+        _class_NSMutableDictionary,
+        _sel_dictionaryWithObject_forKey_,
+        object.ref.pointer,
+        forKey.ref.pointer);
     return NSMutableDictionary.castFromPointer(_ret,
         retain: true, release: true);
   }
 
   /// dictionaryWithObjects:forKeys:
-  static NSMutableDictionary dictionaryWithObjects_forKeys_(
-      NSArray objects, NSArray keys) {
+  static NSMutableDictionary dictionaryWithObjects(NSArray objects,
+      {required NSArray forKeys}) {
     final _ret = _objc_msgSend_15qeuct(
         _class_NSMutableDictionary,
         _sel_dictionaryWithObjects_forKeys_,
         objects.ref.pointer,
-        keys.ref.pointer);
+        forKeys.ref.pointer);
     return NSMutableDictionary.castFromPointer(_ret,
         retain: true, release: true);
   }
 
   /// dictionaryWithObjects:forKeys:count:
-  static NSMutableDictionary dictionaryWithObjects_forKeys_count_(
+  static NSMutableDictionary dictionaryWithObjects$1(
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> keys,
-      int cnt) {
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> forKeys,
+      required int count}) {
     final _ret = _objc_msgSend_1dydpdi(_class_NSMutableDictionary,
-        _sel_dictionaryWithObjects_forKeys_count_, objects, keys, cnt);
+        _sel_dictionaryWithObjects_forKeys_count_, objects, forKeys, count);
     return NSMutableDictionary.castFromPointer(_ret,
         retain: true, release: true);
   }
 
   /// dictionaryWithObjectsAndKeys:
-  static NSMutableDictionary dictionaryWithObjectsAndKeys_(
+  static NSMutableDictionary dictionaryWithObjectsAndKeys(
       objc.ObjCObjectBase firstObject) {
     final _ret = _objc_msgSend_1sotr3r(_class_NSMutableDictionary,
         _sel_dictionaryWithObjectsAndKeys_, firstObject.ref.pointer);
@@ -5949,7 +5990,7 @@ class NSMutableDictionary extends NSDictionary {
   }
 
   /// initWithCapacity:
-  NSMutableDictionary initWithCapacity_(int numItems) {
+  NSMutableDictionary initWithCapacity(int numItems) {
     final _ret = _objc_msgSend_14hpxwa(
         this.ref.retainAndReturnPointer(), _sel_initWithCapacity_, numItems);
     return NSMutableDictionary.castFromPointer(_ret,
@@ -5957,7 +5998,7 @@ class NSMutableDictionary extends NSDictionary {
   }
 
   /// initWithCoder:
-  NSMutableDictionary? initWithCoder_(NSCoder coder) {
+  NSMutableDictionary? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -5967,7 +6008,7 @@ class NSMutableDictionary extends NSDictionary {
   }
 
   /// initWithDictionary:
-  NSMutableDictionary initWithDictionary_(NSDictionary otherDictionary) {
+  NSMutableDictionary initWithDictionary(NSDictionary otherDictionary) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithDictionary_, otherDictionary.ref.pointer);
     return NSMutableDictionary.castFromPointer(_ret,
@@ -5975,35 +6016,42 @@ class NSMutableDictionary extends NSDictionary {
   }
 
   /// initWithDictionary:copyItems:
-  NSMutableDictionary initWithDictionary_copyItems_(
-      NSDictionary otherDictionary, bool flag) {
-    final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
-        _sel_initWithDictionary_copyItems_, otherDictionary.ref.pointer, flag);
+  NSMutableDictionary initWithDictionary$1(NSDictionary otherDictionary,
+      {required bool copyItems}) {
+    final _ret = _objc_msgSend_17amj0z(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithDictionary_copyItems_,
+        otherDictionary.ref.pointer,
+        copyItems);
     return NSMutableDictionary.castFromPointer(_ret,
         retain: false, release: true);
   }
 
   /// initWithObjects:forKeys:
-  NSMutableDictionary initWithObjects_forKeys_(NSArray objects, NSArray keys) {
-    final _ret = _objc_msgSend_15qeuct(this.ref.retainAndReturnPointer(),
-        _sel_initWithObjects_forKeys_, objects.ref.pointer, keys.ref.pointer);
+  NSMutableDictionary initWithObjects(NSArray objects,
+      {required NSArray forKeys}) {
+    final _ret = _objc_msgSend_15qeuct(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithObjects_forKeys_,
+        objects.ref.pointer,
+        forKeys.ref.pointer);
     return NSMutableDictionary.castFromPointer(_ret,
         retain: false, release: true);
   }
 
   /// initWithObjects:forKeys:count:
-  NSMutableDictionary initWithObjects_forKeys_count_(
+  NSMutableDictionary initWithObjects$1(
       ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> keys,
-      int cnt) {
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> forKeys,
+      required int count$1}) {
     final _ret = _objc_msgSend_1dydpdi(this.ref.retainAndReturnPointer(),
-        _sel_initWithObjects_forKeys_count_, objects, keys, cnt);
+        _sel_initWithObjects_forKeys_count_, objects, forKeys, count$1);
     return NSMutableDictionary.castFromPointer(_ret,
         retain: false, release: true);
   }
 
   /// initWithObjectsAndKeys:
-  NSMutableDictionary initWithObjectsAndKeys_(objc.ObjCObjectBase firstObject) {
+  NSMutableDictionary initWithObjectsAndKeys(objc.ObjCObjectBase firstObject) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithObjectsAndKeys_, firstObject.ref.pointer);
     return NSMutableDictionary.castFromPointer(_ret,
@@ -6011,15 +6059,15 @@ class NSMutableDictionary extends NSDictionary {
   }
 
   /// removeObjectForKey:
-  void removeObjectForKey_(objc.ObjCObjectBase aKey) {
+  void removeObjectForKey(objc.ObjCObjectBase aKey) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_removeObjectForKey_, aKey.ref.pointer);
   }
 
   /// setObject:forKey:
-  void setObject_forKey_(objc.ObjCObjectBase anObject, NSCopying aKey) {
+  void setObject(objc.ObjCObjectBase anObject, {required NSCopying forKey}) {
     _objc_msgSend_pfv6jd(this.ref.pointer, _sel_setObject_forKey_,
-        anObject.ref.pointer, aKey.ref.pointer);
+        anObject.ref.pointer, forKey.ref.pointer);
   }
 
   /// Returns a new instance of NSMutableDictionary constructed with the default `new` method.
@@ -6055,7 +6103,7 @@ class NSMutableIndexSet extends NSIndexSet {
   }
 
   /// allocWithZone:
-  static NSMutableIndexSet allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSMutableIndexSet allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret = _objc_msgSend_1cwp428(
         _class_NSMutableIndexSet, _sel_allocWithZone_, zone);
     return NSMutableIndexSet.castFromPointer(_ret,
@@ -6069,14 +6117,14 @@ class NSMutableIndexSet extends NSIndexSet {
   }
 
   /// indexSetWithIndex:
-  static NSMutableIndexSet indexSetWithIndex_(int value) {
+  static NSMutableIndexSet indexSetWithIndex(int value) {
     final _ret = _objc_msgSend_14hpxwa(
         _class_NSMutableIndexSet, _sel_indexSetWithIndex_, value);
     return NSMutableIndexSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// indexSetWithIndexesInRange:
-  static NSMutableIndexSet indexSetWithIndexesInRange_(NSRange range) {
+  static NSMutableIndexSet indexSetWithIndexesInRange(NSRange range) {
     final _ret = _objc_msgSend_1k1o1s7(
         _class_NSMutableIndexSet, _sel_indexSetWithIndexesInRange_, range);
     return NSMutableIndexSet.castFromPointer(_ret, retain: true, release: true);
@@ -6096,18 +6144,18 @@ class NSMutableIndexSet extends NSIndexSet {
   }
 
   /// addIndex:
-  void addIndex_(int value) {
+  void addIndex(int value) {
     _objc_msgSend_1i9r4xy(this.ref.pointer, _sel_addIndex_, value);
   }
 
   /// addIndexes:
-  void addIndexes_(NSIndexSet indexSet) {
+  void addIndexes(NSIndexSet indexSet) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_addIndexes_, indexSet.ref.pointer);
   }
 
   /// addIndexesInRange:
-  void addIndexesInRange_(NSRange range) {
+  void addIndexesInRange(NSRange range) {
     _objc_msgSend_1e3pm0z(this.ref.pointer, _sel_addIndexesInRange_, range);
   }
 
@@ -6122,7 +6170,7 @@ class NSMutableIndexSet extends NSIndexSet {
   }
 
   /// initWithCoder:
-  NSMutableIndexSet? initWithCoder_(NSCoder coder) {
+  NSMutableIndexSet? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -6131,7 +6179,7 @@ class NSMutableIndexSet extends NSIndexSet {
   }
 
   /// initWithIndex:
-  NSMutableIndexSet initWithIndex_(int value) {
+  NSMutableIndexSet initWithIndex(int value) {
     final _ret = _objc_msgSend_14hpxwa(
         this.ref.retainAndReturnPointer(), _sel_initWithIndex_, value);
     return NSMutableIndexSet.castFromPointer(_ret,
@@ -6139,15 +6187,15 @@ class NSMutableIndexSet extends NSIndexSet {
   }
 
   /// initWithIndexSet:
-  NSMutableIndexSet initWithIndexSet_(NSIndexSet indexSet) {
+  NSMutableIndexSet initWithIndexSet(NSIndexSet indexSet$1) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
-        _sel_initWithIndexSet_, indexSet.ref.pointer);
+        _sel_initWithIndexSet_, indexSet$1.ref.pointer);
     return NSMutableIndexSet.castFromPointer(_ret,
         retain: false, release: true);
   }
 
   /// initWithIndexesInRange:
-  NSMutableIndexSet initWithIndexesInRange_(NSRange range) {
+  NSMutableIndexSet initWithIndexesInRange(NSRange range) {
     final _ret = _objc_msgSend_1k1o1s7(
         this.ref.retainAndReturnPointer(), _sel_initWithIndexesInRange_, range);
     return NSMutableIndexSet.castFromPointer(_ret,
@@ -6160,25 +6208,25 @@ class NSMutableIndexSet extends NSIndexSet {
   }
 
   /// removeIndex:
-  void removeIndex_(int value) {
+  void removeIndex(int value) {
     _objc_msgSend_1i9r4xy(this.ref.pointer, _sel_removeIndex_, value);
   }
 
   /// removeIndexes:
-  void removeIndexes_(NSIndexSet indexSet) {
+  void removeIndexes(NSIndexSet indexSet) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_removeIndexes_, indexSet.ref.pointer);
   }
 
   /// removeIndexesInRange:
-  void removeIndexesInRange_(NSRange range) {
+  void removeIndexesInRange(NSRange range) {
     _objc_msgSend_1e3pm0z(this.ref.pointer, _sel_removeIndexesInRange_, range);
   }
 
   /// shiftIndexesStartingAtIndex:by:
-  void shiftIndexesStartingAtIndex_by_(int index, int delta) {
+  void shiftIndexesStartingAtIndex(int index, {required int by}) {
     _objc_msgSend_otx1t4(
-        this.ref.pointer, _sel_shiftIndexesStartingAtIndex_by_, index, delta);
+        this.ref.pointer, _sel_shiftIndexesStartingAtIndex_by_, index, by);
   }
 
   /// Returns a new instance of NSMutableIndexSet constructed with the default `new` method.
@@ -6217,7 +6265,7 @@ class NSMutableOrderedSet extends NSOrderedSet {
   }
 
   /// allocWithZone:
-  static NSMutableOrderedSet allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSMutableOrderedSet allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret = _objc_msgSend_1cwp428(
         _class_NSMutableOrderedSet, _sel_allocWithZone_, zone);
     return NSMutableOrderedSet.castFromPointer(_ret,
@@ -6242,7 +6290,7 @@ class NSMutableOrderedSet extends NSOrderedSet {
   }
 
   /// orderedSetWithArray:
-  static NSMutableOrderedSet orderedSetWithArray_(NSArray array) {
+  static NSMutableOrderedSet orderedSetWithArray(NSArray array) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.orderedSetWithArray:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(_class_NSMutableOrderedSet,
@@ -6252,8 +6300,8 @@ class NSMutableOrderedSet extends NSOrderedSet {
   }
 
   /// orderedSetWithArray:range:copyItems:
-  static NSMutableOrderedSet orderedSetWithArray_range_copyItems_(
-      NSArray array, NSRange range, bool flag) {
+  static NSMutableOrderedSet orderedSetWithArray$1(NSArray array,
+      {required NSRange range, required bool copyItems}) {
     objc.checkOsVersionInternal(
         'NSMutableOrderedSet.orderedSetWithArray:range:copyItems:',
         iOS: (false, (5, 0, 0)),
@@ -6263,13 +6311,13 @@ class NSMutableOrderedSet extends NSOrderedSet {
         _sel_orderedSetWithArray_range_copyItems_,
         array.ref.pointer,
         range,
-        flag);
+        copyItems);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: true, release: true);
   }
 
   /// orderedSetWithCapacity:
-  static NSMutableOrderedSet orderedSetWithCapacity_(int numItems) {
+  static NSMutableOrderedSet orderedSetWithCapacity(int numItems) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.orderedSetWithCapacity:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_14hpxwa(
@@ -6279,7 +6327,7 @@ class NSMutableOrderedSet extends NSOrderedSet {
   }
 
   /// orderedSetWithObject:
-  static NSMutableOrderedSet orderedSetWithObject_(objc.ObjCObjectBase object) {
+  static NSMutableOrderedSet orderedSetWithObject(objc.ObjCObjectBase object) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.orderedSetWithObject:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(_class_NSMutableOrderedSet,
@@ -6289,7 +6337,7 @@ class NSMutableOrderedSet extends NSOrderedSet {
   }
 
   /// orderedSetWithObjects:
-  static NSMutableOrderedSet orderedSetWithObjects_(
+  static NSMutableOrderedSet orderedSetWithObjects(
       objc.ObjCObjectBase firstObj) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.orderedSetWithObjects:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
@@ -6300,31 +6348,32 @@ class NSMutableOrderedSet extends NSOrderedSet {
   }
 
   /// orderedSetWithObjects:count:
-  static NSMutableOrderedSet orderedSetWithObjects_count_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
+  static NSMutableOrderedSet orderedSetWithObjects$1(
+      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      {required int count}) {
     objc.checkOsVersionInternal(
         'NSMutableOrderedSet.orderedSetWithObjects:count:',
         iOS: (false, (5, 0, 0)),
         macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_zmbtbd(_class_NSMutableOrderedSet,
-        _sel_orderedSetWithObjects_count_, objects, cnt);
+        _sel_orderedSetWithObjects_count_, objects, count);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: true, release: true);
   }
 
   /// orderedSetWithOrderedSet:
-  static NSMutableOrderedSet orderedSetWithOrderedSet_(NSOrderedSet set) {
+  static NSMutableOrderedSet orderedSetWithOrderedSet(NSOrderedSet set$) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.orderedSetWithOrderedSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(_class_NSMutableOrderedSet,
-        _sel_orderedSetWithOrderedSet_, set.ref.pointer);
+        _sel_orderedSetWithOrderedSet_, set$.ref.pointer);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: true, release: true);
   }
 
   /// orderedSetWithOrderedSet:range:copyItems:
-  static NSMutableOrderedSet orderedSetWithOrderedSet_range_copyItems_(
-      NSOrderedSet set, NSRange range, bool flag) {
+  static NSMutableOrderedSet orderedSetWithOrderedSet$1(NSOrderedSet set$,
+      {required NSRange range, required bool copyItems}) {
     objc.checkOsVersionInternal(
         'NSMutableOrderedSet.orderedSetWithOrderedSet:range:copyItems:',
         iOS: (false, (5, 0, 0)),
@@ -6332,32 +6381,32 @@ class NSMutableOrderedSet extends NSOrderedSet {
     final _ret = _objc_msgSend_w9bq5x(
         _class_NSMutableOrderedSet,
         _sel_orderedSetWithOrderedSet_range_copyItems_,
-        set.ref.pointer,
+        set$.ref.pointer,
         range,
-        flag);
+        copyItems);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: true, release: true);
   }
 
   /// orderedSetWithSet:
-  static NSMutableOrderedSet orderedSetWithSet_(NSSet set) {
+  static NSMutableOrderedSet orderedSetWithSet(NSSet set$) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.orderedSetWithSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(
-        _class_NSMutableOrderedSet, _sel_orderedSetWithSet_, set.ref.pointer);
+        _class_NSMutableOrderedSet, _sel_orderedSetWithSet_, set$.ref.pointer);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: true, release: true);
   }
 
   /// orderedSetWithSet:copyItems:
-  static NSMutableOrderedSet orderedSetWithSet_copyItems_(
-      NSSet set, bool flag) {
+  static NSMutableOrderedSet orderedSetWithSet$1(NSSet set$,
+      {required bool copyItems}) {
     objc.checkOsVersionInternal(
         'NSMutableOrderedSet.orderedSetWithSet:copyItems:',
         iOS: (false, (5, 0, 0)),
         macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_17amj0z(_class_NSMutableOrderedSet,
-        _sel_orderedSetWithSet_copyItems_, set.ref.pointer, flag);
+        _sel_orderedSetWithSet_copyItems_, set$.ref.pointer, copyItems);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: true, release: true);
   }
@@ -6379,7 +6428,7 @@ class NSMutableOrderedSet extends NSOrderedSet {
   }
 
   /// initWithArray:
-  NSMutableOrderedSet initWithArray_(NSArray array) {
+  NSMutableOrderedSet initWithArray(NSArray array) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.initWithArray:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
@@ -6389,30 +6438,34 @@ class NSMutableOrderedSet extends NSOrderedSet {
   }
 
   /// initWithArray:copyItems:
-  NSMutableOrderedSet initWithArray_copyItems_(NSArray set, bool flag) {
+  NSMutableOrderedSet initWithArray$1(NSArray set$, {required bool copyItems}) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.initWithArray:copyItems:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
-        _sel_initWithArray_copyItems_, set.ref.pointer, flag);
+        _sel_initWithArray_copyItems_, set$.ref.pointer, copyItems);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: false, release: true);
   }
 
   /// initWithArray:range:copyItems:
-  NSMutableOrderedSet initWithArray_range_copyItems_(
-      NSArray set, NSRange range, bool flag) {
+  NSMutableOrderedSet initWithArray$2(NSArray set$,
+      {required NSRange range, required bool copyItems}) {
     objc.checkOsVersionInternal(
         'NSMutableOrderedSet.initWithArray:range:copyItems:',
         iOS: (false, (5, 0, 0)),
         macOS: (false, (10, 7, 0)));
-    final _ret = _objc_msgSend_w9bq5x(this.ref.retainAndReturnPointer(),
-        _sel_initWithArray_range_copyItems_, set.ref.pointer, range, flag);
+    final _ret = _objc_msgSend_w9bq5x(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithArray_range_copyItems_,
+        set$.ref.pointer,
+        range,
+        copyItems);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: false, release: true);
   }
 
   /// initWithCapacity:
-  NSMutableOrderedSet initWithCapacity_(int numItems) {
+  NSMutableOrderedSet initWithCapacity(int numItems) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.initWithCapacity:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_14hpxwa(
@@ -6422,7 +6475,7 @@ class NSMutableOrderedSet extends NSOrderedSet {
   }
 
   /// initWithCoder:
-  NSMutableOrderedSet? initWithCoder_(NSCoder coder) {
+  NSMutableOrderedSet? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -6432,7 +6485,7 @@ class NSMutableOrderedSet extends NSOrderedSet {
   }
 
   /// initWithObject:
-  NSMutableOrderedSet initWithObject_(objc.ObjCObjectBase object) {
+  NSMutableOrderedSet initWithObject(objc.ObjCObjectBase object) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.initWithObject:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
@@ -6442,7 +6495,7 @@ class NSMutableOrderedSet extends NSOrderedSet {
   }
 
   /// initWithObjects:
-  NSMutableOrderedSet initWithObjects_(objc.ObjCObjectBase firstObj) {
+  NSMutableOrderedSet initWithObjects(objc.ObjCObjectBase firstObj) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.initWithObjects:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
@@ -6452,95 +6505,101 @@ class NSMutableOrderedSet extends NSOrderedSet {
   }
 
   /// initWithObjects:count:
-  NSMutableOrderedSet initWithObjects_count_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
+  NSMutableOrderedSet initWithObjects$1(
+      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      {required int count}) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.initWithObjects:count:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_zmbtbd(this.ref.retainAndReturnPointer(),
-        _sel_initWithObjects_count_, objects, cnt);
+        _sel_initWithObjects_count_, objects, count);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: false, release: true);
   }
 
   /// initWithOrderedSet:
-  NSMutableOrderedSet initWithOrderedSet_(NSOrderedSet set) {
+  NSMutableOrderedSet initWithOrderedSet(NSOrderedSet set$) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.initWithOrderedSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
-        _sel_initWithOrderedSet_, set.ref.pointer);
+        _sel_initWithOrderedSet_, set$.ref.pointer);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: false, release: true);
   }
 
   /// initWithOrderedSet:copyItems:
-  NSMutableOrderedSet initWithOrderedSet_copyItems_(
-      NSOrderedSet set, bool flag) {
+  NSMutableOrderedSet initWithOrderedSet$1(NSOrderedSet set$,
+      {required bool copyItems}) {
     objc.checkOsVersionInternal(
         'NSMutableOrderedSet.initWithOrderedSet:copyItems:',
         iOS: (false, (5, 0, 0)),
         macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
-        _sel_initWithOrderedSet_copyItems_, set.ref.pointer, flag);
+        _sel_initWithOrderedSet_copyItems_, set$.ref.pointer, copyItems);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: false, release: true);
   }
 
   /// initWithOrderedSet:range:copyItems:
-  NSMutableOrderedSet initWithOrderedSet_range_copyItems_(
-      NSOrderedSet set, NSRange range, bool flag) {
+  NSMutableOrderedSet initWithOrderedSet$2(NSOrderedSet set$,
+      {required NSRange range, required bool copyItems}) {
     objc.checkOsVersionInternal(
         'NSMutableOrderedSet.initWithOrderedSet:range:copyItems:',
         iOS: (false, (5, 0, 0)),
         macOS: (false, (10, 7, 0)));
-    final _ret = _objc_msgSend_w9bq5x(this.ref.retainAndReturnPointer(),
-        _sel_initWithOrderedSet_range_copyItems_, set.ref.pointer, range, flag);
+    final _ret = _objc_msgSend_w9bq5x(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithOrderedSet_range_copyItems_,
+        set$.ref.pointer,
+        range,
+        copyItems);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: false, release: true);
   }
 
   /// initWithSet:
-  NSMutableOrderedSet initWithSet_(NSSet set) {
+  NSMutableOrderedSet initWithSet(NSSet set$) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.initWithSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(
-        this.ref.retainAndReturnPointer(), _sel_initWithSet_, set.ref.pointer);
+        this.ref.retainAndReturnPointer(), _sel_initWithSet_, set$.ref.pointer);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: false, release: true);
   }
 
   /// initWithSet:copyItems:
-  NSMutableOrderedSet initWithSet_copyItems_(NSSet set, bool flag) {
+  NSMutableOrderedSet initWithSet$1(NSSet set$, {required bool copyItems}) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.initWithSet:copyItems:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
-        _sel_initWithSet_copyItems_, set.ref.pointer, flag);
+        _sel_initWithSet_copyItems_, set$.ref.pointer, copyItems);
     return NSMutableOrderedSet.castFromPointer(_ret,
         retain: false, release: true);
   }
 
   /// insertObject:atIndex:
-  void insertObject_atIndex_(objc.ObjCObjectBase object, int idx) {
+  void insertObject(objc.ObjCObjectBase object, {required int atIndex}) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.insertObject:atIndex:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
-    _objc_msgSend_djsa9o(
-        this.ref.pointer, _sel_insertObject_atIndex_, object.ref.pointer, idx);
+    _objc_msgSend_djsa9o(this.ref.pointer, _sel_insertObject_atIndex_,
+        object.ref.pointer, atIndex);
   }
 
   /// removeObjectAtIndex:
-  void removeObjectAtIndex_(int idx) {
+  void removeObjectAtIndex(int idx) {
     objc.checkOsVersionInternal('NSMutableOrderedSet.removeObjectAtIndex:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     _objc_msgSend_1i9r4xy(this.ref.pointer, _sel_removeObjectAtIndex_, idx);
   }
 
   /// replaceObjectAtIndex:withObject:
-  void replaceObjectAtIndex_withObject_(int idx, objc.ObjCObjectBase object) {
+  void replaceObjectAtIndex(int idx,
+      {required objc.ObjCObjectBase withObject}) {
     objc.checkOsVersionInternal(
         'NSMutableOrderedSet.replaceObjectAtIndex:withObject:',
         iOS: (false, (5, 0, 0)),
         macOS: (false, (10, 7, 0)));
     _objc_msgSend_1gypgok(this.ref.pointer,
-        _sel_replaceObjectAtIndex_withObject_, idx, object.ref.pointer);
+        _sel_replaceObjectAtIndex_withObject_, idx, withObject.ref.pointer);
   }
 
   /// Returns a new instance of NSMutableOrderedSet constructed with the default `new` method.
@@ -6551,12 +6610,12 @@ class NSMutableOrderedSet extends NSOrderedSet {
 class NSMutableSet extends NSSet {
   /// Creates a [NSMutableSet] from [elements].
   static NSMutableSet of(Iterable<objc.ObjCObjectBase> elements) =>
-      setWithCapacity_(elements.length)..addAll(elements);
+      setWithCapacity(elements.length)..addAll(elements);
 
   @override
   bool add(objc.ObjCObjectBase value) {
     final alreadyContains = contains(value);
-    addObject_(value);
+    addObject(value);
     return !alreadyContains;
   }
 
@@ -6564,7 +6623,7 @@ class NSMutableSet extends NSSet {
   bool remove(Object? value) {
     if (value is! objc.ObjCObjectBase) return false;
     final alreadyContains = contains(value);
-    removeObject_(value);
+    removeObject(value);
     return alreadyContains;
   }
 
@@ -6597,7 +6656,7 @@ class NSMutableSet extends NSSet {
   }
 
   /// allocWithZone:
-  static NSMutableSet allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSMutableSet allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSMutableSet, _sel_allocWithZone_, zone);
     return NSMutableSet.castFromPointer(_ret, retain: false, release: true);
@@ -6616,45 +6675,46 @@ class NSMutableSet extends NSSet {
   }
 
   /// setWithArray:
-  static NSMutableSet setWithArray_(NSArray array) {
+  static NSMutableSet setWithArray(NSArray array) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSMutableSet, _sel_setWithArray_, array.ref.pointer);
     return NSMutableSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// setWithCapacity:
-  static NSMutableSet setWithCapacity_(int numItems) {
+  static NSMutableSet setWithCapacity(int numItems) {
     final _ret = _objc_msgSend_14hpxwa(
         _class_NSMutableSet, _sel_setWithCapacity_, numItems);
     return NSMutableSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// setWithObject:
-  static NSMutableSet setWithObject_(objc.ObjCObjectBase object) {
+  static NSMutableSet setWithObject(objc.ObjCObjectBase object) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSMutableSet, _sel_setWithObject_, object.ref.pointer);
     return NSMutableSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// setWithObjects:
-  static NSMutableSet setWithObjects_(objc.ObjCObjectBase firstObj) {
+  static NSMutableSet setWithObjects(objc.ObjCObjectBase firstObj) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSMutableSet, _sel_setWithObjects_, firstObj.ref.pointer);
     return NSMutableSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// setWithObjects:count:
-  static NSMutableSet setWithObjects_count_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
+  static NSMutableSet setWithObjects$1(
+      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      {required int count}) {
     final _ret = _objc_msgSend_zmbtbd(
-        _class_NSMutableSet, _sel_setWithObjects_count_, objects, cnt);
+        _class_NSMutableSet, _sel_setWithObjects_count_, objects, count);
     return NSMutableSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// setWithSet:
-  static NSMutableSet setWithSet_(NSSet set) {
+  static NSMutableSet setWithSet(NSSet set$1) {
     final _ret = _objc_msgSend_1sotr3r(
-        _class_NSMutableSet, _sel_setWithSet_, set.ref.pointer);
+        _class_NSMutableSet, _sel_setWithSet_, set$1.ref.pointer);
     return NSMutableSet.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -6664,7 +6724,7 @@ class NSMutableSet extends NSSet {
   }
 
   /// addObject:
-  void addObject_(objc.ObjCObjectBase object) {
+  void addObject(objc.ObjCObjectBase object) {
     _objc_msgSend_xtuoz7(this.ref.pointer, _sel_addObject_, object.ref.pointer);
   }
 
@@ -6678,21 +6738,21 @@ class NSMutableSet extends NSSet {
   }
 
   /// initWithArray:
-  NSMutableSet initWithArray_(NSArray array) {
+  NSMutableSet initWithArray(NSArray array) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithArray_, array.ref.pointer);
     return NSMutableSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCapacity:
-  NSMutableSet initWithCapacity_(int numItems) {
+  NSMutableSet initWithCapacity(int numItems) {
     final _ret = _objc_msgSend_14hpxwa(
         this.ref.retainAndReturnPointer(), _sel_initWithCapacity_, numItems);
     return NSMutableSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
-  NSMutableSet? initWithCoder_(NSCoder coder) {
+  NSMutableSet? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -6701,36 +6761,37 @@ class NSMutableSet extends NSSet {
   }
 
   /// initWithObjects:
-  NSMutableSet initWithObjects_(objc.ObjCObjectBase firstObj) {
+  NSMutableSet initWithObjects(objc.ObjCObjectBase firstObj) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithObjects_, firstObj.ref.pointer);
     return NSMutableSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithObjects:count:
-  NSMutableSet initWithObjects_count_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
+  NSMutableSet initWithObjects$1(
+      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      {required int count}) {
     final _ret = _objc_msgSend_zmbtbd(this.ref.retainAndReturnPointer(),
-        _sel_initWithObjects_count_, objects, cnt);
+        _sel_initWithObjects_count_, objects, count);
     return NSMutableSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithSet:
-  NSMutableSet initWithSet_(NSSet set) {
-    final _ret = _objc_msgSend_1sotr3r(
-        this.ref.retainAndReturnPointer(), _sel_initWithSet_, set.ref.pointer);
+  NSMutableSet initWithSet(NSSet set$1) {
+    final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
+        _sel_initWithSet_, set$1.ref.pointer);
     return NSMutableSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithSet:copyItems:
-  NSMutableSet initWithSet_copyItems_(NSSet set, bool flag) {
+  NSMutableSet initWithSet$1(NSSet set$1, {required bool copyItems}) {
     final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
-        _sel_initWithSet_copyItems_, set.ref.pointer, flag);
+        _sel_initWithSet_copyItems_, set$1.ref.pointer, copyItems);
     return NSMutableSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// removeObject:
-  void removeObject_(objc.ObjCObjectBase object) {
+  void removeObject(objc.ObjCObjectBase object) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_removeObject_, object.ref.pointer);
   }
@@ -6767,25 +6828,23 @@ class NSMutableString extends NSString {
   }
 
   /// allocWithZone:
-  static NSMutableString allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSMutableString allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret = _objc_msgSend_1cwp428(
         _class_NSMutableString, _sel_allocWithZone_, zone);
     return NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// localizedStringWithFormat:
-  static NSMutableString localizedStringWithFormat_(NSString format) {
+  static NSMutableString localizedStringWithFormat(NSString format) {
     final _ret = _objc_msgSend_1sotr3r(_class_NSMutableString,
         _sel_localizedStringWithFormat_, format.ref.pointer);
     return NSMutableString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// localizedStringWithValidatedFormat:validFormatSpecifiers:error:
-  static NSMutableString?
-      localizedStringWithValidatedFormat_validFormatSpecifiers_error_(
-          NSString format,
-          NSString validFormatSpecifiers,
-          ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  static NSMutableString? localizedStringWithValidatedFormat(NSString format,
+      {required NSString validFormatSpecifiers,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSMutableString.localizedStringWithValidatedFormat:validFormatSpecifiers:error:',
         iOS: (false, (11, 0, 0)),
@@ -6808,10 +6867,9 @@ class NSMutableString extends NSString {
   }
 
   /// objectWithItemProviderData:typeIdentifier:error:
-  static NSMutableString? objectWithItemProviderData_typeIdentifier_error_(
-      NSData data,
-      NSString typeIdentifier,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> outError) {
+  static NSMutableString? objectWithItemProviderData(NSData data,
+      {required NSString typeIdentifier,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSMutableString.objectWithItemProviderData:typeIdentifier:error:',
         iOS: (false, (11, 0, 0)),
@@ -6821,7 +6879,7 @@ class NSMutableString extends NSString {
         _sel_objectWithItemProviderData_typeIdentifier_error_,
         data.ref.pointer,
         typeIdentifier.ref.pointer,
-        outError);
+        error);
     return _ret.address == 0
         ? null
         : NSMutableString.castFromPointer(_ret, retain: true, release: true);
@@ -6834,31 +6892,33 @@ class NSMutableString extends NSString {
   }
 
   /// stringWithCString:encoding:
-  static NSMutableString? stringWithCString_encoding_(
-      ffi.Pointer<ffi.Char> cString, int enc) {
-    final _ret = _objc_msgSend_erqryg(
-        _class_NSMutableString, _sel_stringWithCString_encoding_, cString, enc);
+  static NSMutableString? stringWithCString(ffi.Pointer<ffi.Char> cString,
+      {required int encoding}) {
+    final _ret = _objc_msgSend_erqryg(_class_NSMutableString,
+        _sel_stringWithCString_encoding_, cString, encoding);
     return _ret.address == 0
         ? null
         : NSMutableString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringWithCharacters:length:
-  static NSMutableString stringWithCharacters_length_(
-      ffi.Pointer<ffi.UnsignedShort> characters, int length) {
+  static NSMutableString stringWithCharacters(
+      ffi.Pointer<ffi.UnsignedShort> characters,
+      {required int length}) {
     final _ret = _objc_msgSend_9x4k8x(_class_NSMutableString,
         _sel_stringWithCharacters_length_, characters, length);
     return NSMutableString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringWithContentsOfFile:encoding:error:
-  static NSMutableString? stringWithContentsOfFile_encoding_error_(
-      NSString path, int enc, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  static NSMutableString? stringWithContentsOfFile(NSString path,
+      {required int encoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_1nomli1(
         _class_NSMutableString,
         _sel_stringWithContentsOfFile_encoding_error_,
         path.ref.pointer,
-        enc,
+        encoding,
         error);
     return _ret.address == 0
         ? null
@@ -6866,15 +6926,14 @@ class NSMutableString extends NSString {
   }
 
   /// stringWithContentsOfFile:usedEncoding:error:
-  static NSMutableString? stringWithContentsOfFile_usedEncoding_error_(
-      NSString path,
-      ffi.Pointer<ffi.UnsignedLong> enc,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  static NSMutableString? stringWithContentsOfFile$1(NSString path,
+      {required ffi.Pointer<ffi.UnsignedLong> usedEncoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_1alewu7(
         _class_NSMutableString,
         _sel_stringWithContentsOfFile_usedEncoding_error_,
         path.ref.pointer,
-        enc,
+        usedEncoding,
         error);
     return _ret.address == 0
         ? null
@@ -6882,13 +6941,14 @@ class NSMutableString extends NSString {
   }
 
   /// stringWithContentsOfURL:encoding:error:
-  static NSMutableString? stringWithContentsOfURL_encoding_error_(
-      NSURL url, int enc, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  static NSMutableString? stringWithContentsOfURL(NSURL url,
+      {required int encoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_1nomli1(
         _class_NSMutableString,
         _sel_stringWithContentsOfURL_encoding_error_,
         url.ref.pointer,
-        enc,
+        encoding,
         error);
     return _ret.address == 0
         ? null
@@ -6896,15 +6956,14 @@ class NSMutableString extends NSString {
   }
 
   /// stringWithContentsOfURL:usedEncoding:error:
-  static NSMutableString? stringWithContentsOfURL_usedEncoding_error_(
-      NSURL url,
-      ffi.Pointer<ffi.UnsignedLong> enc,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  static NSMutableString? stringWithContentsOfURL$1(NSURL url,
+      {required ffi.Pointer<ffi.UnsignedLong> usedEncoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_1alewu7(
         _class_NSMutableString,
         _sel_stringWithContentsOfURL_usedEncoding_error_,
         url.ref.pointer,
-        enc,
+        usedEncoding,
         error);
     return _ret.address == 0
         ? null
@@ -6912,21 +6971,21 @@ class NSMutableString extends NSString {
   }
 
   /// stringWithFormat:
-  static NSMutableString stringWithFormat_(NSString format) {
+  static NSMutableString stringWithFormat(NSString format) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSMutableString, _sel_stringWithFormat_, format.ref.pointer);
     return NSMutableString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringWithString:
-  static NSMutableString stringWithString_(NSString string) {
+  static NSMutableString stringWithString(NSString string$1) {
     final _ret = _objc_msgSend_1sotr3r(
-        _class_NSMutableString, _sel_stringWithString_, string.ref.pointer);
+        _class_NSMutableString, _sel_stringWithString_, string$1.ref.pointer);
     return NSMutableString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringWithUTF8String:
-  static NSMutableString? stringWithUTF8String_(
+  static NSMutableString? stringWithUTF8String(
       ffi.Pointer<ffi.Char> nullTerminatedCString) {
     final _ret = _objc_msgSend_56zxyn(_class_NSMutableString,
         _sel_stringWithUTF8String_, nullTerminatedCString);
@@ -6936,11 +6995,9 @@ class NSMutableString extends NSString {
   }
 
   /// stringWithValidatedFormat:validFormatSpecifiers:error:
-  static NSMutableString?
-      stringWithValidatedFormat_validFormatSpecifiers_error_(
-          NSString format,
-          NSString validFormatSpecifiers,
-          ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  static NSMutableString? stringWithValidatedFormat(NSString format,
+      {required NSString validFormatSpecifiers,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSMutableString.stringWithValidatedFormat:validFormatSpecifiers:error:',
         iOS: (false, (11, 0, 0)),
@@ -6978,33 +7035,35 @@ class NSMutableString extends NSString {
   }
 
   /// initWithBytes:length:encoding:
-  NSMutableString? initWithBytes_length_encoding_(
-      ffi.Pointer<ffi.Void> bytes, int len, int encoding) {
+  NSMutableString? initWithBytes(ffi.Pointer<ffi.Void> bytes,
+      {required int length, required int encoding}) {
     final _ret = _objc_msgSend_9b3h4v(this.ref.retainAndReturnPointer(),
-        _sel_initWithBytes_length_encoding_, bytes, len, encoding);
+        _sel_initWithBytes_length_encoding_, bytes, length, encoding);
     return _ret.address == 0
         ? null
         : NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBytesNoCopy:length:encoding:freeWhenDone:
-  NSMutableString? initWithBytesNoCopy_length_encoding_freeWhenDone_(
-      ffi.Pointer<ffi.Void> bytes, int len, int encoding, bool freeBuffer) {
+  NSMutableString? initWithBytesNoCopy(ffi.Pointer<ffi.Void> bytes,
+      {required int length,
+      required int encoding,
+      required bool freeWhenDone}) {
     final _ret = _objc_msgSend_k4j8m3(
         this.ref.retainAndReturnPointer(),
         _sel_initWithBytesNoCopy_length_encoding_freeWhenDone_,
         bytes,
-        len,
+        length,
         encoding,
-        freeBuffer);
+        freeWhenDone);
     return _ret.address == 0
         ? null
         : NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCString:encoding:
-  NSMutableString? initWithCString_encoding_(
-      ffi.Pointer<ffi.Char> nullTerminatedCString, int encoding) {
+  NSMutableString? initWithCString(ffi.Pointer<ffi.Char> nullTerminatedCString,
+      {required int encoding}) {
     final _ret = _objc_msgSend_erqryg(this.ref.retainAndReturnPointer(),
         _sel_initWithCString_encoding_, nullTerminatedCString, encoding);
     return _ret.address == 0
@@ -7013,27 +7072,29 @@ class NSMutableString extends NSString {
   }
 
   /// initWithCharacters:length:
-  NSMutableString initWithCharacters_length_(
-      ffi.Pointer<ffi.UnsignedShort> characters, int length) {
+  NSMutableString initWithCharacters(ffi.Pointer<ffi.UnsignedShort> characters,
+      {required int length}) {
     final _ret = _objc_msgSend_9x4k8x(this.ref.retainAndReturnPointer(),
         _sel_initWithCharacters_length_, characters, length);
     return NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCharactersNoCopy:length:freeWhenDone:
-  NSMutableString initWithCharactersNoCopy_length_freeWhenDone_(
-      ffi.Pointer<ffi.UnsignedShort> characters, int length, bool freeBuffer) {
+  NSMutableString initWithCharactersNoCopy(
+      ffi.Pointer<ffi.UnsignedShort> characters,
+      {required int length,
+      required bool freeWhenDone}) {
     final _ret = _objc_msgSend_lh0jh5(
         this.ref.retainAndReturnPointer(),
         _sel_initWithCharactersNoCopy_length_freeWhenDone_,
         characters,
         length,
-        freeBuffer);
+        freeWhenDone);
     return NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
-  NSMutableString? initWithCoder_(NSCoder coder) {
+  NSMutableString? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -7042,13 +7103,14 @@ class NSMutableString extends NSString {
   }
 
   /// initWithContentsOfFile:encoding:error:
-  NSMutableString? initWithContentsOfFile_encoding_error_(
-      NSString path, int enc, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  NSMutableString? initWithContentsOfFile(NSString path,
+      {required int encoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_1nomli1(
         this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfFile_encoding_error_,
         path.ref.pointer,
-        enc,
+        encoding,
         error);
     return _ret.address == 0
         ? null
@@ -7056,15 +7118,14 @@ class NSMutableString extends NSString {
   }
 
   /// initWithContentsOfFile:usedEncoding:error:
-  NSMutableString? initWithContentsOfFile_usedEncoding_error_(
-      NSString path,
-      ffi.Pointer<ffi.UnsignedLong> enc,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  NSMutableString? initWithContentsOfFile$1(NSString path,
+      {required ffi.Pointer<ffi.UnsignedLong> usedEncoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_1alewu7(
         this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfFile_usedEncoding_error_,
         path.ref.pointer,
-        enc,
+        usedEncoding,
         error);
     return _ret.address == 0
         ? null
@@ -7072,13 +7133,14 @@ class NSMutableString extends NSString {
   }
 
   /// initWithContentsOfURL:encoding:error:
-  NSMutableString? initWithContentsOfURL_encoding_error_(
-      NSURL url, int enc, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  NSMutableString? initWithContentsOfURL(NSURL url,
+      {required int encoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_1nomli1(
         this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_encoding_error_,
         url.ref.pointer,
-        enc,
+        encoding,
         error);
     return _ret.address == 0
         ? null
@@ -7086,15 +7148,14 @@ class NSMutableString extends NSString {
   }
 
   /// initWithContentsOfURL:usedEncoding:error:
-  NSMutableString? initWithContentsOfURL_usedEncoding_error_(
-      NSURL url,
-      ffi.Pointer<ffi.UnsignedLong> enc,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  NSMutableString? initWithContentsOfURL$1(NSURL url,
+      {required ffi.Pointer<ffi.UnsignedLong> usedEncoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_1alewu7(
         this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_usedEncoding_error_,
         url.ref.pointer,
-        enc,
+        usedEncoding,
         error);
     return _ret.address == 0
         ? null
@@ -7102,7 +7163,7 @@ class NSMutableString extends NSString {
   }
 
   /// initWithData:encoding:
-  NSMutableString? initWithData_encoding_(NSData data, int encoding) {
+  NSMutableString? initWithData(NSData data, {required int encoding}) {
     final _ret = _objc_msgSend_1k4kd9s(this.ref.retainAndReturnPointer(),
         _sel_initWithData_encoding_, data.ref.pointer, encoding);
     return _ret.address == 0
@@ -7111,15 +7172,15 @@ class NSMutableString extends NSString {
   }
 
   /// initWithFormat:
-  NSMutableString initWithFormat_(NSString format) {
+  NSMutableString initWithFormat(NSString format) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithFormat_, format.ref.pointer);
     return NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithFormat:locale:
-  NSMutableString initWithFormat_locale_(
-      NSString format, objc.ObjCObjectBase? locale) {
+  NSMutableString initWithFormat$1(NSString format,
+      {objc.ObjCObjectBase? locale}) {
     final _ret = _objc_msgSend_15qeuct(
         this.ref.retainAndReturnPointer(),
         _sel_initWithFormat_locale_,
@@ -7129,14 +7190,14 @@ class NSMutableString extends NSString {
   }
 
   /// initWithString:
-  NSMutableString initWithString_(NSString aString) {
+  NSMutableString initWithString(NSString aString) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithString_, aString.ref.pointer);
     return NSMutableString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithUTF8String:
-  NSMutableString? initWithUTF8String_(
+  NSMutableString? initWithUTF8String(
       ffi.Pointer<ffi.Char> nullTerminatedCString) {
     final _ret = _objc_msgSend_56zxyn(this.ref.retainAndReturnPointer(),
         _sel_initWithUTF8String_, nullTerminatedCString);
@@ -7149,10 +7210,9 @@ class NSMutableString extends NSString {
   ///
   /// iOS: introduced 16.0.0
   /// macOS: introduced 13.0.0
-  NSMutableString? initWithValidatedFormat_validFormatSpecifiers_error_(
-      NSString format,
-      NSString validFormatSpecifiers,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  NSMutableString? initWithValidatedFormat(NSString format,
+      {required NSString validFormatSpecifiers,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSMutableString.initWithValidatedFormat:validFormatSpecifiers:error:',
         iOS: (false, (16, 0, 0)),
@@ -7172,11 +7232,10 @@ class NSMutableString extends NSString {
   ///
   /// iOS: introduced 16.0.0
   /// macOS: introduced 13.0.0
-  NSMutableString? initWithValidatedFormat_validFormatSpecifiers_locale_error_(
-      NSString format,
-      NSString validFormatSpecifiers,
+  NSMutableString? initWithValidatedFormat$1(NSString format,
+      {required NSString validFormatSpecifiers,
       objc.ObjCObjectBase? locale,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSMutableString.initWithValidatedFormat:validFormatSpecifiers:locale:error:',
         iOS: (false, (16, 0, 0)),
@@ -7194,9 +7253,12 @@ class NSMutableString extends NSString {
   }
 
   /// replaceCharactersInRange:withString:
-  void replaceCharactersInRange_withString_(NSRange range, NSString aString) {
-    _objc_msgSend_1tv4uax(this.ref.pointer,
-        _sel_replaceCharactersInRange_withString_, range, aString.ref.pointer);
+  void replaceCharactersInRange(NSRange range, {required NSString withString}) {
+    _objc_msgSend_1tv4uax(
+        this.ref.pointer,
+        _sel_replaceCharactersInRange_withString_,
+        range,
+        withString.ref.pointer);
   }
 
   /// retain
@@ -7243,7 +7305,7 @@ class NSNotification extends NSObject implements NSCopying, NSCoding {
   }
 
   /// allocWithZone:
-  static NSNotification allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSNotification allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSNotification, _sel_allocWithZone_, zone);
     return NSNotification.castFromPointer(_ret, retain: false, release: true);
@@ -7256,25 +7318,25 @@ class NSNotification extends NSObject implements NSCopying, NSCoding {
   }
 
   /// notificationWithName:object:
-  static NSNotification notificationWithName_object_(
-      NSString aName, objc.ObjCObjectBase? anObject) {
+  static NSNotification notificationWithName(NSString aName,
+      {objc.ObjCObjectBase? object}) {
     final _ret = _objc_msgSend_15qeuct(
         _class_NSNotification,
         _sel_notificationWithName_object_,
         aName.ref.pointer,
-        anObject?.ref.pointer ?? ffi.nullptr);
+        object?.ref.pointer ?? ffi.nullptr);
     return NSNotification.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// notificationWithName:object:userInfo:
-  static NSNotification notificationWithName_object_userInfo_(
-      NSString aName, objc.ObjCObjectBase? anObject, NSDictionary? aUserInfo) {
+  static NSNotification notificationWithName$1(NSString aName,
+      {objc.ObjCObjectBase? object, NSDictionary? userInfo}) {
     final _ret = _objc_msgSend_11spmsz(
         _class_NSNotification,
         _sel_notificationWithName_object_userInfo_,
         aName.ref.pointer,
-        anObject?.ref.pointer ?? ffi.nullptr,
-        aUserInfo?.ref.pointer ?? ffi.nullptr);
+        object?.ref.pointer ?? ffi.nullptr,
+        userInfo?.ref.pointer ?? ffi.nullptr);
     return NSNotification.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -7285,7 +7347,7 @@ class NSNotification extends NSObject implements NSCopying, NSCoding {
   }
 
   /// encodeWithCoder:
-  void encodeWithCoder_(NSCoder coder) {
+  void encodeWithCoder(NSCoder coder) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_encodeWithCoder_, coder.ref.pointer);
   }
@@ -7298,7 +7360,7 @@ class NSNotification extends NSObject implements NSCopying, NSCoding {
   }
 
   /// initWithCoder:
-  NSNotification? initWithCoder_(NSCoder coder) {
+  NSNotification? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -7307,8 +7369,8 @@ class NSNotification extends NSObject implements NSCopying, NSCoding {
   }
 
   /// initWithName:object:userInfo:
-  NSNotification initWithName_object_userInfo_(
-      NSString name, objc.ObjCObjectBase? object, NSDictionary? userInfo) {
+  NSNotification initWithName(NSString name,
+      {objc.ObjCObjectBase? object, NSDictionary? userInfo}) {
     objc.checkOsVersionInternal('NSNotification.initWithName:object:userInfo:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
     final _ret = _objc_msgSend_11spmsz(
@@ -7386,7 +7448,7 @@ class NSNumber extends NSValue {
   }
 
   /// allocWithZone:
-  static NSNumber allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSNumber allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSNumber, _sel_allocWithZone_, zone);
     return NSNumber.castFromPointer(_ret, retain: false, release: true);
@@ -7414,14 +7476,14 @@ class NSNumber extends NSValue {
   }
 
   /// compare:
-  NSComparisonResult compare_(NSNumber otherNumber) {
+  NSComparisonResult compare(NSNumber otherNumber) {
     final _ret = _objc_msgSend_1ym6zyw(
         this.ref.pointer, _sel_compare_, otherNumber.ref.pointer);
     return NSComparisonResult.fromValue(_ret);
   }
 
   /// descriptionWithLocale:
-  NSString descriptionWithLocale_(objc.ObjCObjectBase? locale) {
+  NSString descriptionWithLocale(objc.ObjCObjectBase? locale) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.pointer,
         _sel_descriptionWithLocale_, locale?.ref.pointer ?? ffi.nullptr);
     return NSString.castFromPointer(_ret, retain: true, release: true);
@@ -7451,29 +7513,29 @@ class NSNumber extends NSValue {
   }
 
   /// initWithBool:
-  NSNumber initWithBool_(bool value) {
+  NSNumber initWithBool(bool value) {
     final _ret = _objc_msgSend_1t6aok9(
         this.ref.retainAndReturnPointer(), _sel_initWithBool_, value);
     return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBytes:objCType:
-  NSNumber initWithBytes_objCType_(
-      ffi.Pointer<ffi.Void> value, ffi.Pointer<ffi.Char> type) {
+  NSNumber initWithBytes(ffi.Pointer<ffi.Void> value,
+      {required ffi.Pointer<ffi.Char> objCType}) {
     final _ret = _objc_msgSend_e9mncn(this.ref.retainAndReturnPointer(),
-        _sel_initWithBytes_objCType_, value, type);
+        _sel_initWithBytes_objCType_, value, objCType);
     return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithChar:
-  NSNumber initWithChar_(int value) {
+  NSNumber initWithChar(int value) {
     final _ret = _objc_msgSend_13mclwd(
         this.ref.retainAndReturnPointer(), _sel_initWithChar_, value);
     return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
-  NSNumber? initWithCoder_(NSCoder coder) {
+  NSNumber? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -7482,28 +7544,28 @@ class NSNumber extends NSValue {
   }
 
   /// initWithDouble:
-  NSNumber initWithDouble_(double value) {
+  NSNumber initWithDouble(double value) {
     final _ret = _objc_msgSend_oa8mke(
         this.ref.retainAndReturnPointer(), _sel_initWithDouble_, value);
     return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithFloat:
-  NSNumber initWithFloat_(double value) {
+  NSNumber initWithFloat(double value) {
     final _ret = _objc_msgSend_et8cuh(
         this.ref.retainAndReturnPointer(), _sel_initWithFloat_, value);
     return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithInt:
-  NSNumber initWithInt_(int value) {
+  NSNumber initWithInt(int value) {
     final _ret = _objc_msgSend_14hvw5k(
         this.ref.retainAndReturnPointer(), _sel_initWithInt_, value);
     return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithInteger:
-  NSNumber initWithInteger_(int value) {
+  NSNumber initWithInteger(int value) {
     objc.checkOsVersionInternal('NSNumber.initWithInteger:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 5, 0)));
     final _ret = _objc_msgSend_qugqlf(
@@ -7512,42 +7574,42 @@ class NSNumber extends NSValue {
   }
 
   /// initWithLong:
-  NSNumber initWithLong_(int value) {
+  NSNumber initWithLong(int value) {
     final _ret = _objc_msgSend_qugqlf(
         this.ref.retainAndReturnPointer(), _sel_initWithLong_, value);
     return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithLongLong:
-  NSNumber initWithLongLong_(int value) {
+  NSNumber initWithLongLong(int value) {
     final _ret = _objc_msgSend_16f0drb(
         this.ref.retainAndReturnPointer(), _sel_initWithLongLong_, value);
     return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithShort:
-  NSNumber initWithShort_(int value) {
+  NSNumber initWithShort(int value) {
     final _ret = _objc_msgSend_68x6r1(
         this.ref.retainAndReturnPointer(), _sel_initWithShort_, value);
     return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithUnsignedChar:
-  NSNumber initWithUnsignedChar_(int value) {
+  NSNumber initWithUnsignedChar(int value) {
     final _ret = _objc_msgSend_7uautw(
         this.ref.retainAndReturnPointer(), _sel_initWithUnsignedChar_, value);
     return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithUnsignedInt:
-  NSNumber initWithUnsignedInt_(int value) {
+  NSNumber initWithUnsignedInt(int value) {
     final _ret = _objc_msgSend_degb40(
         this.ref.retainAndReturnPointer(), _sel_initWithUnsignedInt_, value);
     return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithUnsignedInteger:
-  NSNumber initWithUnsignedInteger_(int value) {
+  NSNumber initWithUnsignedInteger(int value) {
     objc.checkOsVersionInternal('NSNumber.initWithUnsignedInteger:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 5, 0)));
     final _ret = _objc_msgSend_14hpxwa(this.ref.retainAndReturnPointer(),
@@ -7556,21 +7618,21 @@ class NSNumber extends NSValue {
   }
 
   /// initWithUnsignedLong:
-  NSNumber initWithUnsignedLong_(int value) {
+  NSNumber initWithUnsignedLong(int value) {
     final _ret = _objc_msgSend_14hpxwa(
         this.ref.retainAndReturnPointer(), _sel_initWithUnsignedLong_, value);
     return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithUnsignedLongLong:
-  NSNumber initWithUnsignedLongLong_(int value) {
+  NSNumber initWithUnsignedLongLong(int value) {
     final _ret = _objc_msgSend_1x2hskc(this.ref.retainAndReturnPointer(),
         _sel_initWithUnsignedLongLong_, value);
     return NSNumber.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithUnsignedShort:
-  NSNumber initWithUnsignedShort_(int value) {
+  NSNumber initWithUnsignedShort(int value) {
     final _ret = _objc_msgSend_1njucl2(
         this.ref.retainAndReturnPointer(), _sel_initWithUnsignedShort_, value);
     return NSNumber.castFromPointer(_ret, retain: false, release: true);
@@ -7589,7 +7651,7 @@ class NSNumber extends NSValue {
   }
 
   /// isEqualToNumber:
-  bool isEqualToNumber_(NSNumber number) {
+  bool isEqualToNumber(NSNumber number) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_isEqualToNumber_, number.ref.pointer);
   }
@@ -7654,42 +7716,42 @@ class NSNumber extends NSValue {
 /// NSNumberCreation
 extension NSNumberCreation on NSNumber {
   /// numberWithBool:
-  static NSNumber numberWithBool_(bool value) {
+  static NSNumber numberWithBool(bool value) {
     final _ret =
         _objc_msgSend_1t6aok9(_class_NSNumber, _sel_numberWithBool_, value);
     return NSNumber.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// numberWithChar:
-  static NSNumber numberWithChar_(int value) {
+  static NSNumber numberWithChar(int value) {
     final _ret =
         _objc_msgSend_13mclwd(_class_NSNumber, _sel_numberWithChar_, value);
     return NSNumber.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// numberWithDouble:
-  static NSNumber numberWithDouble_(double value) {
+  static NSNumber numberWithDouble(double value) {
     final _ret =
         _objc_msgSend_oa8mke(_class_NSNumber, _sel_numberWithDouble_, value);
     return NSNumber.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// numberWithFloat:
-  static NSNumber numberWithFloat_(double value) {
+  static NSNumber numberWithFloat(double value) {
     final _ret =
         _objc_msgSend_et8cuh(_class_NSNumber, _sel_numberWithFloat_, value);
     return NSNumber.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// numberWithInt:
-  static NSNumber numberWithInt_(int value) {
+  static NSNumber numberWithInt(int value) {
     final _ret =
         _objc_msgSend_14hvw5k(_class_NSNumber, _sel_numberWithInt_, value);
     return NSNumber.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// numberWithInteger:
-  static NSNumber numberWithInteger_(int value) {
+  static NSNumber numberWithInteger(int value) {
     objc.checkOsVersionInternal('NSNumber.numberWithInteger:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 5, 0)));
     final _ret =
@@ -7698,42 +7760,42 @@ extension NSNumberCreation on NSNumber {
   }
 
   /// numberWithLong:
-  static NSNumber numberWithLong_(int value) {
+  static NSNumber numberWithLong(int value) {
     final _ret =
         _objc_msgSend_qugqlf(_class_NSNumber, _sel_numberWithLong_, value);
     return NSNumber.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// numberWithLongLong:
-  static NSNumber numberWithLongLong_(int value) {
+  static NSNumber numberWithLongLong(int value) {
     final _ret =
         _objc_msgSend_16f0drb(_class_NSNumber, _sel_numberWithLongLong_, value);
     return NSNumber.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// numberWithShort:
-  static NSNumber numberWithShort_(int value) {
+  static NSNumber numberWithShort(int value) {
     final _ret =
         _objc_msgSend_68x6r1(_class_NSNumber, _sel_numberWithShort_, value);
     return NSNumber.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// numberWithUnsignedChar:
-  static NSNumber numberWithUnsignedChar_(int value) {
+  static NSNumber numberWithUnsignedChar(int value) {
     final _ret = _objc_msgSend_7uautw(
         _class_NSNumber, _sel_numberWithUnsignedChar_, value);
     return NSNumber.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// numberWithUnsignedInt:
-  static NSNumber numberWithUnsignedInt_(int value) {
+  static NSNumber numberWithUnsignedInt(int value) {
     final _ret = _objc_msgSend_degb40(
         _class_NSNumber, _sel_numberWithUnsignedInt_, value);
     return NSNumber.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// numberWithUnsignedInteger:
-  static NSNumber numberWithUnsignedInteger_(int value) {
+  static NSNumber numberWithUnsignedInteger(int value) {
     objc.checkOsVersionInternal('NSNumber.numberWithUnsignedInteger:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 5, 0)));
     final _ret = _objc_msgSend_14hpxwa(
@@ -7742,21 +7804,21 @@ extension NSNumberCreation on NSNumber {
   }
 
   /// numberWithUnsignedLong:
-  static NSNumber numberWithUnsignedLong_(int value) {
+  static NSNumber numberWithUnsignedLong(int value) {
     final _ret = _objc_msgSend_14hpxwa(
         _class_NSNumber, _sel_numberWithUnsignedLong_, value);
     return NSNumber.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// numberWithUnsignedLongLong:
-  static NSNumber numberWithUnsignedLongLong_(int value) {
+  static NSNumber numberWithUnsignedLongLong(int value) {
     final _ret = _objc_msgSend_1x2hskc(
         _class_NSNumber, _sel_numberWithUnsignedLongLong_, value);
     return NSNumber.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// numberWithUnsignedShort:
-  static NSNumber numberWithUnsignedShort_(int value) {
+  static NSNumber numberWithUnsignedShort(int value) {
     final _ret = _objc_msgSend_1njucl2(
         _class_NSNumber, _sel_numberWithUnsignedShort_, value);
     return NSNumber.castFromPointer(_ret, retain: true, release: true);
@@ -7802,7 +7864,7 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// allocWithZone:
-  static NSObject allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSObject allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSObject, _sel_allocWithZone_, zone);
     return NSObject.castFromPointer(_ret, retain: false, release: true);
@@ -7815,7 +7877,7 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// conformsToProtocol:
-  static bool conformsToProtocol_(Protocol protocol) {
+  static bool conformsToProtocol(Protocol protocol) {
     objc.checkOsVersionInternal('NSObject.conformsToProtocol:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
     return _objc_msgSend_19nvye5(
@@ -7823,7 +7885,7 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// copyWithZone:
-  static objc.ObjCObjectBase copyWithZone_(ffi.Pointer<NSZone> zone) {
+  static objc.ObjCObjectBase copyWithZone(ffi.Pointer<NSZone> zone) {
     objc.checkOsVersionInternal('NSObject.copyWithZone:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
     final _ret =
@@ -7863,7 +7925,7 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
 
   /// instanceMethodForSelector:
   static ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>>
-      instanceMethodForSelector_(ffi.Pointer<objc.ObjCSelector> aSelector) {
+      instanceMethodForSelector(ffi.Pointer<objc.ObjCSelector> aSelector) {
     objc.checkOsVersionInternal('NSObject.instanceMethodForSelector:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
     return _objc_msgSend_1pa9f4m(
@@ -7871,7 +7933,7 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// instanceMethodSignatureForSelector:
-  static NSMethodSignature instanceMethodSignatureForSelector_(
+  static NSMethodSignature instanceMethodSignatureForSelector(
       ffi.Pointer<objc.ObjCSelector> aSelector) {
     final _ret = _objc_msgSend_3ctkt6(
         _class_NSObject, _sel_instanceMethodSignatureForSelector_, aSelector);
@@ -7879,7 +7941,7 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// instancesRespondToSelector:
-  static bool instancesRespondToSelector_(
+  static bool instancesRespondToSelector(
       ffi.Pointer<objc.ObjCSelector> aSelector) {
     objc.checkOsVersionInternal('NSObject.instancesRespondToSelector:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
@@ -7888,7 +7950,7 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// isSubclassOfClass:
-  static bool isSubclassOfClass_(objc.ObjCObjectBase aClass) {
+  static bool isSubclassOfClass(objc.ObjCObjectBase aClass) {
     objc.checkOsVersionInternal('NSObject.isSubclassOfClass:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
     return _objc_msgSend_19nvye5(
@@ -7903,7 +7965,7 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// mutableCopyWithZone:
-  static objc.ObjCObjectBase mutableCopyWithZone_(ffi.Pointer<NSZone> zone) {
+  static objc.ObjCObjectBase mutableCopyWithZone(ffi.Pointer<NSZone> zone) {
     objc.checkOsVersionInternal('NSObject.mutableCopyWithZone:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
     final _ret =
@@ -7918,7 +7980,7 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// resolveClassMethod:
-  static bool resolveClassMethod_(ffi.Pointer<objc.ObjCSelector> sel) {
+  static bool resolveClassMethod(ffi.Pointer<objc.ObjCSelector> sel) {
     objc.checkOsVersionInternal('NSObject.resolveClassMethod:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 5, 0)));
     return _objc_msgSend_1srf6wk(
@@ -7926,7 +7988,7 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// resolveInstanceMethod:
-  static bool resolveInstanceMethod_(ffi.Pointer<objc.ObjCSelector> sel) {
+  static bool resolveInstanceMethod(ffi.Pointer<objc.ObjCSelector> sel) {
     objc.checkOsVersionInternal('NSObject.resolveInstanceMethod:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 5, 0)));
     return _objc_msgSend_1srf6wk(
@@ -7954,7 +8016,7 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// conformsToProtocol:
-  bool conformsToProtocol_$1(Protocol aProtocol) {
+  bool conformsToProtocol$1(Protocol aProtocol) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_conformsToProtocol_, aProtocol.ref.pointer);
   }
@@ -7989,7 +8051,7 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// doesNotRecognizeSelector:
-  void doesNotRecognizeSelector_(ffi.Pointer<objc.ObjCSelector> aSelector) {
+  void doesNotRecognizeSelector(ffi.Pointer<objc.ObjCSelector> aSelector) {
     objc.checkOsVersionInternal('NSObject.doesNotRecognizeSelector:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
     _objc_msgSend_1d9e4oe(
@@ -7997,13 +8059,13 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// forwardInvocation:
-  void forwardInvocation_(NSInvocation anInvocation) {
+  void forwardInvocation(NSInvocation anInvocation) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_forwardInvocation_, anInvocation.ref.pointer);
   }
 
   /// forwardingTargetForSelector:
-  objc.ObjCObjectBase forwardingTargetForSelector_(
+  objc.ObjCObjectBase forwardingTargetForSelector(
       ffi.Pointer<objc.ObjCSelector> aSelector) {
     objc.checkOsVersionInternal('NSObject.forwardingTargetForSelector:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 5, 0)));
@@ -8027,19 +8089,19 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// isEqual:
-  bool isEqual_(objc.ObjCObjectBase object) {
+  bool isEqual(objc.ObjCObjectBase object) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_isEqual_, object.ref.pointer);
   }
 
   /// isKindOfClass:
-  bool isKindOfClass_(objc.ObjCObjectBase aClass) {
+  bool isKindOfClass(objc.ObjCObjectBase aClass) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_isKindOfClass_, aClass.ref.pointer);
   }
 
   /// isMemberOfClass:
-  bool isMemberOfClass_(objc.ObjCObjectBase aClass) {
+  bool isMemberOfClass(objc.ObjCObjectBase aClass) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_isMemberOfClass_, aClass.ref.pointer);
   }
@@ -8050,7 +8112,7 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// methodForSelector:
-  ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> methodForSelector_(
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function()>> methodForSelector(
       ffi.Pointer<objc.ObjCSelector> aSelector) {
     objc.checkOsVersionInternal('NSObject.methodForSelector:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 0, 0)));
@@ -8059,7 +8121,7 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// methodSignatureForSelector:
-  NSMethodSignature methodSignatureForSelector_(
+  NSMethodSignature methodSignatureForSelector(
       ffi.Pointer<objc.ObjCSelector> aSelector) {
     final _ret = _objc_msgSend_3ctkt6(
         this.ref.pointer, _sel_methodSignatureForSelector_, aSelector);
@@ -8075,7 +8137,7 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// performSelector:
-  objc.ObjCObjectBase performSelector_(
+  objc.ObjCObjectBase performSelector(
       ffi.Pointer<objc.ObjCSelector> aSelector) {
     final _ret = _objc_msgSend_3ctkt6(
         this.ref.pointer, _sel_performSelector_, aSelector);
@@ -8083,24 +8145,25 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// performSelector:withObject:
-  objc.ObjCObjectBase performSelector_withObject_(
-      ffi.Pointer<objc.ObjCSelector> aSelector, objc.ObjCObjectBase object) {
+  objc.ObjCObjectBase performSelector$1(
+      ffi.Pointer<objc.ObjCSelector> aSelector,
+      {required objc.ObjCObjectBase withObject}) {
     final _ret = _objc_msgSend_gx50so(this.ref.pointer,
-        _sel_performSelector_withObject_, aSelector, object.ref.pointer);
+        _sel_performSelector_withObject_, aSelector, withObject.ref.pointer);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
   /// performSelector:withObject:withObject:
-  objc.ObjCObjectBase performSelector_withObject_withObject_(
+  objc.ObjCObjectBase performSelector$2(
       ffi.Pointer<objc.ObjCSelector> aSelector,
-      objc.ObjCObjectBase object1,
-      objc.ObjCObjectBase object2) {
+      {required objc.ObjCObjectBase withObject,
+      required objc.ObjCObjectBase withObject$1}) {
     final _ret = _objc_msgSend_cfx8ce(
         this.ref.pointer,
         _sel_performSelector_withObject_withObject_,
         aSelector,
-        object1.ref.pointer,
-        object2.ref.pointer);
+        withObject.ref.pointer,
+        withObject$1.ref.pointer);
     return objc.ObjCObjectBase(_ret, retain: true, release: true);
   }
 
@@ -8110,7 +8173,7 @@ class NSObject extends objc.ObjCObjectBase implements NSObjectProtocol {
   }
 
   /// respondsToSelector:
-  bool respondsToSelector_(ffi.Pointer<objc.ObjCSelector> aSelector) {
+  bool respondsToSelector(ffi.Pointer<objc.ObjCSelector> aSelector) {
     return _objc_msgSend_1srf6wk(
         this.ref.pointer, _sel_respondsToSelector_, aSelector);
   }
@@ -9064,8 +9127,7 @@ class NSOrderedCollectionDifference extends NSObject
   }
 
   /// allocWithZone:
-  static NSOrderedCollectionDifference allocWithZone_(
-      ffi.Pointer<NSZone> zone) {
+  static NSOrderedCollectionDifference allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret = _objc_msgSend_1cwp428(
         _class_NSOrderedCollectionDifference, _sel_allocWithZone_, zone);
     return NSOrderedCollectionDifference.castFromPointer(_ret,
@@ -9081,12 +9143,15 @@ class NSOrderedCollectionDifference extends NSObject
   }
 
   /// countByEnumeratingWithState:objects:count:
-  int countByEnumeratingWithState_objects_count_(
-      ffi.Pointer<NSFastEnumerationState> state,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> buffer,
-      int len) {
-    return _objc_msgSend_1b5ysjl(this.ref.pointer,
-        _sel_countByEnumeratingWithState_objects_count_, state, buffer, len);
+  int countByEnumeratingWithState(ffi.Pointer<NSFastEnumerationState> state,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      required int count$1}) {
+    return _objc_msgSend_1b5ysjl(
+        this.ref.pointer,
+        _sel_countByEnumeratingWithState_objects_count_,
+        state,
+        objects,
+        count$1);
   }
 
   /// iOS: introduced 13.0.0
@@ -9111,7 +9176,7 @@ class NSOrderedCollectionDifference extends NSObject
   ///
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
-  NSOrderedCollectionDifference initWithChanges_(NSArray changes) {
+  NSOrderedCollectionDifference initWithChanges(NSArray changes) {
     objc.checkOsVersionInternal(
         'NSOrderedCollectionDifference.initWithChanges:',
         iOS: (false, (13, 0, 0)),
@@ -9126,12 +9191,10 @@ class NSOrderedCollectionDifference extends NSObject
   ///
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
-  NSOrderedCollectionDifference
-      initWithInsertIndexes_insertedObjects_removeIndexes_removedObjects_(
-          NSIndexSet inserts,
-          NSArray? insertedObjects,
-          NSIndexSet removes,
-          NSArray? removedObjects) {
+  NSOrderedCollectionDifference initWithInsertIndexes(NSIndexSet inserts,
+      {NSArray? insertedObjects,
+      required NSIndexSet removeIndexes,
+      NSArray? removedObjects}) {
     objc.checkOsVersionInternal(
         'NSOrderedCollectionDifference.initWithInsertIndexes:insertedObjects:removeIndexes:removedObjects:',
         iOS: (false, (13, 0, 0)),
@@ -9141,7 +9204,7 @@ class NSOrderedCollectionDifference extends NSObject
         _sel_initWithInsertIndexes_insertedObjects_removeIndexes_removedObjects_,
         inserts.ref.pointer,
         insertedObjects?.ref.pointer ?? ffi.nullptr,
-        removes.ref.pointer,
+        removeIndexes.ref.pointer,
         removedObjects?.ref.pointer ?? ffi.nullptr);
     return NSOrderedCollectionDifference.castFromPointer(_ret,
         retain: false, release: true);
@@ -9151,13 +9214,11 @@ class NSOrderedCollectionDifference extends NSObject
   ///
   /// iOS: introduced 13.0.0
   /// macOS: introduced 10.15.0
-  NSOrderedCollectionDifference
-      initWithInsertIndexes_insertedObjects_removeIndexes_removedObjects_additionalChanges_(
-          NSIndexSet inserts,
-          NSArray? insertedObjects,
-          NSIndexSet removes,
-          NSArray? removedObjects,
-          NSArray changes) {
+  NSOrderedCollectionDifference initWithInsertIndexes$1(NSIndexSet inserts,
+      {NSArray? insertedObjects,
+      required NSIndexSet removeIndexes,
+      NSArray? removedObjects,
+      required NSArray additionalChanges}) {
     objc.checkOsVersionInternal(
         'NSOrderedCollectionDifference.initWithInsertIndexes:insertedObjects:removeIndexes:removedObjects:additionalChanges:',
         iOS: (false, (13, 0, 0)),
@@ -9167,9 +9228,9 @@ class NSOrderedCollectionDifference extends NSObject
         _sel_initWithInsertIndexes_insertedObjects_removeIndexes_removedObjects_additionalChanges_,
         inserts.ref.pointer,
         insertedObjects?.ref.pointer ?? ffi.nullptr,
-        removes.ref.pointer,
+        removeIndexes.ref.pointer,
         removedObjects?.ref.pointer ?? ffi.nullptr,
-        changes.ref.pointer);
+        additionalChanges.ref.pointer);
     return NSOrderedCollectionDifference.castFromPointer(_ret,
         retain: false, release: true);
   }
@@ -9263,7 +9324,7 @@ class NSOrderedSet extends NSObject
   }
 
   /// allocWithZone:
-  static NSOrderedSet allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSOrderedSet allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSOrderedSet, _sel_allocWithZone_, zone);
     return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
@@ -9284,7 +9345,7 @@ class NSOrderedSet extends NSObject
   }
 
   /// orderedSetWithArray:
-  static NSOrderedSet orderedSetWithArray_(NSArray array) {
+  static NSOrderedSet orderedSetWithArray(NSArray array) {
     objc.checkOsVersionInternal('NSOrderedSet.orderedSetWithArray:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(
@@ -9293,8 +9354,8 @@ class NSOrderedSet extends NSObject
   }
 
   /// orderedSetWithArray:range:copyItems:
-  static NSOrderedSet orderedSetWithArray_range_copyItems_(
-      NSArray array, NSRange range, bool flag) {
+  static NSOrderedSet orderedSetWithArray$1(NSArray array,
+      {required NSRange range, required bool copyItems}) {
     objc.checkOsVersionInternal(
         'NSOrderedSet.orderedSetWithArray:range:copyItems:',
         iOS: (false, (5, 0, 0)),
@@ -9304,12 +9365,12 @@ class NSOrderedSet extends NSObject
         _sel_orderedSetWithArray_range_copyItems_,
         array.ref.pointer,
         range,
-        flag);
+        copyItems);
     return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// orderedSetWithObject:
-  static NSOrderedSet orderedSetWithObject_(objc.ObjCObjectBase object) {
+  static NSOrderedSet orderedSetWithObject(objc.ObjCObjectBase object) {
     objc.checkOsVersionInternal('NSOrderedSet.orderedSetWithObject:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(
@@ -9318,7 +9379,7 @@ class NSOrderedSet extends NSObject
   }
 
   /// orderedSetWithObjects:
-  static NSOrderedSet orderedSetWithObjects_(objc.ObjCObjectBase firstObj) {
+  static NSOrderedSet orderedSetWithObjects(objc.ObjCObjectBase firstObj) {
     objc.checkOsVersionInternal('NSOrderedSet.orderedSetWithObjects:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(
@@ -9327,27 +9388,28 @@ class NSOrderedSet extends NSObject
   }
 
   /// orderedSetWithObjects:count:
-  static NSOrderedSet orderedSetWithObjects_count_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
+  static NSOrderedSet orderedSetWithObjects$1(
+      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      {required int count}) {
     objc.checkOsVersionInternal('NSOrderedSet.orderedSetWithObjects:count:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_zmbtbd(
-        _class_NSOrderedSet, _sel_orderedSetWithObjects_count_, objects, cnt);
+        _class_NSOrderedSet, _sel_orderedSetWithObjects_count_, objects, count);
     return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// orderedSetWithOrderedSet:
-  static NSOrderedSet orderedSetWithOrderedSet_(NSOrderedSet set) {
+  static NSOrderedSet orderedSetWithOrderedSet(NSOrderedSet set$) {
     objc.checkOsVersionInternal('NSOrderedSet.orderedSetWithOrderedSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(
-        _class_NSOrderedSet, _sel_orderedSetWithOrderedSet_, set.ref.pointer);
+        _class_NSOrderedSet, _sel_orderedSetWithOrderedSet_, set$.ref.pointer);
     return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// orderedSetWithOrderedSet:range:copyItems:
-  static NSOrderedSet orderedSetWithOrderedSet_range_copyItems_(
-      NSOrderedSet set, NSRange range, bool flag) {
+  static NSOrderedSet orderedSetWithOrderedSet$1(NSOrderedSet set$,
+      {required NSRange range, required bool copyItems}) {
     objc.checkOsVersionInternal(
         'NSOrderedSet.orderedSetWithOrderedSet:range:copyItems:',
         iOS: (false, (5, 0, 0)),
@@ -9355,27 +9417,28 @@ class NSOrderedSet extends NSObject
     final _ret = _objc_msgSend_w9bq5x(
         _class_NSOrderedSet,
         _sel_orderedSetWithOrderedSet_range_copyItems_,
-        set.ref.pointer,
+        set$.ref.pointer,
         range,
-        flag);
+        copyItems);
     return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// orderedSetWithSet:
-  static NSOrderedSet orderedSetWithSet_(NSSet set) {
+  static NSOrderedSet orderedSetWithSet(NSSet set$) {
     objc.checkOsVersionInternal('NSOrderedSet.orderedSetWithSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(
-        _class_NSOrderedSet, _sel_orderedSetWithSet_, set.ref.pointer);
+        _class_NSOrderedSet, _sel_orderedSetWithSet_, set$.ref.pointer);
     return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// orderedSetWithSet:copyItems:
-  static NSOrderedSet orderedSetWithSet_copyItems_(NSSet set, bool flag) {
+  static NSOrderedSet orderedSetWithSet$1(NSSet set$,
+      {required bool copyItems}) {
     objc.checkOsVersionInternal('NSOrderedSet.orderedSetWithSet:copyItems:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_17amj0z(_class_NSOrderedSet,
-        _sel_orderedSetWithSet_copyItems_, set.ref.pointer, flag);
+        _sel_orderedSetWithSet_copyItems_, set$.ref.pointer, copyItems);
     return NSOrderedSet.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -9392,22 +9455,25 @@ class NSOrderedSet extends NSObject
   }
 
   /// countByEnumeratingWithState:objects:count:
-  int countByEnumeratingWithState_objects_count_(
-      ffi.Pointer<NSFastEnumerationState> state,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> buffer,
-      int len) {
-    return _objc_msgSend_1b5ysjl(this.ref.pointer,
-        _sel_countByEnumeratingWithState_objects_count_, state, buffer, len);
+  int countByEnumeratingWithState(ffi.Pointer<NSFastEnumerationState> state,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      required int count$1}) {
+    return _objc_msgSend_1b5ysjl(
+        this.ref.pointer,
+        _sel_countByEnumeratingWithState_objects_count_,
+        state,
+        objects,
+        count$1);
   }
 
   /// encodeWithCoder:
-  void encodeWithCoder_(NSCoder coder) {
+  void encodeWithCoder(NSCoder coder) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_encodeWithCoder_, coder.ref.pointer);
   }
 
   /// indexOfObject:
-  int indexOfObject_(objc.ObjCObjectBase object) {
+  int indexOfObject(objc.ObjCObjectBase object) {
     objc.checkOsVersionInternal('NSOrderedSet.indexOfObject:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     return _objc_msgSend_1vd1c5m(
@@ -9424,7 +9490,7 @@ class NSOrderedSet extends NSObject
   }
 
   /// initWithArray:
-  NSOrderedSet initWithArray_(NSArray array) {
+  NSOrderedSet initWithArray(NSArray array) {
     objc.checkOsVersionInternal('NSOrderedSet.initWithArray:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
@@ -9433,26 +9499,30 @@ class NSOrderedSet extends NSObject
   }
 
   /// initWithArray:copyItems:
-  NSOrderedSet initWithArray_copyItems_(NSArray set, bool flag) {
+  NSOrderedSet initWithArray$1(NSArray set$, {required bool copyItems}) {
     objc.checkOsVersionInternal('NSOrderedSet.initWithArray:copyItems:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
-        _sel_initWithArray_copyItems_, set.ref.pointer, flag);
+        _sel_initWithArray_copyItems_, set$.ref.pointer, copyItems);
     return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithArray:range:copyItems:
-  NSOrderedSet initWithArray_range_copyItems_(
-      NSArray set, NSRange range, bool flag) {
+  NSOrderedSet initWithArray$2(NSArray set$,
+      {required NSRange range, required bool copyItems}) {
     objc.checkOsVersionInternal('NSOrderedSet.initWithArray:range:copyItems:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
-    final _ret = _objc_msgSend_w9bq5x(this.ref.retainAndReturnPointer(),
-        _sel_initWithArray_range_copyItems_, set.ref.pointer, range, flag);
+    final _ret = _objc_msgSend_w9bq5x(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithArray_range_copyItems_,
+        set$.ref.pointer,
+        range,
+        copyItems);
     return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
-  NSOrderedSet? initWithCoder_(NSCoder coder) {
+  NSOrderedSet? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -9461,7 +9531,7 @@ class NSOrderedSet extends NSObject
   }
 
   /// initWithObject:
-  NSOrderedSet initWithObject_(objc.ObjCObjectBase object) {
+  NSOrderedSet initWithObject(objc.ObjCObjectBase object) {
     objc.checkOsVersionInternal('NSOrderedSet.initWithObject:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
@@ -9470,7 +9540,7 @@ class NSOrderedSet extends NSObject
   }
 
   /// initWithObjects:
-  NSOrderedSet initWithObjects_(objc.ObjCObjectBase firstObj) {
+  NSOrderedSet initWithObjects(objc.ObjCObjectBase firstObj) {
     objc.checkOsVersionInternal('NSOrderedSet.initWithObjects:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
@@ -9479,65 +9549,71 @@ class NSOrderedSet extends NSObject
   }
 
   /// initWithObjects:count:
-  NSOrderedSet initWithObjects_count_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
+  NSOrderedSet initWithObjects$1(
+      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      {required int count}) {
     objc.checkOsVersionInternal('NSOrderedSet.initWithObjects:count:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_zmbtbd(this.ref.retainAndReturnPointer(),
-        _sel_initWithObjects_count_, objects, cnt);
+        _sel_initWithObjects_count_, objects, count);
     return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithOrderedSet:
-  NSOrderedSet initWithOrderedSet_(NSOrderedSet set) {
+  NSOrderedSet initWithOrderedSet(NSOrderedSet set$) {
     objc.checkOsVersionInternal('NSOrderedSet.initWithOrderedSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
-        _sel_initWithOrderedSet_, set.ref.pointer);
+        _sel_initWithOrderedSet_, set$.ref.pointer);
     return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithOrderedSet:copyItems:
-  NSOrderedSet initWithOrderedSet_copyItems_(NSOrderedSet set, bool flag) {
+  NSOrderedSet initWithOrderedSet$1(NSOrderedSet set$,
+      {required bool copyItems}) {
     objc.checkOsVersionInternal('NSOrderedSet.initWithOrderedSet:copyItems:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
-        _sel_initWithOrderedSet_copyItems_, set.ref.pointer, flag);
+        _sel_initWithOrderedSet_copyItems_, set$.ref.pointer, copyItems);
     return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithOrderedSet:range:copyItems:
-  NSOrderedSet initWithOrderedSet_range_copyItems_(
-      NSOrderedSet set, NSRange range, bool flag) {
+  NSOrderedSet initWithOrderedSet$2(NSOrderedSet set$,
+      {required NSRange range, required bool copyItems}) {
     objc.checkOsVersionInternal(
         'NSOrderedSet.initWithOrderedSet:range:copyItems:',
         iOS: (false, (5, 0, 0)),
         macOS: (false, (10, 7, 0)));
-    final _ret = _objc_msgSend_w9bq5x(this.ref.retainAndReturnPointer(),
-        _sel_initWithOrderedSet_range_copyItems_, set.ref.pointer, range, flag);
+    final _ret = _objc_msgSend_w9bq5x(
+        this.ref.retainAndReturnPointer(),
+        _sel_initWithOrderedSet_range_copyItems_,
+        set$.ref.pointer,
+        range,
+        copyItems);
     return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithSet:
-  NSOrderedSet initWithSet_(NSSet set) {
+  NSOrderedSet initWithSet(NSSet set$) {
     objc.checkOsVersionInternal('NSOrderedSet.initWithSet:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_1sotr3r(
-        this.ref.retainAndReturnPointer(), _sel_initWithSet_, set.ref.pointer);
+        this.ref.retainAndReturnPointer(), _sel_initWithSet_, set$.ref.pointer);
     return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithSet:copyItems:
-  NSOrderedSet initWithSet_copyItems_(NSSet set, bool flag) {
+  NSOrderedSet initWithSet$1(NSSet set$, {required bool copyItems}) {
     objc.checkOsVersionInternal('NSOrderedSet.initWithSet:copyItems:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
-        _sel_initWithSet_copyItems_, set.ref.pointer, flag);
+        _sel_initWithSet_copyItems_, set$.ref.pointer, copyItems);
     return NSOrderedSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// objectAtIndex:
-  objc.ObjCObjectBase objectAtIndex_(int idx) {
+  objc.ObjCObjectBase objectAtIndex(int idx) {
     objc.checkOsVersionInternal('NSOrderedSet.objectAtIndex:',
         iOS: (false, (5, 0, 0)), macOS: (false, (10, 7, 0)));
     final _ret =
@@ -9571,18 +9647,18 @@ class NSOutputStream extends NSStream {
   }
 
   /// outputStreamToBuffer:capacity:
-  static NSOutputStream outputStreamToBuffer_capacity_(
-      ffi.Pointer<ffi.Uint8> buffer, int capacity) {
+  static NSOutputStream outputStreamToBuffer(ffi.Pointer<ffi.Uint8> buffer,
+      {required int capacity}) {
     final _ret = _objc_msgSend_158ju31(_class_NSOutputStream,
         _sel_outputStreamToBuffer_capacity_, buffer, capacity);
     return NSOutputStream.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// outputStreamToFileAtPath:append:
-  static NSOutputStream outputStreamToFileAtPath_append_(
-      NSString path, bool shouldAppend) {
+  static NSOutputStream outputStreamToFileAtPath(NSString path,
+      {required bool append}) {
     final _ret = _objc_msgSend_17amj0z(_class_NSOutputStream,
-        _sel_outputStreamToFileAtPath_append_, path.ref.pointer, shouldAppend);
+        _sel_outputStreamToFileAtPath_append_, path.ref.pointer, append);
     return NSOutputStream.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -9594,12 +9670,12 @@ class NSOutputStream extends NSStream {
   }
 
   /// outputStreamWithURL:append:
-  static NSOutputStream? outputStreamWithURL_append_(
-      NSURL url, bool shouldAppend) {
+  static NSOutputStream? outputStreamWithURL(NSURL url,
+      {required bool append}) {
     objc.checkOsVersionInternal('NSOutputStream.outputStreamWithURL:append:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
     final _ret = _objc_msgSend_17amj0z(_class_NSOutputStream,
-        _sel_outputStreamWithURL_append_, url.ref.pointer, shouldAppend);
+        _sel_outputStreamWithURL_append_, url.ref.pointer, append);
     return _ret.address == 0
         ? null
         : NSOutputStream.castFromPointer(_ret, retain: true, release: true);
@@ -9611,17 +9687,17 @@ class NSOutputStream extends NSStream {
   }
 
   /// initToBuffer:capacity:
-  NSOutputStream initToBuffer_capacity_(
-      ffi.Pointer<ffi.Uint8> buffer, int capacity) {
+  NSOutputStream initToBuffer(ffi.Pointer<ffi.Uint8> buffer,
+      {required int capacity}) {
     final _ret = _objc_msgSend_158ju31(this.ref.retainAndReturnPointer(),
         _sel_initToBuffer_capacity_, buffer, capacity);
     return NSOutputStream.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initToFileAtPath:append:
-  NSOutputStream? initToFileAtPath_append_(NSString path, bool shouldAppend) {
+  NSOutputStream? initToFileAtPath(NSString path, {required bool append}) {
     final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
-        _sel_initToFileAtPath_append_, path.ref.pointer, shouldAppend);
+        _sel_initToFileAtPath_append_, path.ref.pointer, append);
     return _ret.address == 0
         ? null
         : NSOutputStream.castFromPointer(_ret, retain: false, release: true);
@@ -9635,20 +9711,20 @@ class NSOutputStream extends NSStream {
   }
 
   /// initWithURL:append:
-  NSOutputStream? initWithURL_append_(NSURL url, bool shouldAppend) {
+  NSOutputStream? initWithURL(NSURL url, {required bool append}) {
     objc.checkOsVersionInternal('NSOutputStream.initWithURL:append:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
     final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
-        _sel_initWithURL_append_, url.ref.pointer, shouldAppend);
+        _sel_initWithURL_append_, url.ref.pointer, append);
     return _ret.address == 0
         ? null
         : NSOutputStream.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// write:maxLength:
-  int write_maxLength_(ffi.Pointer<ffi.Uint8> buffer, int len) {
+  int write(ffi.Pointer<ffi.Uint8> buffer, {required int maxLength}) {
     return _objc_msgSend_11e9f5x(
-        this.ref.pointer, _sel_write_maxLength_, buffer, len);
+        this.ref.pointer, _sel_write_maxLength_, buffer, maxLength);
   }
 }
 
@@ -9680,7 +9756,7 @@ class NSPort extends NSObject implements NSCopying, NSCoding {
   }
 
   /// allocWithZone:
-  static NSPort allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSPort allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSPort, _sel_allocWithZone_, zone);
     return NSPort.castFromPointer(_ret, retain: false, release: true);
@@ -9713,7 +9789,7 @@ class NSPort extends NSObject implements NSCopying, NSCoding {
   }
 
   /// encodeWithCoder:
-  void encodeWithCoder_(NSCoder coder) {
+  void encodeWithCoder(NSCoder coder) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_encodeWithCoder_, coder.ref.pointer);
   }
@@ -9728,7 +9804,7 @@ class NSPort extends NSObject implements NSCopying, NSCoding {
   }
 
   /// initWithCoder:
-  NSPort? initWithCoder_(NSCoder coder) {
+  NSPort? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -9747,9 +9823,9 @@ class NSPort extends NSObject implements NSCopying, NSCoding {
   }
 
   /// removeFromRunLoop:forMode:
-  void removeFromRunLoop_forMode_(NSRunLoop runLoop, NSString mode) {
+  void removeFromRunLoop(NSRunLoop runLoop, {required NSString forMode}) {
     _objc_msgSend_pfv6jd(this.ref.pointer, _sel_removeFromRunLoop_forMode_,
-        runLoop.ref.pointer, mode.ref.pointer);
+        runLoop.ref.pointer, forMode.ref.pointer);
   }
 
   /// reservedSpaceLength
@@ -9764,9 +9840,9 @@ class NSPort extends NSObject implements NSCopying, NSCoding {
   }
 
   /// scheduleInRunLoop:forMode:
-  void scheduleInRunLoop_forMode_(NSRunLoop runLoop, NSString mode) {
+  void scheduleInRunLoop(NSRunLoop runLoop, {required NSString forMode}) {
     _objc_msgSend_pfv6jd(this.ref.pointer, _sel_scheduleInRunLoop_forMode_,
-        runLoop.ref.pointer, mode.ref.pointer);
+        runLoop.ref.pointer, forMode.ref.pointer);
   }
 
   /// self
@@ -9776,39 +9852,35 @@ class NSPort extends NSObject implements NSCopying, NSCoding {
   }
 
   /// sendBeforeDate:components:from:reserved:
-  bool sendBeforeDate_components_from_reserved_(
-      NSDate limitDate,
-      NSMutableArray? components,
-      NSPort? receivePort,
-      int headerSpaceReserved) {
+  bool sendBeforeDate(NSDate limitDate,
+      {NSMutableArray? components, NSPort? from, required int reserved}) {
     return _objc_msgSend_1frfu5e(
         this.ref.pointer,
         _sel_sendBeforeDate_components_from_reserved_,
         limitDate.ref.pointer,
         components?.ref.pointer ?? ffi.nullptr,
-        receivePort?.ref.pointer ?? ffi.nullptr,
-        headerSpaceReserved);
+        from?.ref.pointer ?? ffi.nullptr,
+        reserved);
   }
 
   /// sendBeforeDate:msgid:components:from:reserved:
-  bool sendBeforeDate_msgid_components_from_reserved_(
-      NSDate limitDate,
-      int msgID,
+  bool sendBeforeDate$1(NSDate limitDate,
+      {required int msgid,
       NSMutableArray? components,
-      NSPort? receivePort,
-      int headerSpaceReserved) {
+      NSPort? from,
+      required int reserved}) {
     return _objc_msgSend_gupwtj(
         this.ref.pointer,
         _sel_sendBeforeDate_msgid_components_from_reserved_,
         limitDate.ref.pointer,
-        msgID,
+        msgid,
         components?.ref.pointer ?? ffi.nullptr,
-        receivePort?.ref.pointer ?? ffi.nullptr,
-        headerSpaceReserved);
+        from?.ref.pointer ?? ffi.nullptr,
+        reserved);
   }
 
   /// setDelegate:
-  void setDelegate_(NSPortDelegate? anObject) {
+  void setDelegate(NSPortDelegate? anObject) {
     _objc_msgSend_xtuoz7(this.ref.pointer, _sel_setDelegate_,
         anObject?.ref.pointer ?? ffi.nullptr);
   }
@@ -9986,7 +10058,7 @@ class NSPortMessage extends NSObject {
   }
 
   /// allocWithZone:
-  static NSPortMessage allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSPortMessage allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSPortMessage, _sel_allocWithZone_, zone);
     return NSPortMessage.castFromPointer(_ret, retain: false, release: true);
@@ -10022,14 +10094,14 @@ class NSPortMessage extends NSObject {
   }
 
   /// initWithSendPort:receivePort:components:
-  NSPortMessage initWithSendPort_receivePort_components_(
-      NSPort? sendPort, NSPort? replyPort, NSArray? components) {
+  NSPortMessage initWithSendPort(NSPort? sendPort,
+      {NSPort? receivePort, NSArray? components$1}) {
     final _ret = _objc_msgSend_11spmsz(
         this.ref.retainAndReturnPointer(),
         _sel_initWithSendPort_receivePort_components_,
         sendPort?.ref.pointer ?? ffi.nullptr,
-        replyPort?.ref.pointer ?? ffi.nullptr,
-        components?.ref.pointer ?? ffi.nullptr);
+        receivePort?.ref.pointer ?? ffi.nullptr,
+        components$1?.ref.pointer ?? ffi.nullptr);
     return NSPortMessage.castFromPointer(_ret, retain: false, release: true);
   }
 
@@ -10059,7 +10131,7 @@ class NSPortMessage extends NSObject {
   }
 
   /// sendBeforeDate:
-  bool sendBeforeDate_(NSDate date) {
+  bool sendBeforeDate(NSDate date) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_sendBeforeDate_, date.ref.pointer);
   }
@@ -10155,7 +10227,7 @@ class NSRunLoop extends NSObject {
   }
 
   /// allocWithZone:
-  static NSRunLoop allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSRunLoop allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSRunLoop, _sel_allocWithZone_, zone);
     return NSRunLoop.castFromPointer(_ret, retain: false, release: true);
@@ -10182,21 +10254,21 @@ class NSRunLoop extends NSObject {
   }
 
   /// acceptInputForMode:beforeDate:
-  void acceptInputForMode_beforeDate_(NSString mode, NSDate limitDate) {
+  void acceptInputForMode(NSString mode, {required NSDate beforeDate}) {
     _objc_msgSend_pfv6jd(this.ref.pointer, _sel_acceptInputForMode_beforeDate_,
-        mode.ref.pointer, limitDate.ref.pointer);
+        mode.ref.pointer, beforeDate.ref.pointer);
   }
 
   /// addPort:forMode:
-  void addPort_forMode_(NSPort aPort, NSString mode) {
+  void addPort(NSPort aPort, {required NSString forMode}) {
     _objc_msgSend_pfv6jd(this.ref.pointer, _sel_addPort_forMode_,
-        aPort.ref.pointer, mode.ref.pointer);
+        aPort.ref.pointer, forMode.ref.pointer);
   }
 
   /// addTimer:forMode:
-  void addTimer_forMode_(NSTimer timer, NSString mode) {
+  void addTimer(NSTimer timer, {required NSString forMode}) {
     _objc_msgSend_pfv6jd(this.ref.pointer, _sel_addTimer_forMode_,
-        timer.ref.pointer, mode.ref.pointer);
+        timer.ref.pointer, forMode.ref.pointer);
   }
 
   /// autorelease
@@ -10228,7 +10300,7 @@ class NSRunLoop extends NSObject {
   }
 
   /// limitDateForMode:
-  NSDate? limitDateForMode_(NSString mode) {
+  NSDate? limitDateForMode(NSString mode) {
     final _ret = _objc_msgSend_1sotr3r(
         this.ref.pointer, _sel_limitDateForMode_, mode.ref.pointer);
     return _ret.address == 0
@@ -10237,9 +10309,9 @@ class NSRunLoop extends NSObject {
   }
 
   /// removePort:forMode:
-  void removePort_forMode_(NSPort aPort, NSString mode) {
+  void removePort(NSPort aPort, {required NSString forMode}) {
     _objc_msgSend_pfv6jd(this.ref.pointer, _sel_removePort_forMode_,
-        aPort.ref.pointer, mode.ref.pointer);
+        aPort.ref.pointer, forMode.ref.pointer);
   }
 
   /// retain
@@ -10444,11 +10516,11 @@ class NSSet extends NSObject
 
   @override
   bool contains(Object? element) =>
-      element is objc.ObjCObjectBase ? containsObject_(element) : false;
+      element is objc.ObjCObjectBase ? containsObject(element) : false;
 
   @override
   objc.ObjCObjectBase? lookup(Object? element) =>
-      element is objc.ObjCObjectBase ? member_(element) : null;
+      element is objc.ObjCObjectBase ? member(element) : null;
 
   @override
   Iterator<objc.ObjCObjectBase> get iterator => objectEnumerator();
@@ -10492,7 +10564,7 @@ class NSSet extends NSObject
   }
 
   /// allocWithZone:
-  static NSSet allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSSet allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret = _objc_msgSend_1cwp428(_class_NSSet, _sel_allocWithZone_, zone);
     return NSSet.castFromPointer(_ret, retain: false, release: true);
   }
@@ -10510,38 +10582,39 @@ class NSSet extends NSObject
   }
 
   /// setWithArray:
-  static NSSet setWithArray_(NSArray array) {
+  static NSSet setWithArray(NSArray array) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSSet, _sel_setWithArray_, array.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// setWithObject:
-  static NSSet setWithObject_(objc.ObjCObjectBase object) {
+  static NSSet setWithObject(objc.ObjCObjectBase object) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSSet, _sel_setWithObject_, object.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// setWithObjects:
-  static NSSet setWithObjects_(objc.ObjCObjectBase firstObj) {
+  static NSSet setWithObjects(objc.ObjCObjectBase firstObj) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSSet, _sel_setWithObjects_, firstObj.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// setWithObjects:count:
-  static NSSet setWithObjects_count_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
+  static NSSet setWithObjects$1(
+      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      {required int count}) {
     final _ret = _objc_msgSend_zmbtbd(
-        _class_NSSet, _sel_setWithObjects_count_, objects, cnt);
+        _class_NSSet, _sel_setWithObjects_count_, objects, count);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// setWithSet:
-  static NSSet setWithSet_(NSSet set) {
-    final _ret =
-        _objc_msgSend_1sotr3r(_class_NSSet, _sel_setWithSet_, set.ref.pointer);
+  static NSSet setWithSet(NSSet set$1) {
+    final _ret = _objc_msgSend_1sotr3r(
+        _class_NSSet, _sel_setWithSet_, set$1.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -10556,16 +10629,19 @@ class NSSet extends NSObject
   }
 
   /// countByEnumeratingWithState:objects:count:
-  int countByEnumeratingWithState_objects_count_(
-      ffi.Pointer<NSFastEnumerationState> state,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> buffer,
-      int len) {
-    return _objc_msgSend_1b5ysjl(this.ref.pointer,
-        _sel_countByEnumeratingWithState_objects_count_, state, buffer, len);
+  int countByEnumeratingWithState(ffi.Pointer<NSFastEnumerationState> state,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      required int count$1}) {
+    return _objc_msgSend_1b5ysjl(
+        this.ref.pointer,
+        _sel_countByEnumeratingWithState_objects_count_,
+        state,
+        objects,
+        count$1);
   }
 
   /// encodeWithCoder:
-  void encodeWithCoder_(NSCoder coder) {
+  void encodeWithCoder(NSCoder coder) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_encodeWithCoder_, coder.ref.pointer);
   }
@@ -10580,14 +10656,14 @@ class NSSet extends NSObject
   }
 
   /// initWithArray:
-  NSSet initWithArray_(NSArray array) {
+  NSSet initWithArray(NSArray array) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithArray_, array.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
-  NSSet? initWithCoder_(NSCoder coder) {
+  NSSet? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -10596,36 +10672,36 @@ class NSSet extends NSObject
   }
 
   /// initWithObjects:
-  NSSet initWithObjects_(objc.ObjCObjectBase firstObj) {
+  NSSet initWithObjects(objc.ObjCObjectBase firstObj) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithObjects_, firstObj.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithObjects:count:
-  NSSet initWithObjects_count_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects, int cnt) {
+  NSSet initWithObjects$1(ffi.Pointer<ffi.Pointer<objc.ObjCObject>> objects,
+      {required int count}) {
     final _ret = _objc_msgSend_zmbtbd(this.ref.retainAndReturnPointer(),
-        _sel_initWithObjects_count_, objects, cnt);
+        _sel_initWithObjects_count_, objects, count);
     return NSSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithSet:
-  NSSet initWithSet_(NSSet set) {
-    final _ret = _objc_msgSend_1sotr3r(
-        this.ref.retainAndReturnPointer(), _sel_initWithSet_, set.ref.pointer);
+  NSSet initWithSet(NSSet set$1) {
+    final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
+        _sel_initWithSet_, set$1.ref.pointer);
     return NSSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithSet:copyItems:
-  NSSet initWithSet_copyItems_(NSSet set, bool flag) {
+  NSSet initWithSet$1(NSSet set$1, {required bool copyItems}) {
     final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
-        _sel_initWithSet_copyItems_, set.ref.pointer, flag);
+        _sel_initWithSet_copyItems_, set$1.ref.pointer, copyItems);
     return NSSet.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// member:
-  objc.ObjCObjectBase? member_(objc.ObjCObjectBase object) {
+  objc.ObjCObjectBase? member(objc.ObjCObjectBase object) {
     final _ret = _objc_msgSend_1sotr3r(
         this.ref.pointer, _sel_member_, object.ref.pointer);
     return _ret.address == 0
@@ -10685,7 +10761,7 @@ class NSStream extends NSObject {
   }
 
   /// allocWithZone:
-  static NSStream allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSStream allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSStream, _sel_allocWithZone_, zone);
     return NSStream.castFromPointer(_ret, retain: false, release: true);
@@ -10731,7 +10807,7 @@ class NSStream extends NSObject {
   }
 
   /// propertyForKey:
-  objc.ObjCObjectBase? propertyForKey_(NSString key) {
+  objc.ObjCObjectBase? propertyForKey(NSString key) {
     final _ret = _objc_msgSend_1sotr3r(
         this.ref.pointer, _sel_propertyForKey_, key.ref.pointer);
     return _ret.address == 0
@@ -10740,9 +10816,9 @@ class NSStream extends NSObject {
   }
 
   /// removeFromRunLoop:forMode:
-  void removeFromRunLoop_forMode_(NSRunLoop aRunLoop, NSString mode) {
+  void removeFromRunLoop(NSRunLoop aRunLoop, {required NSString forMode}) {
     _objc_msgSend_pfv6jd(this.ref.pointer, _sel_removeFromRunLoop_forMode_,
-        aRunLoop.ref.pointer, mode.ref.pointer);
+        aRunLoop.ref.pointer, forMode.ref.pointer);
   }
 
   /// retain
@@ -10752,9 +10828,9 @@ class NSStream extends NSObject {
   }
 
   /// scheduleInRunLoop:forMode:
-  void scheduleInRunLoop_forMode_(NSRunLoop aRunLoop, NSString mode) {
+  void scheduleInRunLoop(NSRunLoop aRunLoop, {required NSString forMode}) {
     _objc_msgSend_pfv6jd(this.ref.pointer, _sel_scheduleInRunLoop_forMode_,
-        aRunLoop.ref.pointer, mode.ref.pointer);
+        aRunLoop.ref.pointer, forMode.ref.pointer);
   }
 
   /// self
@@ -10770,9 +10846,9 @@ class NSStream extends NSObject {
   }
 
   /// setProperty:forKey:
-  bool setProperty_forKey_(objc.ObjCObjectBase? property, NSString key) {
+  bool setProperty(objc.ObjCObjectBase? property, {required NSString forKey}) {
     return _objc_msgSend_1lsax7n(this.ref.pointer, _sel_setProperty_forKey_,
-        property?.ref.pointer ?? ffi.nullptr, key.ref.pointer);
+        property?.ref.pointer ?? ffi.nullptr, forKey.ref.pointer);
   }
 
   /// streamError
@@ -10995,7 +11071,7 @@ class NSString extends NSObject
     implements NSCopying, NSMutableCopying, NSSecureCoding {
   factory NSString(String str) {
     final cstr = str.toNativeUtf16();
-    final nsstr = stringWithCharacters_length_(cstr.cast(), str.length);
+    final nsstr = stringWithCharacters(cstr.cast(), length: str.length);
     pkg_ffi.calloc.free(cstr);
     return nsstr;
   }
@@ -11026,25 +11102,23 @@ class NSString extends NSObject
   }
 
   /// allocWithZone:
-  static NSString allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSString allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSString, _sel_allocWithZone_, zone);
     return NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// localizedStringWithFormat:
-  static NSString localizedStringWithFormat_(NSString format) {
+  static NSString localizedStringWithFormat(NSString format) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSString, _sel_localizedStringWithFormat_, format.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// localizedStringWithValidatedFormat:validFormatSpecifiers:error:
-  static NSString?
-      localizedStringWithValidatedFormat_validFormatSpecifiers_error_(
-          NSString format,
-          NSString validFormatSpecifiers,
-          ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  static NSString? localizedStringWithValidatedFormat(NSString format,
+      {required NSString validFormatSpecifiers,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSString.localizedStringWithValidatedFormat:validFormatSpecifiers:error:',
         iOS: (false, (11, 0, 0)),
@@ -11067,10 +11141,9 @@ class NSString extends NSObject
   }
 
   /// objectWithItemProviderData:typeIdentifier:error:
-  static NSString? objectWithItemProviderData_typeIdentifier_error_(
-      NSData data,
-      NSString typeIdentifier,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> outError) {
+  static NSString? objectWithItemProviderData(NSData data,
+      {required NSString typeIdentifier,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSString.objectWithItemProviderData:typeIdentifier:error:',
         iOS: (false, (11, 0, 0)),
@@ -11080,7 +11153,7 @@ class NSString extends NSObject
         _sel_objectWithItemProviderData_typeIdentifier_error_,
         data.ref.pointer,
         typeIdentifier.ref.pointer,
-        outError);
+        error);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
@@ -11093,31 +11166,33 @@ class NSString extends NSObject
   }
 
   /// stringWithCString:encoding:
-  static NSString? stringWithCString_encoding_(
-      ffi.Pointer<ffi.Char> cString, int enc) {
+  static NSString? stringWithCString(ffi.Pointer<ffi.Char> cString,
+      {required int encoding}) {
     final _ret = _objc_msgSend_erqryg(
-        _class_NSString, _sel_stringWithCString_encoding_, cString, enc);
+        _class_NSString, _sel_stringWithCString_encoding_, cString, encoding);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringWithCharacters:length:
-  static NSString stringWithCharacters_length_(
-      ffi.Pointer<ffi.UnsignedShort> characters, int length) {
+  static NSString stringWithCharacters(
+      ffi.Pointer<ffi.UnsignedShort> characters,
+      {required int length}) {
     final _ret = _objc_msgSend_9x4k8x(
         _class_NSString, _sel_stringWithCharacters_length_, characters, length);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringWithContentsOfFile:encoding:error:
-  static NSString? stringWithContentsOfFile_encoding_error_(
-      NSString path, int enc, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  static NSString? stringWithContentsOfFile(NSString path,
+      {required int encoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_1nomli1(
         _class_NSString,
         _sel_stringWithContentsOfFile_encoding_error_,
         path.ref.pointer,
-        enc,
+        encoding,
         error);
     return _ret.address == 0
         ? null
@@ -11125,15 +11200,14 @@ class NSString extends NSObject
   }
 
   /// stringWithContentsOfFile:usedEncoding:error:
-  static NSString? stringWithContentsOfFile_usedEncoding_error_(
-      NSString path,
-      ffi.Pointer<ffi.UnsignedLong> enc,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  static NSString? stringWithContentsOfFile$1(NSString path,
+      {required ffi.Pointer<ffi.UnsignedLong> usedEncoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_1alewu7(
         _class_NSString,
         _sel_stringWithContentsOfFile_usedEncoding_error_,
         path.ref.pointer,
-        enc,
+        usedEncoding,
         error);
     return _ret.address == 0
         ? null
@@ -11141,13 +11215,14 @@ class NSString extends NSObject
   }
 
   /// stringWithContentsOfURL:encoding:error:
-  static NSString? stringWithContentsOfURL_encoding_error_(
-      NSURL url, int enc, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  static NSString? stringWithContentsOfURL(NSURL url,
+      {required int encoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_1nomli1(
         _class_NSString,
         _sel_stringWithContentsOfURL_encoding_error_,
         url.ref.pointer,
-        enc,
+        encoding,
         error);
     return _ret.address == 0
         ? null
@@ -11155,15 +11230,14 @@ class NSString extends NSObject
   }
 
   /// stringWithContentsOfURL:usedEncoding:error:
-  static NSString? stringWithContentsOfURL_usedEncoding_error_(
-      NSURL url,
-      ffi.Pointer<ffi.UnsignedLong> enc,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  static NSString? stringWithContentsOfURL$1(NSURL url,
+      {required ffi.Pointer<ffi.UnsignedLong> usedEncoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_1alewu7(
         _class_NSString,
         _sel_stringWithContentsOfURL_usedEncoding_error_,
         url.ref.pointer,
-        enc,
+        usedEncoding,
         error);
     return _ret.address == 0
         ? null
@@ -11171,21 +11245,21 @@ class NSString extends NSObject
   }
 
   /// stringWithFormat:
-  static NSString stringWithFormat_(NSString format) {
+  static NSString stringWithFormat(NSString format) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSString, _sel_stringWithFormat_, format.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringWithString:
-  static NSString stringWithString_(NSString string) {
+  static NSString stringWithString(NSString string$1) {
     final _ret = _objc_msgSend_1sotr3r(
-        _class_NSString, _sel_stringWithString_, string.ref.pointer);
+        _class_NSString, _sel_stringWithString_, string$1.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringWithUTF8String:
-  static NSString? stringWithUTF8String_(
+  static NSString? stringWithUTF8String(
       ffi.Pointer<ffi.Char> nullTerminatedCString) {
     final _ret = _objc_msgSend_56zxyn(
         _class_NSString, _sel_stringWithUTF8String_, nullTerminatedCString);
@@ -11195,10 +11269,9 @@ class NSString extends NSObject
   }
 
   /// stringWithValidatedFormat:validFormatSpecifiers:error:
-  static NSString? stringWithValidatedFormat_validFormatSpecifiers_error_(
-      NSString format,
-      NSString validFormatSpecifiers,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  static NSString? stringWithValidatedFormat(NSString format,
+      {required NSString validFormatSpecifiers,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSString.stringWithValidatedFormat:validFormatSpecifiers:error:',
         iOS: (false, (11, 0, 0)),
@@ -11226,13 +11299,13 @@ class NSString extends NSObject
   }
 
   /// characterAtIndex:
-  int characterAtIndex_(int index) {
+  int characterAtIndex(int index) {
     return _objc_msgSend_1deg8x(
         this.ref.pointer, _sel_characterAtIndex_, index);
   }
 
   /// encodeWithCoder:
-  void encodeWithCoder_(NSCoder coder) {
+  void encodeWithCoder(NSCoder coder) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_encodeWithCoder_, coder.ref.pointer);
   }
@@ -11247,33 +11320,35 @@ class NSString extends NSObject
   }
 
   /// initWithBytes:length:encoding:
-  NSString? initWithBytes_length_encoding_(
-      ffi.Pointer<ffi.Void> bytes, int len, int encoding) {
+  NSString? initWithBytes(ffi.Pointer<ffi.Void> bytes,
+      {required int length, required int encoding}) {
     final _ret = _objc_msgSend_9b3h4v(this.ref.retainAndReturnPointer(),
-        _sel_initWithBytes_length_encoding_, bytes, len, encoding);
+        _sel_initWithBytes_length_encoding_, bytes, length, encoding);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithBytesNoCopy:length:encoding:freeWhenDone:
-  NSString? initWithBytesNoCopy_length_encoding_freeWhenDone_(
-      ffi.Pointer<ffi.Void> bytes, int len, int encoding, bool freeBuffer) {
+  NSString? initWithBytesNoCopy(ffi.Pointer<ffi.Void> bytes,
+      {required int length,
+      required int encoding,
+      required bool freeWhenDone}) {
     final _ret = _objc_msgSend_k4j8m3(
         this.ref.retainAndReturnPointer(),
         _sel_initWithBytesNoCopy_length_encoding_freeWhenDone_,
         bytes,
-        len,
+        length,
         encoding,
-        freeBuffer);
+        freeWhenDone);
     return _ret.address == 0
         ? null
         : NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCString:encoding:
-  NSString? initWithCString_encoding_(
-      ffi.Pointer<ffi.Char> nullTerminatedCString, int encoding) {
+  NSString? initWithCString(ffi.Pointer<ffi.Char> nullTerminatedCString,
+      {required int encoding}) {
     final _ret = _objc_msgSend_erqryg(this.ref.retainAndReturnPointer(),
         _sel_initWithCString_encoding_, nullTerminatedCString, encoding);
     return _ret.address == 0
@@ -11282,27 +11357,27 @@ class NSString extends NSObject
   }
 
   /// initWithCharacters:length:
-  NSString initWithCharacters_length_(
-      ffi.Pointer<ffi.UnsignedShort> characters, int length) {
+  NSString initWithCharacters(ffi.Pointer<ffi.UnsignedShort> characters,
+      {required int length}) {
     final _ret = _objc_msgSend_9x4k8x(this.ref.retainAndReturnPointer(),
         _sel_initWithCharacters_length_, characters, length);
     return NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCharactersNoCopy:length:freeWhenDone:
-  NSString initWithCharactersNoCopy_length_freeWhenDone_(
-      ffi.Pointer<ffi.UnsignedShort> characters, int length, bool freeBuffer) {
+  NSString initWithCharactersNoCopy(ffi.Pointer<ffi.UnsignedShort> characters,
+      {required int length, required bool freeWhenDone}) {
     final _ret = _objc_msgSend_lh0jh5(
         this.ref.retainAndReturnPointer(),
         _sel_initWithCharactersNoCopy_length_freeWhenDone_,
         characters,
         length,
-        freeBuffer);
+        freeWhenDone);
     return NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
-  NSString? initWithCoder_(NSCoder coder) {
+  NSString? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -11311,13 +11386,14 @@ class NSString extends NSObject
   }
 
   /// initWithContentsOfFile:encoding:error:
-  NSString? initWithContentsOfFile_encoding_error_(
-      NSString path, int enc, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  NSString? initWithContentsOfFile(NSString path,
+      {required int encoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_1nomli1(
         this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfFile_encoding_error_,
         path.ref.pointer,
-        enc,
+        encoding,
         error);
     return _ret.address == 0
         ? null
@@ -11325,15 +11401,14 @@ class NSString extends NSObject
   }
 
   /// initWithContentsOfFile:usedEncoding:error:
-  NSString? initWithContentsOfFile_usedEncoding_error_(
-      NSString path,
-      ffi.Pointer<ffi.UnsignedLong> enc,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  NSString? initWithContentsOfFile$1(NSString path,
+      {required ffi.Pointer<ffi.UnsignedLong> usedEncoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_1alewu7(
         this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfFile_usedEncoding_error_,
         path.ref.pointer,
-        enc,
+        usedEncoding,
         error);
     return _ret.address == 0
         ? null
@@ -11341,13 +11416,14 @@ class NSString extends NSObject
   }
 
   /// initWithContentsOfURL:encoding:error:
-  NSString? initWithContentsOfURL_encoding_error_(
-      NSURL url, int enc, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  NSString? initWithContentsOfURL(NSURL url,
+      {required int encoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_1nomli1(
         this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_encoding_error_,
         url.ref.pointer,
-        enc,
+        encoding,
         error);
     return _ret.address == 0
         ? null
@@ -11355,15 +11431,14 @@ class NSString extends NSObject
   }
 
   /// initWithContentsOfURL:usedEncoding:error:
-  NSString? initWithContentsOfURL_usedEncoding_error_(
-      NSURL url,
-      ffi.Pointer<ffi.UnsignedLong> enc,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  NSString? initWithContentsOfURL$1(NSURL url,
+      {required ffi.Pointer<ffi.UnsignedLong> usedEncoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     final _ret = _objc_msgSend_1alewu7(
         this.ref.retainAndReturnPointer(),
         _sel_initWithContentsOfURL_usedEncoding_error_,
         url.ref.pointer,
-        enc,
+        usedEncoding,
         error);
     return _ret.address == 0
         ? null
@@ -11371,7 +11446,7 @@ class NSString extends NSObject
   }
 
   /// initWithData:encoding:
-  NSString? initWithData_encoding_(NSData data, int encoding) {
+  NSString? initWithData(NSData data, {required int encoding}) {
     final _ret = _objc_msgSend_1k4kd9s(this.ref.retainAndReturnPointer(),
         _sel_initWithData_encoding_, data.ref.pointer, encoding);
     return _ret.address == 0
@@ -11380,15 +11455,14 @@ class NSString extends NSObject
   }
 
   /// initWithFormat:
-  NSString initWithFormat_(NSString format) {
+  NSString initWithFormat(NSString format) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithFormat_, format.ref.pointer);
     return NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithFormat:locale:
-  NSString initWithFormat_locale_(
-      NSString format, objc.ObjCObjectBase? locale) {
+  NSString initWithFormat$1(NSString format, {objc.ObjCObjectBase? locale}) {
     final _ret = _objc_msgSend_15qeuct(
         this.ref.retainAndReturnPointer(),
         _sel_initWithFormat_locale_,
@@ -11398,14 +11472,14 @@ class NSString extends NSObject
   }
 
   /// initWithString:
-  NSString initWithString_(NSString aString) {
+  NSString initWithString(NSString aString) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithString_, aString.ref.pointer);
     return NSString.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithUTF8String:
-  NSString? initWithUTF8String_(ffi.Pointer<ffi.Char> nullTerminatedCString) {
+  NSString? initWithUTF8String(ffi.Pointer<ffi.Char> nullTerminatedCString) {
     final _ret = _objc_msgSend_56zxyn(this.ref.retainAndReturnPointer(),
         _sel_initWithUTF8String_, nullTerminatedCString);
     return _ret.address == 0
@@ -11417,10 +11491,9 @@ class NSString extends NSObject
   ///
   /// iOS: introduced 16.0.0
   /// macOS: introduced 13.0.0
-  NSString? initWithValidatedFormat_validFormatSpecifiers_error_(
-      NSString format,
-      NSString validFormatSpecifiers,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  NSString? initWithValidatedFormat(NSString format,
+      {required NSString validFormatSpecifiers,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSString.initWithValidatedFormat:validFormatSpecifiers:error:',
         iOS: (false, (16, 0, 0)),
@@ -11440,11 +11513,10 @@ class NSString extends NSObject
   ///
   /// iOS: introduced 16.0.0
   /// macOS: introduced 13.0.0
-  NSString? initWithValidatedFormat_validFormatSpecifiers_locale_error_(
-      NSString format,
-      NSString validFormatSpecifiers,
+  NSString? initWithValidatedFormat$1(NSString format,
+      {required NSString validFormatSpecifiers,
       objc.ObjCObjectBase? locale,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSString.initWithValidatedFormat:validFormatSpecifiers:locale:error:',
         iOS: (false, (16, 0, 0)),
@@ -11569,7 +11641,7 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// localizedNameOfStringEncoding:
-  static NSString localizedNameOfStringEncoding_(int encoding) {
+  static NSString localizedNameOfStringEncoding(int encoding) {
     final _ret = _objc_msgSend_14hpxwa(
         _class_NSString, _sel_localizedNameOfStringEncoding_, encoding);
     return NSString.castFromPointer(_ret, retain: true, release: true);
@@ -11588,13 +11660,13 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// cStringUsingEncoding:
-  ffi.Pointer<ffi.Char> cStringUsingEncoding_(int encoding) {
+  ffi.Pointer<ffi.Char> cStringUsingEncoding(int encoding) {
     return _objc_msgSend_1jtxufi(
         this.ref.pointer, _sel_cStringUsingEncoding_, encoding);
   }
 
   /// canBeConvertedToEncoding:
-  bool canBeConvertedToEncoding_(int encoding) {
+  bool canBeConvertedToEncoding(int encoding) {
     return _objc_msgSend_6peh6o(
         this.ref.pointer, _sel_canBeConvertedToEncoding_, encoding);
   }
@@ -11607,7 +11679,7 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// capitalizedStringWithLocale:
-  NSString capitalizedStringWithLocale_(NSLocale? locale) {
+  NSString capitalizedStringWithLocale(NSLocale? locale) {
     objc.checkOsVersionInternal('NSString.capitalizedStringWithLocale:',
         iOS: (false, (6, 0, 0)), macOS: (false, (10, 8, 0)));
     final _ret = _objc_msgSend_1sotr3r(this.ref.pointer,
@@ -11616,65 +11688,60 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// caseInsensitiveCompare:
-  NSComparisonResult caseInsensitiveCompare_(NSString string) {
+  NSComparisonResult caseInsensitiveCompare(NSString string) {
     final _ret = _objc_msgSend_1ym6zyw(
         this.ref.pointer, _sel_caseInsensitiveCompare_, string.ref.pointer);
     return NSComparisonResult.fromValue(_ret);
   }
 
   /// commonPrefixWithString:options:
-  NSString commonPrefixWithString_options_(
-      NSString str, NSStringCompareOptions mask) {
+  NSString commonPrefixWithString(NSString str,
+      {required NSStringCompareOptions options}) {
     final _ret = _objc_msgSend_diypgk(this.ref.pointer,
-        _sel_commonPrefixWithString_options_, str.ref.pointer, mask.value);
+        _sel_commonPrefixWithString_options_, str.ref.pointer, options.value);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// compare:
-  NSComparisonResult compare_(NSString string) {
+  NSComparisonResult compare(NSString string) {
     final _ret = _objc_msgSend_1ym6zyw(
         this.ref.pointer, _sel_compare_, string.ref.pointer);
     return NSComparisonResult.fromValue(_ret);
   }
 
   /// compare:options:
-  NSComparisonResult compare_options_(
-      NSString string, NSStringCompareOptions mask) {
+  NSComparisonResult compare$1(NSString string,
+      {required NSStringCompareOptions options}) {
     final _ret = _objc_msgSend_pg1fnv(this.ref.pointer, _sel_compare_options_,
-        string.ref.pointer, mask.value);
+        string.ref.pointer, options.value);
     return NSComparisonResult.fromValue(_ret);
   }
 
   /// compare:options:range:
-  NSComparisonResult compare_options_range_(NSString string,
-      NSStringCompareOptions mask, NSRange rangeOfReceiverToCompare) {
-    final _ret = _objc_msgSend_xrqic1(
-        this.ref.pointer,
-        _sel_compare_options_range_,
-        string.ref.pointer,
-        mask.value,
-        rangeOfReceiverToCompare);
+  NSComparisonResult compare$2(NSString string,
+      {required NSStringCompareOptions options, required NSRange range}) {
+    final _ret = _objc_msgSend_xrqic1(this.ref.pointer,
+        _sel_compare_options_range_, string.ref.pointer, options.value, range);
     return NSComparisonResult.fromValue(_ret);
   }
 
   /// compare:options:range:locale:
-  NSComparisonResult compare_options_range_locale_(
-      NSString string,
-      NSStringCompareOptions mask,
-      NSRange rangeOfReceiverToCompare,
-      objc.ObjCObjectBase? locale) {
+  NSComparisonResult compare$3(NSString string,
+      {required NSStringCompareOptions options,
+      required NSRange range,
+      objc.ObjCObjectBase? locale}) {
     final _ret = _objc_msgSend_1895u4n(
         this.ref.pointer,
         _sel_compare_options_range_locale_,
         string.ref.pointer,
-        mask.value,
-        rangeOfReceiverToCompare,
+        options.value,
+        range,
         locale?.ref.pointer ?? ffi.nullptr);
     return NSComparisonResult.fromValue(_ret);
   }
 
   /// componentsSeparatedByCharactersInSet:
-  NSArray componentsSeparatedByCharactersInSet_(NSCharacterSet separator) {
+  NSArray componentsSeparatedByCharactersInSet(NSCharacterSet separator) {
     objc.checkOsVersionInternal(
         'NSString.componentsSeparatedByCharactersInSet:',
         iOS: (false, (2, 0, 0)),
@@ -11685,14 +11752,14 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// componentsSeparatedByString:
-  NSArray componentsSeparatedByString_(NSString separator) {
+  NSArray componentsSeparatedByString(NSString separator) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.pointer,
         _sel_componentsSeparatedByString_, separator.ref.pointer);
     return NSArray.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// containsString:
-  bool containsString_(NSString str) {
+  bool containsString(NSString str) {
     objc.checkOsVersionInternal('NSString.containsString:',
         iOS: (false, (8, 0, 0)), macOS: (false, (10, 10, 0)));
     return _objc_msgSend_19nvye5(
@@ -11700,7 +11767,7 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// dataUsingEncoding:
-  NSData? dataUsingEncoding_(int encoding) {
+  NSData? dataUsingEncoding(int encoding) {
     final _ret = _objc_msgSend_14hpxwa(
         this.ref.pointer, _sel_dataUsingEncoding_, encoding);
     return _ret.address == 0
@@ -11709,9 +11776,13 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// dataUsingEncoding:allowLossyConversion:
-  NSData? dataUsingEncoding_allowLossyConversion_(int encoding, bool lossy) {
-    final _ret = _objc_msgSend_hiwitm(this.ref.pointer,
-        _sel_dataUsingEncoding_allowLossyConversion_, encoding, lossy);
+  NSData? dataUsingEncoding$1(int encoding,
+      {required bool allowLossyConversion}) {
+    final _ret = _objc_msgSend_hiwitm(
+        this.ref.pointer,
+        _sel_dataUsingEncoding_allowLossyConversion_,
+        encoding,
+        allowLossyConversion);
     return _ret.address == 0
         ? null
         : NSData.castFromPointer(_ret, retain: true, release: true);
@@ -11757,78 +11828,75 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// getBytes:maxLength:usedLength:encoding:options:range:remainingRange:
-  bool getBytes_maxLength_usedLength_encoding_options_range_remainingRange_(
-      ffi.Pointer<ffi.Void> buffer,
-      int maxBufferCount,
-      ffi.Pointer<ffi.UnsignedLong> usedBufferCount,
-      int encoding,
-      NSStringEncodingConversionOptions options,
-      NSRange range,
-      ffi.Pointer<NSRange> leftover) {
+  bool getBytes(ffi.Pointer<ffi.Void> buffer,
+      {required int maxLength,
+      required ffi.Pointer<ffi.UnsignedLong> usedLength,
+      required int encoding,
+      required NSStringEncodingConversionOptions options,
+      required NSRange range,
+      required ffi.Pointer<NSRange> remainingRange}) {
     return _objc_msgSend_i30zh3(
         this.ref.pointer,
         _sel_getBytes_maxLength_usedLength_encoding_options_range_remainingRange_,
         buffer,
-        maxBufferCount,
-        usedBufferCount,
+        maxLength,
+        usedLength,
         encoding,
         options.value,
         range,
-        leftover);
+        remainingRange);
   }
 
   /// getCString:maxLength:encoding:
-  bool getCString_maxLength_encoding_(
-      ffi.Pointer<ffi.Char> buffer, int maxBufferCount, int encoding) {
+  bool getCString(ffi.Pointer<ffi.Char> buffer,
+      {required int maxLength, required int encoding}) {
     return _objc_msgSend_1lv8yz3(this.ref.pointer,
-        _sel_getCString_maxLength_encoding_, buffer, maxBufferCount, encoding);
+        _sel_getCString_maxLength_encoding_, buffer, maxLength, encoding);
   }
 
   /// getCharacters:range:
-  void getCharacters_range_(
-      ffi.Pointer<ffi.UnsignedShort> buffer, NSRange range) {
+  void getCharacters(ffi.Pointer<ffi.UnsignedShort> buffer,
+      {required NSRange range}) {
     _objc_msgSend_898fog(
         this.ref.pointer, _sel_getCharacters_range_, buffer, range);
   }
 
   /// getLineStart:end:contentsEnd:forRange:
-  void getLineStart_end_contentsEnd_forRange_(
-      ffi.Pointer<ffi.UnsignedLong> startPtr,
-      ffi.Pointer<ffi.UnsignedLong> lineEndPtr,
-      ffi.Pointer<ffi.UnsignedLong> contentsEndPtr,
-      NSRange range) {
+  void getLineStart(ffi.Pointer<ffi.UnsignedLong> startPtr,
+      {required ffi.Pointer<ffi.UnsignedLong> end,
+      required ffi.Pointer<ffi.UnsignedLong> contentsEnd,
+      required NSRange forRange}) {
     _objc_msgSend_ourvf2(
         this.ref.pointer,
         _sel_getLineStart_end_contentsEnd_forRange_,
         startPtr,
-        lineEndPtr,
-        contentsEndPtr,
-        range);
+        end,
+        contentsEnd,
+        forRange);
   }
 
   /// getParagraphStart:end:contentsEnd:forRange:
-  void getParagraphStart_end_contentsEnd_forRange_(
-      ffi.Pointer<ffi.UnsignedLong> startPtr,
-      ffi.Pointer<ffi.UnsignedLong> parEndPtr,
-      ffi.Pointer<ffi.UnsignedLong> contentsEndPtr,
-      NSRange range) {
+  void getParagraphStart(ffi.Pointer<ffi.UnsignedLong> startPtr,
+      {required ffi.Pointer<ffi.UnsignedLong> end,
+      required ffi.Pointer<ffi.UnsignedLong> contentsEnd,
+      required NSRange forRange}) {
     _objc_msgSend_ourvf2(
         this.ref.pointer,
         _sel_getParagraphStart_end_contentsEnd_forRange_,
         startPtr,
-        parEndPtr,
-        contentsEndPtr,
-        range);
+        end,
+        contentsEnd,
+        forRange);
   }
 
   /// hasPrefix:
-  bool hasPrefix_(NSString str) {
+  bool hasPrefix(NSString str) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_hasPrefix_, str.ref.pointer);
   }
 
   /// hasSuffix:
-  bool hasSuffix_(NSString str) {
+  bool hasSuffix(NSString str) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_hasSuffix_, str.ref.pointer);
   }
@@ -11851,19 +11919,19 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// isEqualToString:
-  bool isEqualToString_(NSString aString) {
+  bool isEqualToString(NSString aString) {
     return _objc_msgSend_19nvye5(
         this.ref.pointer, _sel_isEqualToString_, aString.ref.pointer);
   }
 
   /// lengthOfBytesUsingEncoding:
-  int lengthOfBytesUsingEncoding_(int enc) {
+  int lengthOfBytesUsingEncoding(int enc) {
     return _objc_msgSend_12py2ux(
         this.ref.pointer, _sel_lengthOfBytesUsingEncoding_, enc);
   }
 
   /// lineRangeForRange:
-  NSRange lineRangeForRange_(NSRange range) {
+  NSRange lineRangeForRange(NSRange range) {
     final _ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_uimyc7Stret(
@@ -11886,14 +11954,14 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// localizedCaseInsensitiveCompare:
-  NSComparisonResult localizedCaseInsensitiveCompare_(NSString string) {
+  NSComparisonResult localizedCaseInsensitiveCompare(NSString string) {
     final _ret = _objc_msgSend_1ym6zyw(this.ref.pointer,
         _sel_localizedCaseInsensitiveCompare_, string.ref.pointer);
     return NSComparisonResult.fromValue(_ret);
   }
 
   /// localizedCaseInsensitiveContainsString:
-  bool localizedCaseInsensitiveContainsString_(NSString str) {
+  bool localizedCaseInsensitiveContainsString(NSString str) {
     objc.checkOsVersionInternal(
         'NSString.localizedCaseInsensitiveContainsString:',
         iOS: (false, (8, 0, 0)),
@@ -11903,7 +11971,7 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// localizedCompare:
-  NSComparisonResult localizedCompare_(NSString string) {
+  NSComparisonResult localizedCompare(NSString string) {
     final _ret = _objc_msgSend_1ym6zyw(
         this.ref.pointer, _sel_localizedCompare_, string.ref.pointer);
     return NSComparisonResult.fromValue(_ret);
@@ -11919,7 +11987,7 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// localizedStandardCompare:
-  NSComparisonResult localizedStandardCompare_(NSString string) {
+  NSComparisonResult localizedStandardCompare(NSString string) {
     objc.checkOsVersionInternal('NSString.localizedStandardCompare:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
     final _ret = _objc_msgSend_1ym6zyw(
@@ -11928,7 +11996,7 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// localizedStandardContainsString:
-  bool localizedStandardContainsString_(NSString str) {
+  bool localizedStandardContainsString(NSString str) {
     objc.checkOsVersionInternal('NSString.localizedStandardContainsString:',
         iOS: (false, (9, 0, 0)), macOS: (false, (10, 11, 0)));
     return _objc_msgSend_19nvye5(this.ref.pointer,
@@ -11936,7 +12004,7 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// localizedStandardRangeOfString:
-  NSRange localizedStandardRangeOfString_(NSString str) {
+  NSRange localizedStandardRangeOfString(NSString str) {
     objc.checkOsVersionInternal('NSString.localizedStandardRangeOfString:',
         iOS: (false, (9, 0, 0)), macOS: (false, (10, 11, 0)));
     final _ptr = pkg_ffi.calloc<NSRange>();
@@ -11974,7 +12042,7 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// lowercaseStringWithLocale:
-  NSString lowercaseStringWithLocale_(NSLocale? locale) {
+  NSString lowercaseStringWithLocale(NSLocale? locale) {
     objc.checkOsVersionInternal('NSString.lowercaseStringWithLocale:',
         iOS: (false, (6, 0, 0)), macOS: (false, (10, 8, 0)));
     final _ret = _objc_msgSend_1sotr3r(this.ref.pointer,
@@ -11983,13 +12051,13 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// maximumLengthOfBytesUsingEncoding:
-  int maximumLengthOfBytesUsingEncoding_(int enc) {
+  int maximumLengthOfBytesUsingEncoding(int enc) {
     return _objc_msgSend_12py2ux(
         this.ref.pointer, _sel_maximumLengthOfBytesUsingEncoding_, enc);
   }
 
   /// paragraphRangeForRange:
-  NSRange paragraphRangeForRange_(NSRange range) {
+  NSRange paragraphRangeForRange(NSRange range) {
     final _ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_uimyc7Stret(
@@ -12017,7 +12085,7 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// rangeOfCharacterFromSet:
-  NSRange rangeOfCharacterFromSet_(NSCharacterSet searchSet) {
+  NSRange rangeOfCharacterFromSet(NSCharacterSet searchSet) {
     final _ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_182fzonStret(_ptr, this.ref.pointer,
@@ -12031,8 +12099,8 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// rangeOfCharacterFromSet:options:
-  NSRange rangeOfCharacterFromSet_options_(
-      NSCharacterSet searchSet, NSStringCompareOptions mask) {
+  NSRange rangeOfCharacterFromSet$1(NSCharacterSet searchSet,
+      {required NSStringCompareOptions options}) {
     final _ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_102xxo4Stret(
@@ -12040,12 +12108,12 @@ extension NSStringExtensionMethods on NSString {
             this.ref.pointer,
             _sel_rangeOfCharacterFromSet_options_,
             searchSet.ref.pointer,
-            mask.value)
+            options.value)
         : _ptr.ref = _objc_msgSend_102xxo4(
             this.ref.pointer,
             _sel_rangeOfCharacterFromSet_options_,
             searchSet.ref.pointer,
-            mask.value);
+            options.value);
     final _finalizable = _ptr.cast<ffi.Uint8>().asTypedList(
         ffi.sizeOf<NSRange>(),
         finalizer: pkg_ffi.calloc.nativeFree);
@@ -12053,8 +12121,8 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// rangeOfCharacterFromSet:options:range:
-  NSRange rangeOfCharacterFromSet_options_range_(NSCharacterSet searchSet,
-      NSStringCompareOptions mask, NSRange rangeOfReceiverToSearch) {
+  NSRange rangeOfCharacterFromSet$2(NSCharacterSet searchSet,
+      {required NSStringCompareOptions options, required NSRange range}) {
     final _ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_1nmlvqcStret(
@@ -12062,14 +12130,14 @@ extension NSStringExtensionMethods on NSString {
             this.ref.pointer,
             _sel_rangeOfCharacterFromSet_options_range_,
             searchSet.ref.pointer,
-            mask.value,
-            rangeOfReceiverToSearch)
+            options.value,
+            range)
         : _ptr.ref = _objc_msgSend_1nmlvqc(
             this.ref.pointer,
             _sel_rangeOfCharacterFromSet_options_range_,
             searchSet.ref.pointer,
-            mask.value,
-            rangeOfReceiverToSearch);
+            options.value,
+            range);
     final _finalizable = _ptr.cast<ffi.Uint8>().asTypedList(
         ffi.sizeOf<NSRange>(),
         finalizer: pkg_ffi.calloc.nativeFree);
@@ -12077,7 +12145,7 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// rangeOfComposedCharacterSequenceAtIndex:
-  NSRange rangeOfComposedCharacterSequenceAtIndex_(int index) {
+  NSRange rangeOfComposedCharacterSequenceAtIndex(int index) {
     final _ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_d3i1uyStret(_ptr, this.ref.pointer,
@@ -12091,7 +12159,7 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// rangeOfComposedCharacterSequencesForRange:
-  NSRange rangeOfComposedCharacterSequencesForRange_(NSRange range) {
+  NSRange rangeOfComposedCharacterSequencesForRange(NSRange range) {
     objc.checkOsVersionInternal(
         'NSString.rangeOfComposedCharacterSequencesForRange:',
         iOS: (false, (2, 0, 0)),
@@ -12109,7 +12177,7 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// rangeOfString:
-  NSRange rangeOfString_(NSString searchString) {
+  NSRange rangeOfString(NSString searchString) {
     final _ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_182fzonStret(_ptr, this.ref.pointer,
@@ -12123,14 +12191,21 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// rangeOfString:options:
-  NSRange rangeOfString_options_(
-      NSString searchString, NSStringCompareOptions mask) {
+  NSRange rangeOfString$1(NSString searchString,
+      {required NSStringCompareOptions options}) {
     final _ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
-        ? _objc_msgSend_102xxo4Stret(_ptr, this.ref.pointer,
-            _sel_rangeOfString_options_, searchString.ref.pointer, mask.value)
-        : _ptr.ref = _objc_msgSend_102xxo4(this.ref.pointer,
-            _sel_rangeOfString_options_, searchString.ref.pointer, mask.value);
+        ? _objc_msgSend_102xxo4Stret(
+            _ptr,
+            this.ref.pointer,
+            _sel_rangeOfString_options_,
+            searchString.ref.pointer,
+            options.value)
+        : _ptr.ref = _objc_msgSend_102xxo4(
+            this.ref.pointer,
+            _sel_rangeOfString_options_,
+            searchString.ref.pointer,
+            options.value);
     final _finalizable = _ptr.cast<ffi.Uint8>().asTypedList(
         ffi.sizeOf<NSRange>(),
         finalizer: pkg_ffi.calloc.nativeFree);
@@ -12138,8 +12213,8 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// rangeOfString:options:range:
-  NSRange rangeOfString_options_range_(NSString searchString,
-      NSStringCompareOptions mask, NSRange rangeOfReceiverToSearch) {
+  NSRange rangeOfString$2(NSString searchString,
+      {required NSStringCompareOptions options, required NSRange range}) {
     final _ptr = pkg_ffi.calloc<NSRange>();
     objc.useMsgSendVariants
         ? _objc_msgSend_1nmlvqcStret(
@@ -12147,14 +12222,14 @@ extension NSStringExtensionMethods on NSString {
             this.ref.pointer,
             _sel_rangeOfString_options_range_,
             searchString.ref.pointer,
-            mask.value,
-            rangeOfReceiverToSearch)
+            options.value,
+            range)
         : _ptr.ref = _objc_msgSend_1nmlvqc(
             this.ref.pointer,
             _sel_rangeOfString_options_range_,
             searchString.ref.pointer,
-            mask.value,
-            rangeOfReceiverToSearch);
+            options.value,
+            range);
     final _finalizable = _ptr.cast<ffi.Uint8>().asTypedList(
         ffi.sizeOf<NSRange>(),
         finalizer: pkg_ffi.calloc.nativeFree);
@@ -12162,11 +12237,10 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// rangeOfString:options:range:locale:
-  NSRange rangeOfString_options_range_locale_(
-      NSString searchString,
-      NSStringCompareOptions mask,
-      NSRange rangeOfReceiverToSearch,
-      NSLocale? locale) {
+  NSRange rangeOfString$3(NSString searchString,
+      {required NSStringCompareOptions options,
+      required NSRange range,
+      NSLocale? locale}) {
     objc.checkOsVersionInternal('NSString.rangeOfString:options:range:locale:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 5, 0)));
     final _ptr = pkg_ffi.calloc<NSRange>();
@@ -12176,15 +12250,15 @@ extension NSStringExtensionMethods on NSString {
             this.ref.pointer,
             _sel_rangeOfString_options_range_locale_,
             searchString.ref.pointer,
-            mask.value,
-            rangeOfReceiverToSearch,
+            options.value,
+            range,
             locale?.ref.pointer ?? ffi.nullptr)
         : _ptr.ref = _objc_msgSend_gg0462(
             this.ref.pointer,
             _sel_rangeOfString_options_range_locale_,
             searchString.ref.pointer,
-            mask.value,
-            rangeOfReceiverToSearch,
+            options.value,
+            range,
             locale?.ref.pointer ?? ffi.nullptr);
     final _finalizable = _ptr.cast<ffi.Uint8>().asTypedList(
         ffi.sizeOf<NSRange>(),
@@ -12198,22 +12272,22 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// stringByAppendingFormat:
-  NSString stringByAppendingFormat_(NSString format) {
+  NSString stringByAppendingFormat(NSString format) {
     final _ret = _objc_msgSend_1sotr3r(
         this.ref.pointer, _sel_stringByAppendingFormat_, format.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringByAppendingString:
-  NSString stringByAppendingString_(NSString aString) {
+  NSString stringByAppendingString(NSString aString) {
     final _ret = _objc_msgSend_1sotr3r(
         this.ref.pointer, _sel_stringByAppendingString_, aString.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringByApplyingTransform:reverse:
-  NSString? stringByApplyingTransform_reverse_(
-      NSString transform, bool reverse) {
+  NSString? stringByApplyingTransform(NSString transform,
+      {required bool reverse}) {
     objc.checkOsVersionInternal('NSString.stringByApplyingTransform:reverse:',
         iOS: (false, (9, 0, 0)), macOS: (false, (10, 11, 0)));
     final _ret = _objc_msgSend_17amj0z(
@@ -12227,8 +12301,8 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// stringByFoldingWithOptions:locale:
-  NSString stringByFoldingWithOptions_locale_(
-      NSStringCompareOptions options, NSLocale? locale) {
+  NSString stringByFoldingWithOptions(NSStringCompareOptions options,
+      {NSLocale? locale}) {
     objc.checkOsVersionInternal('NSString.stringByFoldingWithOptions:locale:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 5, 0)));
     final _ret = _objc_msgSend_11cbyu0(
@@ -12240,20 +12314,20 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// stringByPaddingToLength:withString:startingAtIndex:
-  NSString stringByPaddingToLength_withString_startingAtIndex_(
-      int newLength, NSString padString, int padIndex) {
+  NSString stringByPaddingToLength(int newLength,
+      {required NSString withString, required int startingAtIndex}) {
     final _ret = _objc_msgSend_1tfztp(
         this.ref.pointer,
         _sel_stringByPaddingToLength_withString_startingAtIndex_,
         newLength,
-        padString.ref.pointer,
-        padIndex);
+        withString.ref.pointer,
+        startingAtIndex);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringByReplacingCharactersInRange:withString:
-  NSString stringByReplacingCharactersInRange_withString_(
-      NSRange range, NSString replacement) {
+  NSString stringByReplacingCharactersInRange(NSRange range,
+      {required NSString withString}) {
     objc.checkOsVersionInternal(
         'NSString.stringByReplacingCharactersInRange:withString:',
         iOS: (false, (2, 0, 0)),
@@ -12262,13 +12336,13 @@ extension NSStringExtensionMethods on NSString {
         this.ref.pointer,
         _sel_stringByReplacingCharactersInRange_withString_,
         range,
-        replacement.ref.pointer);
+        withString.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringByReplacingOccurrencesOfString:withString:
-  NSString stringByReplacingOccurrencesOfString_withString_(
-      NSString target, NSString replacement) {
+  NSString stringByReplacingOccurrencesOfString(NSString target,
+      {required NSString withString}) {
     objc.checkOsVersionInternal(
         'NSString.stringByReplacingOccurrencesOfString:withString:',
         iOS: (false, (2, 0, 0)),
@@ -12277,16 +12351,15 @@ extension NSStringExtensionMethods on NSString {
         this.ref.pointer,
         _sel_stringByReplacingOccurrencesOfString_withString_,
         target.ref.pointer,
-        replacement.ref.pointer);
+        withString.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringByReplacingOccurrencesOfString:withString:options:range:
-  NSString stringByReplacingOccurrencesOfString_withString_options_range_(
-      NSString target,
-      NSString replacement,
-      NSStringCompareOptions options,
-      NSRange searchRange) {
+  NSString stringByReplacingOccurrencesOfString$1(NSString target,
+      {required NSString withString,
+      required NSStringCompareOptions options,
+      required NSRange range}) {
     objc.checkOsVersionInternal(
         'NSString.stringByReplacingOccurrencesOfString:withString:options:range:',
         iOS: (false, (2, 0, 0)),
@@ -12295,35 +12368,35 @@ extension NSStringExtensionMethods on NSString {
         this.ref.pointer,
         _sel_stringByReplacingOccurrencesOfString_withString_options_range_,
         target.ref.pointer,
-        replacement.ref.pointer,
+        withString.ref.pointer,
         options.value,
-        searchRange);
+        range);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// stringByTrimmingCharactersInSet:
-  NSString stringByTrimmingCharactersInSet_(NSCharacterSet set) {
+  NSString stringByTrimmingCharactersInSet(NSCharacterSet set$) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.pointer,
-        _sel_stringByTrimmingCharactersInSet_, set.ref.pointer);
+        _sel_stringByTrimmingCharactersInSet_, set$.ref.pointer);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// substringFromIndex:
-  NSString substringFromIndex_(int from) {
+  NSString substringFromIndex(int from) {
     final _ret =
         _objc_msgSend_14hpxwa(this.ref.pointer, _sel_substringFromIndex_, from);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// substringToIndex:
-  NSString substringToIndex_(int to) {
+  NSString substringToIndex(int to) {
     final _ret =
         _objc_msgSend_14hpxwa(this.ref.pointer, _sel_substringToIndex_, to);
     return NSString.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// substringWithRange:
-  NSString substringWithRange_(NSRange range) {
+  NSString substringWithRange(NSRange range) {
     final _ret = _objc_msgSend_1k1o1s7(
         this.ref.pointer, _sel_substringWithRange_, range);
     return NSString.castFromPointer(_ret, retain: true, release: true);
@@ -12336,7 +12409,7 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// uppercaseStringWithLocale:
-  NSString uppercaseStringWithLocale_(NSLocale? locale) {
+  NSString uppercaseStringWithLocale(NSLocale? locale) {
     objc.checkOsVersionInternal('NSString.uppercaseStringWithLocale:',
         iOS: (false, (6, 0, 0)), macOS: (false, (10, 8, 0)));
     final _ret = _objc_msgSend_1sotr3r(this.ref.pointer,
@@ -12345,29 +12418,30 @@ extension NSStringExtensionMethods on NSString {
   }
 
   /// writeToFile:atomically:encoding:error:
-  bool writeToFile_atomically_encoding_error_(
-      NSString path,
-      bool useAuxiliaryFile,
-      int enc,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  bool writeToFile(NSString path,
+      {required bool atomically,
+      required int encoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     return _objc_msgSend_dv3z6r(
         this.ref.pointer,
         _sel_writeToFile_atomically_encoding_error_,
         path.ref.pointer,
-        useAuxiliaryFile,
-        enc,
+        atomically,
+        encoding,
         error);
   }
 
   /// writeToURL:atomically:encoding:error:
-  bool writeToURL_atomically_encoding_error_(NSURL url, bool useAuxiliaryFile,
-      int enc, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  bool writeToURL(NSURL url,
+      {required bool atomically,
+      required int encoding,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     return _objc_msgSend_dv3z6r(
         this.ref.pointer,
         _sel_writeToURL_atomically_encoding_error_,
         url.ref.pointer,
-        useAuxiliaryFile,
-        enc,
+        atomically,
+        encoding,
         error);
   }
 }
@@ -12400,7 +12474,7 @@ class NSTimer extends NSObject {
   }
 
   /// allocWithZone:
-  static NSTimer allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSTimer allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSTimer, _sel_allocWithZone_, zone);
     return NSTimer.castFromPointer(_ret, retain: false, release: true);
@@ -12413,63 +12487,60 @@ class NSTimer extends NSObject {
   }
 
   /// scheduledTimerWithTimeInterval:invocation:repeats:
-  static NSTimer scheduledTimerWithTimeInterval_invocation_repeats_(
-      double ti, NSInvocation invocation, bool yesOrNo) {
+  static NSTimer scheduledTimerWithTimeInterval(double ti,
+      {required NSInvocation invocation, required bool repeats}) {
     final _ret = _objc_msgSend_r49ehc(
         _class_NSTimer,
         _sel_scheduledTimerWithTimeInterval_invocation_repeats_,
         ti,
         invocation.ref.pointer,
-        yesOrNo);
+        repeats);
     return NSTimer.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// scheduledTimerWithTimeInterval:target:selector:userInfo:repeats:
-  static NSTimer
-      scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
-          double ti,
-          objc.ObjCObjectBase aTarget,
-          ffi.Pointer<objc.ObjCSelector> aSelector,
-          objc.ObjCObjectBase? userInfo,
-          bool yesOrNo) {
+  static NSTimer scheduledTimerWithTimeInterval$1(double ti,
+      {required objc.ObjCObjectBase target,
+      required ffi.Pointer<objc.ObjCSelector> selector,
+      objc.ObjCObjectBase? userInfo,
+      required bool repeats}) {
     final _ret = _objc_msgSend_ot6jdx(
         _class_NSTimer,
         _sel_scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_,
         ti,
-        aTarget.ref.pointer,
-        aSelector,
+        target.ref.pointer,
+        selector,
         userInfo?.ref.pointer ?? ffi.nullptr,
-        yesOrNo);
+        repeats);
     return NSTimer.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// timerWithTimeInterval:invocation:repeats:
-  static NSTimer timerWithTimeInterval_invocation_repeats_(
-      double ti, NSInvocation invocation, bool yesOrNo) {
+  static NSTimer timerWithTimeInterval(double ti,
+      {required NSInvocation invocation, required bool repeats}) {
     final _ret = _objc_msgSend_r49ehc(
         _class_NSTimer,
         _sel_timerWithTimeInterval_invocation_repeats_,
         ti,
         invocation.ref.pointer,
-        yesOrNo);
+        repeats);
     return NSTimer.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// timerWithTimeInterval:target:selector:userInfo:repeats:
-  static NSTimer timerWithTimeInterval_target_selector_userInfo_repeats_(
-      double ti,
-      objc.ObjCObjectBase aTarget,
-      ffi.Pointer<objc.ObjCSelector> aSelector,
+  static NSTimer timerWithTimeInterval$1(double ti,
+      {required objc.ObjCObjectBase target,
+      required ffi.Pointer<objc.ObjCSelector> selector,
       objc.ObjCObjectBase? userInfo,
-      bool yesOrNo) {
+      required bool repeats}) {
     final _ret = _objc_msgSend_ot6jdx(
         _class_NSTimer,
         _sel_timerWithTimeInterval_target_selector_userInfo_repeats_,
         ti,
-        aTarget.ref.pointer,
-        aSelector,
+        target.ref.pointer,
+        selector,
         userInfo?.ref.pointer ?? ffi.nullptr,
-        yesOrNo);
+        repeats);
     return NSTimer.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -12500,22 +12571,21 @@ class NSTimer extends NSObject {
   }
 
   /// initWithFireDate:interval:target:selector:userInfo:repeats:
-  NSTimer initWithFireDate_interval_target_selector_userInfo_repeats_(
-      NSDate date,
-      double ti,
-      objc.ObjCObjectBase t,
-      ffi.Pointer<objc.ObjCSelector> s,
-      objc.ObjCObjectBase? ui,
-      bool rep) {
+  NSTimer initWithFireDate(NSDate date,
+      {required double interval,
+      required objc.ObjCObjectBase target,
+      required ffi.Pointer<objc.ObjCSelector> selector,
+      objc.ObjCObjectBase? userInfo,
+      required bool repeats}) {
     final _ret = _objc_msgSend_14wwtbv(
         this.ref.retainAndReturnPointer(),
         _sel_initWithFireDate_interval_target_selector_userInfo_repeats_,
         date.ref.pointer,
-        ti,
-        t.ref.pointer,
-        s,
-        ui?.ref.pointer ?? ffi.nullptr,
-        rep);
+        interval,
+        target.ref.pointer,
+        selector,
+        userInfo?.ref.pointer ?? ffi.nullptr,
+        repeats);
     return NSTimer.castFromPointer(_ret, retain: false, release: true);
   }
 
@@ -12604,10 +12674,9 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// URLByResolvingAliasFileAtURL:options:error:
-  static NSURL? URLByResolvingAliasFileAtURL_options_error_(
-      NSURL url,
-      NSURLBookmarkResolutionOptions options,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  static NSURL? URLByResolvingAliasFileAtURL(NSURL url,
+      {required NSURLBookmarkResolutionOptions options,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSURL.URLByResolvingAliasFileAtURL:options:error:',
         iOS: (false, (8, 0, 0)),
@@ -12624,13 +12693,11 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// URLByResolvingBookmarkData:options:relativeToURL:bookmarkDataIsStale:error:
-  static NSURL?
-      URLByResolvingBookmarkData_options_relativeToURL_bookmarkDataIsStale_error_(
-          NSData bookmarkData,
-          NSURLBookmarkResolutionOptions options,
-          NSURL? relativeURL,
-          ffi.Pointer<ffi.Bool> isStale,
-          ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  static NSURL? URLByResolvingBookmarkData(NSData bookmarkData,
+      {required NSURLBookmarkResolutionOptions options,
+      NSURL? relativeToURL,
+      required ffi.Pointer<ffi.Bool> bookmarkDataIsStale,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSURL.URLByResolvingBookmarkData:options:relativeToURL:bookmarkDataIsStale:error:',
         iOS: (false, (4, 0, 0)),
@@ -12640,8 +12707,8 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
         _sel_URLByResolvingBookmarkData_options_relativeToURL_bookmarkDataIsStale_error_,
         bookmarkData.ref.pointer,
         options.value,
-        relativeURL?.ref.pointer ?? ffi.nullptr,
-        isStale,
+        relativeToURL?.ref.pointer ?? ffi.nullptr,
+        bookmarkDataIsStale,
         error);
     return _ret.address == 0
         ? null
@@ -12649,8 +12716,7 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// URLWithDataRepresentation:relativeToURL:
-  static NSURL URLWithDataRepresentation_relativeToURL_(
-      NSData data, NSURL? baseURL) {
+  static NSURL URLWithDataRepresentation(NSData data, {NSURL? relativeToURL}) {
     objc.checkOsVersionInternal(
         'NSURL.URLWithDataRepresentation:relativeToURL:',
         iOS: (false, (9, 0, 0)),
@@ -12659,12 +12725,12 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
         _class_NSURL,
         _sel_URLWithDataRepresentation_relativeToURL_,
         data.ref.pointer,
-        baseURL?.ref.pointer ?? ffi.nullptr);
+        relativeToURL?.ref.pointer ?? ffi.nullptr);
     return NSURL.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// URLWithString:
-  static NSURL? URLWithString_(NSString URLString) {
+  static NSURL? URLWithString(NSString URLString) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSURL, _sel_URLWithString_, URLString.ref.pointer);
     return _ret.address == 0
@@ -12676,8 +12742,8 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   ///
   /// iOS: introduced 17.0.0
   /// macOS: introduced 14.0.0
-  static NSURL? URLWithString_encodingInvalidCharacters_(
-      NSString URLString, bool encodingInvalidCharacters) {
+  static NSURL? URLWithString$1(NSString URLString,
+      {required bool encodingInvalidCharacters}) {
     objc.checkOsVersionInternal(
         'NSURL.URLWithString:encodingInvalidCharacters:',
         iOS: (false, (17, 0, 0)),
@@ -12693,21 +12759,20 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// URLWithString:relativeToURL:
-  static NSURL? URLWithString_relativeToURL_(
-      NSString URLString, NSURL? baseURL) {
+  static NSURL? URLWithString$2(NSString URLString, {NSURL? relativeToURL}) {
     final _ret = _objc_msgSend_15qeuct(
         _class_NSURL,
         _sel_URLWithString_relativeToURL_,
         URLString.ref.pointer,
-        baseURL?.ref.pointer ?? ffi.nullptr);
+        relativeToURL?.ref.pointer ?? ffi.nullptr);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// absoluteURLWithDataRepresentation:relativeToURL:
-  static NSURL absoluteURLWithDataRepresentation_relativeToURL_(
-      NSData data, NSURL? baseURL) {
+  static NSURL absoluteURLWithDataRepresentation(NSData data,
+      {NSURL? relativeToURL}) {
     objc.checkOsVersionInternal(
         'NSURL.absoluteURLWithDataRepresentation:relativeToURL:',
         iOS: (false, (9, 0, 0)),
@@ -12716,7 +12781,7 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
         _class_NSURL,
         _sel_absoluteURLWithDataRepresentation_relativeToURL_,
         data.ref.pointer,
-        baseURL?.ref.pointer ?? ffi.nullptr);
+        relativeToURL?.ref.pointer ?? ffi.nullptr);
     return NSURL.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -12727,14 +12792,14 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// allocWithZone:
-  static NSURL allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSURL allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret = _objc_msgSend_1cwp428(_class_NSURL, _sel_allocWithZone_, zone);
     return NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// bookmarkDataWithContentsOfURL:error:
-  static NSData? bookmarkDataWithContentsOfURL_error_(
-      NSURL bookmarkFileURL, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  static NSData? bookmarkDataWithContentsOfURL(NSURL bookmarkFileURL,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal('NSURL.bookmarkDataWithContentsOfURL:error:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
     final _ret = _objc_msgSend_1lhpu4m(
@@ -12748,8 +12813,8 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// fileURLWithFileSystemRepresentation:isDirectory:relativeToURL:
-  static NSURL fileURLWithFileSystemRepresentation_isDirectory_relativeToURL_(
-      ffi.Pointer<ffi.Char> path, bool isDir, NSURL? baseURL) {
+  static NSURL fileURLWithFileSystemRepresentation(ffi.Pointer<ffi.Char> path,
+      {required bool isDirectory, NSURL? relativeToURL}) {
     objc.checkOsVersionInternal(
         'NSURL.fileURLWithFileSystemRepresentation:isDirectory:relativeToURL:',
         iOS: (false, (7, 0, 0)),
@@ -12758,30 +12823,30 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
         _class_NSURL,
         _sel_fileURLWithFileSystemRepresentation_isDirectory_relativeToURL_,
         path,
-        isDir,
-        baseURL?.ref.pointer ?? ffi.nullptr);
+        isDirectory,
+        relativeToURL?.ref.pointer ?? ffi.nullptr);
     return NSURL.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// fileURLWithPath:
-  static NSURL fileURLWithPath_(NSString path) {
+  static NSURL fileURLWithPath(NSString path) {
     final _ret = _objc_msgSend_1sotr3r(
         _class_NSURL, _sel_fileURLWithPath_, path.ref.pointer);
     return NSURL.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// fileURLWithPath:isDirectory:
-  static NSURL fileURLWithPath_isDirectory_(NSString path, bool isDir) {
+  static NSURL fileURLWithPath$1(NSString path, {required bool isDirectory}) {
     objc.checkOsVersionInternal('NSURL.fileURLWithPath:isDirectory:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 5, 0)));
     final _ret = _objc_msgSend_17amj0z(_class_NSURL,
-        _sel_fileURLWithPath_isDirectory_, path.ref.pointer, isDir);
+        _sel_fileURLWithPath_isDirectory_, path.ref.pointer, isDirectory);
     return NSURL.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// fileURLWithPath:isDirectory:relativeToURL:
-  static NSURL fileURLWithPath_isDirectory_relativeToURL_(
-      NSString path, bool isDir, NSURL? baseURL) {
+  static NSURL fileURLWithPath$2(NSString path,
+      {required bool isDirectory, NSURL? relativeToURL}) {
     objc.checkOsVersionInternal(
         'NSURL.fileURLWithPath:isDirectory:relativeToURL:',
         iOS: (false, (9, 0, 0)),
@@ -12790,20 +12855,20 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
         _class_NSURL,
         _sel_fileURLWithPath_isDirectory_relativeToURL_,
         path.ref.pointer,
-        isDir,
-        baseURL?.ref.pointer ?? ffi.nullptr);
+        isDirectory,
+        relativeToURL?.ref.pointer ?? ffi.nullptr);
     return NSURL.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// fileURLWithPath:relativeToURL:
-  static NSURL fileURLWithPath_relativeToURL_(NSString path, NSURL? baseURL) {
+  static NSURL fileURLWithPath$3(NSString path, {NSURL? relativeToURL}) {
     objc.checkOsVersionInternal('NSURL.fileURLWithPath:relativeToURL:',
         iOS: (false, (9, 0, 0)), macOS: (false, (10, 11, 0)));
     final _ret = _objc_msgSend_15qeuct(
         _class_NSURL,
         _sel_fileURLWithPath_relativeToURL_,
         path.ref.pointer,
-        baseURL?.ref.pointer ?? ffi.nullptr);
+        relativeToURL?.ref.pointer ?? ffi.nullptr);
     return NSURL.castFromPointer(_ret, retain: true, release: true);
   }
 
@@ -12814,10 +12879,9 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// objectWithItemProviderData:typeIdentifier:error:
-  static NSURL? objectWithItemProviderData_typeIdentifier_error_(
-      NSData data,
-      NSString typeIdentifier,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> outError) {
+  static NSURL? objectWithItemProviderData(NSData data,
+      {required NSString typeIdentifier,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSURL.objectWithItemProviderData:typeIdentifier:error:',
         iOS: (false, (11, 0, 0)),
@@ -12827,22 +12891,22 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
         _sel_objectWithItemProviderData_typeIdentifier_error_,
         data.ref.pointer,
         typeIdentifier.ref.pointer,
-        outError);
+        error);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: true, release: true);
   }
 
   /// resourceValuesForKeys:fromBookmarkData:
-  static NSDictionary? resourceValuesForKeys_fromBookmarkData_(
-      NSArray keys, NSData bookmarkData) {
+  static NSDictionary? resourceValuesForKeys(NSArray keys,
+      {required NSData fromBookmarkData}) {
     objc.checkOsVersionInternal('NSURL.resourceValuesForKeys:fromBookmarkData:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
     final _ret = _objc_msgSend_15qeuct(
         _class_NSURL,
         _sel_resourceValuesForKeys_fromBookmarkData_,
         keys.ref.pointer,
-        bookmarkData.ref.pointer);
+        fromBookmarkData.ref.pointer);
     return _ret.address == 0
         ? null
         : NSDictionary.castFromPointer(_ret, retain: true, release: true);
@@ -12854,18 +12918,17 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// writeBookmarkData:toURL:options:error:
-  static bool writeBookmarkData_toURL_options_error_(
-      NSData bookmarkData,
-      NSURL bookmarkFileURL,
-      int options,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  static bool writeBookmarkData(NSData bookmarkData,
+      {required NSURL toURL,
+      required int options,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal('NSURL.writeBookmarkData:toURL:options:error:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
     return _objc_msgSend_1vxoo9h(
         _class_NSURL,
         _sel_writeBookmarkData_toURL_options_error_,
         bookmarkData.ref.pointer,
-        bookmarkFileURL.ref.pointer,
+        toURL.ref.pointer,
         options,
         error);
   }
@@ -12895,12 +12958,10 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// bookmarkDataWithOptions:includingResourceValuesForKeys:relativeToURL:error:
-  NSData?
-      bookmarkDataWithOptions_includingResourceValuesForKeys_relativeToURL_error_(
-          NSURLBookmarkCreationOptions options,
-          NSArray? keys,
-          NSURL? relativeURL,
-          ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  NSData? bookmarkDataWithOptions(NSURLBookmarkCreationOptions options,
+      {NSArray? includingResourceValuesForKeys,
+      NSURL? relativeToURL,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSURL.bookmarkDataWithOptions:includingResourceValuesForKeys:relativeToURL:error:',
         iOS: (false, (4, 0, 0)),
@@ -12909,8 +12970,8 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
         this.ref.pointer,
         _sel_bookmarkDataWithOptions_includingResourceValuesForKeys_relativeToURL_error_,
         options.value,
-        keys?.ref.pointer ?? ffi.nullptr,
-        relativeURL?.ref.pointer ?? ffi.nullptr,
+        includingResourceValuesForKeys?.ref.pointer ?? ffi.nullptr,
+        relativeToURL?.ref.pointer ?? ffi.nullptr,
         error);
     return _ret.address == 0
         ? null
@@ -12927,7 +12988,7 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// encodeWithCoder:
-  void encodeWithCoder_(NSCoder coder) {
+  void encodeWithCoder(NSCoder coder) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_encodeWithCoder_, coder.ref.pointer);
   }
@@ -12969,23 +13030,22 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// getFileSystemRepresentation:maxLength:
-  bool getFileSystemRepresentation_maxLength_(
-      ffi.Pointer<ffi.Char> buffer, int maxBufferLength) {
+  bool getFileSystemRepresentation(ffi.Pointer<ffi.Char> buffer,
+      {required int maxLength}) {
     objc.checkOsVersionInternal('NSURL.getFileSystemRepresentation:maxLength:',
         iOS: (false, (7, 0, 0)), macOS: (false, (10, 9, 0)));
     return _objc_msgSend_8cymbm(this.ref.pointer,
-        _sel_getFileSystemRepresentation_maxLength_, buffer, maxBufferLength);
+        _sel_getFileSystemRepresentation_maxLength_, buffer, maxLength);
   }
 
   /// getResourceValue:forKey:error:
-  bool getResourceValue_forKey_error_(
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> value,
-      NSString key,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  bool getResourceValue(ffi.Pointer<ffi.Pointer<objc.ObjCObject>> value,
+      {required NSString forKey,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal('NSURL.getResourceValue:forKey:error:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
     return _objc_msgSend_1j9bhml(this.ref.pointer,
-        _sel_getResourceValue_forKey_error_, value, key.ref.pointer, error);
+        _sel_getResourceValue_forKey_error_, value, forKey.ref.pointer, error);
   }
 
   /// hasDirectoryPath
@@ -13013,8 +13073,8 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// initAbsoluteURLWithDataRepresentation:relativeToURL:
-  NSURL initAbsoluteURLWithDataRepresentation_relativeToURL_(
-      NSData data, NSURL? baseURL) {
+  NSURL initAbsoluteURLWithDataRepresentation(NSData data,
+      {NSURL? relativeToURL}) {
     objc.checkOsVersionInternal(
         'NSURL.initAbsoluteURLWithDataRepresentation:relativeToURL:',
         iOS: (false, (9, 0, 0)),
@@ -13023,18 +13083,16 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
         this.ref.retainAndReturnPointer(),
         _sel_initAbsoluteURLWithDataRepresentation_relativeToURL_,
         data.ref.pointer,
-        baseURL?.ref.pointer ?? ffi.nullptr);
+        relativeToURL?.ref.pointer ?? ffi.nullptr);
     return NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initByResolvingBookmarkData:options:relativeToURL:bookmarkDataIsStale:error:
-  NSURL?
-      initByResolvingBookmarkData_options_relativeToURL_bookmarkDataIsStale_error_(
-          NSData bookmarkData,
-          NSURLBookmarkResolutionOptions options,
-          NSURL? relativeURL,
-          ffi.Pointer<ffi.Bool> isStale,
-          ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  NSURL? initByResolvingBookmarkData(NSData bookmarkData,
+      {required NSURLBookmarkResolutionOptions options,
+      NSURL? relativeToURL,
+      required ffi.Pointer<ffi.Bool> bookmarkDataIsStale,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal(
         'NSURL.initByResolvingBookmarkData:options:relativeToURL:bookmarkDataIsStale:error:',
         iOS: (false, (4, 0, 0)),
@@ -13044,8 +13102,8 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
         _sel_initByResolvingBookmarkData_options_relativeToURL_bookmarkDataIsStale_error_,
         bookmarkData.ref.pointer,
         options.value,
-        relativeURL?.ref.pointer ?? ffi.nullptr,
-        isStale,
+        relativeToURL?.ref.pointer ?? ffi.nullptr,
+        bookmarkDataIsStale,
         error);
     return _ret.address == 0
         ? null
@@ -13053,8 +13111,8 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// initFileURLWithFileSystemRepresentation:isDirectory:relativeToURL:
-  NSURL initFileURLWithFileSystemRepresentation_isDirectory_relativeToURL_(
-      ffi.Pointer<ffi.Char> path, bool isDir, NSURL? baseURL) {
+  NSURL initFileURLWithFileSystemRepresentation(ffi.Pointer<ffi.Char> path,
+      {required bool isDirectory, NSURL? relativeToURL}) {
     objc.checkOsVersionInternal(
         'NSURL.initFileURLWithFileSystemRepresentation:isDirectory:relativeToURL:',
         iOS: (false, (7, 0, 0)),
@@ -13063,30 +13121,30 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
         this.ref.retainAndReturnPointer(),
         _sel_initFileURLWithFileSystemRepresentation_isDirectory_relativeToURL_,
         path,
-        isDir,
-        baseURL?.ref.pointer ?? ffi.nullptr);
+        isDirectory,
+        relativeToURL?.ref.pointer ?? ffi.nullptr);
     return NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initFileURLWithPath:
-  NSURL initFileURLWithPath_(NSString path) {
+  NSURL initFileURLWithPath(NSString path) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initFileURLWithPath_, path.ref.pointer);
     return NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initFileURLWithPath:isDirectory:
-  NSURL initFileURLWithPath_isDirectory_(NSString path, bool isDir) {
+  NSURL initFileURLWithPath$1(NSString path, {required bool isDirectory}) {
     objc.checkOsVersionInternal('NSURL.initFileURLWithPath:isDirectory:',
         iOS: (false, (2, 0, 0)), macOS: (false, (10, 5, 0)));
     final _ret = _objc_msgSend_17amj0z(this.ref.retainAndReturnPointer(),
-        _sel_initFileURLWithPath_isDirectory_, path.ref.pointer, isDir);
+        _sel_initFileURLWithPath_isDirectory_, path.ref.pointer, isDirectory);
     return NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initFileURLWithPath:isDirectory:relativeToURL:
-  NSURL initFileURLWithPath_isDirectory_relativeToURL_(
-      NSString path, bool isDir, NSURL? baseURL) {
+  NSURL initFileURLWithPath$2(NSString path,
+      {required bool isDirectory, NSURL? relativeToURL}) {
     objc.checkOsVersionInternal(
         'NSURL.initFileURLWithPath:isDirectory:relativeToURL:',
         iOS: (false, (9, 0, 0)),
@@ -13095,25 +13153,25 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
         this.ref.retainAndReturnPointer(),
         _sel_initFileURLWithPath_isDirectory_relativeToURL_,
         path.ref.pointer,
-        isDir,
-        baseURL?.ref.pointer ?? ffi.nullptr);
+        isDirectory,
+        relativeToURL?.ref.pointer ?? ffi.nullptr);
     return NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initFileURLWithPath:relativeToURL:
-  NSURL initFileURLWithPath_relativeToURL_(NSString path, NSURL? baseURL) {
+  NSURL initFileURLWithPath$3(NSString path, {NSURL? relativeToURL}) {
     objc.checkOsVersionInternal('NSURL.initFileURLWithPath:relativeToURL:',
         iOS: (false, (9, 0, 0)), macOS: (false, (10, 11, 0)));
     final _ret = _objc_msgSend_15qeuct(
         this.ref.retainAndReturnPointer(),
         _sel_initFileURLWithPath_relativeToURL_,
         path.ref.pointer,
-        baseURL?.ref.pointer ?? ffi.nullptr);
+        relativeToURL?.ref.pointer ?? ffi.nullptr);
     return NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
-  NSURL? initWithCoder_(NSCoder coder) {
+  NSURL? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0
@@ -13122,7 +13180,7 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// initWithDataRepresentation:relativeToURL:
-  NSURL initWithDataRepresentation_relativeToURL_(NSData data, NSURL? baseURL) {
+  NSURL initWithDataRepresentation(NSData data, {NSURL? relativeToURL}) {
     objc.checkOsVersionInternal(
         'NSURL.initWithDataRepresentation:relativeToURL:',
         iOS: (false, (9, 0, 0)),
@@ -13131,12 +13189,12 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
         this.ref.retainAndReturnPointer(),
         _sel_initWithDataRepresentation_relativeToURL_,
         data.ref.pointer,
-        baseURL?.ref.pointer ?? ffi.nullptr);
+        relativeToURL?.ref.pointer ?? ffi.nullptr);
     return NSURL.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithString:
-  NSURL? initWithString_(NSString URLString) {
+  NSURL? initWithString(NSString URLString) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithString_, URLString.ref.pointer);
     return _ret.address == 0
@@ -13148,8 +13206,8 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   ///
   /// iOS: introduced 17.0.0
   /// macOS: introduced 14.0.0
-  NSURL? initWithString_encodingInvalidCharacters_(
-      NSString URLString, bool encodingInvalidCharacters) {
+  NSURL? initWithString$1(NSString URLString,
+      {required bool encodingInvalidCharacters}) {
     objc.checkOsVersionInternal(
         'NSURL.initWithString:encodingInvalidCharacters:',
         iOS: (false, (17, 0, 0)),
@@ -13165,12 +13223,12 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// initWithString:relativeToURL:
-  NSURL? initWithString_relativeToURL_(NSString URLString, NSURL? baseURL) {
+  NSURL? initWithString$2(NSString URLString, {NSURL? relativeToURL}) {
     final _ret = _objc_msgSend_15qeuct(
         this.ref.retainAndReturnPointer(),
         _sel_initWithString_relativeToURL_,
         URLString.ref.pointer,
-        baseURL?.ref.pointer ?? ffi.nullptr);
+        relativeToURL?.ref.pointer ?? ffi.nullptr);
     return _ret.address == 0
         ? null
         : NSURL.castFromPointer(_ret, retain: false, release: true);
@@ -13253,7 +13311,7 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// removeCachedResourceValueForKey:
-  void removeCachedResourceValueForKey_(NSString key) {
+  void removeCachedResourceValueForKey(NSString key) {
     objc.checkOsVersionInternal('NSURL.removeCachedResourceValueForKey:',
         iOS: (false, (7, 0, 0)), macOS: (false, (10, 9, 0)));
     _objc_msgSend_xtuoz7(this.ref.pointer,
@@ -13270,8 +13328,8 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// resourceValuesForKeys:error:
-  NSDictionary? resourceValuesForKeys_error_(
-      NSArray keys, ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  NSDictionary? resourceValuesForKeys$1(NSArray keys,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal('NSURL.resourceValuesForKeys:error:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
     final _ret = _objc_msgSend_1lhpu4m(this.ref.pointer,
@@ -13290,21 +13348,22 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// setResourceValue:forKey:error:
-  bool setResourceValue_forKey_error_(objc.ObjCObjectBase? value, NSString key,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  bool setResourceValue(objc.ObjCObjectBase? value,
+      {required NSString forKey,
+      required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal('NSURL.setResourceValue:forKey:error:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
     return _objc_msgSend_6z4k82(
         this.ref.pointer,
         _sel_setResourceValue_forKey_error_,
         value?.ref.pointer ?? ffi.nullptr,
-        key.ref.pointer,
+        forKey.ref.pointer,
         error);
   }
 
   /// setResourceValues:error:
-  bool setResourceValues_error_(NSDictionary keyedValues,
-      ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error) {
+  bool setResourceValues(NSDictionary keyedValues,
+      {required ffi.Pointer<ffi.Pointer<objc.ObjCObject>> error}) {
     objc.checkOsVersionInternal('NSURL.setResourceValues:error:',
         iOS: (false, (4, 0, 0)), macOS: (false, (10, 6, 0)));
     return _objc_msgSend_l9p60w(this.ref.pointer, _sel_setResourceValues_error_,
@@ -13312,15 +13371,15 @@ class NSURL extends NSObject implements NSSecureCoding, NSCopying {
   }
 
   /// setTemporaryResourceValue:forKey:
-  void setTemporaryResourceValue_forKey_(
-      objc.ObjCObjectBase? value, NSString key) {
+  void setTemporaryResourceValue(objc.ObjCObjectBase? value,
+      {required NSString forKey}) {
     objc.checkOsVersionInternal('NSURL.setTemporaryResourceValue:forKey:',
         iOS: (false, (7, 0, 0)), macOS: (false, (10, 9, 0)));
     _objc_msgSend_pfv6jd(
         this.ref.pointer,
         _sel_setTemporaryResourceValue_forKey_,
         value?.ref.pointer ?? ffi.nullptr,
-        key.ref.pointer);
+        forKey.ref.pointer);
   }
 
   /// standardizedURL
@@ -13429,7 +13488,7 @@ class NSURLHandle extends NSObject {
   }
 
   /// allocWithZone:
-  static NSURLHandle allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSURLHandle allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSURLHandle, _sel_allocWithZone_, zone);
     return NSURLHandle.castFromPointer(_ret, retain: false, release: true);
@@ -13518,7 +13577,7 @@ class NSValue extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// allocWithZone:
-  static NSValue allocWithZone_(ffi.Pointer<NSZone> zone) {
+  static NSValue allocWithZone(ffi.Pointer<NSZone> zone) {
     final _ret =
         _objc_msgSend_1cwp428(_class_NSValue, _sel_allocWithZone_, zone);
     return NSValue.castFromPointer(_ret, retain: false, release: true);
@@ -13536,13 +13595,13 @@ class NSValue extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// encodeWithCoder:
-  void encodeWithCoder_(NSCoder coder) {
+  void encodeWithCoder(NSCoder coder) {
     _objc_msgSend_xtuoz7(
         this.ref.pointer, _sel_encodeWithCoder_, coder.ref.pointer);
   }
 
   /// getValue:size:
-  void getValue_size_(ffi.Pointer<ffi.Void> value, int size) {
+  void getValue(ffi.Pointer<ffi.Void> value, {required int size}) {
     objc.checkOsVersionInternal('NSValue.getValue:size:',
         iOS: (false, (11, 0, 0)), macOS: (false, (10, 13, 0)));
     _objc_msgSend_zuf90e(this.ref.pointer, _sel_getValue_size_, value, size);
@@ -13558,15 +13617,15 @@ class NSValue extends NSObject implements NSCopying, NSSecureCoding {
   }
 
   /// initWithBytes:objCType:
-  NSValue initWithBytes_objCType_(
-      ffi.Pointer<ffi.Void> value, ffi.Pointer<ffi.Char> type) {
+  NSValue initWithBytes(ffi.Pointer<ffi.Void> value,
+      {required ffi.Pointer<ffi.Char> objCType}) {
     final _ret = _objc_msgSend_e9mncn(this.ref.retainAndReturnPointer(),
-        _sel_initWithBytes_objCType_, value, type);
+        _sel_initWithBytes_objCType_, value, objCType);
     return NSValue.castFromPointer(_ret, retain: false, release: true);
   }
 
   /// initWithCoder:
-  NSValue? initWithCoder_(NSCoder coder) {
+  NSValue? initWithCoder(NSCoder coder) {
     final _ret = _objc_msgSend_1sotr3r(this.ref.retainAndReturnPointer(),
         _sel_initWithCoder_, coder.ref.pointer);
     return _ret.address == 0

--- a/pkgs/objective_c/lib/src/protocol_builder.dart
+++ b/pkgs/objective_c/lib/src/protocol_builder.dart
@@ -36,8 +36,11 @@ class ObjCProtocolBuilder {
       throw StateError('Protocol is already built');
     }
     _builder.implementMethod(
-        sel, withBlock: block.ref.pointer.cast(),
-        withTrampoline: trampoline, withSignature: signature,);
+      sel,
+      withBlock: block.ref.pointer.cast(),
+      withTrampoline: trampoline,
+      withSignature: signature,
+    );
   }
 
   /// Builds the object.

--- a/pkgs/objective_c/lib/src/protocol_builder.dart
+++ b/pkgs/objective_c/lib/src/protocol_builder.dart
@@ -35,8 +35,9 @@ class ObjCProtocolBuilder {
     if (_built) {
       throw StateError('Protocol is already built');
     }
-    _builder.implementMethod_withBlock_withTrampoline_withSignature_(
-        sel, block.ref.pointer.cast(), trampoline, signature);
+    _builder.implementMethod(
+        sel, withBlock: block.ref.pointer.cast(),
+        withTrampoline: trampoline, withSignature: signature,);
   }
 
   /// Builds the object.
@@ -55,7 +56,7 @@ class ObjCProtocolBuilder {
       keepAlivePort = RawReceivePort((_) => keepAlivePort.close());
       disposePort = keepAlivePort.sendPort.nativePort;
     }
-    return _builder.buildInstance_(disposePort);
+    return _builder.buildInstance(disposePort);
   }
 
   /// Add the [protocol] to this implementation.
@@ -63,13 +64,13 @@ class ObjCProtocolBuilder {
   /// This essentially declares that the implementation implements the protocol.
   /// There is no automatic check that ensures that the implementation actually
   /// implements all the methods of the protocol.
-  void addProtocol(objc.Protocol protocol) => _builder.addProtocol_(protocol);
+  void addProtocol(objc.Protocol protocol) => _builder.addProtocol(protocol);
 
   static final _rand = Random();
   static objc.DartProtocolBuilder _createBuilder(String debugName) {
     final name = '${debugName}_${_rand.nextInt(1 << 32)}'.toNativeUtf8();
     final builder =
-        objc.DartProtocolBuilder.alloc().initWithClassName_(name.cast());
+        objc.DartProtocolBuilder.alloc().initWithClassName(name.cast());
     calloc.free(name);
     return builder;
   }

--- a/pkgs/objective_c/pubspec.yaml
+++ b/pkgs/objective_c/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: objective_c
 description: 'A library to access Objective C from Flutter that acts as a support library for package:ffigen.'
-version: 8.0.0-wip
+version: 8.0.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/objective_c
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aobjective_c
 

--- a/pkgs/objective_c/test/ns_input_stream_test.dart
+++ b/pkgs/objective_c/test/ns_input_stream_test.dart
@@ -248,8 +248,8 @@ void main() {
 
       test('default delegate', () async {
         expect(inputStream.delegate, inputStream);
-        inputStream.stream(
-            inputStream, handleEvent: NSStreamEvent.NSStreamEventOpenCompleted);
+        inputStream.stream(inputStream,
+            handleEvent: NSStreamEvent.NSStreamEventOpenCompleted);
       });
 
       test('non-self delegate', () async {
@@ -257,8 +257,8 @@ void main() {
 
         inputStream.delegate = NSStreamDelegate.implement(
             stream_handleEvent_: (stream, event) => events.add(event));
-        inputStream.stream(
-            inputStream, handleEvent: NSStreamEvent.NSStreamEventOpenCompleted);
+        inputStream.stream(inputStream,
+            handleEvent: NSStreamEvent.NSStreamEventOpenCompleted);
         expect(events, [NSStreamEvent.NSStreamEventOpenCompleted]);
       });
 

--- a/pkgs/objective_c/test/ns_input_stream_test.dart
+++ b/pkgs/objective_c/test/ns_input_stream_test.dart
@@ -23,7 +23,7 @@ Future<(int, Uint8List, bool, NSStreamStatus, NSError?)> read(
         NSInputStream stream, int size) =>
     Isolate.run(() {
       final buffer = calloc<Uint8>(size);
-      final readSize = stream.read_maxLength_(buffer, size);
+      final readSize = stream.read(buffer, maxLength: size);
       final data =
           Uint8List.fromList(buffer.asTypedList(readSize == -1 ? 0 : readSize));
       calloc.free(buffer);
@@ -248,8 +248,8 @@ void main() {
 
       test('default delegate', () async {
         expect(inputStream.delegate, inputStream);
-        inputStream.stream_handleEvent_(
-            inputStream, NSStreamEvent.NSStreamEventOpenCompleted);
+        inputStream.stream(
+            inputStream, handleEvent: NSStreamEvent.NSStreamEventOpenCompleted);
       });
 
       test('non-self delegate', () async {
@@ -257,8 +257,8 @@ void main() {
 
         inputStream.delegate = NSStreamDelegate.implement(
             stream_handleEvent_: (stream, event) => events.add(event));
-        inputStream.stream_handleEvent_(
-            inputStream, NSStreamEvent.NSStreamEventOpenCompleted);
+        inputStream.stream(
+            inputStream, handleEvent: NSStreamEvent.NSStreamEventOpenCompleted);
         expect(events, [NSStreamEvent.NSStreamEventOpenCompleted]);
       });
 

--- a/pkgs/objective_c/test/ns_mutable_data_test.dart
+++ b/pkgs/objective_c/test/ns_mutable_data_test.dart
@@ -56,7 +56,7 @@ void main() {
           bytes[1] = 2;
           bytes[2] = 3;
 
-          final data = NSMutableData.dataWithBytes_length_(bytes.cast(), 3);
+          final data = NSMutableData.dataWithBytes(bytes.cast(), length: 3);
           expect(data.toList(), [1, 2, 3]);
         });
       });
@@ -70,7 +70,7 @@ void main() {
           bytes[1] = 2;
           bytes[2] = 3;
 
-          final data = NSMutableData.dataWithBytes_length_(bytes.cast(), 3);
+          final data = NSMutableData.dataWithBytes(bytes.cast(), length: 3);
           data[0] = 4;
           data[1] = 5;
           data[2] = 6;
@@ -87,7 +87,7 @@ void main() {
           bytes[1] = 2;
           bytes[2] = 3;
 
-          final data = NSMutableData.dataWithBytes_length_(bytes.cast(), 3);
+          final data = NSMutableData.dataWithBytes(bytes.cast(), length: 3);
           expect(() => data[3] = 2, throwsRangeError);
           expect(() => data[-1] = 1, throwsRangeError);
           expect(data[0], 1);
@@ -103,7 +103,7 @@ void main() {
           bytes[1] = 2;
           bytes[2] = 3;
 
-          final data = NSMutableData.dataWithBytes_length_(bytes.cast(), 3);
+          final data = NSMutableData.dataWithBytes(bytes.cast(), length: 3);
           data[0] = 256;
           data[1] = 257;
           data[2] = -1;
@@ -129,7 +129,7 @@ void main() {
           bytes[1] = 2;
           bytes[2] = 3;
 
-          final data = NSMutableData.dataWithBytes_length_(bytes.cast(), 3);
+          final data = NSMutableData.dataWithBytes(bytes.cast(), length: 3);
           data.addAll([]);
 
           expect(data.length, 3);
@@ -146,7 +146,7 @@ void main() {
           bytes[1] = 2;
           bytes[2] = 3;
 
-          final data = NSMutableData.dataWithBytes_length_(bytes.cast(), 3);
+          final data = NSMutableData.dataWithBytes(bytes.cast(), length: 3);
           data.addAll([4, 5, 6]);
 
           expect(data.length, 6);
@@ -166,7 +166,7 @@ void main() {
           bytes[1] = 2;
           bytes[2] = 3;
 
-          final data = NSMutableData.dataWithBytes_length_(bytes.cast(), 3);
+          final data = NSMutableData.dataWithBytes(bytes.cast(), length: 3);
           data.addAll([-1, 256, 257]);
 
           expect(data.length, 6);

--- a/pkgs/objective_c/test/nsdata_test.dart
+++ b/pkgs/objective_c/test/nsdata_test.dart
@@ -56,7 +56,7 @@ void main() {
           bytes[1] = 2;
           bytes[2] = 3;
 
-          final data = NSData.dataWithBytes_length_(bytes.cast(), 3);
+          final data = NSData.dataWithBytes(bytes.cast(), length: 3);
           expect(data.toList(), [1, 2, 3]);
         });
       });
@@ -70,7 +70,7 @@ void main() {
           bytes[1] = 2;
           bytes[2] = 3;
 
-          final data = NSData.dataWithBytes_length_(bytes.cast(), 3);
+          final data = NSData.dataWithBytes(bytes.cast(), length: 3);
           expect(data[0], 1);
           expect(data[1], 2);
           expect(data[2], 3);
@@ -84,7 +84,7 @@ void main() {
           bytes[1] = 2;
           bytes[2] = 3;
 
-          final data = NSData.dataWithBytes_length_(bytes.cast(), 3);
+          final data = NSData.dataWithBytes(bytes.cast(), length: 3);
           expect(() => data[3], throwsRangeError);
           expect(() => data[-1], throwsRangeError);
         });

--- a/pkgs/objective_c/test/nsdate_test.dart
+++ b/pkgs/objective_c/test/nsdate_test.dart
@@ -26,7 +26,7 @@ void main() {
 
     test('to DateTime', () {
       final dartFirstAppeared =
-          NSDate.dateWithTimeIntervalSince1970_(1318204800);
+          NSDate.dateWithTimeIntervalSince1970(1318204800);
       final dateTime = dartFirstAppeared.toDateTime();
       expect(dateTime.toUtc().toString(), '2011-10-10 00:00:00.000Z');
     });

--- a/pkgs/objective_c/test/nsdictionary_test.dart
+++ b/pkgs/objective_c/test/nsdictionary_test.dart
@@ -63,7 +63,7 @@ void main() {
       // NSDictionary.of actually returns a NSMutableDictionary, so our
       // immutability tests wouldn't actually work. So convert it to a real
       // NSDictionary using an ObjC constructor.
-      final dict = NSDictionary.dictionaryWithDictionary_(NSDictionary.of({
+      final dict = NSDictionary.dictionaryWithDictionary(NSDictionary.of({
         obj1: obj2,
         obj3: obj4,
         obj5: obj6,

--- a/pkgs/objective_c/test/nsset_test.dart
+++ b/pkgs/objective_c/test/nsset_test.dart
@@ -58,7 +58,7 @@ void main() {
       // NSSet.of actually returns a NSMutableSet, so our immutability tests
       // wouldn't actually work. So convert it to a real NSSet using an ObjC
       // constructor.
-      final s = NSSet.setWithSet_(NSSet.of({obj1, obj2, obj3, obj4, obj5}));
+      final s = NSSet.setWithSet(NSSet.of({obj1, obj2, obj3, obj4, obj5}));
 
       expect(() => s.add(NSObject()), throwsUnsupportedError);
       expect(() => s.remove(obj3), throwsUnsupportedError);

--- a/pkgs/objective_c/test/selector_test.dart
+++ b/pkgs/objective_c/test/selector_test.dart
@@ -26,12 +26,12 @@ void main() {
 
     test('responds to selector', () {
       final sel1 = 'addObserver:forKeyPath:options:context:'.toSelector();
-      expect(NSObject().respondsToSelector_(sel1), isTrue);
-      expect(NSObject().respondsToSelector_('foo'.toSelector()), isFalse);
+      expect(NSObject().respondsToSelector(sel1), isTrue);
+      expect(NSObject().respondsToSelector('foo'.toSelector()), isFalse);
 
       final sel2 = 'canBeConvertedToEncoding:'.toSelector();
-      expect(NSString('').respondsToSelector_(sel2), isTrue);
-      expect(NSString('').respondsToSelector_('bar'.toSelector()), isFalse);
+      expect(NSString('').respondsToSelector(sel2), isTrue);
+      expect(NSString('').respondsToSelector('bar'.toSelector()), isFalse);
     });
   });
 }

--- a/pkgs/objective_c/tool/data/extra_methods.dart.in
+++ b/pkgs/objective_c/tool/data/extra_methods.dart.in
@@ -14,7 +14,7 @@
 class NSString {
   factory NSString(String str) {
     final cstr = str.toNativeUtf16();
-    final nsstr = stringWithCharacters_length_(cstr.cast(), str.length);
+    final nsstr = stringWithCharacters(cstr.cast(), length: str.length);
     pkg_ffi.calloc.free(cstr);
     return nsstr;
   }
@@ -35,12 +35,12 @@ class NSArray with Iterable<objc.ObjCObjectBase> {
   int get length => count;
 
   @override
-  objc.ObjCObjectBase elementAt(int index) => objectAtIndex_(index);
+  objc.ObjCObjectBase elementAt(int index) => objectAtIndex(index);
 
   @override
   Iterator<objc.ObjCObjectBase> get iterator => _NSArrayIterator(this);
 
-  objc.ObjCObjectBase operator [](int index) => objectAtIndex_(index);
+  objc.ObjCObjectBase operator [](int index) => objectAtIndex(index);
 }
 
 class NSMutableArray with ListBase<objc.ObjCObjectBase> {
@@ -49,14 +49,14 @@ class NSMutableArray with ListBase<objc.ObjCObjectBase> {
   ///
   /// The [length] must be a non-negative integer.
   static NSMutableArray filled(int length, objc.ObjCObjectBase fill) {
-    final a = arrayWithCapacity_(length);
+    final a = arrayWithCapacity(length);
     for (var i = 0; i < length; ++i) a.add(fill);
     return a;
   }
 
   /// Creates a [NSMutableArray] from [elements].
   static NSMutableArray of(Iterable<objc.ObjCObjectBase> elements) =>
-      arrayWithCapacity_(elements.length)..addAll(elements);
+      arrayWithCapacity(elements.length)..addAll(elements);
 
   @override
   set length(int newLength) {
@@ -69,14 +69,14 @@ class NSMutableArray with ListBase<objc.ObjCObjectBase> {
   Iterator<objc.ObjCObjectBase> get iterator => _NSArrayIterator(this);
 
   @override
-  objc.ObjCObjectBase operator [](int index) => objectAtIndex_(index);
+  objc.ObjCObjectBase operator [](int index) => objectAtIndex(index);
 
   @override
   void operator []=(int index, objc.ObjCObjectBase value) =>
-      replaceObjectAtIndex_withObject_(index, value);
+      replaceObjectAtIndex(index, withObject: value);
 
   @override
-  void add(objc.ObjCObjectBase value) => addObject_(value);
+  void add(objc.ObjCObjectBase value) => addObject(value);
 }
 
 class _NSArrayIterator implements Iterator<objc.ObjCObjectBase> {
@@ -128,7 +128,7 @@ class NSDictionary with MapBase<NSCopying, objc.ObjCObjectBase> {
 
   @override
   objc.ObjCObjectBase? operator [](Object? key) =>
-      key is NSCopying ? objectForKey_(key) : null;
+      key is NSCopying ? objectForKey(key) : null;
 
   @override
   Iterable<NSCopying> get keys => _NSDictionaryKeyIterable(this);
@@ -154,12 +154,12 @@ class NSDictionary with MapBase<NSCopying, objc.ObjCObjectBase> {
 class NSMutableDictionary {
   /// Creates a [NSMutableDictionary] from [other].
   static NSDictionary of(Map<NSCopying, objc.ObjCObjectBase> other) =>
-      NSMutableDictionary.dictionaryWithCapacity_(other.length)..addAll(other);
+      NSMutableDictionary.dictionaryWithCapacity(other.length)..addAll(other);
 
   /// Creates a [NSMutableDictionary] from [entries].
   static NSMutableDictionary fromEntries(
           Iterable<MapEntry<NSCopying, objc.ObjCObjectBase>> entries) =>
-      NSMutableDictionary.dictionaryWithCapacity_(entries.length)
+      NSMutableDictionary.dictionaryWithCapacity(entries.length)
         ..addEntries(entries);
 
   @override
@@ -169,13 +169,13 @@ class NSMutableDictionary {
   objc.ObjCObjectBase? remove(Object? key) {
     if (key is! NSCopying) return null;
     final old = this[key];
-    removeObjectForKey_(key);
+    removeObjectForKey(key);
     return old;
   }
 
   @override
   void operator []=(NSCopying key, objc.ObjCObjectBase value) =>
-      setObject_forKey_(value, NSCopying.castFrom(key));
+      setObject(value, forKey: NSCopying.castFrom(key));
 }
 
 class _NSDictionaryKeyIterable with Iterable<NSCopying> {
@@ -242,11 +242,11 @@ class NSSet with SetBase<objc.ObjCObjectBase> {
 
   @override
   bool contains(Object? element) =>
-      element is objc.ObjCObjectBase ? containsObject_(element) : false;
+      element is objc.ObjCObjectBase ? containsObject(element) : false;
 
   @override
   objc.ObjCObjectBase? lookup(Object? element) =>
-      element is objc.ObjCObjectBase ? member_(element) : null;
+      element is objc.ObjCObjectBase ? member(element) : null;
 
   @override
   Iterator<objc.ObjCObjectBase> get iterator => objectEnumerator();
@@ -268,12 +268,12 @@ class NSSet with SetBase<objc.ObjCObjectBase> {
 class NSMutableSet {
   /// Creates a [NSMutableSet] from [elements].
   static NSMutableSet of(Iterable<objc.ObjCObjectBase> elements) =>
-      setWithCapacity_(elements.length)..addAll(elements);
+      setWithCapacity(elements.length)..addAll(elements);
 
   @override
   bool add(objc.ObjCObjectBase value) {
     final alreadyContains = contains(value);
-    addObject_(value);
+    addObject(value);
     return !alreadyContains;
   }
 
@@ -281,7 +281,7 @@ class NSMutableSet {
   bool remove(Object? value) {
     if (value is! objc.ObjCObjectBase) return false;
     final alreadyContains = contains(value);
-    removeObject_(value);
+    removeObject(value);
     return alreadyContains;
   }
 


### PR DESCRIPTION
Change the way ObjC methods are generated to use named params, similarly to how ObjC works. Eg `dataWithBytes_length_(Pointer<Void> bytes, int length)`, is now generated as `dataWithBytes(Pointer<Void> bytes, {required int length})`. This is generally much more readable, but does lead to more method renamings, since the shorter methods names are more likely to collide.

If the named parameter is nullable, it's generated as optional. Protocol method generation hasn't been changed, and are still generated using the long names.

I'll publish ffigen 19 once this lands.

Fixes #1566