### PR TITLE
Fix underscores in README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ building and bundling.
 
 | Package | Description | Issues | Version |
 | --- | --- | --- | --- |
-| [code_assets](pkgs/code_assets/) | This package contains the Dart API for code assets in `hook/build.dart` and `hook/link.dart`.  | [![issues](https://img.shields.io/badge/package:code_assets-4774bc)][code_assets_issues] |  |
-| [data_assets](pkgs/data_assets/) | This package contains the Dart API for data assets in `hook/build.dart` and `hook/link.dart`.  | [![issues](https://img.shields.io/badge/package:data_assets-4774bc)][data_assets_issues] |  |
+| [code_assets](pkgs/code_assets/) | This package contains the Dart API for code assets in `hook/build.dart` and `hook/link.dart`.  | [![issues](https://img.shields.io/badge/package:code__assets-4774bc)][code_assets_issues] |  |
+| [data_assets](pkgs/data_assets/) | This package contains the Dart API for data assets in `hook/build.dart` and `hook/link.dart`.  | [![issues](https://img.shields.io/badge/package:data__assets-4774bc)][data_assets_issues] |  |
 | [ffi](pkgs/ffi/) | Utilities for working with Foreign Function Interface (FFI) code. | [![issues](https://img.shields.io/badge/package:ffi-4774bc)][ffi_issues] | [![pub package](https://img.shields.io/pub/v/ffi.svg)](https://pub.dev/packages/ffi) |
 | [ffigen](pkgs/ffigen/) | Generator for FFI bindings, using LibClang to parse C, Objective-C, and Swift files. | [![issues](https://img.shields.io/badge/package:ffigen-4774bc)][ffigen_issues] | [![pub package](https://img.shields.io/pub/v/ffigen.svg)](https://pub.dev/packages/ffigen) |
 | [hooks](pkgs/hooks/) | This package contains the API for `hook/build.dart` and `hook/link.dart`. | [![issues](https://img.shields.io/badge/package:hooks-4774bc)][hooks_issues] |  |
-| [hooks_runner](pkgs/hooks_runner/) | This package is the backend that invokes `hook/build.dart` and `hook/link.dart` from Dart and Flutter. | [![issues](https://img.shields.io/badge/package:hooks_runner-4774bc)][hooks_runner_issues] |  |
+| [hooks_runner](pkgs/hooks_runner/) | This package is the backend that invokes `hook/build.dart` and `hook/link.dart` from Dart and Flutter. | [![issues](https://img.shields.io/badge/package:hooks__runner-4774bc)][hooks_runner_issues] |  |
 | [jni](pkgs/jni/) | A library to access JNI from Dart and Flutter that acts as a support library for package:jnigen. | [![issues](https://img.shields.io/badge/package:jni-4774bc)][jni_issues] | [![pub package](https://img.shields.io/pub/v/jni.svg)](https://pub.dev/packages/jni) |
 | [jnigen](pkgs/jnigen/) | A Dart bindings generator for Java and Kotlin that uses JNI under the hood to interop with Java virtual machine. | [![issues](https://img.shields.io/badge/package:jnigen-4774bc)][jnigen_issues] | [![pub package](https://img.shields.io/pub/v/jnigen.svg)](https://pub.dev/packages/jnigen) |
 | [native_toolchain_c](pkgs/native_toolchain_c/) | A library to invoke the native C compiler installed on the host machine. | [![issues](https://img.shields.io/badge/package:native__toolchain__c-4774bc)][native_toolchain_c_issues] |  |


### PR DESCRIPTION
A single underscore in the badge URL gets converted to a space, to actually show an underscore, two underscores must be used. Fixed the badges for some packages.
