### PR TITLE
[infra] Support collecting coverage for multiple packages at once

### DIFF
--- a/tool/ci.dart
+++ b/tool/ci.dart
@@ -113,7 +113,7 @@ void main(List<String> arguments) async {
   if (argResults['coverage'] as bool) {
     final testUris = getTestUris(packages);
     final scopeOutputs = [
-      for (final testUri in testUris) testUri.split('/')[1],
+      for (final testUri in testUris) Uri.directory(testUri).pathSegments[1],
     ];
     if (argResults['pub'] as bool) {
       _runProcess('dart', ['pub', 'global', 'activate', 'coverage']);
@@ -130,23 +130,6 @@ void main(List<String> arguments) async {
       ...testUris,
     ]);
   }
-}
-
-List<String> getTestUris(List<String> packages) {
-  final testUris = <String>[];
-  for (final package in packages) {
-    final packageTestDirectory = Directory.fromUri(
-      repositoryRoot.resolve(package /*might end without slash*/),
-    ).uri.resolve('test/');
-    if (Directory.fromUri(packageTestDirectory).existsSync()) {
-      final relativePath = packageTestDirectory.toFilePath().replaceAll(
-        repositoryRoot.toFilePath(),
-        '',
-      );
-      testUris.add(relativePath);
-    }
-  }
-  return testUris;
 }
 
 ArgParser makeArgParser() {
@@ -214,6 +197,23 @@ List<String> loadPackagesFromPubspec() {
           )
           .toList();
   return packages;
+}
+
+List<String> getTestUris(List<String> packages) {
+  final testUris = <String>[];
+  for (final package in packages) {
+    final packageTestDirectory = Directory.fromUri(
+      repositoryRoot.resolve(package /*might end without slash*/),
+    ).uri.resolve('test/');
+    if (Directory.fromUri(packageTestDirectory).existsSync()) {
+      final relativePath = packageTestDirectory.toFilePath().replaceAll(
+        repositoryRoot.toFilePath(),
+        '',
+      );
+      testUris.add(relativePath);
+    }
+  }
+  return testUris;
 }
 
 void _runProcess(

--- a/tool/ci.dart
+++ b/tool/ci.dart
@@ -148,7 +148,7 @@ ArgParser makeArgParser() {
         )
         ..addFlag(
           'coverage',
-          defaultsTo: true,
+          defaultsTo: false,
           help: 'Run `dart run coverage:test_with_coverage` on the packages.',
         )
         ..addFlag(
@@ -175,7 +175,7 @@ ArgParser makeArgParser() {
         )
         ..addFlag(
           'test',
-          defaultsTo: false,
+          defaultsTo: true,
           help: 'Run `dart test` on the packages.',
         );
   return parser;

--- a/tool/ci.dart
+++ b/tool/ci.dart
@@ -64,19 +64,7 @@ void main(List<String> arguments) async {
   }
 
   if (argResults['test'] as bool) {
-    final testUris = <String>[];
-    for (final package in packages) {
-      final packageTestDirectory = Directory.fromUri(
-        repositoryRoot.resolve(package /*might end without slash*/),
-      ).uri.resolve('test/');
-      if (Directory.fromUri(packageTestDirectory).existsSync()) {
-        final relativePath = packageTestDirectory.toFilePath().replaceAll(
-          repositoryRoot.toFilePath(),
-          '',
-        );
-        testUris.add(relativePath);
-      }
-    }
+    final testUris = getTestUris(packages);
     _runProcess('dart', ['test', ...testUris]);
   }
 
@@ -121,6 +109,44 @@ void main(List<String> arguments) async {
       [],
     );
   }
+
+  if (argResults['coverage'] as bool) {
+    final testUris = getTestUris(packages);
+    final scopeOutputs = [
+      for (final testUri in testUris) testUri.split('/')[1],
+    ];
+    if (argResults['pub'] as bool) {
+      _runProcess('dart', ['pub', 'global', 'activate', 'coverage']);
+    }
+    _runProcess('dart', [
+      'pub',
+      'global',
+      'run',
+      'coverage:test_with_coverage',
+      for (final scopeOutput in scopeOutputs) ...[
+        '--scope-output',
+        scopeOutput,
+      ],
+      ...testUris,
+    ]);
+  }
+}
+
+List<String> getTestUris(List<String> packages) {
+  final testUris = <String>[];
+  for (final package in packages) {
+    final packageTestDirectory = Directory.fromUri(
+      repositoryRoot.resolve(package /*might end without slash*/),
+    ).uri.resolve('test/');
+    if (Directory.fromUri(packageTestDirectory).existsSync()) {
+      final relativePath = packageTestDirectory.toFilePath().replaceAll(
+        repositoryRoot.toFilePath(),
+        '',
+      );
+      testUris.add(relativePath);
+    }
+  }
+  return testUris;
 }
 
 ArgParser makeArgParser() {
@@ -136,6 +162,11 @@ ArgParser makeArgParser() {
           'analyze',
           defaultsTo: true,
           help: 'Run `dart analyze` on the packages.',
+        )
+        ..addFlag(
+          'coverage',
+          defaultsTo: true,
+          help: 'Run `dart run coverage:test_with_coverage` on the packages.',
         )
         ..addFlag(
           'example',
@@ -155,11 +186,13 @@ ArgParser makeArgParser() {
         ..addFlag(
           'pub',
           defaultsTo: false,
-          help: 'Run `dart pub get` on the root and non-workspace packages.',
+          help:
+              'Run `dart pub get` on the root and non-workspace packages.\n'
+              'Run `dart pub global activate coverage`.',
         )
         ..addFlag(
           'test',
-          defaultsTo: true,
+          defaultsTo: false,
           help: 'Run `dart test` on the packages.',
         );
   return parser;


### PR DESCRIPTION
This adds a way to run coverage for multiple packages to the `tools/ci.dart` script. (Based on https://github.com/dart-lang/tools/issues/2083#issuecomment-2892543659.)

Not used yet in the actual coverage collection on the CI, as that will require massaging the coveralls setup.

Using this command means that the local coverage now includes coverage from integration tests from dependent packages. (E.g. the tests in `package:hooks_runner` now add coverage for `package:hooks` for example.)