### PR TITLE
[native_toolchain_c] [code_assets] [data_assets] Fix `dartdoc` on pub.dev

### DIFF
--- a/pkgs/code_assets/CHANGELOG.md
+++ b/pkgs/code_assets/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.19.1
+
+* Bump the SDK constraint to at least the one from `package:hooks` to fix
+  dartdoc generation on https://pub.dev.
+
 ## 0.19.0
 
 - Split up `package:native_assets_cli` in `package:hooks`,

--- a/pkgs/code_assets/pubspec.yaml
+++ b/pkgs/code_assets/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   This library contains the hook protocol specification for bundling native code
   with Dart packages.
 
-version: 0.19.0
+version: 0.19.1
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/code_assets
 
@@ -17,7 +17,7 @@ topics:
 resolution: workspace
 
 environment:
-  sdk: '>=3.8.0 <4.0.0'
+  sdk: '>=3.9.0-21.0.dev <4.0.0'
 
 dependencies:
   collection: ^1.19.1

--- a/pkgs/data_assets/CHANGELOG.md
+++ b/pkgs/data_assets/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.19.1
+
+* Bump the SDK constraint to at least the one from `package:hooks` to fix
+  dartdoc generation on https://pub.dev.
+
 ## 0.19.0
 
 - Split up `package:native_assets_cli` in `package:hooks`,

--- a/pkgs/data_assets/pubspec.yaml
+++ b/pkgs/data_assets/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   This library contains the hook protocol specification for bundling data assets
   with Dart packages.
 
-version: 0.19.0
+version: 0.19.1
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/data_assets
 
@@ -14,7 +14,7 @@ topics:
 resolution: workspace
 
 environment:
-  sdk: '>=3.8.0 <4.0.0'
+  sdk: '>=3.9.0-21.0.dev <4.0.0'
 
 dependencies:
   hooks: ^0.19.1

--- a/pkgs/hooks/example/build/download_asset/pubspec.yaml
+++ b/pkgs/hooks/example/build/download_asset/pubspec.yaml
@@ -11,11 +11,11 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   crypto: ^3.0.6
   hooks: ^0.19.1
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
 
 dev_dependencies:
   args: ^2.6.0

--- a/pkgs/hooks/example/build/local_asset/pubspec.yaml
+++ b/pkgs/hooks/example/build/local_asset/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
 

--- a/pkgs/hooks/example/build/native_add_library/pubspec.yaml
+++ b/pkgs/hooks/example/build/native_add_library/pubspec.yaml
@@ -11,10 +11,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks/example/build/native_dynamic_linking/pubspec.yaml
+++ b/pkgs/hooks/example/build/native_dynamic_linking/pubspec.yaml
@@ -11,10 +11,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks/example/build/system_library/pubspec.yaml
+++ b/pkgs/hooks/example/build/system_library/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks/example/build/use_dart_api/pubspec.yaml
+++ b/pkgs/hooks/example/build/use_dart_api/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks/example/link/package_with_assets/pubspec.yaml
+++ b/pkgs/hooks/example/link/package_with_assets/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  data_assets: ^0.19.0
+  data_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
   meta: ^1.16.0

--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -29,10 +29,10 @@ dependencies:
 
 dev_dependencies:
   args: ^2.6.0
-  code_assets: ^0.19.0 # Used for running tests with real asset types.
+  code_assets: ^0.19.1 # Used for running tests with real asset types.
   custom_lint: ^0.7.5
   dart_flutter_team_lints: ^3.5.1
-  data_assets: ^0.19.0 # Used for running tests with real asset types.
+  data_assets: ^0.19.1 # Used for running tests with real asset types.
   file_testing: ^3.0.2
   glob: any
   json_schema: ^5.2.0 # May only be used in tool/ and test/json_schema/.

--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.20.1
+
+* Bump the SDK constraint to at least the one from `package:hooks` to fix
+  dartdoc generation on https://pub.dev.
+
 ## 0.20.0
 
 - **Breaking change** Refactored error handling to use a `Result` type for more

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,17 +2,17 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 0.20.0
+version: 0.20.1
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 
 resolution: workspace
 
 environment:
-  sdk: '>=3.8.0 <4.0.0'
+  sdk: '>=3.9.0-21.0.dev <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0 # Needed for OS for Target for KernelAssets.
+  code_assets: ^0.19.1 # Needed for OS for Target for KernelAssets.
   collection: ^1.19.1
   crypto: ^3.0.6
   file: ^7.0.1
@@ -27,7 +27,7 @@ dependencies:
 dev_dependencies:
   custom_lint: ^0.7.5
   dart_flutter_team_lints: ^3.5.1
-  data_assets: ^0.19.0 # Used in tests.
+  data_assets: ^0.19.1 # Used in tests.
   file_testing: ^3.0.2
   repo_lint_rules:
     path: ../repo_lint_rules/

--- a/pkgs/hooks_runner/test_data/add_asset_link/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/add_asset_link/pubspec.yaml
@@ -10,11 +10,11 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
   meta: ^1.16.0
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/hooks_runner/test_data/complex_link/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/complex_link/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   cli_config: ^0.2.0
   complex_link_helper:
     path: ../complex_link_helper/
-  data_assets: ^0.19.0
+  data_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
 

--- a/pkgs/hooks_runner/test_data/complex_link_helper/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/complex_link_helper/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   cli_config: ^0.2.0
-  data_assets: ^0.19.0
+  data_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
 

--- a/pkgs/hooks_runner/test_data/drop_dylib_link/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/drop_dylib_link/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/hooks_runner/test_data/fail_build/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/fail_build/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/fail_on_os_sdk_version/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/fail_on_os_sdk_version/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/fail_on_os_sdk_version_link/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/fail_on_os_sdk_version_link/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  data_assets: ^0.19.0
+  data_assets: ^0.19.1
   fail_on_os_sdk_version_linker:
     path: ../fail_on_os_sdk_version_linker/
   hooks: ^0.19.1

--- a/pkgs/hooks_runner/test_data/fail_on_os_sdk_version_linker/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/fail_on_os_sdk_version_linker/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/native_add/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/native_add/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/native_add_add_source/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/native_add_add_source/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/native_add_duplicate/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/native_add_duplicate/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
   native_add:
     path: ../native_add/
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/native_dynamic_linking/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/native_dynamic_linking/pubspec.yaml
@@ -11,10 +11,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/native_subtract/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/native_subtract/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/no_asset_for_link/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/no_asset_for_link/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
-  data_assets: ^0.19.0
+  code_assets: ^0.19.1
+  data_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
   meta: ^1.16.0

--- a/pkgs/hooks_runner/test_data/no_hook/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/no_hook/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/package_reading_metadata/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/package_reading_metadata/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   package_with_metadata:
     path: ../package_with_metadata/

--- a/pkgs/hooks_runner/test_data/package_with_metadata/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/package_with_metadata/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/relative_path/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/relative_path/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  data_assets: ^0.19.0
+  data_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
 

--- a/pkgs/hooks_runner/test_data/reusable_dynamic_library/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/reusable_dynamic_library/pubspec.yaml
@@ -12,10 +12,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/reuse_dynamic_library/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/reuse_dynamic_library/pubspec.yaml
@@ -11,10 +11,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
   reusable_dynamic_library:
     path: ../reusable_dynamic_library/
 

--- a/pkgs/hooks_runner/test_data/simple_data_asset/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/simple_data_asset/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  data_assets: ^0.19.0
+  data_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
 

--- a/pkgs/hooks_runner/test_data/simple_link/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/simple_link/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   cli_config: ^0.2.0
-  data_assets: ^0.19.0
+  data_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
 

--- a/pkgs/hooks_runner/test_data/system_library/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/system_library/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/transformer/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/transformer/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   crypto: ^3.0.6
-  data_assets: ^0.19.0
+  data_assets: ^0.19.1
   hooks: ^0.19.1
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/treeshaking_native_libs/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/treeshaking_native_libs/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.1
+  native_toolchain_c: ^0.16.2
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/use_all_api/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/use_all_api/pubspec.yaml
@@ -12,8 +12,8 @@ environment:
 
 dependencies:
   cli_config: ^0.2.0
-  code_assets: ^0.19.0
-  data_assets: ^0.19.0
+  code_assets: ^0.19.1
+  data_assets: ^0.19.1
   hooks: ^0.19.1
   logging: ^1.3.0
 

--- a/pkgs/hooks_runner/test_data/user_defines/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/user_defines/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  data_assets: ^0.19.0
+  data_assets: ^0.19.1
   hooks: ^0.19.1
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/wrong_build_output/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/wrong_build_output/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/wrong_build_output_2/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/wrong_build_output_2/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/wrong_build_output_3/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/wrong_build_output_3/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/wrong_linker/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/wrong_linker/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/wrong_namespace_asset/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/wrong_namespace_asset/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   hooks: ^0.19.1
 
 dev_dependencies:

--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.16.2
+
+* Bump the SDK constraint to at least the one from `package:hooks` to fix
+  dartdoc generation on https://pub.dev.
+
 ## 0.16.1
 
 - Firebase Studio NixOS support (default install locations for native

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.16.1
+version: 0.16.2
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:
@@ -14,10 +14,10 @@ topics:
 resolution: workspace
 
 environment:
-  sdk: '>=3.8.0 <4.0.0'
+  sdk: '>=3.9.0-21.0.dev <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^0.19.1
   glob: ^2.1.1
   hooks: ^0.19.1
   logging: ^1.3.0


### PR DESCRIPTION
pub.dev checks the SDK constraint in the pubspec, not the ones for dependencies.

So, bump the SDK constraint on all dependees of `package:hooks`.