### PR TITLE
[jni] Fix nullable JCollections

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.14.2-wip
+## 0.14.2
 
 - Fixed a bug where certain method of `JList`, `JSet`, and `JMap` did not work
   with nullable elements.

--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.14.2-wip
+
+- Fixed a bug where certain method of `JList`, `JSet`, and `JMap` did not work
+  with nullable elements.
+- Fixed a bug in `JList.lastIndexOf`.
+
 ## 0.14.1
 
 - Updated `bin/setup.dart` to use Gradle instead of Maven for building Java sources. Added gradle executables 

--- a/pkgs/jni/lib/src/util/jlist.dart
+++ b/pkgs/jni/lib/src/util/jlist.dart
@@ -197,8 +197,8 @@ class JList<$E extends JObject?> extends JObject with ListMixin<$E> {
       _class.instanceMethodId(r'contains', r'(Ljava/lang/Object;)Z');
   @override
   bool contains(Object? element) {
-    if (element is! JObject) return false;
-    final elementRef = element.reference;
+    if (element is! JObject?) return false;
+    final elementRef = element?.reference ?? jNullReference;
     return _containsId(this, const jbooleanType(), [elementRef.pointer])!;
   }
 
@@ -215,9 +215,9 @@ class JList<$E extends JObject?> extends JObject with ListMixin<$E> {
       _class.instanceMethodId(r'indexOf', r'(Ljava/lang/Object;)I');
   @override
   int indexOf(Object? element, [int start = 0]) {
-    if (element is! JObject) return -1;
+    if (element is! JObject?) return -1;
     if (start < 0) start = 0;
-    final elementRef = element.reference;
+    final elementRef = element?.reference ?? jNullReference;
     if (start == 0) {
       return _indexOfId(this, const jintType(), [elementRef.pointer])!;
     }
@@ -270,13 +270,13 @@ class JList<$E extends JObject?> extends JObject with ListMixin<$E> {
       _class.instanceMethodId(r'lastIndexOf', r'(Ljava/lang/Object;)I');
   @override
   int lastIndexOf(Object? element, [int? start]) {
-    if (element is! JObject) return -1;
+    if (element is! JObject?) return -1;
     if (start == null || start >= this.length) start = this.length - 1;
-    final elementRef = element.reference;
+    final elementRef = element?.reference ?? jNullReference;
     if (start == this.length - 1) {
       return _lastIndexOfId(this, const jintType(), [elementRef.pointer]);
     }
-    final range = getRange(start, length);
+    final range = getRange(0, start);
     final res = _lastIndexOfId(
       range,
       const jintType(),
@@ -290,8 +290,8 @@ class JList<$E extends JObject?> extends JObject with ListMixin<$E> {
       _class.instanceMethodId(r'remove', r'(Ljava/lang/Object;)Z');
   @override
   bool remove(Object? element) {
-    if (element is! JObject) return false;
-    final elementRef = element.reference;
+    if (element is! JObject?) return false;
+    final elementRef = element?.reference ?? jNullReference;
     return _removeId(this, const jbooleanType(), [elementRef.pointer]);
   }
 

--- a/pkgs/jni/lib/src/util/jmap.dart
+++ b/pkgs/jni/lib/src/util/jmap.dart
@@ -154,10 +154,10 @@ class JMap<$K extends JObject?, $V extends JObject?> extends JObject
       r'get', r'(Ljava/lang/Object;)Ljava/lang/Object;');
   @override
   $V? operator [](Object? key) {
-    if (key is! JObject) {
+    if (key is! JObject?) {
       return null;
     }
-    final keyRef = key.reference;
+    final keyRef = key?.reference ?? jNullReference;
     final value = _getId(this, V.nullableType, [keyRef.pointer]);
     return value;
   }
@@ -193,10 +193,10 @@ class JMap<$K extends JObject?, $V extends JObject?> extends JObject
       _class.instanceMethodId(r'containsKey', r'(Ljava/lang/Object;)Z');
   @override
   bool containsKey(Object? key) {
-    if (key is! JObject) {
+    if (key is! JObject?) {
       return false;
     }
-    final keyRef = key.reference;
+    final keyRef = key?.reference ?? jNullReference;
     return _containsKeyId(this, const jbooleanType(), [keyRef.pointer]);
   }
 
@@ -204,10 +204,10 @@ class JMap<$K extends JObject?, $V extends JObject?> extends JObject
       _class.instanceMethodId(r'containsValue', r'(Ljava/lang/Object;)Z');
   @override
   bool containsValue(Object? value) {
-    if (value is! JObject) {
+    if (value is! JObject?) {
       return false;
     }
-    final valueRef = value.reference;
+    final valueRef = value?.reference ?? jNullReference;
     return _containsValueId(this, const jbooleanType(), [valueRef.pointer]);
   }
 
@@ -231,10 +231,10 @@ class JMap<$K extends JObject?, $V extends JObject?> extends JObject
       r'remove', r'(Ljava/lang/Object;)Ljava/lang/Object;');
   @override
   $V? remove(Object? key) {
-    if (key is! JObject) {
+    if (key is! JObject?) {
       return null;
     }
-    final keyRef = key.reference;
+    final keyRef = key?.reference ?? jNullReference;
     final value = _removeId(this, V.nullableType, [keyRef.pointer]);
     return value;
   }

--- a/pkgs/jni/lib/src/util/jset.dart
+++ b/pkgs/jni/lib/src/util/jset.dart
@@ -170,10 +170,10 @@ class JSet<$E extends JObject?> extends JObject with SetMixin<$E> {
 
   @override
   bool contains(Object? element) {
-    if (element is! JObject) {
+    if (element is! JObject?) {
       return false;
     }
-    final elementRef = element.reference;
+    final elementRef = element?.reference ?? jNullReference;
     return _containsId(this, const jbooleanType(), [elementRef.pointer]);
   }
 
@@ -212,7 +212,7 @@ class JSet<$E extends JObject?> extends JObject with SetMixin<$E> {
       _class.instanceMethodId(r'remove', r'(Ljava/lang/Object;)Z');
   @override
   bool remove(Object? value) {
-    if (value is! $E) {
+    if (value is! JObject?) {
       return false;
     }
     final valueRef = value?.reference ?? jNullReference;

--- a/pkgs/jni/pubspec.yaml
+++ b/pkgs/jni/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jni
 description: A library to access JNI from Dart and Flutter that acts as a support library for package:jnigen.
-version: 0.14.1
+version: 0.14.2
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jni
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Ajni
 

--- a/pkgs/jni/test/jlist_test.dart
+++ b/pkgs/jni/test/jlist_test.dart
@@ -28,6 +28,15 @@ void run({required TestRunnerCallback testRunner}) {
       ..releasedBy(arena);
   }
 
+  JList<JString?> testNullableDataList(Arena arena) {
+    return [
+      '1'.toJString()..releasedBy(arena),
+      '2'.toJString()..releasedBy(arena),
+      null,
+    ].toJList(JString.nullableType)
+      ..releasedBy(arena);
+  }
+
   testRunner('length get', () {
     using((arena) {
       final list = testDataList(arena);
@@ -57,6 +66,14 @@ void run({required TestRunnerCallback testRunner}) {
       expect(list[2].toDartString(releaseOriginal: true), '3');
     });
   });
+  testRunner('nullable []', () {
+    using((arena) {
+      final list = testNullableDataList(arena);
+      expect(list[0]!.toDartString(releaseOriginal: true), '1');
+      expect(list[1]!.toDartString(releaseOriginal: true), '2');
+      expect(list[2], isNull);
+    });
+  });
   testRunner('[]=', () {
     using((arena) {
       final list = testDataList(arena);
@@ -65,12 +82,32 @@ void run({required TestRunnerCallback testRunner}) {
       expect(list[0].toDartString(releaseOriginal: true), '2');
     });
   });
+  testRunner('nullable []=', () {
+    using((arena) {
+      final list = testNullableDataList(arena);
+      expect(list[0]!.toDartString(releaseOriginal: true), '1');
+      list[0] = '2'.toJString()..releasedBy(arena);
+      expect(list[0]!.toDartString(releaseOriginal: true), '2');
+      list[0] = null;
+      expect(list[0], isNull);
+    });
+  });
   testRunner('add', () {
     using((arena) {
       final list = testDataList(arena);
       list.add('4'.toJString()..releasedBy(arena));
       expect(list.length, 4);
       expect(list[3].toDartString(releaseOriginal: true), '4');
+    });
+  });
+  testRunner('nullable add', () {
+    using((arena) {
+      final list = testNullableDataList(arena);
+      list.add('4'.toJString()..releasedBy(arena));
+      expect(list.length, 4);
+      expect(list[3]!.toDartString(releaseOriginal: true), '4');
+      list.add(null);
+      expect(list[3]!.toDartString(releaseOriginal: true), '4');
     });
   });
   testRunner('addAll', () {
@@ -102,6 +139,16 @@ void run({required TestRunnerCallback testRunner}) {
       expect(list.contains('4'.toJString()..releasedBy(arena)), false);
     });
   });
+  testRunner('nullable contains', () {
+    using((arena) {
+      final list = testNullableDataList(arena);
+      // ignore: collection_methods_unrelated_type
+      expect(list.contains('1'), false);
+      expect(list.contains('1'.toJString()..releasedBy(arena)), true);
+      expect(list.contains('4'.toJString()..releasedBy(arena)), false);
+      expect(list.contains(null), true);
+    });
+  });
   testRunner('getRange', () {
     using((arena) {
       final list = testDataList(arena);
@@ -119,6 +166,37 @@ void run({required TestRunnerCallback testRunner}) {
       expect(list.indexOf('2'.toJString()..toDartString()), 1);
       expect(list.indexOf('1'.toJString()..toDartString(), 1), -1);
       expect(list.indexOf('1'.toJString()..toDartString(), -1), 0);
+    });
+  });
+  testRunner('nullable indexOf', () {
+    using((arena) {
+      final list = testNullableDataList(arena);
+      expect(list.indexOf(1), -1);
+      expect(list.indexOf('1'.toJString()..toDartString()), 0);
+      expect(list.indexOf('2'.toJString()..toDartString()), 1);
+      expect(list.indexOf(null), 2);
+      expect(list.indexOf('1'.toJString()..toDartString(), 1), -1);
+      expect(list.indexOf('1'.toJString()..toDartString(), -1), 0);
+    });
+  });
+  testRunner('lastIndexOf', () {
+    using((arena) {
+      final list = testDataList(arena);
+      expect(list.lastIndexOf(1), -1);
+      expect(list.lastIndexOf('1'.toJString()..toDartString()), 0);
+      expect(list.lastIndexOf('2'.toJString()..toDartString()), 1);
+      expect(list.lastIndexOf('3'.toJString()..toDartString()), 2);
+      expect(list.lastIndexOf('3'.toJString()..toDartString(), 1), -1);
+    });
+  });
+  testRunner('nullable lastIndexOf', () {
+    using((arena) {
+      final list = testNullableDataList(arena);
+      expect(list.lastIndexOf(1), -1);
+      expect(list.lastIndexOf('1'.toJString()..toDartString()), 0);
+      expect(list.lastIndexOf('2'.toJString()..toDartString()), 1);
+      expect(list.lastIndexOf(null), 2);
+      expect(list.lastIndexOf(null, 1), -1);
     });
   });
   testRunner('insert', () {
@@ -160,6 +238,17 @@ void run({required TestRunnerCallback testRunner}) {
       expect(list.remove('3'.toJString()..releasedBy(arena)), true);
       expect(list.length, 2);
       expect(list.remove('4'.toJString()..releasedBy(arena)), false);
+      // ignore: collection_methods_unrelated_type
+      expect(list.remove(1), false);
+    });
+  });
+  testRunner('nullable remove', () {
+    using((arena) {
+      final list = testNullableDataList(arena);
+      expect(list.remove('3'.toJString()..releasedBy(arena)), false);
+      expect(list.length, 3);
+      expect(list.remove(null), true);
+      expect(list.length, 2);
       // ignore: collection_methods_unrelated_type
       expect(list.remove(1), false);
     });

--- a/pkgs/jni/test/jmap_test.dart
+++ b/pkgs/jni/test/jmap_test.dart
@@ -28,6 +28,16 @@ void run({required TestRunnerCallback testRunner}) {
       ..releasedBy(arena);
   }
 
+  JMap<JString?, JString?> testNullableDataMap(Arena arena) {
+    return {
+      '1'.toJString()..releasedBy(arena): 'One'.toJString()..releasedBy(arena),
+      '2'.toJString()..releasedBy(arena): 'Two'.toJString()..releasedBy(arena),
+      '3'.toJString()..releasedBy(arena): null,
+      null: null,
+    }.toJMap(JString.nullableType, JString.nullableType)
+      ..releasedBy(arena);
+  }
+
   testRunner('length', () {
     using((arena) {
       final map = testDataMap(arena);
@@ -46,6 +56,30 @@ void run({required TestRunnerCallback testRunner}) {
       );
       expect(
         map['4'.toJString()..releasedBy(arena)],
+        null,
+      );
+    });
+  });
+  testRunner('nullable []', () {
+    using((arena) {
+      final map = testNullableDataMap(arena);
+      // ignore: collection_methods_unrelated_type
+      expect(map[1], null);
+      expect(
+        map['1'.toJString()..releasedBy(arena)]
+            ?.toDartString(releaseOriginal: true),
+        'One',
+      );
+      expect(
+        map['4'.toJString()..releasedBy(arena)],
+        null,
+      );
+      expect(
+        map['3'.toJString()..releasedBy(arena)],
+        null,
+      );
+      expect(
+        map[null],
         null,
       );
     });
@@ -69,6 +103,35 @@ void run({required TestRunnerCallback testRunner}) {
         'one!',
       );
       expect(map.length, 4);
+    });
+  });
+  testRunner('nullable []=', () {
+    using((arena) {
+      final map = testNullableDataMap(arena);
+      map['0'.toJString()..releasedBy(arena)] = 'Zero'.toJString()
+        ..releasedBy(arena);
+      expect(
+        map['0'.toJString()..releasedBy(arena)]
+            ?.toDartString(releaseOriginal: true),
+        'Zero',
+      );
+      expect(map.length, 5);
+      map['1'.toJString()..releasedBy(arena)] = 'one!'.toJString()
+        ..releasedBy(arena);
+      expect(
+        map['1'.toJString()..releasedBy(arena)]
+            ?.toDartString(releaseOriginal: true),
+        'one!',
+      );
+      expect(map.length, 5);
+      map['1'.toJString()..releasedBy(arena)] = null;
+      expect(map['1'.toJString()..releasedBy(arena)], null);
+      expect(map.length, 5);
+      map[null] = 'null'.toJString()..releasedBy(arena);
+      expect(
+        map[null]?.toDartString(releaseOriginal: true),
+        'null',
+      );
     });
   });
   testRunner('addAll', () {
@@ -118,6 +181,16 @@ void run({required TestRunnerCallback testRunner}) {
       expect(map.containsKey('4'.toJString()..releasedBy(arena)), false);
     });
   });
+  testRunner('nullable containsKey', () {
+    using((arena) {
+      final map = testNullableDataMap(arena);
+      // ignore: collection_methods_unrelated_type
+      expect(map.containsKey(1), false);
+      expect(map.containsKey('1'.toJString()..releasedBy(arena)), true);
+      expect(map.containsKey('4'.toJString()..releasedBy(arena)), false);
+      expect(map.containsKey(null), true);
+    });
+  });
   testRunner('containsValue', () {
     using((arena) {
       final map = testDataMap(arena);
@@ -125,6 +198,16 @@ void run({required TestRunnerCallback testRunner}) {
       expect(map.containsValue(1), false);
       expect(map.containsValue('One'.toJString()..releasedBy(arena)), true);
       expect(map.containsValue('Four'.toJString()..releasedBy(arena)), false);
+    });
+  });
+  testRunner('nullable containsValue', () {
+    using((arena) {
+      final map = testNullableDataMap(arena);
+      // ignore: collection_methods_unrelated_type
+      expect(map.containsValue(1), false);
+      expect(map.containsValue('One'.toJString()..releasedBy(arena)), true);
+      expect(map.containsValue('Four'.toJString()..releasedBy(arena)), false);
+      expect(map.containsValue(null), true);
     });
   });
   testRunner('keys', () {
@@ -151,6 +234,27 @@ void run({required TestRunnerCallback testRunner}) {
             .remove('3'.toJString()..releasedBy(arena))
             ?.toDartString(releaseOriginal: true),
         'Three',
+      );
+      expect(map.length, 2);
+    });
+  });
+  testRunner('nullable remove', () {
+    using((arena) {
+      final map = testNullableDataMap(arena);
+      // ignore: collection_methods_unrelated_type
+      expect(map.remove(1), null);
+      expect(map.remove('4'.toJString()..releasedBy(arena)), null);
+      expect(map.length, 4);
+      expect(
+        map
+            .remove('3'.toJString()..releasedBy(arena))
+            ?.toDartString(releaseOriginal: true),
+        null,
+      );
+      expect(map.length, 3);
+      expect(
+        map.remove(null),
+        null,
       );
       expect(map.length, 2);
     });

--- a/pkgs/jni/test/jset_test.dart
+++ b/pkgs/jni/test/jset_test.dart
@@ -28,6 +28,15 @@ void run({required TestRunnerCallback testRunner}) {
       ..releasedBy(arena);
   }
 
+  JSet<JString?> testNullableDataSet(Arena arena) {
+    return {
+      '1'.toJString()..releasedBy(arena),
+      '2'.toJString()..releasedBy(arena),
+      null,
+    }.toJSet(JString.nullableType)
+      ..releasedBy(arena);
+  }
+
   testRunner('length', () {
     using((arena) {
       final set = testDataSet(arena);
@@ -40,6 +49,17 @@ void run({required TestRunnerCallback testRunner}) {
       set.add('1'.toJString()..releasedBy(arena));
       expect(set.length, 3);
       set.add('4'.toJString()..releasedBy(arena));
+      expect(set.length, 4);
+    });
+  });
+  testRunner('nullable add', () {
+    using((arena) {
+      final set = testNullableDataSet(arena);
+      set.add('1'.toJString()..releasedBy(arena));
+      expect(set.length, 3);
+      set.add('4'.toJString()..releasedBy(arena));
+      expect(set.length, 4);
+      set.add(null);
       expect(set.length, 4);
     });
   });
@@ -71,6 +91,16 @@ void run({required TestRunnerCallback testRunner}) {
       // ignore: collection_methods_unrelated_type
       expect(set.contains(1), false);
       expect(set.contains('1'.toJString()..releasedBy(arena)), true);
+      expect(set.contains('4'.toJString()..releasedBy(arena)), false);
+    });
+  });
+  testRunner('nullable contains', () {
+    using((arena) {
+      final set = testNullableDataSet(arena);
+      // ignore: collection_methods_unrelated_type
+      expect(set.contains(1), false);
+      expect(set.contains('1'.toJString()..releasedBy(arena)), true);
+      expect(set.contains(null), true);
       expect(set.contains('4'.toJString()..releasedBy(arena)), false);
     });
   });
@@ -116,6 +146,17 @@ void run({required TestRunnerCallback testRunner}) {
       expect(set.remove('4'.toJString()..releasedBy(arena)), false);
       expect(set.length, 3);
       expect(set.remove('3'.toJString()..releasedBy(arena)), true);
+      expect(set.length, 2);
+    });
+  });
+  testRunner('nullable remove', () {
+    using((arena) {
+      final set = testNullableDataSet(arena);
+      // ignore: collection_methods_unrelated_type
+      expect(set.remove(1), false);
+      expect(set.remove('4'.toJString()..releasedBy(arena)), false);
+      expect(set.length, 3);
+      expect(set.remove(null), true);
       expect(set.length, 2);
     });
   });

--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.14.2-wip
+## 0.14.2
 
 - The name `factory` can now also be used in a method name without renaming.
 - Throw when output folder contains non JNIgen files. Users with existing

--- a/pkgs/jnigen/pubspec.yaml
+++ b/pkgs/jnigen/pubspec.yaml
@@ -5,7 +5,7 @@
 name: jnigen
 description: A Dart bindings generator for Java and Kotlin that uses JNI under the hood to interop with Java virtual machine.
 # Keep in sync with `version` in `dart_generator.dart`.
-version: 0.14.2-wip
+version: 0.14.2
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jnigen
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Ajnigen
 


### PR DESCRIPTION
After adding nullablities to collections, I didn't add tests to test collections with nullable types. Adding these tests uncovered some bugs that are now fixed.

Also `JList.lastIndexOf` was not tested at all, testing that uncovered another bug which is also fixed now.

@liamappelbe Overall it's probably best to have a unified test for all of our collection types to avoid duplicate work. I'll open an issue about that.