### PR TITLE
[objective_c] Handle globals in objc_built_in_types.dart

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/objc_built_in_types.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_built_in_types.dart
@@ -129,3 +129,7 @@ const objCBuiltInCategories = {
   'NSNumberIsFloat',
   'NSStringExtensionMethods',
 };
+
+const objCBuiltInGlobals = {
+  'NSLocalizedDescriptionKey',
+};

--- a/pkgs/objective_c/lib/src/objective_c_bindings_exported.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_exported.dart
@@ -66,6 +66,7 @@ export 'objective_c_bindings_generated.dart'
         NSLinguisticTaggerOptions,
         NSLocale,
         NSLocaleLanguageDirection,
+        NSLocalizedDescriptionKey,
         NSMethodSignature,
         NSMutableArray,
         NSMutableCopying,

--- a/pkgs/objective_c/test/interface_lists_test.dart
+++ b/pkgs/objective_c/test/interface_lists_test.dart
@@ -68,9 +68,24 @@ void main() {
           'generated categories', objCBuiltInCategories, allCategoryNames);
     });
 
+    test('All code genned globals are included in the list', () {
+      final allGlobals = findBindings(RegExp(r'^\w+ get (\w+) =>'));
+      expectSetsEqual('generated globals', objCBuiltInGlobals, allGlobals);
+    });
+
     test('No stubs', () {
       final stubRegExp = RegExp(r'\Wstub\W');
       expect(bindings.where(stubRegExp.hasMatch).toList(), <String>[]);
+    });
+
+    test('No automatically renamed classes', () {
+      // All automatically renamed classes or enums should be given an explicit
+      // name. Note that we're not checking for renamed extensions, because ObjC
+      // allows categories with identical names (so we can't unambiguously
+      // rename them), and users don't need to refer to the extension by name
+      // anyway.
+      final renameRegExp = RegExp(r'(class|enum) .*\$');
+      expect(bindings.where(renameRegExp.hasMatch).toList(), <String>[]);
     });
   });
 }

--- a/pkgs/objective_c/tool/generate_code.dart
+++ b/pkgs/objective_c/tool/generate_code.dart
@@ -163,6 +163,7 @@ ${elements.join('\n')}
   writeDecls('objCBuiltInEnums', 'enums');
   writeDecls('objCBuiltInProtocols', 'objc-protocols');
   writeDecls('objCBuiltInCategories', 'objc-categories');
+  writeDecls('objCBuiltInGlobals', 'globals');
 
   File(out).writeAsStringSync(s.toString());
 


### PR DESCRIPTION
Start tracking the ObjC built in globals in ffigen. Unlike the lists in objc_built_in_types.dart, `objCBuiltInGlobals` isn't directly used by ffigen, it's just used for testing. Add tests to interface_lists_test.dart for the generated globals.

Also add a test to make sure we don't have any automatically renamed bindings (just checking for `$` in the name).