### PR TITLE
[hooks] [hooks_runner] Use `any` deps in example and test_data

### DIFF
--- a/pkgs/hooks/example/build/download_asset/pubspec.yaml
+++ b/pkgs/hooks/example/build/download_asset/pubspec.yaml
@@ -11,11 +11,11 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
+  code_assets: any
   crypto: ^3.0.6
-  hooks: ^0.19.3
+  hooks: any
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
 
 dev_dependencies:
   args: ^2.6.0

--- a/pkgs/hooks/example/build/local_asset/pubspec.yaml
+++ b/pkgs/hooks/example/build/local_asset/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
 
 dev_dependencies:

--- a/pkgs/hooks/example/build/native_add_library/pubspec.yaml
+++ b/pkgs/hooks/example/build/native_add_library/pubspec.yaml
@@ -11,10 +11,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks/example/build/native_dynamic_linking/pubspec.yaml
+++ b/pkgs/hooks/example/build/native_dynamic_linking/pubspec.yaml
@@ -11,10 +11,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks/example/build/system_library/pubspec.yaml
+++ b/pkgs/hooks/example/build/system_library/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks/example/build/use_dart_api/pubspec.yaml
+++ b/pkgs/hooks/example/build/use_dart_api/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks/example/link/package_with_assets/pubspec.yaml
+++ b/pkgs/hooks/example/link/package_with_assets/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  data_assets: ^0.19.1
-  hooks: ^0.19.3
+  data_assets: any
+  hooks: any
   logging: ^1.3.0
   meta: ^1.16.0
   record_use: ^0.3.0

--- a/pkgs/hooks_runner/test_data/add_asset_link/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/add_asset_link/pubspec.yaml
@@ -10,11 +10,11 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
   meta: ^1.16.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/hooks_runner/test_data/complex_link/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/complex_link/pubspec.yaml
@@ -13,8 +13,8 @@ dependencies:
   cli_config: ^0.2.0
   complex_link_helper:
     path: ../complex_link_helper/
-  data_assets: ^0.19.1
-  hooks: ^0.19.3
+  data_assets: any
+  hooks: any
   logging: ^1.3.0
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/complex_link_helper/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/complex_link_helper/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   cli_config: ^0.2.0
-  data_assets: ^0.19.1
-  hooks: ^0.19.3
+  data_assets: any
+  hooks: any
   logging: ^1.3.0
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/cyclic_package_1/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/cyclic_package_1/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cyclic_package_2:
     path: ../cyclic_package_2
-  hooks: ^0.19.3
+  hooks: any
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/hooks_runner/test_data/cyclic_package_2/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/cyclic_package_2/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cyclic_package_1:
     path: ../cyclic_package_1
-  hooks: ^0.19.3
+  hooks: any
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/hooks_runner/test_data/depend_on_fail_build/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/depend_on_fail_build/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   fail_build:
     path: ../fail_build/
-  hooks: ^0.19.3
+  hooks: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/depend_on_fail_build_app/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/depend_on_fail_build_app/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   depend_on_fail_build:
     path: ../depend_on_fail_build/
-  hooks: ^0.19.3
+  hooks: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/drop_dylib_link/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/drop_dylib_link/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/hooks_runner/test_data/fail_build/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/fail_build/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/fail_on_os_sdk_version/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/fail_on_os_sdk_version/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/fail_on_os_sdk_version_link/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/fail_on_os_sdk_version_link/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  data_assets: ^0.19.1
+  data_assets: any
   fail_on_os_sdk_version_linker:
     path: ../fail_on_os_sdk_version_linker/
-  hooks: ^0.19.3
+  hooks: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/fail_on_os_sdk_version_linker/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/fail_on_os_sdk_version_linker/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/native_add/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/native_add/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/native_add_add_source/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/native_add_add_source/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/native_add_duplicate/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/native_add_duplicate/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
   native_add:
     path: ../native_add/
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/native_dynamic_linking/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/native_dynamic_linking/pubspec.yaml
@@ -11,10 +11,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/native_subtract/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/native_subtract/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/no_asset_for_link/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/no_asset_for_link/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  data_assets: ^0.19.1
-  hooks: ^0.19.3
+  code_assets: any
+  data_assets: any
+  hooks: any
   logging: ^1.3.0
   meta: ^1.16.0
 

--- a/pkgs/hooks_runner/test_data/no_hook/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/no_hook/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/package_reading_metadata/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/package_reading_metadata/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   package_with_metadata:
     path: ../package_with_metadata/
 

--- a/pkgs/hooks_runner/test_data/package_with_metadata/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/package_with_metadata/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/hooks_runner/test_data/relative_path/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/relative_path/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  data_assets: ^0.19.1
-  hooks: ^0.19.3
+  data_assets: any
+  hooks: any
   logging: ^1.3.0
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/reusable_dynamic_library/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/reusable_dynamic_library/pubspec.yaml
@@ -12,10 +12,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/reuse_dynamic_library/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/reuse_dynamic_library/pubspec.yaml
@@ -11,10 +11,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
   reusable_dynamic_library:
     path: ../reusable_dynamic_library/
 

--- a/pkgs/hooks_runner/test_data/simple_data_asset/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/simple_data_asset/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  data_assets: ^0.19.1
-  hooks: ^0.19.3
+  data_assets: any
+  hooks: any
   logging: ^1.3.0
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/simple_link/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/simple_link/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   cli_config: ^0.2.0
-  data_assets: ^0.19.1
-  hooks: ^0.19.3
+  data_assets: any
+  hooks: any
   logging: ^1.3.0
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/system_library/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/system_library/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/transformer/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/transformer/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   crypto: ^3.0.6
-  data_assets: ^0.19.1
-  hooks: ^0.19.3
+  data_assets: any
+  hooks: any
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/hooks_runner/test_data/treeshaking_native_libs/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/treeshaking_native_libs/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.2
+  native_toolchain_c: any
 
 dev_dependencies:
   ffigen: ^18.0.0

--- a/pkgs/hooks_runner/test_data/use_all_api/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/use_all_api/pubspec.yaml
@@ -12,9 +12,9 @@ environment:
 
 dependencies:
   cli_config: ^0.2.0
-  code_assets: ^0.19.3
-  data_assets: ^0.19.1
-  hooks: ^0.19.3
+  code_assets: any
+  data_assets: any
+  hooks: any
   logging: ^1.3.0
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/user_defines/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/user_defines/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  data_assets: ^0.19.1
-  hooks: ^0.19.3
+  data_assets: any
+  hooks: any
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/hooks_runner/test_data/wrong_build_output/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/wrong_build_output/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/hooks_runner/test_data/wrong_build_output_2/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/wrong_build_output_2/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/hooks_runner/test_data/wrong_build_output_3/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/wrong_build_output_3/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/hooks_runner/test_data/wrong_linker/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/wrong_linker/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pkgs/hooks_runner/test_data/wrong_namespace_asset/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/wrong_namespace_asset/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.3
-  hooks: ^0.19.3
+  code_assets: any
+  hooks: any
 
 dev_dependencies:
   lints: ^5.1.1


### PR DESCRIPTION
Those packages are not published, so they are only available in the git checkout. In the git checkout, they will always have the same version as the code in the workspace.

This will reduce the diff on PRs which change the version number of `package:hooks` etc.