### PR TITLE
[hooks] Stop leaking `MetadataAsset`

### DIFF
--- a/pkgs/code_assets/pubspec.yaml
+++ b/pkgs/code_assets/pubspec.yaml
@@ -21,7 +21,7 @@ environment:
 
 dependencies:
   collection: ^1.19.1
-  hooks: ^0.19.4
+  hooks: ^0.19.5
 
 dev_dependencies:
   custom_lint: ^0.7.5

--- a/pkgs/data_assets/pubspec.yaml
+++ b/pkgs/data_assets/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   sdk: '>=3.9.0-21.0.dev <4.0.0'
 
 dependencies:
-  hooks: ^0.19.4
+  hooks: ^0.19.5
 
 dev_dependencies:
   custom_lint: ^0.7.5

--- a/pkgs/hooks/CHANGELOG.md
+++ b/pkgs/hooks/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.19.5
+
+* Stop leaking unexported symbols.
+
 ## 0.19.4
 
 * Add doc comments to all public members.

--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A library that contains a Dart API for the JSON-based protocol for
   `hook/build.dart` and `hook/link.dart`.
 
-version: 0.19.4
+version: 0.19.5
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks
 
@@ -29,7 +29,7 @@ dependencies:
 
 dev_dependencies:
   args: ^2.6.0
-  code_assets: any # Used for running tests with real asset types.
+  code_assets: ^0.19.4 # Used for running tests with real asset types.
   custom_lint: ^0.7.5
   dart_flutter_team_lints: ^3.5.1
   data_assets: any # Used for running tests with real asset types.

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   crypto: ^3.0.6
   file: ^7.0.1
   graphs: ^2.3.2
-  hooks: ^0.19.4
+  hooks: ^0.19.5
   logging: ^1.3.0
   meta: ^1.16.0
   package_config: ^2.1.0

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -19,7 +19,7 @@ environment:
 dependencies:
   code_assets: ^0.19.4
   glob: ^2.1.1
-  hooks: ^0.19.4
+  hooks: ^0.19.5
   logging: ^1.3.0
   meta: ^1.16.0
   pub_semver: ^2.2.0


### PR DESCRIPTION
Also, nest `_parseAssets` in an extension. The leaking tool seems to think it's exported. So just work around it. (And make the `fromSyntax` similar to other syntax methods.)