### PR TITLE
[native_toolchain_c] Add linking for iOS

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.16.5
+
+* Support linking for iOS.
+
 ## 0.16.4
 
 * Support linking for MacOS.

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
@@ -53,7 +53,7 @@ class CLinker extends CTool implements Linker {
     required LinkOutputBuilder output,
     required Logger? logger,
   }) async {
-    const supportedTargetOSs = [OS.linux, OS.android, OS.macOS];
+    const supportedTargetOSs = [OS.linux, OS.android, OS.macOS, OS.iOS];
     if (!supportedTargetOSs.contains(input.config.code.targetOS)) {
       throw UnsupportedError(
         'This feature is only supported when targeting '

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/linker_options.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/linker_options.dart
@@ -98,7 +98,7 @@ extension LinkerOptionsExt on LinkerOptions {
     final includeAllSymbols = _symbolsToKeep == null;
 
     switch (targetOS) {
-      case OS.macOS:
+      case OS.macOS || OS.iOS:
         return [
           if (!includeAllSymbols) ...sourceFiles,
           ..._toLinkerSyntax(tool, [

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.16.4
+version: 0.16.5
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -16,9 +16,6 @@ import 'package:test/test.dart';
 
 import '../helpers.dart';
 
-const flutteriOSHighestBestEffort = 16;
-const flutteriOSHighestSupported = 17;
-
 void main() {
   if (!Platform.isMacOS) {
     // Avoid needing status files on Dart SDK CI.
@@ -26,12 +23,6 @@ void main() {
   }
 
   const targets = [Architecture.arm64, Architecture.x64];
-
-  // Dont include 'mach-o' or 'Mach-O', different spelling is used.
-  const objdumpFileFormat = {
-    Architecture.arm64: 'arm64',
-    Architecture.x64: '64-bit x86-64',
-  };
 
   const name = 'add';
 
@@ -124,7 +115,7 @@ void main() {
                 final machine = objdumpResult.stdout
                     .split('\n')
                     .firstWhere((e) => e.contains('file format'));
-                expect(machine, contains(objdumpFileFormat[target]));
+                expect(machine, contains(objdumpFileFormatIOS[target]));
 
                 final otoolResult = await runProcess(
                   executable: Uri.file('otool'),

--- a/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
+++ b/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
@@ -17,12 +17,18 @@ Future<Uri> buildTestArchive(
   Architecture architecture, {
   int? androidTargetNdkApi, // Must be specified iff targetOS is OS.android.
   int? macOSTargetVersion, // Must be specified iff targetOS is OS.macos.
+  int? iOSTargetVersion, // Must be specified iff targetOS is OS.iOS.
+  IOSSdk? iOSTargetSdk, // Must be specified iff targetOS is OS.iOS.
 }) async {
   if (targetOS == OS.android) {
     ArgumentError.checkNotNull(androidTargetNdkApi, 'androidTargetNdkApi');
   }
   if (targetOS == OS.macOS) {
     ArgumentError.checkNotNull(macOSTargetVersion, 'macOSTargetVersion');
+  }
+  if (targetOS == OS.iOS) {
+    ArgumentError.checkNotNull(iOSTargetVersion, 'iOSTargetVersion');
+    ArgumentError.checkNotNull(iOSTargetSdk, 'iOSTargetSdk');
   }
 
   final test1Uri = packageUri.resolve('test/clinker/testfiles/linker/test1.c');
@@ -55,6 +61,12 @@ Future<Uri> buildTestArchive(
             : null,
         macOS: macOSTargetVersion != null
             ? MacOSCodeConfig(targetVersion: macOSTargetVersion)
+            : null,
+        iOS: iOSTargetVersion != null && iOSTargetSdk != null
+            ? IOSCodeConfig(
+                targetSdk: iOSTargetSdk,
+                targetVersion: iOSTargetVersion,
+              )
             : null,
       ),
     );

--- a/pkgs/native_toolchain_c/test/clinker/objects_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/objects_cross_android_test.dart
@@ -16,7 +16,7 @@ void main() {
     flutterAndroidNdkVersionLowestSupported,
     flutterAndroidNdkVersionHighestSupported,
   ]) {
-    group('Android API$apiLevel', () {
+    group('Android API$apiLevel:', () {
       runObjectsTests(targetOS, architectures, androidTargetNdkApi: apiLevel);
     });
   }

--- a/pkgs/native_toolchain_c/test/clinker/objects_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/objects_cross_ios_test.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('mac-os')
+library;
+
+import 'dart:io';
+
+import 'package:code_assets/code_assets.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+import 'objects_helper.dart';
+
+void main() {
+  if (!Platform.isMacOS) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
+
+  const targetOS = OS.iOS;
+
+  for (final iOSVersion in [
+    flutteriOSHighestBestEffort,
+    flutteriOSHighestSupported,
+  ]) {
+    for (final iOSTargetSdk in IOSSdk.values) {
+      group('$iOSTargetSdk $iOSVersion:', () {
+        runObjectsTests(
+          targetOS,
+          iOSSupportedArchitecturesFor(iOSTargetSdk),
+          iOSTargetVersion: iOSVersion,
+          iOSTargetSdk: iOSTargetSdk,
+        );
+      });
+    }
+  }
+}

--- a/pkgs/native_toolchain_c/test/clinker/objects_helper.dart
+++ b/pkgs/native_toolchain_c/test/clinker/objects_helper.dart
@@ -17,12 +17,18 @@ void runObjectsTests(
   List<Architecture> architectures, {
   int? androidTargetNdkApi, // Must be specified iff targetOS is OS.android.
   int? macOSTargetVersion, // Must be specified iff targetOS is OS.macos.
+  int? iOSTargetVersion, // Must be specified iff targetOS is OS.iOS.
+  IOSSdk? iOSTargetSdk, // Must be specified iff targetOS is OS.iOS.
 }) {
   if (targetOS == OS.android) {
     ArgumentError.checkNotNull(androidTargetNdkApi, 'androidTargetNdkApi');
   }
   if (targetOS == OS.macOS) {
     ArgumentError.checkNotNull(macOSTargetVersion, 'macOSTargetVersion');
+  }
+  if (targetOS == OS.iOS) {
+    ArgumentError.checkNotNull(iOSTargetVersion, 'iOSTargetVersion');
+    ArgumentError.checkNotNull(iOSTargetSdk, 'iOSTargetSdk');
   }
 
   const name = 'mylibname';
@@ -39,6 +45,8 @@ void runObjectsTests(
         architecture,
         androidTargetNdkApi: androidTargetNdkApi,
         macOSTargetVersion: macOSTargetVersion,
+        iOSTargetVersion: iOSTargetVersion,
+        iOSTargetSdk: iOSTargetSdk,
       );
 
       final linkInputBuilder = LinkInputBuilder()
@@ -60,6 +68,12 @@ void runObjectsTests(
                 : null,
             macOS: macOSTargetVersion != null
                 ? MacOSCodeConfig(targetVersion: macOSTargetVersion)
+                : null,
+            iOS: iOSTargetVersion != null && iOSTargetSdk != null
+                ? IOSCodeConfig(
+                    targetSdk: iOSTargetSdk,
+                    targetVersion: iOSTargetVersion,
+                  )
                 : null,
           ),
         );

--- a/pkgs/native_toolchain_c/test/clinker/throws_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/throws_test.dart
@@ -13,7 +13,8 @@ void main() {
   for (final targetOS in OS.values) {
     if (targetOS == OS.linux ||
         targetOS == OS.android ||
-        targetOS == OS.macOS) {
+        targetOS == OS.macOS ||
+        targetOS == OS.iOS) {
       // Is implemented.
       continue;
     }

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_cross_android_test.dart
@@ -10,14 +10,19 @@ import 'treeshake_helper.dart';
 
 void main() {
   const targetOS = OS.android;
-  final architectures = supportedArchitecturesFor(targetOS);
 
   for (final apiLevel in [
     flutterAndroidNdkVersionLowestSupported,
     flutterAndroidNdkVersionHighestSupported,
   ]) {
-    group('Android API$apiLevel', () {
-      runTreeshakeTests(targetOS, architectures, androidTargetNdkApi: apiLevel);
-    });
+    for (final architecture in supportedArchitecturesFor(targetOS)) {
+      group('Android API$apiLevel ($architecture):', () {
+        runTreeshakeTests(
+          targetOS,
+          architecture,
+          androidTargetNdkApi: apiLevel,
+        );
+      });
+    }
   }
 }

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_cross_ios_test.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('mac-os')
+library;
+
+import 'dart:io';
+
+import 'package:code_assets/code_assets.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+import 'treeshake_helper.dart';
+
+void main() {
+  if (!Platform.isMacOS) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
+
+  const targetOS = OS.iOS;
+
+  for (final iOSVersion in [
+    flutteriOSHighestBestEffort,
+    flutteriOSHighestSupported,
+  ]) {
+    for (final iOSTargetSdk in IOSSdk.values) {
+      for (final architecture in iOSSupportedArchitecturesFor(iOSTargetSdk)) {
+        group('$iOSTargetSdk $iOSVersion ($architecture):', () {
+          runTreeshakeTests(
+            targetOS,
+            architecture,
+            iOSTargetVersion: iOSVersion,
+            iOSTargetSdk: iOSTargetSdk,
+          );
+        });
+      }
+    }
+  }
+}

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_cross_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_cross_test.dart
@@ -23,10 +23,13 @@ void main() {
 
   final architectures = supportedArchitecturesFor(OS.current)
     ..remove(Architecture.current); // See treeshake_test.dart for current arch.
-
-  runTreeshakeTests(
-    OS.current,
-    architectures,
-    macOSTargetVersion: OS.current == OS.macOS ? defaultMacOSVersion : null,
-  );
+  for (final architecture in architectures) {
+    group('${OS.current} ($architecture):', () {
+      runTreeshakeTests(
+        OS.current,
+        architecture,
+        macOSTargetVersion: OS.current == OS.macOS ? defaultMacOSVersion : null,
+      );
+    });
+  }
 }

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
@@ -14,15 +14,21 @@ import 'build_testfiles.dart';
 
 void runTreeshakeTests(
   OS targetOS,
-  List<Architecture> architectures, {
+  Architecture targetArchitecture, {
   int? androidTargetNdkApi, // Must be specified iff targetOS is OS.android.
   int? macOSTargetVersion, // Must be specified iff targetOS is OS.macos.
+  int? iOSTargetVersion, // Must be specified iff targetOS is OS.iOS.
+  IOSSdk? iOSTargetSdk, // Must be specified iff targetOS is OS.iOS.
 }) {
   if (targetOS == OS.android) {
     ArgumentError.checkNotNull(androidTargetNdkApi, 'androidTargetNdkApi');
   }
   if (targetOS == OS.macOS) {
     ArgumentError.checkNotNull(macOSTargetVersion, 'macOSTargetVersion');
+  }
+  if (targetOS == OS.iOS) {
+    ArgumentError.checkNotNull(iOSTargetVersion, 'iOSTargetVersion');
+    ArgumentError.checkNotNull(iOSTargetSdk, 'iOSTargetSdk');
   }
 
   CLinker linkerManual(List<String> sources) => CLinker.library(
@@ -53,75 +59,86 @@ void runTreeshakeTests(
 
   late Map<String, int> sizes;
   sizes = <String, int>{};
-  for (final architecture in architectures) {
-    for (final clinker in [
-      (name: 'manual', linker: linkerManual),
-      (name: 'auto', linker: linkerAuto),
-      (name: 'autoEmpty', linker: linkerAutoEmpty),
-    ]) {
-      test('link test with CLinker ${clinker.name} and target '
-          '$architecture for targetOS $targetOS', () async {
-        final tempUri = await tempDirForTest();
-        final tempUri2 = await tempDirForTest();
-        final testArchive = await buildTestArchive(
-          tempUri,
-          tempUri2,
-          targetOS,
-          architecture,
-          androidTargetNdkApi: androidTargetNdkApi,
-          macOSTargetVersion: macOSTargetVersion,
+  for (final clinker in [
+    (name: 'manual', linker: linkerManual),
+    (name: 'auto', linker: linkerAuto),
+    (name: 'autoEmpty', linker: linkerAutoEmpty),
+  ]) {
+    test('link test with CLinker ${clinker.name}', () async {
+      final tempUri = await tempDirForTest();
+      final tempUri2 = await tempDirForTest();
+      final testArchive = await buildTestArchive(
+        tempUri,
+        tempUri2,
+        targetOS,
+        targetArchitecture,
+        androidTargetNdkApi: androidTargetNdkApi,
+        macOSTargetVersion: macOSTargetVersion,
+        iOSTargetVersion: iOSTargetVersion,
+        iOSTargetSdk: iOSTargetSdk,
+      );
+
+      final linkInputBuilder = LinkInputBuilder()
+        ..setupShared(
+          packageName: 'testpackage',
+          packageRoot: tempUri,
+          outputFile: tempUri.resolve('output.json'),
+          outputDirectoryShared: tempUri2,
+        )
+        ..setupLink(assets: [], recordedUsesFile: null)
+        ..addExtension(
+          CodeAssetExtension(
+            targetOS: targetOS,
+            targetArchitecture: targetArchitecture,
+            linkModePreference: LinkModePreference.dynamic,
+            cCompiler: cCompiler,
+            android: androidTargetNdkApi != null
+                ? AndroidCodeConfig(targetNdkApi: androidTargetNdkApi)
+                : null,
+            macOS: macOSTargetVersion != null
+                ? MacOSCodeConfig(targetVersion: macOSTargetVersion)
+                : null,
+            iOS: iOSTargetVersion != null && iOSTargetSdk != null
+                ? IOSCodeConfig(
+                    targetSdk: iOSTargetSdk,
+                    targetVersion: iOSTargetVersion,
+                  )
+                : null,
+          ),
         );
 
-        final linkInputBuilder = LinkInputBuilder()
-          ..setupShared(
-            packageName: 'testpackage',
-            packageRoot: tempUri,
-            outputFile: tempUri.resolve('output.json'),
-            outputDirectoryShared: tempUri2,
-          )
-          ..setupLink(assets: [], recordedUsesFile: null)
-          ..addExtension(
-            CodeAssetExtension(
-              targetOS: targetOS,
-              targetArchitecture: architecture,
-              linkModePreference: LinkModePreference.dynamic,
-              cCompiler: cCompiler,
-              android: androidTargetNdkApi != null
-                  ? AndroidCodeConfig(targetNdkApi: androidTargetNdkApi)
-                  : null,
-              macOS: macOSTargetVersion != null
-                  ? MacOSCodeConfig(targetVersion: macOSTargetVersion)
-                  : null,
-            ),
-          );
+      final linkInput = linkInputBuilder.build();
+      final linkOutputBuilder = LinkOutputBuilder();
 
-        final linkInput = linkInputBuilder.build();
-        final linkOutputBuilder = LinkOutputBuilder();
+      printOnFailure(linkInput.config.code.cCompiler.toString());
+      printOnFailure(Platform.environment.keys.toList().toString());
+      await clinker
+          .linker([testArchive.toFilePath()])
+          .run(input: linkInput, output: linkOutputBuilder, logger: logger);
 
-        printOnFailure(linkInput.config.code.cCompiler.toString());
-        printOnFailure(Platform.environment.keys.toList().toString());
-        await clinker
-            .linker([testArchive.toFilePath()])
-            .run(input: linkInput, output: linkOutputBuilder, logger: logger);
+      final linkOutput = linkOutputBuilder.build();
+      final asset = linkOutput.assets.code.first;
 
-        final linkOutput = linkOutputBuilder.build();
-        final asset = linkOutput.assets.code.first;
+      await expectMachineArchitecture(
+        asset.file!,
+        targetArchitecture,
+        targetOS,
+      );
 
-        await expectMachineArchitecture(asset.file!, architecture, targetOS);
+      final symbols = await nmReadSymbols(asset, targetOS);
+      if (clinker.linker != linkerAutoEmpty) {
+        expect(symbols, contains('my_other_func'));
+        expect(symbols, isNot(contains('my_func')));
+      } else {
+        expect(symbols, contains('my_other_func'));
+        expect(symbols, contains('my_func'));
+      }
 
-        final symbols = await nmReadSymbols(asset, targetOS);
-        if (clinker.linker != linkerAutoEmpty) {
-          expect(symbols, contains('my_other_func'));
-          expect(symbols, isNot(contains('my_func')));
-        } else {
-          expect(symbols, contains('my_other_func'));
-          expect(symbols, contains('my_func'));
-        }
-
-        final sizeInBytes = await File.fromUri(asset.file!).length();
-        sizes[clinker.name] = sizeInBytes;
-      });
-    }
+      final sizeInBytes = await File.fromUri(asset.file!).length();
+      // Make sure we don't override any results.
+      expect(sizes[clinker.name], isNull);
+      sizes[clinker.name] = sizeInBytes;
+    });
     tearDownAll(() {
       expect(
         sizes['manual'],

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_test.dart
@@ -23,7 +23,7 @@ void main() {
 
   runTreeshakeTests(
     OS.current,
-    [Architecture.current],
+    Architecture.current,
     macOSTargetVersion: OS.current == OS.macOS ? defaultMacOSVersion : null,
   );
 }


### PR DESCRIPTION
Towards https://github.com/dart-lang/native/issues/1376

We were basically able re reuse all the macOS work from https://github.com/dart-lang/native/pull/2360 for iOS and just had to add iOS-specific Tests.

This PR also fixes an issue with the treeshaking tests, which were accidentally overwriting size results from other test cases. An `expect` has been added to guard against this issue in the future.

Hint for reviewers: `treeshake_helper.dart` is easier to review with github's `Hide whitespace` option turned on.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
