### PR TITLE
[native_doc_dartifier] Extract Public API Signatures for LLM Context

### DIFF
--- a/pkgs/native_doc_dartifier/lib/src/ast.dart
+++ b/pkgs/native_doc_dartifier/lib/src/ast.dart
@@ -27,9 +27,16 @@ class Class {
       getters = [],
       setters = [];
 
-  @override
-  String toString() =>
-      '''- ${isInterface ? 'interface ' : ''}${isAbstract ? 'abstract ' : ''}class $name ${extendedClass.isNotEmpty ? 'extends $extendedClass ' : ''}${implementedInterfaces.isNotEmpty ? 'implements ${implementedInterfaces.join(', ')} ' : ''}''';
+  String toDartLikeRepresentaion() => '''
+${isInterface ? 'interface ' : ''}${isAbstract ? 'abstract ' : ''}class $name ${extendedClass.isNotEmpty ? 'extends $extendedClass ' : ''}${implementedInterfaces.isNotEmpty ? 'implements ${implementedInterfaces.join(', ')} ' : ''}
+{
+${constructors.map((c) => '${c.toString()};').join('\n')}
+${fields.map((f) => '${f.toString()};').join('\n')}
+${methods.map((m) => '${m.toString()};').join('\n')}
+${getters.map((g) => '${g.toString()};').join('\n')}
+${setters.map((s) => '${s.toString()};').join('\n')}
+}
+''';
 
   void addField(Field field) {
     fields.add(field);
@@ -51,8 +58,7 @@ class Field {
 
   Field(this.name, this.type, {this.isStatic = false});
 
-  @override
-  String toString() => '${isStatic ? 'static ' : ''}$type $name';
+  String toDartLikeRepresentaion() => '${isStatic ? 'static ' : ''}$type $name';
 }
 
 class Method {
@@ -72,8 +78,7 @@ class Method {
     this.operatorKeyword = '',
   });
 
-  @override
-  String toString() {
+  String toDartLikeRepresentaion() {
     final staticPrefix = isStatic ? 'static ' : '';
     final operatorPrefix =
         operatorKeyword.isNotEmpty ? '$operatorKeyword ' : '';
@@ -91,10 +96,10 @@ class Constructor {
 
   Constructor(this.className, this.name, this.parameters, this.factoryKeyword);
 
-  @override
-  String toString() {
+  String toDartLikeRepresentaion() {
     final constructorName = name.isNotEmpty ? '$className.$name' : className;
-    return '${factoryKeyword ?? ''} $constructorName$parameters';
+    return '${factoryKeyword != null ? '$factoryKeyword ' : ''}'
+        '$constructorName$parameters';
   }
 }
 
@@ -105,8 +110,7 @@ class Getter {
 
   Getter(this.name, this.returnType, this.isStatic);
 
-  @override
-  String toString() {
+  String toDartLikeRepresentaion() {
     final staticPrefix = isStatic ? 'static ' : '';
     return '$staticPrefix$returnType get $name';
   }
@@ -120,8 +124,7 @@ class Setter {
 
   Setter(this.name, this.parameterType, this.isStatic, this.parameter);
 
-  @override
-  String toString() {
+  String toDartLikeRepresentaion() {
     final staticPrefix = isStatic ? 'static ' : '';
     return '$staticPrefix$parameterType set $name($parameter)';
   }

--- a/pkgs/native_doc_dartifier/lib/src/public_abstractor.dart
+++ b/pkgs/native_doc_dartifier/lib/src/public_abstractor.dart
@@ -2,9 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'ast.dart';
+
+String generateBindingsSummary(String sourceCode) {
+  final abstractor = PublicAbstractor();
+  parseString(content: sourceCode).unit.visitChildren(abstractor);
+  final summary = abstractor.getRepresentation();
+  return summary.replaceAll('jni\$_.', '').replaceAll('core\$_.', '');
+}
 
 class PublicAbstractor extends RecursiveAstVisitor<void> {
   final Map<String, Class> _classes = {};
@@ -134,11 +142,11 @@ class PublicAbstractor extends RecursiveAstVisitor<void> {
     );
   }
 
-  String generateClassRepresentation() {
+  String getRepresentation() {
     final buffer = StringBuffer();
 
     for (final classInfo in _classes.values) {
-      buffer.writeln(classInfo.toString());
+      buffer.writeln(classInfo.toDartLikeRepresentaion());
       buffer.writeln();
     }
     return buffer.toString();

--- a/pkgs/native_doc_dartifier/test/public_abstractor_test.dart
+++ b/pkgs/native_doc_dartifier/test/public_abstractor_test.dart
@@ -28,8 +28,6 @@ void main() {
       expect(classes['Bar']?.implementedInterfaces, isEmpty);
       expect(classes['Bar']?.extendedClass, isEmpty);
       expect(classes['Bar']?.isAbstract, isFalse);
-
-      expect(classes['Bar']?.toString(), '- class Bar ');
     });
 
     test('interface class and abstract class', () {
@@ -53,13 +51,11 @@ void main() {
       expect(classes['Bar']?.implementedInterfaces, isEmpty);
       expect(classes['Bar']?.isAbstract, isFalse);
       expect(classes['Bar']?.isInterface, isTrue);
-      expect(classes['Bar']?.toString(), '- interface class Bar ');
 
       expect(classes['Foo']?.name, 'Foo');
       expect(classes['Foo']?.implementedInterfaces, isEmpty);
       expect(classes['Foo']?.isAbstract, isTrue);
       expect(classes['Foo']?.isInterface, isFalse);
-      expect(classes['Foo']?.toString(), '- abstract class Foo ');
     });
 
     test('implements and extends classes', () {
@@ -79,11 +75,6 @@ void main() {
       expect(classes['Bar']?.extendedClass, '_Foo');
       expect(classes['Bar']?.isAbstract, isFalse);
       expect(classes['Bar']?.isInterface, isFalse);
-
-      expect(
-        classes['Bar']?.toString(),
-        '- class Bar extends _Foo implements Foo, _Baz ',
-      );
     });
   });
 


### PR DESCRIPTION
closes #2309 
This PR statically extracts public API signatures from Dart source code. The extracted information includes:

- Public class names
- Public Constructors
- Public methods
- Public fields
- Getters and setters

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.