### PR TITLE
[infra] Re-enable analyzer plugin for custom_lint

### DIFF
--- a/pkgs/code_assets/analysis_options.yaml
+++ b/pkgs/code_assets/analysis_options.yaml
@@ -8,7 +8,7 @@ analyzer:
     strict-inference: true
     strict-raw-types: true
   plugins:
-    # - custom_lint # https://github.com/dart-lang/sdk/issues/60784
+    - custom_lint
 
 linter:
   rules:

--- a/pkgs/data_assets/analysis_options.yaml
+++ b/pkgs/data_assets/analysis_options.yaml
@@ -8,7 +8,7 @@ analyzer:
     strict-inference: true
     strict-raw-types: true
   plugins:
-    # - custom_lint # https://github.com/dart-lang/sdk/issues/60784
+    - custom_lint
 
 linter:
   rules:

--- a/pkgs/hooks/analysis_options.yaml
+++ b/pkgs/hooks/analysis_options.yaml
@@ -8,7 +8,7 @@ analyzer:
     strict-inference: true
     strict-raw-types: true
   plugins:
-    # - custom_lint # https://github.com/dart-lang/sdk/issues/60784
+    - custom_lint
 
 linter:
   rules:

--- a/pkgs/hooks_runner/analysis_options.yaml
+++ b/pkgs/hooks_runner/analysis_options.yaml
@@ -8,7 +8,7 @@ analyzer:
     strict-inference: true
     strict-raw-types: true
   plugins:
-    # - custom_lint # https://github.com/dart-lang/sdk/issues/60784
+    - custom_lint
 
 linter:
   rules:

--- a/pkgs/json_syntax_generator/analysis_options.yaml
+++ b/pkgs/json_syntax_generator/analysis_options.yaml
@@ -8,7 +8,7 @@ analyzer:
     strict-inference: true
     strict-raw-types: true
   plugins:
-    # - custom_lint # https://github.com/dart-lang/sdk/issues/60784
+    - custom_lint
 
 linter:
   rules:

--- a/pkgs/native_toolchain_c/analysis_options.yaml
+++ b/pkgs/native_toolchain_c/analysis_options.yaml
@@ -8,7 +8,7 @@ analyzer:
     strict-inference: true
     strict-raw-types: true
   plugins:
-    # - custom_lint # https://github.com/dart-lang/sdk/issues/60784
+    - custom_lint
 
 linter:
   rules:

--- a/pkgs/repo_lint_rules/analysis_options.yaml
+++ b/pkgs/repo_lint_rules/analysis_options.yaml
@@ -8,7 +8,7 @@ analyzer:
     strict-inference: true
     strict-raw-types: true
   plugins:
-    # - custom_lint # https://github.com/dart-lang/sdk/issues/60784
+    - custom_lint
 
 linter:
   rules:


### PR DESCRIPTION
Looks like https://github.com/dart-lang/sdk/issues/60784 was fixed a while ago, so this can probably be re-enabled.