### PR TITLE
[native_toolchain_c] Support Module Definitions for linking on Windows

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.16.7
+
+* Support Module Definitions for linking on Windows.
+
 ## 0.16.6
 
 * Support linking for Windows.

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.16.6
+version: 0.16.7
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:

--- a/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
+++ b/pkgs/native_toolchain_c/test/clinker/build_testfiles.dart
@@ -15,6 +15,7 @@ Future<Uri> buildTestArchive(
   Uri tempUri2,
   OS targetOS,
   Architecture architecture, {
+  List<Uri>? extraSources,
   int? androidTargetNdkApi, // Must be specified iff targetOS is OS.android.
   int? macOSTargetVersion, // Must be specified iff targetOS is OS.macos.
   int? iOSTargetVersion, // Must be specified iff targetOS is OS.iOS.
@@ -77,7 +78,11 @@ Future<Uri> buildTestArchive(
   final cbuilder = CBuilder.library(
     name: name,
     assetName: '',
-    sources: [test1Uri.toFilePath(), test2Uri.toFilePath()],
+    sources: [
+      test1Uri.toFilePath(),
+      test2Uri.toFilePath(),
+      ...?extraSources?.map((src) => src.toFilePath()),
+    ],
     linkModePreference: LinkModePreference.static,
     buildMode: BuildMode.release,
   );

--- a/pkgs/native_toolchain_c/test/clinker/testfiles/linker/symbols.def
+++ b/pkgs/native_toolchain_c/test/clinker/testfiles/linker/symbols.def
@@ -1,0 +1,3 @@
+LIBRARY MyDLL
+EXPORTS
+    my_other_func

--- a/pkgs/native_toolchain_c/test/clinker/testfiles/linker/test3.c
+++ b/pkgs/native_toolchain_c/test/clinker/testfiles/linker/test3.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+// Explicitly not marked for export.
+void my_unexported_func()
+{
+  printf("Hello unexported World");
+}

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_helper.dart
@@ -39,9 +39,9 @@ void runTreeshakeTests(
       symbolsToKeep: ['my_other_func'],
       stripDebug: true,
       gcSections: true,
-      linkerScript: packageUri.resolve(
-        'test/clinker/testfiles/linker/symbols.lds',
-      ),
+      linkerScript: targetOS == OS.windows
+          ? packageUri.resolve('test/clinker/testfiles/linker/symbols.def')
+          : packageUri.resolve('test/clinker/testfiles/linker/symbols.lds'),
     ),
   );
   CLinker linkerAuto(List<String> sources) => CLinker.library(

--- a/pkgs/native_toolchain_c/test/clinker/windows_module_definition_cross_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/windows_module_definition_cross_test.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('windows')
+library;
+
+import 'dart:io';
+
+import 'package:code_assets/code_assets.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+import 'windows_module_definition_helper.dart';
+
+void main() {
+  if (!Platform.isWindows) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
+
+  final architectures = supportedArchitecturesFor(OS.current)
+    // See windows_module_definition_test.dart for current arch.
+    ..remove(Architecture.current);
+  runWindowsModuleDefinitionTests(architectures);
+}

--- a/pkgs/native_toolchain_c/test/clinker/windows_module_definition_helper.dart
+++ b/pkgs/native_toolchain_c/test/clinker/windows_module_definition_helper.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:code_assets/code_assets.dart';
+import 'package:hooks/hooks.dart';
+import 'package:native_toolchain_c/native_toolchain_c.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+import 'build_testfiles.dart';
+
+void runWindowsModuleDefinitionTests(List<Architecture> architectures) {
+  const name = 'mylibname';
+  const targetOS = OS.windows;
+
+  for (final architecture in architectures) {
+    test(
+      'Module definition script can export unexported function ($architecture)',
+      () async {
+        final tempUri = await tempDirForTest();
+        final tempUri2 = await tempDirForTest();
+
+        final uri = await buildTestArchive(
+          tempUri,
+          tempUri2,
+          targetOS,
+          architecture,
+          extraSources: [
+            packageUri.resolve('test/clinker/testfiles/linker/test3.c'),
+          ],
+        );
+
+        final linkInputBuilder = LinkInputBuilder()
+          ..setupShared(
+            packageName: 'testpackage',
+            packageRoot: tempUri,
+            outputFile: tempUri.resolve('output.json'),
+            outputDirectoryShared: tempUri2,
+          )
+          ..setupLink(assets: [], recordedUsesFile: null)
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: targetOS,
+              targetArchitecture: architecture,
+              linkModePreference: LinkModePreference.dynamic,
+              cCompiler: cCompiler,
+            ),
+          );
+
+        final linkInput = linkInputBuilder.build();
+        final linkOutput = LinkOutputBuilder();
+
+        printOnFailure(linkInput.config.code.cCompiler.toString());
+        printOnFailure(Platform.environment.keys.toList().toString());
+        await CLinker.library(
+          name: name,
+          assetName: '',
+          linkerOptions: LinkerOptions.treeshake(
+            symbols: ['my_func', 'my_unexported_func'],
+          ),
+          sources: [uri.toFilePath()],
+        ).run(input: linkInput, output: linkOutput, logger: logger);
+
+        final codeAssets = LinkOutput(linkOutput.json).assets.code;
+        expect(codeAssets, hasLength(1));
+        final asset = codeAssets.first;
+        expect(asset, isA<CodeAsset>());
+        final symbols = await readSymbols(asset, targetOS);
+        final skipReason = symbols == null
+            ? 'tool to extract symbols unavailable'
+            : false;
+        expect(symbols, contains('my_func'), skip: skipReason);
+        // Module Definition file causes my_unexported_func to be exported even
+        // though it wasn't marked for export.
+        expect(symbols, contains('my_unexported_func'), skip: skipReason);
+        expect(symbols, isNot(contains('my_other_func')), skip: skipReason);
+      },
+    );
+  }
+}

--- a/pkgs/native_toolchain_c/test/clinker/windows_module_definition_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/windows_module_definition_test.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('windows')
+library;
+
+import 'dart:io';
+
+import 'package:code_assets/code_assets.dart';
+import 'package:test/test.dart';
+
+import 'windows_module_definition_helper.dart';
+
+void main() {
+  if (!Platform.isWindows) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
+  runWindowsModuleDefinitionTests([Architecture.current]);
+}


### PR DESCRIPTION
Towards https://github.com/dart-lang/i18n/issues/987.

Module Definitions specify which functions will be exported from the treeshaken DLL. We have implement a similar functionality on Linux with linker scripts. This change builds on top of that for Windows.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
