### PR TITLE
[ffigen] Fix flutter CI

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/library.dart
+++ b/pkgs/ffigen/lib/src/code_generator/library.dart
@@ -8,6 +8,7 @@ import 'package:logging/logging.dart';
 import 'package:yaml_edit/yaml_edit.dart';
 
 import '../code_generator.dart';
+import '../code_generator/utils.dart';
 import '../config_provider/config.dart' show Config;
 import '../config_provider/config_types.dart';
 
@@ -96,7 +97,7 @@ class Library {
     if (!file.existsSync()) file.createSync(recursive: true);
     file.writeAsStringSync(generate());
     if (format) {
-      final result = Process.runSync(Platform.resolvedExecutable, [
+      final result = Process.runSync(dartExecutable, [
         'format',
         file.absolute.path,
       ], workingDirectory: file.parent.absolute.path);

--- a/pkgs/ffigen/lib/src/code_generator/utils.dart
+++ b/pkgs/ffigen/lib/src/code_generator/utils.dart
@@ -81,7 +81,9 @@ int fnvHash32(String input) {
 /// This is usually just Platform.resolvedExecutable. But when running flutter
 /// tests, the resolvedExecutable will be flutter_tester, and Dart will be in a
 /// directory a few levels up from it.
-String findDart() {
+final String dartExecutable = _findDart();
+
+String _findDart() {
   var path = Platform.resolvedExecutable;
   if (p.basenameWithoutExtension(path) == 'dart') return path;
   final dartExe = 'dart${p.extension(path)}';


### PR DESCRIPTION
When formatting the generated Dart code using `dart format`, we can't assume that `Platform.resolvedExecutable` will be the dart executable. For flutter tests it's `flutter_tester`. In fact there's already a util in ffigen that solves this problem.

Fixes #2388