### PR TITLE
[infra] clean up analysis options files

### DIFF
--- a/pkgs/code_assets/analysis_options.yaml
+++ b/pkgs/code_assets/analysis_options.yaml
@@ -1,11 +1,7 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
-  errors:
-    todo: ignore
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true
   plugins:
     # - custom_lint # https://github.com/dart-lang/sdk/issues/60784
@@ -13,7 +9,6 @@ analyzer:
 linter:
   rules:
     - avoid_positional_boolean_parameters
-    - dangling_library_doc_comments
     - public_member_api_docs
     - prefer_const_declarations
     - prefer_expression_function_bodies

--- a/pkgs/data_assets/analysis_options.yaml
+++ b/pkgs/data_assets/analysis_options.yaml
@@ -1,11 +1,7 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
-  errors:
-    todo: ignore
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true
   plugins:
     # - custom_lint # https://github.com/dart-lang/sdk/issues/60784
@@ -13,7 +9,6 @@ analyzer:
 linter:
   rules:
     - avoid_positional_boolean_parameters
-    - dangling_library_doc_comments
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_in_for_each

--- a/pkgs/ffi/analysis_options.yaml
+++ b/pkgs/ffi/analysis_options.yaml
@@ -1,11 +1,7 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
-  errors:
-    todo: ignore
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true
 
 linter:

--- a/pkgs/ffigen/analysis_options.yaml
+++ b/pkgs/ffigen/analysis_options.yaml
@@ -5,8 +5,6 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
-  errors:
-    todo: ignore
   exclude:
     - 'test/**_expected*'
 
@@ -17,14 +15,9 @@ analyzer:
     - test_flutter/native_objc_test/**
     - test/native_objc_test/**
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true
 
 linter:
   rules:
-    dangling_library_doc_comments: true
-    directives_ordering: true
     prefer_final_locals: true
     prefer_final_in_for_each: true
-    use_super_parameters: true

--- a/pkgs/hooks/analysis_options.yaml
+++ b/pkgs/hooks/analysis_options.yaml
@@ -1,11 +1,7 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
-  errors:
-    todo: ignore
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true
   plugins:
     # - custom_lint # https://github.com/dart-lang/sdk/issues/60784
@@ -13,7 +9,6 @@ analyzer:
 linter:
   rules:
     - avoid_positional_boolean_parameters
-    - dangling_library_doc_comments
     - public_member_api_docs
     - prefer_const_declarations
     - prefer_expression_function_bodies

--- a/pkgs/hooks/example/link/app_with_asset_treeshaking/analysis_options.yaml
+++ b/pkgs/hooks/example/link/app_with_asset_treeshaking/analysis_options.yaml
@@ -1,30 +1,4 @@
-# This file configures the static analysis results for your project (errors,
-# warnings, and lints).
-#
-# This enables the 'recommended' set of lints from `package:lints`.
-# This set helps identify many issues that may lead to problems when running
-# or consuming Dart code, and enforces writing Dart using a single, idiomatic
-# style and format.
-#
-# If you want a smaller set of lints you can change this to specify
-# 'package:lints/core.yaml'. These are just the most critical lints
-# (the recommended set includes the core lints).
-# The core lints are also what is used by pub.dev for scoring packages.
-
 include: package:lints/recommended.yaml
-
-# Uncomment the following section to specify additional rules.
-
-# linter:
-#   rules:
-#     - camel_case_types
-
-# analyzer:
-#   exclude:
-#     - path/to/excluded/files/**
-
-# For more information about the core and recommended set of lints, see
-# https://dart.dev/go/core-lints
 
 # For additional information about configuring this file, see
 # https://dart.dev/guides/language/analysis-options

--- a/pkgs/hooks_runner/analysis_options.yaml
+++ b/pkgs/hooks_runner/analysis_options.yaml
@@ -1,11 +1,7 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
-  errors:
-    todo: ignore
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true
   plugins:
     # - custom_lint # https://github.com/dart-lang/sdk/issues/60784
@@ -13,7 +9,6 @@ analyzer:
 linter:
   rules:
     - avoid_positional_boolean_parameters
-    - dangling_library_doc_comments
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_in_for_each

--- a/pkgs/hooks_runner/test_data/native_add_version_skew/analysis_options.yaml
+++ b/pkgs/hooks_runner/test_data/native_add_version_skew/analysis_options.yaml
@@ -1,17 +1,12 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
-  errors:
-    todo: ignore
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true
 
 linter:
   rules:
     - avoid_positional_boolean_parameters
-    - dangling_library_doc_comments
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_in_for_each

--- a/pkgs/hooks_runner/test_data/native_add_version_skew_2/analysis_options.yaml
+++ b/pkgs/hooks_runner/test_data/native_add_version_skew_2/analysis_options.yaml
@@ -1,17 +1,12 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
-  errors:
-    todo: ignore
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true
 
 linter:
   rules:
     - avoid_positional_boolean_parameters
-    - dangling_library_doc_comments
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_in_for_each

--- a/pkgs/json_syntax_generator/analysis_options.yaml
+++ b/pkgs/json_syntax_generator/analysis_options.yaml
@@ -1,11 +1,7 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
-  errors:
-    todo: ignore
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true
   plugins:
     # - custom_lint # https://github.com/dart-lang/sdk/issues/60784
@@ -13,7 +9,6 @@ analyzer:
 linter:
   rules:
     - avoid_positional_boolean_parameters
-    - dangling_library_doc_comments
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_in_for_each

--- a/pkgs/native_test_helpers/analysis_options.yaml
+++ b/pkgs/native_test_helpers/analysis_options.yaml
@@ -1,11 +1,7 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
-  errors:
-    todo: ignore
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true
   plugins:
     # - custom_lint # https://github.com/dart-lang/sdk/issues/60784
@@ -13,13 +9,10 @@ analyzer:
 linter:
   rules:
     - avoid_positional_boolean_parameters
-    - dangling_library_doc_comments
-    - directives_ordering
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_in_for_each
     - prefer_final_locals
-    - use_super_parameters
 
 custom_lint:
   rules:

--- a/pkgs/native_toolchain_c/analysis_options.yaml
+++ b/pkgs/native_toolchain_c/analysis_options.yaml
@@ -1,11 +1,7 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
-  errors:
-    todo: ignore
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true
   plugins:
     # - custom_lint # https://github.com/dart-lang/sdk/issues/60784
@@ -13,7 +9,6 @@ analyzer:
 linter:
   rules:
     - avoid_positional_boolean_parameters
-    - dangling_library_doc_comments
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_in_for_each

--- a/pkgs/objective_c/analysis_options.yaml
+++ b/pkgs/objective_c/analysis_options.yaml
@@ -1,9 +1,5 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
-  errors:
-    todo: ignore
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true

--- a/pkgs/objective_c/example/analysis_options.yaml
+++ b/pkgs/objective_c/example/analysis_options.yaml
@@ -1,6 +1,4 @@
 include: package:flutter_lints/flutter.yaml
 
-analyzer:
-  language:
-    strict-casts: true
-    strict-inference: true
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/pkgs/repo_lint_rules/analysis_options.yaml
+++ b/pkgs/repo_lint_rules/analysis_options.yaml
@@ -1,11 +1,7 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
-  errors:
-    todo: ignore
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true
   plugins:
     # - custom_lint # https://github.com/dart-lang/sdk/issues/60784
@@ -13,7 +9,6 @@ analyzer:
 linter:
   rules:
     - avoid_positional_boolean_parameters
-    - dangling_library_doc_comments
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_in_for_each

--- a/pkgs/swift2objc/analysis_options.yaml
+++ b/pkgs/swift2objc/analysis_options.yaml
@@ -2,6 +2,4 @@ include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true

--- a/pkgs/swiftgen/analysis_options.yaml
+++ b/pkgs/swiftgen/analysis_options.yaml
@@ -2,6 +2,4 @@ include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true


### PR DESCRIPTION
This removes the following from the analysis options files:

- boilerplate comments
- options that are already enabled by imported analysis options files
- the ignore for TODOs since the analyzer has been fixed to no longer complain about these.

Clean-up powered by Gemini CLI.

This PR cleans up all packages except for jni, jnigen and native_doc_dartifier. Those packages are dealt with in https://github.com/dart-lang/native/pull/2411 and https://github.com/dart-lang/native/pull/2412.