### PR TITLE
[ffigen] Prepare to publish v19.1.0

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 19.1.0-wip
+## 19.1.0
 
 - Bump minimum Dart version to 3.8.0.
 - Format using `dart format` so that the formatter uses the target package's

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 19.1.0-wip
+version: 19.1.0
 description: >
   Generator for FFI bindings, using LibClang to parse C, Objective-C, and Swift
   files.

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 8.1.0-wip
+## 8.1.0
 
 - Bump minimum Dart version to 3.8.0.
 - Support the KVO pattern by adding `Observer`, `Observation`, and

--- a/pkgs/objective_c/pubspec.yaml
+++ b/pkgs/objective_c/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: objective_c
 description: 'A library to access Objective C from Flutter that acts as a support library for package:ffigen.'
-version: 8.1.0-wip
+version: 8.1.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/objective_c
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aobjective_c
 


### PR DESCRIPTION
#2409 is a breaking change, and I don't plan to release v20 for a while, so publish v19.1 first.