### PR TITLE
[native_doc_dartifier] Clean up analysis option file

### DIFF
--- a/pkgs/native_doc_dartifier/analysis_options.yaml
+++ b/pkgs/native_doc_dartifier/analysis_options.yaml
@@ -1,16 +1,11 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
-  errors:
-    todo: ignore
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true
 
 linter:
   rules:
-    - dangling_library_doc_comments
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_in_for_each


### PR DESCRIPTION
Follow-up to https://github.com/dart-lang/native/pull/2407

This removes the following from the analysis options files:

- boilerplate comments
- options that are already enabled by imported analysis options files
- the ignore for TODOs since the analyzer has been fixed to no longer complain about these.

Clean-up powered by Gemini CLI.