### PR TITLE
[jnigen] clean up analysis option files

### DIFF
--- a/pkgs/jni/analysis_options.yaml
+++ b/pkgs/jni/analysis_options.yaml
@@ -1,16 +1,11 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
-  errors:
-    todo: ignore
   exclude: [build/**, third_party/**]
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true
 
 linter:
   rules:
-    dangling_library_doc_comments: true
     prefer_final_locals: true
     prefer_const_declarations: true

--- a/pkgs/jni/example/analysis_options.yaml
+++ b/pkgs/jni/example/analysis_options.yaml
@@ -1,12 +1,3 @@
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
-
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
@@ -15,22 +6,9 @@ analyzer:
     strict-raw-types: true
 
 linter:
-  # The lint rules applied to this project can be customized in the
-  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
-  # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at
-  # https://dart-lang.github.io/linter/lints/index.html.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
   rules:
-    - dangling_library_doc_comments
     - prefer_final_locals
     - prefer_const_declarations
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/pkgs/jnigen/analysis_options.yaml
+++ b/pkgs/jnigen/analysis_options.yaml
@@ -5,16 +5,11 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
-  errors:
-    todo: ignore
   exclude: [build/**, example/**]
   language:
-    strict-casts: true
-    strict-inference: true
     strict-raw-types: true
 
 linter:
   rules:
-    dangling_library_doc_comments: true
     prefer_final_locals: true
     prefer_const_declarations: true

--- a/pkgs/jnigen/android_test_runner/analysis_options.yaml
+++ b/pkgs/jnigen/android_test_runner/analysis_options.yaml
@@ -1,29 +1,4 @@
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
-
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
-linter:
-  # The lint rules applied to this project can be customized in the
-  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
-  # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at
-  # https://dart-lang.github.io/linter/lints/index.html.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
-  rules:
-    - dangling_library_doc_comments
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/pkgs/jnigen/example/in_app_java/analysis_options.yaml
+++ b/pkgs/jnigen/example/in_app_java/analysis_options.yaml
@@ -1,29 +1,4 @@
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
-
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
-linter:
-  # The lint rules applied to this project can be customized in the
-  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
-  # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at
-  # https://dart-lang.github.io/linter/lints/index.html.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
-  rules:
-    - dangling_library_doc_comments
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/pkgs/jnigen/example/kotlin_plugin/analysis_options.yaml
+++ b/pkgs/jnigen/example/kotlin_plugin/analysis_options.yaml
@@ -1,1 +1,4 @@
 include: package:flutter_lints/flutter.yaml
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/pkgs/jnigen/example/kotlin_plugin/example/analysis_options.yaml
+++ b/pkgs/jnigen/example/kotlin_plugin/example/analysis_options.yaml
@@ -1,29 +1,4 @@
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
-
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
-
-linter:
-  # The lint rules applied to this project can be customized in the
-  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
-  # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at
-  # https://dart-lang.github.io/linter/lints/index.html.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
-  rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/pkgs/jnigen/example/notification_plugin/example/analysis_options.yaml
+++ b/pkgs/jnigen/example/notification_plugin/example/analysis_options.yaml
@@ -1,29 +1,4 @@
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
-
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
-linter:
-  # The lint rules applied to this project can be customized in the
-  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
-  # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at
-  # https://dart-lang.github.io/linter/lints/index.html.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
-  rules:
-    - dangling_library_doc_comments
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/pkgs/jnigen/example/pdfbox_plugin/analysis_options.yaml
+++ b/pkgs/jnigen/example/pdfbox_plugin/analysis_options.yaml
@@ -1,4 +1,4 @@
-#include: package:flutter_lints/flutter.yaml
+include: package:lints/recommended.yaml
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/pkgs/jnigen/example/pdfbox_plugin/dart_example/analysis_options.yaml
+++ b/pkgs/jnigen/example/pdfbox_plugin/dart_example/analysis_options.yaml
@@ -1,31 +1,4 @@
-# This file configures the static analysis results for your project (errors,
-# warnings, and lints).
-#
-# This enables the 'recommended' set of lints from `package:lints`.
-# This set helps identify many issues that may lead to problems when running
-# or consuming Dart code, and enforces writing Dart using a single, idiomatic
-# style and format.
-#
-# If you want a smaller set of lints you can change this to specify
-# 'package:lints/core.yaml'. These are just the most critical lints
-# (the recommended set includes the core lints).
-# The core lints are also what is used by pub.dev for scoring packages.
-
 include: package:lints/recommended.yaml
-
-# Uncomment the following section to specify additional rules.
-
-linter:
-  rules:
-    - dangling_library_doc_comments
-#     - camel_case_types
-
-# analyzer:
-#   exclude:
-#     - path/to/excluded/files/**
-
-# For more information about the core and recommended set of lints, see
-# https://dart.dev/go/core-lints
 
 # For additional information about configuring this file, see
 # https://dart.dev/guides/language/analysis-options

--- a/pkgs/jnigen/example/pdfbox_plugin/example/analysis_options.yaml
+++ b/pkgs/jnigen/example/pdfbox_plugin/example/analysis_options.yaml
@@ -1,29 +1,4 @@
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
-
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
-linter:
-  # The lint rules applied to this project can be customized in the
-  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
-  # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at
-  # https://dart-lang.github.io/linter/lints/index.html.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
-  rules:
-    - dangling_library_doc_comments
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/pdfbox_plugin.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/pdfbox_plugin.dart
@@ -1,5 +1,5 @@
 /// File merely exporting the generated bindings from lib/src/third_party
-library pdfbox_plugin;
+library;
 
 export 'src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart';
 export 'src/third_party/org/apache/pdfbox/pdmodel/PDDocumentInformation.dart';


### PR DESCRIPTION
Follow-up to https://github.com/dart-lang/native/pull/2407

This removes the following from the analysis options files:

- boilerplate comments
- options that are already enabled by imported analysis options files
- the ignore for TODOs since the analyzer has been fixed to no longer complain about these.

Clean-up powered by Gemini CLI.