### PR TITLE
[infra] Remove version argument to java formatter

### DIFF
--- a/.github/workflows/jnigen.yaml
+++ b/.github/workflows/jnigen.yaml
@@ -49,7 +49,6 @@ jobs:
       - uses: axel-op/googlejavaformat-action@c1134ebd196c4cbffb077f9476585b0be8b6afcd
         name: 'Check Java formatting with google-java-format'
         with:
-          version: 'v1.24.0'
           args: '--set-exit-if-changed'
       - id: install
         name: Install dependencies
@@ -167,7 +166,6 @@ jobs:
       - uses: axel-op/googlejavaformat-action@c1134ebd196c4cbffb077f9476585b0be8b6afcd
         name: 'Check Java formatting with google-java-format'
         with:
-          version: 'v1.24.0'
           args: '--set-exit-if-changed'
       - name: install clang tools & CMake
         run: |


### PR DESCRIPTION
The check complains about the `version` argument:

> Warning: Unexpected input(s) 'version', valid inputs are ['args', 'files', 'files-excluded', 'skip-commit', 'release-name', 'github-token', 'commit-message']

It is indeed not an available argument: https://github.com/axel-op/googlejavaformat-action. Other than that, the formatter seems to be configured correctly.

I also double checked that we are using the latest version of the formatter. No newer version is currently available.