### PR TITLE
[native_doc_dartifier] Retry loop to fix compile errors of generated snippets

### DIFF
--- a/pkgs/native_doc_dartifier/lib/src/code_processor.dart
+++ b/pkgs/native_doc_dartifier/lib/src/code_processor.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+class CodeProcessor {
+  final Directory _tempDir;
+  final String _dartifiedCodeFileName = 'dartified_code.dart';
+  final String _helperCodeFileName = 'helper_code.dart';
+
+  CodeProcessor() : _tempDir = Directory('${Directory.current.path}/temp') {
+    if (!_tempDir.existsSync()) {
+      _tempDir.createSync(recursive: true);
+    }
+  }
+
+  Future<String> analyzeCode(String mainCode, String helperCode) async {
+    await _saveCodeToFile(mainCode, helperCode);
+    final dartifiedFile = File('${_tempDir.path}/$_dartifiedCodeFileName');
+    final analysisResult = await Process.run('dart', [
+      'analyze',
+      dartifiedFile.absolute.path,
+    ], runInShell: true);
+
+    var errorMessage = '';
+    if (analysisResult.exitCode != 0) {
+      print('Dart analysis found issues:');
+      final allLines = analysisResult.stdout.toString().trim().split('\n');
+      final errorLines =
+          allLines.where((line) => line.trim().startsWith('error -')).toList();
+
+      errorMessage = errorLines.join('\n');
+      print(errorMessage);
+    } else {
+      print('Dart analysis completed successfully with no errors.');
+    }
+    await _cleanUp();
+    return errorMessage;
+  }
+
+  Future<void> _saveCodeToFile(String mainCode, String helperCode) async {
+    try {
+      final dartifiedFile = File('${_tempDir.path}/$_dartifiedCodeFileName');
+      await dartifiedFile.writeAsString(mainCode);
+
+      final helperFile = File('${_tempDir.path}/$_helperCodeFileName');
+      await helperFile.writeAsString(helperCode);
+    } catch (e) {
+      print('Error saving code to file: $e');
+    }
+  }
+
+  String addImports(String code, List<String> imports) {
+    final buffer = StringBuffer();
+    for (final import in imports) {
+      buffer.writeln("import '$import';");
+    }
+    buffer.writeln("import '$_helperCodeFileName';");
+    buffer.writeln();
+    buffer.write(code);
+    return buffer.toString();
+  }
+
+  Future<void> _cleanUp() async {
+    try {
+      if (await _tempDir.exists()) {
+        final files = _tempDir.listSync().whereType<File>();
+        for (final file in files) {
+          await file.delete();
+        }
+      }
+    } catch (e) {
+      print('Error cleaning up temporary directory: $e');
+    }
+  }
+}

--- a/pkgs/native_doc_dartifier/lib/src/code_processor.dart
+++ b/pkgs/native_doc_dartifier/lib/src/code_processor.dart
@@ -25,7 +25,6 @@ class CodeProcessor {
 
     var errorMessage = '';
     if (analysisResult.exitCode != 0) {
-      print('Dart analysis found issues:');
       final allLines = analysisResult.stdout.toString().trim().split('\n');
       final errorLines =
           allLines.where((line) => line.trim().startsWith('error -')).toList();
@@ -60,6 +59,12 @@ class CodeProcessor {
     buffer.writeln();
     buffer.write(code);
     return buffer.toString();
+  }
+
+  String removeImports(String code) {
+    final lines = code.split('\n');
+    final filteredLines = lines.where((line) => !line.startsWith('import'));
+    return filteredLines.join('\n');
   }
 
   Future<void> _cleanUp() async {

--- a/pkgs/native_doc_dartifier/lib/src/dartify_code.dart
+++ b/pkgs/native_doc_dartifier/lib/src/dartify_code.dart
@@ -4,13 +4,14 @@
 
 import 'dart:io';
 import 'package:google_generative_ai/google_generative_ai.dart';
+import 'code_processor.dart';
 import 'prompts.dart';
 import 'public_abstractor.dart';
 
 Future<String> dartifyNativeCode(String sourceCode, String bindingsPath) async {
-  final file = File(bindingsPath);
+  final bindingsFile = File(bindingsPath);
 
-  if (!await file.exists()) {
+  if (!await bindingsFile.exists()) {
     stderr.writeln('File not found: $bindingsPath');
     exit(1);
   }
@@ -22,7 +23,7 @@ Future<String> dartifyNativeCode(String sourceCode, String bindingsPath) async {
     exit(1);
   }
 
-  final bindings = await file.readAsString();
+  final bindings = await bindingsFile.readAsString();
 
   final model = GenerativeModel(
     model: 'gemini-2.0-flash',
@@ -41,12 +42,35 @@ Future<String> dartifyNativeCode(String sourceCode, String bindingsPath) async {
     generateBindingsSummary(bindings),
   );
 
-  print('Prompt:\n${translatePrompt.prompt}\n');
+  final chatSession = model.startChat();
 
-  final content = [Content.text(translatePrompt.prompt)];
+  final response = await chatSession.sendMessage(
+    Content.text(translatePrompt.prompt),
+  );
+  var mainCode = translatePrompt.getParsedResponse(response.text ?? '');
+  var helperCode = '';
 
-  final response = await model.generateContent(content);
-  final dartCode = translatePrompt.getParsedResponse(response.text ?? '');
+  final codeProcessor = CodeProcessor();
+  mainCode = codeProcessor.addImports(mainCode, [
+    'package:jni/jni.dart',
+    bindingsFile.path,
+  ]);
 
-  return dartCode;
+  for (var i = 0; i < 3; i++) {
+    final errorMessage = await codeProcessor.analyzeCode(mainCode, helperCode);
+    if (errorMessage.isEmpty) {
+      break;
+    }
+    stderr.writeln('Dart analysis found issues: $errorMessage');
+    final fixPrompt = FixPrompt(mainCode, helperCode, errorMessage);
+    final fixResponse = await chatSession.sendMessage(
+      Content.text(fixPrompt.prompt),
+    );
+    final fixedCode = fixPrompt.getParsedResponse(fixResponse.text ?? '');
+
+    mainCode = fixedCode.mainCode;
+    helperCode = fixedCode.helperCode;
+  }
+
+  return mainCode;
 }

--- a/pkgs/native_doc_dartifier/lib/src/dartify_code.dart
+++ b/pkgs/native_doc_dartifier/lib/src/dartify_code.dart
@@ -71,6 +71,6 @@ Future<String> dartifyNativeCode(String sourceCode, String bindingsPath) async {
     mainCode = fixedCode.mainCode;
     helperCode = fixedCode.helperCode;
   }
-
+  mainCode = codeProcessor.removeImports(mainCode);
   return mainCode;
 }

--- a/pkgs/native_doc_dartifier/tool/prepare_dartify_test.dart
+++ b/pkgs/native_doc_dartifier/tool/prepare_dartify_test.dart
@@ -59,7 +59,10 @@ void compileJavaPackage() {
 void generateDartSnippets() async {
   for (final snippet in snippets) {
     final sourceCode = snippet['code'] as String;
-    final dartCode = await dartifyNativeCode(sourceCode, bindingsPath);
+    final dartCode = await dartifyNativeCode(
+      sourceCode,
+      File(bindingsPath).absolute.path,
+    );
     final fileName = snippet['fileName'];
     final outputFile = File('$workingDir/$dartifiedSnippetsDir/$fileName');
     if (!outputFile.parent.existsSync()) {


### PR DESCRIPTION
closes #2401
- Added a simple **retry loop** that attempts to fix **compilation errors** in the generated Dart snippets.
  - Uses a `helper.dart` file to inject additional initialization or logic when needed.
  - Also allows modifying the original generated snippet directly.
  - Retries up to **3 times**, or until compilation passes.

- Switched to using a **chat-based interface** instead of independent prompts.
  - This gives the LLM **context across turns**, including:
    - The original JNI bindings provided earlier.
    - Previous attempts and corresponding compilation errors.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.