### PR TITLE
[native_toolchain_c] Skip `rust_test` without Rust

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.17.1-wip
+
+* Skip Rust test when no toolchain is installed.
+
 ## 0.17.0
 
 * Fix treeshaking on mac.

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.17.0
+version: 0.17.1-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:


### PR DESCRIPTION
This time using a `try-catch` instead of just checking the exit code - this didn't seem to work on Dart CI.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
