### PR TITLE
[hooks] Cleanup encoded assets encoding

### DIFF
--- a/pkgs/code_assets/CHANGELOG.md
+++ b/pkgs/code_assets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.19.5-wip
+
+- Bump `package:hooks` to 0.20.0.
+
 ## 0.19.4
 
 * Add doc comments to all public members.

--- a/pkgs/code_assets/lib/src/code_assets/code_asset.dart
+++ b/pkgs/code_assets/lib/src/code_assets/code_asset.dart
@@ -89,7 +89,7 @@ final class CodeAsset {
     assert(asset.isCodeAsset);
     final syntaxNode = NativeCodeAssetEncodingSyntax.fromJson(
       asset.encoding,
-      path: asset.jsonPath ?? [],
+      path: asset.encodingJsonPath ?? [],
     );
     return CodeAsset._(
       id: syntaxNode.id,

--- a/pkgs/code_assets/lib/src/code_assets/validation.dart
+++ b/pkgs/code_assets/lib/src/code_assets/validation.dart
@@ -194,7 +194,7 @@ ValidationErrors _validateCodeAssetSyntax(EncodedAsset encodedAsset) {
   }
   final syntaxNode = NativeCodeAssetEncodingSyntax.fromJson(
     encodedAsset.encoding,
-    path: encodedAsset.jsonPath ?? [],
+    path: encodedAsset.encodingJsonPath ?? [],
   );
   final syntaxErrors = syntaxNode.validate();
   if (syntaxErrors.isEmpty) {

--- a/pkgs/code_assets/pubspec.yaml
+++ b/pkgs/code_assets/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   This library contains the hook protocol specification for bundling native code
   with Dart packages.
 
-version: 0.19.4
+version: 0.19.5-wip
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/code_assets
 
@@ -21,7 +21,7 @@ environment:
 
 dependencies:
   collection: ^1.19.1
-  hooks: ^0.19.5
+  hooks: ^0.20.0-wip
 
 dev_dependencies:
   custom_lint: ^0.7.5

--- a/pkgs/data_assets/CHANGELOG.md
+++ b/pkgs/data_assets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.19.2-wip
+
+- Bump `package:hooks` to 0.20.0.
+
 ## 0.19.1
 
 * Bump the SDK constraint to at least the one from `package:hooks` to fix

--- a/pkgs/data_assets/lib/src/data_assets/data_asset.dart
+++ b/pkgs/data_assets/lib/src/data_assets/data_asset.dart
@@ -47,7 +47,7 @@ final class DataAsset {
     assert(asset.isDataAsset);
     final syntaxNode = DataAssetEncodingSyntax.fromJson(
       asset.encoding,
-      path: asset.jsonPath ?? [],
+      path: asset.encodingJsonPath ?? [],
     );
     return DataAsset(
       file: syntaxNode.file,

--- a/pkgs/data_assets/lib/src/data_assets/validation.dart
+++ b/pkgs/data_assets/lib/src/data_assets/validation.dart
@@ -107,7 +107,7 @@ ValidationErrors _validateDataAssetSyntax(EncodedAsset encodedAsset) {
   }
   final syntaxNode = DataAssetEncodingSyntax.fromJson(
     encodedAsset.encoding,
-    path: encodedAsset.jsonPath ?? [],
+    path: encodedAsset.encodingJsonPath ?? [],
   );
   final syntaxErrors = syntaxNode.validate();
   if (syntaxErrors.isEmpty) {

--- a/pkgs/data_assets/pubspec.yaml
+++ b/pkgs/data_assets/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   This library contains the hook protocol specification for bundling data assets
   with Dart packages.
 
-version: 0.19.1
+version: 0.19.2-wip
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/data_assets
 
@@ -17,7 +17,7 @@ environment:
   sdk: '>=3.9.0-21.0.dev <4.0.0'
 
 dependencies:
-  hooks: ^0.19.5
+  hooks: ^0.20.0-wip
 
 dev_dependencies:
   custom_lint: ^0.7.5

--- a/pkgs/hooks/CHANGELOG.md
+++ b/pkgs/hooks/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.20.0-wip
+
+* **Breaking change**  Rename `EncodedAsset.jsonPath` to
+  `EncodedAsset.encodingJsonPath`. This field only governs the `EncodedAsset.encoding` field, not the whole object.
+
 ## 0.19.5
 
 * Stop leaking unexported symbols.

--- a/pkgs/hooks/lib/src/config.dart
+++ b/pkgs/hooks/lib/src/config.dart
@@ -277,10 +277,7 @@ final class BuildInputBuilder extends HookInputBuilder {
           ? null
           : {
               for (final MapEntry(:key, :value) in assets.entries)
-                key: [
-                  for (final asset in value)
-                    AssetSyntax.fromJson(asset.toJson()),
-                ],
+                key: [for (final asset in value) asset.toSyntax()],
             },
     );
   }
@@ -378,9 +375,7 @@ final class LinkInputBuilder extends HookInputBuilder {
     required Uri? recordedUsesFile,
   }) {
     _syntax.setup(
-      assets: [
-        for (final asset in assets) AssetSyntax.fromJson(asset.toJson()),
-      ],
+      assets: [for (final asset in assets) asset.toSyntax()],
       resourceIdentifiers: recordedUsesFile,
     );
   }
@@ -696,19 +691,17 @@ final class BuildOutputAssetsBuilder {
     switch (routing) {
       case ToAppBundle():
         final assets = _syntax.assets ?? [];
-        assets.add(AssetSyntax.fromJson(asset.toJson()));
+        assets.add(asset.toSyntax());
         _syntax.assets = assets;
       case ToBuildHooks():
         final assets = _syntax.assetsForBuild ?? [];
-        assets.add(AssetSyntax.fromJson(asset.toJson()));
+        assets.add(asset.toSyntax());
         _syntax.assetsForBuild = assets;
       case ToLinkHook():
         final packageName = routing.packageName;
         final assetsForLinking = _syntax.assetsForLinking ?? {};
         assetsForLinking[packageName] ??= [];
-        assetsForLinking[packageName]!.add(
-          AssetSyntax.fromJson(asset.toJson()),
-        );
+        assetsForLinking[packageName]!.add(asset.toSyntax());
         _syntax.assetsForLinking = assetsForLinking;
     }
   }
@@ -736,13 +729,13 @@ final class BuildOutputAssetsBuilder {
       case ToAppBundle():
         final list = _syntax.assets ?? [];
         for (final asset in assets) {
-          list.add(AssetSyntax.fromJson(asset.toJson()));
+          list.add(asset.toSyntax());
         }
         _syntax.assets = list;
       case ToBuildHooks():
         final list = _syntax.assetsForBuild ?? [];
         for (final asset in assets) {
-          list.add(AssetSyntax.fromJson(asset.toJson()));
+          list.add(asset.toSyntax());
         }
         _syntax.assetsForBuild = list;
       case ToLinkHook():
@@ -750,7 +743,7 @@ final class BuildOutputAssetsBuilder {
         final assetsForLinking = _syntax.assetsForLinking ?? {};
         final list = assetsForLinking[linkInPackage] ??= [];
         for (final asset in assets) {
-          list.add(AssetSyntax.fromJson(asset.toJson()));
+          list.add(asset.toSyntax());
         }
         _syntax.assetsForLinking = assetsForLinking;
     }
@@ -827,7 +820,7 @@ final class LinkOutputAssetsBuilder {
   /// ```
   void addEncodedAsset(EncodedAsset asset) {
     final list = _syntax.assets ?? [];
-    list.add(AssetSyntax.fromJson(asset.toJson()));
+    list.add(asset.toSyntax());
     _syntax.assets = list;
   }
 
@@ -847,7 +840,7 @@ final class LinkOutputAssetsBuilder {
   void addEncodedAssets(Iterable<EncodedAsset> assets) {
     final list = _syntax.assets ?? [];
     for (final asset in assets) {
-      list.add(AssetSyntax.fromJson(asset.toJson()));
+      list.add(asset.toSyntax());
     }
     _syntax.assets = list;
   }

--- a/pkgs/hooks/lib/src/encoded_asset.dart
+++ b/pkgs/hooks/lib/src/encoded_asset.dart
@@ -5,7 +5,6 @@
 import 'package:collection/collection.dart';
 
 import 'hooks/syntax.g.dart';
-import 'utils/json.dart';
 
 /// An encoded asset.
 ///
@@ -18,40 +17,32 @@ final class EncodedAsset {
   /// The json encoding of the asset.
   final UnmodifiableMapView<String, Object?> encoding;
 
-  /// The path of this object in a larger JSON.
+  /// The path of the [encoding] in a larger JSON.
   ///
   /// If provided, used for more precise error messages.
-  final List<Object>? jsonPath;
-
-  EncodedAsset._(this.type, this.encoding, {this.jsonPath});
+  final List<Object>? encodingJsonPath;
 
   /// Creates an [EncodedAsset].
-  EncodedAsset(this.type, Map<String, Object?> encoding, {this.jsonPath})
-    : encoding = UnmodifiableMapView(
-        // It would be better if `encoding` would be deep copied.
-        // https://github.com/dart-lang/native/issues/2045
-        Map.of(encoding),
-      );
+  EncodedAsset(
+    this.type,
+    Map<String, Object?> encoding, {
+    this.encodingJsonPath,
+  }) : encoding = UnmodifiableMapView(
+         // It would be better if `encoding` would be deep copied.
+         // https://github.com/dart-lang/native/issues/2045
+         Map.of(encoding),
+       );
 
   /// Decode an [EncodedAsset] from json.
   factory EncodedAsset.fromJson(
     Map<String, Object?> json, [
     List<Object>? path,
-  ]) {
-    final syntax_ = AssetSyntax.fromJson(json, path: path ?? []);
-    final encoding = Map<String, Object?>.of(syntax_.encoding?.json ?? {});
-    final path_ = syntax_.encoding != null ? [...?path, 'encoding'] : path;
-
-    return EncodedAsset._(
-      syntax_.type,
-      UnmodifiableMapView(encoding),
-      jsonPath: path_,
-    );
-  }
+  ]) => EncodedAssetSyntaxExtension.fromSyntax(
+    AssetSyntax.fromJson(json, path: path ?? []),
+  );
 
   /// Encode this [EncodedAsset] tojson.
-  Map<String, Object?> toJson() =>
-      {'encoding': Map.of(encoding)..sortOnKey(), _typeKey: type}..sortOnKey();
+  Map<String, Object?> toJson() => toSyntax().json;
 
   @override
   String toString() => 'EncodedAsset($type, $encoding)';
@@ -66,4 +57,28 @@ final class EncodedAsset {
       const DeepCollectionEquality().equals(encoding, other.encoding);
 }
 
-const String _typeKey = 'type';
+/// Extension methods for [EncodedAsset] to convert to and from syntax
+/// nodes.
+extension EncodedAssetSyntaxExtension on EncodedAsset {
+  /// Creates a [EncodedAsset] from a [AssetSyntax] node.
+  static EncodedAsset fromSyntax(AssetSyntax syntaxNode) => EncodedAsset(
+    syntaxNode.type,
+    syntaxNode.encoding?.json ?? {},
+    encodingJsonPath: syntaxNode.encoding?.path,
+  );
+
+  /// Converts this [EncodedAsset] to a [AssetSyntax] node.
+  AssetSyntax toSyntax() {
+    // TODO: Add optional json path argument to constructor that takes parts.
+    final syntaxNodeWithoutPath = AssetSyntax(
+      encoding: JsonObjectSyntax.fromJson(Map.of(encoding)),
+      type: type,
+    );
+    final path = switch (encodingJsonPath) {
+      // Remove the last element from the encoding path.
+      final List<Object> l => l.sublist(0, l.length - 1),
+      null => <Object>[],
+    };
+    return AssetSyntax.fromJson(syntaxNodeWithoutPath.json, path: path);
+  }
+}

--- a/pkgs/hooks/lib/src/metadata.dart
+++ b/pkgs/hooks/lib/src/metadata.dart
@@ -29,7 +29,7 @@ final class MetadataAsset {
     assert(asset.type == _type);
     final syntaxNode = MetadataAssetEncodingSyntax.fromJson(
       asset.encoding,
-      path: asset.jsonPath ?? [],
+      path: asset.encodingJsonPath ?? [],
     );
     return MetadataAsset(key: syntaxNode.key, value: syntaxNode.value);
   }

--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A library that contains a Dart API for the JSON-based protocol for
   `hook/build.dart` and `hook/link.dart`.
 
-version: 0.19.5
+version: 0.20.0-wip
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks
 
@@ -29,7 +29,7 @@ dependencies:
 
 dev_dependencies:
   args: ^2.6.0
-  code_assets: ^0.19.4 # Used for running tests with real asset types.
+  code_assets: ^0.19.5-wip # Used for running tests with real asset types.
   custom_lint: ^0.7.5
   dart_flutter_team_lints: ^3.5.2
   data_assets: any # Used for running tests with real asset types.

--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.21.1-wip
+
+- Bump `package:hooks` to 0.20.0.
+
 ## 0.21.0
 
 * Add `includeDevDependencies` param to `BuildLayout` to enable building the

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 0.21.0
+version: 0.21.1-wip
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 
@@ -12,12 +12,12 @@ environment:
   sdk: '>=3.9.0-21.0.dev <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.4 # Needed for OS for Target for KernelAssets.
+  code_assets: ^0.19.5-wip # Needed for OS for Target for KernelAssets.
   collection: ^1.19.1
   crypto: ^3.0.6
   file: ^7.0.1
   graphs: ^2.3.2
-  hooks: ^0.19.5
+  hooks: ^0.20.0-wip
   logging: ^1.3.0
   meta: ^1.16.0
   package_config: ^2.1.0

--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.17.1-wip
+
+- Bump `package:hooks` to 0.20.0.
+
 ## 0.17.0
 
 * Fix treeshaking on mac.

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.17.0
+version: 0.17.1-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:
@@ -17,9 +17,9 @@ environment:
   sdk: '>=3.9.0-21.0.dev <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.4
+  code_assets: ^0.19.5-wip
   glob: ^2.1.1
-  hooks: ^0.19.5
+  hooks: ^0.20.0-wip
   logging: ^1.3.0
   meta: ^1.16.0
   pub_semver: ^2.2.0


### PR DESCRIPTION
After https://github.com/dart-lang/native/pull/2220, we don't have to account for assets mixing their encoding map with the type. This means we can rely on the syntax nodes. This PR cleans the JSON handling up to use the syntax nodes.

The `EncodedAsset` is the extension point where the protocol is extended. So, it is expected that a `fromJson` and `toJson` exist here. `package:code_assets` and `package:data_assets` use this.

This PR removes the internal uses in `package:hooks` and uses the syntax directly. https://github.com/dart-lang/native/pull/2417/files#r2228488916

To provide good error message with validation crossing protocol extension boundaries, the `EncodedAsset` also contains the JSON path for the `encoding`. This PR renames the `jsonPath` field to `encodingJsonPath`.