### PR TITLE
[json_syntax_generator] Add `path` to default constructors

### DIFF
--- a/pkgs/code_assets/lib/src/code_assets/syntax.g.dart
+++ b/pkgs/code_assets/lib/src/code_assets/syntax.g.dart
@@ -14,7 +14,8 @@ class AndroidCodeConfigSyntax extends JsonObjectSyntax {
   AndroidCodeConfigSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  AndroidCodeConfigSyntax({required int targetNdkApi}) : super() {
+  AndroidCodeConfigSyntax({required int targetNdkApi, super.path = const []})
+    : super() {
     _targetNdkApi = targetNdkApi;
     json.sortOnKey();
   }
@@ -95,7 +96,7 @@ class AssetSyntax extends JsonObjectSyntax {
 
   AssetSyntax._fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  AssetSyntax({required String? type}) : super() {
+  AssetSyntax({required String? type, super.path = const []}) : super() {
     _type = type;
     json.sortOnKey();
   }
@@ -124,6 +125,7 @@ class CCompilerConfigSyntax extends JsonObjectSyntax {
     required Uri cc,
     required Uri ld,
     required WindowsSyntax? windows,
+    super.path = const [],
   }) : super() {
     _ar = ar;
     _cc = cc;
@@ -199,6 +201,7 @@ class CodeConfigSyntax extends JsonObjectSyntax {
     required MacOSCodeConfigSyntax? macOS,
     required ArchitectureSyntax targetArchitecture,
     required OSSyntax targetOs,
+    super.path = const [],
   }) : super() {
     _android = android;
     _cCompiler = cCompiler;
@@ -370,7 +373,10 @@ class CodeConfigSyntax extends JsonObjectSyntax {
 class ConfigSyntax extends JsonObjectSyntax {
   ConfigSyntax.fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  ConfigSyntax({required ConfigExtensionsSyntax? extensions}) : super() {
+  ConfigSyntax({
+    required ConfigExtensionsSyntax? extensions,
+    super.path = const [],
+  }) : super() {
     this.extensions = extensions;
     json.sortOnKey();
   }
@@ -408,7 +414,10 @@ class ConfigExtensionsSyntax extends JsonObjectSyntax {
   ConfigExtensionsSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  ConfigExtensionsSyntax({required CodeConfigSyntax? codeAssets}) : super() {
+  ConfigExtensionsSyntax({
+    required CodeConfigSyntax? codeAssets,
+    super.path = const [],
+  }) : super() {
     this.codeAssets = codeAssets;
     json.sortOnKey();
   }
@@ -446,6 +455,7 @@ class DeveloperCommandPromptSyntax extends JsonObjectSyntax {
   DeveloperCommandPromptSyntax({
     required List<String> arguments,
     required Uri script,
+    super.path = const [],
   }) : super() {
     _arguments = arguments;
     _script = script;
@@ -483,7 +493,8 @@ class DynamicLoadingBundleLinkModeSyntax extends LinkModeSyntax {
   DynamicLoadingBundleLinkModeSyntax.fromJson(super.json, {super.path})
     : super._fromJson();
 
-  DynamicLoadingBundleLinkModeSyntax() : super(type: 'dynamic_loading_bundle');
+  DynamicLoadingBundleLinkModeSyntax({super.path = const []})
+    : super(type: 'dynamic_loading_bundle');
 
   @override
   List<String> validate() => [...super.validate()];
@@ -503,7 +514,7 @@ class DynamicLoadingExecutableLinkModeSyntax extends LinkModeSyntax {
   DynamicLoadingExecutableLinkModeSyntax.fromJson(super.json, {super.path})
     : super._fromJson();
 
-  DynamicLoadingExecutableLinkModeSyntax()
+  DynamicLoadingExecutableLinkModeSyntax({super.path = const []})
     : super(type: 'dynamic_loading_executable');
 
   @override
@@ -526,7 +537,7 @@ class DynamicLoadingProcessLinkModeSyntax extends LinkModeSyntax {
   DynamicLoadingProcessLinkModeSyntax.fromJson(super.json, {super.path})
     : super._fromJson();
 
-  DynamicLoadingProcessLinkModeSyntax()
+  DynamicLoadingProcessLinkModeSyntax({super.path = const []})
     : super(type: 'dynamic_loading_process');
 
   @override
@@ -547,7 +558,7 @@ class DynamicLoadingSystemLinkModeSyntax extends LinkModeSyntax {
   DynamicLoadingSystemLinkModeSyntax.fromJson(super.json, {super.path})
     : super._fromJson();
 
-  DynamicLoadingSystemLinkModeSyntax({required Uri uri})
+  DynamicLoadingSystemLinkModeSyntax({required Uri uri, super.path = const []})
     : super(type: 'dynamic_loading_system') {
     _uri = uri;
     json.sortOnKey();
@@ -586,8 +597,11 @@ class IOSCodeConfigSyntax extends JsonObjectSyntax {
   IOSCodeConfigSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  IOSCodeConfigSyntax({required String targetSdk, required int targetVersion})
-    : super() {
+  IOSCodeConfigSyntax({
+    required String targetSdk,
+    required int targetVersion,
+    super.path = const [],
+  }) : super() {
     _targetSdk = targetSdk;
     _targetVersion = targetVersion;
     json.sortOnKey();
@@ -648,7 +662,7 @@ class LinkModeSyntax extends JsonObjectSyntax {
   LinkModeSyntax._fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  LinkModeSyntax({required String type}) : super() {
+  LinkModeSyntax({required String type, super.path = const []}) : super() {
     _type = type;
     json.sortOnKey();
   }
@@ -713,7 +727,8 @@ class MacOSCodeConfigSyntax extends JsonObjectSyntax {
   MacOSCodeConfigSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  MacOSCodeConfigSyntax({required int targetVersion}) : super() {
+  MacOSCodeConfigSyntax({required int targetVersion, super.path = const []})
+    : super() {
     _targetVersion = targetVersion;
     json.sortOnKey();
   }
@@ -742,6 +757,7 @@ class NativeCodeAssetEncodingSyntax extends JsonObjectSyntax {
     required Uri? file,
     required String id,
     required LinkModeSyntax linkMode,
+    super.path = const [],
   }) : super() {
     _file = file;
     _id = id;
@@ -812,8 +828,10 @@ class NativeCodeAssetNewSyntax extends AssetSyntax {
   NativeCodeAssetNewSyntax.fromJson(super.json, {super.path})
     : super._fromJson();
 
-  NativeCodeAssetNewSyntax({required NativeCodeAssetEncodingSyntax? encoding})
-    : super(type: 'code_assets/code') {
+  NativeCodeAssetNewSyntax({
+    required NativeCodeAssetEncodingSyntax? encoding,
+    super.path = const [],
+  }) : super(type: 'code_assets/code') {
     _encoding = encoding;
     json.sortOnKey();
   }
@@ -900,7 +918,7 @@ class OSSyntax {
 class StaticLinkModeSyntax extends LinkModeSyntax {
   StaticLinkModeSyntax.fromJson(super.json, {super.path}) : super._fromJson();
 
-  StaticLinkModeSyntax() : super(type: 'static');
+  StaticLinkModeSyntax({super.path = const []}) : super(type: 'static');
 
   @override
   List<String> validate() => [...super.validate()];
@@ -920,8 +938,10 @@ class WindowsSyntax extends JsonObjectSyntax {
   WindowsSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  WindowsSyntax({required DeveloperCommandPromptSyntax? developerCommandPrompt})
-    : super() {
+  WindowsSyntax({
+    required DeveloperCommandPromptSyntax? developerCommandPrompt,
+    super.path = const [],
+  }) : super() {
     _developerCommandPrompt = developerCommandPrompt;
     json.sortOnKey();
   }
@@ -966,7 +986,7 @@ class JsonObjectSyntax {
 
   _JsonReader get _reader => _JsonReader(json, path);
 
-  JsonObjectSyntax() : json = {}, path = const [];
+  JsonObjectSyntax({this.path = const []}) : json = {};
 
   JsonObjectSyntax.fromJson(this.json, {this.path = const []});
 

--- a/pkgs/data_assets/lib/src/data_assets/syntax.g.dart
+++ b/pkgs/data_assets/lib/src/data_assets/syntax.g.dart
@@ -24,7 +24,7 @@ class AssetSyntax extends JsonObjectSyntax {
 
   AssetSyntax._fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  AssetSyntax({required String? type}) : super() {
+  AssetSyntax({required String? type, super.path = const []}) : super() {
     _type = type;
     json.sortOnKey();
   }
@@ -52,6 +52,7 @@ class DataAssetEncodingSyntax extends JsonObjectSyntax {
     required Uri file,
     required String name,
     required String package,
+    super.path = const [],
   }) : super() {
     _file = file;
     _name = name;
@@ -100,8 +101,10 @@ class DataAssetNewSyntax extends AssetSyntax {
 
   DataAssetNewSyntax.fromJson(super.json, {super.path}) : super._fromJson();
 
-  DataAssetNewSyntax({required DataAssetEncodingSyntax? encoding})
-    : super(type: 'data_assets/data') {
+  DataAssetNewSyntax({
+    required DataAssetEncodingSyntax? encoding,
+    super.path = const [],
+  }) : super(type: 'data_assets/data') {
     _encoding = encoding;
     json.sortOnKey();
   }
@@ -155,7 +158,7 @@ class JsonObjectSyntax {
 
   _JsonReader get _reader => _JsonReader(json, path);
 
-  JsonObjectSyntax() : json = {}, path = const [];
+  JsonObjectSyntax({this.path = const []}) : json = {};
 
   JsonObjectSyntax.fromJson(this.json, {this.path = const []});
 

--- a/pkgs/hooks/lib/src/encoded_asset.dart
+++ b/pkgs/hooks/lib/src/encoded_asset.dart
@@ -69,16 +69,15 @@ extension EncodedAssetSyntaxExtension on EncodedAsset {
 
   /// Converts this [EncodedAsset] to a [AssetSyntax] node.
   AssetSyntax toSyntax() {
-    // TODO: Add optional json path argument to constructor that takes parts.
-    final syntaxNodeWithoutPath = AssetSyntax(
-      encoding: JsonObjectSyntax.fromJson(Map.of(encoding)),
-      type: type,
-    );
     final path = switch (encodingJsonPath) {
       // Remove the last element from the encoding path.
       final List<Object> l => l.sublist(0, l.length - 1),
       null => <Object>[],
     };
-    return AssetSyntax.fromJson(syntaxNodeWithoutPath.json, path: path);
+    return AssetSyntax(
+      encoding: JsonObjectSyntax.fromJson(Map.of(encoding)),
+      type: type,
+      path: path,
+    );
   }
 }

--- a/pkgs/hooks/lib/src/hooks/syntax.g.dart
+++ b/pkgs/hooks/lib/src/hooks/syntax.g.dart
@@ -24,8 +24,11 @@ class AssetSyntax extends JsonObjectSyntax {
 
   AssetSyntax._fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  AssetSyntax({required JsonObjectSyntax? encoding, required String type})
-    : super() {
+  AssetSyntax({
+    required JsonObjectSyntax? encoding,
+    required String type,
+    super.path = const [],
+  }) : super() {
     _encoding = encoding;
     _type = type;
     json.sortOnKey();
@@ -92,6 +95,7 @@ class BuildConfigSyntax extends ConfigSyntax {
     required super.buildAssetTypes,
     required super.extensions,
     required bool linkingEnabled,
+    super.path = const [],
   }) : super() {
     _linkingEnabled = linkingEnabled;
     json.sortOnKey();
@@ -134,6 +138,7 @@ class BuildInputSyntax extends HookInputSyntax {
     required super.packageName,
     required super.packageRoot,
     required super.userDefines,
+    super.path = const [],
   }) : super(config: config) {
     _assets = assets;
     json.sortOnKey();
@@ -222,6 +227,7 @@ class BuildOutputSyntax extends HookOutputSyntax {
     required super.failureDetails,
     required super.status,
     required super.timestamp,
+    super.path = const [],
   }) : super() {
     this.assetsForBuild = assetsForBuild;
     this.assetsForLinking = assetsForLinking;
@@ -349,6 +355,7 @@ class ConfigSyntax extends JsonObjectSyntax {
   ConfigSyntax({
     required List<String> buildAssetTypes,
     required JsonObjectSyntax? extensions,
+    super.path = const [],
   }) : super() {
     this.buildAssetTypes = buildAssetTypes;
     this.extensions = extensions;
@@ -399,7 +406,8 @@ class FailureSyntax extends JsonObjectSyntax {
   FailureSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  FailureSyntax({required FailureTypeSyntax type}) : super() {
+  FailureSyntax({required FailureTypeSyntax type, super.path = const []})
+    : super() {
     _type = type;
     json.sortOnKey();
   }
@@ -466,6 +474,7 @@ class HookInputSyntax extends JsonObjectSyntax {
     required String packageName,
     required Uri packageRoot,
     required UserDefinesSyntax? userDefines,
+    super.path = const [],
   }) : super() {
     this.config = config;
     this.outDirShared = outDirShared;
@@ -579,6 +588,7 @@ class HookOutputSyntax extends JsonObjectSyntax {
     required FailureSyntax? failureDetails,
     required OutputStatusSyntax? status,
     required String timestamp,
+    super.path = const [],
   }) : super() {
     this.assets = assets;
     this.dependencies = dependencies;
@@ -708,8 +718,10 @@ class HooksMetadataAssetSyntax extends AssetSyntax {
   HooksMetadataAssetSyntax.fromJson(super.json, {super.path})
     : super._fromJson();
 
-  HooksMetadataAssetSyntax({required MetadataAssetEncodingSyntax encoding})
-    : super(type: 'hooks/metadata', encoding: encoding);
+  HooksMetadataAssetSyntax({
+    required MetadataAssetEncodingSyntax encoding,
+    super.path = const [],
+  }) : super(type: 'hooks/metadata', encoding: encoding);
 
   /// Setup all fields for [HooksMetadataAssetSyntax] that are not in
   /// [AssetSyntax].
@@ -750,6 +762,7 @@ class LinkInputSyntax extends HookInputSyntax {
     required super.packageRoot,
     required Uri? resourceIdentifiers,
     required super.userDefines,
+    super.path = const [],
   }) : super() {
     _assets = assets;
     _resourceIdentifiers = resourceIdentifiers;
@@ -830,6 +843,7 @@ class LinkOutputSyntax extends HookOutputSyntax {
     required super.failureDetails,
     required super.status,
     required super.timestamp,
+    super.path = const [],
   }) : super();
 
   @override
@@ -854,8 +868,11 @@ class MetadataAssetEncodingSyntax extends JsonObjectSyntax {
   MetadataAssetEncodingSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  MetadataAssetEncodingSyntax({required String key, required Object? value})
-    : super() {
+  MetadataAssetEncodingSyntax({
+    required String key,
+    required Object? value,
+    super.path = const [],
+  }) : super() {
     _key = key;
     _value = value;
     json.sortOnKey();
@@ -923,8 +940,10 @@ class UserDefinesSyntax extends JsonObjectSyntax {
   UserDefinesSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  UserDefinesSyntax({required UserDefinesSourceSyntax? workspacePubspec})
-    : super() {
+  UserDefinesSyntax({
+    required UserDefinesSourceSyntax? workspacePubspec,
+    super.path = const [],
+  }) : super() {
     _workspacePubspec = workspacePubspec;
     json.sortOnKey();
   }
@@ -969,6 +988,7 @@ class UserDefinesSourceSyntax extends JsonObjectSyntax {
   UserDefinesSourceSyntax({
     required Uri basePath,
     required JsonObjectSyntax defines,
+    super.path = const [],
   }) : super() {
     _basePath = basePath;
     _defines = defines;
@@ -1018,7 +1038,7 @@ class JsonObjectSyntax {
 
   _JsonReader get _reader => _JsonReader(json, path);
 
-  JsonObjectSyntax() : json = {}, path = const [];
+  JsonObjectSyntax({this.path = const []}) : json = {};
 
   JsonObjectSyntax.fromJson(this.json, {this.path = const []});
 

--- a/pkgs/json_syntax_generator/lib/src/generator/helper_library.dart
+++ b/pkgs/json_syntax_generator/lib/src/generator/helper_library.dart
@@ -15,7 +15,7 @@ class JsonObjectSyntax {
 
   _JsonReader get _reader => _JsonReader(json, path);
 
-  JsonObjectSyntax() : json = {}, path = const [];
+  JsonObjectSyntax({this.path = const []}) : json = {};
 
   JsonObjectSyntax.fromJson(this.json, {this.path = const []});
 

--- a/pkgs/json_syntax_generator/lib/src/generator/normal_class_generator.dart
+++ b/pkgs/json_syntax_generator/lib/src/generator/normal_class_generator.dart
@@ -165,6 +165,7 @@ static const ${tagProperty}Value = '$tagValue';
         result.add('required $dartType $propertyName');
       }
     }
+    result.add('super.path = const []');
     return result;
   }
 

--- a/pkgs/pub_formats/lib/src/pubspec_lock_syntax.g.dart
+++ b/pkgs/pub_formats/lib/src/pubspec_lock_syntax.g.dart
@@ -51,6 +51,7 @@ class GitPackageDescriptionSyntax extends PackageDescriptionSyntax {
     required String ref,
     required String resolvedRef,
     required String url,
+    super.path = const [],
   }) : super() {
     _path$ = path$;
     _ref = ref;
@@ -137,6 +138,7 @@ class HostedPackageDescriptionSyntax extends PackageDescriptionSyntax {
     required String name,
     required String sha256,
     required String url,
+    super.path = const [],
   }) : super() {
     _name = name;
     _sha256 = sha256;
@@ -221,6 +223,7 @@ class PackageSyntax extends JsonObjectSyntax {
     required PackageDescriptionSyntax description,
     required PackageSourceSyntax source,
     required String version,
+    super.path = const [],
   }) : super() {
     _dependency = dependency;
     _description = description;
@@ -308,7 +311,7 @@ class PackageDescriptionSyntax extends JsonObjectSyntax {
   PackageDescriptionSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  PackageDescriptionSyntax() : super();
+  PackageDescriptionSyntax({super.path = const []}) : super();
 
   @override
   List<String> validate() => [...super.validate()];
@@ -354,8 +357,11 @@ class PathPackageDescriptionSyntax extends PackageDescriptionSyntax {
   PathPackageDescriptionSyntax.fromJson(super.json, {super.path})
     : super.fromJson();
 
-  PathPackageDescriptionSyntax({required String path$, required bool relative})
-    : super() {
+  PathPackageDescriptionSyntax({
+    required String path$,
+    required bool relative,
+    super.path = const [],
+  }) : super() {
     _path$ = path$;
     _relative = relative;
     json.sortOnKey();
@@ -403,6 +409,7 @@ class PubspecLockFileSyntax extends JsonObjectSyntax {
   PubspecLockFileSyntax({
     required Map<String, PackageSyntax>? packages,
     required SDKsSyntax sdks,
+    super.path = const [],
   }) : super() {
     _packages = packages;
     _sdks = sdks;
@@ -489,7 +496,7 @@ class PubspecLockFileSyntax extends JsonObjectSyntax {
 class SDKsSyntax extends JsonObjectSyntax {
   SDKsSyntax.fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  SDKsSyntax({required String dart}) : super() {
+  SDKsSyntax({required String dart, super.path = const []}) : super() {
     _dart = dart;
     json.sortOnKey();
   }
@@ -516,7 +523,7 @@ class JsonObjectSyntax {
 
   _JsonReader get _reader => _JsonReader(json, path);
 
-  JsonObjectSyntax() : json = {}, path = const [];
+  JsonObjectSyntax({this.path = const []}) : json = {};
 
   JsonObjectSyntax.fromJson(this.json, {this.path = const []});
 

--- a/pkgs/pub_formats/lib/src/pubspec_syntax.g.dart
+++ b/pkgs/pub_formats/lib/src/pubspec_syntax.g.dart
@@ -14,7 +14,7 @@ class DependencySourceSyntax extends JsonObjectSyntax {
   DependencySourceSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  DependencySourceSyntax() : super();
+  DependencySourceSyntax({super.path = const []}) : super();
 
   @override
   List<String> validate() => [...super.validate()];
@@ -27,7 +27,11 @@ class EnvironmentSyntax extends JsonObjectSyntax {
   EnvironmentSyntax.fromJson(super.json, {super.path = const []})
     : super.fromJson();
 
-  EnvironmentSyntax({required String? flutter, required String sdk}) : super() {
+  EnvironmentSyntax({
+    required String? flutter,
+    required String sdk,
+    super.path = const [],
+  }) : super() {
     _flutter = flutter;
     _sdk = sdk;
     json.sortOnKey();
@@ -63,8 +67,12 @@ class EnvironmentSyntax extends JsonObjectSyntax {
 class GitSyntax extends JsonObjectSyntax {
   GitSyntax.fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  GitSyntax({required String? path$, required String? ref, required String url})
-    : super() {
+  GitSyntax({
+    required String? path$,
+    required String? ref,
+    required String url,
+    super.path = const [],
+  }) : super() {
     _path$ = path$;
     _ref = ref;
     _url = url;
@@ -111,7 +119,8 @@ class GitDependencySourceSyntax extends DependencySourceSyntax {
   GitDependencySourceSyntax.fromJson(super.json, {super.path})
     : super.fromJson();
 
-  GitDependencySourceSyntax({required GitSyntax git}) : super() {
+  GitDependencySourceSyntax({required GitSyntax git, super.path = const []})
+    : super() {
     _git = git;
     json.sortOnKey();
   }
@@ -150,8 +159,10 @@ class GitDependencySourceSyntax extends DependencySourceSyntax {
 class HooksSyntax extends JsonObjectSyntax {
   HooksSyntax.fromJson(super.json, {super.path = const []}) : super.fromJson();
 
-  HooksSyntax({required Map<String, Map<String, Object?>>? userDefines})
-    : super() {
+  HooksSyntax({
+    required Map<String, Map<String, Object?>>? userDefines,
+    super.path = const [],
+  }) : super() {
     _userDefines = userDefines;
     json.sortOnKey();
   }
@@ -189,6 +200,7 @@ class HostedDependencySourceSyntax extends DependencySourceSyntax {
   HostedDependencySourceSyntax({
     required String? hosted,
     required String version,
+    super.path = const [],
   }) : super() {
     _hosted = hosted;
     _version = version;
@@ -244,7 +256,8 @@ class PathDependencySourceSyntax extends DependencySourceSyntax {
   PathDependencySourceSyntax.fromJson(super.json, {super.path})
     : super.fromJson();
 
-  PathDependencySourceSyntax({required String path$}) : super() {
+  PathDependencySourceSyntax({required String path$, super.path = const []})
+    : super() {
     _path$ = path$;
     json.sortOnKey();
   }
@@ -290,6 +303,7 @@ class PubspecYamlFileSyntax extends JsonObjectSyntax {
     required String? publishTo,
     required String? repository,
     required String? version,
+    super.path = const [],
   }) : super() {
     this.dependencies = dependencies;
     this.dependencyOverrides = dependencyOverrides;
@@ -673,7 +687,8 @@ class SdkDependencySourceSyntax extends DependencySourceSyntax {
   SdkDependencySourceSyntax.fromJson(super.json, {super.path})
     : super.fromJson();
 
-  SdkDependencySourceSyntax({required String sdk}) : super() {
+  SdkDependencySourceSyntax({required String sdk, super.path = const []})
+    : super() {
     _sdk = sdk;
     json.sortOnKey();
   }
@@ -707,7 +722,7 @@ class JsonObjectSyntax {
 
   _JsonReader get _reader => _JsonReader(json, path);
 
-  JsonObjectSyntax() : json = {}, path = const [];
+  JsonObjectSyntax({this.path = const []}) : json = {};
 
   JsonObjectSyntax.fromJson(this.json, {this.path = const []});
 


### PR DESCRIPTION
Only the `fromJson` syntax classes had an optional `path` argument for better error messages. That constructor is mainly used for parsing.

However, in some cases one might want to construct a syntax object from its constituents, but still get proper error messages. This is mostly relevant when a JSON/YAML format has extensions nested somewhere deeper.

This PR removes the TODO added in https://github.com/dart-lang/native/pull/2454.