### PR TITLE
[hooks] Update example to be `dart install`able

### DIFF
--- a/pkgs/hooks_runner/test_data/dart_app/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/dart_app/pubspec.yaml
@@ -12,3 +12,6 @@ dependencies:
     path: ../native_add
   native_subtract:
     path: ../native_subtract
+
+executables:
+  dart_app:


### PR DESCRIPTION
If a package can be `dart install`ed or `dart pub global activate`d, it needs to provide more guarantees than if it can only be `dart run`ned. (For example, the package cannot have access to its on source code.) Therefore, the `executables` section in the `pubspec.yaml` signals that a package can be `dart install`ed.

This PR makes our example app `dart install`able. It is standalone and provides those guarantees.