### PR TITLE
[pub_formats] `pubspec.yaml` allow `version: any`

### DIFF
--- a/pkgs/pub_formats/doc/schema/pubspec.schema.json
+++ b/pkgs/pub_formats/doc/schema/pubspec.schema.json
@@ -123,8 +123,7 @@
         },
         "version": {
           "description": "The version constraint for the package on the custom hosted server.",
-          "type": "string",
-          "pattern": "^[<>=~^0-9. -]+$"
+          "type": "string"
         }
       },
       "required": [

--- a/pkgs/pub_formats/lib/src/pubspec_syntax.g.dart
+++ b/pkgs/pub_formats/lib/src/pubspec_syntax.g.dart
@@ -223,23 +223,13 @@ class HostedDependencySourceSyntax extends DependencySourceSyntax {
 
   List<String> _validateHosted() => _reader.validate<String?>('hosted');
 
-  static final _versionPattern = RegExp(r'^[<>=~^0-9. -]+$');
-
-  String get version => _reader.string('version', _versionPattern);
+  String get version => _reader.get<String>('version');
 
   set _version(String value) {
-    if (!_versionPattern.hasMatch(value)) {
-      throw ArgumentError.value(
-        value,
-        'value',
-        'Value does not satisify pattern: ${_versionPattern.pattern}.',
-      );
-    }
     json.setOrRemove('version', value);
   }
 
-  List<String> _validateVersion() =>
-      _reader.validateString('version', _versionPattern);
+  List<String> _validateVersion() => _reader.validate<String>('version');
 
   @override
   List<String> validate() => [

--- a/pkgs/pub_formats/test_data/pubspec_1.yaml
+++ b/pkgs/pub_formats/test_data/pubspec_1.yaml
@@ -26,6 +26,8 @@ dependencies:
     version: ^1.4.0
   some_hosted_dependency_2:
     version: ^1.4.0
+  some_hosted_dependency_3:
+    version: any
   some_path_dependency:
     path: ../some_path_dependency/
 


### PR DESCRIPTION
Gemini was smart in creating Regexes for the data it saw, a bit too smart. 😄 

This PR relaxes the constraint, and simply removes the regex.