### PR TITLE
[swift2objc] Split `NestableDeclaration`

### DIFF
--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/compound_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/compound_declaration.dart
@@ -18,7 +18,8 @@ abstract interface class CompoundDeclaration
         Declaration,
         TypeParameterizable,
         ProtocolConformable,
-        NestableDeclaration {
+        OuterNestableDeclaration,
+        InnerNestableDeclaration {
   abstract List<PropertyDeclaration> properties;
   abstract List<MethodDeclaration> methods;
   abstract List<InitializerDeclaration> initializers;

--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/enum_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/enum_declaration.dart
@@ -15,7 +15,8 @@ abstract interface class EnumDeclaration
         Declaration,
         TypeParameterizable,
         ProtocolConformable,
-        NestableDeclaration {
+        OuterNestableDeclaration,
+        InnerNestableDeclaration {
   abstract List<EnumCase> cases;
 }
 

--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/nestable_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/nestable_declaration.dart
@@ -5,14 +5,20 @@
 import '../../ast_node.dart';
 import 'declaration.dart';
 
-/// A Swift entity that can be nested inside other declarations.
-abstract interface class NestableDeclaration implements Declaration, AstNode {
-  abstract NestableDeclaration? nestingParent;
-  abstract final List<NestableDeclaration> nestedDeclarations;
+/// A Swift entity that can contain other declarations.
+abstract interface class OuterNestableDeclaration
+    implements Declaration, AstNode {
+  abstract final List<InnerNestableDeclaration> nestedDeclarations;
 }
 
-extension FillNestingParents on List<NestableDeclaration> {
-  void fillNestingParents(NestableDeclaration parent) {
+/// A Swift entity that can be nested inside other declarations.
+abstract interface class InnerNestableDeclaration
+    implements Declaration, AstNode {
+  abstract OuterNestableDeclaration? nestingParent;
+}
+
+extension FillNestingParents on List<InnerNestableDeclaration> {
+  void fillNestingParents(OuterNestableDeclaration parent) {
     for (final nested in this) {
       assert(nested.nestingParent == null);
       nested.nestingParent = parent;

--- a/pkgs/swift2objc/lib/src/ast/_core/shared/referred_type.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/shared/referred_type.dart
@@ -30,7 +30,7 @@ class DeclaredType<T extends Declaration> extends AstNode
 
   String get name {
     final decl = declaration;
-    final parent = decl is NestableDeclaration ? decl.nestingParent : null;
+    final parent = decl is InnerNestableDeclaration ? decl.nestingParent : null;
     final nesting = parent != null ? '${parent.name}.' : '';
     return '$nesting${declaration.name}';
   }

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/class_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/class_declaration.dart
@@ -55,10 +55,10 @@ class ClassDeclaration extends AstNode
   List<InitializerDeclaration> initializers;
 
   @override
-  NestableDeclaration? nestingParent;
+  OuterNestableDeclaration? nestingParent;
 
   @override
-  List<NestableDeclaration> nestedDeclarations;
+  List<InnerNestableDeclaration> nestedDeclarations;
 
   ClassDeclaration({
     required this.id,

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/protocol_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/protocol_declaration.dart
@@ -34,10 +34,10 @@ class ProtocolDeclaration extends AstNode implements CompoundDeclaration {
   List<InitializerDeclaration> initializers;
 
   @override
-  NestableDeclaration? nestingParent;
+  OuterNestableDeclaration? nestingParent;
 
   @override
-  List<NestableDeclaration> nestedDeclarations;
+  List<InnerNestableDeclaration> nestedDeclarations;
 
   ProtocolDeclaration({
     required this.id,

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/struct_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/struct_declaration.dart
@@ -35,10 +35,10 @@ class StructDeclaration extends AstNode implements CompoundDeclaration {
   List<InitializerDeclaration> initializers;
 
   @override
-  NestableDeclaration? nestingParent;
+  OuterNestableDeclaration? nestingParent;
 
   @override
-  List<NestableDeclaration> nestedDeclarations;
+  List<InnerNestableDeclaration> nestedDeclarations;
 
   StructDeclaration({
     required this.id,

--- a/pkgs/swift2objc/lib/src/ast/declarations/enums/associated_value_enum_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/enums/associated_value_enum_declaration.dart
@@ -29,10 +29,10 @@ class AssociatedValueEnumDeclaration extends AstNode
   List<DeclaredType<ProtocolDeclaration>> conformedProtocols;
 
   @override
-  NestableDeclaration? nestingParent;
+  OuterNestableDeclaration? nestingParent;
 
   @override
-  List<NestableDeclaration> nestedDeclarations;
+  List<InnerNestableDeclaration> nestedDeclarations;
 
   AssociatedValueEnumDeclaration({
     required this.id,

--- a/pkgs/swift2objc/lib/src/ast/declarations/enums/normal_enum_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/enums/normal_enum_declaration.dart
@@ -27,10 +27,10 @@ class NormalEnumDeclaration extends AstNode implements EnumDeclaration {
   List<DeclaredType<ProtocolDeclaration>> conformedProtocols;
 
   @override
-  NestableDeclaration? nestingParent;
+  OuterNestableDeclaration? nestingParent;
 
   @override
-  List<NestableDeclaration> nestedDeclarations;
+  List<InnerNestableDeclaration> nestedDeclarations;
 
   NormalEnumDeclaration({
     required this.id,

--- a/pkgs/swift2objc/lib/src/ast/declarations/enums/raw_value_enum_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/enums/raw_value_enum_declaration.dart
@@ -31,10 +31,10 @@ class RawValueEnumDeclaration<T> extends AstNode
   bool hasObjCAnnotation;
 
   @override
-  NestableDeclaration? nestingParent;
+  OuterNestableDeclaration? nestingParent;
 
   @override
-  List<NestableDeclaration> nestedDeclarations;
+  List<InnerNestableDeclaration> nestedDeclarations;
 
   ReferredType rawValueType;
 

--- a/pkgs/swift2objc/lib/src/parser/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/parser/_core/utils.dart
@@ -31,7 +31,7 @@ extension AddIdSuffix on String {
 
 extension TopLevelOnly<T extends Declaration> on List<T> {
   List<Declaration> get topLevelOnly => where((declaration) {
-        if (declaration is NestableDeclaration) {
+        if (declaration is InnerNestableDeclaration) {
           return declaration.nestingParent == null;
         }
         return declaration is GlobalVariableDeclaration ||

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_compound_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_compound_declaration.dart
@@ -19,7 +19,7 @@ typedef CompoundTearOff<T extends CompoundDeclaration> = T Function({
   required List<PropertyDeclaration> properties,
   required List<MethodDeclaration> methods,
   required List<InitializerDeclaration> initializers,
-  required List<NestableDeclaration> nestedDeclarations,
+  required List<InnerNestableDeclaration> nestedDeclarations,
 });
 
 T _parseCompoundDeclaration<T extends CompoundDeclaration>(
@@ -78,7 +78,7 @@ T _parseCompoundDeclaration<T extends CompoundDeclaration>(
         .dedupeBy((m) => m.fullName),
   );
   compound.nestedDeclarations.addAll(
-    memberDeclarations.whereType<NestableDeclaration>(),
+    memberDeclarations.whereType<InnerNestableDeclaration>(),
   );
 
   compound.nestedDeclarations.fillNestingParents(compound);

--- a/pkgs/swift2objc/lib/src/transformer/transform.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transform.dart
@@ -67,7 +67,8 @@ Declaration transformDeclaration(
     return transformationMap[declaration]!;
   }
 
-  if (declaration is NestableDeclaration && declaration.nestingParent != null) {
+  if (declaration is InnerNestableDeclaration &&
+      declaration.nestingParent != null) {
     // It's important that nested declarations are only transformed in the
     // context of their parent, so that their parentNamer is correct.
     assert(nested);

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_compound.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_compound.dart
@@ -46,7 +46,7 @@ ClassDeclaration transformCompound(
   transformedCompound.nestedDeclarations = originalCompound.nestedDeclarations
       .map((nested) => transformDeclaration(
               nested, compoundNamer, transformationMap, nested: true)
-          as NestableDeclaration)
+          as InnerNestableDeclaration)
       .toList()
     ..sort((Declaration a, Declaration b) => a.id.compareTo(b.id));
   transformedCompound.nestedDeclarations


### PR DESCRIPTION
Split `NestableDeclaration` into `InnerNestableDeclaration` and `OuterNestableDeclaration`, since there are declarations that can be nested inside other declarations, but can't contain other declarations. Eg typealiases.

Part of #1775