### PR TITLE
[swift2objc] Availability annotations

### DIFF
--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/availability.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/availability.dart
@@ -18,16 +18,21 @@ class AvailabilityInfo {
   AvailabilityInfo({
     required this.domain,
     required this.unavailable,
-    this.introduced,
-    this.deprecated,
-    this.obsoleted,
+    required this.introduced,
+    required this.deprecated,
+    required this.obsoleted,
   });
 }
 
 /// A version for availability.
 class AvailabilityVersion {
-  int? major;
+  int major;
   int? minor;
   int? patch;
-  AvailabilityVersion({this.major, this.minor, this.patch});
+
+  AvailabilityVersion(
+      {required this.major, required this.minor, required this.patch});
+
+  @override
+  String toString() => [major, minor, patch].nonNulls.join('.');
 }

--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/availability.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/availability.dart
@@ -10,14 +10,14 @@ abstract interface class Availability {
 /// The availability for a single domain.
 class AvailabilityInfo {
   String domain;
-  bool? unavailable;
+  bool unavailable;
   AvailabilityVersion? introduced;
   AvailabilityVersion? deprecated;
   AvailabilityVersion? obsoleted;
 
   AvailabilityInfo({
     required this.domain,
-    this.unavailable,
+    required this.unavailable,
     this.introduced,
     this.deprecated,
     this.obsoleted,

--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/availability.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/availability.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// A Swift declaration's availability info.
+abstract interface class Availability {
+  abstract final List<AvailabilityInfo> availability;
+}
+
+/// The availability for a single domain.
+class AvailabilityInfo {
+  String domain;
+  bool? unavailable;
+  AvailabilityVersion? introduced;
+  AvailabilityVersion? deprecated;
+  AvailabilityVersion? obsoleted;
+
+  AvailabilityInfo({
+    required this.domain,
+    this.unavailable,
+    this.introduced,
+    this.deprecated,
+    this.obsoleted,
+  });
+}
+
+/// A version for availability.
+class AvailabilityVersion {
+  int? major;
+  int? minor;
+  int? patch;
+  AvailabilityVersion({this.major, this.minor, this.patch});
+}

--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/declaration.dart
@@ -4,9 +4,10 @@
 
 import '../../ast_node.dart';
 import '../shared/referred_type.dart';
+import 'availability.dart';
 
 /// A common interface for all Swift entities declarations.
-abstract interface class Declaration implements AstNode {
+abstract interface class Declaration implements AstNode, Availability {
   abstract final String id;
   abstract final String name;
 }

--- a/pkgs/swift2objc/lib/src/ast/declarations/built_in/built_in_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/built_in/built_in_declaration.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../_core/interfaces/availability.dart';
 import '../../_core/interfaces/declaration.dart';
 import '../../_core/interfaces/objc_annotatable.dart';
 import '../../ast_node.dart';
@@ -14,6 +15,9 @@ class BuiltInDeclaration extends AstNode
 
   @override
   final String name;
+
+  @override
+  List<AvailabilityInfo> get availability => const [];
 
   @override
   bool get hasObjCAnnotation => true;

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/class_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/class_declaration.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../_core/interfaces/availability.dart';
 import '../../_core/interfaces/compound_declaration.dart';
 import '../../_core/interfaces/declaration.dart';
 import '../../_core/interfaces/nestable_declaration.dart';
@@ -22,6 +23,9 @@ class ClassDeclaration extends AstNode
 
   @override
   String name;
+
+  @override
+  List<AvailabilityInfo> availability;
 
   @override
   covariant List<PropertyDeclaration> properties;
@@ -63,6 +67,7 @@ class ClassDeclaration extends AstNode
   ClassDeclaration({
     required this.id,
     required this.name,
+    required this.availability,
     this.properties = const [],
     this.methods = const [],
     this.nestingParent,

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/initializer_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/initializer_declaration.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../../_core/interfaces/availability.dart';
 import '../../../_core/interfaces/can_async.dart';
 import '../../../_core/interfaces/can_throw.dart';
 import '../../../_core/interfaces/declaration.dart';
@@ -27,6 +28,9 @@ class InitializerDeclaration extends AstNode
 
   @override
   String get name => 'init';
+
+  @override
+  List<AvailabilityInfo> availability;
 
   @override
   bool hasObjCAnnotation;
@@ -55,6 +59,7 @@ class InitializerDeclaration extends AstNode
 
   InitializerDeclaration({
     required this.id,
+    required this.availability,
     required this.params,
     this.statements = const [],
     required this.hasObjCAnnotation,

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/method_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/method_declaration.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../../_core/interfaces/availability.dart';
 import '../../../_core/interfaces/function_declaration.dart';
 import '../../../_core/interfaces/objc_annotatable.dart';
 import '../../../_core/interfaces/overridable.dart';
@@ -18,6 +19,9 @@ class MethodDeclaration extends AstNode
 
   @override
   String name;
+
+  @override
+  List<AvailabilityInfo> availability;
 
   @override
   List<Parameter> params;
@@ -55,6 +59,7 @@ class MethodDeclaration extends AstNode
   MethodDeclaration(
       {required this.id,
       required this.name,
+      required this.availability,
       required this.returnType,
       required this.params,
       this.typeParams = const [],

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/property_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/members/property_declaration.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../../_core/interfaces/availability.dart';
 import '../../../_core/interfaces/executable.dart';
 import '../../../_core/interfaces/objc_annotatable.dart';
 import '../../../_core/interfaces/variable_declaration.dart';
@@ -17,6 +18,9 @@ class PropertyDeclaration extends AstNode
 
   @override
   String name;
+
+  @override
+  List<AvailabilityInfo> availability;
 
   @override
   bool hasObjCAnnotation;
@@ -51,6 +55,7 @@ class PropertyDeclaration extends AstNode
   PropertyDeclaration(
       {required this.id,
       required this.name,
+      required this.availability,
       required this.type,
       this.hasSetter = false,
       this.isConstant = false,

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/protocol_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/protocol_declaration.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../_core/interfaces/availability.dart';
 import '../../_core/interfaces/compound_declaration.dart';
 import '../../_core/interfaces/nestable_declaration.dart';
 import '../../_core/shared/referred_type.dart';
@@ -17,6 +18,9 @@ class ProtocolDeclaration extends AstNode implements CompoundDeclaration {
 
   @override
   String name;
+
+  @override
+  List<AvailabilityInfo> availability;
 
   @override
   covariant List<PropertyDeclaration> properties;
@@ -42,6 +46,7 @@ class ProtocolDeclaration extends AstNode implements CompoundDeclaration {
   ProtocolDeclaration({
     required this.id,
     required this.name,
+    required this.availability,
     required this.properties,
     required this.methods,
     required this.initializers,

--- a/pkgs/swift2objc/lib/src/ast/declarations/compounds/struct_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/compounds/struct_declaration.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../_core/interfaces/availability.dart';
 import '../../_core/interfaces/compound_declaration.dart';
 import '../../_core/interfaces/nestable_declaration.dart';
 import '../../_core/shared/referred_type.dart';
@@ -18,6 +19,9 @@ class StructDeclaration extends AstNode implements CompoundDeclaration {
 
   @override
   String name;
+
+  @override
+  List<AvailabilityInfo> availability;
 
   @override
   covariant List<PropertyDeclaration> properties;
@@ -43,6 +47,7 @@ class StructDeclaration extends AstNode implements CompoundDeclaration {
   StructDeclaration({
     required this.id,
     required this.name,
+    required this.availability,
     this.properties = const [],
     this.methods = const [],
     this.initializers = const [],

--- a/pkgs/swift2objc/lib/src/ast/declarations/enums/associated_value_enum_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/enums/associated_value_enum_declaration.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../_core/interfaces/availability.dart';
 import '../../_core/interfaces/enum_declaration.dart';
 import '../../_core/interfaces/nestable_declaration.dart';
 import '../../_core/interfaces/parameterizable.dart';
@@ -18,6 +19,9 @@ class AssociatedValueEnumDeclaration extends AstNode
 
   @override
   String name;
+
+  @override
+  List<AvailabilityInfo> availability;
 
   @override
   covariant List<AssociatedValueEnumCase> cases;
@@ -37,6 +41,7 @@ class AssociatedValueEnumDeclaration extends AstNode
   AssociatedValueEnumDeclaration({
     required this.id,
     required this.name,
+    required this.availability,
     required this.cases,
     required this.typeParams,
     required this.conformedProtocols,
@@ -69,11 +74,15 @@ class AssociatedValueEnumCase extends AstNode
   String name;
 
   @override
+  List<AvailabilityInfo> availability;
+
+  @override
   covariant List<AssociatedValueParam> params;
 
   AssociatedValueEnumCase({
     required this.id,
     required this.name,
+    required this.availability,
     required this.params,
   });
 

--- a/pkgs/swift2objc/lib/src/ast/declarations/enums/normal_enum_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/enums/normal_enum_declaration.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../_core/interfaces/availability.dart';
 import '../../_core/interfaces/enum_declaration.dart';
 import '../../_core/interfaces/nestable_declaration.dart';
 import '../../_core/shared/referred_type.dart';
@@ -16,6 +17,9 @@ class NormalEnumDeclaration extends AstNode implements EnumDeclaration {
 
   @override
   String name;
+
+  @override
+  List<AvailabilityInfo> availability;
 
   @override
   covariant List<NormalEnumCase> cases;
@@ -35,6 +39,7 @@ class NormalEnumDeclaration extends AstNode implements EnumDeclaration {
   NormalEnumDeclaration({
     required this.id,
     required this.name,
+    required this.availability,
     required this.cases,
     required this.typeParams,
     required this.conformedProtocols,
@@ -66,8 +71,12 @@ class NormalEnumCase extends AstNode implements EnumCase {
   @override
   String name;
 
+  @override
+  List<AvailabilityInfo> availability;
+
   NormalEnumCase({
     required this.id,
     required this.name,
+    required this.availability,
   });
 }

--- a/pkgs/swift2objc/lib/src/ast/declarations/enums/raw_value_enum_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/enums/raw_value_enum_declaration.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../_core/interfaces/availability.dart';
 import '../../_core/interfaces/enum_declaration.dart';
 import '../../_core/interfaces/nestable_declaration.dart';
 import '../../_core/interfaces/objc_annotatable.dart';
@@ -17,6 +18,9 @@ class RawValueEnumDeclaration<T> extends AstNode
 
   @override
   String name;
+
+  @override
+  List<AvailabilityInfo> availability;
 
   @override
   covariant List<RawValueEnumCase<T>> cases;
@@ -41,6 +45,7 @@ class RawValueEnumDeclaration<T> extends AstNode
   RawValueEnumDeclaration({
     required this.id,
     required this.name,
+    required this.availability,
     required this.cases,
     required this.typeParams,
     required this.conformedProtocols,
@@ -74,11 +79,15 @@ class RawValueEnumCase<T> extends AstNode implements EnumCase {
   @override
   String name;
 
+  @override
+  List<AvailabilityInfo> availability;
+
   T rawValue;
 
   RawValueEnumCase({
     required this.id,
     required this.name,
+    required this.availability,
     required this.rawValue,
   });
 }

--- a/pkgs/swift2objc/lib/src/ast/declarations/globals/globals.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/globals/globals.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../_core/interfaces/availability.dart';
 import '../../_core/interfaces/function_declaration.dart';
 import '../../_core/interfaces/variable_declaration.dart';
 import '../../_core/shared/parameter.dart';
@@ -29,6 +30,9 @@ class GlobalFunctionDeclaration extends AstNode implements FunctionDeclaration {
   String name;
 
   @override
+  List<AvailabilityInfo> availability;
+
+  @override
   List<Parameter> params;
 
   @override
@@ -49,6 +53,7 @@ class GlobalFunctionDeclaration extends AstNode implements FunctionDeclaration {
   GlobalFunctionDeclaration({
     required this.id,
     required this.name,
+    required this.availability,
     required this.params,
     required this.returnType,
     this.typeParams = const [],
@@ -75,6 +80,9 @@ class GlobalVariableDeclaration extends AstNode implements VariableDeclaration {
   String name;
 
   @override
+  List<AvailabilityInfo> availability;
+
+  @override
   ReferredType type;
 
   @override
@@ -89,6 +97,7 @@ class GlobalVariableDeclaration extends AstNode implements VariableDeclaration {
   GlobalVariableDeclaration({
     required this.id,
     required this.name,
+    required this.availability,
     required this.type,
     required this.isConstant,
     required this.throws,

--- a/pkgs/swift2objc/lib/src/ast/declarations/typealias_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/typealias_declaration.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../_core/interfaces/availability.dart';
 import '../_core/interfaces/nestable_declaration.dart';
 import '../_core/shared/referred_type.dart';
 import '../ast_node.dart';
@@ -14,13 +15,20 @@ class TypealiasDeclaration extends AstNode implements InnerNestableDeclaration {
   @override
   final String name;
 
+  @override
+  List<AvailabilityInfo> availability;
+
   final ReferredType target;
 
   @override
   OuterNestableDeclaration? nestingParent;
 
-  TypealiasDeclaration(
-      {required this.id, required this.name, required this.target});
+  TypealiasDeclaration({
+    required this.id,
+    required this.name,
+    required this.target,
+    required this.availability,
+  });
 
   @override
   void visit(Visitation visitation) =>

--- a/pkgs/swift2objc/lib/src/generator/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/generator/_core/utils.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:path/path.dart' as path;
+import '../../ast/_core/interfaces/availability.dart';
 import '../../ast/_core/interfaces/can_async.dart';
 import '../../ast/_core/interfaces/can_throw.dart';
 import '../../ast/_core/interfaces/declaration.dart';
@@ -48,3 +49,20 @@ String generateAnnotations(Declaration decl) {
   }
   return annotations.toString();
 }
+
+List<String> generateAvailability(Declaration decl) =>
+    decl.availability.map(_generateAvailabilityInfo).toList();
+
+String _generateAvailabilityInfo(AvailabilityInfo info) =>
+    '@available(${_generateAvailabilityInfoList(info).join(', ')})';
+
+Iterable<String> _generateAvailabilityInfoList(AvailabilityInfo info) => [
+      info.domain,
+      info.unavailable ? 'unavailable' : null,
+      _generateAvailabilityVersion(info.introduced, 'introduced'),
+      _generateAvailabilityVersion(info.deprecated, 'deprecated'),
+      _generateAvailabilityVersion(info.obsoleted, 'obsoleted'),
+    ].nonNulls;
+
+String? _generateAvailabilityVersion(AvailabilityVersion? v, String key) =>
+    v == null ? null : '$key: $v';

--- a/pkgs/swift2objc/lib/src/generator/generators/class_generator.dart
+++ b/pkgs/swift2objc/lib/src/generator/generators/class_generator.dart
@@ -13,6 +13,7 @@ import '../generator.dart';
 
 List<String> generateClass(ClassDeclaration declaration) {
   return [
+    ...generateAvailability(declaration),
     '${_generateClassHeader(declaration)} {',
     ...[
       _generateClassWrappedInstance(declaration),
@@ -88,6 +89,7 @@ List<String> _generateInitializer(InitializerDeclaration initializer) {
   header.write('(${generateParameters(initializer.params)})');
 
   return [
+    ...generateAvailability(initializer),
     '$header ${generateAnnotations(initializer)}{',
     ...initializer.statements.indent(),
     '}\n',
@@ -123,6 +125,7 @@ List<String> _generateClassMethod(MethodDeclaration method) {
   }
 
   return [
+    ...generateAvailability(method),
     '$header{',
     ...method.statements.indent(),
     '}\n',
@@ -167,6 +170,7 @@ List<String> _generateClassProperty(PropertyDeclaration property) {
   ];
 
   return [
+    ...generateAvailability(property),
     header.toString(),
     ...getterLines.indent(),
     if (property.hasSetter) ...setterLines.indent(),

--- a/pkgs/swift2objc/lib/src/parser/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/parser/_core/utils.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import '../../ast/_core/interfaces/availability.dart';
 import '../../ast/_core/interfaces/declaration.dart';
 import '../../ast/_core/interfaces/nestable_declaration.dart';
 import '../../ast/_core/shared/referred_type.dart';
@@ -75,6 +76,11 @@ bool parseSymbolHasObjcAnnotation(Json symbolJson) {
 bool parseIsOverriding(Json symbolJson) {
   return symbolJson['declarationFragments']
       .any((json) => matchFragment(json, 'keyword', 'override'));
+}
+
+List<AvailabilityInfo> parseAvailability(Json symbolJson) {
+  // TODO
+  return [];
 }
 
 final class ObsoleteException implements Exception {

--- a/pkgs/swift2objc/lib/src/parser/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/parser/_core/utils.dart
@@ -73,8 +73,11 @@ bool parseSymbolHasObjcAnnotation(Json symbolJson) =>
 bool parseIsOverriding(Json symbolJson) => symbolJson['declarationFragments']
     .any((json) => matchFragment(json, 'keyword', 'override'));
 
-List<AvailabilityInfo> parseAvailability(Json symbolJson) =>
-    symbolJson['availability'].map(_parseAvailabilityInfo).toList();
+List<AvailabilityInfo> parseAvailability(Json symbolJson) {
+  final availability = symbolJson['availability'];
+  if (!availability.exists) return const [];
+  return availability.map(_parseAvailabilityInfo).toList();
+}
 
 AvailabilityInfo _parseAvailabilityInfo(Json json) => AvailabilityInfo(
       domain: json['domain'].get(),

--- a/pkgs/swift2objc/lib/src/parser/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/parser/_core/utils.dart
@@ -62,26 +62,35 @@ String parseSymbolId(Json symbolJson) {
   return id;
 }
 
-String parseSymbolName(Json symbolJson) {
-  return symbolJson['declarationFragments']
-      .firstJsonWhereKey('kind', 'identifier')['spelling']
-      .get();
-}
+String parseSymbolName(Json symbolJson) => symbolJson['declarationFragments']
+    .firstJsonWhereKey('kind', 'identifier')['spelling']
+    .get();
 
-bool parseSymbolHasObjcAnnotation(Json symbolJson) {
-  return symbolJson['declarationFragments']
-      .any((json) => matchFragment(json, 'attribute', '@objc'));
-}
+bool parseSymbolHasObjcAnnotation(Json symbolJson) =>
+    symbolJson['declarationFragments']
+        .any((json) => matchFragment(json, 'attribute', '@objc'));
 
-bool parseIsOverriding(Json symbolJson) {
-  return symbolJson['declarationFragments']
-      .any((json) => matchFragment(json, 'keyword', 'override'));
-}
+bool parseIsOverriding(Json symbolJson) => symbolJson['declarationFragments']
+    .any((json) => matchFragment(json, 'keyword', 'override'));
 
-List<AvailabilityInfo> parseAvailability(Json symbolJson) {
-  // TODO
-  return [];
-}
+List<AvailabilityInfo> parseAvailability(Json symbolJson) =>
+    symbolJson['availability'].map(_parseAvailabilityInfo).toList();
+
+AvailabilityInfo _parseAvailabilityInfo(Json json) => AvailabilityInfo(
+      domain: json['domain'].get(),
+      unavailable: json['isUnconditionallyUnavailable'].get<bool?>() ?? false,
+      introduced: _parseAvailabilityVersion(json['introduced']),
+      deprecated: _parseAvailabilityVersion(json['deprecated']),
+      obsoleted: _parseAvailabilityVersion(json['obsoleted']),
+    );
+
+AvailabilityVersion? _parseAvailabilityVersion(Json json) => !json.exists
+    ? null
+    : AvailabilityVersion(
+        major: json['major'].get(),
+        minor: json['minor'].get(),
+        patch: json['patch'].get(),
+      );
 
 final class ObsoleteException implements Exception {
   final String symbol;

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_compound_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_compound_declaration.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../../ast/_core/interfaces/availability.dart';
 import '../../../ast/_core/interfaces/compound_declaration.dart';
 import '../../../ast/_core/interfaces/nestable_declaration.dart';
 import '../../../ast/declarations/compounds/class_declaration.dart';
@@ -16,6 +17,7 @@ import '../parse_declarations.dart';
 typedef CompoundTearOff<T extends CompoundDeclaration> = T Function({
   required String id,
   required String name,
+  required List<AvailabilityInfo> availability,
   required List<PropertyDeclaration> properties,
   required List<MethodDeclaration> methods,
   required List<InitializerDeclaration> initializers,
@@ -34,6 +36,7 @@ T _parseCompoundDeclaration<T extends CompoundDeclaration>(
   final compound = tearoffConstructor(
     id: compoundId,
     name: parseSymbolName(compoundSymbol.json),
+    availability: parseAvailability(compoundSymbol.json),
     methods: [],
     properties: [],
     initializers: [],

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_function_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_function_declaration.dart
@@ -21,6 +21,7 @@ GlobalFunctionDeclaration parseGlobalFunctionDeclaration(
   return GlobalFunctionDeclaration(
     id: parseSymbolId(globalFunctionSymbolJson),
     name: parseSymbolName(globalFunctionSymbolJson),
+    availability: parseAvailability(globalFunctionSymbolJson),
     returnType: _parseFunctionReturnType(globalFunctionSymbolJson, symbolgraph),
     params: info.params,
     throws: info.throws,
@@ -38,6 +39,7 @@ MethodDeclaration parseMethodDeclaration(
   return MethodDeclaration(
       id: parseSymbolId(methodSymbolJson),
       name: parseSymbolName(methodSymbolJson),
+      availability: parseAvailability(methodSymbolJson),
       returnType: _parseFunctionReturnType(methodSymbolJson, symbolgraph),
       params: info.params,
       hasObjCAnnotation: parseSymbolHasObjcAnnotation(methodSymbolJson),

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_initializer_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_initializer_declaration.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import '../../../ast/declarations/compounds/members/initializer_declaration.dart';
 import '../../_core/json.dart';
 import '../../_core/parsed_symbolgraph.dart';
@@ -23,6 +27,7 @@ InitializerDeclaration parseInitializerDeclaration(
 
   return InitializerDeclaration(
     id: id,
+    availability: parseAvailability(initializerSymbolJson),
     params: info.params,
     hasObjCAnnotation: parseSymbolHasObjcAnnotation(initializerSymbolJson),
     isOverriding: parseIsOverriding(initializerSymbolJson),

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_typealias_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_typealias_declaration.dart
@@ -13,6 +13,7 @@ TypealiasDeclaration? parseTypealiasDeclaration(
     Json typealiasSymbolJson, ParsedSymbolgraph symbolgraph) {
   final id = parseSymbolId(typealiasSymbolJson);
   final name = parseSymbolName(typealiasSymbolJson);
+  final availability = parseAvailability(typealiasSymbolJson);
   final declarationFragments = typealiasSymbolJson['declarationFragments'];
 
   final malformedException = Exception(
@@ -27,5 +28,6 @@ TypealiasDeclaration? parseTypealiasDeclaration(
   final (target, remaining) = parseType(symbolgraph, tokens.slice(equals + 1));
   if (remaining.isNotEmpty) throw malformedException;
 
-  return TypealiasDeclaration(id: id, name: name, target: target);
+  return TypealiasDeclaration(
+      id: id, name: name, availability: availability, target: target);
 }

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_variable_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_variable_declaration.dart
@@ -19,6 +19,7 @@ PropertyDeclaration parsePropertyDeclaration(
   return PropertyDeclaration(
     id: parseSymbolId(propertySymbolJson),
     name: parseSymbolName(propertySymbolJson),
+    availability: parseAvailability(propertySymbolJson),
     type: _parseVariableType(propertySymbolJson, symbolgraph),
     hasObjCAnnotation: parseSymbolHasObjcAnnotation(propertySymbolJson),
     isConstant: info.constant,
@@ -41,6 +42,7 @@ GlobalVariableDeclaration parseGlobalVariableDeclaration(
   return GlobalVariableDeclaration(
     id: parseSymbolId(variableSymbolJson),
     name: parseSymbolName(variableSymbolJson),
+    availability: parseAvailability(variableSymbolJson),
     type: _parseVariableType(variableSymbolJson, symbolgraph),
     isConstant: info.constant || !info.setter,
     throws: info.throws,

--- a/pkgs/swift2objc/lib/src/transformer/_core/primitive_wrappers.dart
+++ b/pkgs/swift2objc/lib/src/transformer/_core/primitive_wrappers.dart
@@ -21,14 +21,17 @@ final _primitiveWrappers = List<(ReferredType, ReferredType)>.unmodifiable([
 ]);
 
 ReferredType _createWrapperClass(DeclaredType primitiveType) {
+  final availability = primitiveType.declaration.availability;
   final property = PropertyDeclaration(
     id: primitiveType.id.addIdSuffix('wrappedInstance'),
     name: 'wrappedInstance',
+    availability: availability,
     type: primitiveType,
   );
   return ClassDeclaration(
           id: primitiveType.id.addIdSuffix('wrapper'),
           name: '${primitiveType.name}Wrapper',
+          availability: availability,
           hasObjCAnnotation: true,
           superClass: objectType,
           isWrapper: true,

--- a/pkgs/swift2objc/lib/src/transformer/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/transformer/_core/utils.dart
@@ -103,6 +103,7 @@ InitializerDeclaration buildWrapperInitializer(
 ) {
   return InitializerDeclaration(
     id: '',
+    availability: const [],
     params: [
       Parameter(
         name: '_',

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_compound.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_compound.dart
@@ -28,12 +28,14 @@ ClassDeclaration transformCompound(
   final wrappedCompoundInstance = PropertyDeclaration(
     id: originalCompound.id.addIdSuffix('wrappedInstance'),
     name: compoundNamer.makeUnique('wrappedInstance'),
+    availability: const [],
     type: originalCompound.asDeclaredType,
   );
 
   final transformedCompound = ClassDeclaration(
     id: originalCompound.id.addIdSuffix('wrapper'),
     name: parentNamer.makeUnique('${originalCompound.name}Wrapper'),
+    availability: originalCompound.availability,
     hasObjCAnnotation: true,
     superClass: objectType,
     isWrapper: true,

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_function.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_function.dart
@@ -94,6 +94,7 @@ MethodDeclaration _transformFunction(
   final transformedMethod = MethodDeclaration(
     id: originalFunction.id,
     name: wrapperMethodName,
+    availability: originalFunction.availability,
     returnType: type,
     params: transformedParams,
     hasObjCAnnotation: true,

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_globals.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_globals.dart
@@ -18,6 +18,7 @@ ClassDeclaration transformGlobals(
   final transformedGlobals = ClassDeclaration(
     id: 'globals'.addIdSuffix('wrapper'),
     name: globalNamer.makeUnique('GlobalsWrapper'),
+    availability: const [],
     hasObjCAnnotation: true,
     superClass: objectType,
     isWrapper: true,

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_initializer.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_initializer.dart
@@ -40,6 +40,7 @@ Declaration transformInitializer(
     return MethodDeclaration(
       id: originalInitializer.id,
       name: '${originalInitializer.name}Wrapper',
+      availability: originalInitializer.availability,
       returnType: originalInitializer.isFailable
           ? OptionalType(methodReturnType)
           : methodReturnType,
@@ -59,6 +60,7 @@ Declaration transformInitializer(
 
   final transformedInitializer = InitializerDeclaration(
       id: originalInitializer.id,
+      availability: originalInitializer.availability,
       params: transformedParams,
       hasObjCAnnotation: true,
       isFailable: originalInitializer.isFailable,

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_variable.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_variable.dart
@@ -93,6 +93,7 @@ Declaration _transformVariable(
     return MethodDeclaration(
       id: originalVariable.id,
       name: wrapperPropertyName,
+      availability: originalVariable.availability,
       returnType: type,
       params: [],
       hasObjCAnnotation: true,
@@ -111,6 +112,7 @@ Declaration _transformVariable(
   final transformedProperty = PropertyDeclaration(
     id: originalVariable.id,
     name: wrapperPropertyName,
+    availability: originalVariable.availability,
     type: transformedType,
     hasObjCAnnotation: true,
     hasSetter: shouldGenerateSetter,

--- a/pkgs/swift2objc/test/integration/available_input.swift
+++ b/pkgs/swift2objc/test/integration/available_input.swift
@@ -1,12 +1,49 @@
 @available(iOS 100, macOS 123.0.0, *)
 public class NewApi {
+  @available(iOS 101, macOS 456, *)
+  public init(x: Int) {
+    prop1 = x;
+    prop2 = x;
+  }
+
   public func method1() -> Int { return 123; }
 
-  @available(iOS 100.0, macOS 123.4.5, *)
+  @available(iOS 100.1, macOS 123.4.5, *)
   public func method2() -> Int { return 123; }
 
   @available(iOS, unavailable)
   @available(macOS, introduced: 200, deprecated: 201, obsoleted: 202,
       message: "Hello")
   public func method3() -> Int { return 123; }
+
+  public var prop1: Int;
+
+  @available(iOS, introduced: 234.5.6)
+  @available(macOS, deprecated: 345.6)
+  public var prop2: Int;
 }
+
+@available(iOS 100, macOS 123.0.0, *)
+public struct NewStruct {
+  public func method1() -> Int { return 123; }
+
+  @available(iOS 100.1, macOS 123.4.5, *)
+  public func method2() -> Int { return 123; }
+
+  public var prop1: Int;
+
+  @available(iOS, introduced: 234.5.6)
+  @available(macOS, deprecated: 345.6)
+  public var prop2: Int;
+}
+
+@available(iOS 200, macOS 200, *)
+public typealias NewerApi = NewApi;
+
+@available(iOS, introduced: 1234.5.6)
+@available(macOS, obsoleted: 999)
+public var globalVar: Int = 123;
+
+@available(iOS, unavailable)
+@available(macOS, introduced: 234.5.6)
+public func globalFunc(x: NewerApi) -> Int { return 123; }

--- a/pkgs/swift2objc/test/integration/available_input.swift
+++ b/pkgs/swift2objc/test/integration/available_input.swift
@@ -1,0 +1,12 @@
+@available(iOS 100, macOS 123.0.0, *)
+public class NewApi {
+  public func method1() -> Int { return 123; }
+
+  @available(iOS 100.0, macOS 123.4.5, *)
+  public func method2() -> Int { return 123; }
+
+  @available(iOS, unavailable)
+  @available(macOS, introduced: 200, deprecated: 201, obsoleted: 202,
+      message: "Hello")
+  public func method3() -> Int { return 123; }
+}

--- a/pkgs/swift2objc/test/integration/available_output.swift
+++ b/pkgs/swift2objc/test/integration/available_output.swift
@@ -2,12 +2,111 @@
 
 import Foundation
 
+@objc public class GlobalsWrapper: NSObject {
+  @available(macOS, obsoleted: 999)
+  @available(iOS, introduced: 1234.5.6)
+  @objc static public var globalVarWrapper: Int {
+    get {
+      globalVar
+    }
+    set {
+      globalVar = newValue
+    }
+  }
+
+  @available(macOS, introduced: 234.5.6)
+  @available(iOS, unavailable)
+  @objc static public func globalFuncWrapper(x: NewApiWrapper) -> Int {
+    return globalFunc(x: x.wrappedInstance)
+  }
+
+}
+
 @available(macOS, introduced: 123.0.0)
 @available(iOS, introduced: 100)
 @objc public class NewApiWrapper: NSObject {
   var wrappedInstance: NewApi
 
+  @available(macOS, introduced: 123.0.0)
+  @available(iOS, introduced: 100)
+  @objc public var prop1: Int {
+    get {
+      wrappedInstance.prop1
+    }
+    set {
+      wrappedInstance.prop1 = newValue
+    }
+  }
+
+  @available(macOS, introduced: 123.0.0, deprecated: 345.6)
+  @available(iOS, introduced: 234.5.6)
+  @objc public var prop2: Int {
+    get {
+      wrappedInstance.prop2
+    }
+    set {
+      wrappedInstance.prop2 = newValue
+    }
+  }
+
   init(_ wrappedInstance: NewApi) {
+    self.wrappedInstance = wrappedInstance
+  }
+
+  @available(macOS, introduced: 456)
+  @available(iOS, introduced: 101)
+  @objc init(x: Int) {
+    wrappedInstance = NewApi(x: x)
+  }
+
+  @available(macOS, introduced: 123.0.0)
+  @available(iOS, introduced: 100)
+  @objc public func method1() -> Int {
+    return wrappedInstance.method1()
+  }
+
+  @available(macOS, introduced: 123.4.5)
+  @available(iOS, introduced: 100.1)
+  @objc public func method2() -> Int {
+    return wrappedInstance.method2()
+  }
+
+  @available(macOS, introduced: 200, deprecated: 201, obsoleted: 202)
+  @available(iOS, unavailable, introduced: 100)
+  @objc public func method3() -> Int {
+    return wrappedInstance.method3()
+  }
+
+}
+
+@available(macOS, introduced: 123.0.0)
+@available(iOS, introduced: 100)
+@objc public class NewStructWrapper: NSObject {
+  var wrappedInstance: NewStruct
+
+  @available(macOS, introduced: 123.0.0)
+  @available(iOS, introduced: 100)
+  @objc public var prop1: Int {
+    get {
+      wrappedInstance.prop1
+    }
+    set {
+      wrappedInstance.prop1 = newValue
+    }
+  }
+
+  @available(macOS, introduced: 123.0.0, deprecated: 345.6)
+  @available(iOS, introduced: 234.5.6)
+  @objc public var prop2: Int {
+    get {
+      wrappedInstance.prop2
+    }
+    set {
+      wrappedInstance.prop2 = newValue
+    }
+  }
+
+  init(_ wrappedInstance: NewStruct) {
     self.wrappedInstance = wrappedInstance
   }
 
@@ -18,15 +117,9 @@ import Foundation
   }
 
   @available(macOS, introduced: 123.4.5)
-  @available(iOS, introduced: 100.0)
+  @available(iOS, introduced: 100.1)
   @objc public func method2() -> Int {
     return wrappedInstance.method2()
-  }
-
-  @available(macOS, introduced: 200, deprecated: 201, obsoleted: 202)
-  @available(iOS, unavailable, introduced: 100)
-  @objc public func method3() -> Int {
-    return wrappedInstance.method3()
   }
 
 }

--- a/pkgs/swift2objc/test/integration/available_output.swift
+++ b/pkgs/swift2objc/test/integration/available_output.swift
@@ -1,0 +1,33 @@
+// Test preamble text
+
+import Foundation
+
+@available(macOS, introduced: 123.0.0)
+@available(iOS, introduced: 100)
+@objc public class NewApiWrapper: NSObject {
+  var wrappedInstance: NewApi
+
+  init(_ wrappedInstance: NewApi) {
+    self.wrappedInstance = wrappedInstance
+  }
+
+  @available(macOS, introduced: 123.0.0)
+  @available(iOS, introduced: 100)
+  @objc public func method1() -> Int {
+    return wrappedInstance.method1()
+  }
+
+  @available(macOS, introduced: 123.4.5)
+  @available(iOS, introduced: 100.0)
+  @objc public func method2() -> Int {
+    return wrappedInstance.method2()
+  }
+
+  @available(macOS, introduced: 200, deprecated: 201, obsoleted: 202)
+  @available(iOS, unavailable, introduced: 100)
+  @objc public func method3() -> Int {
+    return wrappedInstance.method3()
+  }
+
+}
+

--- a/pkgs/swift2objc/test/unit/parse_type_test.dart
+++ b/pkgs/swift2objc/test/unit/parse_type_test.dart
@@ -15,8 +15,10 @@ import 'package:swift2objc/src/parser/parsers/parse_type.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final classFoo = ClassDeclaration(id: 'Foo', name: 'Foo');
-  final classBar = ClassDeclaration(id: 'Bar', name: 'Bar');
+  final classFoo =
+      ClassDeclaration(id: 'Foo', name: 'Foo', availability: const []);
+  final classBar =
+      ClassDeclaration(id: 'Bar', name: 'Bar', availability: const []);
 
   final testDecls = <Declaration>[
     ...builtInDeclarations,


### PR DESCRIPTION
Swift has an `@available` annotation that indicates when an API was introduced, deprecated, or obsoleted. It can also indicate if the API is completely unavailable on a platform. This annotation can be applied to any declaration (class, method, property, global variable etc).

We need to parse these annotations in swift2objc, and reproduce them in the generated wrapper API. If we don't, the swift compiler complains that our wrapper method (which is available in all versions by default) is calling a method that isn't always available.

```swift
@available(iOS 100, macOS 123.0.0, *)
public class SomeClass {
  @available(iOS 100.1, macOS 123.4.5, *)
  public func method() -> Int { return 123; }
}
```

That short syntax only describes when the API was introduced. For the other stuff there's this alternative syntax, where each OS (aka domain) has a separate annotation:

```swift
@available(iOS, unavailable)
@available(macOS, introduced: 200, deprecated: 201, obsoleted: 202, message: "Hello")
public func globalFunc() -> Int { return 123; }
```

Both syntaxes look identical after being parsed into the symbolgraph, which is convenient. I just used the more verbose syntax when doing code gen, otherwise I'd have to implement a check for whether the annotations can fit in the short syntax.

The PR is straightforward. Just had to add the availability info to the AST (added an `Availability` interface and made `Declaration` implement it), parse it from the symbolgraph, plumb the availability through the transformer, and then code gen it.

Fixes https://github.com/dart-lang/native/issues/2428