### PR TITLE
[hooks_runner] Make link hook test data more readable

### DIFF
--- a/pkgs/hooks_runner/test_data/treeshaking_native_libs/hook/link.dart
+++ b/pkgs/hooks_runner/test_data/treeshaking_native_libs/hook/link.dart
@@ -10,7 +10,7 @@ import 'package:native_toolchain_c/native_toolchain_c.dart';
 void main(List<String> arguments) async {
   await link(arguments, (input, output) async {
     final asset = input.assets.code.single;
-    final packageName = asset.id.split('/').first;
+    final packageName = asset.id.split('/').first.replaceAll('package:', '');
     final assetName = asset.id.split('/').skip(1).join('/');
     final linker = CLinker.library(
       name: packageName,


### PR DESCRIPTION
When browsing our examples/test_data for link hooks for https://github.com/dart-lang/site-www/pull/6759, I noticed this could use a clean up.