### PR TITLE
[swift2objc] Add toll free bridged types

### DIFF
--- a/pkgs/swift2objc/lib/src/ast/declarations/built_in/built_in_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/built_in/built_in_declaration.dart
@@ -41,12 +41,13 @@ const _voidDecl = BuiltInDeclaration(id: 's:s4Voida', name: 'Void');
 // need @objc compatible wrappers. There's no complete list of these types in
 // the documentation. The closest thing is this, but it's incomplete:
 // https://developer.apple.com/documentation/swift/working-with-foundation-types
+// TODO(https://github.com/dart-lang/native/issues/2485): Add Array, Set, and
+// Dictionary to this list.
 const _objectDecl =
     BuiltInDeclaration(id: 'c:objc(cs)NSObject', name: 'NSObject');
 const _errorDecl = BuiltInDeclaration(id: 'c:objc(cs)NSError', name: 'NSError');
 const _affineTransformDecl = BuiltInDeclaration(
     id: 's:10Foundation15AffineTransformV', name: 'AffineTransform');
-const _arrayDecl = BuiltInDeclaration(id: 's:Sa', name: 'Array');
 const _calendarDecl =
     BuiltInDeclaration(id: 's:10Foundation8CalendarV', name: 'Calendar');
 const _characterSetDecl = BuiltInDeclaration(
@@ -57,7 +58,6 @@ const _dateComponentsDecl = BuiltInDeclaration(
     id: 's:10Foundation14DateComponentsV', name: 'DateComponents');
 const _dateIntervalDecl = BuiltInDeclaration(
     id: 's:10Foundation12DateIntervalV', name: 'DateInterval');
-const _dictionaryDecl = BuiltInDeclaration(id: 's:SD', name: 'Dictionary');
 const _indexPathDecl =
     BuiltInDeclaration(id: 's:10Foundation9IndexPathV', name: 'IndexPath');
 const _indexSetDecl =
@@ -66,7 +66,6 @@ const _localeDecl =
     BuiltInDeclaration(id: 's:10Foundation6LocaleV', name: 'Locale');
 const _notificationDecl = BuiltInDeclaration(
     id: 's:10Foundation12NotificationV', name: 'Notification');
-const _setDecl = BuiltInDeclaration(id: 's:Sh', name: 'Set');
 const _stringDecl = BuiltInDeclaration(id: 's:SS', name: 'String');
 const _timeZoneDecl =
     BuiltInDeclaration(id: 's:10Foundation8TimeZoneV', name: 'TimeZone');
@@ -81,7 +80,6 @@ const _uuidDecl = BuiltInDeclaration(id: 's:10Foundation4UUIDV', name: 'UUID');
 
 const builtInDeclarations = [
   _affineTransformDecl,
-  _arrayDecl,
   _boolDecl,
   _calendarDecl,
   _characterSetDecl,
@@ -89,7 +87,6 @@ const builtInDeclarations = [
   _dateComponentsDecl,
   _dateDecl,
   _dateIntervalDecl,
-  _dictionaryDecl,
   _doubleDecl,
   _errorDecl,
   _floatDecl,
@@ -99,7 +96,6 @@ const builtInDeclarations = [
   _localeDecl,
   _notificationDecl,
   _objectDecl,
-  _setDecl,
   _stringDecl,
   _timeZoneDecl,
   _urlComponentsDecl,

--- a/pkgs/swift2objc/lib/src/ast/declarations/built_in/built_in_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/built_in/built_in_declaration.dart
@@ -39,8 +39,7 @@ const _voidDecl = BuiltInDeclaration(id: 's:s4Voida', name: 'Void');
 
 // Certain types are toll-free bridged between Swift and ObjC. These types don't
 // need @objc compatible wrappers. There's no complete list of these types in
-// the documentation. The closest thing is this, but it's missing a lot of
-// entries, and also contains incorrect entries:
+// the documentation. The closest thing is this, but it's incomplete:
 // https://developer.apple.com/documentation/swift/working-with-foundation-types
 const _objectDecl =
     BuiltInDeclaration(id: 'c:objc(cs)NSObject', name: 'NSObject');

--- a/pkgs/swift2objc/lib/src/ast/declarations/built_in/built_in_declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/declarations/built_in/built_in_declaration.dart
@@ -31,22 +31,83 @@ class BuiltInDeclaration extends AstNode
   void visit(Visitation visitation) => visitation.visitBuiltInDeclaration(this);
 }
 
-const _objectDecl =
-    BuiltInDeclaration(id: 'c:objc(cs)NSObject', name: 'NSObject');
-const _stringDecl = BuiltInDeclaration(id: 's:SS', name: 'String');
 const _intDecl = BuiltInDeclaration(id: 's:Si', name: 'Int');
 const _floatDecl = BuiltInDeclaration(id: 's:Sf', name: 'Float');
 const _doubleDecl = BuiltInDeclaration(id: 's:Sd', name: 'Double');
 const _boolDecl = BuiltInDeclaration(id: 's:Sb', name: 'Bool');
 const _voidDecl = BuiltInDeclaration(id: 's:s4Voida', name: 'Void');
 
+// Certain types are toll-free bridged between Swift and ObjC. These types don't
+// need @objc compatible wrappers. There's no complete list of these types in
+// the documentation. The closest thing is this, but it's missing a lot of
+// entries, and also contains incorrect entries:
+// https://developer.apple.com/documentation/swift/working-with-foundation-types
+const _objectDecl =
+    BuiltInDeclaration(id: 'c:objc(cs)NSObject', name: 'NSObject');
+const _errorDecl = BuiltInDeclaration(id: 'c:objc(cs)NSError', name: 'NSError');
+const _affineTransformDecl = BuiltInDeclaration(
+    id: 's:10Foundation15AffineTransformV', name: 'AffineTransform');
+const _arrayDecl = BuiltInDeclaration(id: 's:Sa', name: 'Array');
+const _calendarDecl =
+    BuiltInDeclaration(id: 's:10Foundation8CalendarV', name: 'Calendar');
+const _characterSetDecl = BuiltInDeclaration(
+    id: 's:10Foundation12CharacterSetV', name: 'CharacterSet');
+const _dataDecl = BuiltInDeclaration(id: 's:10Foundation4DataV', name: 'Data');
+const _dateDecl = BuiltInDeclaration(id: 's:10Foundation4DateV', name: 'Date');
+const _dateComponentsDecl = BuiltInDeclaration(
+    id: 's:10Foundation14DateComponentsV', name: 'DateComponents');
+const _dateIntervalDecl = BuiltInDeclaration(
+    id: 's:10Foundation12DateIntervalV', name: 'DateInterval');
+const _dictionaryDecl = BuiltInDeclaration(id: 's:SD', name: 'Dictionary');
+const _indexPathDecl =
+    BuiltInDeclaration(id: 's:10Foundation9IndexPathV', name: 'IndexPath');
+const _indexSetDecl =
+    BuiltInDeclaration(id: 's:10Foundation8IndexSetV', name: 'IndexSet');
+const _localeDecl =
+    BuiltInDeclaration(id: 's:10Foundation6LocaleV', name: 'Locale');
+const _notificationDecl = BuiltInDeclaration(
+    id: 's:10Foundation12NotificationV', name: 'Notification');
+const _setDecl = BuiltInDeclaration(id: 's:Sh', name: 'Set');
+const _stringDecl = BuiltInDeclaration(id: 's:SS', name: 'String');
+const _timeZoneDecl =
+    BuiltInDeclaration(id: 's:10Foundation8TimeZoneV', name: 'TimeZone');
+const _urlDecl = BuiltInDeclaration(id: 's:10Foundation3URLV', name: 'URL');
+const _urlComponentsDecl = BuiltInDeclaration(
+    id: 's:10Foundation13URLComponentsV', name: 'URLComponents');
+const _urlQueryItemDecl = BuiltInDeclaration(
+    id: 's:10Foundation12URLQueryItemV', name: 'URLQueryItem');
+const _urlRequestDecl =
+    BuiltInDeclaration(id: 's:10Foundation10URLRequestV', name: 'URLRequest');
+const _uuidDecl = BuiltInDeclaration(id: 's:10Foundation4UUIDV', name: 'UUID');
+
 const builtInDeclarations = [
-  _objectDecl,
-  _stringDecl,
-  _intDecl,
-  _floatDecl,
-  _doubleDecl,
+  _affineTransformDecl,
+  _arrayDecl,
   _boolDecl,
+  _calendarDecl,
+  _characterSetDecl,
+  _dataDecl,
+  _dateComponentsDecl,
+  _dateDecl,
+  _dateIntervalDecl,
+  _dictionaryDecl,
+  _doubleDecl,
+  _errorDecl,
+  _floatDecl,
+  _indexPathDecl,
+  _indexSetDecl,
+  _intDecl,
+  _localeDecl,
+  _notificationDecl,
+  _objectDecl,
+  _setDecl,
+  _stringDecl,
+  _timeZoneDecl,
+  _urlComponentsDecl,
+  _urlDecl,
+  _urlQueryItemDecl,
+  _urlRequestDecl,
+  _uuidDecl,
   _voidDecl,
 ];
 

--- a/pkgs/swift2objc/test/integration/bridging_input.swift
+++ b/pkgs/swift2objc/test/integration/bridging_input.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+// TODO(https://github.com/dart-lang/native/issues/2485): Uncomment the Array,
+// Dictionary, and Set functions.
+
+public func funcAffineTransform() -> AffineTransform? { return nil; }
+// public func funcArray() -> Array<String>? { return nil; }
+public func funcCalendar() -> Calendar? { return nil; }
+public func funcCharacterSet() -> CharacterSet? { return nil; }
+public func funcData() -> Data? { return nil; }
+public func funcDate() -> Date? { return nil; }
+public func funcDateComponents() -> DateComponents? { return nil; }
+public func funcDateInterval() -> DateInterval? { return nil; }
+// public func funcDictionary() -> Dictionary<String, String>? { return nil; }
+public func funcIndexPath() -> IndexPath? { return nil; }
+public func funcIndexSet() -> IndexSet? { return nil; }
+public func funcLocale() -> Locale? { return nil; }
+public func funcNotification() -> Notification? { return nil; }
+public func funcNSError() -> NSError? { return nil; }
+// public func funcSet() -> Set<String>? { return nil; }
+public func funcString() -> String? { return nil; }
+public func funcTimeZone() -> TimeZone? { return nil; }
+public func funcURL() -> URL? { return nil; }
+public func funcURLComponents() -> URLComponents? { return nil; }
+public func funcURLQueryItem() -> URLQueryItem? { return nil; }
+public func funcURLRequest() -> URLRequest? { return nil; }
+public func funcUUID() -> UUID? { return nil; }

--- a/pkgs/swift2objc/test/integration/bridging_output.swift
+++ b/pkgs/swift2objc/test/integration/bridging_output.swift
@@ -1,0 +1,83 @@
+// Test preamble text
+
+import Foundation
+
+@objc public class GlobalsWrapper: NSObject {
+  @objc static public func funcLocaleWrapper() -> Locale? {
+    return funcLocale()
+  }
+
+  @objc static public func funcStringWrapper() -> String? {
+    return funcString()
+  }
+
+  @objc static public func funcNSErrorWrapper() -> NSError? {
+    return funcNSError()
+  }
+
+  @objc static public func funcCalendarWrapper() -> Calendar? {
+    return funcCalendar()
+  }
+
+  @objc static public func funcIndexSetWrapper() -> IndexSet? {
+    return funcIndexSet()
+  }
+
+  @objc static public func funcTimeZoneWrapper() -> TimeZone? {
+    return funcTimeZone()
+  }
+
+  @objc static public func funcIndexPathWrapper() -> IndexPath? {
+    return funcIndexPath()
+  }
+
+  @objc static public func funcURLRequestWrapper() -> URLRequest? {
+    return funcURLRequest()
+  }
+
+  @objc static public func funcCharacterSetWrapper() -> CharacterSet? {
+    return funcCharacterSet()
+  }
+
+  @objc static public func funcDateIntervalWrapper() -> DateInterval? {
+    return funcDateInterval()
+  }
+
+  @objc static public func funcNotificationWrapper() -> Notification? {
+    return funcNotification()
+  }
+
+  @objc static public func funcURLQueryItemWrapper() -> URLQueryItem? {
+    return funcURLQueryItem()
+  }
+
+  @objc static public func funcURLComponentsWrapper() -> URLComponents? {
+    return funcURLComponents()
+  }
+
+  @objc static public func funcDateComponentsWrapper() -> DateComponents? {
+    return funcDateComponents()
+  }
+
+  @objc static public func funcAffineTransformWrapper() -> AffineTransform? {
+    return funcAffineTransform()
+  }
+
+  @objc static public func funcURLWrapper() -> URL? {
+    return funcURL()
+  }
+
+  @objc static public func funcDataWrapper() -> Data? {
+    return funcData()
+  }
+
+  @objc static public func funcDateWrapper() -> Date? {
+    return funcDate()
+  }
+
+  @objc static public func funcUUIDWrapper() -> UUID? {
+    return funcUUID()
+  }
+
+}
+


### PR DESCRIPTION
There are a lot of "toll-free bridging" types in Swift. These are types that are special cased in the swift compiler to be `@objc` compatible, even though the declarations don't have `@objc` annotations. We also need to special case these types in the same way. The easiest way is to make them `BuiltInDeclaration`s.

Unfortunately, there's no canonical list of these bridged types that I can find. The closest thing is https://developer.apple.com/documentation/swift/working-with-foundation-types, but it's incomplete.

Note that the integration test tries to compile the generated wrapper code, which effectively tests that these types do bridge as expected. If any of these types were not `@objc` compatible, the compiler would complain and the test would fail.