### PR TITLE
[hooks_runner] Add the manifest generator to the ci checks

### DIFF
--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   yaml: ^3.1.3
 
 dev_dependencies:
+  args: any
   custom_lint: ^0.7.5
   dart_flutter_team_lints: ^3.5.2
   data_assets: any # Used in tests.

--- a/pkgs/hooks_runner/test_data/manifest_generator.dart
+++ b/pkgs/hooks_runner/test_data/manifest_generator.dart
@@ -114,6 +114,8 @@ void updateManifest(
     manifestFile.writeAsStringSync(newContent);
     print('Generated ${manifestFile.uri} (content changed)');
     counts.changed++;
+    print(oldContentNormalized);
+    print(newContentNormalized);
   }
   counts.generated++;
 }

--- a/pkgs/hooks_runner/test_data/manifest_generator.dart
+++ b/pkgs/hooks_runner/test_data/manifest_generator.dart
@@ -80,7 +80,7 @@ void updateManifest(
     return;
   }
   final all = directory.listSync(recursive: true);
-  final dirPath = directory.uri.toFilePath();
+  final dirPath = directory.uri.toFilePath(windows: false);
   final files =
       all
           .whereType<File>()
@@ -97,7 +97,9 @@ void updateManifest(
 
             return true;
           })
-          .map((e) => e.path.replaceFirst(dirPath, ''))
+          .map(
+            (e) => e.uri.toFilePath(windows: false).replaceFirst(dirPath, ''),
+          )
           .toList()
         ..sort();
 

--- a/pkgs/hooks_runner/test_data/manifest_generator.dart
+++ b/pkgs/hooks_runner/test_data/manifest_generator.dart
@@ -4,12 +4,48 @@
 
 import 'dart:io';
 
-void main(List<String> args) async {
-  final testDataDirectory = Directory.fromUri(Platform.script.resolve('.'));
-  updateManifest(testDataDirectory, allowPartialProjects: false);
+import 'package:args/args.dart';
+import 'package:native_test_helpers/native_test_helpers.dart';
+
+void main(List<String> args) {
+  final stopwatch = Stopwatch()..start();
+  final parser = ArgParser()
+    ..addFlag(
+      'set-exit-if-changed',
+      negatable: false,
+      help: 'Return a non-zero exit code if any files were changed.',
+    );
+  final argResults = parser.parse(args);
+  final setExitIfChanged = argResults['set-exit-if-changed'] as bool;
+
+  final counts = Counts();
+
+  updateManifests(counts);
+
+  stopwatch.stop();
+  final duration = stopwatch.elapsedMilliseconds / 1000.0;
+  print(
+    'Generated ${counts.generated} files (${counts.changed} changed) in '
+    '${duration.toStringAsFixed(2)} seconds.',
+  );
+  if (setExitIfChanged && counts.changed > 0) {
+    exit(1);
+  }
+}
+
+class Counts {
+  int generated = 0;
+  int changed = 0;
+}
+
+void updateManifests(Counts counts) async {
+  final packageUri = findPackageRoot('hooks_runner');
+  final testDataUri = packageUri.resolve('test_data/');
+  final testDataDirectory = Directory.fromUri(testDataUri);
+  updateManifest(testDataDirectory, counts, allowPartialProjects: false);
   final all = testDataDirectory.listSync(recursive: true);
   all.whereType<Directory>().forEach(
-    (e) => updateManifest(e, allowPartialProjects: true),
+    (e) => updateManifest(e, counts, allowPartialProjects: true),
   );
 }
 
@@ -34,7 +70,11 @@ const partialProjects = [
   'simple_link_change_asset',
 ];
 
-void updateManifest(Directory directory, {required bool allowPartialProjects}) {
+void updateManifest(
+  Directory directory,
+  Counts counts, {
+  required bool allowPartialProjects,
+}) {
   final manifestFile = File.fromUri(directory.uri.resolve('manifest.yaml'));
   if (!manifestFile.existsSync()) {
     return;
@@ -60,7 +100,20 @@ void updateManifest(Directory directory, {required bool allowPartialProjects}) {
           .map((e) => e.path.replaceFirst(dirPath, ''))
           .toList()
         ..sort();
-  manifestFile.writeAsStringSync(header + files.map((e) => '- $e\n').join());
+
+  var oldContent = '';
+  if (manifestFile.existsSync()) {
+    oldContent = manifestFile.readAsStringSync();
+  }
+  final newContent = header + files.map((e) => '- $e\n').join();
+  final newContentNormalized = newContent.replaceAll('\r\n', '\n');
+  final oldContentNormalized = oldContent.replaceAll('\r\n', '\n');
+  if (newContentNormalized != oldContentNormalized) {
+    manifestFile.writeAsStringSync(newContent);
+    print('Generated ${manifestFile.uri} (content changed)');
+    counts.changed++;
+  }
+  counts.generated++;
 }
 
 const header = '''

--- a/pkgs/hooks_runner/test_data/manifest_generator.dart
+++ b/pkgs/hooks_runner/test_data/manifest_generator.dart
@@ -92,7 +92,9 @@ void updateManifest(
                 '$partialProject/pubspec.yaml',
               ],
             ]) {
-              if (f.path.contains(denyString)) return false;
+              if (f.uri.toFilePath(windows: false).contains(denyString)) {
+                return false;
+              }
             }
 
             return true;
@@ -114,8 +116,6 @@ void updateManifest(
     manifestFile.writeAsStringSync(newContent);
     print('Generated ${manifestFile.uri} (content changed)');
     counts.changed++;
-    print(oldContentNormalized);
-    print(newContentNormalized);
   }
   counts.generated++;
 }

--- a/tool/ci.dart
+++ b/tool/ci.dart
@@ -55,6 +55,7 @@ void main(List<String> arguments) async {
 
   if (argResults['generate'] as bool) {
     const generators = [
+      'pkgs/hooks_runner/test_data/manifest_generator.dart',
       'pkgs/hooks/tool/generate_schemas.dart',
       'pkgs/hooks/tool/generate_syntax.dart',
       'pkgs/hooks/tool/normalize.dart',


### PR DESCRIPTION
Addressing the fact we're not checking this automaticaly:

* https://github.com/dart-lang/native/pull/2417#discussion_r2235135012