### PR TITLE
[swift2objc] Fix availability annotation bug

### DIFF
--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/availability.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/availability.dart
@@ -22,6 +22,13 @@ class AvailabilityInfo {
     required this.deprecated,
     required this.obsoleted,
   });
+
+  bool get isEmpty =>
+      domain == '*' &&
+      !unavailable &&
+      introduced == null &&
+      deprecated == null &&
+      obsoleted == null;
 }
 
 /// A version for availability.

--- a/pkgs/swift2objc/lib/src/parser/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/parser/_core/utils.dart
@@ -76,7 +76,10 @@ bool parseIsOverriding(Json symbolJson) => symbolJson['declarationFragments']
 List<AvailabilityInfo> parseAvailability(Json symbolJson) {
   final availability = symbolJson['availability'];
   if (!availability.exists) return const [];
-  return availability.map(_parseAvailabilityInfo).toList();
+  return availability
+      .map(_parseAvailabilityInfo)
+      .where((a) => !a.isEmpty)
+      .toList();
 }
 
 AvailabilityInfo _parseAvailabilityInfo(Json json) => AvailabilityInfo(


### PR DESCRIPTION
Running swift2objc on some Apple APIs, I sometimes get an empty `@available` annotation: `@available(*)`. The swift compiler says this is invalid syntax, and it's not really doing anything, so just omit these ones.

Unfortunately I'm not sure what sort of declaration is actually causing this, since I can't see the source code of the precompiled internal library, so I can't write a test. It'll be tested when I some more issues and can add a test that parses Apple APIs.