### PR TITLE
[code_assets] Validate unique asset ids across build and link hooks

### DIFF
--- a/pkgs/code_assets/CHANGELOG.md
+++ b/pkgs/code_assets/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.19.6-wip
 
 - Added a library comment detailing how to use the package.
+- Fixed duplicate asset id detection with assets coming from both build and
+  link hooks.
 
 ## 0.19.5
 


### PR DESCRIPTION
When assets with the same asset id were emitted from a link hook and build hook this was not caught in the validation.

This meant that in https://github.com/dart-lang/sdk/issues/61285, the hook run didn't fail, and it continued on in dartdev trying to `install_name_tool` twice on the same file.

(This PR doesn't address https://github.com/dart-lang/sdk/issues/61285 yet, it merely gives a more sane error message.)