### PR TITLE
[swift2objc] Fix stubbing edge cases for nested types

### DIFF
--- a/pkgs/swift2objc/lib/src/transformer/_core/dependencies.dart
+++ b/pkgs/swift2objc/lib/src/transformer/_core/dependencies.dart
@@ -23,6 +23,16 @@ class FindIncludesVisitation extends Visitation {
       node.visitChildren(visitor);
     }
   }
+
+  @override
+  void visitCompoundDeclaration(CompoundDeclaration node) {
+    visitDeclaration(node);
+
+    // Visit the nested declarations even if this declaration is filtered. That
+    // way the nested declarations may pass the filter (in which case this
+    // declaration would be stubbed).
+    node.nestedDeclarations.forEach(visitor.visit);
+  }
 }
 
 class ListDeclsVisitation extends Visitation {

--- a/pkgs/swift2objc/lib/src/transformer/_core/dependencies.dart
+++ b/pkgs/swift2objc/lib/src/transformer/_core/dependencies.dart
@@ -34,21 +34,22 @@ class ListDeclsVisitation extends Visitation {
   ListDeclsVisitation(this.includes, this.directTransitives);
 
   @override
+  void visitDeclaration(Declaration node) {
+    // Already did all the children visitiing in the other visitors.
+  }
+
+  @override
   void visitGlobalFunctionDeclaration(GlobalFunctionDeclaration node) {
-    node.visitChildren(visitor);
     topLevelDecls.add(node);
   }
 
   @override
   void visitGlobalVariableDeclaration(GlobalVariableDeclaration node) {
-    node.visitChildren(visitor);
     topLevelDecls.add(node);
   }
 
   @override
   void visitCompoundDeclaration(CompoundDeclaration node) {
-    node.visitChildren(visitor);
-
     // Don't add nested classes etc to the top level declarations.
     if (node.nestingParent == null) topLevelDecls.add(node);
 

--- a/pkgs/swift2objc/lib/src/transformer/transform.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transform.dart
@@ -17,15 +17,15 @@ import 'transformers/transform_compound.dart';
 import 'transformers/transform_globals.dart';
 
 class TransformationState {
-  // Map from untransformed decleration to its transformed declaration, or null
-  // if there is generated code for the declaration.
-  final map = <Declaration, Declaration?>{};
-
   // All the bindings to be generated.
   final bindings = <Declaration>{};
 
   // Bindings that will be generated as stubs.
   final stubs = <Declaration>{};
+
+  // Map from untransformed decleration to its transformed declaration, or null
+  // if there is generated code for the declaration.
+  final map = <Declaration, Declaration?>{};
 }
 
 /// Transforms the given declarations into the desired ObjC wrapped declarations
@@ -87,7 +87,9 @@ Declaration? maybeTransformDeclaration(
   TransformationState state, {
   bool nested = false,
 }) {
-  if (!state.bindings.contains(declaration)) return null;
+  if (!state.bindings.contains(declaration)) {
+    return null;
+  }
 
   if (state.map.containsKey(declaration)) {
     return state.map[declaration];

--- a/pkgs/swift2objc/lib/src/transformer/transform.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transform.dart
@@ -45,7 +45,7 @@ List<Declaration> transform(List<Declaration> declarations,
   state.bindings.addAll(listDecls.stubDecls);
 
   final globalNamer = UniqueNamer(
-    state.bindings.map((declaration) => declaration.name),
+    topLevelDecls.map((declaration) => declaration.name),
   );
 
   final globals = Globals(

--- a/pkgs/swift2objc/test/unit/filter_test.dart
+++ b/pkgs/swift2objc/test/unit/filter_test.dart
@@ -14,8 +14,9 @@ import 'package:test/test.dart';
 import '../utils.dart';
 
 void main([List<String>? args]) {
-  final regen = args == null ? false :
-      (ArgParser()..addFlag('regen')).parse(args).flag('regen');
+  final regen = args == null
+      ? false
+      : (ArgParser()..addFlag('regen')).parse(args).flag('regen');
 
   group('Unit test for filter', () {
     final thisDir = p.join(testDir, 'unit');

--- a/pkgs/swift2objc/test/unit/filter_test_input.swift
+++ b/pkgs/swift2objc/test/unit/filter_test_input.swift
@@ -132,4 +132,16 @@ public class Garage {
             print("- \(vehicle.make) \(vehicle.model)")
         }
     }
+
+    public class Door {
+        public var isOpen: Bool = false
+    }
+}
+
+public func openDoor(door: Garage.Door) {
+  door.isOpen = true
+}
+
+public func listGarageVehicles(garage: Garage) {
+  return garage.listVehicles();
 }

--- a/pkgs/swift2objc/test/unit/filter_test_output_b.swift
+++ b/pkgs/swift2objc/test/unit/filter_test_output_b.swift
@@ -87,6 +87,24 @@ import Foundation
     return wrappedInstance.listVehicles()
   }
 
+  @objc public class DoorWrapper: NSObject {
+    var wrappedInstance: Garage.Door
+
+    @objc public var isOpen: Bool {
+      get {
+        wrappedInstance.isOpen
+      }
+      set {
+        wrappedInstance.isOpen = newValue
+      }
+    }
+
+    init(_ wrappedInstance: Garage.Door) {
+      self.wrappedInstance = wrappedInstance
+    }
+
+  }
+
 }
 
 @objc public class BicycleWrapper: NSObject {

--- a/pkgs/swift2objc/test/unit/filter_test_output_e.swift
+++ b/pkgs/swift2objc/test/unit/filter_test_output_e.swift
@@ -1,0 +1,33 @@
+// Test preamble text
+
+import Foundation
+
+// This wrapper is a stub. To generate the full wrapper, add Garage
+// to your config's include function.
+@objc public class GarageWrapper: NSObject {
+  var wrappedInstance: Garage
+
+  init(_ wrappedInstance: Garage) {
+    self.wrappedInstance = wrappedInstance
+  }
+
+  @objc public class DoorWrapper: NSObject {
+    var wrappedInstance: Garage.Door
+
+    @objc public var isOpen: Bool {
+      get {
+        wrappedInstance.isOpen
+      }
+      set {
+        wrappedInstance.isOpen = newValue
+      }
+    }
+
+    init(_ wrappedInstance: Garage.Door) {
+      self.wrappedInstance = wrappedInstance
+    }
+
+  }
+
+}
+

--- a/pkgs/swift2objc/test/unit/filter_test_output_f.swift
+++ b/pkgs/swift2objc/test/unit/filter_test_output_f.swift
@@ -1,0 +1,33 @@
+// Test preamble text
+
+import Foundation
+
+@objc public class GlobalsWrapper: NSObject {
+  @objc static public func openDoorWrapper(door: GarageWrapper.DoorWrapper) {
+    return openDoor(door: door.wrappedInstance)
+  }
+
+}
+
+// This wrapper is a stub. To generate the full wrapper, add Garage
+// to your config's include function.
+@objc public class GarageWrapper: NSObject {
+  var wrappedInstance: Garage
+
+  init(_ wrappedInstance: Garage) {
+    self.wrappedInstance = wrappedInstance
+  }
+
+  // This wrapper is a stub. To generate the full wrapper, add Garage.Door
+  // to your config's include function.
+  @objc public class DoorWrapper: NSObject {
+    var wrappedInstance: Garage.Door
+
+    init(_ wrappedInstance: Garage.Door) {
+      self.wrappedInstance = wrappedInstance
+    }
+
+  }
+
+}
+

--- a/pkgs/swift2objc/test/unit/filter_test_output_g.swift
+++ b/pkgs/swift2objc/test/unit/filter_test_output_g.swift
@@ -1,0 +1,47 @@
+// Test preamble text
+
+import Foundation
+
+@objc public class GarageWrapper: NSObject {
+  var wrappedInstance: Garage
+
+  init(_ wrappedInstance: Garage) {
+    self.wrappedInstance = wrappedInstance
+  }
+
+  @objc override init() {
+    wrappedInstance = Garage()
+  }
+
+  @objc public func addVehicle(_ vehicle: VehicleWrapper) {
+    return wrappedInstance.addVehicle(vehicle.wrappedInstance)
+  }
+
+  @objc public func listVehicles() {
+    return wrappedInstance.listVehicles()
+  }
+
+  // This wrapper is a stub. To generate the full wrapper, add Garage.Door
+  // to your config's include function.
+  @objc public class DoorWrapper: NSObject {
+    var wrappedInstance: Garage.Door
+
+    init(_ wrappedInstance: Garage.Door) {
+      self.wrappedInstance = wrappedInstance
+    }
+
+  }
+
+}
+
+// This wrapper is a stub. To generate the full wrapper, add Vehicle
+// to your config's include function.
+@objc public class VehicleWrapper: NSObject {
+  var wrappedInstance: Vehicle
+
+  init(_ wrappedInstance: Vehicle) {
+    self.wrappedInstance = wrappedInstance
+  }
+
+}
+

--- a/pkgs/swift2objc/test/unit/filter_test_output_h.swift
+++ b/pkgs/swift2objc/test/unit/filter_test_output_h.swift
@@ -1,0 +1,22 @@
+// Test preamble text
+
+import Foundation
+
+@objc public class GlobalsWrapper: NSObject {
+  @objc static public func listGarageVehiclesWrapper(garage: GarageWrapper) {
+    return listGarageVehicles(garage: garage.wrappedInstance)
+  }
+
+}
+
+// This wrapper is a stub. To generate the full wrapper, add Garage
+// to your config's include function.
+@objc public class GarageWrapper: NSObject {
+  var wrappedInstance: Garage
+
+  init(_ wrappedInstance: Garage) {
+    self.wrappedInstance = wrappedInstance
+  }
+
+}
+


### PR DESCRIPTION
Found a bunch of edge cases where the stubbing doesn't work correctly, to do with nested types. Fixed them and added more tests. Also added a `--regen` option to the filtering test, to make development easier.

Fixes:
- Apply the include/exclude filter to nested types in `FindIncludesVisitation`, even if the parent type has been filtered out. If a child is included/stubbed but the parent is included, the parent should be stubbed.
- Don't visit children in `ListDeclsVisitation`. Doing so was causing nested types to be code genned even when the parent type was stubbed.
- Keep track of all the bindings that are included or stubbed. During the later transformation stages, if we try to transform a declaration that isn't included or stubbed, omit it (return null).