### PR TITLE
[infra] CI script: don't run tests twice

### DIFF
--- a/pkgs/hooks/example/build/native_dynamic_linking/test/add_test.dart
+++ b/pkgs/hooks/example/build/native_dynamic_linking/test/add_test.dart
@@ -2,11 +2,21 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:native_dynamic_linking_example/add.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('invoke native function', () {
-    expect(add(24, 18), 42);
-  });
+  test(
+    'invoke native function',
+    skip:
+        (Platform.isMacOS || Platform.isWindows) &&
+            Platform.environment['GITHUB_ACTIONS'] != null
+        ? 'https://github.com/dart-lang/native/issues/2501'
+        : false,
+    () {
+      expect(add(24, 18), 42);
+    },
+  );
 }


### PR DESCRIPTION
Only run the tests once while running coverage.

On my local machine:

* `dart test` without coverage: 40 seconds
* `dart test` with coverage: 1 minute
* formatting the coverage: fast

So, this refactoring takes 40 seconds off `--all`. And `--none --test` is still 40 seconds.