### PR TITLE
[ffigen][jnigen] Update Dart API to resolve compiler warnings

### DIFF
--- a/pkgs/jni/src/include/analyze_snapshot_api.h
+++ b/pkgs/jni/src/include/analyze_snapshot_api.h
@@ -8,6 +8,7 @@
 #define RUNTIME_INCLUDE_ANALYZE_SNAPSHOT_API_H_
 
 #include <stdint.h>
+#include <optional>
 
 namespace dart {
 namespace snapshot_analyzer {
@@ -18,11 +19,10 @@ typedef struct {
   const uint8_t* vm_isolate_instructions;
 } Dart_SnapshotAnalyzerInformation;
 
-void Dart_DumpSnapshotInformationAsJson(char** buffer,
-                                        intptr_t* buffer_length,
-                                        Dart_SnapshotAnalyzerInformation* info);
-
-void Dart_DumpSnapshotInformationPP(Dart_SnapshotAnalyzerInformation* info);
+void Dart_DumpSnapshotInformationAsJson(
+    const Dart_SnapshotAnalyzerInformation& info,
+    char** buffer,
+    intptr_t* buffer_length);
 
 }  // namespace snapshot_analyzer
 }  // namespace dart

--- a/pkgs/jni/src/include/bin/dart_io_api.h
+++ b/pkgs/jni/src/include/bin/dart_io_api.h
@@ -5,7 +5,7 @@
 #ifndef RUNTIME_INCLUDE_BIN_DART_IO_API_H_
 #define RUNTIME_INCLUDE_BIN_DART_IO_API_H_
 
-#include "dart_tools_api.h"
+#include "../dart_tools_api.h"
 
 namespace dart {
 namespace bin {

--- a/pkgs/jni/src/include/bin/native_assets_api.h
+++ b/pkgs/jni/src/include/bin/native_assets_api.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#ifndef RUNTIME_INCLUDE_BIN_NATIVE_ASSETS_API_H_
+#define RUNTIME_INCLUDE_BIN_NATIVE_ASSETS_API_H_
+
+namespace dart {
+namespace bin {
+
+class NativeAssets {
+ public:
+  static void* DlopenAbsolute(const char* path, char** error);
+  static void* DlopenRelative(const char* path,
+                              const char* script_uri,
+                              char** error);
+  static void* DlopenSystem(const char* path, char** error);
+  static void* DlopenProcess(char** error);
+  static void* DlopenExecutable(char** error);
+  static void* Dlsym(void* handle, const char* symbol, char** error);
+};
+
+}  // namespace bin
+}  // namespace dart
+
+#endif  // RUNTIME_INCLUDE_BIN_NATIVE_ASSETS_API_H_

--- a/pkgs/jni/src/include/dart_api.h
+++ b/pkgs/jni/src/include/dart_api.h
@@ -57,11 +57,14 @@
 #endif
 
 #if __GNUC__
-#define DART_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#define DART_API_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#define DART_API_DEPRECATED(msg) __attribute__((deprecated(msg)))
 #elif _MSC_VER
-#define DART_WARN_UNUSED_RESULT _Check_return_
+#define DART_API_WARN_UNUSED_RESULT _Check_return_
+#define DART_API_DEPRECATED(msg) __declspec(deprecated(msg))
 #else
-#define DART_WARN_UNUSED_RESULT
+#define DART_API_WARN_UNUSED_RESULT
+#define DART_API_DEPRECATED(msg)
 #endif
 
 /*
@@ -503,14 +506,6 @@ DART_EXPORT void Dart_DeleteWeakPersistentHandle(
     Dart_WeakPersistentHandle object);
 
 /**
- * Updates the external memory size for the given weak persistent handle.
- *
- * May trigger garbage collection.
- */
-DART_EXPORT void Dart_UpdateExternalSize(Dart_WeakPersistentHandle object,
-                                         intptr_t external_allocation_size);
-
-/**
  * Allocates a finalizable handle for an object.
  *
  * This handle has the lifetime of the current isolate group unless the object
@@ -561,19 +556,6 @@ Dart_NewFinalizableHandle(Dart_Handle object,
 DART_EXPORT void Dart_DeleteFinalizableHandle(Dart_FinalizableHandle object,
                                               Dart_Handle strong_ref_to_object);
 
-/**
- * Updates the external memory size for the given finalizable handle.
- *
- * The caller has to provide the actual Dart object the handle was created from
- * to prove the object (and therefore the finalizable handle) is still alive.
- *
- * May trigger garbage collection.
- */
-DART_EXPORT void Dart_UpdateFinalizableExternalSize(
-    Dart_FinalizableHandle object,
-    Dart_Handle strong_ref_to_object,
-    intptr_t external_allocation_size);
-
 /*
  * ==========================
  * Initialization and Globals
@@ -597,7 +579,7 @@ DART_EXPORT const char* Dart_VersionString(void);
  * for each part.
  */
 
-#define DART_FLAGS_CURRENT_VERSION (0x0000000c)
+#define DART_FLAGS_CURRENT_VERSION (0x0000000d)
 
 typedef struct {
   int32_t version;
@@ -606,11 +588,13 @@ typedef struct {
   bool use_osr;
   bool obfuscate;
   bool load_vmservice_library;
-  bool copy_parent_code;
   bool null_safety;
   bool is_system_isolate;
+  bool is_service_isolate;
+  bool is_kernel_isolate;
   bool snapshot_is_dontneed_safe;
   bool branch_coverage;
+  bool coverage;
 } Dart_IsolateFlags;
 
 /**
@@ -853,7 +837,7 @@ typedef Dart_Handle (*Dart_GetVMServiceAssetsArchive)(void);
  * The current version of the Dart_InitializeFlags. Should be incremented every
  * time Dart_InitializeFlags changes in a binary incompatible way.
  */
-#define DART_INITIALIZE_PARAMS_CURRENT_VERSION (0x00000008)
+#define DART_INITIALIZE_PARAMS_CURRENT_VERSION (0x00000009)
 
 /** Forward declaration */
 struct Dart_CodeObserver;
@@ -878,36 +862,6 @@ typedef struct Dart_CodeObserver {
 
   Dart_OnNewCodeCallback on_new_code;
 } Dart_CodeObserver;
-
-/**
- * Optional callback provided by the embedder that is used by the VM to
- * implement registration of kernel blobs for the subsequent Isolate.spawnUri
- * If no callback is provided, the registration of kernel blobs will throw
- * an error.
- * 
- * \param kernel_buffer A buffer which contains a kernel program. Callback
- *                      should copy the contents of `kernel_buffer` as
- *                      it may be freed immediately after registration.
- * \param kernel_buffer_size The size of `kernel_buffer`.
- *
- * \return A C string representing URI which can be later used
- *         to spawn a new isolate. This C String should be scope allocated
- *         or owned by the embedder.
- *         Returns NULL if embedder runs out of memory.
- */
-typedef const char* (*Dart_RegisterKernelBlobCallback)(
-    const uint8_t* kernel_buffer,
-    intptr_t kernel_buffer_size);
-
-/**
- * Optional callback provided by the embedder that is used by the VM to
- * unregister kernel blobs.
- * If no callback is provided, the unregistration of kernel blobs will throw
- * an error.
- * 
- * \param kernel_blob_uri URI of the kernel blob to unregister.
- */
-typedef void (*Dart_UnregisterKernelBlobCallback)(const char* kernel_blob_uri);
 
 /**
  * Describes how to initialize the VM. Used with Dart_Initialize.
@@ -976,6 +930,8 @@ typedef struct {
   /**
    * A function to be called by the service isolate when it requires the
    * vmservice assets archive. See Dart_GetVMServiceAssetsArchive.
+   * 
+   * This field is deprecated and has no effect.
    */
   Dart_GetVMServiceAssetsArchive get_service_assets;
 
@@ -986,16 +942,6 @@ typedef struct {
    * as early as during the Dart_Initialize() call.
    */
   Dart_CodeObserver* code_observer;
-
-  /**
-   * Kernel blob registration callback function. See Dart_RegisterKernelBlobCallback.
-   */
-  Dart_RegisterKernelBlobCallback register_kernel_blob;
-
-  /**
-   * Kernel blob unregistration callback function. See Dart_UnregisterKernelBlobCallback.
-   */
-  Dart_UnregisterKernelBlobCallback unregister_kernel_blob;
 
 #if defined(__Fuchsia__)
   /**
@@ -1016,7 +962,7 @@ typedef struct {
  * \return NULL if initialization is successful. Returns an error message
  *   otherwise. The caller is responsible for freeing the error message.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_Initialize(
+DART_EXPORT DART_API_WARN_UNUSED_RESULT char* Dart_Initialize(
     Dart_InitializeParams* params);
 
 /**
@@ -1028,7 +974,7 @@ DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_Initialize(
  * NOTE: This function must not be called on a thread that was created by the VM
  * itself.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_Cleanup(void);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT char* Dart_Cleanup(void);
 
 /**
  * Sets command line flags. Should be called before Dart_Initialize.
@@ -1041,8 +987,9 @@ DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_Cleanup(void);
  *
  * NOTE: This call does not store references to the passed in c-strings.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_SetVMFlags(int argc,
-                                                          const char** argv);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT char* Dart_SetVMFlags(
+    int argc,
+    const char** argv);
 
 /**
  * Returns true if the named VM flag is of boolean type, specified, and set to
@@ -1294,8 +1241,7 @@ DART_EXPORT void Dart_KillIsolate(Dart_Isolate isolate);
  */
 DART_EXPORT void Dart_NotifyIdle(int64_t deadline);
 
-typedef void (*Dart_HeapSamplingReportCallback)(void* context,
-                                                void* data);
+typedef void (*Dart_HeapSamplingReportCallback)(void* context, void* data);
 
 typedef void* (*Dart_HeapSamplingCreateCallback)(
     Dart_Isolate isolate,
@@ -1497,7 +1443,7 @@ DART_EXPORT void Dart_ExitIsolate(void);
  *
  * \return A valid handle if no error occurs during the operation.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_CreateSnapshot(uint8_t** vm_snapshot_data_buffer,
                     intptr_t* vm_snapshot_data_size,
                     uint8_t** isolate_snapshot_data_buffer,
@@ -1515,6 +1461,16 @@ Dart_CreateSnapshot(uint8_t** vm_snapshot_data_buffer,
 DART_EXPORT bool Dart_IsKernel(const uint8_t* buffer, intptr_t buffer_size);
 
 /**
+ * Returns whether the buffer contains a bytecode file.
+ *
+ * \param buffer Pointer to a buffer that might contain a bytecode binary.
+ * \param buffer_size Size of the buffer.
+ *
+ * \return Whether the buffer contains a bytecode binary.
+ */
+DART_EXPORT bool Dart_IsBytecode(const uint8_t* buffer, intptr_t buffer_size);
+
+/**
  * Make isolate runnable.
  *
  * When isolates are spawned, this function is used to indicate that
@@ -1527,7 +1483,7 @@ DART_EXPORT bool Dart_IsKernel(const uint8_t* buffer, intptr_t buffer_size);
  * \return NULL if successful. Returns an error message otherwise. The caller
  * is responsible for freeing the error message.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_IsolateMakeRunnable(
+DART_EXPORT DART_API_WARN_UNUSED_RESULT char* Dart_IsolateMakeRunnable(
     Dart_Isolate isolate);
 
 /*
@@ -1540,6 +1496,10 @@ DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_IsolateMakeRunnable(
  * A port is used to send or receive inter-isolate messages
  */
 typedef int64_t Dart_Port;
+typedef struct {
+  int64_t port_id;
+  int64_t origin_id;
+} Dart_PortEx;
 
 /**
  * ILLEGAL_PORT is a port number guaranteed never to be associated with a valid
@@ -1693,18 +1653,7 @@ DART_EXPORT Dart_Handle Dart_GetStickyError(void);
  *
  * \return A valid handle if no error occurs during the operation.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_HandleMessage(void);
-
-/**
- * Drains the microtask queue, then blocks the calling thread until the current
- * isolate receives a message, then handles all messages.
- *
- * \param timeout_millis When non-zero, the call returns after the indicated
-          number of milliseconds even if no message was received.
- * \return A valid handle if no error occurs, otherwise an error handle.
- */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
-Dart_WaitForEvent(int64_t timeout_millis);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle Dart_HandleMessage(void);
 
 /**
  * Handles any pending messages for the vm service for the current
@@ -1744,7 +1693,7 @@ DART_EXPORT bool Dart_HasServiceMessages(void);
  *   exception or other error occurs while processing messages, an
  *   error handle is returned.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_RunLoop(void);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle Dart_RunLoop(void);
 
 /**
  * Lets the VM run message processing for the isolate.
@@ -1764,13 +1713,11 @@ DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_RunLoop(void);
  *   of its message loop. If not successful the caller retains ownership of the
  *   isolate.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT bool Dart_RunLoopAsync(
+DART_EXPORT DART_API_WARN_UNUSED_RESULT bool Dart_RunLoopAsync(
     bool errors_are_fatal,
     Dart_Port on_error_port,
     Dart_Port on_exit_port,
     char** error);
-
-/* TODO(turnidge): Should this be removed from the public api? */
 
 /**
  * Gets the main port id for the current isolate.
@@ -1802,12 +1749,26 @@ DART_EXPORT bool Dart_Post(Dart_Port port_id, Dart_Handle object);
 /**
  * Returns a new SendPort with the provided port id.
  *
+ * If there is a possibility of a port closing since port_id was acquired
+ * for a SendPort, one should use Dart_NewSendPortEx and
+ * Dart_SendPortGetIdEx.
+ *
  * \param port_id The destination port.
  *
  * \return A new SendPort if no errors occurs. Otherwise returns
  *   an error handle.
  */
 DART_EXPORT Dart_Handle Dart_NewSendPort(Dart_Port port_id);
+
+/**
+ * Returns a new SendPort with the provided port id and origin id.
+ *
+ * \param portex_id The destination composte port id.
+ *
+ * \return A new SendPort if no errors occurs. Otherwise returns
+ *   an error handle.
+ */
+DART_EXPORT Dart_Handle Dart_NewSendPortEx(Dart_PortEx portex_id);
 
 /**
  * Gets the SendPort id for the provided SendPort.
@@ -1818,6 +1779,33 @@ DART_EXPORT Dart_Handle Dart_NewSendPort(Dart_Port port_id);
  */
 DART_EXPORT Dart_Handle Dart_SendPortGetId(Dart_Handle port,
                                            Dart_Port* port_id);
+
+/**
+ * Gets the SendPort and Origin ids for the provided SendPort.
+ * \param port A SendPort object whose id is desired.
+ * \param portex_id Returns composite id of the SendPort.
+ * \return Success if no error occurs. Otherwise returns
+ *   an error handle.
+ */
+DART_EXPORT Dart_Handle Dart_SendPortGetIdEx(Dart_Handle port,
+                                             Dart_PortEx* portex_id);
+
+/**
+ * Sets the owner thread of the current isolate to be the current thread.
+ *
+ * Requires there to be a current isolate, and that the isolate is unowned.
+ */
+DART_EXPORT void Dart_SetCurrentThreadOwnsIsolate(void);
+
+/**
+ * Returns whether the current thread owns the isolate that owns the given port.
+ *
+ * The port can be the isolate's main port, or any other port owned by the
+ * isolate.
+ *
+ * \param port The port to be checked.
+ */
+DART_EXPORT bool Dart_GetCurrentThreadOwnsIsolate(Dart_Port port);
 
 /*
  * ======
@@ -1953,7 +1941,6 @@ DART_EXPORT bool Dart_IsDouble(Dart_Handle object);
 DART_EXPORT bool Dart_IsBoolean(Dart_Handle object);
 DART_EXPORT bool Dart_IsString(Dart_Handle object);
 DART_EXPORT bool Dart_IsStringLatin1(Dart_Handle object); /* (ISO-8859-1) */
-DART_EXPORT bool Dart_IsExternalString(Dart_Handle object);
 DART_EXPORT bool Dart_IsList(Dart_Handle object);
 DART_EXPORT bool Dart_IsMap(Dart_Handle object);
 DART_EXPORT bool Dart_IsLibrary(Dart_Handle object);
@@ -2259,6 +2246,17 @@ DART_EXPORT Dart_Handle Dart_BooleanValue(Dart_Handle boolean_obj, bool* value);
 DART_EXPORT Dart_Handle Dart_StringLength(Dart_Handle str, intptr_t* length);
 
 /**
+ * Gets the length of UTF-8 encoded representation for a string.
+ *
+ * \param str A String.
+ * \param length Returns the length of UTF-8 encoded representation for string.
+ *
+ * \return A valid handle if no error occurs during the operation.
+ */
+DART_EXPORT Dart_Handle Dart_StringUTF8Length(Dart_Handle str,
+                                              intptr_t* length);
+
+/**
  * Returns a String built from the provided C string
  * (There is an implicit assumption that the C string passed in contains
  *  UTF-8 encoded characters and '\0' is considered as a termination
@@ -2310,48 +2308,6 @@ DART_EXPORT Dart_Handle Dart_NewStringFromUTF32(const int32_t* utf32_array,
                                                 intptr_t length);
 
 /**
- * Returns a String which references an external array of
- * Latin-1 (ISO-8859-1) encoded characters.
- *
- * \param latin1_array Array of Latin-1 encoded characters. This must not move.
- * \param length The length of the characters array.
- * \param peer An external pointer to associate with this string.
- * \param external_allocation_size The number of externally allocated
- *   bytes for peer. Used to inform the garbage collector.
- * \param callback A callback to be called when this string is finalized.
- *
- * \return The String object if no error occurs. Otherwise returns
- *   an error handle.
- */
-DART_EXPORT Dart_Handle
-Dart_NewExternalLatin1String(const uint8_t* latin1_array,
-                             intptr_t length,
-                             void* peer,
-                             intptr_t external_allocation_size,
-                             Dart_HandleFinalizer callback);
-
-/**
- * Returns a String which references an external array of UTF-16 encoded
- * characters.
- *
- * \param utf16_array An array of UTF-16 encoded characters. This must not move.
- * \param length The length of the characters array.
- * \param peer An external pointer to associate with this string.
- * \param external_allocation_size The number of externally allocated
- *   bytes for peer. Used to inform the garbage collector.
- * \param callback A callback to be called when this string is finalized.
- *
- * \return The String object if no error occurs. Otherwise returns
- *   an error handle.
- */
-DART_EXPORT Dart_Handle
-Dart_NewExternalUTF16String(const uint16_t* utf16_array,
-                            intptr_t length,
-                            void* peer,
-                            intptr_t external_allocation_size,
-                            Dart_HandleFinalizer callback);
-
-/**
  * Gets the C string representation of a String.
  * (It is a sequence of UTF-8 encoded values with a '\0' termination.)
  *
@@ -2384,6 +2340,24 @@ DART_EXPORT Dart_Handle Dart_StringToCString(Dart_Handle str,
 DART_EXPORT Dart_Handle Dart_StringToUTF8(Dart_Handle str,
                                           uint8_t** utf8_array,
                                           intptr_t* length);
+
+/**
+ * Copies the UTF-8 encoded representation of a String into specified buffer.
+ *
+ * Any unpaired surrogate code points in the string will be converted as
+ * replacement characters (U+FFFD, 0xEF 0xBF 0xBD in UTF-8).
+ *
+ * \param str A string.
+ * \param utf8_array Buffer into which the UTF-8 encoded representation of
+ *   the string is copied into.
+ *   The buffer is allocated and managed by the caller.
+ * \param length Specifies the length of the buffer passed in.
+ *
+ * \return A valid handle if no error occurs during the operation.
+ */
+DART_EXPORT Dart_Handle Dart_CopyUTF8EncodingOfString(Dart_Handle str,
+                                                      uint8_t* utf8_array,
+                                                      intptr_t length);
 
 /**
  * Gets the data corresponding to the string object. This function returns
@@ -2462,25 +2436,6 @@ DART_EXPORT Dart_Handle Dart_StringGetProperties(Dart_Handle str,
  *   an error handle.
  */
 DART_EXPORT Dart_Handle Dart_NewList(intptr_t length);
-
-typedef enum {
-  Dart_CoreType_Dynamic,
-  Dart_CoreType_Int,
-  Dart_CoreType_String,
-} Dart_CoreType_Id;
-
-// TODO(bkonyi): convert this to use nullable types once NNBD is enabled.
-/**
- * Returns a List of the desired length with the desired legacy element type.
- *
- * \param element_type_id The type of elements of the list.
- * \param length The length of the list.
- *
- * \return The List object if no error occurs. Otherwise returns an error
- * handle.
- */
-DART_EXPORT Dart_Handle Dart_NewListOf(Dart_CoreType_Id element_type_id,
-                                       intptr_t length);
 
 /**
  * Returns a List of the desired length with the desired element type.
@@ -2819,7 +2774,7 @@ DART_EXPORT Dart_Handle Dart_GetDataFromByteBuffer(Dart_Handle byte_buffer);
  *   then the new object. If an error occurs during execution, then an
  *   error handle is returned.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_New(Dart_Handle type,
          Dart_Handle constructor_name,
          int number_of_arguments,
@@ -2833,7 +2788,8 @@ Dart_New(Dart_Handle type,
  * \return The new object. If an error occurs during execution, then an
  *   error handle is returned.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_Allocate(Dart_Handle type);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_Allocate(Dart_Handle type);
 
 /**
  * Allocate a new object without invoking a constructor, and sets specified
@@ -2874,7 +2830,7 @@ Dart_AllocateWithNativeFields(Dart_Handle type,
  *   successfully, then the return value is returned. If an error
  *   occurs during execution, then an error handle is returned.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_Invoke(Dart_Handle target,
             Dart_Handle name,
             int number_of_arguments,
@@ -2890,7 +2846,7 @@ Dart_Invoke(Dart_Handle target,
  *   invoking the closure is returned. If an error occurs during
  *   execution, then an error handle is returned.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_InvokeClosure(Dart_Handle closure,
                    int number_of_arguments,
                    Dart_Handle* arguments);
@@ -2915,7 +2871,7 @@ Dart_InvokeClosure(Dart_Handle closure,
  *   successfully, then the object is returned. If an error
  *   occurs during execution, then an error handle is returned.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_InvokeConstructor(Dart_Handle object,
                        Dart_Handle name,
                        int number_of_arguments,
@@ -2941,7 +2897,7 @@ Dart_InvokeConstructor(Dart_Handle object,
  * \return If no error occurs, then the value of the field is
  *   returned. Otherwise an error handle is returned.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_GetField(Dart_Handle container, Dart_Handle name);
 
 /**
@@ -2964,7 +2920,7 @@ Dart_GetField(Dart_Handle container, Dart_Handle name);
  *
  * \return A valid handle if no error occurs.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_SetField(Dart_Handle container, Dart_Handle name, Dart_Handle value);
 
 /*
@@ -3360,7 +3316,7 @@ DART_EXPORT Dart_Handle Dart_GetNativeSymbol(Dart_Handle library,
 /**
  * Sets the callback used to resolve FFI native functions for a library.
  * The resolved functions are expected to be a C function pointer of the
- * correct signature (as specified in the `@FfiNative<NFT>()` function
+ * correct signature (as specified in the `@Native<NFT>()` function
  * annotation in Dart code).
  *
  * NOTE: This is an experimental feature and might change in the future.
@@ -3372,6 +3328,107 @@ DART_EXPORT Dart_Handle Dart_GetNativeSymbol(Dart_Handle library,
  */
 DART_EXPORT Dart_Handle
 Dart_SetFfiNativeResolver(Dart_Handle library, Dart_FfiNativeResolver resolver);
+
+/**
+ * Callback provided by the embedder that is used by the VM to resolve asset
+ * paths.
+ *
+ * The VM is responsible for looking up the asset path with the asset id in the
+ * kernel mapping. The embedder is responsible for providing the asset mapping
+ * during kernel compilation and using the asset path to return a library handle
+ * in this function.
+ *
+ * \param path The string in the asset path as passed in native_assets.yaml
+ *             during kernel compilation.
+ *
+ * \param error Returns NULL if successful, an error message otherwise. The
+ *   caller is responsible for calling free() on the error message.
+ *
+ * \return The library handle. If |error| is not-null, the return value is
+ *         undefined.
+ */
+typedef void* (*Dart_NativeAssetsDlopenCallback)(const char* path,
+                                                 char** error);
+typedef void* (*Dart_NativeAssetsDlopenCallbackNoPath)(char** error);
+
+/**
+ * Callback provided by the embedder that is used by the VM to resolve asset
+ * ids.
+ *
+ * The embedder can freely chose how to bundle asset id to asset path mappings
+ * and how to perform this lookup.
+ *
+ * If the embedder provides this callback, it must also provide
+ * `Dart_NativeAssetsAvailableAssets`.
+ *
+ * If provided, takes prescedence over `Dart_NativeAssetsDlopenCallback`.
+ *
+ * \param asset_id The asset id requested in the `@Native` external function.
+ *
+ * \param error Returns NULL if successful, an error message otherwise. The
+ *   caller is responsible for calling free() on the error message.
+ *
+ * \return The library handle. If |error| is not-null, the return value is
+ *         undefined.
+ */
+typedef void* (*Dart_NativeAssetsDlopenAssetId)(const char* asset_id,
+                                                char** error);
+
+/**
+ * Callback provided by the embedder that is used  by the VM to request a
+ * description of the available assets
+ *
+ * \return A malloced string containing all asset ids. The caller must free this
+ *   string.
+ */
+typedef char* (*Dart_NativeAssetsAvailableAssets)(void);
+
+/**
+ * Callback provided by the embedder that is used by the VM to lookup symbols
+ * in native code assets.
+ * If no callback is provided, using `@Native`s with `native_asset.yaml`s will
+ * fail.
+ *
+ * \param handle The library handle returned from a
+ *               `Dart_NativeAssetsDlopenCallback` or
+ *               `Dart_NativeAssetsDlopenCallbackNoPath`.
+ *
+ * \param symbol The symbol to look up. Is a string.
+ *
+ * \param error Returns NULL if creation is successful, an error message
+ *   otherwise. The caller is responsible for calling free() on the error
+ *   message.
+ *
+ * \return The symbol address. If |error| is not-null, the return value is
+ *         undefined.
+ */
+typedef void* (*Dart_NativeAssetsDlsymCallback)(void* handle,
+                                                const char* symbol,
+                                                char** error);
+
+typedef struct {
+  Dart_NativeAssetsDlopenCallback dlopen_absolute;
+  Dart_NativeAssetsDlopenCallback dlopen_relative;
+  Dart_NativeAssetsDlopenCallback dlopen_system;
+  Dart_NativeAssetsDlopenCallbackNoPath dlopen_process;
+  Dart_NativeAssetsDlopenCallbackNoPath dlopen_executable;
+  Dart_NativeAssetsDlsymCallback dlsym;
+  Dart_NativeAssetsDlopenAssetId dlopen;
+  Dart_NativeAssetsAvailableAssets available_assets;
+} NativeAssetsApi;
+
+/**
+ * Initializes native asset resolution for the current isolate group.
+ *
+ * The caller is responsible for ensuring this is called right after isolate
+ * group creation, and before running any dart code (or spawning isolates).
+ *
+ * @param native_assets_api The callbacks used by native assets resolution.
+ *                          The VM does not take ownership of the parameter,
+ *                          it can be freed immediately after the call.
+ */
+DART_EXPORT void Dart_InitializeNativeAssetsResolver(
+    NativeAssetsApi* native_assets_api);
 
 /*
  * =====================
@@ -3395,10 +3452,8 @@ typedef enum {
  * Dart_kCanonicalizeUrl
  *
  * This tag indicates that the embedder should canonicalize 'url' with
- * respect to 'library'.  For most embedders, the
- * Dart_DefaultCanonicalizeUrl function is a sufficient implementation
- * of this tag.  The return value should be a string holding the
- * canonicalized url.
+ * respect to 'library'.  For most embedders, this is resolving the `url`
+ * relative to the `library`s url (see `Dart_LibraryUrl`).
  *
  * Dart_kImportTag
  *
@@ -3470,7 +3525,7 @@ Dart_SetDeferredLoadHandler(Dart_DeferredLoadHandler handler);
  * Requires the current isolate to be the same current isolate during the
  * invocation of the Dart_DeferredLoadHandler.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_DeferredLoadComplete(intptr_t loading_unit_id,
                           const uint8_t* snapshot_data,
                           const uint8_t* snapshot_instructions);
@@ -3487,30 +3542,10 @@ Dart_DeferredLoadComplete(intptr_t loading_unit_id,
  * Requires the current isolate to be the same current isolate during the
  * invocation of the Dart_DeferredLoadHandler.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_DeferredLoadCompleteError(intptr_t loading_unit_id,
                                const char* error_message,
                                bool transient);
-
-/**
- * Canonicalizes a url with respect to some library.
- *
- * The url is resolved with respect to the library's url and some url
- * normalizations are performed.
- *
- * This canonicalization function should be sufficient for most
- * embedders to implement the Dart_kCanonicalizeUrl tag.
- *
- * \param base_url The base url relative to which the url is
- *                being resolved.
- * \param url The url being resolved and canonicalized.  This
- *            parameter is a string handle.
- *
- * \return If no error occurs, a String object is returned.  Otherwise
- *   an error handle is returned.
- */
-DART_EXPORT Dart_Handle Dart_DefaultCanonicalizeUrl(Dart_Handle base_url,
-                                                    Dart_Handle url);
 
 /**
  * Loads the root library for the current isolate.
@@ -3523,8 +3558,22 @@ DART_EXPORT Dart_Handle Dart_DefaultCanonicalizeUrl(Dart_Handle base_url,
  *
  * \return A handle to the root library, or an error.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_LoadScriptFromKernel(const uint8_t* kernel_buffer, intptr_t kernel_size);
+
+/**
+ * Loads the root library for the current isolate.
+ *
+ * Requires there to be no current root library.
+ *
+ * \param kernel_buffer A buffer which contains a bytecode binary.
+ *   Must remain valid until isolate group shutdown.
+ * \param kernel_size Length of the passed in buffer.
+ *
+ * \return A handle to the root library, or an error.
+ */
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_LoadScriptFromBytecode(const uint8_t* kernel_buffer, intptr_t kernel_size);
 
 /**
  * Gets the library for the root script for the current isolate.
@@ -3633,7 +3682,6 @@ DART_EXPORT Dart_Handle Dart_TypeToNonNullableType(Dart_Handle type);
  */
 DART_EXPORT Dart_Handle Dart_IsNullableType(Dart_Handle type, bool* result);
 DART_EXPORT Dart_Handle Dart_IsNonNullableType(Dart_Handle type, bool* result);
-DART_EXPORT Dart_Handle Dart_IsLegacyType(Dart_Handle type, bool* result);
 
 /**
  * Lookup a class or interface by name from a Library.
@@ -3692,11 +3740,22 @@ DART_EXPORT Dart_Handle Dart_LibraryHandleError(Dart_Handle library,
  *
  * \return A handle to the main library of the compilation unit, or an error.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_LoadLibraryFromKernel(const uint8_t* kernel_buffer,
                            intptr_t kernel_buffer_size);
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_LoadLibrary(Dart_Handle kernel_buffer);
+
+/**
+ * Called by the embedder to load a partial program. Does not set the root
+ * library.
+ *
+ * \param bytecode_buffer An external typed data containing bytecode binary.
+ *
+ * \return A handle to the main library of the compilation unit, or an error.
+ */
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_LoadLibraryFromBytecode(Dart_Handle bytecode_buffer);
 
 /**
  * Indicates that all outstanding load requests have been satisfied.
@@ -3711,7 +3770,7 @@ Dart_LoadLibrary(Dart_Handle kernel_buffer);
  * \return Success if all classes have been finalized and deferred library
  *   futures are completed. Otherwise, returns an error.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_FinalizeLoading(bool complete_futures);
 
 /*
@@ -3776,7 +3835,6 @@ typedef enum {
 
 typedef struct {
   Dart_KernelCompilationStatus status;
-  bool null_safety;
   char* error;
   uint8_t* kernel;
   intptr_t kernel_size;
@@ -3797,13 +3855,16 @@ DART_EXPORT Dart_Port Dart_KernelPort(void);
  * Compiles the given `script_uri` to a kernel file.
  *
  * \param platform_kernel A buffer containing the kernel of the platform (e.g.
- * `vm_platform_strong.dill`). The VM does not take ownership of this memory.
+ * `vm_platform.dill`). The VM does not take ownership of this memory.
  *
  * \param platform_kernel_size The length of the platform_kernel buffer.
  *
  * \param snapshot_compile Set to `true` when the compilation is for a snapshot.
  * This is used by the frontend to determine if compilation related information
  * should be printed to console (e.g., null safety mode).
+ *
+ * \param embed_sources Set to `true` when sources should be embedded in the
+ * kernel file.
  *
  * \param verbosity Specifies the logging behavior of the kernel compilation
  * service.
@@ -3826,6 +3887,7 @@ Dart_CompileToKernel(const char* script_uri,
                      const intptr_t platform_kernel_size,
                      bool incremental_compile,
                      bool snapshot_compile,
+                     bool embed_sources,
                      const char* package_config,
                      Dart_KernelCompilationVerbosityLevel verbosity);
 
@@ -3850,41 +3912,7 @@ DART_EXPORT void Dart_SetDartLibrarySourcesKernel(
     const intptr_t platform_kernel_size);
 
 /**
- * Detect the null safety opt-in status.
- *
- * When running from source, it is based on the opt-in status of `script_uri`.
- * When running from a kernel buffer, it is based on the mode used when
- *   generating `kernel_buffer`.
- * When running from an appJIT or AOT snapshot, it is based on the mode used
- *   when generating `snapshot_data`.
- *
- * \param script_uri Uri of the script that contains the source code
- *
- * \param package_config Uri of the package configuration file (either in format
- *   of .packages or .dart_tool/package_config.json) for the null safety
- *   detection to resolve package imports against. If this parameter is not
- *   passed the package resolution of the parent isolate should be used.
- *
- * \param original_working_directory current working directory when the VM
- *   process was launched, this is used to correctly resolve the path specified
- *   for package_config.
- *
- * \param snapshot_data Buffer containing the snapshot data of the
- *   isolate or NULL if no snapshot is provided. If provided, the buffers must
- *   remain valid until the isolate shuts down.
- *
- * \param snapshot_instructions Buffer containing the snapshot instructions of
- *   the isolate or NULL if no snapshot is provided. If provided, the buffers
- *   must remain valid until the isolate shuts down.
- *
- * \param kernel_buffer A buffer which contains a kernel/DIL program. Must
- *   remain valid until isolate shutdown.
- *
- * \param kernel_buffer_size The size of `kernel_buffer`.
- *
- * \return Returns true if the null safety is opted in by the input being
- *   run `script_uri`, `snapshot_data` or `kernel_buffer`.
- *
+ * Always return true as the VM only supports strong null safety.
  */
 DART_EXPORT bool Dart_DetectNullSafety(const char* script_uri,
                                        const char* package_config,
@@ -3996,7 +4024,7 @@ DART_EXPORT Dart_Handle Dart_LoadingUnitLibraryUris(intptr_t loading_unit_id);
  *
  *  The assembly should be compiled as a static or shared library and linked or
  *  loaded by the embedder. Running this snapshot requires a VM compiled with
- *  DART_PRECOMPILED_SNAPSHOT. The kDartVmSnapshotData and
+ *  DART_PRECOMPILED_RUNTIME. The kDartVmSnapshotData and
  *  kDartVmSnapshotInstructions should be passed to Dart_Initialize. The
  *  kDartIsolateSnapshotData and kDartIsolateSnapshotInstructions should be
  *  passed to Dart_CreateIsolateGroup.
@@ -4007,16 +4035,17 @@ DART_EXPORT Dart_Handle Dart_LoadingUnitLibraryUris(intptr_t loading_unit_id);
  *  debugging sections.
  *
  *  If debug_callback_data is provided, debug_callback_data will be used with
- *  the callback to provide separate debugging information.
+ *  the callback to provide separate debugging information. Ignored when
+ *  targeting Windows.
  *
  *  \return A valid handle if no error occurs during the operation.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_CreateAppAOTSnapshotAsAssembly(Dart_StreamingWriteCallback callback,
                                     void* callback_data,
                                     bool stripped,
                                     void* debug_callback_data);
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_CreateAppAOTSnapshotAsAssemblies(
     Dart_CreateLoadingUnitCallback next_callback,
     void* next_callback_data,
@@ -4036,7 +4065,7 @@ Dart_CreateAppAOTSnapshotAsAssemblies(
  *   - _kDartIsolateSnapshotInstructions
  *
  *  The shared library should be dynamically loaded by the embedder.
- *  Running this snapshot requires a VM compiled with DART_PRECOMPILED_SNAPSHOT.
+ *  Running this snapshot requires a VM compiled with DART_PRECOMPILED_RUNTIME.
  *  The kDartVmSnapshotData and kDartVmSnapshotInstructions should be passed to
  *  Dart_Initialize. The kDartIsolateSnapshotData and
  *  kDartIsolateSnapshotInstructions should be passed to Dart_CreateIsolate.
@@ -4051,17 +4080,69 @@ Dart_CreateAppAOTSnapshotAsAssemblies(
  *
  * \return A valid handle if no error occurs during the operation.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_CreateAppAOTSnapshotAsElf(Dart_StreamingWriteCallback callback,
                                void* callback_data,
                                bool stripped,
                                void* debug_callback_data);
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_CreateAppAOTSnapshotAsElfs(Dart_CreateLoadingUnitCallback next_callback,
                                 void* next_callback_data,
                                 bool stripped,
                                 Dart_StreamingWriteCallback write_callback,
                                 Dart_StreamingCloseCallback close_callback);
+
+typedef enum {
+  Dart_AotBinaryFormat_Elf = 0,
+  Dart_AotBinaryFormat_Assembly = 1,
+  Dart_AotBinaryFormat_MachO_Dylib = 2,
+} Dart_AotBinaryFormat;
+
+/**
+ *  Creates a precompiled snapshot.
+ *   - A root library must have been loaded.
+ *   - Dart_Precompile must have been called.
+ *
+ *  Outputs a snapshot in the specified binary format defining the symbols
+ *   - _kDartVmSnapshotData
+ *   - _kDartVmSnapshotInstructions
+ *   - _kDartIsolateSnapshotData
+ *   - _kDartIsolateSnapshotInstructions
+ *
+ *  The shared library should be dynamically loaded by the embedder.
+ *  Running this snapshot requires a VM compiled with DART_PRECOMPILED_RUNTIME.
+ *  The kDartVmSnapshotData and kDartVmSnapshotInstructions should be passed to
+ *  Dart_Initialize. The kDartIsolateSnapshotData and
+ *  kDartIsolateSnapshotInstructions should be passed to Dart_CreateIsolate.
+ *
+ *  The callback will be invoked one or more times to provide the binary output.
+ *
+ *  If stripped is true, then the binary output will not include DWARF
+ *  debugging sections.
+ *
+ *  If debug_callback_data is provided, debug_callback_data will be used with
+ *  the callback to provide separate debugging information.
+ *
+ *  The identifier should be an appropriate string for identifying the resulting
+ *  dynamic library. For example, the identifier is used in ID_DYLIB and
+ *  CODE_SIGNATURE load commands for Mach-O dynamic libraries and for DW_AT_name
+ *  in the Dart progam's root DWARF compilation unit.
+ *
+ *  The path should be the full path of the resulting dynamic library.
+ *  Currently, it is only used in unstripped Mach-O snapshots to create an
+ *  appropriate N_OSO symbolic debugging variable so dsymutil can be used.
+ *  The N_OSO symbol is not created if the path is nullptr.
+ *
+ * \return A valid handle if no error occurs during the operation.
+ */
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_CreateAppAOTSnapshotAsBinary(Dart_AotBinaryFormat format,
+                                  Dart_StreamingWriteCallback callback,
+                                  void* callback_data,
+                                  bool stripped,
+                                  void* debug_callback_data,
+                                  const char* identifier,
+                                  const char* path);
 
 /**
  *  Like Dart_CreateAppAOTSnapshotAsAssembly, but only includes
@@ -4069,7 +4150,7 @@ Dart_CreateAppAOTSnapshotAsElfs(Dart_CreateLoadingUnitCallback next_callback,
  *  not strip DWARF information from the generated assembly or allow for
  *  separate debug information.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_CreateVMAOTSnapshotAsAssembly(Dart_StreamingWriteCallback callback,
                                    void* callback_data);
 
@@ -4080,7 +4161,7 @@ Dart_CreateVMAOTSnapshotAsAssembly(Dart_StreamingWriteCallback callback,
  *
  * \return A valid handle if no error occurs during the operation.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_SortClasses(void);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle Dart_SortClasses(void);
 
 /**
  *  Creates a snapshot that caches compiled code and type feedback for faster
@@ -4103,25 +4184,11 @@ DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_SortClasses(void);
  *
  * \return A valid handle if no error occurs during the operation.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_CreateAppJITSnapshotAsBlobs(uint8_t** isolate_snapshot_data_buffer,
                                  intptr_t* isolate_snapshot_data_size,
                                  uint8_t** isolate_snapshot_instructions_buffer,
                                  intptr_t* isolate_snapshot_instructions_size);
-
-/**
- * Like Dart_CreateAppJITSnapshotAsBlobs, but also creates a new VM snapshot.
- */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
-Dart_CreateCoreJITSnapshotAsBlobs(
-    uint8_t** vm_snapshot_data_buffer,
-    intptr_t* vm_snapshot_data_size,
-    uint8_t** vm_snapshot_instructions_buffer,
-    intptr_t* vm_snapshot_instructions_size,
-    uint8_t** isolate_snapshot_data_buffer,
-    intptr_t* isolate_snapshot_data_size,
-    uint8_t** isolate_snapshot_instructions_buffer,
-    intptr_t* isolate_snapshot_instructions_size);
 
 /**
  * Get obfuscation map for precompiled code.
@@ -4132,7 +4199,7 @@ Dart_CreateCoreJITSnapshotAsBlobs(
  * \return Returns an error handler if the VM was built in a mode that does not
  * support obfuscation.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_GetObfuscationMap(uint8_t** buffer, intptr_t* buffer_length);
 
 /**

--- a/pkgs/jni/src/include/dart_api_dl.c
+++ b/pkgs/jni/src/include/dart_api_dl.c
@@ -8,11 +8,13 @@
 #include "dart_version.h"              /* NOLINT */
 #include "internal/dart_api_dl_impl.h" /* NOLINT */
 
+#include <stdio.h>
 #include <string.h>
 
 #define DART_API_DL_DEFINITIONS(name, R, A) name##_Type name##_DL = NULL;
 
 DART_API_ALL_DL_SYMBOLS(DART_API_DL_DEFINITIONS)
+DART_API_DEPRECATED_DL_SYMBOLS(DART_API_DL_DEFINITIONS)
 
 #undef DART_API_DL_DEFINITIONS
 
@@ -25,6 +27,19 @@ DartApiEntry_function FindFunctionPointer(const DartApiEntry* entries,
     entries++;
   }
   return NULL;
+}
+
+DART_EXPORT void Dart_UpdateExternalSize_Deprecated(
+    Dart_WeakPersistentHandle object, intptr_t external_size) {
+  printf("Dart_UpdateExternalSize is a nop, it has been deprecated\n");
+}
+
+DART_EXPORT void Dart_UpdateFinalizableExternalSize_Deprecated(
+    Dart_FinalizableHandle object,
+    Dart_Handle strong_ref_to_object,
+    intptr_t external_allocation_size) {
+  printf("Dart_UpdateFinalizableExternalSize is a nop, "
+         "it has been deprecated\n");
 }
 
 intptr_t Dart_InitializeApiDL(void* data) {
@@ -54,6 +69,11 @@ intptr_t Dart_InitializeApiDL(void* data) {
       (name##_Type)(FindFunctionPointer(dart_api_function_pointers, #name));
   DART_API_ALL_DL_SYMBOLS(DART_API_DL_INIT)
 #undef DART_API_DL_INIT
+
+#define DART_API_DEPRECATED_DL_INIT(name, R, A)                                \
+  name##_DL = name##_Deprecated;
+  DART_API_DEPRECATED_DL_SYMBOLS(DART_API_DEPRECATED_DL_INIT)
+#undef DART_API_DEPRECATED_DL_INIT
 
   return 0;
 }

--- a/pkgs/jni/src/include/dart_api_dl.h
+++ b/pkgs/jni/src/include/dart_api_dl.h
@@ -20,6 +20,8 @@
  *
  * Link `dart_api_dl.c` file into your library and invoke
  * `Dart_InitializeApiDL` with `NativeApi.initializeApiDLData`.
+ *
+ * Returns 0 on success.
  */
 
 DART_EXPORT intptr_t Dart_InitializeApiDL(void* data);
@@ -36,6 +38,10 @@ DART_EXPORT intptr_t Dart_InitializeApiDL(void* data);
 // are typechecked nominally in C/C++, so they are not copied, instead a
 // comment is added to their definition.
 typedef int64_t Dart_Port_DL;
+typedef struct {
+  int64_t port_id;
+  int64_t origin_id;
+} Dart_PortEx_DL;
 
 typedef void (*Dart_NativeMessageHandler_DL)(Dart_Port_DL dest_port_id,
                                              Dart_CObject* message);
@@ -80,30 +86,41 @@ typedef void (*Dart_NativeMessageHandler_DL)(Dart_Port_DL dest_port_id,
     (Dart_Handle object, void* peer, intptr_t external_allocation_size,        \
      Dart_HandleFinalizer callback))                                           \
   F(Dart_DeleteWeakPersistentHandle, void, (Dart_WeakPersistentHandle object)) \
-  F(Dart_UpdateExternalSize, void,                                             \
-    (Dart_WeakPersistentHandle object, intptr_t external_allocation_size))     \
   F(Dart_NewFinalizableHandle, Dart_FinalizableHandle,                         \
     (Dart_Handle object, void* peer, intptr_t external_allocation_size,        \
      Dart_HandleFinalizer callback))                                           \
   F(Dart_DeleteFinalizableHandle, void,                                        \
     (Dart_FinalizableHandle object, Dart_Handle strong_ref_to_object))         \
-  F(Dart_UpdateFinalizableExternalSize, void,                                  \
-    (Dart_FinalizableHandle object, Dart_Handle strong_ref_to_object,          \
-     intptr_t external_allocation_size))                                       \
   /* Isolates */                                                               \
   F(Dart_CurrentIsolate, Dart_Isolate, (void))                                 \
   F(Dart_ExitIsolate, void, (void))                                            \
   F(Dart_EnterIsolate, void, (Dart_Isolate))                                   \
   /* Dart_Port */                                                              \
+  F(Dart_GetMainPortId, Dart_Port, (void))                                     \
   F(Dart_Post, bool, (Dart_Port_DL port_id, Dart_Handle object))               \
   F(Dart_NewSendPort, Dart_Handle, (Dart_Port_DL port_id))                     \
+  F(Dart_NewSendPortEx, Dart_Handle, (Dart_PortEx_DL portex_id))               \
   F(Dart_SendPortGetId, Dart_Handle,                                           \
     (Dart_Handle port, Dart_Port_DL * port_id))                                \
+  F(Dart_SendPortGetIdEx, Dart_Handle,                                         \
+    (Dart_Handle port, Dart_PortEx_DL * portex_id))                            \
+  F(Dart_GetCurrentThreadOwnsIsolate, bool, (Dart_Port))                       \
   /* Scopes */                                                                 \
   F(Dart_EnterScope, void, (void))                                             \
   F(Dart_ExitScope, void, (void))                                              \
   /* Objects */                                                                \
-  F(Dart_IsNull, bool, (Dart_Handle))
+  F(Dart_IsNull, bool, (Dart_Handle))                                          \
+  F(Dart_Null, Dart_Handle, (void))
+
+// dart_api.h symbols that have been deprecated but are retained here
+// until we can make a breaking change bumping the major version number
+// (DART_API_DL_MAJOR_VERSION)
+#define DART_API_DEPRECATED_DL_SYMBOLS(F)                                      \
+  F(Dart_UpdateExternalSize, void,                                             \
+    (Dart_WeakPersistentHandle object, intptr_t external_allocation_size))     \
+  F(Dart_UpdateFinalizableExternalSize, void,                                  \
+    (Dart_FinalizableHandle object, Dart_Handle strong_ref_to_object,          \
+     intptr_t external_allocation_size))
 
 #define DART_API_ALL_DL_SYMBOLS(F)                                             \
   DART_NATIVE_API_DL_SYMBOLS(F)                                                \
@@ -148,6 +165,7 @@ typedef void (*Dart_NativeMessageHandler_DL)(Dart_Port_DL dest_port_id,
   DART_EXPORT_DL name##_Type name##_DL;
 
 DART_API_ALL_DL_SYMBOLS(DART_API_DL_DECLARATIONS)
+DART_API_DEPRECATED_DL_SYMBOLS(DART_API_DL_DECLARATIONS)
 
 #undef DART_API_DL_DECLARATIONS
 

--- a/pkgs/jni/src/include/dart_embedder_api.h
+++ b/pkgs/jni/src/include/dart_embedder_api.h
@@ -18,7 +18,7 @@ namespace embedder {
 //
 // Returns true on success and false otherwise, in which case error would
 // contain error message.
-DART_WARN_UNUSED_RESULT bool InitOnce(char** error);
+DART_API_WARN_UNUSED_RESULT bool InitOnce(char** error);
 
 // Cleans up all subsystems of the embedder.
 //
@@ -51,7 +51,7 @@ struct IsolateCreationData {
 // script_uri.
 // The isolate is created from the given snapshot (might be kernel data or
 // app-jit snapshot).
-DART_WARN_UNUSED_RESULT Dart_Isolate
+DART_API_WARN_UNUSED_RESULT Dart_Isolate
 CreateKernelServiceIsolate(const IsolateCreationData& data,
                            const uint8_t* buffer,
                            intptr_t buffer_size,
@@ -59,10 +59,7 @@ CreateKernelServiceIsolate(const IsolateCreationData& data,
 
 // Service isolate configuration.
 struct VmServiceConfiguration {
-  enum {
-    kBindHttpServerToAFreePort = 0,
-    kDoNotAutoStartHttpServer = -1
-  };
+  enum { kBindHttpServerToAFreePort = 0, kDoNotAutoStartHttpServer = -1 };
 
   // Address to which HTTP server will be bound.
   const char* ip;
@@ -84,7 +81,7 @@ struct VmServiceConfiguration {
 // is expected to contain all necessary 'vm-service' libraries.
 // This method should be used when VM invokes isolate creation callback with
 // DART_VM_SERVICE_ISOLATE_NAME as script_uri.
-DART_WARN_UNUSED_RESULT Dart_Isolate
+DART_API_WARN_UNUSED_RESULT Dart_Isolate
 CreateVmServiceIsolate(const IsolateCreationData& data,
                        const VmServiceConfiguration& config,
                        const uint8_t* isolate_data,
@@ -95,7 +92,7 @@ CreateVmServiceIsolate(const IsolateCreationData& data,
 // is expected to contain all necessary 'vm-service' libraries.
 // This method should be used when VM invokes isolate creation callback with
 // DART_VM_SERVICE_ISOLATE_NAME as script_uri.
-DART_WARN_UNUSED_RESULT Dart_Isolate
+DART_API_WARN_UNUSED_RESULT Dart_Isolate
 CreateVmServiceIsolateFromKernel(const IsolateCreationData& data,
                                  const VmServiceConfiguration& config,
                                  const uint8_t* kernel_buffer,

--- a/pkgs/jni/src/include/dart_native_api.h
+++ b/pkgs/jni/src/include/dart_native_api.h
@@ -166,7 +166,23 @@ typedef void (*Dart_NativeMessageHandler)(Dart_Port dest_port_id,
 DART_EXPORT Dart_Port Dart_NewNativePort(const char* name,
                                          Dart_NativeMessageHandler handler,
                                          bool handle_concurrently);
-/* TODO(turnidge): Currently handle_concurrently is ignored. */
+
+/**
+ * Creates a new native port.  When messages are received on this
+ * native port, then they will be dispatched to the provided native
+ * message handler using up to |max_concurrency| concurrent threads.
+ *
+ * \param name The name of this port in debugging messages.
+ * \param handler The C handler to run when messages arrive on the port.
+ * \param max_concurrency Size of the thread pool used by the native port.
+ *
+ * \return If successful, returns the port id for the native port.  In
+ *   case of error, returns ILLEGAL_PORT.
+ */
+DART_EXPORT Dart_Port
+Dart_NewConcurrentNativePort(const char* name,
+                             Dart_NativeMessageHandler handler,
+                             intptr_t max_concurrency);
 
 /**
  * Closes the native port with the given id.
@@ -191,12 +207,13 @@ DART_EXPORT bool Dart_CloseNativePort(Dart_Port native_port_id);
  *
  * TODO(turnidge): Document.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_CompileAll(void);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle Dart_CompileAll(void);
 
 /**
  * Finalizes all classes.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_FinalizeAllClasses(void);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_FinalizeAllClasses(void);
 
 /*  This function is intentionally undocumented.
  *

--- a/pkgs/jni/src/include/dart_version.h
+++ b/pkgs/jni/src/include/dart_version.h
@@ -11,6 +11,6 @@
 // On backwards compatible changes the minor version is increased.
 // The versioning covers the symbols exposed in dart_api_dl.h
 #define DART_API_DL_MAJOR_VERSION 2
-#define DART_API_DL_MINOR_VERSION 3
+#define DART_API_DL_MINOR_VERSION 6
 
 #endif /* RUNTIME_INCLUDE_DART_VERSION_H_ */ /* NOLINT */

--- a/pkgs/objective_c/src/include/dart_api.h
+++ b/pkgs/objective_c/src/include/dart_api.h
@@ -930,6 +930,8 @@ typedef struct {
   /**
    * A function to be called by the service isolate when it requires the
    * vmservice assets archive. See Dart_GetVMServiceAssetsArchive.
+   * 
+   * This field is deprecated and has no effect.
    */
   Dart_GetVMServiceAssetsArchive get_service_assets;
 
@@ -1459,6 +1461,16 @@ Dart_CreateSnapshot(uint8_t** vm_snapshot_data_buffer,
 DART_EXPORT bool Dart_IsKernel(const uint8_t* buffer, intptr_t buffer_size);
 
 /**
+ * Returns whether the buffer contains a bytecode file.
+ *
+ * \param buffer Pointer to a buffer that might contain a bytecode binary.
+ * \param buffer_size Size of the buffer.
+ *
+ * \return Whether the buffer contains a bytecode binary.
+ */
+DART_EXPORT bool Dart_IsBytecode(const uint8_t* buffer, intptr_t buffer_size);
+
+/**
  * Make isolate runnable.
  *
  * When isolates are spawned, this function is used to indicate that
@@ -1791,7 +1803,7 @@ DART_EXPORT void Dart_SetCurrentThreadOwnsIsolate(void);
  * The port can be the isolate's main port, or any other port owned by the
  * isolate.
  *
- * \param port_id The port to be checked.
+ * \param port The port to be checked.
  */
 DART_EXPORT bool Dart_GetCurrentThreadOwnsIsolate(Dart_Port port);
 
@@ -3351,7 +3363,7 @@ typedef void* (*Dart_NativeAssetsDlopenCallbackNoPath)(char** error);
  *
  * If provided, takes prescedence over `Dart_NativeAssetsDlopenCallback`.
  *
- * \param path The asset id requested in the `@Native` external function.
+ * \param asset_id The asset id requested in the `@Native` external function.
  *
  * \param error Returns NULL if successful, an error message otherwise. The
  *   caller is responsible for calling free() on the error message.
@@ -3369,7 +3381,7 @@ typedef void* (*Dart_NativeAssetsDlopenAssetId)(const char* asset_id,
  * \return A malloced string containing all asset ids. The caller must free this
  *   string.
  */
-typedef char* (*Dart_NativeAssetsAvailableAssets)();
+typedef char* (*Dart_NativeAssetsAvailableAssets)(void);
 
 /**
  * Callback provided by the embedder that is used by the VM to lookup symbols
@@ -3550,6 +3562,20 @@ DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_LoadScriptFromKernel(const uint8_t* kernel_buffer, intptr_t kernel_size);
 
 /**
+ * Loads the root library for the current isolate.
+ *
+ * Requires there to be no current root library.
+ *
+ * \param kernel_buffer A buffer which contains a bytecode binary.
+ *   Must remain valid until isolate group shutdown.
+ * \param kernel_size Length of the passed in buffer.
+ *
+ * \return A handle to the root library, or an error.
+ */
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_LoadScriptFromBytecode(const uint8_t* kernel_buffer, intptr_t kernel_size);
+
+/**
  * Gets the library for the root script for the current isolate.
  *
  * If the root script has not yet been set for the current isolate,
@@ -3721,6 +3747,17 @@ DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_LoadLibrary(Dart_Handle kernel_buffer);
 
 /**
+ * Called by the embedder to load a partial program. Does not set the root
+ * library.
+ *
+ * \param bytecode_buffer An external typed data containing bytecode binary.
+ *
+ * \return A handle to the main library of the compilation unit, or an error.
+ */
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_LoadLibraryFromBytecode(Dart_Handle bytecode_buffer);
+
+/**
  * Indicates that all outstanding load requests have been satisfied.
  * This finalizes all the new classes loaded and optionally completes
  * deferred library futures.
@@ -3818,7 +3855,7 @@ DART_EXPORT Dart_Port Dart_KernelPort(void);
  * Compiles the given `script_uri` to a kernel file.
  *
  * \param platform_kernel A buffer containing the kernel of the platform (e.g.
- * `vm_platform_strong.dill`). The VM does not take ownership of this memory.
+ * `vm_platform.dill`). The VM does not take ownership of this memory.
  *
  * \param platform_kernel_size The length of the platform_kernel buffer.
  *
@@ -3987,7 +4024,7 @@ DART_EXPORT Dart_Handle Dart_LoadingUnitLibraryUris(intptr_t loading_unit_id);
  *
  *  The assembly should be compiled as a static or shared library and linked or
  *  loaded by the embedder. Running this snapshot requires a VM compiled with
- *  DART_PRECOMPILED_SNAPSHOT. The kDartVmSnapshotData and
+ *  DART_PRECOMPILED_RUNTIME. The kDartVmSnapshotData and
  *  kDartVmSnapshotInstructions should be passed to Dart_Initialize. The
  *  kDartIsolateSnapshotData and kDartIsolateSnapshotInstructions should be
  *  passed to Dart_CreateIsolateGroup.
@@ -3998,7 +4035,8 @@ DART_EXPORT Dart_Handle Dart_LoadingUnitLibraryUris(intptr_t loading_unit_id);
  *  debugging sections.
  *
  *  If debug_callback_data is provided, debug_callback_data will be used with
- *  the callback to provide separate debugging information.
+ *  the callback to provide separate debugging information. Ignored when
+ *  targeting Windows.
  *
  *  \return A valid handle if no error occurs during the operation.
  */
@@ -4027,7 +4065,7 @@ Dart_CreateAppAOTSnapshotAsAssemblies(
  *   - _kDartIsolateSnapshotInstructions
  *
  *  The shared library should be dynamically loaded by the embedder.
- *  Running this snapshot requires a VM compiled with DART_PRECOMPILED_SNAPSHOT.
+ *  Running this snapshot requires a VM compiled with DART_PRECOMPILED_RUNTIME.
  *  The kDartVmSnapshotData and kDartVmSnapshotInstructions should be passed to
  *  Dart_Initialize. The kDartIsolateSnapshotData and
  *  kDartIsolateSnapshotInstructions should be passed to Dart_CreateIsolate.
@@ -4053,6 +4091,58 @@ Dart_CreateAppAOTSnapshotAsElfs(Dart_CreateLoadingUnitCallback next_callback,
                                 bool stripped,
                                 Dart_StreamingWriteCallback write_callback,
                                 Dart_StreamingCloseCallback close_callback);
+
+typedef enum {
+  Dart_AotBinaryFormat_Elf = 0,
+  Dart_AotBinaryFormat_Assembly = 1,
+  Dart_AotBinaryFormat_MachO_Dylib = 2,
+} Dart_AotBinaryFormat;
+
+/**
+ *  Creates a precompiled snapshot.
+ *   - A root library must have been loaded.
+ *   - Dart_Precompile must have been called.
+ *
+ *  Outputs a snapshot in the specified binary format defining the symbols
+ *   - _kDartVmSnapshotData
+ *   - _kDartVmSnapshotInstructions
+ *   - _kDartIsolateSnapshotData
+ *   - _kDartIsolateSnapshotInstructions
+ *
+ *  The shared library should be dynamically loaded by the embedder.
+ *  Running this snapshot requires a VM compiled with DART_PRECOMPILED_RUNTIME.
+ *  The kDartVmSnapshotData and kDartVmSnapshotInstructions should be passed to
+ *  Dart_Initialize. The kDartIsolateSnapshotData and
+ *  kDartIsolateSnapshotInstructions should be passed to Dart_CreateIsolate.
+ *
+ *  The callback will be invoked one or more times to provide the binary output.
+ *
+ *  If stripped is true, then the binary output will not include DWARF
+ *  debugging sections.
+ *
+ *  If debug_callback_data is provided, debug_callback_data will be used with
+ *  the callback to provide separate debugging information.
+ *
+ *  The identifier should be an appropriate string for identifying the resulting
+ *  dynamic library. For example, the identifier is used in ID_DYLIB and
+ *  CODE_SIGNATURE load commands for Mach-O dynamic libraries and for DW_AT_name
+ *  in the Dart progam's root DWARF compilation unit.
+ *
+ *  The path should be the full path of the resulting dynamic library.
+ *  Currently, it is only used in unstripped Mach-O snapshots to create an
+ *  appropriate N_OSO symbolic debugging variable so dsymutil can be used.
+ *  The N_OSO symbol is not created if the path is nullptr.
+ *
+ * \return A valid handle if no error occurs during the operation.
+ */
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_CreateAppAOTSnapshotAsBinary(Dart_AotBinaryFormat format,
+                                  Dart_StreamingWriteCallback callback,
+                                  void* callback_data,
+                                  bool stripped,
+                                  void* debug_callback_data,
+                                  const char* identifier,
+                                  const char* path);
 
 /**
  *  Like Dart_CreateAppAOTSnapshotAsAssembly, but only includes

--- a/pkgs/objective_c/src/include/dart_tools_api.h
+++ b/pkgs/objective_c/src/include/dart_tools_api.h
@@ -300,6 +300,7 @@ DART_EXPORT bool Dart_IsReloading();
  *   "Embedder" - Execution of Dart embedder code
  *   "GC" - Execution of Dart Garbage Collector
  *   "Isolate" - Dart Isolate lifecycle execution
+ *   "Microtask" - Execution of Dart microtasks
  *   "VM" - Execution in Dart VM runtime code
  *   "" - None
  *


### PR DESCRIPTION
The warnings were fixed in the SDK in https://github.com/dart-lang/sdk/commit/f3bbeb61f7da10ad538953b409c16b12ead9a086. There's no need to wait for these changes to be released to stable. This PR just copies the SDK's runtime/include directory into ffigen and jnigen.

Fixes https://github.com/dart-lang/native/issues/2482