### PR TITLE
[native_doc_dartifier] Add more context for imported packages

### DIFF
--- a/pkgs/native_doc_dartifier/lib/src/ast.dart
+++ b/pkgs/native_doc_dartifier/lib/src/ast.dart
@@ -29,6 +29,7 @@ class Class {
 
   String toDartLikeRepresentation() {
     final classDecleration =
+        // ignore: lines_longer_than_80_chars
         '${isInterface ? 'interface ' : ''}${isAbstract ? 'abstract ' : ''}class $name ${extendedClass.isNotEmpty ? 'extends $extendedClass ' : ''}${implementedInterfaces.isNotEmpty ? 'implements ${implementedInterfaces.join(', ')} ' : ''}';
 
     final buffer = StringBuffer();

--- a/pkgs/native_doc_dartifier/lib/src/ast.dart
+++ b/pkgs/native_doc_dartifier/lib/src/ast.dart
@@ -27,7 +27,7 @@ class Class {
       getters = [],
       setters = [];
 
-  String toDartLikeRepresentaion() {
+  String toDartLikeRepresentation() {
     final classDecleration =
         '${isInterface ? 'interface ' : ''}${isAbstract ? 'abstract ' : ''}class $name ${extendedClass.isNotEmpty ? 'extends $extendedClass ' : ''}${implementedInterfaces.isNotEmpty ? 'implements ${implementedInterfaces.join(', ')} ' : ''}';
 
@@ -35,19 +35,19 @@ class Class {
 
     buffer.writeln('$classDecleration {');
     for (final constructor in constructors) {
-      buffer.writeln('  $constructor;');
+      buffer.writeln('  ${constructor.toDartLikeRepresentation()};');
     }
     for (final field in fields) {
-      buffer.writeln('  $field;');
+      buffer.writeln('  ${field.toDartLikeRepresentation()};');
     }
     for (final method in methods) {
-      buffer.writeln('  $method;');
+      buffer.writeln('  ${method.toDartLikeRepresentation()};');
     }
     for (final getter in getters) {
-      buffer.writeln('  $getter;');
+      buffer.writeln('  ${getter.toDartLikeRepresentation()};');
     }
     for (final setter in setters) {
-      buffer.writeln('  $setter;');
+      buffer.writeln('  ${setter.toDartLikeRepresentation()};');
     }
     buffer.writeln('}');
     return buffer.toString();
@@ -73,7 +73,8 @@ class Field {
 
   Field(this.name, this.type, {this.isStatic = false});
 
-  String toDartLikeRepresentaion() => '${isStatic ? 'static ' : ''}$type $name';
+  String toDartLikeRepresentation() =>
+      '${isStatic ? 'static ' : ''}$type $name';
 }
 
 class Method {
@@ -93,7 +94,7 @@ class Method {
     this.operatorKeyword = '',
   });
 
-  String toDartLikeRepresentaion() {
+  String toDartLikeRepresentation() {
     final staticPrefix = isStatic ? 'static ' : '';
     final operatorPrefix =
         operatorKeyword.isNotEmpty ? '$operatorKeyword ' : '';
@@ -111,7 +112,7 @@ class Constructor {
 
   Constructor(this.className, this.name, this.parameters, this.factoryKeyword);
 
-  String toDartLikeRepresentaion() {
+  String toDartLikeRepresentation() {
     final constructorName = name.isNotEmpty ? '$className.$name' : className;
     return '${factoryKeyword != null ? '$factoryKeyword ' : ''}'
         '$constructorName$parameters';
@@ -125,7 +126,7 @@ class Getter {
 
   Getter(this.name, this.returnType, this.isStatic);
 
-  String toDartLikeRepresentaion() {
+  String toDartLikeRepresentation() {
     final staticPrefix = isStatic ? 'static ' : '';
     return '$staticPrefix$returnType get $name';
   }
@@ -139,29 +140,24 @@ class Setter {
 
   Setter(this.name, this.parameterType, this.isStatic, this.parameter);
 
-  String toDartLikeRepresentaion() {
+  String toDartLikeRepresentation() {
     final staticPrefix = isStatic ? 'static ' : '';
     return '$staticPrefix$parameterType set $name($parameter)';
   }
 }
 
-class LibrarySummary {
-  final String libraryName;
-  final List<LibraryClassSummary> classesSummaries;
-  final List<String> topLevelFunctions;
-  final List<String> topLevelVariables;
+class PackageSummary {
+  final String packageName;
+  final List<LibraryClassSummary> classesSummaries = [];
+  final List<String> topLevelFunctions = [];
+  final List<String> topLevelVariables = [];
 
-  LibrarySummary({
-    required this.libraryName,
-    required this.classesSummaries,
-    required this.topLevelFunctions,
-    required this.topLevelVariables,
-  });
+  PackageSummary({required this.packageName});
 
   String toDartLikeRepresentation() {
     final buffer = StringBuffer();
-    if (libraryName.isNotEmpty) {
-      buffer.writeln('From: $libraryName');
+    if (packageName.isNotEmpty) {
+      buffer.writeln('// From: $packageName');
     }
     for (final function in topLevelFunctions) {
       buffer.writeln('$function;');
@@ -171,7 +167,8 @@ class LibrarySummary {
     }
     buffer.writeln();
     for (final classSummary in classesSummaries) {
-      buffer.writeln(classSummary.toDartLikeRepresentaion());
+      buffer.writeln('// From: $packageName');
+      buffer.writeln(classSummary.toDartLikeRepresentation());
       buffer.writeln();
     }
     return buffer.toString();
@@ -179,7 +176,6 @@ class LibrarySummary {
 }
 
 class LibraryClassSummary {
-  final String libraryName;
   final String classDeclerationDisplay;
   final List<String> methodsDeclerationDisplay;
   final List<String> fieldsDeclerationDisplay;
@@ -188,7 +184,6 @@ class LibraryClassSummary {
   final List<String> constructorsDeclerationDisplay;
 
   LibraryClassSummary({
-    required this.libraryName,
     required this.classDeclerationDisplay,
     required this.methodsDeclerationDisplay,
     required this.fieldsDeclerationDisplay,
@@ -197,11 +192,8 @@ class LibraryClassSummary {
     required this.constructorsDeclerationDisplay,
   });
 
-  String toDartLikeRepresentaion() {
+  String toDartLikeRepresentation() {
     final buffer = StringBuffer();
-    if (libraryName.isNotEmpty) {
-      buffer.writeln('From: $libraryName');
-    }
     buffer.writeln('$classDeclerationDisplay {');
     for (final constructor in constructorsDeclerationDisplay) {
       buffer.writeln('  $constructor;');

--- a/pkgs/native_doc_dartifier/lib/src/ast.dart
+++ b/pkgs/native_doc_dartifier/lib/src/ast.dart
@@ -27,16 +27,31 @@ class Class {
       getters = [],
       setters = [];
 
-  String toDartLikeRepresentaion() => '''
-${isInterface ? 'interface ' : ''}${isAbstract ? 'abstract ' : ''}class $name ${extendedClass.isNotEmpty ? 'extends $extendedClass ' : ''}${implementedInterfaces.isNotEmpty ? 'implements ${implementedInterfaces.join(', ')} ' : ''}
-{
-${constructors.map((c) => '${c.toDartLikeRepresentaion()};').join('\n')}
-${fields.map((f) => '${f.toDartLikeRepresentaion()};').join('\n')}
-${methods.map((m) => '${m.toDartLikeRepresentaion()};').join('\n')}
-${getters.map((g) => '${g.toDartLikeRepresentaion()};').join('\n')}
-${setters.map((s) => '${s.toDartLikeRepresentaion()};').join('\n')}
-}
-''';
+  String toDartLikeRepresentaion() {
+    final classDecleration =
+        '${isInterface ? 'interface ' : ''}${isAbstract ? 'abstract ' : ''}class $name ${extendedClass.isNotEmpty ? 'extends $extendedClass ' : ''}${implementedInterfaces.isNotEmpty ? 'implements ${implementedInterfaces.join(', ')} ' : ''}';
+
+    final buffer = StringBuffer();
+
+    buffer.writeln('$classDecleration {');
+    for (final constructor in constructors) {
+      buffer.writeln('  $constructor;');
+    }
+    for (final field in fields) {
+      buffer.writeln('  $field;');
+    }
+    for (final method in methods) {
+      buffer.writeln('  $method;');
+    }
+    for (final getter in getters) {
+      buffer.writeln('  $getter;');
+    }
+    for (final setter in setters) {
+      buffer.writeln('  $setter;');
+    }
+    buffer.writeln('}');
+    return buffer.toString();
+  }
 
   void addField(Field field) {
     fields.add(field);
@@ -130,6 +145,39 @@ class Setter {
   }
 }
 
+class LibrarySummary {
+  final String libraryName;
+  final List<LibraryClassSummary> classesSummaries;
+  final List<String> topLevelFunctions;
+  final List<String> topLevelVariables;
+
+  LibrarySummary({
+    required this.libraryName,
+    required this.classesSummaries,
+    required this.topLevelFunctions,
+    required this.topLevelVariables,
+  });
+
+  String toDartLikeRepresentation() {
+    final buffer = StringBuffer();
+    if (libraryName.isNotEmpty) {
+      buffer.writeln('From: $libraryName');
+    }
+    for (final function in topLevelFunctions) {
+      buffer.writeln('$function;');
+    }
+    for (final variable in topLevelVariables) {
+      buffer.writeln('$variable;');
+    }
+    buffer.writeln();
+    for (final classSummary in classesSummaries) {
+      buffer.writeln(classSummary.toDartLikeRepresentaion());
+      buffer.writeln();
+    }
+    return buffer.toString();
+  }
+}
+
 class LibraryClassSummary {
   final String libraryName;
   final String classDeclerationDisplay;
@@ -156,19 +204,19 @@ class LibraryClassSummary {
     }
     buffer.writeln('$classDeclerationDisplay {');
     for (final constructor in constructorsDeclerationDisplay) {
-      buffer.writeln('  $constructor');
+      buffer.writeln('  $constructor;');
     }
     for (final field in fieldsDeclerationDisplay) {
-      buffer.writeln('  $field');
+      buffer.writeln('  $field;');
     }
     for (final method in methodsDeclerationDisplay) {
-      buffer.writeln('  $method');
+      buffer.writeln('  $method;');
     }
     for (final getter in gettersDeclerationDisplay) {
-      buffer.writeln('  $getter');
+      buffer.writeln('  $getter;');
     }
     for (final setter in settersDeclerationDisplay) {
-      buffer.writeln('  $setter');
+      buffer.writeln('  $setter;');
     }
     buffer.writeln('}');
     return buffer.toString();

--- a/pkgs/native_doc_dartifier/lib/src/context.dart
+++ b/pkgs/native_doc_dartifier/lib/src/context.dart
@@ -109,27 +109,27 @@ class Context {
               classDeclerationDisplay: element.displayString(),
               methodsDeclerationDisplay:
                   element.methods
-                      .takeWhile((m) => m.isPublic)
+                      .where((m) => m.isPublic)
                       .map((m) => m.displayString())
                       .toList(),
               fieldsDeclerationDisplay:
                   element.fields
-                      .takeWhile((f) => f.isPublic)
+                      .where((f) => f.isPublic)
                       .map((f) => f.displayString())
                       .toList(),
               gettersDeclerationDisplay:
                   element.getters
-                      .takeWhile((g) => g.isPublic)
+                      .where((g) => g.isPublic)
                       .map((g) => g.displayString())
                       .toList(),
               settersDeclerationDisplay:
                   element.setters
-                      .takeWhile((s) => s.isPublic)
+                      .where((s) => s.isPublic)
                       .map((s) => s.displayString())
                       .toList(),
               constructorsDeclerationDisplay:
                   element.constructors
-                      .takeWhile((c) => c.isPublic)
+                      .where((c) => c.isPublic)
                       .map((c) => c.displayString())
                       .toList(),
             ),

--- a/pkgs/native_doc_dartifier/test/context_test.dart
+++ b/pkgs/native_doc_dartifier/test/context_test.dart
@@ -14,6 +14,9 @@ void main() {
       Directory.current.path,
       p.absolute('test/dartify_simple_cases/bindings.dart'),
     );
+
+    final file = File('output.txt');
+    await file.writeAsString(context.toDartLikeRepresentation());
     expect(context.importedPackages.contains('package:jni/jni.dart'), isTrue);
     expect(
       context.importedPackages.contains('package:jni/_internal.dart'),

--- a/pkgs/native_doc_dartifier/test/context_test.dart
+++ b/pkgs/native_doc_dartifier/test/context_test.dart
@@ -68,6 +68,7 @@ void main() {
     expect(
       jniSummary.topLevelFunctions.any(
         (function) => function.contains(
+          // ignore: lines_longer_than_80_chars
           'using<R>(R Function(Arena) computation, [Allocator wrappedAllocator = calloc])',
         ),
       ),


### PR DESCRIPTION
closes: #2507 
closes: #2488
CI output: marshelino-maged/native#14


## Description
- Added the `PackageSummary` class, which includes:  
  - List of classes  
  - List of top-level functions  
  - List of top-level variables  

- Implemented recursion for exports:  
  - Now all exported classes can be collected, even across multiple levels (e.g., file `A` exports `B`, and file `B` exports `C`, etc.).  
  - Added support for including signatures directly from the library file itself (e.g., if `jni.dart` itself contains signatures in addition to its exports). 

## Known Limitation
- When using `export A hide Foo`, `Foo` is currently **not hidden** and still appears in the context.  
- I’ll open a separate issue to address this behavior.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
