### PR TITLE
[jnigen] Change typeclass names and remove API leaks

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 0.14.3-wip
+## 0.15.0-wip
 
+- **Breaking Change**: Made `Jni.env` internal.
+- **Breaking Change**: Renamed `JObjType` to `JType`.
+- **Breaking Change**: Made all of the type classes internal.
 - Update to the latest lints.
 
 ## 0.14.2

--- a/pkgs/jni/ffigen.yaml
+++ b/pkgs/jni/ffigen.yaml
@@ -72,6 +72,7 @@ structs:
     - 'CallbackResult'
   rename:
     ## opaque struct definitions, base types of jfieldID and jmethodID
+    '_Dart_FinalizableHandle': 'Dart_FinalizableHandle_'
     '_jfieldID': 'jfieldID_'
     '_jmethodID':
       'jmethodID_'

--- a/pkgs/jni/lib/_internal.dart
+++ b/pkgs/jni/lib/_internal.dart
@@ -68,6 +68,8 @@ export 'src/method_invocation.dart';
 export 'src/nio/jbuffer.dart' show $JBuffer$NullableType$, $JBuffer$Type$;
 export 'src/nio/jbyte_buffer.dart'
     show $JByteBuffer$NullableType$, $JByteBuffer$Type$;
+export 'src/third_party/generated_bindings.dart'
+    show JFieldIDPtr, JMethodIDPtr, JObjectPtr, JThrowablePtr, JniResult;
 export 'src/types.dart' show JTypeBase, lowestCommonSuperType, referenceType;
 export 'src/util/jiterator.dart'
     show $JIterator$NullableType$, $JIterator$Type$;

--- a/pkgs/jni/lib/_internal.dart
+++ b/pkgs/jni/lib/_internal.dart
@@ -69,7 +69,13 @@ export 'src/nio/jbuffer.dart' show $JBuffer$NullableType$, $JBuffer$Type$;
 export 'src/nio/jbyte_buffer.dart'
     show $JByteBuffer$NullableType$, $JByteBuffer$Type$;
 export 'src/third_party/generated_bindings.dart'
-    show JFieldIDPtr, JMethodIDPtr, JObjectPtr, JThrowablePtr, JniResult;
+    show
+        Dart_FinalizableHandle,
+        JFieldIDPtr,
+        JMethodIDPtr,
+        JObjectPtr,
+        JThrowablePtr,
+        JniResult;
 export 'src/types.dart' show JTypeBase, lowestCommonSuperType, referenceType;
 export 'src/util/jiterator.dart'
     show $JIterator$NullableType$, $JIterator$Type$;

--- a/pkgs/jni/lib/_internal.dart
+++ b/pkgs/jni/lib/_internal.dart
@@ -69,13 +69,7 @@ export 'src/nio/jbuffer.dart' show $JBuffer$NullableType$, $JBuffer$Type$;
 export 'src/nio/jbyte_buffer.dart'
     show $JByteBuffer$NullableType$, $JByteBuffer$Type$;
 export 'src/third_party/generated_bindings.dart'
-    show
-        Dart_FinalizableHandle,
-        JFieldIDPtr,
-        JMethodIDPtr,
-        JObjectPtr,
-        JThrowablePtr,
-        JniResult;
+    show JFieldIDPtr, JMethodIDPtr, JObjectPtr, JThrowablePtr, JniResult;
 export 'src/types.dart' show JTypeBase, lowestCommonSuperType, referenceType;
 export 'src/util/jiterator.dart'
     show $JIterator$NullableType$, $JIterator$Type$;

--- a/pkgs/jni/lib/_internal.dart
+++ b/pkgs/jni/lib/_internal.dart
@@ -28,20 +28,52 @@ export 'dart:isolate' show RawReceivePort, ReceivePort;
 export 'package:meta/meta.dart' show internal;
 
 export 'src/accessors.dart';
+export 'src/jarray.dart'
+    show
+        $JArray$NullableType$,
+        $JArray$Type$,
+        $JBooleanArray$NullableType$,
+        $JBooleanArray$Type$,
+        $JByteArray$NullableType$,
+        $JByteArray$Type$,
+        $JCharArray$NullableType$,
+        $JCharArray$Type$,
+        $JDoubleArray$NullableType$,
+        $JDoubleArray$Type$,
+        $JFloatArray$NullableType$,
+        $JFloatArray$Type$,
+        $JIntArray$NullableType$,
+        $JIntArray$Type$,
+        $JLongArray$NullableType$,
+        $JLongArray$Type$,
+        $JShortArray$NullableType$,
+        $JShortArray$Type$;
 export 'src/jni.dart' show ProtectedJniExtensions;
+export 'src/jobject.dart' show $JObject$NullableType$, $JObject$Type$;
 export 'src/jreference.dart';
 export 'src/kotlin.dart'
     show coroutineSingletonsClass, failureExceptionField, result$FailureClass;
+export 'src/lang/jboolean.dart' show $JBoolean$NullableType$, $JBoolean$Type$;
+export 'src/lang/jbyte.dart' show $JByte$NullableType$, $JByte$Type$;
+export 'src/lang/jcharacter.dart'
+    show $JCharacter$NullableType$, $JCharacter$Type$;
+export 'src/lang/jdouble.dart' show $JDouble$NullableType$, $JDouble$Type$;
+export 'src/lang/jfloat.dart' show $JFloat$NullableType$, $JFloat$Type$;
+export 'src/lang/jinteger.dart' show $JInteger$NullableType$, $JInteger$Type$;
+export 'src/lang/jlong.dart' show $JLong$NullableType$, $JLong$Type$;
+export 'src/lang/jnumber.dart' show $JNumber$NullableType$, $JNumber$Type$;
+export 'src/lang/jshort.dart' show $JShort$NullableType$, $JShort$Type$;
+export 'src/lang/jstring.dart' show $JString$NullableType$, $JString$Type$;
 export 'src/method_invocation.dart';
-export 'src/types.dart'
-    show
-        JAccessible,
-        JCallable,
-        JConstructable,
-        JObjType,
-        JType,
-        lowestCommonSuperType,
-        referenceType;
+export 'src/nio/jbuffer.dart' show $JBuffer$NullableType$, $JBuffer$Type$;
+export 'src/nio/jbyte_buffer.dart'
+    show $JByteBuffer$NullableType$, $JByteBuffer$Type$;
+export 'src/types.dart' show JTypeBase, lowestCommonSuperType, referenceType;
+export 'src/util/jiterator.dart'
+    show $JIterator$NullableType$, $JIterator$Type$;
+export 'src/util/jlist.dart' show $JList$NullableType$, $JList$Type$;
+export 'src/util/jmap.dart' show $JMap$NullableType$, $JMap$Type$;
+export 'src/util/jset.dart' show $JSet$NullableType$, $JSet$Type$;
 
 /// Temporary fix for the macOS arm64 varargs problem.
 ///

--- a/pkgs/jni/lib/jni.dart
+++ b/pkgs/jni/lib/jni.dart
@@ -63,22 +63,32 @@ library;
 export 'package:ffi/ffi.dart' show Arena, using;
 
 export 'src/errors.dart';
-export 'src/jarray.dart';
+export 'src/jarray.dart'
+    hide
+        $JArray$NullableType$,
+        $JArray$Type$,
+        $JBooleanArray$NullableType$,
+        $JBooleanArray$Type$,
+        $JByteArray$NullableType$,
+        $JByteArray$Type$,
+        $JCharArray$NullableType$,
+        $JCharArray$Type$,
+        $JDoubleArray$NullableType$,
+        $JDoubleArray$Type$,
+        $JFloatArray$NullableType$,
+        $JFloatArray$Type$,
+        $JIntArray$NullableType$,
+        $JIntArray$Type$,
+        $JLongArray$NullableType$,
+        $JLongArray$Type$,
+        $JShortArray$NullableType$,
+        $JShortArray$Type$;
 export 'src/jimplementer.dart';
 export 'src/jni.dart' hide ProtectedJniExtensions, StringMethodsForJni;
-export 'src/jobject.dart';
+export 'src/jobject.dart' hide $JObject$NullableType$, $JObject$Type$;
 export 'src/jreference.dart' hide ProtectedJReference;
 export 'src/jvalues.dart';
 export 'src/lang/lang.dart';
 export 'src/nio/nio.dart';
-export 'src/third_party/generated_bindings.dart'
-    hide JniBindings, JniEnv, JniEnv1, JniExceptionDetails;
-export 'src/types.dart'
-    hide
-        JAccessible,
-        JCallable,
-        JConstructable,
-        JObjType,
-        JType,
-        lowestCommonSuperType;
+export 'src/types.dart' hide JTypeBase, lowestCommonSuperType;
 export 'src/util/util.dart';

--- a/pkgs/jni/lib/jni.dart
+++ b/pkgs/jni/lib/jni.dart
@@ -84,7 +84,8 @@ export 'src/jarray.dart'
         $JShortArray$NullableType$,
         $JShortArray$Type$;
 export 'src/jimplementer.dart';
-export 'src/jni.dart' hide ProtectedJniExtensions, StringMethodsForJni;
+export 'src/jni.dart'
+    hide InternalJniExtension, ProtectedJniExtensions, StringMethodsForJni;
 export 'src/jobject.dart' hide $JObject$NullableType$, $JObject$Type$;
 export 'src/jreference.dart' hide ProtectedJReference;
 export 'src/jvalues.dart';

--- a/pkgs/jni/lib/jni_symbols.yaml
+++ b/pkgs/jni/lib/jni_symbols.yaml
@@ -3,87 +3,57 @@ files:
   'jni.dart':
     'java.lang.Object':
       name: JObject
-      type_class: JObjectType
-      nullable_type_class: JObjectNullableType
       super_count: 0
     'java.lang.String':
       name: JString
-      type_class: JStringType
-      nullable_type_class: JStringNullableType
       super_count: 1
     'java.lang.Number':
       name: JNumber
-      type_class: JNumberType
-      nullable_type_class: JNumberNullableType
       super_count: 1
     'java.lang.Byte':
       name: JByte
-      type_class: JByteType
-      nullable_type_class: JByteNullableType
       super_count: 2
     'java.lang.Short':
       name: JShort
-      type_class: JShortType
-      nullable_type_class: JShortNullableType
       super_count: 2
     'java.lang.Integer':
       name: JInteger
-      type_class: JIntegerType
-      nullable_type_class: JIntegerNullableType
       super_count: 2
     'java.lang.Long':
       name: JLong
-      type_class: JLongType
-      nullable_type_class: JLongNullableType
       super_count: 2
     'java.lang.Float':
       name: JFloat
-      type_class: JFloatType
-      nullable_type_class: JFloatNullableType
       super_count: 2
     'java.lang.Double':
       name: JDouble
-      type_class: JDoubleType
-      nullable_type_class: JDoubleNullableType
       super_count: 2
     'java.lang.Boolean':
       name: JBoolean
-      type_class: JBooleanType
-      nullable_type_class: JBooleanNullableType
       super_count: 1
     'java.lang.Character':
       name: JCharacter
-      type_class: JCharacterType
-      nullable_type_class: JCharacterNullableType
       super_count: 1
     'java.util.Set':
       name: JSet
-      type_class: JSetType
-      nullable_type_class: JSetNullableType
       super_count: 1
       type_params:
         E:
           'java.lang.Object': DECLARED
     'java.util.List':
       name: JList
-      type_class: JListType
-      nullable_type_class: JListNullableType
       super_count: 1
       type_params:
         E:
           'java.lang.Object': DECLARED
     'java.util.Iterator':
       name: JIterator
-      type_class: JIteratorType
-      nullable_type_class: JIteratorNullableType
       super_count: 1
       type_params:
         E:
           'java.lang.Object': DECLARED
     'java.util.Map':
       name: JMap
-      type_class: JMapType
-      nullable_type_class: JMapNullableType
       super_count: 1
       type_params:
         K:
@@ -92,11 +62,7 @@ files:
           'java.lang.Object': DECLARED
     'java.nio.Buffer':
       name: JBuffer
-      type_class: JBufferType
-      nullable_type_class: JBufferNullableType
       super_count: 1
     'java.nio.ByteBuffer':
       name: JByteBuffer
-      type_class: JByteBufferType
-      nullable_type_class: JByteBufferNullableType
       super_count: 2

--- a/pkgs/jni/lib/src/accessors.dart
+++ b/pkgs/jni/lib/src/accessors.dart
@@ -72,7 +72,7 @@ extension JniResultMethods on JniResult {
     return pointer == nullptr ? jNullReference : JGlobalReference(pointer);
   }
 
-  T object<T extends JObject?>(JObjType<T> type) {
+  T object<T extends JObject?>(JType<T> type) {
     return type.fromReference(reference);
   }
 

--- a/pkgs/jni/lib/src/errors.dart
+++ b/pkgs/jni/lib/src/errors.dart
@@ -4,7 +4,8 @@
 
 import 'dart:io';
 
-import '../_internal.dart';
+import 'package:meta/meta.dart' show internal;
+
 import 'third_party/generated_bindings.dart';
 
 // TODO(#567): Add the fact that [JException] is now a [JObject] to the

--- a/pkgs/jni/lib/src/errors.dart
+++ b/pkgs/jni/lib/src/errors.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import '../_internal.dart';
 import 'third_party/generated_bindings.dart';
 
 // TODO(#567): Add the fact that [JException] is now a [JObject] to the
@@ -37,6 +38,7 @@ sealed class JniError extends Error {
 
   JniError(this.message);
 
+  @internal
   factory JniError.of(JniErrorCode status) {
     if (!_errors.containsKey(status)) {
       status = JniErrorCode.ERR;

--- a/pkgs/jni/lib/src/jarray.dart
+++ b/pkgs/jni/lib/src/jarray.dart
@@ -86,15 +86,16 @@ final class $JArray$Type$<E extends JObject?> extends JType<JArray<E>> {
 class JArray<E extends JObject?> extends JObject with Iterable<E> {
   final JType<E> elementType;
 
+  @internal
   @override
-  final $JArray$Type$<E> $type;
+  final JType<JArray<E>> $type;
 
   /// The type which includes information such as the signature of this class.
-  static $JArray$Type$<E> type<E extends JObject?>(JType<E> innerType) =>
+  static JType<JArray<E>> type<E extends JObject?>(JType<E> innerType) =>
       $JArray$Type$<E>(innerType);
 
   /// The type which includes information such as the signature of this class.
-  static $JArray$NullableType$<E> nullableType<E extends JObject?>(
+  static JType<JArray<E>?> nullableType<E extends JObject?>(
           JType<E> innerType) =>
       $JArray$NullableType$<E>(innerType);
 

--- a/pkgs/jni/lib/src/jarray.dart
+++ b/pkgs/jni/lib/src/jarray.dart
@@ -8,7 +8,7 @@ import 'dart:ffi';
 import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
-import 'package:meta/meta.dart';
+import 'package:meta/meta.dart' show internal;
 
 import 'jni.dart';
 import 'jobject.dart';
@@ -16,101 +16,87 @@ import 'jreference.dart';
 import 'third_party/generated_bindings.dart';
 import 'types.dart';
 
-final class JArrayNullableType<E extends JObject?>
-    extends JObjType<JArray<E>?> {
-  @internal
-  final JObjType<E> elementType;
+@internal
+final class $JArray$NullableType$<E extends JObject?>
+    extends JType<JArray<E>?> {
+  final JType<E> elementType;
 
-  @internal
-  const JArrayNullableType(this.elementType);
+  const $JArray$NullableType$(this.elementType);
 
-  @internal
   @override
   String get signature => '[${elementType.signature}';
 
-  @internal
   @override
   JArray<E>? fromReference(JReference reference) =>
       reference.isNull ? null : JArray<E>.fromReference(elementType, reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectNullableType();
+  JType get superType => const $JObject$NullableType$();
 
-  @internal
   @override
-  JObjType<JArray<E>?> get nullableType => this;
+  JType<JArray<E>?> get nullableType => this;
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => Object.hash(JArrayNullableType, elementType);
+  int get hashCode => Object.hash($JArray$NullableType$, elementType);
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == (JArrayNullableType<E>) &&
-        other is JArrayNullableType<E> &&
+    return other.runtimeType == ($JArray$NullableType$<E>) &&
+        other is $JArray$NullableType$<E> &&
         elementType == other.elementType;
   }
 }
 
-final class JArrayType<E extends JObject?> extends JObjType<JArray<E>> {
-  @internal
-  final JObjType<E> elementType;
+@internal
+final class $JArray$Type$<E extends JObject?> extends JType<JArray<E>> {
+  final JType<E> elementType;
 
-  @internal
-  const JArrayType(this.elementType);
+  const $JArray$Type$(this.elementType);
 
-  @internal
   @override
   String get signature => '[${elementType.signature}';
 
-  @internal
   @override
   JArray<E> fromReference(JReference reference) =>
       JArray<E>.fromReference(elementType, reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JArray<E>?> get nullableType => JArrayNullableType<E>(elementType);
+  JType<JArray<E>?> get nullableType => $JArray$NullableType$<E>(elementType);
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => Object.hash(JArrayType, elementType);
+  int get hashCode => Object.hash($JArray$Type$, elementType);
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == (JArrayType<E>) &&
-        other is JArrayType<E> &&
+    return other.runtimeType == ($JArray$Type$<E>) &&
+        other is $JArray$Type$<E> &&
         elementType == other.elementType;
   }
 }
 
 class JArray<E extends JObject?> extends JObject with Iterable<E> {
-  @internal
-  final JObjType<E> elementType;
+  final JType<E> elementType;
 
-  @internal
   @override
-  final JArrayType<E> $type;
+  final $JArray$Type$<E> $type;
 
   /// The type which includes information such as the signature of this class.
-  static JArrayType<E> type<E extends JObject?>(JObjType<E> innerType) =>
-      JArrayType<E>(innerType);
+  static $JArray$Type$<E> type<E extends JObject?>(JType<E> innerType) =>
+      $JArray$Type$<E>(innerType);
 
   /// The type which includes information such as the signature of this class.
-  static JArrayNullableType<E> nullableType<E extends JObject?>(
-          JObjType<E> innerType) =>
-      JArrayNullableType<E>(innerType);
+  static $JArray$NullableType$<E> nullableType<E extends JObject?>(
+          JType<E> innerType) =>
+      $JArray$NullableType$<E>(innerType);
 
   /// Construct a new [JArray] with [reference] as its underlying reference.
   JArray.fromReference(this.elementType, JReference reference)
@@ -122,7 +108,7 @@ class JArray<E extends JObject?> extends JObject with Iterable<E> {
   /// The [length] must be a non-negative integer.
   /// For objects, [elementType] must be a nullable type as this constructor
   /// initializes all elements with `null`.
-  factory JArray(JObjType<E> elementType, int length) {
+  factory JArray(JType<E> elementType, int length) {
     RangeError.checkNotNegative(length);
     if (!elementType.isNullable) {
       throw ArgumentError.value(
@@ -136,7 +122,7 @@ class JArray<E extends JObject?> extends JObject with Iterable<E> {
   }
 
   static JArray<$E> _newArray<$E extends JObject?>(
-      JObjType<$E> elementType, int length,
+      JType<$E> elementType, int length,
       [$E? fill]) {
     final classRef = elementType.jClass.reference;
     final fillRef = fill?.reference ?? jNullReference;
@@ -156,15 +142,15 @@ class JArray<E extends JObject?> extends JObject with Iterable<E> {
   ///
   /// The [length] must be a non-negative integer.
   static JArray<$E> filled<$E extends JObject>(int length, $E fill,
-      {JObjType<$E>? E}) {
+      {JType<$E>? E}) {
     RangeError.checkNotNegative(length);
-    E ??= fill.$type as JObjType<$E>;
+    E ??= fill.$type as JType<$E>;
     return _newArray<$E>(E, length, fill);
   }
 
   /// Creates a [JArray] from `elements`.
   static JArray<$E> of<$E extends JObject?>(
-      JObjType<$E> elementType, Iterable<$E> elements) {
+      JType<$E> elementType, Iterable<$E> elements) {
     return _newArray<$E>(elementType, elements.length)
       ..setRange(0, elements.length, elements);
   }
@@ -180,8 +166,7 @@ class JArray<E extends JObject?> extends JObject with Iterable<E> {
     if (pointer == nullptr) {
       return null as E;
     }
-    return (elementType as JObjType<E>)
-        .fromReference(JGlobalReference(pointer));
+    return (elementType as JType<E>).fromReference(JGlobalReference(pointer));
   }
 
   E operator [](int index) {
@@ -258,86 +243,78 @@ extension on Allocator {
   }
 }
 
-final class JBooleanArrayNullableType extends JObjType<JBooleanArray?> {
-  @internal
-  const JBooleanArrayNullableType();
+@internal
+final class $JBooleanArray$NullableType$ extends JType<JBooleanArray?> {
+  const $JBooleanArray$NullableType$();
 
-  @internal
   @override
   String get signature => '[Z';
 
-  @internal
   @override
   JBooleanArray? fromReference(JReference reference) =>
       reference.isNull ? null : JBooleanArray.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectNullableType();
+  JType get superType => const $JObject$NullableType$();
 
-  @internal
   @override
-  JObjType<JBooleanArray?> get nullableType => this;
+  JType<JBooleanArray?> get nullableType => this;
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JBooleanArrayNullableType).hashCode;
+  int get hashCode => ($JBooleanArray$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JBooleanArrayNullableType &&
-        other is JBooleanArrayNullableType;
+    return other.runtimeType == $JBooleanArray$NullableType$ &&
+        other is $JBooleanArray$NullableType$;
   }
 }
 
-final class JBooleanArrayType extends JObjType<JBooleanArray> {
-  @internal
-  const JBooleanArrayType();
+@internal
+final class $JBooleanArray$Type$ extends JType<JBooleanArray> {
+  const $JBooleanArray$Type$();
 
-  @internal
   @override
   String get signature => '[Z';
 
-  @internal
   @override
   JBooleanArray fromReference(JReference reference) =>
       JBooleanArray.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JBooleanArray?> get nullableType =>
-      const JBooleanArrayNullableType();
+  JType<JBooleanArray?> get nullableType =>
+      const $JBooleanArray$NullableType$();
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JBooleanArrayType).hashCode;
+  int get hashCode => ($JBooleanArray$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JBooleanArrayType && other is JBooleanArrayType;
+    return other.runtimeType == $JBooleanArray$Type$ &&
+        other is $JBooleanArray$Type$;
   }
 }
 
 class JBooleanArray extends JObject with Iterable<bool> {
   @internal
   @override
-  final JBooleanArrayType $type;
+  final JType<JBooleanArray> $type;
 
   /// The type which includes information such as the signature of this class.
-  static const type = JBooleanArrayType();
+  static const JType<JBooleanArray> type = $JBooleanArray$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JBooleanArrayNullableType();
+  static const JType<JBooleanArray?> nullableType =
+      $JBooleanArray$NullableType$();
 
   /// Construct a new [JBooleanArray] with [reference] as its underlying
   /// reference.
@@ -399,72 +376,62 @@ class JBooleanArray extends JObject with Iterable<bool> {
   Iterator<bool> get iterator => _JArrayIterator(this);
 }
 
-final class JByteArrayNullableType extends JObjType<JByteArray?> {
-  @internal
-  const JByteArrayNullableType();
+@internal
+final class $JByteArray$NullableType$ extends JType<JByteArray?> {
+  const $JByteArray$NullableType$();
 
-  @internal
   @override
   String get signature => '[B';
 
-  @internal
   @override
   JByteArray? fromReference(JReference reference) =>
       reference.isNull ? null : JByteArray.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectNullableType();
+  JType get superType => const $JObject$NullableType$();
 
-  @internal
   @override
-  JObjType<JByteArray?> get nullableType => this;
+  JType<JByteArray?> get nullableType => this;
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JByteArrayNullableType).hashCode;
+  int get hashCode => ($JByteArray$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JByteArrayNullableType &&
-        other is JByteArrayNullableType;
+    return other.runtimeType == $JByteArray$NullableType$ &&
+        other is $JByteArray$NullableType$;
   }
 }
 
-final class JByteArrayType extends JObjType<JByteArray> {
-  @internal
-  const JByteArrayType();
+@internal
+final class $JByteArray$Type$ extends JType<JByteArray> {
+  const $JByteArray$Type$();
 
-  @internal
   @override
   String get signature => '[B';
 
-  @internal
   @override
   JByteArray fromReference(JReference reference) =>
       JByteArray.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JByteArray?> get nullableType => const JByteArrayNullableType();
+  JType<JByteArray?> get nullableType => const $JByteArray$NullableType$();
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JByteArrayType).hashCode;
+  int get hashCode => ($JByteArray$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JByteArrayType && other is JByteArrayType;
+    return other.runtimeType == $JByteArray$Type$ && other is $JByteArray$Type$;
   }
 }
 
@@ -478,13 +445,13 @@ final class JByteArrayType extends JObjType<JByteArray> {
 class JByteArray extends JObject with Iterable<int> {
   @internal
   @override
-  final JByteArrayType $type;
+  final JType<JByteArray> $type;
 
   /// The type which includes information such as the signature of this class.
-  static const type = JByteArrayType();
+  static const JType<JByteArray> type = $JByteArray$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JByteArrayNullableType();
+  static const JType<JByteArray?> nullableType = $JByteArray$NullableType$();
 
   /// Construct a new [JByteArray] with [reference] as its underlying
   /// reference.
@@ -554,72 +521,62 @@ class JByteArray extends JObject with Iterable<int> {
   Iterator<int> get iterator => _JArrayIterator(this);
 }
 
-final class JCharArrayNullableType extends JObjType<JCharArray?> {
-  @internal
-  const JCharArrayNullableType();
+@internal
+final class $JCharArray$NullableType$ extends JType<JCharArray?> {
+  const $JCharArray$NullableType$();
 
-  @internal
   @override
   String get signature => '[C';
 
-  @internal
   @override
   JCharArray? fromReference(JReference reference) =>
       reference.isNull ? null : JCharArray.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectNullableType();
+  JType get superType => const $JObject$NullableType$();
 
-  @internal
   @override
-  JObjType<JCharArray?> get nullableType => this;
+  JType<JCharArray?> get nullableType => this;
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JCharArrayNullableType).hashCode;
+  int get hashCode => ($JCharArray$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JCharArrayNullableType &&
-        other is JCharArrayNullableType;
+    return other.runtimeType == $JCharArray$NullableType$ &&
+        other is $JCharArray$NullableType$;
   }
 }
 
-final class JCharArrayType extends JObjType<JCharArray> {
-  @internal
-  const JCharArrayType();
+@internal
+final class $JCharArray$Type$ extends JType<JCharArray> {
+  const $JCharArray$Type$();
 
-  @internal
   @override
   String get signature => '[C';
 
-  @internal
   @override
   JCharArray fromReference(JReference reference) =>
       JCharArray.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JCharArray?> get nullableType => const JCharArrayNullableType();
+  JType<JCharArray?> get nullableType => const $JCharArray$NullableType$();
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JCharArrayType).hashCode;
+  int get hashCode => ($JCharArray$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JCharArrayType && other is JCharArrayType;
+    return other.runtimeType == $JCharArray$Type$ && other is $JCharArray$Type$;
   }
 }
 
@@ -630,13 +587,13 @@ final class JCharArrayType extends JObjType<JCharArray> {
 class JCharArray extends JObject with Iterable<int> {
   @internal
   @override
-  final JCharArrayType $type;
+  final JType<JCharArray> $type;
 
   /// The type which includes information such as the signature of this class.
-  static const type = JCharArrayType();
+  static const JType<JCharArray> type = $JCharArray$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JCharArrayNullableType();
+  static const JType<JCharArray?> nullableType = $JCharArray$NullableType$();
 
   /// Construct a new [JCharArray] with [reference] as its underlying
   /// reference.
@@ -696,85 +653,76 @@ class JCharArray extends JObject with Iterable<int> {
   Iterator<int> get iterator => _JArrayIterator(this);
 }
 
-final class JShortArrayNullableType extends JObjType<JShortArray?> {
-  @internal
-  const JShortArrayNullableType();
+@internal
+final class $JShortArray$NullableType$ extends JType<JShortArray?> {
+  const $JShortArray$NullableType$();
 
-  @internal
   @override
   String get signature => '[S';
 
-  @internal
   @override
   JShortArray? fromReference(JReference reference) =>
       reference.isNull ? null : JShortArray.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectNullableType();
+  JType get superType => const $JObject$NullableType$();
 
-  @internal
   @override
-  JObjType<JShortArray?> get nullableType => this;
+  JType<JShortArray?> get nullableType => this;
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JShortArrayNullableType).hashCode;
+  int get hashCode => ($JShortArray$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JShortArrayNullableType &&
-        other is JShortArrayNullableType;
+    return other.runtimeType == $JShortArray$NullableType$ &&
+        other is $JShortArray$NullableType$;
   }
 }
 
-final class JShortArrayType extends JObjType<JShortArray> {
-  @internal
-  const JShortArrayType();
+@internal
+final class $JShortArray$Type$ extends JType<JShortArray> {
+  const $JShortArray$Type$();
 
-  @internal
   @override
   String get signature => '[S';
 
-  @internal
   @override
   JShortArray fromReference(JReference reference) =>
       JShortArray.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JShortArray?> get nullableType => const JShortArrayNullableType();
+  JType<JShortArray?> get nullableType => const $JShortArray$NullableType$();
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JShortArrayType).hashCode;
+  int get hashCode => ($JShortArray$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JShortArrayType && other is JShortArrayType;
+    return other.runtimeType == $JShortArray$Type$ &&
+        other is $JShortArray$Type$;
   }
 }
 
 class JShortArray extends JObject with Iterable<int> {
   @internal
   @override
-  final JShortArrayType $type;
+  final JType<JShortArray> $type;
 
   /// The type which includes information such as the signature of this class.
-  static const type = JShortArrayType();
+  static const JType<JShortArray> type = $JShortArray$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JShortArrayNullableType();
+  static const JType<JShortArray?> nullableType = $JShortArray$NullableType$();
 
   /// Construct a new [JShortArray] with [reference] as its underlying
   /// reference.
@@ -834,85 +782,75 @@ class JShortArray extends JObject with Iterable<int> {
   Iterator<int> get iterator => _JArrayIterator(this);
 }
 
-final class JIntArrayNullableType extends JObjType<JIntArray?> {
-  @internal
-  const JIntArrayNullableType();
+@internal
+final class $JIntArray$NullableType$ extends JType<JIntArray?> {
+  const $JIntArray$NullableType$();
 
-  @internal
   @override
   String get signature => '[I';
 
-  @internal
   @override
   JIntArray? fromReference(JReference reference) =>
       reference.isNull ? null : JIntArray.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectNullableType();
+  JType get superType => const $JObject$NullableType$();
 
-  @internal
   @override
-  JObjType<JIntArray?> get nullableType => this;
+  JType<JIntArray?> get nullableType => this;
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JIntArrayNullableType).hashCode;
+  int get hashCode => ($JIntArray$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JIntArrayNullableType &&
-        other is JIntArrayNullableType;
+    return other.runtimeType == $JIntArray$NullableType$ &&
+        other is $JIntArray$NullableType$;
   }
 }
 
-final class JIntArrayType extends JObjType<JIntArray> {
-  @internal
-  const JIntArrayType();
+@internal
+final class $JIntArray$Type$ extends JType<JIntArray> {
+  const $JIntArray$Type$();
 
-  @internal
   @override
   String get signature => '[I';
 
-  @internal
   @override
   JIntArray fromReference(JReference reference) =>
       JIntArray.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JIntArray?> get nullableType => const JIntArrayNullableType();
+  JType<JIntArray?> get nullableType => const $JIntArray$NullableType$();
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JIntArrayType).hashCode;
+  int get hashCode => ($JIntArray$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JIntArrayType && other is JIntArrayType;
+    return other.runtimeType == $JIntArray$Type$ && other is $JIntArray$Type$;
   }
 }
 
 class JIntArray extends JObject with Iterable<int> {
   @internal
   @override
-  final JIntArrayType $type;
+  final JType<JIntArray> $type;
 
   /// The type which includes information such as the signature of this class.
-  static const type = JIntArrayType();
+  static const JType<JIntArray> type = $JIntArray$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JIntArrayNullableType();
+  static const JType<JIntArray?> nullableType = $JIntArray$NullableType$();
 
   /// Construct a new [JIntArray] with [reference] as its underlying
   /// reference.
@@ -972,85 +910,75 @@ class JIntArray extends JObject with Iterable<int> {
   Iterator<int> get iterator => _JArrayIterator(this);
 }
 
-final class JLongArrayNullableType extends JObjType<JLongArray?> {
-  @internal
-  const JLongArrayNullableType();
+@internal
+final class $JLongArray$NullableType$ extends JType<JLongArray?> {
+  const $JLongArray$NullableType$();
 
-  @internal
   @override
   String get signature => '[J';
 
-  @internal
   @override
   JLongArray? fromReference(JReference reference) =>
       reference.isNull ? null : JLongArray.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectNullableType();
+  JType get superType => const $JObject$NullableType$();
 
-  @internal
   @override
-  JObjType<JLongArray?> get nullableType => this;
+  JType<JLongArray?> get nullableType => this;
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JLongArrayNullableType).hashCode;
+  int get hashCode => ($JLongArray$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JLongArrayNullableType &&
-        other is JLongArrayNullableType;
+    return other.runtimeType == $JLongArray$NullableType$ &&
+        other is $JLongArray$NullableType$;
   }
 }
 
-final class JLongArrayType extends JObjType<JLongArray> {
-  @internal
-  const JLongArrayType();
+@internal
+final class $JLongArray$Type$ extends JType<JLongArray> {
+  const $JLongArray$Type$();
 
-  @internal
   @override
   String get signature => '[J';
 
-  @internal
   @override
   JLongArray fromReference(JReference reference) =>
       JLongArray.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JLongArray?> get nullableType => const JLongArrayNullableType();
+  JType<JLongArray?> get nullableType => const $JLongArray$NullableType$();
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JLongArrayType).hashCode;
+  int get hashCode => ($JLongArray$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JLongArrayType && other is JLongArrayType;
+    return other.runtimeType == $JLongArray$Type$ && other is $JLongArray$Type$;
   }
 }
 
 class JLongArray extends JObject with Iterable<int> {
   @internal
   @override
-  final JLongArrayType $type;
+  final JType<JLongArray> $type;
 
   /// The type which includes information such as the signature of this class.
-  static const type = JLongArrayType();
+  static const JType<JLongArray> type = $JLongArray$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JLongArrayNullableType();
+  static const JType<JLongArray?> nullableType = $JLongArray$NullableType$();
 
   /// Construct a new [JLongArray] with [reference] as its underlying
   /// reference.
@@ -1110,85 +1038,76 @@ class JLongArray extends JObject with Iterable<int> {
   Iterator<int> get iterator => _JArrayIterator(this);
 }
 
-final class JFloatArrayNullableType extends JObjType<JFloatArray?> {
-  @internal
-  const JFloatArrayNullableType();
+@internal
+final class $JFloatArray$NullableType$ extends JType<JFloatArray?> {
+  const $JFloatArray$NullableType$();
 
-  @internal
   @override
   String get signature => '[F';
 
-  @internal
   @override
   JFloatArray? fromReference(JReference reference) =>
       reference.isNull ? null : JFloatArray.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectNullableType();
+  JType get superType => const $JObject$NullableType$();
 
-  @internal
   @override
-  JObjType<JFloatArray?> get nullableType => this;
+  JType<JFloatArray?> get nullableType => this;
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JFloatArrayNullableType).hashCode;
+  int get hashCode => ($JFloatArray$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JFloatArrayNullableType &&
-        other is JFloatArrayNullableType;
+    return other.runtimeType == $JFloatArray$NullableType$ &&
+        other is $JFloatArray$NullableType$;
   }
 }
 
-final class JFloatArrayType extends JObjType<JFloatArray> {
-  @internal
-  const JFloatArrayType();
+@internal
+final class $JFloatArray$Type$ extends JType<JFloatArray> {
+  const $JFloatArray$Type$();
 
-  @internal
   @override
   String get signature => '[F';
 
-  @internal
   @override
   JFloatArray fromReference(JReference reference) =>
       JFloatArray.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JFloatArray?> get nullableType => const JFloatArrayNullableType();
+  JType<JFloatArray?> get nullableType => const $JFloatArray$NullableType$();
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JFloatArrayType).hashCode;
+  int get hashCode => ($JFloatArray$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JFloatArrayType && other is JFloatArrayType;
+    return other.runtimeType == $JFloatArray$Type$ &&
+        other is $JFloatArray$Type$;
   }
 }
 
 class JFloatArray extends JObject with Iterable<double> {
   @internal
   @override
-  final JFloatArrayType $type;
+  final JType<JFloatArray> $type;
 
   /// The type which includes information such as the signature of this class.
-  static const type = JFloatArrayType();
+  static const JType<JFloatArray> type = $JFloatArray$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JFloatArrayNullableType();
+  static const JType<JFloatArray?> nullableType = $JFloatArray$NullableType$();
 
   /// Construct a new [JFloatArray] with [reference] as its underlying
   /// reference.
@@ -1248,85 +1167,77 @@ class JFloatArray extends JObject with Iterable<double> {
   Iterator<double> get iterator => _JArrayIterator(this);
 }
 
-final class JDoubleArrayNullableType extends JObjType<JDoubleArray?> {
-  @internal
-  const JDoubleArrayNullableType();
+@internal
+final class $JDoubleArray$NullableType$ extends JType<JDoubleArray?> {
+  const $JDoubleArray$NullableType$();
 
-  @internal
   @override
   String get signature => '[D';
 
-  @internal
   @override
   JDoubleArray? fromReference(JReference reference) =>
       reference.isNull ? null : JDoubleArray.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectNullableType();
+  JType get superType => const $JObject$NullableType$();
 
-  @internal
   @override
-  JObjType<JDoubleArray?> get nullableType => this;
+  JType<JDoubleArray?> get nullableType => this;
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JDoubleArrayNullableType).hashCode;
+  int get hashCode => ($JDoubleArray$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JDoubleArrayNullableType &&
-        other is JDoubleArrayNullableType;
+    return other.runtimeType == $JDoubleArray$NullableType$ &&
+        other is $JDoubleArray$NullableType$;
   }
 }
 
-final class JDoubleArrayType extends JObjType<JDoubleArray> {
-  @internal
-  const JDoubleArrayType();
+@internal
+final class $JDoubleArray$Type$ extends JType<JDoubleArray> {
+  const $JDoubleArray$Type$();
 
-  @internal
   @override
   String get signature => '[D';
 
-  @internal
   @override
   JDoubleArray fromReference(JReference reference) =>
       JDoubleArray.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JDoubleArray?> get nullableType => const JDoubleArrayNullableType();
+  JType<JDoubleArray?> get nullableType => const $JDoubleArray$NullableType$();
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JDoubleArrayType).hashCode;
+  int get hashCode => ($JDoubleArray$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JDoubleArrayType && other is JDoubleArrayType;
+    return other.runtimeType == $JDoubleArray$Type$ &&
+        other is $JDoubleArray$Type$;
   }
 }
 
 class JDoubleArray extends JObject with Iterable<double> {
   @internal
   @override
-  final JDoubleArrayType $type;
+  final JType<JDoubleArray> $type;
 
   /// The type which includes information such as the signature of this class.
-  static const type = JDoubleArrayType();
+  static const JType<JDoubleArray> type = $JDoubleArray$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JDoubleArrayNullableType();
+  static const JType<JDoubleArray?> nullableType =
+      $JDoubleArray$NullableType$();
 
   /// Construct a new [JDoubleArray] with [reference] as its underlying
   /// reference.

--- a/pkgs/jni/lib/src/jimplementer.dart
+++ b/pkgs/jni/lib/src/jimplementer.dart
@@ -5,12 +5,17 @@
 import 'dart:ffi';
 import 'dart:isolate';
 
+import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart' show internal;
 
-import '../jni.dart';
 import 'accessors.dart';
 import 'jni.dart';
+import 'jobject.dart';
+import 'jreference.dart';
+import 'lang/jstring.dart';
 import 'third_party/generated_bindings.dart';
+import 'types.dart';
+import 'util/jlist.dart';
 
 /// A builder that builds proxy objects that implement one or more interfaces.
 ///

--- a/pkgs/jni/lib/src/jimplementer.dart
+++ b/pkgs/jni/lib/src/jimplementer.dart
@@ -10,7 +10,7 @@ import 'package:meta/meta.dart' show internal;
 import '../jni.dart';
 import 'accessors.dart';
 import 'jni.dart';
-import 'types.dart';
+import 'third_party/generated_bindings.dart';
 
 /// A builder that builds proxy objects that implement one or more interfaces.
 ///
@@ -109,7 +109,7 @@ class JImplementer extends JObject {
   /// added interfaces with the given implementations.
   ///
   /// Releases this implementer.
-  T implement<T extends JObject>(JObjType<T> type) {
+  T implement<T extends JObject>(JType<T> type) {
     return type.fromReference(implementReference());
   }
 

--- a/pkgs/jni/lib/src/jni.dart
+++ b/pkgs/jni/lib/src/jni.dart
@@ -209,6 +209,7 @@ abstract final class Jni {
   ///
   /// It provides an indirection over [JniEnv] so that it can be used from
   /// any thread, and always returns global object references.
+  @internal
   static final env = GlobalJniEnv(_fetchGlobalEnv());
 
   /// Returns current application context on Android.

--- a/pkgs/jni/lib/src/jni.dart
+++ b/pkgs/jni/lib/src/jni.dart
@@ -287,12 +287,19 @@ extension ProtectedJniExtensions on Jni {
     }
   }
 
+  static Pointer<T> Function<T extends NativeType>(String) get lookup =>
+      Jni._dylib.lookup;
+}
+
+/// Used only inside `package:jni`.
+@internal
+extension InternalJniExtension on Jni {
   static Dart_FinalizableHandle newJObjectFinalizableHandle(
     Object object,
     Pointer<Void> reference,
     JObjectRefType refType,
   ) {
-    ensureInitialized();
+    ProtectedJniExtensions.ensureInitialized();
     return Jni._bindings
         .newJObjectFinalizableHandle(object, reference, refType);
   }
@@ -301,18 +308,15 @@ extension ProtectedJniExtensions on Jni {
     Object object,
     Pointer<Bool> reference,
   ) {
-    ensureInitialized();
+    ProtectedJniExtensions.ensureInitialized();
     return Jni._bindings.newBooleanFinalizableHandle(object, reference);
   }
 
   static void deleteFinalizableHandle(
       Dart_FinalizableHandle finalizableHandle, Object object) {
-    ensureInitialized();
+    ProtectedJniExtensions.ensureInitialized();
     Jni._bindings.deleteFinalizableHandle(finalizableHandle, object);
   }
-
-  static Pointer<T> Function<T extends NativeType>(String) get lookup =>
-      Jni._dylib.lookup;
 }
 
 extension AdditionalEnvMethods on GlobalJniEnv {

--- a/pkgs/jni/lib/src/jobject.dart
+++ b/pkgs/jni/lib/src/jobject.dart
@@ -3,10 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:ffi';
 
+import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart' show internal;
 
-import '../jni.dart';
+import 'errors.dart';
+import 'jni.dart';
 import 'jreference.dart';
+import 'lang/jstring.dart';
 import 'types.dart';
 
 // Error thrown when casting between incompatible `JObject` subclasses.
@@ -21,78 +24,68 @@ final class CastError extends Error {
   }
 }
 
-final class JObjectNullableType extends JObjType<JObject?> {
-  @internal
-  const JObjectNullableType();
+@internal
+final class $JObject$NullableType$ extends JType<JObject?> {
+  const $JObject$NullableType$();
 
-  @internal
   @override
   String get signature => 'Ljava/lang/Object;';
 
-  @internal
   @override
   JObject? fromReference(JReference reference) =>
       reference.isNull ? null : JObject.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectNullableType();
+  JType get superType => const $JObject$NullableType$();
 
-  @internal
   @override
-  JObjType get nullableType => this;
+  JType get nullableType => this;
 
   // TODO(#70): Once interface implementation lands, other than [superType],
   // we should have a list of implemented interfaces.
 
-  @internal
   @override
   final int superCount = 0;
 
   @override
-  int get hashCode => (JObjectNullableType).hashCode;
+  int get hashCode => ($JObject$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JObjectNullableType &&
-        other is JObjectNullableType;
+    return other.runtimeType == $JObject$NullableType$ &&
+        other is $JObject$NullableType$;
   }
 }
 
-final class JObjectType extends JObjType<JObject> {
-  @internal
-  const JObjectType();
+@internal
+final class $JObject$Type$ extends JType<JObject> {
+  const $JObject$Type$();
 
-  @internal
   @override
   String get signature => 'Ljava/lang/Object;';
 
-  @internal
   @override
   JObject fromReference(JReference reference) =>
       JObject.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType get nullableType => const JObjectNullableType();
+  JType get nullableType => const $JObject$NullableType$();
 
   // TODO(#70): Once interface implementation lands, other than [superType],
   // we should have a list of implemented interfaces.
 
-  @internal
   @override
   final int superCount = 0;
 
   @override
-  int get hashCode => (JObjectType).hashCode;
+  int get hashCode => ($JObject$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JObjectType && other is JObjectType;
+    return other.runtimeType == $JObject$Type$ && other is $JObject$Type$;
   }
 }
 
@@ -104,12 +97,13 @@ class JObject {
   final JReference reference;
 
   @internal
-  final JObjType<JObject> $type = type;
+  final JType<JObject> $type = type;
 
   /// The type which includes information such as the signature of this class.
-  static const JObjType<JObject> type = JObjectType();
+  static const JType<JObject> type = $JObject$Type$();
 
-  static const JObjType<JObject?> nullableType = JObjectNullableType();
+  /// The type which includes information such as the signature of this class.
+  static const JType<JObject?> nullableType = $JObject$NullableType$();
 
   /// Constructs a [JObject] with the underlying [reference].
   JObject.fromReference(this.reference) {
@@ -153,7 +147,7 @@ class JObject {
   ///   ...
   /// }
   /// ```
-  bool isA<T extends JObject?>(JObjType<T> type) {
+  bool isA<T extends JObject?>(JType<T> type) {
     final targetJClass = type.jClass;
     final canBeCasted = isInstanceOf(targetJClass);
     targetJClass.release();
@@ -171,7 +165,7 @@ class JObject {
   ///
   /// Throws [CastError] if this object is not an instance of [type].
   T as<T extends JObject?>(
-    JObjType<T> type, {
+    JType<T> type, {
     bool releaseOriginal = false,
   }) {
     if (!isA(type)) {
@@ -209,7 +203,7 @@ class JObject {
       _class.instanceMethodId(r'toString', r'()Ljava/lang/String;');
   @override
   String toString() {
-    return _toStringId(this, const JStringType(), [])
+    return _toStringId(this, const $JString$Type$(), [])
         .toDartString(releaseOriginal: true);
   }
 

--- a/pkgs/jni/lib/src/jprimitives.dart
+++ b/pkgs/jni/lib/src/jprimitives.dart
@@ -14,12 +14,11 @@ abstract final class jbyte extends JPrimitive {
   static const type = jbyteType();
 }
 
-final class jbyteType extends JType<jbyte>
+final class jbyteType extends JTypeBase<jbyte>
     with JCallable<jbyte, int>, JAccessible<jbyte, int> {
   @internal
   const jbyteType();
 
-  @internal
   @override
   final signature = 'B';
 
@@ -60,12 +59,11 @@ abstract final class jboolean extends JPrimitive {
   static const type = jbooleanType();
 }
 
-final class jbooleanType extends JType<jboolean>
+final class jbooleanType extends JTypeBase<jboolean>
     with JCallable<jboolean, bool>, JAccessible<jboolean, bool> {
   @internal
   const jbooleanType();
 
-  @internal
   @override
   final signature = 'Z';
 
@@ -106,12 +104,11 @@ abstract final class jchar extends JPrimitive {
   static const type = jcharType();
 }
 
-final class jcharType extends JType<jchar>
+final class jcharType extends JTypeBase<jchar>
     with JCallable<jchar, int>, JAccessible<jchar, int> {
   @internal
   const jcharType();
 
-  @internal
   @override
   final signature = 'C';
 
@@ -152,12 +149,11 @@ abstract final class jshort extends JPrimitive {
   static const type = jshortType();
 }
 
-final class jshortType extends JType<jshort>
+final class jshortType extends JTypeBase<jshort>
     with JCallable<jshort, int>, JAccessible<jshort, int> {
   @internal
   const jshortType();
 
-  @internal
   @override
   final signature = 'S';
 
@@ -198,7 +194,7 @@ abstract final class jint extends JPrimitive {
   static const type = jintType();
 }
 
-final class jintType extends JType<jint>
+final class jintType extends JTypeBase<jint>
     with JCallable<jint, int>, JAccessible<jint, int> {
   @internal
   const jintType();
@@ -243,7 +239,7 @@ abstract final class jlong extends JPrimitive {
   static const type = jlongType();
 }
 
-final class jlongType extends JType<jlong>
+final class jlongType extends JTypeBase<jlong>
     with JCallable<jlong, int>, JAccessible<jlong, int> {
   @internal
   const jlongType();
@@ -288,12 +284,11 @@ abstract final class jfloat extends JPrimitive {
   static const type = jfloatType();
 }
 
-final class jfloatType extends JType<jfloat>
+final class jfloatType extends JTypeBase<jfloat>
     with JCallable<jfloat, double>, JAccessible<jfloat, double> {
   @internal
   const jfloatType();
 
-  @internal
   @override
   final signature = 'F';
 
@@ -334,12 +329,11 @@ abstract final class jdouble extends JPrimitive {
   static const type = jdoubleType();
 }
 
-final class jdoubleType extends JType<jdouble>
+final class jdoubleType extends JTypeBase<jdouble>
     with JCallable<jdouble, double>, JAccessible<jdouble, double> {
   @internal
   const jdoubleType();
 
-  @internal
   @override
   final signature = 'D';
 
@@ -380,11 +374,10 @@ abstract final class jvoid extends JPrimitive {
   static const type = jvoidType();
 }
 
-final class jvoidType extends JType<jvoid> with JCallable<jvoid, void> {
+final class jvoidType extends JTypeBase<jvoid> with JCallable<jvoid, void> {
   @internal
   const jvoidType();
 
-  @internal
   @override
   final signature = 'V';
 

--- a/pkgs/jni/lib/src/jreference.dart
+++ b/pkgs/jni/lib/src/jreference.dart
@@ -38,7 +38,7 @@ final class _JFinalizable implements Finalizable {
 abstract final class JReference implements Finalizable {
   final _JFinalizable _finalizable;
 
-  JReference(this._finalizable);
+  JReference._(this._finalizable);
 
   /// The underlying JNI reference.
   ///
@@ -85,7 +85,8 @@ final class JGlobalReference extends JReference {
   final Pointer<Bool> _isReleased;
 
   JGlobalReference._(
-      super._finalizable, this._jobjectFinalizableHandle, this._isReleased);
+      super.finalizable, this._jobjectFinalizableHandle, this._isReleased)
+      : super._();
 
   factory JGlobalReference(Pointer<Void> pointer) {
     final finalizable = _JFinalizable(pointer);
@@ -124,7 +125,7 @@ final JReference jNullReference = _JNullReference();
 
 @pragma('vm:deeply-immutable')
 final class _JNullReference extends JReference {
-  _JNullReference() : super(_JFinalizable(nullptr));
+  _JNullReference() : super._(_JFinalizable(nullptr));
 
   @override
   bool get isReleased => false;

--- a/pkgs/jni/lib/src/jreference.dart
+++ b/pkgs/jni/lib/src/jreference.dart
@@ -92,9 +92,9 @@ final class JGlobalReference extends JReference {
     final finalizable = _JFinalizable(pointer);
     final isReleased = calloc<Bool>();
     final jobjectFinalizableHandle =
-        ProtectedJniExtensions.newJObjectFinalizableHandle(
+        InternalJniExtension.newJObjectFinalizableHandle(
             finalizable, finalizable.pointer, JObjectRefType.JNIGlobalRefType);
-    ProtectedJniExtensions.newBooleanFinalizableHandle(finalizable, isReleased);
+    InternalJniExtension.newBooleanFinalizableHandle(finalizable, isReleased);
     return JGlobalReference._(
         finalizable, jobjectFinalizableHandle, isReleased);
   }
@@ -108,7 +108,7 @@ final class JGlobalReference extends JReference {
       throw DoubleReleaseError();
     }
     _isReleased.value = true;
-    ProtectedJniExtensions.deleteFinalizableHandle(
+    InternalJniExtension.deleteFinalizableHandle(
         _jobjectFinalizableHandle, _finalizable);
   }
 

--- a/pkgs/jni/lib/src/jvalues.dart
+++ b/pkgs/jni/lib/src/jvalues.dart
@@ -4,8 +4,8 @@
 
 import 'dart:ffi';
 
-import '../_internal.dart';
 import 'jobject.dart';
+import 'jreference.dart';
 import 'third_party/generated_bindings.dart';
 
 void _fillJValue(Pointer<JValue> pos, dynamic arg) {

--- a/pkgs/jni/lib/src/lang/jboolean.dart
+++ b/pkgs/jni/lib/src/lang/jboolean.dart
@@ -8,72 +8,62 @@ import '../jobject.dart';
 import '../jreference.dart';
 import '../types.dart';
 
-final class JBooleanNullableType extends JObjType<JBoolean?> {
-  @internal
-  const JBooleanNullableType();
+@internal
+final class $JBoolean$NullableType$ extends JType<JBoolean?> {
+  const $JBoolean$NullableType$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Boolean;';
 
-  @internal
   @override
   JBoolean? fromReference(JReference reference) =>
       reference.isNull ? null : JBoolean.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectNullableType();
+  JType get superType => const $JObject$NullableType$();
 
-  @internal
   @override
-  JObjType<JBoolean?> get nullableType => this;
+  JType<JBoolean?> get nullableType => this;
 
-  @internal
   @override
   final superCount = 2;
 
   @override
-  int get hashCode => (JBooleanNullableType).hashCode;
+  int get hashCode => ($JBoolean$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JBooleanNullableType &&
-        other is JBooleanNullableType;
+    return other.runtimeType == $JBoolean$NullableType$ &&
+        other is $JBoolean$NullableType$;
   }
 }
 
-final class JBooleanType extends JObjType<JBoolean> {
-  @internal
-  const JBooleanType();
+@internal
+final class $JBoolean$Type$ extends JType<JBoolean> {
+  const $JBoolean$Type$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Boolean;';
 
-  @internal
   @override
   JBoolean fromReference(JReference reference) =>
       JBoolean.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JBoolean?> get nullableType => const JBooleanNullableType();
+  JType<JBoolean?> get nullableType => const $JBoolean$NullableType$();
 
-  @internal
   @override
   final superCount = 2;
 
   @override
-  int get hashCode => (JBooleanType).hashCode;
+  int get hashCode => ($JBoolean$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JBooleanType && other is JBooleanType;
+    return other.runtimeType == $JBoolean$Type$ && other is $JBoolean$Type$;
   }
 }
 
@@ -81,17 +71,17 @@ class JBoolean extends JObject {
   @internal
   @override
   // ignore: overridden_fields
-  final JObjType<JBoolean> $type = type;
+  final JType<JBoolean> $type = type;
 
   JBoolean.fromReference(
     super.reference,
   ) : super.fromReference();
 
   /// The type which includes information such as the signature of this class.
-  static const type = JBooleanType();
+  static const JType<JBoolean> type = $JBoolean$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JBooleanNullableType();
+  static const JType<JBoolean?> nullableType = $JBoolean$NullableType$();
 
   static final _class = JClass.forName(r'java/lang/Boolean');
 

--- a/pkgs/jni/lib/src/lang/jbyte.dart
+++ b/pkgs/jni/lib/src/lang/jbyte.dart
@@ -9,70 +9,61 @@ import '../jvalues.dart';
 import '../types.dart';
 import 'jnumber.dart';
 
-final class JByteNullableType extends JObjType<JByte?> {
-  @internal
-  const JByteNullableType();
+@internal
+final class $JByte$NullableType$ extends JType<JByte?> {
+  const $JByte$NullableType$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Byte;';
 
-  @internal
   @override
   JByte? fromReference(JReference reference) =>
       reference.isNull ? null : JByte.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JNumberNullableType();
+  JType get superType => const $JNumber$NullableType$();
 
-  @internal
   @override
-  JObjType<JByte?> get nullableType => this;
+  JType<JByte?> get nullableType => this;
 
-  @internal
   @override
   final superCount = 2;
 
   @override
-  int get hashCode => (JByteNullableType).hashCode;
+  int get hashCode => ($JByte$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JByteNullableType && other is JByteNullableType;
+    return other.runtimeType == $JByte$NullableType$ &&
+        other is $JByte$NullableType$;
   }
 }
 
-final class JByteType extends JObjType<JByte> {
-  @internal
-  const JByteType();
+@internal
+final class $JByte$Type$ extends JType<JByte> {
+  const $JByte$Type$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Byte;';
 
-  @internal
   @override
   JByte fromReference(JReference reference) => JByte.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JNumberType();
+  JType get superType => const $JNumber$Type$();
 
-  @internal
   @override
-  JObjType<JByte?> get nullableType => const JByteNullableType();
+  JType<JByte?> get nullableType => const $JByte$NullableType$();
 
-  @internal
   @override
   final superCount = 2;
 
   @override
-  int get hashCode => (JByteType).hashCode;
+  int get hashCode => ($JByte$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JByteType && other is JByteType;
+    return other.runtimeType == $JByte$Type$ && other is $JByte$Type$;
   }
 }
 
@@ -80,17 +71,17 @@ class JByte extends JNumber {
   @internal
   @override
   // ignore: overridden_fields
-  final JObjType<JByte> $type = type;
+  final JType<JByte> $type = type;
 
   JByte.fromReference(
     super.reference,
   ) : super.fromReference();
 
   /// The type which includes information such as the signature of this class.
-  static const type = JByteType();
+  static const JType<JByte> type = $JByte$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JByteNullableType();
+  static const JType<JByte?> nullableType = $JByte$NullableType$();
 
   static final _class = JClass.forName(r'java/lang/Byte');
 

--- a/pkgs/jni/lib/src/lang/jcharacter.dart
+++ b/pkgs/jni/lib/src/lang/jcharacter.dart
@@ -9,72 +9,62 @@ import '../jreference.dart';
 import '../jvalues.dart';
 import '../types.dart';
 
-final class JCharacterNullableType extends JObjType<JCharacter?> {
-  @internal
-  const JCharacterNullableType();
+@internal
+final class $JCharacter$NullableType$ extends JType<JCharacter?> {
+  const $JCharacter$NullableType$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Character;';
 
-  @internal
   @override
   JCharacter? fromReference(JReference reference) =>
       reference.isNull ? null : JCharacter.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectNullableType();
+  JType get superType => const $JObject$NullableType$();
 
-  @internal
   @override
-  JObjType<JCharacter?> get nullableType => this;
+  JType<JCharacter?> get nullableType => this;
 
-  @internal
   @override
   final superCount = 1;
 
   @override
-  int get hashCode => (JCharacterNullableType).hashCode;
+  int get hashCode => ($JCharacter$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JCharacterNullableType &&
-        other is JCharacterNullableType;
+    return other.runtimeType == $JCharacter$NullableType$ &&
+        other is $JCharacter$NullableType$;
   }
 }
 
-final class JCharacterType extends JObjType<JCharacter> {
-  @internal
-  const JCharacterType();
+@internal
+final class $JCharacter$Type$ extends JType<JCharacter> {
+  const $JCharacter$Type$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Character;';
 
-  @internal
   @override
   JCharacter fromReference(JReference reference) =>
       JCharacter.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JCharacter?> get nullableType => const JCharacterNullableType();
+  JType<JCharacter?> get nullableType => const $JCharacter$NullableType$();
 
-  @internal
   @override
   final superCount = 1;
 
   @override
-  int get hashCode => (JCharacterType).hashCode;
+  int get hashCode => ($JCharacter$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JCharacterType && other is JCharacterType;
+    return other.runtimeType == $JCharacter$Type$ && other is $JCharacter$Type$;
   }
 }
 
@@ -82,17 +72,17 @@ class JCharacter extends JObject {
   @internal
   @override
   // ignore: overridden_fields
-  final JObjType<JCharacter> $type = type;
+  final JType<JCharacter> $type = type;
 
   JCharacter.fromReference(
     super.reference,
   ) : super.fromReference();
 
   /// The type which includes information such as the signature of this class.
-  static const type = JCharacterType();
+  static const JType<JCharacter> type = $JCharacter$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JCharacterNullableType();
+  static const JType<JCharacter?> nullableType = $JCharacter$NullableType$();
 
   static final _class = JClass.forName(r'java/lang/Character');
 

--- a/pkgs/jni/lib/src/lang/jdouble.dart
+++ b/pkgs/jni/lib/src/lang/jdouble.dart
@@ -8,72 +8,62 @@ import '../jreference.dart';
 import '../types.dart';
 import 'jnumber.dart';
 
-final class JDoubleNullableType extends JObjType<JDouble?> {
-  @internal
-  const JDoubleNullableType();
+@internal
+final class $JDouble$NullableType$ extends JType<JDouble?> {
+  const $JDouble$NullableType$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Double;';
 
-  @internal
   @override
   JDouble? fromReference(JReference reference) =>
       reference.isNull ? null : JDouble.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JNumberNullableType();
+  JType get superType => const $JNumber$NullableType$();
 
-  @internal
   @override
-  JObjType<JDouble?> get nullableType => this;
+  JType<JDouble?> get nullableType => this;
 
-  @internal
   @override
   final superCount = 2;
 
   @override
-  int get hashCode => (JDoubleNullableType).hashCode;
+  int get hashCode => ($JDouble$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JDoubleNullableType &&
-        other is JDoubleNullableType;
+    return other.runtimeType == $JDouble$NullableType$ &&
+        other is $JDouble$NullableType$;
   }
 }
 
-final class JDoubleType extends JObjType<JDouble> {
-  @internal
-  const JDoubleType();
+@internal
+final class $JDouble$Type$ extends JType<JDouble> {
+  const $JDouble$Type$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Double;';
 
-  @internal
   @override
   JDouble fromReference(JReference reference) =>
       JDouble.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JNumberType();
+  JType get superType => const $JNumber$Type$();
 
-  @internal
   @override
-  JObjType<JDouble?> get nullableType => const JDoubleNullableType();
+  JType<JDouble?> get nullableType => const $JDouble$NullableType$();
 
-  @internal
   @override
   final superCount = 2;
 
   @override
-  int get hashCode => (JDoubleType).hashCode;
+  int get hashCode => ($JDouble$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JDoubleType && other is JDoubleType;
+    return other.runtimeType == $JDouble$Type$ && other is $JDouble$Type$;
   }
 }
 
@@ -81,17 +71,17 @@ class JDouble extends JNumber {
   @internal
   @override
   // ignore: overridden_fields
-  final JObjType<JDouble> $type = type;
+  final JType<JDouble> $type = type;
 
   JDouble.fromReference(
     super.reference,
   ) : super.fromReference();
 
   /// The type which includes information such as the signature of this class.
-  static const type = JDoubleType();
+  static const JType<JDouble> type = $JDouble$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JDoubleNullableType();
+  static const JType<JDouble?> nullableType = $JDouble$NullableType$();
 
   static final _class = JClass.forName(r'java/lang/Double');
 

--- a/pkgs/jni/lib/src/lang/jfloat.dart
+++ b/pkgs/jni/lib/src/lang/jfloat.dart
@@ -9,71 +9,61 @@ import '../jvalues.dart';
 import '../types.dart';
 import 'jnumber.dart';
 
-final class JFloatNullableType extends JObjType<JFloat?> {
-  @internal
-  const JFloatNullableType();
+@internal
+final class $JFloat$NullableType$ extends JType<JFloat?> {
+  const $JFloat$NullableType$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Float;';
 
-  @internal
   @override
   JFloat? fromReference(JReference reference) =>
       reference.isNull ? null : JFloat.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JNumberNullableType();
+  JType get superType => const $JNumber$NullableType$();
 
-  @internal
   @override
-  JObjType<JFloat?> get nullableType => this;
+  JType<JFloat?> get nullableType => this;
 
-  @internal
   @override
   final superCount = 2;
 
   @override
-  int get hashCode => (JFloatNullableType).hashCode;
+  int get hashCode => ($JFloat$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JFloatNullableType &&
-        other is JFloatNullableType;
+    return other.runtimeType == $JFloat$NullableType$ &&
+        other is $JFloat$NullableType$;
   }
 }
 
-final class JFloatType extends JObjType<JFloat> {
-  @internal
-  const JFloatType();
+@internal
+final class $JFloat$Type$ extends JType<JFloat> {
+  const $JFloat$Type$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Float;';
 
-  @internal
   @override
   JFloat fromReference(JReference reference) => JFloat.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JNumberType();
+  JType get superType => const $JNumber$Type$();
 
-  @internal
   @override
-  JObjType<JFloat?> get nullableType => const JFloatNullableType();
+  JType<JFloat?> get nullableType => const $JFloat$NullableType$();
 
-  @internal
   @override
   final superCount = 2;
 
   @override
-  int get hashCode => (JFloatType).hashCode;
+  int get hashCode => ($JFloat$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JFloatType && other is JFloatType;
+    return other.runtimeType == $JFloat$Type$ && other is $JFloat$Type$;
   }
 }
 
@@ -81,17 +71,17 @@ class JFloat extends JNumber {
   @internal
   @override
   // ignore: overridden_fields
-  final JObjType<JFloat> $type = type;
+  final JType<JFloat> $type = type;
 
   JFloat.fromReference(
     super.reference,
   ) : super.fromReference();
 
   /// The type which includes information such as the signature of this class.
-  static const type = JFloatType();
+  static const JType<JFloat> type = $JFloat$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JFloatNullableType();
+  static const JType<JFloat?> nullableType = $JFloat$NullableType$();
 
   static final _class = JClass.forName(r'java/lang/Float');
 

--- a/pkgs/jni/lib/src/lang/jinteger.dart
+++ b/pkgs/jni/lib/src/lang/jinteger.dart
@@ -9,90 +9,79 @@ import '../jvalues.dart';
 import '../types.dart';
 import 'jnumber.dart';
 
-final class JIntegerNullableType extends JObjType<JInteger?> {
-  @internal
-  const JIntegerNullableType();
+@internal
+final class $JInteger$NullableType$ extends JType<JInteger?> {
+  const $JInteger$NullableType$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Integer;';
 
-  @internal
   @override
   JInteger? fromReference(JReference reference) =>
       reference.isNull ? null : JInteger.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JNumberNullableType();
+  JType get superType => const $JNumber$NullableType$();
 
-  @internal
   @override
-  JObjType<JInteger?> get nullableType => this;
+  JType<JInteger?> get nullableType => this;
 
-  @internal
   @override
   final superCount = 2;
 
   @override
-  int get hashCode => (JIntegerNullableType).hashCode;
+  int get hashCode => ($JInteger$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JIntegerNullableType &&
-        other is JIntegerNullableType;
+    return other.runtimeType == $JInteger$NullableType$ &&
+        other is $JInteger$NullableType$;
   }
 }
 
-final class JIntegerType extends JObjType<JInteger> {
-  @internal
-  const JIntegerType();
+@internal
+final class $JInteger$Type$ extends JType<JInteger> {
+  const $JInteger$Type$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Integer;';
 
-  @internal
   @override
   JInteger fromReference(JReference reference) =>
       JInteger.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JNumberType();
+  JType get superType => const $JNumber$Type$();
 
-  @internal
   @override
-  JObjType<JInteger?> get nullableType => const JIntegerNullableType();
+  JType<JInteger?> get nullableType => const $JInteger$NullableType$();
 
-  @internal
   @override
   final superCount = 2;
 
   @override
-  int get hashCode => (JIntegerType).hashCode;
+  int get hashCode => ($JInteger$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JIntegerType && other is JIntegerType;
+    return other.runtimeType == $JInteger$Type$ && other is $JInteger$Type$;
   }
 }
 
 class JInteger extends JNumber {
-  @internal
   @override
   // ignore: overridden_fields
-  final JObjType<JInteger> $type = type;
+  final JType<JInteger> $type = type;
 
   JInteger.fromReference(
     super.reference,
   ) : super.fromReference();
 
   /// The type which includes information such as the signature of this class.
-  static const type = JIntegerType();
+  static const JType<JInteger> type = $JInteger$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JIntegerNullableType();
+  static const JType<JInteger?> nullableType = $JInteger$NullableType$();
 
   static final _class = JClass.forName(r'java/lang/Integer');
 

--- a/pkgs/jni/lib/src/lang/jlong.dart
+++ b/pkgs/jni/lib/src/lang/jlong.dart
@@ -8,70 +8,61 @@ import '../jreference.dart';
 import '../types.dart';
 import 'jnumber.dart';
 
-final class JLongNullableType extends JObjType<JLong?> {
-  @internal
-  const JLongNullableType();
+@internal
+final class $JLong$NullableType$ extends JType<JLong?> {
+  const $JLong$NullableType$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Long;';
 
-  @internal
   @override
   JLong? fromReference(JReference reference) =>
       reference.isNull ? null : JLong.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JNumberNullableType();
+  JType get superType => const $JNumber$NullableType$();
 
-  @internal
   @override
-  JObjType<JLong?> get nullableType => this;
+  JType<JLong?> get nullableType => this;
 
-  @internal
   @override
   final superCount = 2;
 
   @override
-  int get hashCode => (JLongNullableType).hashCode;
+  int get hashCode => ($JLong$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JLongNullableType && other is JLongNullableType;
+    return other.runtimeType == $JLong$NullableType$ &&
+        other is $JLong$NullableType$;
   }
 }
 
-final class JLongType extends JObjType<JLong> {
-  @internal
-  const JLongType();
+@internal
+final class $JLong$Type$ extends JType<JLong> {
+  const $JLong$Type$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Long;';
 
-  @internal
   @override
   JLong fromReference(JReference reference) => JLong.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JNumberType();
+  JType get superType => const $JNumber$Type$();
 
-  @internal
   @override
-  JObjType<JLong?> get nullableType => const JLongNullableType();
+  JType<JLong?> get nullableType => const $JLong$NullableType$();
 
-  @internal
   @override
   final superCount = 2;
 
   @override
-  int get hashCode => (JLongType).hashCode;
+  int get hashCode => ($JLong$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JLongType && other is JLongType;
+    return other.runtimeType == $JLong$Type$ && other is $JLong$Type$;
   }
 }
 
@@ -79,17 +70,17 @@ class JLong extends JNumber {
   @internal
   @override
   // ignore: overridden_fields
-  final JObjType<JLong> $type = type;
+  final JType<JLong> $type = type;
 
   JLong.fromReference(
     super.reference,
   ) : super.fromReference();
 
   /// The type which includes information such as the signature of this class.
-  static const type = JLongType();
+  static const JType<JLong> type = $JLong$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JLongNullableType();
+  static const JType<JLong?> nullableType = $JLong$NullableType$();
 
   static final _class = JClass.forName(r'java/lang/Long');
 

--- a/pkgs/jni/lib/src/lang/jnumber.dart
+++ b/pkgs/jni/lib/src/lang/jnumber.dart
@@ -16,72 +16,62 @@ import 'jinteger.dart';
 import 'jlong.dart';
 import 'jshort.dart';
 
-final class JNumberNullableType extends JObjType<JNumber?> {
-  @internal
-  const JNumberNullableType();
+@internal
+final class $JNumber$NullableType$ extends JType<JNumber?> {
+  const $JNumber$NullableType$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Number;';
 
-  @internal
   @override
   JNumber? fromReference(JReference reference) =>
       reference.isNull ? null : JNumber.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectNullableType();
+  JType get superType => const $JObject$NullableType$();
 
-  @internal
   @override
-  JObjType<JNumber?> get nullableType => this;
+  JType<JNumber?> get nullableType => this;
 
-  @internal
   @override
   final superCount = 1;
 
   @override
-  int get hashCode => (JNumberNullableType).hashCode;
+  int get hashCode => ($JNumber$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JNumberNullableType &&
-        other is JNumberNullableType;
+    return other.runtimeType == $JNumber$NullableType$ &&
+        other is $JNumber$NullableType$;
   }
 }
 
-final class JNumberType extends JObjType<JNumber> {
-  @internal
-  const JNumberType();
+@internal
+final class $JNumber$Type$ extends JType<JNumber> {
+  const $JNumber$Type$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Number;';
 
-  @internal
   @override
   JNumber fromReference(JReference reference) =>
       JNumber.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JNumber?> get nullableType => const JNumberNullableType();
+  JType<JNumber?> get nullableType => const $JNumber$NullableType$();
 
-  @internal
   @override
   final superCount = 1;
 
   @override
-  int get hashCode => (JNumberType).hashCode;
+  int get hashCode => ($JNumber$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JNumberType && other is JNumberType;
+    return other.runtimeType == $JNumber$Type$ && other is $JNumber$Type$;
   }
 }
 
@@ -89,7 +79,7 @@ class JNumber extends JObject {
   @internal
   @override
   // ignore: overridden_fields
-  final JObjType<JNumber> $type = type;
+  final JType<JNumber> $type = type;
 
   JNumber.fromReference(
     super.reference,
@@ -98,10 +88,11 @@ class JNumber extends JObject {
   static final _class = JClass.forName(r'java/lang/Number');
 
   /// The type which includes information such as the signature of this class.
-  static const type = JNumberType();
+  static const JType<JNumber> type = $JNumber$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JNumberNullableType();
+  static const JType<JNumber?> nullableType = $JNumber$NullableType$();
+
   static final _ctorId = _class.constructorId(r'()V');
 
   JNumber() : super.fromReference(_ctorId(_class, referenceType, []));

--- a/pkgs/jni/lib/src/lang/jshort.dart
+++ b/pkgs/jni/lib/src/lang/jshort.dart
@@ -9,71 +9,61 @@ import '../jvalues.dart';
 import '../types.dart';
 import 'jnumber.dart';
 
-final class JShortNullableType extends JObjType<JShort?> {
-  @internal
-  const JShortNullableType();
+@internal
+final class $JShort$NullableType$ extends JType<JShort?> {
+  const $JShort$NullableType$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Short;';
 
-  @internal
   @override
   JShort? fromReference(JReference reference) =>
       reference.isNull ? null : JShort.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JNumberNullableType();
+  JType get superType => const $JNumber$NullableType$();
 
-  @internal
   @override
-  JObjType<JShort?> get nullableType => this;
+  JType<JShort?> get nullableType => this;
 
-  @internal
   @override
   final superCount = 2;
 
   @override
-  int get hashCode => (JShortNullableType).hashCode;
+  int get hashCode => ($JShort$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JShortNullableType &&
-        other is JShortNullableType;
+    return other.runtimeType == $JShort$NullableType$ &&
+        other is $JShort$NullableType$;
   }
 }
 
-final class JShortType extends JObjType<JShort> {
-  @internal
-  const JShortType();
+@internal
+final class $JShort$Type$ extends JType<JShort> {
+  const $JShort$Type$();
 
-  @internal
   @override
   String get signature => r'Ljava/lang/Short;';
 
-  @internal
   @override
   JShort fromReference(JReference reference) => JShort.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JNumberType();
+  JType get superType => const $JNumber$Type$();
 
-  @internal
   @override
-  JObjType<JShort?> get nullableType => const JShortNullableType();
+  JType<JShort?> get nullableType => const $JShort$NullableType$();
 
-  @internal
   @override
   final superCount = 2;
 
   @override
-  int get hashCode => (JShortType).hashCode;
+  int get hashCode => ($JShort$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JShortType && other is JShortType;
+    return other.runtimeType == $JShort$Type$ && other is $JShort$Type$;
   }
 }
 
@@ -81,17 +71,17 @@ class JShort extends JNumber {
   @internal
   @override
   // ignore: overridden_fields
-  final JObjType<JShort> $type = type;
+  final JType<JShort> $type = type;
 
   JShort.fromReference(
     super.reference,
   ) : super.fromReference();
 
   /// The type which includes information such as the signature of this class.
-  static const type = JShortType();
+  static const JType<JShort> type = $JShort$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JShortNullableType();
+  static const JType<JShort?> nullableType = $JShort$NullableType$();
 
   static final _class = JClass.forName(r'java/lang/Short');
 

--- a/pkgs/jni/lib/src/lang/jstring.dart
+++ b/pkgs/jni/lib/src/lang/jstring.dart
@@ -9,72 +9,62 @@ import '../jobject.dart';
 import '../jreference.dart';
 import '../types.dart';
 
-final class JStringNullableType extends JObjType<JString?> {
-  @internal
-  const JStringNullableType();
+@internal
+final class $JString$NullableType$ extends JType<JString?> {
+  const $JString$NullableType$();
 
-  @internal
   @override
   String get signature => 'Ljava/lang/String;';
 
-  @internal
   @override
   JString? fromReference(JReference reference) =>
       reference.isNull ? null : JString.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectNullableType();
+  JType get superType => const $JObject$NullableType$();
 
-  @internal
   @override
-  JObjType<JString?> get nullableType => this;
+  JType<JString?> get nullableType => this;
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JStringNullableType).hashCode;
+  int get hashCode => ($JString$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JStringNullableType &&
-        other is JStringNullableType;
+    return other.runtimeType == $JString$NullableType$ &&
+        other is $JString$NullableType$;
   }
 }
 
-final class JStringType extends JObjType<JString> {
-  @internal
-  const JStringType();
+@internal
+final class $JString$Type$ extends JType<JString> {
+  const $JString$Type$();
 
-  @internal
   @override
   String get signature => 'Ljava/lang/String;';
 
-  @internal
   @override
   JString fromReference(JReference reference) =>
       JString.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JString?> get nullableType => const JStringNullableType();
+  JType<JString?> get nullableType => const $JString$NullableType$();
 
-  @internal
   @override
   final int superCount = 1;
 
   @override
-  int get hashCode => (JStringType).hashCode;
+  int get hashCode => ($JString$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JStringType && other is JStringType;
+    return other.runtimeType == $JString$Type$ && other is $JString$Type$;
   }
 }
 
@@ -82,13 +72,13 @@ class JString extends JObject {
   @internal
   @override
   // ignore: overridden_fields
-  final JObjType<JString> $type = type;
+  final JType<JString> $type = type;
 
   /// The type which includes information such as the signature of this class.
-  static const JObjType<JString> type = JStringType();
+  static const JType<JString> type = $JString$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const JObjType<JString?> nullableType = JStringNullableType();
+  static const JType<JString?> nullableType = $JString$NullableType$();
 
   /// Construct a new [JString] with [reference] as its underlying reference.
   JString.fromReference(super.reference) : super.fromReference();

--- a/pkgs/jni/lib/src/lang/lang.dart
+++ b/pkgs/jni/lib/src/lang/lang.dart
@@ -2,13 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'jboolean.dart';
-export 'jbyte.dart';
-export 'jcharacter.dart';
-export 'jdouble.dart';
-export 'jfloat.dart';
-export 'jinteger.dart';
-export 'jlong.dart';
-export 'jnumber.dart';
-export 'jshort.dart';
-export 'jstring.dart';
+export 'jboolean.dart' hide $JBoolean$NullableType$, $JBoolean$Type$;
+export 'jbyte.dart' hide $JByte$NullableType$, $JByte$Type$;
+export 'jcharacter.dart' hide $JCharacter$NullableType$, $JCharacter$Type$;
+export 'jdouble.dart' hide $JDouble$NullableType$, $JDouble$Type$;
+export 'jfloat.dart' hide $JFloat$NullableType$, $JFloat$Type$;
+export 'jinteger.dart' hide $JInteger$NullableType$, $JInteger$Type$;
+export 'jlong.dart' hide $JLong$NullableType$, $JLong$Type$;
+export 'jnumber.dart' hide $JNumber$NullableType$, $JNumber$Type$;
+export 'jshort.dart' hide $JShort$NullableType$, $JShort$Type$;
+export 'jstring.dart' hide $JString$NullableType$, $JString$Type$;

--- a/pkgs/jni/lib/src/method_invocation.dart
+++ b/pkgs/jni/lib/src/method_invocation.dart
@@ -32,7 +32,7 @@ class MethodInvocation {
       argsAddress == 0
           ? null
           : JArray.fromReference(
-              const JObjectNullableType(),
+              const $JObject$NullableType$(),
               JGlobalReference(Pointer<Void>.fromAddress(argsAddress)),
             ),
     );

--- a/pkgs/jni/lib/src/nio/jbuffer.dart
+++ b/pkgs/jni/lib/src/nio/jbuffer.dart
@@ -10,72 +10,62 @@ import '../jvalues.dart';
 import '../types.dart';
 import 'jbyte_buffer.dart';
 
-final class JBufferNullableType extends JObjType<JBuffer?> {
-  @internal
-  const JBufferNullableType();
+@internal
+final class $JBuffer$NullableType$ extends JType<JBuffer?> {
+  const $JBuffer$NullableType$();
 
-  @internal
   @override
   String get signature => r'Ljava/nio/Buffer;';
 
-  @internal
   @override
   JBuffer? fromReference(JReference reference) =>
       reference.isNull ? null : JBuffer.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectNullableType();
+  JType get superType => const $JObject$NullableType$();
 
-  @internal
   @override
-  JObjType<JBuffer?> get nullableType => this;
+  JType<JBuffer?> get nullableType => this;
 
-  @internal
   @override
   final superCount = 1;
 
   @override
-  int get hashCode => (JBufferNullableType).hashCode;
+  int get hashCode => ($JBuffer$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JBufferNullableType &&
-        other is JBufferNullableType;
+    return other.runtimeType == $JBuffer$NullableType$ &&
+        other is $JBuffer$NullableType$;
   }
 }
 
-final class JBufferType extends JObjType<JBuffer> {
-  @internal
-  const JBufferType();
+@internal
+final class $JBuffer$Type$ extends JType<JBuffer> {
+  const $JBuffer$Type$();
 
-  @internal
   @override
   String get signature => r'Ljava/nio/Buffer;';
 
-  @internal
   @override
   JBuffer fromReference(JReference reference) =>
       JBuffer.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JBuffer?> get nullableType => const JBufferNullableType();
+  JType<JBuffer?> get nullableType => const $JBuffer$NullableType$();
 
-  @internal
   @override
   final superCount = 1;
 
   @override
-  int get hashCode => (JBufferType).hashCode;
+  int get hashCode => ($JBuffer$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JBufferType && other is JBufferType;
+    return other.runtimeType == $JBuffer$Type$ && other is $JBuffer$Type$;
   }
 }
 
@@ -94,7 +84,7 @@ class JBuffer extends JObject {
   @internal
   @override
   // ignore: overridden_fields
-  final JObjType<JBuffer> $type = type;
+  final JType<JBuffer> $type = type;
 
   JBuffer.fromReference(
     super.reference,
@@ -103,10 +93,10 @@ class JBuffer extends JObject {
   static final _class = JClass.forName(r'java/nio/Buffer');
 
   /// The type which includes information such as the signature of this class.
-  static const type = JBufferType();
+  static const JType<JBuffer> type = $JBuffer$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JBufferNullableType();
+  static const JType<JBuffer?> nullableType = $JBuffer$NullableType$();
 
   static final _capacityId = _class.instanceMethodId(r'capacity', r'()I');
 
@@ -133,7 +123,7 @@ class JBuffer extends JObject {
   /// * `IllegalArgumentException` - If the preconditions on [newPosition] do
   ///   not hold.
   set position(int newPosition) {
-    _setPositionId(this, const JObjectType(), [JValueInt(newPosition)])
+    _setPositionId(this, const $JObject$Type$(), [JValueInt(newPosition)])
         .release();
   }
 
@@ -153,7 +143,7 @@ class JBuffer extends JObject {
   /// * `IllegalArgumentException` - If the preconditions on [newLimit] do not
   ///   hold.
   set limit(int newLimit) {
-    _setLimitId(this, const JObjectType(), [JValueInt(newLimit)]).release();
+    _setLimitId(this, const $JObject$Type$(), [JValueInt(newLimit)]).release();
   }
 
   static final _markId =
@@ -164,7 +154,7 @@ class JBuffer extends JObject {
   /// Mark is the index to which its [position] will be reset when the [reset]
   /// method is invoked.
   void mark() {
-    _markId(this, const JObjectType(), []).release();
+    _markId(this, const $JObject$Type$(), []).release();
   }
 
   static final _resetId =
@@ -175,7 +165,7 @@ class JBuffer extends JObject {
   /// Throws:
   /// * `InvalidMarkException` - If the mark has not been set
   void reset() {
-    _resetId(this, const JObjectType(), []).release();
+    _resetId(this, const $JObject$Type$(), []).release();
   }
 
   static final _clearId =
@@ -186,7 +176,7 @@ class JBuffer extends JObject {
   /// The [position] is set to zero, the [limit] is set to
   /// the [capacity], and the mark is discarded.
   void clear() {
-    _clearId(this, const JObjectType(), []).release();
+    _clearId(this, const $JObject$Type$(), []).release();
   }
 
   static final _flipId =
@@ -197,7 +187,7 @@ class JBuffer extends JObject {
   /// The limit is set to the current [position] and then the [position] is set
   /// to zero. If the mark is defined then it is discarded.
   void flip() {
-    _flipId(this, const JObjectType(), []).release();
+    _flipId(this, const $JObject$Type$(), []).release();
   }
 
   static final _rewindId =
@@ -207,7 +197,7 @@ class JBuffer extends JObject {
   ///
   /// The [position] is set to zero and the mark is discarded.
   void rewind() {
-    _rewindId(this, const JObjectType(), []).release();
+    _rewindId(this, const $JObject$Type$(), []).release();
   }
 
   static final _remainingId = _class.instanceMethodId(r'remaining', r'()I');
@@ -261,7 +251,7 @@ class JBuffer extends JObject {
   /// * `UnsupportedOperationException` - If this buffer is not backed by an
   ///   accessible array
   JObject get array {
-    return _arrayId(this, const JObjectType(), [])!;
+    return _arrayId(this, const $JObject$Type$(), [])!;
   }
 
   static final _arrayOffsetId = _class.instanceMethodId(r'arrayOffset', r'()I');

--- a/pkgs/jni/lib/src/nio/jbyte_buffer.dart
+++ b/pkgs/jni/lib/src/nio/jbyte_buffer.dart
@@ -15,72 +15,63 @@ import '../jvalues.dart';
 import '../types.dart';
 import 'jbuffer.dart';
 
-final class JByteBufferNullableType extends JObjType<JByteBuffer?> {
-  @internal
-  const JByteBufferNullableType();
+@internal
+final class $JByteBuffer$NullableType$ extends JType<JByteBuffer?> {
+  const $JByteBuffer$NullableType$();
 
-  @internal
   @override
   String get signature => r'Ljava/nio/ByteBuffer;';
 
-  @internal
   @override
   JByteBuffer? fromReference(JReference reference) =>
       reference.isNull ? null : JByteBuffer.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JByteBufferNullableType();
+  JType get superType => const $JByteBuffer$NullableType$();
 
-  @internal
   @override
-  JObjType<JByteBuffer?> get nullableType => this;
+  JType<JByteBuffer?> get nullableType => this;
 
-  @internal
   @override
   final superCount = 2;
 
   @override
-  int get hashCode => (JByteBufferNullableType).hashCode;
+  int get hashCode => ($JByteBuffer$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JByteBufferNullableType &&
-        other is JByteBufferNullableType;
+    return other.runtimeType == $JByteBuffer$NullableType$ &&
+        other is $JByteBuffer$NullableType$;
   }
 }
 
-final class JByteBufferType extends JObjType<JByteBuffer> {
-  @internal
-  const JByteBufferType();
+@internal
+final class $JByteBuffer$Type$ extends JType<JByteBuffer> {
+  const $JByteBuffer$Type$();
 
-  @internal
   @override
   String get signature => r'Ljava/nio/ByteBuffer;';
 
-  @internal
   @override
   JByteBuffer fromReference(JReference reference) =>
       JByteBuffer.fromReference(reference);
 
-  @internal
   @override
-  JObjType get superType => const JBufferType();
+  JType get superType => const $JBuffer$Type$();
 
-  @internal
   @override
-  JObjType<JByteBuffer?> get nullableType => const JByteBufferNullableType();
+  JType<JByteBuffer?> get nullableType => const $JByteBuffer$NullableType$();
 
-  @internal
   @override
   final superCount = 2;
 
   @override
-  int get hashCode => (JByteBufferType).hashCode;
+  int get hashCode => ($JByteBuffer$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == JByteBufferType && other is JByteBufferType;
+    return other.runtimeType == $JByteBuffer$Type$ &&
+        other is $JByteBuffer$Type$;
   }
 }
 
@@ -137,7 +128,7 @@ class JByteBuffer extends JBuffer {
   @internal
   @override
   // ignore: overridden_fields
-  final JObjType<JByteBuffer> $type = type;
+  final JType<JByteBuffer> $type = type;
 
   JByteBuffer.fromReference(
     super.reference,
@@ -146,10 +137,10 @@ class JByteBuffer extends JBuffer {
   static final _class = JClass.forName(r'java/nio/ByteBuffer');
 
   /// The type which includes information such as the signature of this class.
-  static const type = JByteBufferType();
+  static const JType<JByteBuffer> type = $JByteBuffer$Type$();
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = JByteBufferNullableType();
+  static const JType<JByteBuffer?> nullableType = $JByteBuffer$NullableType$();
 
   static final _allocateDirectId =
       _class.staticMethodId(r'allocateDirect', r'(I)Ljava/nio/ByteBuffer;');
@@ -160,7 +151,7 @@ class JByteBuffer extends JBuffer {
   /// * `IllegalArgumentException` - If the capacity is a negative integer
   factory JByteBuffer.allocateDirect(int capacity) {
     return _allocateDirectId(
-        _class, const JByteBufferType(), [JValueInt(capacity)])!;
+        _class, const $JByteBuffer$Type$(), [JValueInt(capacity)])!;
   }
 
   static final _allocateId =
@@ -171,7 +162,8 @@ class JByteBuffer extends JBuffer {
   /// Throws:
   /// * `IllegalArgumentException` - If the capacity is a negative integer
   factory JByteBuffer.allocate(int capacity) {
-    return _allocateId(_class, const JByteBufferType(), [JValueInt(capacity)])!;
+    return _allocateId(
+        _class, const $JByteBuffer$Type$(), [JValueInt(capacity)])!;
   }
 
   static final _wrapWholeId =
@@ -193,7 +185,7 @@ class JByteBuffer extends JBuffer {
     if (offset == null && length == null) {
       return _wrapWholeId(
         _class,
-        const JByteBufferType(),
+        const $JByteBuffer$Type$(),
         [arrayRef.pointer],
       )!;
     }
@@ -201,7 +193,7 @@ class JByteBuffer extends JBuffer {
     length ??= array.length - offset;
     return _wrapId(
       _class,
-      const JByteBufferType(),
+      const $JByteBuffer$Type$(),
       [arrayRef.pointer, JValueInt(offset), JValueInt(length)],
     )!;
   }
@@ -221,7 +213,7 @@ class JByteBuffer extends JBuffer {
   /// Creates a new byte buffer whose content is a shared subsequence of this
   /// buffer's content.
   JByteBuffer slice() {
-    return _sliceId(this, const JByteBufferType(), [])!;
+    return _sliceId(this, const $JByteBuffer$Type$(), [])!;
   }
 
   static final _duplicateId =
@@ -229,7 +221,7 @@ class JByteBuffer extends JBuffer {
 
   /// Creates a new byte buffer that shares this buffer's content.
   JByteBuffer duplicate() {
-    return _duplicateId(this, const JByteBufferType(), [])!;
+    return _duplicateId(this, const $JByteBuffer$Type$(), [])!;
   }
 
   static final _asReadOnlyBufferId =
@@ -237,7 +229,7 @@ class JByteBuffer extends JBuffer {
 
   /// Creates a new, read-only byte buffer that shares this buffer's content.
   JByteBuffer asReadOnlyBuffer() {
-    return _asReadOnlyBufferId(this, const JByteBufferType(), [])!;
+    return _asReadOnlyBufferId(this, const $JByteBuffer$Type$(), [])!;
   }
 
   static final _getId = _class.instanceMethodId(r'get', r'()B');
@@ -263,7 +255,7 @@ class JByteBuffer extends JBuffer {
   ///   smaller than its [limit]
   /// * `ReadOnlyBufferException` - If this buffer is read-only
   set nextByte(int b) {
-    _putId(this, const JObjectType(), [JValueByte(b)]).release();
+    _putId(this, const $JObject$Type$(), [JValueByte(b)]).release();
   }
 
   static final _arrayId = _class.instanceMethodId(r'array', r'()[B');

--- a/pkgs/jni/lib/src/nio/nio.dart
+++ b/pkgs/jni/lib/src/nio/nio.dart
@@ -2,5 +2,5 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'jbuffer.dart';
-export 'jbyte_buffer.dart';
+export 'jbuffer.dart' hide $JBuffer$NullableType$, $JBuffer$Type$;
+export 'jbyte_buffer.dart' hide $JByteBuffer$NullableType$, $JByteBuffer$Type$;

--- a/pkgs/jni/lib/src/third_party/generated_bindings.dart
+++ b/pkgs/jni/lib/src/third_party/generated_bindings.dart
@@ -1,2 +1,7 @@
+@internal
+library;
+
+import 'package:meta/meta.dart' show internal;
+
 export 'global_env_extensions.dart';
 export 'jni_bindings_generated.dart';

--- a/pkgs/jni/lib/src/third_party/generated_bindings.dart
+++ b/pkgs/jni/lib/src/third_party/generated_bindings.dart
@@ -1,7 +1,2 @@
-@internal
-library;
-
-import 'package:meta/meta.dart' show internal;
-
 export 'global_env_extensions.dart';
 export 'jni_bindings_generated.dart';

--- a/pkgs/jni/lib/src/third_party/generated_bindings.dart
+++ b/pkgs/jni/lib/src/third_party/generated_bindings.dart
@@ -1,2 +1,6 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 export 'global_env_extensions.dart';
 export 'jni_bindings_generated.dart';

--- a/pkgs/jni/lib/src/third_party/global_env_extensions.dart
+++ b/pkgs/jni/lib/src/third_party/global_env_extensions.dart
@@ -42,25 +42,32 @@ import 'jni_bindings_generated.dart';
 class GlobalJniEnv {
   final ffi.Pointer<GlobalJniEnvStruct> ptr;
   GlobalJniEnv(this.ptr);
-  late final _GetVersion =
-      ptr.ref.GetVersion.asFunction<JniResult Function()>(isLeaf: true);
+  late final _GetVersion = ptr.ref.GetVersion.asFunction<JniResult Function()>(
+    isLeaf: true,
+  );
 
   DartJIntMarker GetVersion() => _GetVersion().integer;
 
   late final _DefineClass = ptr.ref.DefineClass.asFunction<
       JniClassLookupResult Function(
-          ffi.Pointer<ffi.Char> name,
-          JObjectPtr loader,
-          ffi.Pointer<JByteMarker> buf,
-          DartJIntMarker bufLen)>();
+        ffi.Pointer<ffi.Char> name,
+        JObjectPtr loader,
+        ffi.Pointer<JByteMarker> buf,
+        DartJIntMarker bufLen,
+      )>();
 
-  JClassPtr DefineClass(ffi.Pointer<ffi.Char> name, JObjectPtr loader,
-          ffi.Pointer<JByteMarker> buf, DartJIntMarker bufLen) =>
+  JClassPtr DefineClass(
+    ffi.Pointer<ffi.Char> name,
+    JObjectPtr loader,
+    ffi.Pointer<JByteMarker> buf,
+    DartJIntMarker bufLen,
+  ) =>
       _DefineClass(name, loader, buf, bufLen).value;
 
   late final _FindClass = ptr.ref.FindClass
       .asFunction<JniClassLookupResult Function(ffi.Pointer<ffi.Char> name)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   JClassPtr FindClass(ffi.Pointer<ffi.Char> name) => _FindClass(name).value;
 
@@ -78,10 +85,16 @@ class GlobalJniEnv {
 
   late final _ToReflectedMethod = ptr.ref.ToReflectedMethod.asFunction<
       JniResult Function(
-          JClassPtr cls, JMethodIDPtr methodId, DartJBooleanMarker isStatic)>();
+        JClassPtr cls,
+        JMethodIDPtr methodId,
+        DartJBooleanMarker isStatic,
+      )>();
 
   JObjectPtr ToReflectedMethod(
-          JClassPtr cls, JMethodIDPtr methodId, DartJBooleanMarker isStatic) =>
+    JClassPtr cls,
+    JMethodIDPtr methodId,
+    DartJBooleanMarker isStatic,
+  ) =>
       _ToReflectedMethod(cls, methodId, isStatic).objectPointer;
 
   late final _GetSuperclass = ptr.ref.GetSuperclass
@@ -91,17 +104,24 @@ class GlobalJniEnv {
 
   late final _IsAssignableFrom = ptr.ref.IsAssignableFrom
       .asFunction<JniResult Function(JClassPtr clazz1, JClassPtr clazz2)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   bool IsAssignableFrom(JClassPtr clazz1, JClassPtr clazz2) =>
       _IsAssignableFrom(clazz1, clazz2).boolean;
 
   late final _ToReflectedField = ptr.ref.ToReflectedField.asFunction<
       JniResult Function(
-          JClassPtr cls, JFieldIDPtr fieldID, DartJBooleanMarker isStatic)>();
+        JClassPtr cls,
+        JFieldIDPtr fieldID,
+        DartJBooleanMarker isStatic,
+      )>();
 
   JObjectPtr ToReflectedField(
-          JClassPtr cls, JFieldIDPtr fieldID, DartJBooleanMarker isStatic) =>
+    JClassPtr cls,
+    JFieldIDPtr fieldID,
+    DartJBooleanMarker isStatic,
+  ) =>
       _ToReflectedField(cls, fieldID, isStatic).objectPointer;
 
   late final _Throw =
@@ -165,7 +185,8 @@ class GlobalJniEnv {
 
   late final _IsSameObject = ptr.ref.IsSameObject
       .asFunction<JniResult Function(JObjectPtr ref1, JObjectPtr ref2)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   bool IsSameObject(JObjectPtr ref1, JObjectPtr ref2) =>
       _IsSameObject(ref1, ref2).boolean;
@@ -194,10 +215,16 @@ class GlobalJniEnv {
 
   late final _NewObjectA = ptr.ref.NewObjectA.asFunction<
       JniResult Function(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+        JClassPtr clazz,
+        JMethodIDPtr methodID,
+        ffi.Pointer<JValue> args,
+      )>();
 
   JObjectPtr NewObjectA(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _NewObjectA(clazz, methodID, args).objectPointer;
 
   late final _GetObjectClass = ptr.ref.GetObjectClass
@@ -212,11 +239,17 @@ class GlobalJniEnv {
       _IsInstanceOf(obj, clazz).boolean;
 
   late final _GetMethodID = ptr.ref.GetMethodID.asFunction<
-      JniPointerResult Function(JClassPtr clazz, ffi.Pointer<ffi.Char> name,
-          ffi.Pointer<ffi.Char> sig)>(isLeaf: true);
+      JniPointerResult Function(
+        JClassPtr clazz,
+        ffi.Pointer<ffi.Char> name,
+        ffi.Pointer<ffi.Char> sig,
+      )>(isLeaf: true);
 
-  JMethodIDPtr GetMethodID(JClassPtr clazz, ffi.Pointer<ffi.Char> name,
-          ffi.Pointer<ffi.Char> sig) =>
+  JMethodIDPtr GetMethodID(
+    JClassPtr clazz,
+    ffi.Pointer<ffi.Char> name,
+    ffi.Pointer<ffi.Char> sig,
+  ) =>
       _GetMethodID(clazz, name, sig).methodID;
 
   late final _CallObjectMethod = ptr.ref.CallObjectMethod
@@ -227,10 +260,16 @@ class GlobalJniEnv {
 
   late final _CallObjectMethodA = ptr.ref.CallObjectMethodA.asFunction<
       JniResult Function(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+        JObjectPtr obj,
+        JMethodIDPtr methodID,
+        ffi.Pointer<JValue> args,
+      )>();
 
   JObjectPtr CallObjectMethodA(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JObjectPtr obj,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallObjectMethodA(obj, methodID, args).objectPointer;
 
   late final _CallBooleanMethod = ptr.ref.CallBooleanMethod
@@ -241,10 +280,16 @@ class GlobalJniEnv {
 
   late final _CallBooleanMethodA = ptr.ref.CallBooleanMethodA.asFunction<
       JniResult Function(
-          JObjectPtr obj, JMethodIDPtr methodId, ffi.Pointer<JValue> args)>();
+        JObjectPtr obj,
+        JMethodIDPtr methodId,
+        ffi.Pointer<JValue> args,
+      )>();
 
   bool CallBooleanMethodA(
-          JObjectPtr obj, JMethodIDPtr methodId, ffi.Pointer<JValue> args) =>
+    JObjectPtr obj,
+    JMethodIDPtr methodId,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallBooleanMethodA(obj, methodId, args).boolean;
 
   late final _CallByteMethod = ptr.ref.CallByteMethod
@@ -255,10 +300,16 @@ class GlobalJniEnv {
 
   late final _CallByteMethodA = ptr.ref.CallByteMethodA.asFunction<
       JniResult Function(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+        JObjectPtr obj,
+        JMethodIDPtr methodID,
+        ffi.Pointer<JValue> args,
+      )>();
 
   DartJByteMarker CallByteMethodA(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JObjectPtr obj,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallByteMethodA(obj, methodID, args).byte;
 
   late final _CallCharMethod = ptr.ref.CallCharMethod
@@ -269,10 +320,16 @@ class GlobalJniEnv {
 
   late final _CallCharMethodA = ptr.ref.CallCharMethodA.asFunction<
       JniResult Function(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+        JObjectPtr obj,
+        JMethodIDPtr methodID,
+        ffi.Pointer<JValue> args,
+      )>();
 
   DartJCharMarker CallCharMethodA(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JObjectPtr obj,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallCharMethodA(obj, methodID, args).char;
 
   late final _CallShortMethod = ptr.ref.CallShortMethod
@@ -283,10 +340,16 @@ class GlobalJniEnv {
 
   late final _CallShortMethodA = ptr.ref.CallShortMethodA.asFunction<
       JniResult Function(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+        JObjectPtr obj,
+        JMethodIDPtr methodID,
+        ffi.Pointer<JValue> args,
+      )>();
 
   DartJShortMarker CallShortMethodA(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JObjectPtr obj,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallShortMethodA(obj, methodID, args).short;
 
   late final _CallIntMethod = ptr.ref.CallIntMethod
@@ -297,10 +360,16 @@ class GlobalJniEnv {
 
   late final _CallIntMethodA = ptr.ref.CallIntMethodA.asFunction<
       JniResult Function(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+        JObjectPtr obj,
+        JMethodIDPtr methodID,
+        ffi.Pointer<JValue> args,
+      )>();
 
   DartJIntMarker CallIntMethodA(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JObjectPtr obj,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallIntMethodA(obj, methodID, args).integer;
 
   late final _CallLongMethod = ptr.ref.CallLongMethod
@@ -311,10 +380,16 @@ class GlobalJniEnv {
 
   late final _CallLongMethodA = ptr.ref.CallLongMethodA.asFunction<
       JniResult Function(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+        JObjectPtr obj,
+        JMethodIDPtr methodID,
+        ffi.Pointer<JValue> args,
+      )>();
 
   DartJLongMarker CallLongMethodA(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JObjectPtr obj,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallLongMethodA(obj, methodID, args).long;
 
   late final _CallFloatMethod = ptr.ref.CallFloatMethod
@@ -325,10 +400,16 @@ class GlobalJniEnv {
 
   late final _CallFloatMethodA = ptr.ref.CallFloatMethodA.asFunction<
       JniResult Function(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+        JObjectPtr obj,
+        JMethodIDPtr methodID,
+        ffi.Pointer<JValue> args,
+      )>();
 
   DartJFloatMarker CallFloatMethodA(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JObjectPtr obj,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallFloatMethodA(obj, methodID, args).float;
 
   late final _CallDoubleMethod = ptr.ref.CallDoubleMethod
@@ -339,10 +420,16 @@ class GlobalJniEnv {
 
   late final _CallDoubleMethodA = ptr.ref.CallDoubleMethodA.asFunction<
       JniResult Function(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+        JObjectPtr obj,
+        JMethodIDPtr methodID,
+        ffi.Pointer<JValue> args,
+      )>();
 
   DartJDoubleMarker CallDoubleMethodA(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JObjectPtr obj,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallDoubleMethodA(obj, methodID, args).doubleFloat;
 
   late final _CallVoidMethod = ptr.ref.CallVoidMethod.asFunction<
@@ -353,336 +440,542 @@ class GlobalJniEnv {
 
   late final _CallVoidMethodA = ptr.ref.CallVoidMethodA.asFunction<
       JThrowablePtr Function(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+        JObjectPtr obj,
+        JMethodIDPtr methodID,
+        ffi.Pointer<JValue> args,
+      )>();
 
   void CallVoidMethodA(
-          JObjectPtr obj, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JObjectPtr obj,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallVoidMethodA(obj, methodID, args).check();
 
-  late final _CallNonvirtualObjectMethod = ptr.ref.CallNonvirtualObjectMethod
-      .asFunction<
+  late final _CallNonvirtualObjectMethod =
+      ptr.ref.CallNonvirtualObjectMethod.asFunction<
           JniResult Function(
-              JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID)>();
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>();
 
   JObjectPtr CallNonvirtualObjectMethod(
-          JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID) =>
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+  ) =>
       _CallNonvirtualObjectMethod(obj, clazz, methodID).objectPointer;
 
-  late final _CallNonvirtualObjectMethodA = ptr.ref.CallNonvirtualObjectMethodA
-      .asFunction<
-          JniResult Function(JObjectPtr obj, JClassPtr clazz,
-              JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+  late final _CallNonvirtualObjectMethodA =
+      ptr.ref.CallNonvirtualObjectMethodA.asFunction<
+          JniResult Function(
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>();
 
-  JObjectPtr CallNonvirtualObjectMethodA(JObjectPtr obj, JClassPtr clazz,
-          JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+  JObjectPtr CallNonvirtualObjectMethodA(
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallNonvirtualObjectMethodA(obj, clazz, methodID, args).objectPointer;
 
-  late final _CallNonvirtualBooleanMethod = ptr.ref.CallNonvirtualBooleanMethod
-      .asFunction<
+  late final _CallNonvirtualBooleanMethod =
+      ptr.ref.CallNonvirtualBooleanMethod.asFunction<
           JniResult Function(
-              JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID)>();
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>();
 
   bool CallNonvirtualBooleanMethod(
-          JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID) =>
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+  ) =>
       _CallNonvirtualBooleanMethod(obj, clazz, methodID).boolean;
 
   late final _CallNonvirtualBooleanMethodA =
       ptr.ref.CallNonvirtualBooleanMethodA.asFunction<
-          JniResult Function(JObjectPtr obj, JClassPtr clazz,
-              JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+          JniResult Function(
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>();
 
-  bool CallNonvirtualBooleanMethodA(JObjectPtr obj, JClassPtr clazz,
-          JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+  bool CallNonvirtualBooleanMethodA(
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallNonvirtualBooleanMethodA(obj, clazz, methodID, args).boolean;
 
-  late final _CallNonvirtualByteMethod = ptr.ref.CallNonvirtualByteMethod
-      .asFunction<
+  late final _CallNonvirtualByteMethod =
+      ptr.ref.CallNonvirtualByteMethod.asFunction<
           JniResult Function(
-              JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID)>();
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>();
 
   DartJByteMarker CallNonvirtualByteMethod(
-          JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID) =>
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+  ) =>
       _CallNonvirtualByteMethod(obj, clazz, methodID).byte;
 
-  late final _CallNonvirtualByteMethodA = ptr.ref.CallNonvirtualByteMethodA
-      .asFunction<
-          JniResult Function(JObjectPtr obj, JClassPtr clazz,
-              JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+  late final _CallNonvirtualByteMethodA =
+      ptr.ref.CallNonvirtualByteMethodA.asFunction<
+          JniResult Function(
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>();
 
-  DartJByteMarker CallNonvirtualByteMethodA(JObjectPtr obj, JClassPtr clazz,
-          JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+  DartJByteMarker CallNonvirtualByteMethodA(
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallNonvirtualByteMethodA(obj, clazz, methodID, args).byte;
 
-  late final _CallNonvirtualCharMethod = ptr.ref.CallNonvirtualCharMethod
-      .asFunction<
+  late final _CallNonvirtualCharMethod =
+      ptr.ref.CallNonvirtualCharMethod.asFunction<
           JniResult Function(
-              JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID)>();
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>();
 
   DartJCharMarker CallNonvirtualCharMethod(
-          JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID) =>
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+  ) =>
       _CallNonvirtualCharMethod(obj, clazz, methodID).char;
 
-  late final _CallNonvirtualCharMethodA = ptr.ref.CallNonvirtualCharMethodA
-      .asFunction<
-          JniResult Function(JObjectPtr obj, JClassPtr clazz,
-              JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+  late final _CallNonvirtualCharMethodA =
+      ptr.ref.CallNonvirtualCharMethodA.asFunction<
+          JniResult Function(
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>();
 
-  DartJCharMarker CallNonvirtualCharMethodA(JObjectPtr obj, JClassPtr clazz,
-          JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+  DartJCharMarker CallNonvirtualCharMethodA(
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallNonvirtualCharMethodA(obj, clazz, methodID, args).char;
 
-  late final _CallNonvirtualShortMethod = ptr.ref.CallNonvirtualShortMethod
-      .asFunction<
+  late final _CallNonvirtualShortMethod =
+      ptr.ref.CallNonvirtualShortMethod.asFunction<
           JniResult Function(
-              JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID)>();
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>();
 
   DartJShortMarker CallNonvirtualShortMethod(
-          JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID) =>
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+  ) =>
       _CallNonvirtualShortMethod(obj, clazz, methodID).short;
 
-  late final _CallNonvirtualShortMethodA = ptr.ref.CallNonvirtualShortMethodA
-      .asFunction<
-          JniResult Function(JObjectPtr obj, JClassPtr clazz,
-              JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+  late final _CallNonvirtualShortMethodA =
+      ptr.ref.CallNonvirtualShortMethodA.asFunction<
+          JniResult Function(
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>();
 
-  DartJShortMarker CallNonvirtualShortMethodA(JObjectPtr obj, JClassPtr clazz,
-          JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+  DartJShortMarker CallNonvirtualShortMethodA(
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallNonvirtualShortMethodA(obj, clazz, methodID, args).short;
 
-  late final _CallNonvirtualIntMethod = ptr.ref.CallNonvirtualIntMethod
-      .asFunction<
+  late final _CallNonvirtualIntMethod =
+      ptr.ref.CallNonvirtualIntMethod.asFunction<
           JniResult Function(
-              JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID)>();
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>();
 
   DartJIntMarker CallNonvirtualIntMethod(
-          JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID) =>
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+  ) =>
       _CallNonvirtualIntMethod(obj, clazz, methodID).integer;
 
-  late final _CallNonvirtualIntMethodA = ptr.ref.CallNonvirtualIntMethodA
-      .asFunction<
-          JniResult Function(JObjectPtr obj, JClassPtr clazz,
-              JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+  late final _CallNonvirtualIntMethodA =
+      ptr.ref.CallNonvirtualIntMethodA.asFunction<
+          JniResult Function(
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>();
 
-  DartJIntMarker CallNonvirtualIntMethodA(JObjectPtr obj, JClassPtr clazz,
-          JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+  DartJIntMarker CallNonvirtualIntMethodA(
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallNonvirtualIntMethodA(obj, clazz, methodID, args).integer;
 
-  late final _CallNonvirtualLongMethod = ptr.ref.CallNonvirtualLongMethod
-      .asFunction<
+  late final _CallNonvirtualLongMethod =
+      ptr.ref.CallNonvirtualLongMethod.asFunction<
           JniResult Function(
-              JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID)>();
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>();
 
   DartJLongMarker CallNonvirtualLongMethod(
-          JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID) =>
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+  ) =>
       _CallNonvirtualLongMethod(obj, clazz, methodID).long;
 
-  late final _CallNonvirtualLongMethodA = ptr.ref.CallNonvirtualLongMethodA
-      .asFunction<
-          JniResult Function(JObjectPtr obj, JClassPtr clazz,
-              JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+  late final _CallNonvirtualLongMethodA =
+      ptr.ref.CallNonvirtualLongMethodA.asFunction<
+          JniResult Function(
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>();
 
-  DartJLongMarker CallNonvirtualLongMethodA(JObjectPtr obj, JClassPtr clazz,
-          JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+  DartJLongMarker CallNonvirtualLongMethodA(
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallNonvirtualLongMethodA(obj, clazz, methodID, args).long;
 
-  late final _CallNonvirtualFloatMethod = ptr.ref.CallNonvirtualFloatMethod
-      .asFunction<
+  late final _CallNonvirtualFloatMethod =
+      ptr.ref.CallNonvirtualFloatMethod.asFunction<
           JniResult Function(
-              JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID)>();
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>();
 
   DartJFloatMarker CallNonvirtualFloatMethod(
-          JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID) =>
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+  ) =>
       _CallNonvirtualFloatMethod(obj, clazz, methodID).float;
 
-  late final _CallNonvirtualFloatMethodA = ptr.ref.CallNonvirtualFloatMethodA
-      .asFunction<
-          JniResult Function(JObjectPtr obj, JClassPtr clazz,
-              JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+  late final _CallNonvirtualFloatMethodA =
+      ptr.ref.CallNonvirtualFloatMethodA.asFunction<
+          JniResult Function(
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>();
 
-  DartJFloatMarker CallNonvirtualFloatMethodA(JObjectPtr obj, JClassPtr clazz,
-          JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+  DartJFloatMarker CallNonvirtualFloatMethodA(
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallNonvirtualFloatMethodA(obj, clazz, methodID, args).float;
 
-  late final _CallNonvirtualDoubleMethod = ptr.ref.CallNonvirtualDoubleMethod
-      .asFunction<
+  late final _CallNonvirtualDoubleMethod =
+      ptr.ref.CallNonvirtualDoubleMethod.asFunction<
           JniResult Function(
-              JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID)>();
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>();
 
   DartJDoubleMarker CallNonvirtualDoubleMethod(
-          JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID) =>
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+  ) =>
       _CallNonvirtualDoubleMethod(obj, clazz, methodID).doubleFloat;
 
-  late final _CallNonvirtualDoubleMethodA = ptr.ref.CallNonvirtualDoubleMethodA
-      .asFunction<
-          JniResult Function(JObjectPtr obj, JClassPtr clazz,
-              JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+  late final _CallNonvirtualDoubleMethodA =
+      ptr.ref.CallNonvirtualDoubleMethodA.asFunction<
+          JniResult Function(
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>();
 
-  DartJDoubleMarker CallNonvirtualDoubleMethodA(JObjectPtr obj, JClassPtr clazz,
-          JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+  DartJDoubleMarker CallNonvirtualDoubleMethodA(
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallNonvirtualDoubleMethodA(obj, clazz, methodID, args).doubleFloat;
 
-  late final _CallNonvirtualVoidMethod = ptr.ref.CallNonvirtualVoidMethod
-      .asFunction<
+  late final _CallNonvirtualVoidMethod =
+      ptr.ref.CallNonvirtualVoidMethod.asFunction<
           JThrowablePtr Function(
-              JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID)>();
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>();
 
   void CallNonvirtualVoidMethod(
-          JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID) =>
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+  ) =>
       _CallNonvirtualVoidMethod(obj, clazz, methodID).check();
 
-  late final _CallNonvirtualVoidMethodA = ptr.ref.CallNonvirtualVoidMethodA
-      .asFunction<
-          JThrowablePtr Function(JObjectPtr obj, JClassPtr clazz,
-              JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+  late final _CallNonvirtualVoidMethodA =
+      ptr.ref.CallNonvirtualVoidMethodA.asFunction<
+          JThrowablePtr Function(
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>();
 
-  void CallNonvirtualVoidMethodA(JObjectPtr obj, JClassPtr clazz,
-          JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+  void CallNonvirtualVoidMethodA(
+    JObjectPtr obj,
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallNonvirtualVoidMethodA(obj, clazz, methodID, args).check();
 
   late final _GetFieldID = ptr.ref.GetFieldID.asFunction<
-      JniPointerResult Function(JClassPtr clazz, ffi.Pointer<ffi.Char> name,
-          ffi.Pointer<ffi.Char> sig)>(isLeaf: true);
+      JniPointerResult Function(
+        JClassPtr clazz,
+        ffi.Pointer<ffi.Char> name,
+        ffi.Pointer<ffi.Char> sig,
+      )>(isLeaf: true);
 
-  JFieldIDPtr GetFieldID(JClassPtr clazz, ffi.Pointer<ffi.Char> name,
-          ffi.Pointer<ffi.Char> sig) =>
+  JFieldIDPtr GetFieldID(
+    JClassPtr clazz,
+    ffi.Pointer<ffi.Char> name,
+    ffi.Pointer<ffi.Char> sig,
+  ) =>
       _GetFieldID(clazz, name, sig).fieldID;
 
   late final _GetObjectField = ptr.ref.GetObjectField
       .asFunction<JniResult Function(JObjectPtr obj, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   JObjectPtr GetObjectField(JObjectPtr obj, JFieldIDPtr fieldID) =>
       _GetObjectField(obj, fieldID).objectPointer;
 
   late final _GetBooleanField = ptr.ref.GetBooleanField
       .asFunction<JniResult Function(JObjectPtr obj, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   bool GetBooleanField(JObjectPtr obj, JFieldIDPtr fieldID) =>
       _GetBooleanField(obj, fieldID).boolean;
 
   late final _GetByteField = ptr.ref.GetByteField
       .asFunction<JniResult Function(JObjectPtr obj, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   DartJByteMarker GetByteField(JObjectPtr obj, JFieldIDPtr fieldID) =>
       _GetByteField(obj, fieldID).byte;
 
   late final _GetCharField = ptr.ref.GetCharField
       .asFunction<JniResult Function(JObjectPtr obj, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   DartJCharMarker GetCharField(JObjectPtr obj, JFieldIDPtr fieldID) =>
       _GetCharField(obj, fieldID).char;
 
   late final _GetShortField = ptr.ref.GetShortField
       .asFunction<JniResult Function(JObjectPtr obj, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   DartJShortMarker GetShortField(JObjectPtr obj, JFieldIDPtr fieldID) =>
       _GetShortField(obj, fieldID).short;
 
   late final _GetIntField = ptr.ref.GetIntField
       .asFunction<JniResult Function(JObjectPtr obj, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   DartJIntMarker GetIntField(JObjectPtr obj, JFieldIDPtr fieldID) =>
       _GetIntField(obj, fieldID).integer;
 
   late final _GetLongField = ptr.ref.GetLongField
       .asFunction<JniResult Function(JObjectPtr obj, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   DartJLongMarker GetLongField(JObjectPtr obj, JFieldIDPtr fieldID) =>
       _GetLongField(obj, fieldID).long;
 
   late final _GetFloatField = ptr.ref.GetFloatField
       .asFunction<JniResult Function(JObjectPtr obj, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   DartJFloatMarker GetFloatField(JObjectPtr obj, JFieldIDPtr fieldID) =>
       _GetFloatField(obj, fieldID).float;
 
   late final _GetDoubleField = ptr.ref.GetDoubleField
       .asFunction<JniResult Function(JObjectPtr obj, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   DartJDoubleMarker GetDoubleField(JObjectPtr obj, JFieldIDPtr fieldID) =>
       _GetDoubleField(obj, fieldID).doubleFloat;
 
   late final _SetObjectField = ptr.ref.SetObjectField.asFunction<
       JThrowablePtr Function(
-          JObjectPtr obj, JFieldIDPtr fieldID, JObjectPtr val)>(isLeaf: true);
+        JObjectPtr obj,
+        JFieldIDPtr fieldID,
+        JObjectPtr val,
+      )>(isLeaf: true);
 
   void SetObjectField(JObjectPtr obj, JFieldIDPtr fieldID, JObjectPtr val) =>
       _SetObjectField(obj, fieldID, val).check();
 
   late final _SetBooleanField = ptr.ref.SetBooleanField.asFunction<
-      JThrowablePtr Function(JObjectPtr obj, JFieldIDPtr fieldID,
-          DartJBooleanMarker val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JObjectPtr obj,
+        JFieldIDPtr fieldID,
+        DartJBooleanMarker val,
+      )>(isLeaf: true);
 
   void SetBooleanField(
-          JObjectPtr obj, JFieldIDPtr fieldID, DartJBooleanMarker val) =>
+    JObjectPtr obj,
+    JFieldIDPtr fieldID,
+    DartJBooleanMarker val,
+  ) =>
       _SetBooleanField(obj, fieldID, val).check();
 
   late final _SetByteField = ptr.ref.SetByteField.asFunction<
-      JThrowablePtr Function(JObjectPtr obj, JFieldIDPtr fieldID,
-          DartJByteMarker val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JObjectPtr obj,
+        JFieldIDPtr fieldID,
+        DartJByteMarker val,
+      )>(isLeaf: true);
 
   void SetByteField(JObjectPtr obj, JFieldIDPtr fieldID, DartJByteMarker val) =>
       _SetByteField(obj, fieldID, val).check();
 
   late final _SetCharField = ptr.ref.SetCharField.asFunction<
-      JThrowablePtr Function(JObjectPtr obj, JFieldIDPtr fieldID,
-          DartJCharMarker val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JObjectPtr obj,
+        JFieldIDPtr fieldID,
+        DartJCharMarker val,
+      )>(isLeaf: true);
 
   void SetCharField(JObjectPtr obj, JFieldIDPtr fieldID, DartJCharMarker val) =>
       _SetCharField(obj, fieldID, val).check();
 
   late final _SetShortField = ptr.ref.SetShortField.asFunction<
-      JThrowablePtr Function(JObjectPtr obj, JFieldIDPtr fieldID,
-          DartJShortMarker val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JObjectPtr obj,
+        JFieldIDPtr fieldID,
+        DartJShortMarker val,
+      )>(isLeaf: true);
 
   void SetShortField(
-          JObjectPtr obj, JFieldIDPtr fieldID, DartJShortMarker val) =>
+    JObjectPtr obj,
+    JFieldIDPtr fieldID,
+    DartJShortMarker val,
+  ) =>
       _SetShortField(obj, fieldID, val).check();
 
   late final _SetIntField = ptr.ref.SetIntField.asFunction<
-      JThrowablePtr Function(JObjectPtr obj, JFieldIDPtr fieldID,
-          DartJIntMarker val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JObjectPtr obj,
+        JFieldIDPtr fieldID,
+        DartJIntMarker val,
+      )>(isLeaf: true);
 
   void SetIntField(JObjectPtr obj, JFieldIDPtr fieldID, DartJIntMarker val) =>
       _SetIntField(obj, fieldID, val).check();
 
   late final _SetLongField = ptr.ref.SetLongField.asFunction<
-      JThrowablePtr Function(JObjectPtr obj, JFieldIDPtr fieldID,
-          DartJLongMarker val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JObjectPtr obj,
+        JFieldIDPtr fieldID,
+        DartJLongMarker val,
+      )>(isLeaf: true);
 
   void SetLongField(JObjectPtr obj, JFieldIDPtr fieldID, DartJLongMarker val) =>
       _SetLongField(obj, fieldID, val).check();
 
   late final _SetFloatField = ptr.ref.SetFloatField.asFunction<
-      JThrowablePtr Function(JObjectPtr obj, JFieldIDPtr fieldID,
-          DartJFloatMarker val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JObjectPtr obj,
+        JFieldIDPtr fieldID,
+        DartJFloatMarker val,
+      )>(isLeaf: true);
 
   void SetFloatField(
-          JObjectPtr obj, JFieldIDPtr fieldID, DartJFloatMarker val) =>
+    JObjectPtr obj,
+    JFieldIDPtr fieldID,
+    DartJFloatMarker val,
+  ) =>
       _SetFloatField(obj, fieldID, val).check();
 
   late final _SetDoubleField = ptr.ref.SetDoubleField.asFunction<
-      JThrowablePtr Function(JObjectPtr obj, JFieldIDPtr fieldID,
-          DartJDoubleMarker val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JObjectPtr obj,
+        JFieldIDPtr fieldID,
+        DartJDoubleMarker val,
+      )>(isLeaf: true);
 
   void SetDoubleField(
-          JObjectPtr obj, JFieldIDPtr fieldID, DartJDoubleMarker val) =>
+    JObjectPtr obj,
+    JFieldIDPtr fieldID,
+    DartJDoubleMarker val,
+  ) =>
       _SetDoubleField(obj, fieldID, val).check();
 
   late final _GetStaticMethodID = ptr.ref.GetStaticMethodID.asFunction<
-      JniPointerResult Function(JClassPtr clazz, ffi.Pointer<ffi.Char> name,
-          ffi.Pointer<ffi.Char> sig)>(isLeaf: true);
+      JniPointerResult Function(
+        JClassPtr clazz,
+        ffi.Pointer<ffi.Char> name,
+        ffi.Pointer<ffi.Char> sig,
+      )>(isLeaf: true);
 
-  JMethodIDPtr GetStaticMethodID(JClassPtr clazz, ffi.Pointer<ffi.Char> name,
-          ffi.Pointer<ffi.Char> sig) =>
+  JMethodIDPtr GetStaticMethodID(
+    JClassPtr clazz,
+    ffi.Pointer<ffi.Char> name,
+    ffi.Pointer<ffi.Char> sig,
+  ) =>
       _GetStaticMethodID(clazz, name, sig).methodID;
 
   late final _CallStaticObjectMethod = ptr.ref.CallStaticObjectMethod
@@ -691,13 +984,19 @@ class GlobalJniEnv {
   JObjectPtr CallStaticObjectMethod(JClassPtr clazz, JMethodIDPtr methodID) =>
       _CallStaticObjectMethod(clazz, methodID).objectPointer;
 
-  late final _CallStaticObjectMethodA = ptr.ref.CallStaticObjectMethodA
-      .asFunction<
-          JniResult Function(JClassPtr clazz, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>();
+  late final _CallStaticObjectMethodA =
+      ptr.ref.CallStaticObjectMethodA.asFunction<
+          JniResult Function(
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>();
 
   JObjectPtr CallStaticObjectMethodA(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallStaticObjectMethodA(clazz, methodID, args).objectPointer;
 
   late final _CallStaticBooleanMethod = ptr.ref.CallStaticBooleanMethod
@@ -706,59 +1005,89 @@ class GlobalJniEnv {
   bool CallStaticBooleanMethod(JClassPtr clazz, JMethodIDPtr methodID) =>
       _CallStaticBooleanMethod(clazz, methodID).boolean;
 
-  late final _CallStaticBooleanMethodA = ptr.ref.CallStaticBooleanMethodA
-      .asFunction<
-          JniResult Function(JClassPtr clazz, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>();
+  late final _CallStaticBooleanMethodA =
+      ptr.ref.CallStaticBooleanMethodA.asFunction<
+          JniResult Function(
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>();
 
   bool CallStaticBooleanMethodA(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallStaticBooleanMethodA(clazz, methodID, args).boolean;
 
   late final _CallStaticByteMethod = ptr.ref.CallStaticByteMethod
       .asFunction<JniResult Function(JClassPtr clazz, JMethodIDPtr methodID)>();
 
   DartJByteMarker CallStaticByteMethod(
-          JClassPtr clazz, JMethodIDPtr methodID) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+  ) =>
       _CallStaticByteMethod(clazz, methodID).byte;
 
   late final _CallStaticByteMethodA = ptr.ref.CallStaticByteMethodA.asFunction<
       JniResult Function(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+        JClassPtr clazz,
+        JMethodIDPtr methodID,
+        ffi.Pointer<JValue> args,
+      )>();
 
   DartJByteMarker CallStaticByteMethodA(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallStaticByteMethodA(clazz, methodID, args).byte;
 
   late final _CallStaticCharMethod = ptr.ref.CallStaticCharMethod
       .asFunction<JniResult Function(JClassPtr clazz, JMethodIDPtr methodID)>();
 
   DartJCharMarker CallStaticCharMethod(
-          JClassPtr clazz, JMethodIDPtr methodID) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+  ) =>
       _CallStaticCharMethod(clazz, methodID).char;
 
   late final _CallStaticCharMethodA = ptr.ref.CallStaticCharMethodA.asFunction<
       JniResult Function(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+        JClassPtr clazz,
+        JMethodIDPtr methodID,
+        ffi.Pointer<JValue> args,
+      )>();
 
   DartJCharMarker CallStaticCharMethodA(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallStaticCharMethodA(clazz, methodID, args).char;
 
   late final _CallStaticShortMethod = ptr.ref.CallStaticShortMethod
       .asFunction<JniResult Function(JClassPtr clazz, JMethodIDPtr methodID)>();
 
   DartJShortMarker CallStaticShortMethod(
-          JClassPtr clazz, JMethodIDPtr methodID) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+  ) =>
       _CallStaticShortMethod(clazz, methodID).short;
 
-  late final _CallStaticShortMethodA = ptr.ref.CallStaticShortMethodA
-      .asFunction<
-          JniResult Function(JClassPtr clazz, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>();
+  late final _CallStaticShortMethodA =
+      ptr.ref.CallStaticShortMethodA.asFunction<
+          JniResult Function(
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>();
 
   DartJShortMarker CallStaticShortMethodA(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallStaticShortMethodA(clazz, methodID, args).short;
 
   late final _CallStaticIntMethod = ptr.ref.CallStaticIntMethod
@@ -769,57 +1098,87 @@ class GlobalJniEnv {
 
   late final _CallStaticIntMethodA = ptr.ref.CallStaticIntMethodA.asFunction<
       JniResult Function(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+        JClassPtr clazz,
+        JMethodIDPtr methodID,
+        ffi.Pointer<JValue> args,
+      )>();
 
   DartJIntMarker CallStaticIntMethodA(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallStaticIntMethodA(clazz, methodID, args).integer;
 
   late final _CallStaticLongMethod = ptr.ref.CallStaticLongMethod
       .asFunction<JniResult Function(JClassPtr clazz, JMethodIDPtr methodID)>();
 
   DartJLongMarker CallStaticLongMethod(
-          JClassPtr clazz, JMethodIDPtr methodID) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+  ) =>
       _CallStaticLongMethod(clazz, methodID).long;
 
   late final _CallStaticLongMethodA = ptr.ref.CallStaticLongMethodA.asFunction<
       JniResult Function(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+        JClassPtr clazz,
+        JMethodIDPtr methodID,
+        ffi.Pointer<JValue> args,
+      )>();
 
   DartJLongMarker CallStaticLongMethodA(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallStaticLongMethodA(clazz, methodID, args).long;
 
   late final _CallStaticFloatMethod = ptr.ref.CallStaticFloatMethod
       .asFunction<JniResult Function(JClassPtr clazz, JMethodIDPtr methodID)>();
 
   DartJFloatMarker CallStaticFloatMethod(
-          JClassPtr clazz, JMethodIDPtr methodID) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+  ) =>
       _CallStaticFloatMethod(clazz, methodID).float;
 
-  late final _CallStaticFloatMethodA = ptr.ref.CallStaticFloatMethodA
-      .asFunction<
-          JniResult Function(JClassPtr clazz, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>();
+  late final _CallStaticFloatMethodA =
+      ptr.ref.CallStaticFloatMethodA.asFunction<
+          JniResult Function(
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>();
 
   DartJFloatMarker CallStaticFloatMethodA(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallStaticFloatMethodA(clazz, methodID, args).float;
 
   late final _CallStaticDoubleMethod = ptr.ref.CallStaticDoubleMethod
       .asFunction<JniResult Function(JClassPtr clazz, JMethodIDPtr methodID)>();
 
   DartJDoubleMarker CallStaticDoubleMethod(
-          JClassPtr clazz, JMethodIDPtr methodID) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+  ) =>
       _CallStaticDoubleMethod(clazz, methodID).doubleFloat;
 
-  late final _CallStaticDoubleMethodA = ptr.ref.CallStaticDoubleMethodA
-      .asFunction<
-          JniResult Function(JClassPtr clazz, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>();
+  late final _CallStaticDoubleMethodA =
+      ptr.ref.CallStaticDoubleMethodA.asFunction<
+          JniResult Function(
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>();
 
   DartJDoubleMarker CallStaticDoubleMethodA(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallStaticDoubleMethodA(clazz, methodID, args).doubleFloat;
 
   late final _CallStaticVoidMethod = ptr.ref.CallStaticVoidMethod.asFunction<
@@ -830,162 +1189,243 @@ class GlobalJniEnv {
 
   late final _CallStaticVoidMethodA = ptr.ref.CallStaticVoidMethodA.asFunction<
       JThrowablePtr Function(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args)>();
+        JClassPtr clazz,
+        JMethodIDPtr methodID,
+        ffi.Pointer<JValue> args,
+      )>();
 
   void CallStaticVoidMethodA(
-          JClassPtr clazz, JMethodIDPtr methodID, ffi.Pointer<JValue> args) =>
+    JClassPtr clazz,
+    JMethodIDPtr methodID,
+    ffi.Pointer<JValue> args,
+  ) =>
       _CallStaticVoidMethodA(clazz, methodID, args).check();
 
   late final _GetStaticFieldID = ptr.ref.GetStaticFieldID.asFunction<
-      JniPointerResult Function(JClassPtr clazz, ffi.Pointer<ffi.Char> name,
-          ffi.Pointer<ffi.Char> sig)>(isLeaf: true);
+      JniPointerResult Function(
+        JClassPtr clazz,
+        ffi.Pointer<ffi.Char> name,
+        ffi.Pointer<ffi.Char> sig,
+      )>(isLeaf: true);
 
-  JFieldIDPtr GetStaticFieldID(JClassPtr clazz, ffi.Pointer<ffi.Char> name,
-          ffi.Pointer<ffi.Char> sig) =>
+  JFieldIDPtr GetStaticFieldID(
+    JClassPtr clazz,
+    ffi.Pointer<ffi.Char> name,
+    ffi.Pointer<ffi.Char> sig,
+  ) =>
       _GetStaticFieldID(clazz, name, sig).fieldID;
 
   late final _GetStaticObjectField = ptr.ref.GetStaticObjectField
       .asFunction<JniResult Function(JClassPtr clazz, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   JObjectPtr GetStaticObjectField(JClassPtr clazz, JFieldIDPtr fieldID) =>
       _GetStaticObjectField(clazz, fieldID).objectPointer;
 
   late final _GetStaticBooleanField = ptr.ref.GetStaticBooleanField
       .asFunction<JniResult Function(JClassPtr clazz, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   bool GetStaticBooleanField(JClassPtr clazz, JFieldIDPtr fieldID) =>
       _GetStaticBooleanField(clazz, fieldID).boolean;
 
   late final _GetStaticByteField = ptr.ref.GetStaticByteField
       .asFunction<JniResult Function(JClassPtr clazz, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   DartJByteMarker GetStaticByteField(JClassPtr clazz, JFieldIDPtr fieldID) =>
       _GetStaticByteField(clazz, fieldID).byte;
 
   late final _GetStaticCharField = ptr.ref.GetStaticCharField
       .asFunction<JniResult Function(JClassPtr clazz, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   DartJCharMarker GetStaticCharField(JClassPtr clazz, JFieldIDPtr fieldID) =>
       _GetStaticCharField(clazz, fieldID).char;
 
   late final _GetStaticShortField = ptr.ref.GetStaticShortField
       .asFunction<JniResult Function(JClassPtr clazz, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   DartJShortMarker GetStaticShortField(JClassPtr clazz, JFieldIDPtr fieldID) =>
       _GetStaticShortField(clazz, fieldID).short;
 
   late final _GetStaticIntField = ptr.ref.GetStaticIntField
       .asFunction<JniResult Function(JClassPtr clazz, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   DartJIntMarker GetStaticIntField(JClassPtr clazz, JFieldIDPtr fieldID) =>
       _GetStaticIntField(clazz, fieldID).integer;
 
   late final _GetStaticLongField = ptr.ref.GetStaticLongField
       .asFunction<JniResult Function(JClassPtr clazz, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   DartJLongMarker GetStaticLongField(JClassPtr clazz, JFieldIDPtr fieldID) =>
       _GetStaticLongField(clazz, fieldID).long;
 
   late final _GetStaticFloatField = ptr.ref.GetStaticFloatField
       .asFunction<JniResult Function(JClassPtr clazz, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   DartJFloatMarker GetStaticFloatField(JClassPtr clazz, JFieldIDPtr fieldID) =>
       _GetStaticFloatField(clazz, fieldID).float;
 
   late final _GetStaticDoubleField = ptr.ref.GetStaticDoubleField
       .asFunction<JniResult Function(JClassPtr clazz, JFieldIDPtr fieldID)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   DartJDoubleMarker GetStaticDoubleField(
-          JClassPtr clazz, JFieldIDPtr fieldID) =>
+    JClassPtr clazz,
+    JFieldIDPtr fieldID,
+  ) =>
       _GetStaticDoubleField(clazz, fieldID).doubleFloat;
 
   late final _SetStaticObjectField = ptr.ref.SetStaticObjectField.asFunction<
       JThrowablePtr Function(
-          JClassPtr clazz, JFieldIDPtr fieldID, JObjectPtr val)>(isLeaf: true);
+        JClassPtr clazz,
+        JFieldIDPtr fieldID,
+        JObjectPtr val,
+      )>(isLeaf: true);
 
   void SetStaticObjectField(
-          JClassPtr clazz, JFieldIDPtr fieldID, JObjectPtr val) =>
+    JClassPtr clazz,
+    JFieldIDPtr fieldID,
+    JObjectPtr val,
+  ) =>
       _SetStaticObjectField(clazz, fieldID, val).check();
 
   late final _SetStaticBooleanField = ptr.ref.SetStaticBooleanField.asFunction<
-      JThrowablePtr Function(JClassPtr clazz, JFieldIDPtr fieldID,
-          DartJBooleanMarker val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JClassPtr clazz,
+        JFieldIDPtr fieldID,
+        DartJBooleanMarker val,
+      )>(isLeaf: true);
 
   void SetStaticBooleanField(
-          JClassPtr clazz, JFieldIDPtr fieldID, DartJBooleanMarker val) =>
+    JClassPtr clazz,
+    JFieldIDPtr fieldID,
+    DartJBooleanMarker val,
+  ) =>
       _SetStaticBooleanField(clazz, fieldID, val).check();
 
   late final _SetStaticByteField = ptr.ref.SetStaticByteField.asFunction<
-      JThrowablePtr Function(JClassPtr clazz, JFieldIDPtr fieldID,
-          DartJByteMarker val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JClassPtr clazz,
+        JFieldIDPtr fieldID,
+        DartJByteMarker val,
+      )>(isLeaf: true);
 
   void SetStaticByteField(
-          JClassPtr clazz, JFieldIDPtr fieldID, DartJByteMarker val) =>
+    JClassPtr clazz,
+    JFieldIDPtr fieldID,
+    DartJByteMarker val,
+  ) =>
       _SetStaticByteField(clazz, fieldID, val).check();
 
   late final _SetStaticCharField = ptr.ref.SetStaticCharField.asFunction<
-      JThrowablePtr Function(JClassPtr clazz, JFieldIDPtr fieldID,
-          DartJCharMarker val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JClassPtr clazz,
+        JFieldIDPtr fieldID,
+        DartJCharMarker val,
+      )>(isLeaf: true);
 
   void SetStaticCharField(
-          JClassPtr clazz, JFieldIDPtr fieldID, DartJCharMarker val) =>
+    JClassPtr clazz,
+    JFieldIDPtr fieldID,
+    DartJCharMarker val,
+  ) =>
       _SetStaticCharField(clazz, fieldID, val).check();
 
   late final _SetStaticShortField = ptr.ref.SetStaticShortField.asFunction<
-      JThrowablePtr Function(JClassPtr clazz, JFieldIDPtr fieldID,
-          DartJShortMarker val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JClassPtr clazz,
+        JFieldIDPtr fieldID,
+        DartJShortMarker val,
+      )>(isLeaf: true);
 
   void SetStaticShortField(
-          JClassPtr clazz, JFieldIDPtr fieldID, DartJShortMarker val) =>
+    JClassPtr clazz,
+    JFieldIDPtr fieldID,
+    DartJShortMarker val,
+  ) =>
       _SetStaticShortField(clazz, fieldID, val).check();
 
   late final _SetStaticIntField = ptr.ref.SetStaticIntField.asFunction<
-      JThrowablePtr Function(JClassPtr clazz, JFieldIDPtr fieldID,
-          DartJIntMarker val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JClassPtr clazz,
+        JFieldIDPtr fieldID,
+        DartJIntMarker val,
+      )>(isLeaf: true);
 
   void SetStaticIntField(
-          JClassPtr clazz, JFieldIDPtr fieldID, DartJIntMarker val) =>
+    JClassPtr clazz,
+    JFieldIDPtr fieldID,
+    DartJIntMarker val,
+  ) =>
       _SetStaticIntField(clazz, fieldID, val).check();
 
   late final _SetStaticLongField = ptr.ref.SetStaticLongField.asFunction<
-      JThrowablePtr Function(JClassPtr clazz, JFieldIDPtr fieldID,
-          DartJLongMarker val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JClassPtr clazz,
+        JFieldIDPtr fieldID,
+        DartJLongMarker val,
+      )>(isLeaf: true);
 
   void SetStaticLongField(
-          JClassPtr clazz, JFieldIDPtr fieldID, DartJLongMarker val) =>
+    JClassPtr clazz,
+    JFieldIDPtr fieldID,
+    DartJLongMarker val,
+  ) =>
       _SetStaticLongField(clazz, fieldID, val).check();
 
   late final _SetStaticFloatField = ptr.ref.SetStaticFloatField.asFunction<
-      JThrowablePtr Function(JClassPtr clazz, JFieldIDPtr fieldID,
-          DartJFloatMarker val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JClassPtr clazz,
+        JFieldIDPtr fieldID,
+        DartJFloatMarker val,
+      )>(isLeaf: true);
 
   void SetStaticFloatField(
-          JClassPtr clazz, JFieldIDPtr fieldID, DartJFloatMarker val) =>
+    JClassPtr clazz,
+    JFieldIDPtr fieldID,
+    DartJFloatMarker val,
+  ) =>
       _SetStaticFloatField(clazz, fieldID, val).check();
 
   late final _SetStaticDoubleField = ptr.ref.SetStaticDoubleField.asFunction<
-      JThrowablePtr Function(JClassPtr clazz, JFieldIDPtr fieldID,
-          DartJDoubleMarker val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JClassPtr clazz,
+        JFieldIDPtr fieldID,
+        DartJDoubleMarker val,
+      )>(isLeaf: true);
 
   void SetStaticDoubleField(
-          JClassPtr clazz, JFieldIDPtr fieldID, DartJDoubleMarker val) =>
+    JClassPtr clazz,
+    JFieldIDPtr fieldID,
+    DartJDoubleMarker val,
+  ) =>
       _SetStaticDoubleField(clazz, fieldID, val).check();
 
   late final _NewString = ptr.ref.NewString.asFunction<
       JniResult Function(
-          ffi.Pointer<JCharMarker> unicodeChars, DartJIntMarker len)>();
+        ffi.Pointer<JCharMarker> unicodeChars,
+        DartJIntMarker len,
+      )>();
 
   JStringPtr NewString(
-          ffi.Pointer<JCharMarker> unicodeChars, DartJIntMarker len) =>
+    ffi.Pointer<JCharMarker> unicodeChars,
+    DartJIntMarker len,
+  ) =>
       _NewString(unicodeChars, len).objectPointer;
 
   late final _GetStringLength = ptr.ref.GetStringLength
@@ -996,15 +1436,21 @@ class GlobalJniEnv {
 
   late final _GetStringChars = ptr.ref.GetStringChars.asFunction<
       JniPointerResult Function(
-          JStringPtr string, ffi.Pointer<JBooleanMarker> isCopy)>();
+        JStringPtr string,
+        ffi.Pointer<JBooleanMarker> isCopy,
+      )>();
 
   ffi.Pointer<JCharMarker> GetStringChars(
-          JStringPtr string, ffi.Pointer<JBooleanMarker> isCopy) =>
+    JStringPtr string,
+    ffi.Pointer<JBooleanMarker> isCopy,
+  ) =>
       _GetStringChars(string, isCopy).getPointer<JCharMarker>();
 
   late final _ReleaseStringChars = ptr.ref.ReleaseStringChars.asFunction<
       JThrowablePtr Function(
-          JStringPtr string, ffi.Pointer<JCharMarker> isCopy)>();
+        JStringPtr string,
+        ffi.Pointer<JCharMarker> isCopy,
+      )>();
 
   void ReleaseStringChars(JStringPtr string, ffi.Pointer<JCharMarker> isCopy) =>
       _ReleaseStringChars(string, isCopy).check();
@@ -1023,10 +1469,14 @@ class GlobalJniEnv {
 
   late final _GetStringUTFChars = ptr.ref.GetStringUTFChars.asFunction<
       JniPointerResult Function(
-          JStringPtr string, ffi.Pointer<JBooleanMarker> isCopy)>();
+        JStringPtr string,
+        ffi.Pointer<JBooleanMarker> isCopy,
+      )>();
 
   ffi.Pointer<ffi.Char> GetStringUTFChars(
-          JStringPtr string, ffi.Pointer<JBooleanMarker> isCopy) =>
+    JStringPtr string,
+    ffi.Pointer<JBooleanMarker> isCopy,
+  ) =>
       _GetStringUTFChars(string, isCopy).getPointer<ffi.Char>();
 
   late final _ReleaseStringUTFChars = ptr.ref.ReleaseStringUTFChars.asFunction<
@@ -1042,11 +1492,17 @@ class GlobalJniEnv {
       _GetArrayLength(array).integer;
 
   late final _NewObjectArray = ptr.ref.NewObjectArray.asFunction<
-      JniResult Function(DartJIntMarker length, JClassPtr elementClass,
-          JObjectPtr initialElement)>();
+      JniResult Function(
+        DartJIntMarker length,
+        JClassPtr elementClass,
+        JObjectPtr initialElement,
+      )>();
 
-  JObjectArrayPtr NewObjectArray(DartJIntMarker length, JClassPtr elementClass,
-          JObjectPtr initialElement) =>
+  JObjectArrayPtr NewObjectArray(
+    DartJIntMarker length,
+    JClassPtr elementClass,
+    JObjectPtr initialElement,
+  ) =>
       _NewObjectArray(length, elementClass, initialElement).objectPointer;
 
   late final _GetObjectArrayElement = ptr.ref.GetObjectArrayElement.asFunction<
@@ -1054,15 +1510,23 @@ class GlobalJniEnv {
           JObjectArrayPtr array, DartJIntMarker index)>(isLeaf: true);
 
   JObjectPtr GetObjectArrayElement(
-          JObjectArrayPtr array, DartJIntMarker index) =>
+    JObjectArrayPtr array,
+    DartJIntMarker index,
+  ) =>
       _GetObjectArrayElement(array, index).objectPointer;
 
   late final _SetObjectArrayElement = ptr.ref.SetObjectArrayElement.asFunction<
-      JThrowablePtr Function(JObjectArrayPtr array, DartJIntMarker index,
-          JObjectPtr val)>(isLeaf: true);
+      JThrowablePtr Function(
+        JObjectArrayPtr array,
+        DartJIntMarker index,
+        JObjectPtr val,
+      )>(isLeaf: true);
 
   void SetObjectArrayElement(
-          JObjectArrayPtr array, DartJIntMarker index, JObjectPtr val) =>
+    JObjectArrayPtr array,
+    DartJIntMarker index,
+    JObjectPtr val,
+  ) =>
       _SetObjectArrayElement(array, index, val).check();
 
   late final _NewBooleanArray = ptr.ref.NewBooleanArray
@@ -1113,278 +1577,492 @@ class GlobalJniEnv {
   JDoubleArrayPtr NewDoubleArray(DartJIntMarker length) =>
       _NewDoubleArray(length).objectPointer;
 
-  late final _GetBooleanArrayElements = ptr.ref.GetBooleanArrayElements
-      .asFunction<
+  late final _GetBooleanArrayElements =
+      ptr.ref.GetBooleanArrayElements.asFunction<
           JniPointerResult Function(
-              JBooleanArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>();
+            JBooleanArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>();
 
   ffi.Pointer<JBooleanMarker> GetBooleanArrayElements(
-          JBooleanArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy) =>
+    JBooleanArrayPtr array,
+    ffi.Pointer<JBooleanMarker> isCopy,
+  ) =>
       _GetBooleanArrayElements(array, isCopy).getPointer<JBooleanMarker>();
 
   late final _GetByteArrayElements = ptr.ref.GetByteArrayElements.asFunction<
       JniPointerResult Function(
-          JByteArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>();
+        JByteArrayPtr array,
+        ffi.Pointer<JBooleanMarker> isCopy,
+      )>();
 
   ffi.Pointer<JByteMarker> GetByteArrayElements(
-          JByteArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy) =>
+    JByteArrayPtr array,
+    ffi.Pointer<JBooleanMarker> isCopy,
+  ) =>
       _GetByteArrayElements(array, isCopy).getPointer<JByteMarker>();
 
   late final _GetCharArrayElements = ptr.ref.GetCharArrayElements.asFunction<
       JniPointerResult Function(
-          JCharArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>();
+        JCharArrayPtr array,
+        ffi.Pointer<JBooleanMarker> isCopy,
+      )>();
 
   ffi.Pointer<JCharMarker> GetCharArrayElements(
-          JCharArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy) =>
+    JCharArrayPtr array,
+    ffi.Pointer<JBooleanMarker> isCopy,
+  ) =>
       _GetCharArrayElements(array, isCopy).getPointer<JCharMarker>();
 
   late final _GetShortArrayElements = ptr.ref.GetShortArrayElements.asFunction<
       JniPointerResult Function(
-          JShortArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>();
+        JShortArrayPtr array,
+        ffi.Pointer<JBooleanMarker> isCopy,
+      )>();
 
   ffi.Pointer<JShortMarker> GetShortArrayElements(
-          JShortArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy) =>
+    JShortArrayPtr array,
+    ffi.Pointer<JBooleanMarker> isCopy,
+  ) =>
       _GetShortArrayElements(array, isCopy).getPointer<JShortMarker>();
 
   late final _GetIntArrayElements = ptr.ref.GetIntArrayElements.asFunction<
       JniPointerResult Function(
-          JIntArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>();
+        JIntArrayPtr array,
+        ffi.Pointer<JBooleanMarker> isCopy,
+      )>();
 
   ffi.Pointer<JIntMarker> GetIntArrayElements(
-          JIntArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy) =>
+    JIntArrayPtr array,
+    ffi.Pointer<JBooleanMarker> isCopy,
+  ) =>
       _GetIntArrayElements(array, isCopy).getPointer<JIntMarker>();
 
   late final _GetLongArrayElements = ptr.ref.GetLongArrayElements.asFunction<
       JniPointerResult Function(
-          JLongArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>();
+        JLongArrayPtr array,
+        ffi.Pointer<JBooleanMarker> isCopy,
+      )>();
 
   ffi.Pointer<JLongMarker> GetLongArrayElements(
-          JLongArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy) =>
+    JLongArrayPtr array,
+    ffi.Pointer<JBooleanMarker> isCopy,
+  ) =>
       _GetLongArrayElements(array, isCopy).getPointer<JLongMarker>();
 
   late final _GetFloatArrayElements = ptr.ref.GetFloatArrayElements.asFunction<
       JniPointerResult Function(
-          JFloatArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>();
+        JFloatArrayPtr array,
+        ffi.Pointer<JBooleanMarker> isCopy,
+      )>();
 
   ffi.Pointer<JFloatMarker> GetFloatArrayElements(
-          JFloatArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy) =>
+    JFloatArrayPtr array,
+    ffi.Pointer<JBooleanMarker> isCopy,
+  ) =>
       _GetFloatArrayElements(array, isCopy).getPointer<JFloatMarker>();
 
-  late final _GetDoubleArrayElements = ptr.ref.GetDoubleArrayElements
-      .asFunction<
+  late final _GetDoubleArrayElements =
+      ptr.ref.GetDoubleArrayElements.asFunction<
           JniPointerResult Function(
-              JDoubleArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>();
+            JDoubleArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>();
 
   ffi.Pointer<JDoubleMarker> GetDoubleArrayElements(
-          JDoubleArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy) =>
+    JDoubleArrayPtr array,
+    ffi.Pointer<JBooleanMarker> isCopy,
+  ) =>
       _GetDoubleArrayElements(array, isCopy).getPointer<JDoubleMarker>();
 
-  late final _ReleaseBooleanArrayElements = ptr.ref.ReleaseBooleanArrayElements
-      .asFunction<
-          JThrowablePtr Function(JBooleanArrayPtr array,
-              ffi.Pointer<JBooleanMarker> elems, DartJIntMarker mode)>();
+  late final _ReleaseBooleanArrayElements =
+      ptr.ref.ReleaseBooleanArrayElements.asFunction<
+          JThrowablePtr Function(
+            JBooleanArrayPtr array,
+            ffi.Pointer<JBooleanMarker> elems,
+            DartJIntMarker mode,
+          )>();
 
-  void ReleaseBooleanArrayElements(JBooleanArrayPtr array,
-          ffi.Pointer<JBooleanMarker> elems, DartJIntMarker mode) =>
+  void ReleaseBooleanArrayElements(
+    JBooleanArrayPtr array,
+    ffi.Pointer<JBooleanMarker> elems,
+    DartJIntMarker mode,
+  ) =>
       _ReleaseBooleanArrayElements(array, elems, mode).check();
 
-  late final _ReleaseByteArrayElements = ptr.ref.ReleaseByteArrayElements
-      .asFunction<
-          JThrowablePtr Function(JByteArrayPtr array,
-              ffi.Pointer<JByteMarker> elems, DartJIntMarker mode)>();
+  late final _ReleaseByteArrayElements =
+      ptr.ref.ReleaseByteArrayElements.asFunction<
+          JThrowablePtr Function(
+            JByteArrayPtr array,
+            ffi.Pointer<JByteMarker> elems,
+            DartJIntMarker mode,
+          )>();
 
-  void ReleaseByteArrayElements(JByteArrayPtr array,
-          ffi.Pointer<JByteMarker> elems, DartJIntMarker mode) =>
+  void ReleaseByteArrayElements(
+    JByteArrayPtr array,
+    ffi.Pointer<JByteMarker> elems,
+    DartJIntMarker mode,
+  ) =>
       _ReleaseByteArrayElements(array, elems, mode).check();
 
-  late final _ReleaseCharArrayElements = ptr.ref.ReleaseCharArrayElements
-      .asFunction<
-          JThrowablePtr Function(JCharArrayPtr array,
-              ffi.Pointer<JCharMarker> elems, DartJIntMarker mode)>();
+  late final _ReleaseCharArrayElements =
+      ptr.ref.ReleaseCharArrayElements.asFunction<
+          JThrowablePtr Function(
+            JCharArrayPtr array,
+            ffi.Pointer<JCharMarker> elems,
+            DartJIntMarker mode,
+          )>();
 
-  void ReleaseCharArrayElements(JCharArrayPtr array,
-          ffi.Pointer<JCharMarker> elems, DartJIntMarker mode) =>
+  void ReleaseCharArrayElements(
+    JCharArrayPtr array,
+    ffi.Pointer<JCharMarker> elems,
+    DartJIntMarker mode,
+  ) =>
       _ReleaseCharArrayElements(array, elems, mode).check();
 
-  late final _ReleaseShortArrayElements = ptr.ref.ReleaseShortArrayElements
-      .asFunction<
-          JThrowablePtr Function(JShortArrayPtr array,
-              ffi.Pointer<JShortMarker> elems, DartJIntMarker mode)>();
+  late final _ReleaseShortArrayElements =
+      ptr.ref.ReleaseShortArrayElements.asFunction<
+          JThrowablePtr Function(
+            JShortArrayPtr array,
+            ffi.Pointer<JShortMarker> elems,
+            DartJIntMarker mode,
+          )>();
 
-  void ReleaseShortArrayElements(JShortArrayPtr array,
-          ffi.Pointer<JShortMarker> elems, DartJIntMarker mode) =>
+  void ReleaseShortArrayElements(
+    JShortArrayPtr array,
+    ffi.Pointer<JShortMarker> elems,
+    DartJIntMarker mode,
+  ) =>
       _ReleaseShortArrayElements(array, elems, mode).check();
 
-  late final _ReleaseIntArrayElements = ptr.ref.ReleaseIntArrayElements
-      .asFunction<
-          JThrowablePtr Function(JIntArrayPtr array,
-              ffi.Pointer<JIntMarker> elems, DartJIntMarker mode)>();
+  late final _ReleaseIntArrayElements =
+      ptr.ref.ReleaseIntArrayElements.asFunction<
+          JThrowablePtr Function(
+            JIntArrayPtr array,
+            ffi.Pointer<JIntMarker> elems,
+            DartJIntMarker mode,
+          )>();
 
-  void ReleaseIntArrayElements(JIntArrayPtr array,
-          ffi.Pointer<JIntMarker> elems, DartJIntMarker mode) =>
+  void ReleaseIntArrayElements(
+    JIntArrayPtr array,
+    ffi.Pointer<JIntMarker> elems,
+    DartJIntMarker mode,
+  ) =>
       _ReleaseIntArrayElements(array, elems, mode).check();
 
-  late final _ReleaseLongArrayElements = ptr.ref.ReleaseLongArrayElements
-      .asFunction<
-          JThrowablePtr Function(JLongArrayPtr array,
-              ffi.Pointer<JLongMarker> elems, DartJIntMarker mode)>();
+  late final _ReleaseLongArrayElements =
+      ptr.ref.ReleaseLongArrayElements.asFunction<
+          JThrowablePtr Function(
+            JLongArrayPtr array,
+            ffi.Pointer<JLongMarker> elems,
+            DartJIntMarker mode,
+          )>();
 
-  void ReleaseLongArrayElements(JLongArrayPtr array,
-          ffi.Pointer<JLongMarker> elems, DartJIntMarker mode) =>
+  void ReleaseLongArrayElements(
+    JLongArrayPtr array,
+    ffi.Pointer<JLongMarker> elems,
+    DartJIntMarker mode,
+  ) =>
       _ReleaseLongArrayElements(array, elems, mode).check();
 
-  late final _ReleaseFloatArrayElements = ptr.ref.ReleaseFloatArrayElements
-      .asFunction<
-          JThrowablePtr Function(JFloatArrayPtr array,
-              ffi.Pointer<JFloatMarker> elems, DartJIntMarker mode)>();
+  late final _ReleaseFloatArrayElements =
+      ptr.ref.ReleaseFloatArrayElements.asFunction<
+          JThrowablePtr Function(
+            JFloatArrayPtr array,
+            ffi.Pointer<JFloatMarker> elems,
+            DartJIntMarker mode,
+          )>();
 
-  void ReleaseFloatArrayElements(JFloatArrayPtr array,
-          ffi.Pointer<JFloatMarker> elems, DartJIntMarker mode) =>
+  void ReleaseFloatArrayElements(
+    JFloatArrayPtr array,
+    ffi.Pointer<JFloatMarker> elems,
+    DartJIntMarker mode,
+  ) =>
       _ReleaseFloatArrayElements(array, elems, mode).check();
 
-  late final _ReleaseDoubleArrayElements = ptr.ref.ReleaseDoubleArrayElements
-      .asFunction<
-          JThrowablePtr Function(JDoubleArrayPtr array,
-              ffi.Pointer<JDoubleMarker> elems, DartJIntMarker mode)>();
+  late final _ReleaseDoubleArrayElements =
+      ptr.ref.ReleaseDoubleArrayElements.asFunction<
+          JThrowablePtr Function(
+            JDoubleArrayPtr array,
+            ffi.Pointer<JDoubleMarker> elems,
+            DartJIntMarker mode,
+          )>();
 
-  void ReleaseDoubleArrayElements(JDoubleArrayPtr array,
-          ffi.Pointer<JDoubleMarker> elems, DartJIntMarker mode) =>
+  void ReleaseDoubleArrayElements(
+    JDoubleArrayPtr array,
+    ffi.Pointer<JDoubleMarker> elems,
+    DartJIntMarker mode,
+  ) =>
       _ReleaseDoubleArrayElements(array, elems, mode).check();
 
   late final _GetBooleanArrayRegion = ptr.ref.GetBooleanArrayRegion.asFunction<
-      JThrowablePtr Function(JBooleanArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JBooleanMarker> buf)>();
+      JThrowablePtr Function(
+        JBooleanArrayPtr array,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JBooleanMarker> buf,
+      )>();
 
-  void GetBooleanArrayRegion(JBooleanArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JBooleanMarker> buf) =>
+  void GetBooleanArrayRegion(
+    JBooleanArrayPtr array,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JBooleanMarker> buf,
+  ) =>
       _GetBooleanArrayRegion(array, start, len, buf).check();
 
   late final _GetByteArrayRegion = ptr.ref.GetByteArrayRegion.asFunction<
-      JThrowablePtr Function(JByteArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JByteMarker> buf)>();
+      JThrowablePtr Function(
+        JByteArrayPtr array,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JByteMarker> buf,
+      )>();
 
-  void GetByteArrayRegion(JByteArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JByteMarker> buf) =>
+  void GetByteArrayRegion(
+    JByteArrayPtr array,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JByteMarker> buf,
+  ) =>
       _GetByteArrayRegion(array, start, len, buf).check();
 
   late final _GetCharArrayRegion = ptr.ref.GetCharArrayRegion.asFunction<
-      JThrowablePtr Function(JCharArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JCharMarker> buf)>();
+      JThrowablePtr Function(
+        JCharArrayPtr array,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JCharMarker> buf,
+      )>();
 
-  void GetCharArrayRegion(JCharArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JCharMarker> buf) =>
+  void GetCharArrayRegion(
+    JCharArrayPtr array,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JCharMarker> buf,
+  ) =>
       _GetCharArrayRegion(array, start, len, buf).check();
 
   late final _GetShortArrayRegion = ptr.ref.GetShortArrayRegion.asFunction<
-      JThrowablePtr Function(JShortArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JShortMarker> buf)>();
+      JThrowablePtr Function(
+        JShortArrayPtr array,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JShortMarker> buf,
+      )>();
 
-  void GetShortArrayRegion(JShortArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JShortMarker> buf) =>
+  void GetShortArrayRegion(
+    JShortArrayPtr array,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JShortMarker> buf,
+  ) =>
       _GetShortArrayRegion(array, start, len, buf).check();
 
   late final _GetIntArrayRegion = ptr.ref.GetIntArrayRegion.asFunction<
-      JThrowablePtr Function(JIntArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JIntMarker> buf)>();
+      JThrowablePtr Function(
+        JIntArrayPtr array,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JIntMarker> buf,
+      )>();
 
-  void GetIntArrayRegion(JIntArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JIntMarker> buf) =>
+  void GetIntArrayRegion(
+    JIntArrayPtr array,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JIntMarker> buf,
+  ) =>
       _GetIntArrayRegion(array, start, len, buf).check();
 
   late final _GetLongArrayRegion = ptr.ref.GetLongArrayRegion.asFunction<
-      JThrowablePtr Function(JLongArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JLongMarker> buf)>();
+      JThrowablePtr Function(
+        JLongArrayPtr array,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JLongMarker> buf,
+      )>();
 
-  void GetLongArrayRegion(JLongArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JLongMarker> buf) =>
+  void GetLongArrayRegion(
+    JLongArrayPtr array,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JLongMarker> buf,
+  ) =>
       _GetLongArrayRegion(array, start, len, buf).check();
 
   late final _GetFloatArrayRegion = ptr.ref.GetFloatArrayRegion.asFunction<
-      JThrowablePtr Function(JFloatArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JFloatMarker> buf)>();
+      JThrowablePtr Function(
+        JFloatArrayPtr array,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JFloatMarker> buf,
+      )>();
 
-  void GetFloatArrayRegion(JFloatArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JFloatMarker> buf) =>
+  void GetFloatArrayRegion(
+    JFloatArrayPtr array,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JFloatMarker> buf,
+  ) =>
       _GetFloatArrayRegion(array, start, len, buf).check();
 
   late final _GetDoubleArrayRegion = ptr.ref.GetDoubleArrayRegion.asFunction<
-      JThrowablePtr Function(JDoubleArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JDoubleMarker> buf)>();
+      JThrowablePtr Function(
+        JDoubleArrayPtr array,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JDoubleMarker> buf,
+      )>();
 
-  void GetDoubleArrayRegion(JDoubleArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JDoubleMarker> buf) =>
+  void GetDoubleArrayRegion(
+    JDoubleArrayPtr array,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JDoubleMarker> buf,
+  ) =>
       _GetDoubleArrayRegion(array, start, len, buf).check();
 
   late final _SetBooleanArrayRegion = ptr.ref.SetBooleanArrayRegion.asFunction<
-      JThrowablePtr Function(JBooleanArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JBooleanMarker> buf)>();
+      JThrowablePtr Function(
+        JBooleanArrayPtr array,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JBooleanMarker> buf,
+      )>();
 
-  void SetBooleanArrayRegion(JBooleanArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JBooleanMarker> buf) =>
+  void SetBooleanArrayRegion(
+    JBooleanArrayPtr array,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JBooleanMarker> buf,
+  ) =>
       _SetBooleanArrayRegion(array, start, len, buf).check();
 
   late final _SetByteArrayRegion = ptr.ref.SetByteArrayRegion.asFunction<
-      JThrowablePtr Function(JByteArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JByteMarker> buf)>();
+      JThrowablePtr Function(
+        JByteArrayPtr array,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JByteMarker> buf,
+      )>();
 
-  void SetByteArrayRegion(JByteArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JByteMarker> buf) =>
+  void SetByteArrayRegion(
+    JByteArrayPtr array,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JByteMarker> buf,
+  ) =>
       _SetByteArrayRegion(array, start, len, buf).check();
 
   late final _SetCharArrayRegion = ptr.ref.SetCharArrayRegion.asFunction<
-      JThrowablePtr Function(JCharArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JCharMarker> buf)>();
+      JThrowablePtr Function(
+        JCharArrayPtr array,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JCharMarker> buf,
+      )>();
 
-  void SetCharArrayRegion(JCharArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JCharMarker> buf) =>
+  void SetCharArrayRegion(
+    JCharArrayPtr array,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JCharMarker> buf,
+  ) =>
       _SetCharArrayRegion(array, start, len, buf).check();
 
   late final _SetShortArrayRegion = ptr.ref.SetShortArrayRegion.asFunction<
-      JThrowablePtr Function(JShortArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JShortMarker> buf)>();
+      JThrowablePtr Function(
+        JShortArrayPtr array,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JShortMarker> buf,
+      )>();
 
-  void SetShortArrayRegion(JShortArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JShortMarker> buf) =>
+  void SetShortArrayRegion(
+    JShortArrayPtr array,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JShortMarker> buf,
+  ) =>
       _SetShortArrayRegion(array, start, len, buf).check();
 
   late final _SetIntArrayRegion = ptr.ref.SetIntArrayRegion.asFunction<
-      JThrowablePtr Function(JIntArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JIntMarker> buf)>();
+      JThrowablePtr Function(
+        JIntArrayPtr array,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JIntMarker> buf,
+      )>();
 
-  void SetIntArrayRegion(JIntArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JIntMarker> buf) =>
+  void SetIntArrayRegion(
+    JIntArrayPtr array,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JIntMarker> buf,
+  ) =>
       _SetIntArrayRegion(array, start, len, buf).check();
 
   late final _SetLongArrayRegion = ptr.ref.SetLongArrayRegion.asFunction<
-      JThrowablePtr Function(JLongArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JLongMarker> buf)>();
+      JThrowablePtr Function(
+        JLongArrayPtr array,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JLongMarker> buf,
+      )>();
 
-  void SetLongArrayRegion(JLongArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JLongMarker> buf) =>
+  void SetLongArrayRegion(
+    JLongArrayPtr array,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JLongMarker> buf,
+  ) =>
       _SetLongArrayRegion(array, start, len, buf).check();
 
   late final _SetFloatArrayRegion = ptr.ref.SetFloatArrayRegion.asFunction<
-      JThrowablePtr Function(JFloatArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JFloatMarker> buf)>();
+      JThrowablePtr Function(
+        JFloatArrayPtr array,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JFloatMarker> buf,
+      )>();
 
-  void SetFloatArrayRegion(JFloatArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JFloatMarker> buf) =>
+  void SetFloatArrayRegion(
+    JFloatArrayPtr array,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JFloatMarker> buf,
+  ) =>
       _SetFloatArrayRegion(array, start, len, buf).check();
 
   late final _SetDoubleArrayRegion = ptr.ref.SetDoubleArrayRegion.asFunction<
-      JThrowablePtr Function(JDoubleArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JDoubleMarker> buf)>();
+      JThrowablePtr Function(
+        JDoubleArrayPtr array,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JDoubleMarker> buf,
+      )>();
 
-  void SetDoubleArrayRegion(JDoubleArrayPtr array, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JDoubleMarker> buf) =>
+  void SetDoubleArrayRegion(
+    JDoubleArrayPtr array,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JDoubleMarker> buf,
+  ) =>
       _SetDoubleArrayRegion(array, start, len, buf).check();
 
   late final _RegisterNatives = ptr.ref.RegisterNatives.asFunction<
-      JniResult Function(JClassPtr clazz, ffi.Pointer<JNINativeMethod> methods,
-          DartJIntMarker nMethods)>();
+      JniResult Function(
+        JClassPtr clazz,
+        ffi.Pointer<JNINativeMethod> methods,
+        DartJIntMarker nMethods,
+      )>();
 
-  DartJIntMarker RegisterNatives(JClassPtr clazz,
-          ffi.Pointer<JNINativeMethod> methods, DartJIntMarker nMethods) =>
+  DartJIntMarker RegisterNatives(
+    JClassPtr clazz,
+    ffi.Pointer<JNINativeMethod> methods,
+    DartJIntMarker nMethods,
+  ) =>
       _RegisterNatives(clazz, methods, nMethods).integer;
 
   late final _UnregisterNatives = ptr.ref.UnregisterNatives
@@ -1405,51 +2083,82 @@ class GlobalJniEnv {
 
   late final _GetJavaVM = ptr.ref.GetJavaVM
       .asFunction<JniResult Function(ffi.Pointer<ffi.Pointer<JavaVM>> vm)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   DartJIntMarker GetJavaVM(ffi.Pointer<ffi.Pointer<JavaVM>> vm) =>
       _GetJavaVM(vm).integer;
 
   late final _GetStringRegion = ptr.ref.GetStringRegion.asFunction<
-      JThrowablePtr Function(JStringPtr str, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<JCharMarker> buf)>();
+      JThrowablePtr Function(
+        JStringPtr str,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<JCharMarker> buf,
+      )>();
 
-  void GetStringRegion(JStringPtr str, DartJIntMarker start, DartJIntMarker len,
-          ffi.Pointer<JCharMarker> buf) =>
+  void GetStringRegion(
+    JStringPtr str,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<JCharMarker> buf,
+  ) =>
       _GetStringRegion(str, start, len, buf).check();
 
   late final _GetStringUTFRegion = ptr.ref.GetStringUTFRegion.asFunction<
-      JThrowablePtr Function(JStringPtr str, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<ffi.Char> buf)>();
+      JThrowablePtr Function(
+        JStringPtr str,
+        DartJIntMarker start,
+        DartJIntMarker len,
+        ffi.Pointer<ffi.Char> buf,
+      )>();
 
-  void GetStringUTFRegion(JStringPtr str, DartJIntMarker start,
-          DartJIntMarker len, ffi.Pointer<ffi.Char> buf) =>
+  void GetStringUTFRegion(
+    JStringPtr str,
+    DartJIntMarker start,
+    DartJIntMarker len,
+    ffi.Pointer<ffi.Char> buf,
+  ) =>
       _GetStringUTFRegion(str, start, len, buf).check();
 
-  late final _GetPrimitiveArrayCritical = ptr.ref.GetPrimitiveArrayCritical
-      .asFunction<
+  late final _GetPrimitiveArrayCritical =
+      ptr.ref.GetPrimitiveArrayCritical.asFunction<
           JniPointerResult Function(
-              JArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>();
+            JArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>();
 
   ffi.Pointer<ffi.Void> GetPrimitiveArrayCritical(
-          JArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy) =>
+    JArrayPtr array,
+    ffi.Pointer<JBooleanMarker> isCopy,
+  ) =>
       _GetPrimitiveArrayCritical(array, isCopy).getPointer<ffi.Void>();
 
   late final _ReleasePrimitiveArrayCritical =
       ptr.ref.ReleasePrimitiveArrayCritical.asFunction<
-          JThrowablePtr Function(JArrayPtr array, ffi.Pointer<ffi.Void> carray,
-              DartJIntMarker mode)>();
+          JThrowablePtr Function(
+            JArrayPtr array,
+            ffi.Pointer<ffi.Void> carray,
+            DartJIntMarker mode,
+          )>();
 
   void ReleasePrimitiveArrayCritical(
-          JArrayPtr array, ffi.Pointer<ffi.Void> carray, DartJIntMarker mode) =>
+    JArrayPtr array,
+    ffi.Pointer<ffi.Void> carray,
+    DartJIntMarker mode,
+  ) =>
       _ReleasePrimitiveArrayCritical(array, carray, mode).check();
 
   late final _GetStringCritical = ptr.ref.GetStringCritical.asFunction<
       JniPointerResult Function(
-          JStringPtr str, ffi.Pointer<JBooleanMarker> isCopy)>();
+        JStringPtr str,
+        ffi.Pointer<JBooleanMarker> isCopy,
+      )>();
 
   ffi.Pointer<JCharMarker> GetStringCritical(
-          JStringPtr str, ffi.Pointer<JBooleanMarker> isCopy) =>
+    JStringPtr str,
+    ffi.Pointer<JBooleanMarker> isCopy,
+  ) =>
       _GetStringCritical(str, isCopy).getPointer<JCharMarker>();
 
   late final _ReleaseStringCritical = ptr.ref.ReleaseStringCritical.asFunction<
@@ -1477,10 +2186,14 @@ class GlobalJniEnv {
 
   late final _NewDirectByteBuffer = ptr.ref.NewDirectByteBuffer.asFunction<
       JniResult Function(
-          ffi.Pointer<ffi.Void> address, DartJLongMarker capacity)>();
+        ffi.Pointer<ffi.Void> address,
+        DartJLongMarker capacity,
+      )>();
 
   JObjectPtr NewDirectByteBuffer(
-          ffi.Pointer<ffi.Void> address, DartJLongMarker capacity) =>
+    ffi.Pointer<ffi.Void> address,
+    DartJLongMarker capacity,
+  ) =>
       _NewDirectByteBuffer(address, capacity).objectPointer;
 
   late final _GetDirectBufferAddress = ptr.ref.GetDirectBufferAddress
@@ -1503,7 +2216,8 @@ class GlobalJniEnv {
 
   late final _GetBooleanArrayElement = ptr.ref.GetBooleanArrayElement
       .asFunction<JniResult Function(JBooleanArrayPtr array, int index)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   bool GetBooleanArrayElement(JBooleanArrayPtr array, int index) =>
       _GetBooleanArrayElement(array, index).boolean;
@@ -1518,7 +2232,8 @@ class GlobalJniEnv {
 
   late final _GetByteArrayElement = ptr.ref.GetByteArrayElement
       .asFunction<JniResult Function(JByteArrayPtr array, int index)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   int GetByteArrayElement(JByteArrayPtr array, int index) =>
       _GetByteArrayElement(array, index).byte;
@@ -1532,7 +2247,8 @@ class GlobalJniEnv {
 
   late final _GetCharArrayElement = ptr.ref.GetCharArrayElement
       .asFunction<JniResult Function(JCharArrayPtr array, int index)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   int GetCharArrayElement(JCharArrayPtr array, int index) =>
       _GetCharArrayElement(array, index).char;
@@ -1546,7 +2262,8 @@ class GlobalJniEnv {
 
   late final _GetShortArrayElement = ptr.ref.GetShortArrayElement
       .asFunction<JniResult Function(JShortArrayPtr array, int index)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   int GetShortArrayElement(JShortArrayPtr array, int index) =>
       _GetShortArrayElement(array, index).short;
@@ -1560,7 +2277,8 @@ class GlobalJniEnv {
 
   late final _GetIntArrayElement = ptr.ref.GetIntArrayElement
       .asFunction<JniResult Function(JIntArrayPtr array, int index)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   int GetIntArrayElement(JIntArrayPtr array, int index) =>
       _GetIntArrayElement(array, index).integer;
@@ -1574,7 +2292,8 @@ class GlobalJniEnv {
 
   late final _GetLongArrayElement = ptr.ref.GetLongArrayElement
       .asFunction<JniResult Function(JLongArrayPtr array, int index)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   int GetLongArrayElement(JLongArrayPtr array, int index) =>
       _GetLongArrayElement(array, index).long;
@@ -1588,7 +2307,8 @@ class GlobalJniEnv {
 
   late final _GetFloatArrayElement = ptr.ref.GetFloatArrayElement
       .asFunction<JniResult Function(JFloatArrayPtr array, int index)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   double GetFloatArrayElement(JFloatArrayPtr array, int index) =>
       _GetFloatArrayElement(array, index).float;
@@ -1602,7 +2322,8 @@ class GlobalJniEnv {
 
   late final _GetDoubleArrayElement = ptr.ref.GetDoubleArrayElement
       .asFunction<JniResult Function(JDoubleArrayPtr array, int index)>(
-          isLeaf: true);
+    isLeaf: true,
+  );
 
   double GetDoubleArrayElement(JDoubleArrayPtr array, int index) =>
       _GetDoubleArrayElement(array, index).doubleFloat;

--- a/pkgs/jni/lib/src/third_party/jni_bindings_generated.dart
+++ b/pkgs/jni/lib/src/third_party/jni_bindings_generated.dart
@@ -59,23 +59,19 @@ class JniBindings {
 
   /// The symbols are looked up with [lookup].
   JniBindings.fromLookup(
-      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
-          lookup)
-      : _lookup = lookup;
+    ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) lookup,
+  ) : _lookup = lookup;
 
-  late final ffi.Pointer<pthread_key_t> _tlsKey =
-      _lookup<pthread_key_t>('tlsKey');
+  late final ffi.Pointer<pthread_key_t> _tlsKey = _lookup<pthread_key_t>(
+    'tlsKey',
+  );
 
   Dart__darwin_pthread_key_t get tlsKey => _tlsKey.value;
 
   set tlsKey(Dart__darwin_pthread_key_t value) => _tlsKey.value = value;
 
-  JniClassLookupResult FindClass(
-    ffi.Pointer<ffi.Char> name,
-  ) {
-    return _FindClass(
-      name,
-    );
+  JniClassLookupResult FindClass(ffi.Pointer<ffi.Char> name) {
+    return _FindClass(name);
   }
 
   late final _FindClassPtr = _lookup<
@@ -84,49 +80,46 @@ class JniBindings {
   late final _FindClass = _FindClassPtr.asFunction<
       JniClassLookupResult Function(ffi.Pointer<ffi.Char>)>();
 
-  JniExceptionDetails GetExceptionDetails(
-    JThrowablePtr exception,
-  ) {
-    return _GetExceptionDetails(
-      exception,
-    );
+  JniExceptionDetails GetExceptionDetails(JThrowablePtr exception) {
+    return _GetExceptionDetails(exception);
   }
 
   late final _GetExceptionDetailsPtr =
       _lookup<ffi.NativeFunction<JniExceptionDetails Function(JThrowablePtr)>>(
-          'GetExceptionDetails');
+    'GetExceptionDetails',
+  );
   late final _GetExceptionDetails = _GetExceptionDetailsPtr.asFunction<
       JniExceptionDetails Function(JThrowablePtr)>();
 
-  ffi.Pointer<JavaVM1> GetJavaVM() {
+  ffi.Pointer<JavaVM$1> GetJavaVM() {
     return _GetJavaVM();
   }
 
   late final _GetJavaVMPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<JavaVM1> Function()>>('GetJavaVM');
+      _lookup<ffi.NativeFunction<ffi.Pointer<JavaVM$1> Function()>>(
+    'GetJavaVM',
+  );
   late final _GetJavaVM =
-      _GetJavaVMPtr.asFunction<ffi.Pointer<JavaVM1> Function()>();
+      _GetJavaVMPtr.asFunction<ffi.Pointer<JavaVM$1> Function()>();
 
-  ffi.Pointer<JniEnv1> GetJniEnv() {
+  ffi.Pointer<JniEnv$1> GetJniEnv() {
     return _GetJniEnv();
   }
 
   late final _GetJniEnvPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<JniEnv1> Function()>>('GetJniEnv');
+      _lookup<ffi.NativeFunction<ffi.Pointer<JniEnv$1> Function()>>(
+    'GetJniEnv',
+  );
   late final _GetJniEnv =
-      _GetJniEnvPtr.asFunction<ffi.Pointer<JniEnv1> Function()>();
+      _GetJniEnvPtr.asFunction<ffi.Pointer<JniEnv$1> Function()>();
 
   /// Spawn a JVM with given arguments.
   ///
   /// Returns JNI_OK on success, and one of the documented JNI error codes on
   /// failure. It returns DART_JNI_SINGLETON_EXISTS if an attempt to spawn multiple
   /// JVMs is made, even if the underlying API potentially supports multiple VMs.
-  JniErrorCode SpawnJvm(
-    ffi.Pointer<JavaVMInitArgs> args,
-  ) {
-    return JniErrorCode.fromValue(_SpawnJvm(
-      args,
-    ));
+  JniErrorCode SpawnJvm(ffi.Pointer<JavaVMInitArgs> args) {
+    return JniErrorCode.fromValue(_SpawnJvm(args));
   }
 
   late final _SpawnJvmPtr = _lookup<
@@ -157,7 +150,8 @@ class JniBindings {
 
   late final _GetApplicationContextPtr =
       _lookup<ffi.NativeFunction<JObjectPtr Function()>>(
-          'GetApplicationContext');
+    'GetApplicationContext',
+  );
   late final _GetApplicationContext =
       _GetApplicationContextPtr.asFunction<JObjectPtr Function()>();
 
@@ -171,17 +165,14 @@ class JniBindings {
   late final _GetCurrentActivity =
       _GetCurrentActivityPtr.asFunction<JObjectPtr Function()>();
 
-  int InitDartApiDL(
-    ffi.Pointer<ffi.Void> data,
-  ) {
-    return _InitDartApiDL(
-      data,
-    );
+  int InitDartApiDL(ffi.Pointer<ffi.Void> data) {
+    return _InitDartApiDL(data);
   }
 
   late final _InitDartApiDLPtr =
       _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.Pointer<ffi.Void>)>>(
-          'InitDartApiDL');
+    'InitDartApiDL',
+  );
   late final _InitDartApiDL =
       _InitDartApiDLPtr.asFunction<int Function(ffi.Pointer<ffi.Void>)>();
 
@@ -194,14 +185,8 @@ class JniBindings {
   late final _GetCurrentIsolateId =
       _GetCurrentIsolateIdPtr.asFunction<int Function()>();
 
-  JniResult DartException__ctor(
-    JStringPtr message,
-    JThrowablePtr cause,
-  ) {
-    return _DartException__ctor(
-      message,
-      cause,
-    );
+  JniResult DartException__ctor(JStringPtr message, JThrowablePtr cause) {
+    return _DartException__ctor(message, cause);
   }
 
   late final _DartException__ctorPtr = _lookup<
@@ -210,28 +195,19 @@ class JniBindings {
   late final _DartException__ctor = _DartException__ctorPtr.asFunction<
       JniResult Function(JStringPtr, JThrowablePtr)>();
 
-  JniResult PortContinuation__ctor(
-    int j,
-  ) {
-    return _PortContinuation__ctor(
-      j,
-    );
+  JniResult PortContinuation__ctor(int j) {
+    return _PortContinuation__ctor(j);
   }
 
   late final _PortContinuation__ctorPtr =
       _lookup<ffi.NativeFunction<JniResult Function(ffi.Int64)>>(
-          'PortContinuation__ctor');
+    'PortContinuation__ctor',
+  );
   late final _PortContinuation__ctor =
       _PortContinuation__ctorPtr.asFunction<JniResult Function(int)>();
 
-  void resultFor(
-    ffi.Pointer<CallbackResult> result,
-    JObjectPtr object,
-  ) {
-    return _resultFor(
-      result,
-      object,
-    );
+  void resultFor(ffi.Pointer<CallbackResult> result, JObjectPtr object) {
+    return _resultFor(result, object);
   }
 
   late final _resultForPtr = _lookup<
@@ -246,17 +222,16 @@ class JniBindings {
     JObjectPtr reference,
     JObjectRefType refType,
   ) {
-    return _newJObjectFinalizableHandle(
-      object,
-      reference,
-      refType.value,
-    );
+    return _newJObjectFinalizableHandle(object, reference, refType.value);
   }
 
   late final _newJObjectFinalizableHandlePtr = _lookup<
       ffi.NativeFunction<
-          Dart_FinalizableHandle Function(ffi.Handle, JObjectPtr,
-              ffi.UnsignedInt)>>('newJObjectFinalizableHandle');
+          Dart_FinalizableHandle Function(
+            ffi.Handle,
+            JObjectPtr,
+            ffi.UnsignedInt,
+          )>>('newJObjectFinalizableHandle');
   late final _newJObjectFinalizableHandle = _newJObjectFinalizableHandlePtr
       .asFunction<Dart_FinalizableHandle Function(Object, JObjectPtr, int)>();
 
@@ -264,10 +239,7 @@ class JniBindings {
     Object object,
     ffi.Pointer<ffi.Bool> reference,
   ) {
-    return _newBooleanFinalizableHandle(
-      object,
-      reference,
-    );
+    return _newBooleanFinalizableHandle(object, reference);
   }
 
   late final _newBooleanFinalizableHandlePtr = _lookup<
@@ -282,10 +254,7 @@ class JniBindings {
     Dart_FinalizableHandle finalizableHandle,
     Object object,
   ) {
-    return _deleteFinalizableHandle(
-      finalizableHandle,
-      object,
-    );
+    return _deleteFinalizableHandle(finalizableHandle, object);
   }
 
   late final _deleteFinalizableHandlePtr = _lookup<
@@ -301,7 +270,8 @@ class JniBindings {
 
   late final _GetGlobalEnvPtr =
       _lookup<ffi.NativeFunction<ffi.Pointer<GlobalJniEnvStruct> Function()>>(
-          'GetGlobalEnv');
+    'GetGlobalEnv',
+  );
   late final _GetGlobalEnv =
       _GetGlobalEnvPtr.asFunction<ffi.Pointer<GlobalJniEnvStruct> Function()>();
 }
@@ -316,7 +286,7 @@ enum JniBooleanValues {
   static JniBooleanValues fromValue(int value) => switch (value) {
         0 => FALSE,
         1 => TRUE,
-        _ => throw ArgumentError("Unknown value for JniBooleanValues: $value"),
+        _ => throw ArgumentError('Unknown value for JniBooleanValues: $value'),
       };
 }
 
@@ -334,7 +304,7 @@ enum JniVersions {
         65538 => VERSION_1_2,
         65540 => VERSION_1_4,
         65542 => VERSION_1_6,
-        _ => throw ArgumentError("Unknown value for JniVersions: $value"),
+        _ => throw ArgumentError('Unknown value for JniVersions: $value'),
       };
 }
 
@@ -373,7 +343,7 @@ enum JniErrorCode {
         -5 => EEXIST,
         -6 => EINVAL,
         -99 => SINGLETON_EXISTS,
-        _ => throw ArgumentError("Unknown value for JniErrorCode: $value"),
+        _ => throw ArgumentError('Unknown value for JniErrorCode: $value'),
       };
 }
 
@@ -391,7 +361,7 @@ enum JniBufferWriteBack {
         1 => COMMIT,
         2 => ABORT,
         _ =>
-          throw ArgumentError("Unknown value for JniBufferWriteBack: $value"),
+          throw ArgumentError('Unknown value for JniBufferWriteBack: $value'),
       };
 }
 
@@ -464,7 +434,7 @@ enum JniCallType {
         7 => doubleType,
         8 => objectType,
         9 => voidType,
-        _ => throw ArgumentError("Unknown value for JniCallType: $value"),
+        _ => throw ArgumentError('Unknown value for JniCallType: $value'),
       };
 }
 
@@ -600,7 +570,7 @@ enum JObjectRefType {
         1 => JNILocalRefType,
         2 => JNIGlobalRefType,
         3 => JNIWeakGlobalRefType,
-        _ => throw ArgumentError("Unknown value for JObjectRefType: $value"),
+        _ => throw ArgumentError('Unknown value for JObjectRefType: $value'),
       };
 }
 
@@ -621,11 +591,12 @@ final class JNINativeInterface extends ffi.Struct {
   external ffi.Pointer<
       ffi.NativeFunction<
           JClassPtr Function(
-              ffi.Pointer<JniEnv> env,
-              ffi.Pointer<ffi.Char> name,
-              JObjectPtr loader,
-              ffi.Pointer<JByteMarker> buf,
-              JSizeMarker bufLen)>> DefineClass;
+            ffi.Pointer<JniEnv> env,
+            ffi.Pointer<ffi.Char> name,
+            JObjectPtr loader,
+            ffi.Pointer<JByteMarker> buf,
+            JSizeMarker bufLen,
+          )>> DefineClass;
 
   external ffi.Pointer<
       ffi.NativeFunction<
@@ -646,10 +617,11 @@ final class JNINativeInterface extends ffi.Struct {
   external ffi.Pointer<
       ffi.NativeFunction<
           JObjectPtr Function(
-              ffi.Pointer<JniEnv> env,
-              JClassPtr cls,
-              JMethodIDPtr methodId,
-              JBooleanMarker isStatic)>> ToReflectedMethod;
+            ffi.Pointer<JniEnv> env,
+            JClassPtr cls,
+            JMethodIDPtr methodId,
+            JBooleanMarker isStatic,
+          )>> ToReflectedMethod;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -657,16 +629,22 @@ final class JNINativeInterface extends ffi.Struct {
       GetSuperclass;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JBooleanMarker Function(
-                  ffi.Pointer<JniEnv> env, JClassPtr clazz1, JClassPtr clazz2)>>
-      IsAssignableFrom;
+      ffi.NativeFunction<
+          JBooleanMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz1,
+            JClassPtr clazz2,
+          )>> IsAssignableFrom;
 
   /// spec doesn't show jboolean parameter
   external ffi.Pointer<
       ffi.NativeFunction<
-          JObjectPtr Function(ffi.Pointer<JniEnv> env, JClassPtr cls,
-              JFieldIDPtr fieldID, JBooleanMarker isStatic)>> ToReflectedField;
+          JObjectPtr Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr cls,
+            JFieldIDPtr fieldID,
+            JBooleanMarker isStatic,
+          )>> ToReflectedField;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -675,8 +653,11 @@ final class JNINativeInterface extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JIntMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              ffi.Pointer<ffi.Char> message)>> ThrowNew;
+          JIntMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            ffi.Pointer<ffi.Char> message,
+          )>> ThrowNew;
 
   external ffi.Pointer<
           ffi.NativeFunction<JThrowablePtr Function(ffi.Pointer<JniEnv> env)>>
@@ -721,10 +702,12 @@ final class JNINativeInterface extends ffi.Struct {
       DeleteLocalRef;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JBooleanMarker Function(
-                  ffi.Pointer<JniEnv> env, JObjectPtr ref1, JObjectPtr ref2)>>
-      IsSameObject;
+      ffi.NativeFunction<
+          JBooleanMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr ref1,
+            JObjectPtr ref2,
+          )>> IsSameObject;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -744,18 +727,29 @@ final class JNINativeInterface extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JObjectPtr Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JMethodIDPtr methodID)>> NewObject;
+          JObjectPtr Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> NewObject;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JObjectPtr Function(ffi.Pointer<JniEnv>, JClassPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> NewObjectV;
+          JObjectPtr Function(
+            ffi.Pointer<JniEnv>,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> NewObjectV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JObjectPtr Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JMethodIDPtr methodID, ffi.Pointer<JValue> args)>> NewObjectA;
+          JObjectPtr Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> NewObjectA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -763,815 +757,1172 @@ final class JNINativeInterface extends ffi.Struct {
       GetObjectClass;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JBooleanMarker Function(
-                  ffi.Pointer<JniEnv> env, JObjectPtr obj, JClassPtr clazz)>>
-      IsInstanceOf;
+      ffi.NativeFunction<
+          JBooleanMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+          )>> IsInstanceOf;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JMethodIDPtr Function(
-              ffi.Pointer<JniEnv> env,
-              JClassPtr clazz,
-              ffi.Pointer<ffi.Char> name,
-              ffi.Pointer<ffi.Char> sig)>> GetMethodID;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JObjectPtr Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JMethodIDPtr methodID)>> CallObjectMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JObjectPtr Function(ffi.Pointer<JniEnv>, JObjectPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallObjectMethodV;
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            ffi.Pointer<ffi.Char> name,
+            ffi.Pointer<ffi.Char> sig,
+          )>> GetMethodID;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JObjectPtr Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallObjectMethodA;
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+          )>> CallObjectMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JBooleanMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JMethodIDPtr methodID)>> CallBooleanMethod;
+          JObjectPtr Function(
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallObjectMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JBooleanMarker Function(ffi.Pointer<JniEnv>, JObjectPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallBooleanMethodV;
+          JObjectPtr Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallObjectMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JBooleanMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JMethodIDPtr methodId,
-              ffi.Pointer<JValue> args)>> CallBooleanMethodA;
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+          )>> CallBooleanMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JByteMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JMethodIDPtr methodID)>> CallByteMethod;
+          JBooleanMarker Function(
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallBooleanMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JByteMarker Function(ffi.Pointer<JniEnv>, JObjectPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallByteMethodV;
+          JBooleanMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodId,
+            ffi.Pointer<JValue> args,
+          )>> CallBooleanMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JByteMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallByteMethodA;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JCharMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JMethodIDPtr methodID)>> CallCharMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JCharMarker Function(ffi.Pointer<JniEnv>, JObjectPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallCharMethodV;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JCharMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallCharMethodA;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JShortMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JMethodIDPtr methodID)>> CallShortMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JShortMarker Function(ffi.Pointer<JniEnv>, JObjectPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallShortMethodV;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JShortMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallShortMethodA;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JIntMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JMethodIDPtr methodID)>> CallIntMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JIntMarker Function(ffi.Pointer<JniEnv>, JObjectPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallIntMethodV;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JIntMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JMethodIDPtr methodID, ffi.Pointer<JValue> args)>> CallIntMethodA;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JLongMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JMethodIDPtr methodID)>> CallLongMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JLongMarker Function(ffi.Pointer<JniEnv>, JObjectPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallLongMethodV;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JLongMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallLongMethodA;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JFloatMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JMethodIDPtr methodID)>> CallFloatMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JFloatMarker Function(ffi.Pointer<JniEnv>, JObjectPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallFloatMethodV;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JFloatMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallFloatMethodA;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JDoubleMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JMethodIDPtr methodID)>> CallDoubleMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JDoubleMarker Function(ffi.Pointer<JniEnv>, JObjectPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallDoubleMethodV;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JDoubleMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallDoubleMethodA;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JMethodIDPtr methodID)>> CallVoidMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv>, JObjectPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallVoidMethodV;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallVoidMethodA;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JObjectPtr Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallNonvirtualObjectMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JObjectPtr Function(
-              ffi.Pointer<JniEnv>,
-              JObjectPtr,
-              JClassPtr,
-              JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallNonvirtualObjectMethodV;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JObjectPtr Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualObjectMethodA;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JBooleanMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallNonvirtualBooleanMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JBooleanMarker Function(
-              ffi.Pointer<JniEnv>,
-              JObjectPtr,
-              JClassPtr,
-              JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallNonvirtualBooleanMethodV;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JBooleanMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualBooleanMethodA;
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+          )>> CallByteMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JByteMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallNonvirtualByteMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JByteMarker Function(ffi.Pointer<JniEnv>, JObjectPtr, JClassPtr,
-              JMethodIDPtr, ffi.Pointer<ffi.Void>)>> CallNonvirtualByteMethodV;
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallByteMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JByteMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualByteMethodA;
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallByteMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JCharMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallNonvirtualCharMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JCharMarker Function(ffi.Pointer<JniEnv>, JObjectPtr, JClassPtr,
-              JMethodIDPtr, ffi.Pointer<ffi.Void>)>> CallNonvirtualCharMethodV;
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+          )>> CallCharMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JCharMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualCharMethodA;
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallCharMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JCharMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallCharMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JShortMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallNonvirtualShortMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JShortMarker Function(ffi.Pointer<JniEnv>, JObjectPtr, JClassPtr,
-              JMethodIDPtr, ffi.Pointer<ffi.Void>)>> CallNonvirtualShortMethodV;
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+          )>> CallShortMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JShortMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualShortMethodA;
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallShortMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JIntMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JClassPtr clazz, JMethodIDPtr methodID)>> CallNonvirtualIntMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JIntMarker Function(ffi.Pointer<JniEnv>, JObjectPtr, JClassPtr,
-              JMethodIDPtr, ffi.Pointer<ffi.Void>)>> CallNonvirtualIntMethodV;
+          JShortMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallShortMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JIntMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualIntMethodA;
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+          )>> CallIntMethod;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JIntMarker Function(
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallIntMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JIntMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallIntMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JLongMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallNonvirtualLongMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JLongMarker Function(ffi.Pointer<JniEnv>, JObjectPtr, JClassPtr,
-              JMethodIDPtr, ffi.Pointer<ffi.Void>)>> CallNonvirtualLongMethodV;
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+          )>> CallLongMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JLongMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualLongMethodA;
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallLongMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JLongMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallLongMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JFloatMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallNonvirtualFloatMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JFloatMarker Function(ffi.Pointer<JniEnv>, JObjectPtr, JClassPtr,
-              JMethodIDPtr, ffi.Pointer<ffi.Void>)>> CallNonvirtualFloatMethodV;
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+          )>> CallFloatMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JFloatMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualFloatMethodA;
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallFloatMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JFloatMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallFloatMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JDoubleMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallNonvirtualDoubleMethod;
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+          )>> CallDoubleMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JDoubleMarker Function(
-              ffi.Pointer<JniEnv>,
-              JObjectPtr,
-              JClassPtr,
-              JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallNonvirtualDoubleMethodV;
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallDoubleMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JDoubleMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualDoubleMethodA;
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallDoubleMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallNonvirtualVoidMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv>, JObjectPtr, JClassPtr,
-              JMethodIDPtr, ffi.Pointer<ffi.Void>)>> CallNonvirtualVoidMethodV;
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+          )>> CallVoidMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualVoidMethodA;
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallVoidMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallVoidMethodA;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JObjectPtr Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallNonvirtualObjectMethod;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JObjectPtr Function(
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualObjectMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JObjectPtr Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualObjectMethodA;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JBooleanMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallNonvirtualBooleanMethod;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JBooleanMarker Function(
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualBooleanMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JBooleanMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualBooleanMethodA;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JByteMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallNonvirtualByteMethod;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JByteMarker Function(
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualByteMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JByteMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualByteMethodA;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JCharMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallNonvirtualCharMethod;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JCharMarker Function(
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualCharMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JCharMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualCharMethodA;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JShortMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallNonvirtualShortMethod;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JShortMarker Function(
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualShortMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JShortMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualShortMethodA;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JIntMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallNonvirtualIntMethod;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JIntMarker Function(
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualIntMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JIntMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualIntMethodA;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JLongMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallNonvirtualLongMethod;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JLongMarker Function(
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualLongMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JLongMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualLongMethodA;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JFloatMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallNonvirtualFloatMethod;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JFloatMarker Function(
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualFloatMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JFloatMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualFloatMethodA;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JDoubleMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallNonvirtualDoubleMethod;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JDoubleMarker Function(
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualDoubleMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JDoubleMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualDoubleMethodA;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallNonvirtualVoidMethod;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Pointer<JniEnv>,
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualVoidMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualVoidMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JFieldIDPtr Function(
-              ffi.Pointer<JniEnv> env,
-              JClassPtr clazz,
-              ffi.Pointer<ffi.Char> name,
-              ffi.Pointer<ffi.Char> sig)>> GetFieldID;
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            ffi.Pointer<ffi.Char> name,
+            ffi.Pointer<ffi.Char> sig,
+          )>> GetFieldID;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JObjectPtr Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID)>> GetObjectField;
+          JObjectPtr Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+          )>> GetObjectField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JBooleanMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID)>> GetBooleanField;
+          JBooleanMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+          )>> GetBooleanField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JByteMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID)>> GetByteField;
+          JByteMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+          )>> GetByteField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JCharMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID)>> GetCharField;
+          JCharMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+          )>> GetCharField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JShortMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID)>> GetShortField;
+          JShortMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+          )>> GetShortField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JIntMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID)>> GetIntField;
+          JIntMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+          )>> GetIntField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JLongMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID)>> GetLongField;
+          JLongMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+          )>> GetLongField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JFloatMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID)>> GetFloatField;
+          JFloatMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+          )>> GetFloatField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JDoubleMarker Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID)>> GetDoubleField;
+          JDoubleMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+          )>> GetDoubleField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID, JObjectPtr val)>> SetObjectField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JObjectPtr val,
+          )>> SetObjectField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID, JBooleanMarker val)>> SetBooleanField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JBooleanMarker val,
+          )>> SetBooleanField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID, JByteMarker val)>> SetByteField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JByteMarker val,
+          )>> SetByteField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID, JCharMarker val)>> SetCharField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JCharMarker val,
+          )>> SetCharField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID, JShortMarker val)>> SetShortField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JShortMarker val,
+          )>> SetShortField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID, JIntMarker val)>> SetIntField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JIntMarker val,
+          )>> SetIntField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID, JLongMarker val)>> SetLongField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JLongMarker val,
+          )>> SetLongField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID, JFloatMarker val)>> SetFloatField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JFloatMarker val,
+          )>> SetFloatField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JObjectPtr obj,
-              JFieldIDPtr fieldID, JDoubleMarker val)>> SetDoubleField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JDoubleMarker val,
+          )>> SetDoubleField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JMethodIDPtr Function(
-              ffi.Pointer<JniEnv> env,
-              JClassPtr clazz,
-              ffi.Pointer<ffi.Char> name,
-              ffi.Pointer<ffi.Char> sig)>> GetStaticMethodID;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JObjectPtr Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallStaticObjectMethod;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JObjectPtr Function(ffi.Pointer<JniEnv>, JClassPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallStaticObjectMethodV;
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            ffi.Pointer<ffi.Char> name,
+            ffi.Pointer<ffi.Char> sig,
+          )>> GetStaticMethodID;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JObjectPtr Function(
-              ffi.Pointer<JniEnv> env,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticObjectMethodA;
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallStaticObjectMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JBooleanMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallStaticBooleanMethod;
+          JObjectPtr Function(
+            ffi.Pointer<JniEnv>,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallStaticObjectMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JBooleanMarker Function(ffi.Pointer<JniEnv>, JClassPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallStaticBooleanMethodV;
+          JObjectPtr Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticObjectMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JBooleanMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticBooleanMethodA;
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallStaticBooleanMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JByteMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallStaticByteMethod;
+          JBooleanMarker Function(
+            ffi.Pointer<JniEnv>,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallStaticBooleanMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JByteMarker Function(ffi.Pointer<JniEnv>, JClassPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallStaticByteMethodV;
+          JBooleanMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticBooleanMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JByteMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticByteMethodA;
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallStaticByteMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JCharMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallStaticCharMethod;
+          JByteMarker Function(
+            ffi.Pointer<JniEnv>,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallStaticByteMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JCharMarker Function(ffi.Pointer<JniEnv>, JClassPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallStaticCharMethodV;
+          JByteMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticByteMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JCharMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticCharMethodA;
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallStaticCharMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JShortMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallStaticShortMethod;
+          JCharMarker Function(
+            ffi.Pointer<JniEnv>,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallStaticCharMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JShortMarker Function(ffi.Pointer<JniEnv>, JClassPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallStaticShortMethodV;
+          JCharMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticCharMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JShortMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticShortMethodA;
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallStaticShortMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JIntMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallStaticIntMethod;
+          JShortMarker Function(
+            ffi.Pointer<JniEnv>,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallStaticShortMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JIntMarker Function(ffi.Pointer<JniEnv>, JClassPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallStaticIntMethodV;
+          JShortMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticShortMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JIntMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticIntMethodA;
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallStaticIntMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JLongMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallStaticLongMethod;
+          JIntMarker Function(
+            ffi.Pointer<JniEnv>,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallStaticIntMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JLongMarker Function(ffi.Pointer<JniEnv>, JClassPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallStaticLongMethodV;
+          JIntMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticIntMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JLongMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticLongMethodA;
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallStaticLongMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JFloatMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallStaticFloatMethod;
+          JLongMarker Function(
+            ffi.Pointer<JniEnv>,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallStaticLongMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JFloatMarker Function(ffi.Pointer<JniEnv>, JClassPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallStaticFloatMethodV;
+          JLongMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticLongMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JFloatMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticFloatMethodA;
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallStaticFloatMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JDoubleMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallStaticDoubleMethod;
+          JFloatMarker Function(
+            ffi.Pointer<JniEnv>,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallStaticFloatMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JDoubleMarker Function(ffi.Pointer<JniEnv>, JClassPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallStaticDoubleMethodV;
+          JFloatMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticFloatMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JDoubleMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticDoubleMethodA;
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallStaticDoubleMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JMethodIDPtr methodID)>> CallStaticVoidMethod;
+          JDoubleMarker Function(
+            ffi.Pointer<JniEnv>,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallStaticDoubleMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv>, JClassPtr, JMethodIDPtr,
-              ffi.Pointer<ffi.Void>)>> CallStaticVoidMethodV;
+          JDoubleMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticDoubleMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticVoidMethodA;
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallStaticVoidMethod;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Pointer<JniEnv>,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallStaticVoidMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticVoidMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JFieldIDPtr Function(
-              ffi.Pointer<JniEnv> env,
-              JClassPtr clazz,
-              ffi.Pointer<ffi.Char> name,
-              ffi.Pointer<ffi.Char> sig)>> GetStaticFieldID;
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            ffi.Pointer<ffi.Char> name,
+            ffi.Pointer<ffi.Char> sig,
+          )>> GetStaticFieldID;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JObjectPtr Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID)>> GetStaticObjectField;
+          JObjectPtr Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+          )>> GetStaticObjectField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JBooleanMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID)>> GetStaticBooleanField;
+          JBooleanMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+          )>> GetStaticBooleanField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JByteMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID)>> GetStaticByteField;
+          JByteMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+          )>> GetStaticByteField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JCharMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID)>> GetStaticCharField;
+          JCharMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+          )>> GetStaticCharField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JShortMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID)>> GetStaticShortField;
+          JShortMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+          )>> GetStaticShortField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JIntMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID)>> GetStaticIntField;
+          JIntMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+          )>> GetStaticIntField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JLongMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID)>> GetStaticLongField;
+          JLongMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+          )>> GetStaticLongField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JFloatMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID)>> GetStaticFloatField;
+          JFloatMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+          )>> GetStaticFloatField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JDoubleMarker Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID)>> GetStaticDoubleField;
+          JDoubleMarker Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+          )>> GetStaticDoubleField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID, JObjectPtr val)>> SetStaticObjectField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JObjectPtr val,
+          )>> SetStaticObjectField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID, JBooleanMarker val)>> SetStaticBooleanField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JBooleanMarker val,
+          )>> SetStaticBooleanField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID, JByteMarker val)>> SetStaticByteField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JByteMarker val,
+          )>> SetStaticByteField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID, JCharMarker val)>> SetStaticCharField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JCharMarker val,
+          )>> SetStaticCharField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID, JShortMarker val)>> SetStaticShortField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JShortMarker val,
+          )>> SetStaticShortField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID, JIntMarker val)>> SetStaticIntField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JIntMarker val,
+          )>> SetStaticIntField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID, JLongMarker val)>> SetStaticLongField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JLongMarker val,
+          )>> SetStaticLongField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID, JFloatMarker val)>> SetStaticFloatField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JFloatMarker val,
+          )>> SetStaticFloatField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JClassPtr clazz,
-              JFieldIDPtr fieldID, JDoubleMarker val)>> SetStaticDoubleField;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JDoubleMarker val,
+          )>> SetStaticDoubleField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JStringPtr Function(
-              ffi.Pointer<JniEnv> env,
-              ffi.Pointer<JCharMarker> unicodeChars,
-              JSizeMarker len)>> NewString;
+            ffi.Pointer<JniEnv> env,
+            ffi.Pointer<JCharMarker> unicodeChars,
+            JSizeMarker len,
+          )>> NewString;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -1581,14 +1932,18 @@ final class JNINativeInterface extends ffi.Struct {
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Pointer<JCharMarker> Function(
-              ffi.Pointer<JniEnv> env,
-              JStringPtr string,
-              ffi.Pointer<JBooleanMarker> isCopy)>> GetStringChars;
+            ffi.Pointer<JniEnv> env,
+            JStringPtr string,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetStringChars;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JStringPtr string,
-              ffi.Pointer<JCharMarker> isCopy)>> ReleaseStringChars;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JStringPtr string,
+            ffi.Pointer<JCharMarker> isCopy,
+          )>> ReleaseStringChars;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -1604,14 +1959,18 @@ final class JNINativeInterface extends ffi.Struct {
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Pointer<ffi.Char> Function(
-              ffi.Pointer<JniEnv> env,
-              JStringPtr string,
-              ffi.Pointer<JBooleanMarker> isCopy)>> GetStringUTFChars;
+            ffi.Pointer<JniEnv> env,
+            JStringPtr string,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetStringUTFChars;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JStringPtr string,
-              ffi.Pointer<ffi.Char> utf)>> ReleaseStringUTFChars;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JStringPtr string,
+            ffi.Pointer<ffi.Char> utf,
+          )>> ReleaseStringUTFChars;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -1621,20 +1980,28 @@ final class JNINativeInterface extends ffi.Struct {
   external ffi.Pointer<
       ffi.NativeFunction<
           JObjectArrayPtr Function(
-              ffi.Pointer<JniEnv> env,
-              JSizeMarker length,
-              JClassPtr elementClass,
-              JObjectPtr initialElement)>> NewObjectArray;
+            ffi.Pointer<JniEnv> env,
+            JSizeMarker length,
+            JClassPtr elementClass,
+            JObjectPtr initialElement,
+          )>> NewObjectArray;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JObjectPtr Function(ffi.Pointer<JniEnv> env, JObjectArrayPtr array,
-              JSizeMarker index)>> GetObjectArrayElement;
+          JObjectPtr Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectArrayPtr array,
+            JSizeMarker index,
+          )>> GetObjectArrayElement;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JObjectArrayPtr array,
-              JSizeMarker index, JObjectPtr val)>> SetObjectArrayElement;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JObjectArrayPtr array,
+            JSizeMarker index,
+            JObjectPtr val,
+          )>> SetObjectArrayElement;
 
   external ffi.Pointer<
       ffi.NativeFunction<
@@ -1679,275 +2046,308 @@ final class JNINativeInterface extends ffi.Struct {
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Pointer<JBooleanMarker> Function(
-              ffi.Pointer<JniEnv> env,
-              JBooleanArrayPtr array,
-              ffi.Pointer<JBooleanMarker> isCopy)>> GetBooleanArrayElements;
+            ffi.Pointer<JniEnv> env,
+            JBooleanArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetBooleanArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Pointer<JByteMarker> Function(
-              ffi.Pointer<JniEnv> env,
-              JByteArrayPtr array,
-              ffi.Pointer<JBooleanMarker> isCopy)>> GetByteArrayElements;
+            ffi.Pointer<JniEnv> env,
+            JByteArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetByteArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Pointer<JCharMarker> Function(
-              ffi.Pointer<JniEnv> env,
-              JCharArrayPtr array,
-              ffi.Pointer<JBooleanMarker> isCopy)>> GetCharArrayElements;
+            ffi.Pointer<JniEnv> env,
+            JCharArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetCharArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Pointer<JShortMarker> Function(
-              ffi.Pointer<JniEnv> env,
-              JShortArrayPtr array,
-              ffi.Pointer<JBooleanMarker> isCopy)>> GetShortArrayElements;
+            ffi.Pointer<JniEnv> env,
+            JShortArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetShortArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Pointer<JIntMarker> Function(
-              ffi.Pointer<JniEnv> env,
-              JIntArrayPtr array,
-              ffi.Pointer<JBooleanMarker> isCopy)>> GetIntArrayElements;
+            ffi.Pointer<JniEnv> env,
+            JIntArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetIntArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Pointer<JLongMarker> Function(
-              ffi.Pointer<JniEnv> env,
-              JLongArrayPtr array,
-              ffi.Pointer<JBooleanMarker> isCopy)>> GetLongArrayElements;
+            ffi.Pointer<JniEnv> env,
+            JLongArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetLongArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Pointer<JFloatMarker> Function(
-              ffi.Pointer<JniEnv> env,
-              JFloatArrayPtr array,
-              ffi.Pointer<JBooleanMarker> isCopy)>> GetFloatArrayElements;
+            ffi.Pointer<JniEnv> env,
+            JFloatArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetFloatArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Pointer<JDoubleMarker> Function(
-              ffi.Pointer<JniEnv> env,
-              JDoubleArrayPtr array,
-              ffi.Pointer<JBooleanMarker> isCopy)>> GetDoubleArrayElements;
+            ffi.Pointer<JniEnv> env,
+            JDoubleArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetDoubleArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JBooleanArrayPtr array,
-              ffi.Pointer<JBooleanMarker> elems,
-              JIntMarker mode)>> ReleaseBooleanArrayElements;
+            ffi.Pointer<JniEnv> env,
+            JBooleanArrayPtr array,
+            ffi.Pointer<JBooleanMarker> elems,
+            JIntMarker mode,
+          )>> ReleaseBooleanArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JByteArrayPtr array,
-              ffi.Pointer<JByteMarker> elems,
-              JIntMarker mode)>> ReleaseByteArrayElements;
+            ffi.Pointer<JniEnv> env,
+            JByteArrayPtr array,
+            ffi.Pointer<JByteMarker> elems,
+            JIntMarker mode,
+          )>> ReleaseByteArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JCharArrayPtr array,
-              ffi.Pointer<JCharMarker> elems,
-              JIntMarker mode)>> ReleaseCharArrayElements;
+            ffi.Pointer<JniEnv> env,
+            JCharArrayPtr array,
+            ffi.Pointer<JCharMarker> elems,
+            JIntMarker mode,
+          )>> ReleaseCharArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JShortArrayPtr array,
-              ffi.Pointer<JShortMarker> elems,
-              JIntMarker mode)>> ReleaseShortArrayElements;
+            ffi.Pointer<JniEnv> env,
+            JShortArrayPtr array,
+            ffi.Pointer<JShortMarker> elems,
+            JIntMarker mode,
+          )>> ReleaseShortArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JIntArrayPtr array,
-              ffi.Pointer<JIntMarker> elems,
-              JIntMarker mode)>> ReleaseIntArrayElements;
+            ffi.Pointer<JniEnv> env,
+            JIntArrayPtr array,
+            ffi.Pointer<JIntMarker> elems,
+            JIntMarker mode,
+          )>> ReleaseIntArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JLongArrayPtr array,
-              ffi.Pointer<JLongMarker> elems,
-              JIntMarker mode)>> ReleaseLongArrayElements;
+            ffi.Pointer<JniEnv> env,
+            JLongArrayPtr array,
+            ffi.Pointer<JLongMarker> elems,
+            JIntMarker mode,
+          )>> ReleaseLongArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JFloatArrayPtr array,
-              ffi.Pointer<JFloatMarker> elems,
-              JIntMarker mode)>> ReleaseFloatArrayElements;
+            ffi.Pointer<JniEnv> env,
+            JFloatArrayPtr array,
+            ffi.Pointer<JFloatMarker> elems,
+            JIntMarker mode,
+          )>> ReleaseFloatArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JDoubleArrayPtr array,
-              ffi.Pointer<JDoubleMarker> elems,
-              JIntMarker mode)>> ReleaseDoubleArrayElements;
+            ffi.Pointer<JniEnv> env,
+            JDoubleArrayPtr array,
+            ffi.Pointer<JDoubleMarker> elems,
+            JIntMarker mode,
+          )>> ReleaseDoubleArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JBooleanArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JBooleanMarker> buf)>> GetBooleanArrayRegion;
+            ffi.Pointer<JniEnv> env,
+            JBooleanArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JBooleanMarker> buf,
+          )>> GetBooleanArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JByteArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JByteMarker> buf)>> GetByteArrayRegion;
+            ffi.Pointer<JniEnv> env,
+            JByteArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JByteMarker> buf,
+          )>> GetByteArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JCharArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JCharMarker> buf)>> GetCharArrayRegion;
+            ffi.Pointer<JniEnv> env,
+            JCharArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JCharMarker> buf,
+          )>> GetCharArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JShortArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JShortMarker> buf)>> GetShortArrayRegion;
+            ffi.Pointer<JniEnv> env,
+            JShortArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JShortMarker> buf,
+          )>> GetShortArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JIntArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JIntMarker> buf)>> GetIntArrayRegion;
+            ffi.Pointer<JniEnv> env,
+            JIntArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JIntMarker> buf,
+          )>> GetIntArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JLongArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JLongMarker> buf)>> GetLongArrayRegion;
+            ffi.Pointer<JniEnv> env,
+            JLongArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JLongMarker> buf,
+          )>> GetLongArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JFloatArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JFloatMarker> buf)>> GetFloatArrayRegion;
+            ffi.Pointer<JniEnv> env,
+            JFloatArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JFloatMarker> buf,
+          )>> GetFloatArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JDoubleArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JDoubleMarker> buf)>> GetDoubleArrayRegion;
+            ffi.Pointer<JniEnv> env,
+            JDoubleArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JDoubleMarker> buf,
+          )>> GetDoubleArrayRegion;
 
   /// spec shows these without const; some jni.h do, some don't
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JBooleanArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JBooleanMarker> buf)>> SetBooleanArrayRegion;
+            ffi.Pointer<JniEnv> env,
+            JBooleanArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JBooleanMarker> buf,
+          )>> SetBooleanArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JByteArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JByteMarker> buf)>> SetByteArrayRegion;
+            ffi.Pointer<JniEnv> env,
+            JByteArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JByteMarker> buf,
+          )>> SetByteArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JCharArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JCharMarker> buf)>> SetCharArrayRegion;
+            ffi.Pointer<JniEnv> env,
+            JCharArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JCharMarker> buf,
+          )>> SetCharArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JShortArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JShortMarker> buf)>> SetShortArrayRegion;
+            ffi.Pointer<JniEnv> env,
+            JShortArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JShortMarker> buf,
+          )>> SetShortArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JIntArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JIntMarker> buf)>> SetIntArrayRegion;
+            ffi.Pointer<JniEnv> env,
+            JIntArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JIntMarker> buf,
+          )>> SetIntArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JLongArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JLongMarker> buf)>> SetLongArrayRegion;
+            ffi.Pointer<JniEnv> env,
+            JLongArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JLongMarker> buf,
+          )>> SetLongArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JFloatArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JFloatMarker> buf)>> SetFloatArrayRegion;
+            ffi.Pointer<JniEnv> env,
+            JFloatArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JFloatMarker> buf,
+          )>> SetFloatArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JDoubleArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JDoubleMarker> buf)>> SetDoubleArrayRegion;
+            ffi.Pointer<JniEnv> env,
+            JDoubleArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JDoubleMarker> buf,
+          )>> SetDoubleArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JIntMarker Function(
-              ffi.Pointer<JniEnv> env,
-              JClassPtr clazz,
-              ffi.Pointer<JNINativeMethod> methods,
-              JIntMarker nMethods)>> RegisterNatives;
+            ffi.Pointer<JniEnv> env,
+            JClassPtr clazz,
+            ffi.Pointer<JNINativeMethod> methods,
+            JIntMarker nMethods,
+          )>> RegisterNatives;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -1966,53 +2366,63 @@ final class JNINativeInterface extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JIntMarker Function(ffi.Pointer<JniEnv> env,
-              ffi.Pointer<ffi.Pointer<JavaVM>> vm)>> GetJavaVM;
+          JIntMarker Function(
+            ffi.Pointer<JniEnv> env,
+            ffi.Pointer<ffi.Pointer<JavaVM>> vm,
+          )>> GetJavaVM;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JStringPtr str,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JCharMarker> buf)>> GetStringRegion;
+            ffi.Pointer<JniEnv> env,
+            JStringPtr str,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JCharMarker> buf,
+          )>> GetStringRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JStringPtr str,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<ffi.Char> buf)>> GetStringUTFRegion;
+            ffi.Pointer<JniEnv> env,
+            JStringPtr str,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<ffi.Char> buf,
+          )>> GetStringUTFRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Pointer<ffi.Void> Function(
-              ffi.Pointer<JniEnv> env,
-              JArrayPtr array,
-              ffi.Pointer<JBooleanMarker> isCopy)>> GetPrimitiveArrayCritical;
+            ffi.Pointer<JniEnv> env,
+            JArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetPrimitiveArrayCritical;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Void Function(
-              ffi.Pointer<JniEnv> env,
-              JArrayPtr array,
-              ffi.Pointer<ffi.Void> carray,
-              JIntMarker mode)>> ReleasePrimitiveArrayCritical;
+            ffi.Pointer<JniEnv> env,
+            JArrayPtr array,
+            ffi.Pointer<ffi.Void> carray,
+            JIntMarker mode,
+          )>> ReleasePrimitiveArrayCritical;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           ffi.Pointer<JCharMarker> Function(
-              ffi.Pointer<JniEnv> env,
-              JStringPtr str,
-              ffi.Pointer<JBooleanMarker> isCopy)>> GetStringCritical;
+            ffi.Pointer<JniEnv> env,
+            JStringPtr str,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetStringCritical;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<JniEnv> env, JStringPtr str,
-              ffi.Pointer<JCharMarker> carray)>> ReleaseStringCritical;
+          ffi.Void Function(
+            ffi.Pointer<JniEnv> env,
+            JStringPtr str,
+            ffi.Pointer<JCharMarker> carray,
+          )>> ReleaseStringCritical;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2031,9 +2441,10 @@ final class JNINativeInterface extends ffi.Struct {
   external ffi.Pointer<
       ffi.NativeFunction<
           JObjectPtr Function(
-              ffi.Pointer<JniEnv> env,
-              ffi.Pointer<ffi.Void> address,
-              JLongMarker capacity)>> NewDirectByteBuffer;
+            ffi.Pointer<JniEnv> env,
+            ffi.Pointer<ffi.Void> address,
+            JLongMarker capacity,
+          )>> NewDirectByteBuffer;
 
   external ffi.Pointer<
       ffi.NativeFunction<
@@ -2052,7 +2463,7 @@ final class JNINativeInterface extends ffi.Struct {
               ffi.Pointer<JniEnv> env, JObjectPtr obj)>> GetObjectRefType;
 }
 
-typedef JniEnv1 = ffi.Pointer<JNINativeInterface>;
+typedef JniEnv$1 = ffi.Pointer<JNINativeInterface>;
 
 /// JNI invocation interface.
 final class JNIInvokeInterface extends ffi.Struct {
@@ -2069,9 +2480,10 @@ final class JNIInvokeInterface extends ffi.Struct {
   external ffi.Pointer<
       ffi.NativeFunction<
           JIntMarker Function(
-              ffi.Pointer<JavaVM> vm,
-              ffi.Pointer<ffi.Pointer<JniEnv1>> p_env,
-              ffi.Pointer<ffi.Void> thr_args)>> AttachCurrentThread;
+            ffi.Pointer<JavaVM> vm,
+            ffi.Pointer<ffi.Pointer<JniEnv$1>> p_env,
+            ffi.Pointer<ffi.Void> thr_args,
+          )>> AttachCurrentThread;
 
   external ffi
       .Pointer<ffi.NativeFunction<JIntMarker Function(ffi.Pointer<JavaVM> vm)>>
@@ -2080,19 +2492,21 @@ final class JNIInvokeInterface extends ffi.Struct {
   external ffi.Pointer<
       ffi.NativeFunction<
           JIntMarker Function(
-              ffi.Pointer<JavaVM> vm,
-              ffi.Pointer<ffi.Pointer<ffi.Void>> p_env,
-              JIntMarker version)>> GetEnv;
+            ffi.Pointer<JavaVM> vm,
+            ffi.Pointer<ffi.Pointer<ffi.Void>> p_env,
+            JIntMarker version,
+          )>> GetEnv;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JIntMarker Function(
-              ffi.Pointer<JavaVM> vm,
-              ffi.Pointer<ffi.Pointer<JniEnv1>> p_env,
-              ffi.Pointer<ffi.Void> thr_args)>> AttachCurrentThreadAsDaemon;
+            ffi.Pointer<JavaVM> vm,
+            ffi.Pointer<ffi.Pointer<JniEnv$1>> p_env,
+            ffi.Pointer<ffi.Void> thr_args,
+          )>> AttachCurrentThreadAsDaemon;
 }
 
-typedef JavaVM1 = ffi.Pointer<JNIInvokeInterface>;
+typedef JavaVM$1 = ffi.Pointer<JNIInvokeInterface>;
 
 /// JNI 1.2+ initialization.  (As of 1.6, the pre-1.2 structures are no
 /// longer supported.)
@@ -2116,9 +2530,9 @@ final class JavaVMInitArgs extends ffi.Struct {
   external int ignoreUnrecognized;
 }
 
-final class _Dart_FinalizableHandle extends ffi.Opaque {}
+final class Dart_FinalizableHandle_ extends ffi.Opaque {}
 
-typedef Dart_FinalizableHandle = ffi.Pointer<_Dart_FinalizableHandle>;
+typedef Dart_FinalizableHandle = ffi.Pointer<Dart_FinalizableHandle_>;
 
 final class GlobalJniEnvStruct extends ffi.Struct {
   external ffi.Pointer<ffi.Void> reserved0;
@@ -2134,10 +2548,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
   external ffi.Pointer<
       ffi.NativeFunction<
           JniClassLookupResult Function(
-              ffi.Pointer<ffi.Char> name,
-              JObjectPtr loader,
-              ffi.Pointer<JByteMarker> buf,
-              JSizeMarker bufLen)>> DefineClass;
+            ffi.Pointer<ffi.Char> name,
+            JObjectPtr loader,
+            ffi.Pointer<JByteMarker> buf,
+            JSizeMarker bufLen,
+          )>> DefineClass;
 
   external ffi.Pointer<
       ffi.NativeFunction<
@@ -2153,8 +2568,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JClassPtr cls, JMethodIDPtr methodId,
-              JBooleanMarker isStatic)>> ToReflectedMethod;
+          JniResult Function(
+            JClassPtr cls,
+            JMethodIDPtr methodId,
+            JBooleanMarker isStatic,
+          )>> ToReflectedMethod;
 
   external ffi.Pointer<
           ffi.NativeFunction<JniClassLookupResult Function(JClassPtr clazz)>>
@@ -2166,10 +2584,12 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       IsAssignableFrom;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniResult Function(
-                  JClassPtr cls, JFieldIDPtr fieldID, JBooleanMarker isStatic)>>
-      ToReflectedField;
+      ffi.NativeFunction<
+          JniResult Function(
+            JClassPtr cls,
+            JFieldIDPtr fieldID,
+            JBooleanMarker isStatic,
+          )>> ToReflectedField;
 
   external ffi
       .Pointer<ffi.NativeFunction<JniResult Function(JThrowablePtr obj)>> Throw;
@@ -2238,8 +2658,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JClassPtr clazz, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> NewObjectA;
+          JniResult Function(
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> NewObjectA;
 
   external ffi.Pointer<
           ffi.NativeFunction<JniClassLookupResult Function(JObjectPtr obj)>>
@@ -2252,8 +2675,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniPointerResult Function(JClassPtr clazz, ffi.Pointer<ffi.Char> name,
-              ffi.Pointer<ffi.Char> sig)>> GetMethodID;
+          JniPointerResult Function(
+            JClassPtr clazz,
+            ffi.Pointer<ffi.Char> name,
+            ffi.Pointer<ffi.Char> sig,
+          )>> GetMethodID;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2268,8 +2694,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JObjectPtr obj, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallObjectMethodA;
+          JniResult Function(
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallObjectMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2284,8 +2713,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JObjectPtr obj, JMethodIDPtr methodId,
-              ffi.Pointer<JValue> args)>> CallBooleanMethodA;
+          JniResult Function(
+            JObjectPtr obj,
+            JMethodIDPtr methodId,
+            ffi.Pointer<JValue> args,
+          )>> CallBooleanMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2300,8 +2732,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JObjectPtr obj, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallByteMethodA;
+          JniResult Function(
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallByteMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2316,8 +2751,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JObjectPtr obj, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallCharMethodA;
+          JniResult Function(
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallCharMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2332,8 +2770,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JObjectPtr obj, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallShortMethodA;
+          JniResult Function(
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallShortMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2347,8 +2788,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JObjectPtr obj, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallIntMethodA;
+          JniResult Function(
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallIntMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2363,8 +2807,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JObjectPtr obj, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallLongMethodA;
+          JniResult Function(
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallLongMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2379,8 +2826,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JObjectPtr obj, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallFloatMethodA;
+          JniResult Function(
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallFloatMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2395,8 +2845,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JObjectPtr obj, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallDoubleMethodA;
+          JniResult Function(
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallDoubleMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2411,8 +2864,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JThrowablePtr Function(JObjectPtr obj, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallVoidMethodA;
+          JThrowablePtr Function(
+            JObjectPtr obj,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallVoidMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2421,18 +2877,22 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       CallNonvirtualObjectMethod;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniResult Function(
-                  JObjectPtr, JClassPtr, JMethodIDPtr, ffi.Pointer<ffi.Void>)>>
-      CallNonvirtualObjectMethodV;
+      ffi.NativeFunction<
+          JniResult Function(
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualObjectMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JniResult Function(
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualObjectMethodA;
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualObjectMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2441,18 +2901,22 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       CallNonvirtualBooleanMethod;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniResult Function(
-                  JObjectPtr, JClassPtr, JMethodIDPtr, ffi.Pointer<ffi.Void>)>>
-      CallNonvirtualBooleanMethodV;
+      ffi.NativeFunction<
+          JniResult Function(
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualBooleanMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JniResult Function(
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualBooleanMethodA;
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualBooleanMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2461,18 +2925,22 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       CallNonvirtualByteMethod;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniResult Function(
-                  JObjectPtr, JClassPtr, JMethodIDPtr, ffi.Pointer<ffi.Void>)>>
-      CallNonvirtualByteMethodV;
+      ffi.NativeFunction<
+          JniResult Function(
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualByteMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JniResult Function(
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualByteMethodA;
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualByteMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2481,18 +2949,22 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       CallNonvirtualCharMethod;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniResult Function(
-                  JObjectPtr, JClassPtr, JMethodIDPtr, ffi.Pointer<ffi.Void>)>>
-      CallNonvirtualCharMethodV;
+      ffi.NativeFunction<
+          JniResult Function(
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualCharMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JniResult Function(
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualCharMethodA;
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualCharMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2501,18 +2973,22 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       CallNonvirtualShortMethod;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniResult Function(
-                  JObjectPtr, JClassPtr, JMethodIDPtr, ffi.Pointer<ffi.Void>)>>
-      CallNonvirtualShortMethodV;
+      ffi.NativeFunction<
+          JniResult Function(
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualShortMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JniResult Function(
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualShortMethodA;
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualShortMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2521,18 +2997,22 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       CallNonvirtualIntMethod;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniResult Function(
-                  JObjectPtr, JClassPtr, JMethodIDPtr, ffi.Pointer<ffi.Void>)>>
-      CallNonvirtualIntMethodV;
+      ffi.NativeFunction<
+          JniResult Function(
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualIntMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JniResult Function(
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualIntMethodA;
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualIntMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2541,18 +3021,22 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       CallNonvirtualLongMethod;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniResult Function(
-                  JObjectPtr, JClassPtr, JMethodIDPtr, ffi.Pointer<ffi.Void>)>>
-      CallNonvirtualLongMethodV;
+      ffi.NativeFunction<
+          JniResult Function(
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualLongMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JniResult Function(
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualLongMethodA;
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualLongMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2561,18 +3045,22 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       CallNonvirtualFloatMethod;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniResult Function(
-                  JObjectPtr, JClassPtr, JMethodIDPtr, ffi.Pointer<ffi.Void>)>>
-      CallNonvirtualFloatMethodV;
+      ffi.NativeFunction<
+          JniResult Function(
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualFloatMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JniResult Function(
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualFloatMethodA;
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualFloatMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2581,43 +3069,56 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       CallNonvirtualDoubleMethod;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniResult Function(
-                  JObjectPtr, JClassPtr, JMethodIDPtr, ffi.Pointer<ffi.Void>)>>
-      CallNonvirtualDoubleMethodV;
+      ffi.NativeFunction<
+          JniResult Function(
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualDoubleMethodV;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JniResult Function(
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualDoubleMethodA;
-
-  external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JObjectPtr obj, JClassPtr clazz, JMethodIDPtr methodID)>>
-      CallNonvirtualVoidMethod;
-
-  external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JObjectPtr, JClassPtr, JMethodIDPtr, ffi.Pointer<ffi.Void>)>>
-      CallNonvirtualVoidMethodV;
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualDoubleMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JObjectPtr obj,
-              JClassPtr clazz,
-              JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallNonvirtualVoidMethodA;
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+          )>> CallNonvirtualVoidMethod;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniPointerResult Function(JClassPtr clazz, ffi.Pointer<ffi.Char> name,
-              ffi.Pointer<ffi.Char> sig)>> GetFieldID;
+          JThrowablePtr Function(
+            JObjectPtr,
+            JClassPtr,
+            JMethodIDPtr,
+            ffi.Pointer<ffi.Void>,
+          )>> CallNonvirtualVoidMethodV;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JObjectPtr obj,
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallNonvirtualVoidMethodA;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JniPointerResult Function(
+            JClassPtr clazz,
+            ffi.Pointer<ffi.Char> name,
+            ffi.Pointer<ffi.Char> sig,
+          )>> GetFieldID;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2664,63 +3165,84 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       GetDoubleField;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JObjectPtr obj, JFieldIDPtr fieldID, JObjectPtr val)>>
-      SetObjectField;
-
-  external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JObjectPtr obj, JFieldIDPtr fieldID, JBooleanMarker val)>>
-      SetBooleanField;
-
-  external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JObjectPtr obj, JFieldIDPtr fieldID, JByteMarker val)>>
-      SetByteField;
-
-  external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JObjectPtr obj, JFieldIDPtr fieldID, JCharMarker val)>>
-      SetCharField;
-
-  external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JObjectPtr obj, JFieldIDPtr fieldID, JShortMarker val)>>
-      SetShortField;
-
-  external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JObjectPtr obj, JFieldIDPtr fieldID, JIntMarker val)>>
-      SetIntField;
-
-  external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JObjectPtr obj, JFieldIDPtr fieldID, JLongMarker val)>>
-      SetLongField;
-
-  external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JObjectPtr obj, JFieldIDPtr fieldID, JFloatMarker val)>>
-      SetFloatField;
-
-  external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JObjectPtr obj, JFieldIDPtr fieldID, JDoubleMarker val)>>
-      SetDoubleField;
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JObjectPtr val,
+          )>> SetObjectField;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniPointerResult Function(JClassPtr clazz, ffi.Pointer<ffi.Char> name,
-              ffi.Pointer<ffi.Char> sig)>> GetStaticMethodID;
+          JThrowablePtr Function(
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JBooleanMarker val,
+          )>> SetBooleanField;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JByteMarker val,
+          )>> SetByteField;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JCharMarker val,
+          )>> SetCharField;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JShortMarker val,
+          )>> SetShortField;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JIntMarker val,
+          )>> SetIntField;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JLongMarker val,
+          )>> SetLongField;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JFloatMarker val,
+          )>> SetFloatField;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JObjectPtr obj,
+            JFieldIDPtr fieldID,
+            JDoubleMarker val,
+          )>> SetDoubleField;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JniPointerResult Function(
+            JClassPtr clazz,
+            ffi.Pointer<ffi.Char> name,
+            ffi.Pointer<ffi.Char> sig,
+          )>> GetStaticMethodID;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2735,8 +3257,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JClassPtr clazz, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticObjectMethodA;
+          JniResult Function(
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticObjectMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2751,8 +3276,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JClassPtr clazz, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticBooleanMethodA;
+          JniResult Function(
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticBooleanMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2767,8 +3295,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JClassPtr clazz, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticByteMethodA;
+          JniResult Function(
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticByteMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2783,8 +3314,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JClassPtr clazz, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticCharMethodA;
+          JniResult Function(
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticCharMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2799,8 +3333,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JClassPtr clazz, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticShortMethodA;
+          JniResult Function(
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticShortMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2815,8 +3352,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JClassPtr clazz, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticIntMethodA;
+          JniResult Function(
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticIntMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2831,8 +3371,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JClassPtr clazz, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticLongMethodA;
+          JniResult Function(
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticLongMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2847,8 +3390,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JClassPtr clazz, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticFloatMethodA;
+          JniResult Function(
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticFloatMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2863,8 +3409,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JClassPtr clazz, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticDoubleMethodA;
+          JniResult Function(
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticDoubleMethodA;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2879,13 +3428,19 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JThrowablePtr Function(JClassPtr clazz, JMethodIDPtr methodID,
-              ffi.Pointer<JValue> args)>> CallStaticVoidMethodA;
+          JThrowablePtr Function(
+            JClassPtr clazz,
+            JMethodIDPtr methodID,
+            ffi.Pointer<JValue> args,
+          )>> CallStaticVoidMethodA;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniPointerResult Function(JClassPtr clazz, ffi.Pointer<ffi.Char> name,
-              ffi.Pointer<ffi.Char> sig)>> GetStaticFieldID;
+          JniPointerResult Function(
+            JClassPtr clazz,
+            ffi.Pointer<ffi.Char> name,
+            ffi.Pointer<ffi.Char> sig,
+          )>> GetStaticFieldID;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2933,58 +3488,76 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       GetStaticDoubleField;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JClassPtr clazz, JFieldIDPtr fieldID, JObjectPtr val)>>
-      SetStaticObjectField;
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JObjectPtr val,
+          )>> SetStaticObjectField;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JClassPtr clazz, JFieldIDPtr fieldID, JBooleanMarker val)>>
-      SetStaticBooleanField;
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JBooleanMarker val,
+          )>> SetStaticBooleanField;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JClassPtr clazz, JFieldIDPtr fieldID, JByteMarker val)>>
-      SetStaticByteField;
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JByteMarker val,
+          )>> SetStaticByteField;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JClassPtr clazz, JFieldIDPtr fieldID, JCharMarker val)>>
-      SetStaticCharField;
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JCharMarker val,
+          )>> SetStaticCharField;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JClassPtr clazz, JFieldIDPtr fieldID, JShortMarker val)>>
-      SetStaticShortField;
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JShortMarker val,
+          )>> SetStaticShortField;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JClassPtr clazz, JFieldIDPtr fieldID, JIntMarker val)>>
-      SetStaticIntField;
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JIntMarker val,
+          )>> SetStaticIntField;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JClassPtr clazz, JFieldIDPtr fieldID, JLongMarker val)>>
-      SetStaticLongField;
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JLongMarker val,
+          )>> SetStaticLongField;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JClassPtr clazz, JFieldIDPtr fieldID, JFloatMarker val)>>
-      SetStaticFloatField;
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JFloatMarker val,
+          )>> SetStaticFloatField;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JClassPtr clazz, JFieldIDPtr fieldID, JDoubleMarker val)>>
-      SetStaticDoubleField;
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JClassPtr clazz,
+            JFieldIDPtr fieldID,
+            JDoubleMarker val,
+          )>> SetStaticDoubleField;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -2997,10 +3570,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       GetStringLength;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniPointerResult Function(
-                  JStringPtr string, ffi.Pointer<JBooleanMarker> isCopy)>>
-      GetStringChars;
+      ffi.NativeFunction<
+          JniPointerResult Function(
+            JStringPtr string,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetStringChars;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -3017,10 +3591,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       GetStringUTFLength;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniPointerResult Function(
-                  JStringPtr string, ffi.Pointer<JBooleanMarker> isCopy)>>
-      GetStringUTFChars;
+      ffi.NativeFunction<
+          JniPointerResult Function(
+            JStringPtr string,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetStringUTFChars;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -3033,8 +3608,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(JSizeMarker length, JClassPtr elementClass,
-              JObjectPtr initialElement)>> NewObjectArray;
+          JniResult Function(
+            JSizeMarker length,
+            JClassPtr elementClass,
+            JObjectPtr initialElement,
+          )>> NewObjectArray;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -3042,10 +3620,12 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       GetObjectArrayElement;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JObjectArrayPtr array, JSizeMarker index, JObjectPtr val)>>
-      SetObjectArrayElement;
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JObjectArrayPtr array,
+            JSizeMarker index,
+            JObjectPtr val,
+          )>> SetObjectArrayElement;
 
   external ffi
       .Pointer<ffi.NativeFunction<JniResult Function(JSizeMarker length)>>
@@ -3080,237 +3660,276 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       NewDoubleArray;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniPointerResult Function(
-                  JBooleanArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>>
-      GetBooleanArrayElements;
+      ffi.NativeFunction<
+          JniPointerResult Function(
+            JBooleanArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetBooleanArrayElements;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniPointerResult Function(
-                  JByteArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>>
-      GetByteArrayElements;
+      ffi.NativeFunction<
+          JniPointerResult Function(
+            JByteArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetByteArrayElements;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniPointerResult Function(
-                  JCharArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>>
-      GetCharArrayElements;
+      ffi.NativeFunction<
+          JniPointerResult Function(
+            JCharArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetCharArrayElements;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniPointerResult Function(
-                  JShortArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>>
-      GetShortArrayElements;
+      ffi.NativeFunction<
+          JniPointerResult Function(
+            JShortArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetShortArrayElements;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniPointerResult Function(
-                  JIntArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>>
-      GetIntArrayElements;
+      ffi.NativeFunction<
+          JniPointerResult Function(
+            JIntArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetIntArrayElements;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniPointerResult Function(
-                  JLongArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>>
-      GetLongArrayElements;
+      ffi.NativeFunction<
+          JniPointerResult Function(
+            JLongArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetLongArrayElements;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniPointerResult Function(
-                  JFloatArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>>
-      GetFloatArrayElements;
+      ffi.NativeFunction<
+          JniPointerResult Function(
+            JFloatArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetFloatArrayElements;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniPointerResult Function(
-                  JDoubleArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>>
-      GetDoubleArrayElements;
+      ffi.NativeFunction<
+          JniPointerResult Function(
+            JDoubleArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetDoubleArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JBooleanArrayPtr array,
-              ffi.Pointer<JBooleanMarker> elems,
-              JIntMarker mode)>> ReleaseBooleanArrayElements;
+            JBooleanArrayPtr array,
+            ffi.Pointer<JBooleanMarker> elems,
+            JIntMarker mode,
+          )>> ReleaseBooleanArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JByteArrayPtr array,
-              ffi.Pointer<JByteMarker> elems,
-              JIntMarker mode)>> ReleaseByteArrayElements;
+            JByteArrayPtr array,
+            ffi.Pointer<JByteMarker> elems,
+            JIntMarker mode,
+          )>> ReleaseByteArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JCharArrayPtr array,
-              ffi.Pointer<JCharMarker> elems,
-              JIntMarker mode)>> ReleaseCharArrayElements;
+            JCharArrayPtr array,
+            ffi.Pointer<JCharMarker> elems,
+            JIntMarker mode,
+          )>> ReleaseCharArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JShortArrayPtr array,
-              ffi.Pointer<JShortMarker> elems,
-              JIntMarker mode)>> ReleaseShortArrayElements;
+            JShortArrayPtr array,
+            ffi.Pointer<JShortMarker> elems,
+            JIntMarker mode,
+          )>> ReleaseShortArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JIntArrayPtr array,
-              ffi.Pointer<JIntMarker> elems,
-              JIntMarker mode)>> ReleaseIntArrayElements;
+            JIntArrayPtr array,
+            ffi.Pointer<JIntMarker> elems,
+            JIntMarker mode,
+          )>> ReleaseIntArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JLongArrayPtr array,
-              ffi.Pointer<JLongMarker> elems,
-              JIntMarker mode)>> ReleaseLongArrayElements;
+            JLongArrayPtr array,
+            ffi.Pointer<JLongMarker> elems,
+            JIntMarker mode,
+          )>> ReleaseLongArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JFloatArrayPtr array,
-              ffi.Pointer<JFloatMarker> elems,
-              JIntMarker mode)>> ReleaseFloatArrayElements;
+            JFloatArrayPtr array,
+            ffi.Pointer<JFloatMarker> elems,
+            JIntMarker mode,
+          )>> ReleaseFloatArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JDoubleArrayPtr array,
-              ffi.Pointer<JDoubleMarker> elems,
-              JIntMarker mode)>> ReleaseDoubleArrayElements;
+            JDoubleArrayPtr array,
+            ffi.Pointer<JDoubleMarker> elems,
+            JIntMarker mode,
+          )>> ReleaseDoubleArrayElements;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JBooleanArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JBooleanMarker> buf)>> GetBooleanArrayRegion;
+            JBooleanArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JBooleanMarker> buf,
+          )>> GetBooleanArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JByteArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JByteMarker> buf)>> GetByteArrayRegion;
+            JByteArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JByteMarker> buf,
+          )>> GetByteArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JCharArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JCharMarker> buf)>> GetCharArrayRegion;
+            JCharArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JCharMarker> buf,
+          )>> GetCharArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JShortArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JShortMarker> buf)>> GetShortArrayRegion;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JThrowablePtr Function(JIntArrayPtr array, JSizeMarker start,
-              JSizeMarker len, ffi.Pointer<JIntMarker> buf)>> GetIntArrayRegion;
+            JShortArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JShortMarker> buf,
+          )>> GetShortArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JLongArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JLongMarker> buf)>> GetLongArrayRegion;
+            JIntArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JIntMarker> buf,
+          )>> GetIntArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JFloatArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JFloatMarker> buf)>> GetFloatArrayRegion;
+            JLongArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JLongMarker> buf,
+          )>> GetLongArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JDoubleArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JDoubleMarker> buf)>> GetDoubleArrayRegion;
+            JFloatArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JFloatMarker> buf,
+          )>> GetFloatArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JBooleanArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JBooleanMarker> buf)>> SetBooleanArrayRegion;
+            JDoubleArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JDoubleMarker> buf,
+          )>> GetDoubleArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JByteArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JByteMarker> buf)>> SetByteArrayRegion;
+            JBooleanArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JBooleanMarker> buf,
+          )>> SetBooleanArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JCharArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JCharMarker> buf)>> SetCharArrayRegion;
+            JByteArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JByteMarker> buf,
+          )>> SetByteArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JShortArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JShortMarker> buf)>> SetShortArrayRegion;
-
-  external ffi.Pointer<
-      ffi.NativeFunction<
-          JThrowablePtr Function(JIntArrayPtr array, JSizeMarker start,
-              JSizeMarker len, ffi.Pointer<JIntMarker> buf)>> SetIntArrayRegion;
+            JCharArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JCharMarker> buf,
+          )>> SetCharArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JLongArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JLongMarker> buf)>> SetLongArrayRegion;
+            JShortArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JShortMarker> buf,
+          )>> SetShortArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JFloatArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JFloatMarker> buf)>> SetFloatArrayRegion;
+            JIntArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JIntMarker> buf,
+          )>> SetIntArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JThrowablePtr Function(
-              JDoubleArrayPtr array,
-              JSizeMarker start,
-              JSizeMarker len,
-              ffi.Pointer<JDoubleMarker> buf)>> SetDoubleArrayRegion;
+            JLongArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JLongMarker> buf,
+          )>> SetLongArrayRegion;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JFloatArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JFloatMarker> buf,
+          )>> SetFloatArrayRegion;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JDoubleArrayPtr array,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JDoubleMarker> buf,
+          )>> SetDoubleArrayRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
           JniResult Function(
-              JClassPtr clazz,
-              ffi.Pointer<JNINativeMethod> methods,
-              JIntMarker nMethods)>> RegisterNatives;
+            JClassPtr clazz,
+            ffi.Pointer<JNINativeMethod> methods,
+            JIntMarker nMethods,
+          )>> RegisterNatives;
 
   external ffi.Pointer<ffi.NativeFunction<JniResult Function(JClassPtr clazz)>>
       UnregisterNatives;
@@ -3323,34 +3942,47 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JniResult Function(ffi.Pointer<ffi.Pointer<JavaVM1>> vm)>> GetJavaVM;
+          JniResult Function(ffi.Pointer<ffi.Pointer<JavaVM$1>> vm)>> GetJavaVM;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JThrowablePtr Function(JStringPtr str, JSizeMarker start,
-              JSizeMarker len, ffi.Pointer<JCharMarker> buf)>> GetStringRegion;
+          JThrowablePtr Function(
+            JStringPtr str,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<JCharMarker> buf,
+          )>> GetStringRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JThrowablePtr Function(JStringPtr str, JSizeMarker start,
-              JSizeMarker len, ffi.Pointer<ffi.Char> buf)>> GetStringUTFRegion;
-
-  external ffi.Pointer<
-          ffi.NativeFunction<
-              JniPointerResult Function(
-                  JArrayPtr array, ffi.Pointer<JBooleanMarker> isCopy)>>
-      GetPrimitiveArrayCritical;
+          JThrowablePtr Function(
+            JStringPtr str,
+            JSizeMarker start,
+            JSizeMarker len,
+            ffi.Pointer<ffi.Char> buf,
+          )>> GetStringUTFRegion;
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JThrowablePtr Function(JArrayPtr array, ffi.Pointer<ffi.Void> carray,
-              JIntMarker mode)>> ReleasePrimitiveArrayCritical;
+          JniPointerResult Function(
+            JArrayPtr array,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetPrimitiveArrayCritical;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JniPointerResult Function(
-                  JStringPtr str, ffi.Pointer<JBooleanMarker> isCopy)>>
-      GetStringCritical;
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JArrayPtr array,
+            ffi.Pointer<ffi.Void> carray,
+            JIntMarker mode,
+          )>> ReleasePrimitiveArrayCritical;
+
+  external ffi.Pointer<
+      ffi.NativeFunction<
+          JniPointerResult Function(
+            JStringPtr str,
+            ffi.Pointer<JBooleanMarker> isCopy,
+          )>> GetStringCritical;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -3389,8 +4021,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JThrowablePtr Function(JBooleanArrayPtr array, JSizeMarker index,
-              JBooleanMarker element)>> SetBooleanArrayElement;
+          JThrowablePtr Function(
+            JBooleanArrayPtr array,
+            JSizeMarker index,
+            JBooleanMarker element,
+          )>> SetBooleanArrayElement;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -3398,10 +4033,12 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       GetByteArrayElement;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JByteArrayPtr array, JSizeMarker index, JByteMarker element)>>
-      SetByteArrayElement;
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JByteArrayPtr array,
+            JSizeMarker index,
+            JByteMarker element,
+          )>> SetByteArrayElement;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -3409,10 +4046,12 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       GetCharArrayElement;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JCharArrayPtr array, JSizeMarker index, JCharMarker element)>>
-      SetCharArrayElement;
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JCharArrayPtr array,
+            JSizeMarker index,
+            JCharMarker element,
+          )>> SetCharArrayElement;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -3421,8 +4060,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JThrowablePtr Function(JShortArrayPtr array, JSizeMarker index,
-              JShortMarker element)>> SetShortArrayElement;
+          JThrowablePtr Function(
+            JShortArrayPtr array,
+            JSizeMarker index,
+            JShortMarker element,
+          )>> SetShortArrayElement;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -3430,10 +4072,12 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       GetIntArrayElement;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JIntArrayPtr array, JSizeMarker index, JIntMarker element)>>
-      SetIntArrayElement;
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JIntArrayPtr array,
+            JSizeMarker index,
+            JIntMarker element,
+          )>> SetIntArrayElement;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -3441,10 +4085,12 @@ final class GlobalJniEnvStruct extends ffi.Struct {
       GetLongArrayElement;
 
   external ffi.Pointer<
-          ffi.NativeFunction<
-              JThrowablePtr Function(
-                  JLongArrayPtr array, JSizeMarker index, JLongMarker element)>>
-      SetLongArrayElement;
+      ffi.NativeFunction<
+          JThrowablePtr Function(
+            JLongArrayPtr array,
+            JSizeMarker index,
+            JLongMarker element,
+          )>> SetLongArrayElement;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -3453,8 +4099,11 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JThrowablePtr Function(JFloatArrayPtr array, JSizeMarker index,
-              JFloatMarker element)>> SetFloatArrayElement;
+          JThrowablePtr Function(
+            JFloatArrayPtr array,
+            JSizeMarker index,
+            JFloatMarker element,
+          )>> SetFloatArrayElement;
 
   external ffi.Pointer<
           ffi.NativeFunction<
@@ -3463,6 +4112,9 @@ final class GlobalJniEnvStruct extends ffi.Struct {
 
   external ffi.Pointer<
       ffi.NativeFunction<
-          JThrowablePtr Function(JDoubleArrayPtr array, JSizeMarker index,
-              JDoubleMarker element)>> SetDoubleArrayElement;
+          JThrowablePtr Function(
+            JDoubleArrayPtr array,
+            JSizeMarker index,
+            JDoubleMarker element,
+          )>> SetDoubleArrayElement;
 }

--- a/pkgs/jni/lib/src/types.dart
+++ b/pkgs/jni/lib/src/types.dart
@@ -2,11 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:ffi/ffi.dart';
+import 'dart:ffi';
 
-import '../_internal.dart';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart' show internal;
+
 import 'jni.dart';
 import 'jobject.dart';
+import 'jreference.dart';
 import 'jvalues.dart';
 import 'third_party/generated_bindings.dart';
 
@@ -14,15 +17,14 @@ part 'jclass.dart';
 part 'jprimitives.dart';
 
 @internal
-sealed class JType<JavaT> {
-  const JType();
+sealed class JTypeBase<JavaT> {
+  const JTypeBase();
 
   String get signature;
 }
 
 /// Able to be a return type of a method that can be called.
-@internal
-mixin JCallable<JavaT, DartT> on JType<JavaT> {
+mixin JCallable<JavaT, DartT> on JTypeBase<JavaT> {
   DartT _staticCall(
       JClassPtr clazz, JMethodIDPtr methodID, Pointer<JValue> args);
   DartT _instanceCall(
@@ -30,15 +32,13 @@ mixin JCallable<JavaT, DartT> on JType<JavaT> {
 }
 
 /// Able to be constructed.
-@internal
-mixin JConstructable<JavaT, DartT> on JType<JavaT> {
+mixin JConstructable<JavaT, DartT> on JTypeBase<JavaT> {
   DartT _newObject(
       JClassPtr clazz, JMethodIDPtr methodID, Pointer<JValue> args);
 }
 
 /// Able to be the type of a field that can be get and set.
-@internal
-mixin JAccessible<JavaT, DartT> on JType<JavaT> {
+mixin JAccessible<JavaT, DartT> on JTypeBase<JavaT> {
   DartT _staticGet(JClassPtr clazz, JFieldIDPtr fieldID);
   DartT _instanceGet(JObjectPtr obj, JFieldIDPtr fieldID);
   void _staticSet(JClassPtr clazz, JFieldIDPtr fieldID, DartT val);
@@ -53,7 +53,7 @@ mixin JAccessible<JavaT, DartT> on JType<JavaT> {
 @internal
 const referenceType = _ReferenceType();
 
-final class _ReferenceType extends JType<JReference>
+final class _ReferenceType extends JTypeBase<JReference>
     with JConstructable<JReference, JReference> {
   const _ReferenceType();
 
@@ -68,21 +68,26 @@ final class _ReferenceType extends JType<JReference>
   String get signature => 'Ljava/lang/Object;';
 }
 
-@internal
-abstract class JObjType<T extends JObject?> extends JType<T>
+abstract class JType<T extends JObject?> extends JTypeBase<T>
     with JCallable<T, T>, JConstructable<T, T>, JAccessible<T, T> {
   /// Number of super types. Distance to the root type.
+  @internal
   int get superCount;
 
-  JObjType get superType;
+  @internal
+  JType get superType;
 
-  JObjType<T?> get nullableType;
+  @internal
+  JType<T?> get nullableType;
 
+  @internal
   bool get isNullable => this == nullableType;
 
-  const JObjType();
+  @internal
+  const JType();
 
   /// Creates an object from this type using the reference.
+  @internal
   T fromReference(JReference reference);
 
   JClass get jClass {
@@ -136,9 +141,8 @@ abstract class JObjType<T extends JObject?> extends JType<T>
 }
 
 /// Lowest common ancestor of two types in the inheritance tree.
-JObjType<dynamic> _lowestCommonAncestor(
-    JObjType<dynamic> a, JObjType<dynamic> b) {
-  if (a is! JObjType<JObject> || b is! JObjType<JObject>) {
+JType<dynamic> _lowestCommonAncestor(JType<dynamic> a, JType<dynamic> b) {
+  if (a is! JType<JObject> || b is! JType<JObject>) {
     // If one of the types are nullable, the common super type should also be
     // nullable.
     a = a.nullableType;
@@ -158,6 +162,6 @@ JObjType<dynamic> _lowestCommonAncestor(
 }
 
 @internal
-JObjType<dynamic> lowestCommonSuperType(List<JObjType<dynamic>> types) {
+JType<dynamic> lowestCommonSuperType(List<JType<dynamic>> types) {
   return types.reduce(_lowestCommonAncestor);
 }

--- a/pkgs/jni/lib/src/util/jiterator.dart
+++ b/pkgs/jni/lib/src/util/jiterator.dart
@@ -8,85 +8,73 @@ import '../jobject.dart';
 import '../jreference.dart';
 import '../types.dart';
 
-final class JIteratorNullableType<$E extends JObject?>
-    extends JObjType<JIterator<$E>?> {
-  @internal
-  final JObjType<$E> E;
+@internal
+final class $JIterator$NullableType$<$E extends JObject?>
+    extends JType<JIterator<$E>?> {
+  final JType<$E> E;
 
-  @internal
-  const JIteratorNullableType(
+  const $JIterator$NullableType$(
     this.E,
   );
 
-  @internal
   @override
   String get signature => r'Ljava/util/Iterator;';
 
-  @internal
   @override
   JIterator<$E>? fromReference(JReference reference) =>
       reference.isNull ? null : JIterator<$E>.fromReference(E, reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectNullableType();
+  JType get superType => const $JObject$NullableType$();
 
-  @internal
   @override
-  JObjType<JIterator<$E>?> get nullableType => this;
+  JType<JIterator<$E>?> get nullableType => this;
 
-  @internal
   @override
   final superCount = 1;
 
   @override
-  int get hashCode => Object.hash(JIteratorNullableType, E);
+  int get hashCode => Object.hash($JIterator$NullableType$, E);
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == (JIteratorNullableType<$E>) &&
-        other is JIteratorNullableType<$E> &&
+    return other.runtimeType == ($JIterator$NullableType$<$E>) &&
+        other is $JIterator$NullableType$<$E> &&
         E == other.E;
   }
 }
 
-final class JIteratorType<$E extends JObject?> extends JObjType<JIterator<$E>> {
-  @internal
-  final JObjType<$E> E;
+@internal
+final class $JIterator$Type$<$E extends JObject?> extends JType<JIterator<$E>> {
+  final JType<$E> E;
 
-  @internal
-  const JIteratorType(
+  const $JIterator$Type$(
     this.E,
   );
 
-  @internal
   @override
   String get signature => r'Ljava/util/Iterator;';
 
-  @internal
   @override
   JIterator<$E> fromReference(JReference reference) =>
       JIterator<$E>.fromReference(E, reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JIterator<$E>?> get nullableType => JIteratorNullableType<$E>(E);
+  JType<JIterator<$E>?> get nullableType => $JIterator$NullableType$<$E>(E);
 
-  @internal
   @override
   final superCount = 1;
 
   @override
-  int get hashCode => Object.hash(JIteratorType, E);
+  int get hashCode => Object.hash($JIterator$Type$, E);
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == (JIteratorType<$E>) &&
-        other is JIteratorType<$E> &&
+    return other.runtimeType == ($JIterator$Type$<$E>) &&
+        other is $JIterator$Type$<$E> &&
         E == other.E;
   }
 }
@@ -95,10 +83,10 @@ class JIterator<$E extends JObject?> extends JObject implements Iterator<$E> {
   @internal
   @override
   // ignore: overridden_fields
-  final JObjType<JIterator<$E>> $type;
+  final JType<JIterator<$E>> $type;
 
   @internal
-  final JObjType<$E> E;
+  final JType<$E> E;
 
   JIterator.fromReference(
     this.E,
@@ -109,17 +97,17 @@ class JIterator<$E extends JObject?> extends JObject implements Iterator<$E> {
   static final _class = JClass.forName(r'java/util/Iterator');
 
   /// The type which includes information such as the signature of this class.
-  static JIteratorType<$E> type<$E extends JObject?>(
-    JObjType<$E> E,
+  static JType<JIterator<$E>> type<$E extends JObject?>(
+    JType<$E> E,
   ) {
-    return JIteratorType<$E>(E);
+    return $JIterator$Type$<$E>(E);
   }
 
   /// The type which includes information such as the signature of this class.
-  static JIteratorNullableType<$E> nullableType<$E extends JObject?>(
-    JObjType<$E> E,
+  static JType<JIterator<$E>?> nullableType<$E extends JObject?>(
+    JType<$E> E,
   ) {
-    return JIteratorNullableType<$E>(E);
+    return $JIterator$NullableType$<$E>(E);
   }
 
   $E? _current;

--- a/pkgs/jni/lib/src/util/jlist.dart
+++ b/pkgs/jni/lib/src/util/jlist.dart
@@ -14,85 +14,73 @@ import '../types.dart';
 import 'jiterator.dart';
 import 'jset.dart';
 
-final class JListNullableType<$E extends JObject?>
-    extends JObjType<JList<$E>?> {
-  @internal
-  final JObjType<$E> E;
+@internal
+final class $JList$NullableType$<$E extends JObject?>
+    extends JType<JList<$E>?> {
+  final JType<$E> E;
 
-  @internal
-  const JListNullableType(
+  const $JList$NullableType$(
     this.E,
   );
 
-  @internal
   @override
   String get signature => r'Ljava/util/List;';
 
-  @internal
   @override
   JList<$E>? fromReference(JReference reference) =>
       reference.isNull ? null : JList<$E>.fromReference(E, reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JList<$E>?> get nullableType => this;
+  JType<JList<$E>?> get nullableType => this;
 
-  @internal
   @override
   final superCount = 1;
 
   @override
-  int get hashCode => Object.hash(JListNullableType, E);
+  int get hashCode => Object.hash($JList$NullableType$, E);
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == (JListNullableType<$E>) &&
-        other is JListNullableType<$E> &&
+    return other.runtimeType == ($JList$NullableType$<$E>) &&
+        other is $JList$NullableType$<$E> &&
         E == other.E;
   }
 }
 
-final class JListType<$E extends JObject?> extends JObjType<JList<$E>> {
-  @internal
-  final JObjType<$E> E;
+@internal
+final class $JList$Type$<$E extends JObject?> extends JType<JList<$E>> {
+  final JType<$E> E;
 
-  @internal
-  const JListType(
+  const $JList$Type$(
     this.E,
   );
 
-  @internal
   @override
   String get signature => r'Ljava/util/List;';
 
-  @internal
   @override
   JList<$E> fromReference(JReference reference) =>
       JList<$E>.fromReference(E, reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JList<$E>?> get nullableType => JListNullableType<$E>(E);
+  JType<JList<$E>?> get nullableType => $JList$NullableType$<$E>(E);
 
-  @internal
   @override
   final superCount = 1;
 
   @override
-  int get hashCode => Object.hash(JListType, E);
+  int get hashCode => Object.hash($JList$Type$, E);
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == (JListType<$E>) &&
-        other is JListType<$E> &&
+    return other.runtimeType == ($JList$Type$<$E>) &&
+        other is $JList$Type$<$E> &&
         E == other.E;
   }
 }
@@ -101,10 +89,10 @@ class JList<$E extends JObject?> extends JObject with ListMixin<$E> {
   @internal
   @override
   // ignore: overridden_fields
-  final JObjType<JList<$E>> $type;
+  final JType<JList<$E>> $type;
 
   @internal
-  final JObjType<$E> E;
+  final JType<$E> E;
 
   JList.fromReference(
     this.E,
@@ -115,16 +103,15 @@ class JList<$E extends JObject?> extends JObject with ListMixin<$E> {
   static final _class = JClass.forName(r'java/util/List');
 
   /// The type which includes information such as the signature of this class.
-  static JListType<$E> type<$E extends JObject?>(
-    JObjType<$E> E,
+  static JType<JList<$E>> type<$E extends JObject?>(
+    JType<$E> E,
   ) {
-    return JListType<$E>(E);
+    return $JList$Type$<$E>(E);
   }
 
   /// The type which includes information such as the signature of this class.
-  static JListNullableType<$E> nullableType<$E extends JObject?>(
-      JObjType<$E> E) {
-    return JListNullableType<$E>(E);
+  static JType<JList<$E>?> nullableType<$E extends JObject?>(JType<$E> E) {
+    return $JList$NullableType$<$E>(E);
   }
 
   static final _arrayListClassRef = JClass.forName(r'java/util/ArrayList');
@@ -208,7 +195,7 @@ class JList<$E extends JObject?> extends JObject with ListMixin<$E> {
   JList<$E> getRange(int start, int end) {
     RangeError.checkValidRange(start, end, length);
     return _getRangeId(
-        this, JListType<$E>(E), [JValueInt(start), JValueInt(end)])!;
+        this, $JList$Type$<$E>(E), [JValueInt(start), JValueInt(end)])!;
   }
 
   static final _indexOfId =
@@ -264,7 +251,7 @@ class JList<$E extends JObject?> extends JObject with ListMixin<$E> {
   static final _iteratorId =
       _class.instanceMethodId(r'iterator', r'()Ljava/util/Iterator;');
   @override
-  JIterator<$E> get iterator => _iteratorId(this, JIteratorType<$E>(E), [])!;
+  JIterator<$E> get iterator => _iteratorId(this, $JIterator$Type$<$E>(E), [])!;
 
   static final _lastIndexOfId =
       _class.instanceMethodId(r'lastIndexOf', r'(Ljava/lang/Object;)I');
@@ -316,7 +303,7 @@ class JList<$E extends JObject?> extends JObject with ListMixin<$E> {
 }
 
 extension ToJavaList<E extends JObject?> on Iterable<E> {
-  JList<E> toJList(JObjType<E> type) {
+  JList<E> toJList(JType<E> type) {
     final list = JList.array(type);
     list.addAll(this);
     return list;

--- a/pkgs/jni/lib/src/util/jmap.dart
+++ b/pkgs/jni/lib/src/util/jmap.dart
@@ -11,95 +11,81 @@ import '../jreference.dart';
 import '../types.dart';
 import 'jset.dart';
 
-final class JMapNullableType<$K extends JObject?, $V extends JObject?>
-    extends JObjType<JMap<$K, $V>?> {
-  @internal
-  final JObjType<$K> K;
+@internal
+final class $JMap$NullableType$<$K extends JObject?, $V extends JObject?>
+    extends JType<JMap<$K, $V>?> {
+  final JType<$K> K;
 
-  @internal
-  final JObjType<$V> V;
+  final JType<$V> V;
 
-  @internal
-  const JMapNullableType(
+  const $JMap$NullableType$(
     this.K,
     this.V,
   );
 
-  @internal
   @override
   String get signature => r'Ljava/util/Map;';
 
-  @internal
   @override
   JMap<$K, $V>? fromReference(JReference reference) =>
       reference.isNull ? null : JMap<$K, $V>.fromReference(K, V, reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JMap<$K, $V>?> get nullableType => this;
+  JType<JMap<$K, $V>?> get nullableType => this;
 
-  @internal
   @override
   final superCount = 1;
 
   @override
-  int get hashCode => Object.hash(JMapNullableType, K, V);
+  int get hashCode => Object.hash($JMap$NullableType$, K, V);
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == (JMapNullableType<$K, $V>) &&
-        other is JMapNullableType<$K, $V> &&
+    return other.runtimeType == ($JMap$NullableType$<$K, $V>) &&
+        other is $JMap$NullableType$<$K, $V> &&
         K == other.K &&
         V == other.V;
   }
 }
 
-final class JMapType<$K extends JObject?, $V extends JObject?>
-    extends JObjType<JMap<$K, $V>> {
-  @internal
-  final JObjType<$K> K;
+@internal
+final class $JMap$Type$<$K extends JObject?, $V extends JObject?>
+    extends JType<JMap<$K, $V>> {
+  final JType<$K> K;
 
-  @internal
-  final JObjType<$V> V;
+  final JType<$V> V;
 
-  @internal
-  const JMapType(
+  const $JMap$Type$(
     this.K,
     this.V,
   );
 
-  @internal
   @override
   String get signature => r'Ljava/util/Map;';
 
-  @internal
   @override
   JMap<$K, $V> fromReference(JReference reference) =>
       JMap<$K, $V>.fromReference(K, V, reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JMap<$K, $V>?> get nullableType => JMapNullableType<$K, $V>(K, V);
+  JType<JMap<$K, $V>?> get nullableType => $JMap$NullableType$<$K, $V>(K, V);
 
-  @internal
   @override
   final superCount = 1;
 
   @override
-  int get hashCode => Object.hash(JMapType, K, V);
+  int get hashCode => Object.hash($JMap$Type$, K, V);
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == (JMapType<$K, $V>) &&
-        other is JMapType<$K, $V> &&
+    return other.runtimeType == ($JMap$Type$<$K, $V>) &&
+        other is $JMap$Type$<$K, $V> &&
         K == other.K &&
         V == other.V;
   }
@@ -110,13 +96,13 @@ class JMap<$K extends JObject?, $V extends JObject?> extends JObject
   @internal
   @override
   // ignore: overridden_fields
-  final JObjType<JMap<$K, $V>> $type;
+  final JType<JMap<$K, $V>> $type;
 
   @internal
-  final JObjType<$K> K;
+  final JType<$K> K;
 
   @internal
-  final JObjType<$V> V;
+  final JType<$V> V;
 
   JMap.fromReference(
     this.K,
@@ -128,20 +114,20 @@ class JMap<$K extends JObject?, $V extends JObject?> extends JObject
   static final _class = JClass.forName(r'java/util/Map');
 
   /// The type which includes information such as the signature of this class.
-  static JMapType<$K, $V> type<$K extends JObject?, $V extends JObject?>(
-    JObjType<$K> K,
-    JObjType<$V> V,
+  static JType<JMap<$K, $V>> type<$K extends JObject?, $V extends JObject?>(
+    JType<$K> K,
+    JType<$V> V,
   ) {
-    return JMapType<$K, $V>(K, V);
+    return $JMap$Type$<$K, $V>(K, V);
   }
 
   /// The type which includes information such as the signature of this class.
-  static JMapNullableType<$K, $V>
+  static JType<JMap<$K, $V>?>
       nullableType<$K extends JObject?, $V extends JObject?>(
-    JObjType<$K> K,
-    JObjType<$V> V,
+    JType<$K> K,
+    JType<$V> V,
   ) {
-    return JMapNullableType<$K, $V>(K, V);
+    return $JMap$NullableType$<$K, $V>(K, V);
   }
 
   static final _hashMapClass = JClass.forName(r'java/util/HashMap');
@@ -221,7 +207,7 @@ class JMap<$K extends JObject?, $V extends JObject?> extends JObject
   static final _keysId =
       _class.instanceMethodId(r'keySet', r'()Ljava/util/Set;');
   @override
-  JSet<$K> get keys => _keysId(this, JSetType<$K>(K), [])!;
+  JSet<$K> get keys => _keysId(this, $JSet$Type$<$K>(K), [])!;
 
   static final _sizeId = _class.instanceMethodId(r'size', r'()I');
   @override
@@ -241,7 +227,7 @@ class JMap<$K extends JObject?, $V extends JObject?> extends JObject
 }
 
 extension ToJavaMap<K extends JObject?, V extends JObject?> on Map<K, V> {
-  JMap<K, V> toJMap(JObjType<K> keyType, JObjType<V> valueType) {
+  JMap<K, V> toJMap(JType<K> keyType, JType<V> valueType) {
     final map = JMap.hash(keyType, valueType);
     map.addAll(this);
     return map;

--- a/pkgs/jni/lib/src/util/jset.dart
+++ b/pkgs/jni/lib/src/util/jset.dart
@@ -12,84 +12,72 @@ import '../jreference.dart';
 import '../types.dart';
 import 'jiterator.dart';
 
-final class JSetNullableType<$E extends JObject?> extends JObjType<JSet<$E>?> {
-  @internal
-  final JObjType<$E> E;
+@internal
+final class $JSet$NullableType$<$E extends JObject?> extends JType<JSet<$E>?> {
+  final JType<$E> E;
 
-  @internal
-  const JSetNullableType(
+  const $JSet$NullableType$(
     this.E,
   );
 
-  @internal
   @override
   String get signature => r'Ljava/util/Set;';
 
-  @internal
   @override
   JSet<$E>? fromReference(JReference reference) =>
       reference.isNull ? null : JSet<$E>.fromReference(E, reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JSet<$E>?> get nullableType => this;
+  JType<JSet<$E>?> get nullableType => this;
 
-  @internal
   @override
   final superCount = 1;
 
   @override
-  int get hashCode => Object.hash(JSetNullableType, E);
+  int get hashCode => Object.hash($JSet$NullableType$, E);
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == (JSetNullableType<$E>) &&
-        other is JSetNullableType<$E> &&
+    return other.runtimeType == ($JSet$NullableType$<$E>) &&
+        other is $JSet$NullableType$<$E> &&
         E == other.E;
   }
 }
 
-final class JSetType<$E extends JObject?> extends JObjType<JSet<$E>> {
-  @internal
-  final JObjType<$E> E;
+@internal
+final class $JSet$Type$<$E extends JObject?> extends JType<JSet<$E>> {
+  final JType<$E> E;
 
-  @internal
-  const JSetType(
+  const $JSet$Type$(
     this.E,
   );
 
-  @internal
   @override
   String get signature => r'Ljava/util/Set;';
 
-  @internal
   @override
   JSet<$E> fromReference(JReference reference) =>
       JSet<$E>.fromReference(E, reference);
 
-  @internal
   @override
-  JObjType get superType => const JObjectType();
+  JType get superType => const $JObject$Type$();
 
-  @internal
   @override
-  JObjType<JSet<$E>?> get nullableType => JSetNullableType<$E>(E);
+  JType<JSet<$E>?> get nullableType => $JSet$NullableType$<$E>(E);
 
-  @internal
   @override
   final superCount = 1;
 
   @override
-  int get hashCode => Object.hash(JSetType, E);
+  int get hashCode => Object.hash($JSet$Type$, E);
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == (JSetType<$E>) &&
-        other is JSetType<$E> &&
+    return other.runtimeType == ($JSet$Type$<$E>) &&
+        other is $JSet$Type$<$E> &&
         E == other.E;
   }
 }
@@ -98,10 +86,10 @@ class JSet<$E extends JObject?> extends JObject with SetMixin<$E> {
   @internal
   @override
   // ignore: overridden_fields
-  final JObjType<JSet<$E>> $type;
+  final JType<JSet<$E>> $type;
 
   @internal
-  final JObjType<$E> E;
+  final JType<$E> E;
 
   JSet.fromReference(
     this.E,
@@ -112,17 +100,17 @@ class JSet<$E extends JObject?> extends JObject with SetMixin<$E> {
   static final _class = JClass.forName(r'java/util/Set');
 
   /// The type which includes information such as the signature of this class.
-  static JSetType<$E> type<$E extends JObject?>(
-    JObjType<$E> E,
+  static JType<JSet<$E>> type<$E extends JObject?>(
+    JType<$E> E,
   ) {
-    return JSetType<$E>(E);
+    return $JSet$Type$<$E>(E);
   }
 
   /// The type which includes information such as the signature of this class.
-  static JSetNullableType<$E> nullableType<$E extends JObject?>(
-    JObjType<$E> E,
+  static JType<JSet<$E>?> nullableType<$E extends JObject?>(
+    JType<$E> E,
   ) {
-    return JSetNullableType<$E>(E);
+    return $JSet$NullableType$<$E>(E);
   }
 
   static final _hashSetClass = JClass.forName(r'java/util/HashSet');
@@ -202,7 +190,7 @@ class JSet<$E extends JObject?> extends JObject with SetMixin<$E> {
   static final _iteratorId =
       _class.instanceMethodId(r'iterator', r'()Ljava/util/Iterator;');
   @override
-  JIterator<$E> get iterator => _iteratorId(this, JIteratorType<$E>(E), [])!;
+  JIterator<$E> get iterator => _iteratorId(this, $JIterator$Type$<$E>(E), [])!;
 
   static final _sizeId = _class.instanceMethodId(r'size', r'()I');
   @override
@@ -262,7 +250,7 @@ class JSet<$E extends JObject?> extends JObject with SetMixin<$E> {
 }
 
 extension ToJavaSet<E extends JObject?> on Iterable<E> {
-  JSet<E> toJSet(JObjType<E> type) {
+  JSet<E> toJSet(JType<E> type) {
     final set = JSet.hash(type);
     set.addAll(this);
     return set;

--- a/pkgs/jni/lib/src/util/util.dart
+++ b/pkgs/jni/lib/src/util/util.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'jiterator.dart';
-export 'jlist.dart';
-export 'jmap.dart';
-export 'jset.dart';
+export 'jiterator.dart' hide $JIterator$NullableType$, $JIterator$Type$;
+export 'jlist.dart' hide $JList$NullableType$, $JList$Type$;
+export 'jmap.dart' hide $JMap$NullableType$, $JMap$Type$;
+export 'jset.dart' hide $JSet$NullableType$, $JSet$Type$;

--- a/pkgs/jni/pubspec.yaml
+++ b/pkgs/jni/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jni
 description: A library to access JNI from Dart and Flutter that acts as a support library for package:jnigen.
-version: 0.14.3-wip
+version: 0.15.0-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jni
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Ajni
 

--- a/pkgs/jni/test/exception_test.dart
+++ b/pkgs/jni/test/exception_test.dart
@@ -55,7 +55,7 @@ void run({required TestRunnerCallback testRunner}) {
     expect(
         () => rc
             .instanceMethodId('nextInt', '(I)I')
-            .call(r, const jintType(), [JValueInt(256)]),
+            .call(r, jint.type, [JValueInt(256)]),
         throwsA(isA<UseAfterReleaseError>()));
   });
 
@@ -65,7 +65,7 @@ void run({required TestRunnerCallback testRunner}) {
     expect(
         () => rc
             .instanceMethodId('nextInt', '(I)I')
-            .call(r, const jintType(), [JValueInt(-1)]),
+            .call(r, jint.type, [JValueInt(-1)]),
         throwsA(isA<JniException>()));
   });
 }

--- a/pkgs/jni/test/global_env_test.dart
+++ b/pkgs/jni/test/global_env_test.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:ffi/ffi.dart';
 import 'package:jni/jni.dart';
 import 'package:jni/src/jni.dart';
+import 'package:jni/src/third_party/generated_bindings.dart';
 import 'package:test/test.dart';
 
 import 'test_util/test_util.dart';

--- a/pkgs/jni/test/jarray_test.dart
+++ b/pkgs/jni/test/jarray_test.dart
@@ -6,6 +6,7 @@ import 'dart:ffi';
 import 'dart:io';
 
 import 'package:jni/jni.dart';
+import 'package:jni/src/third_party/generated_bindings.dart';
 import 'package:test/test.dart';
 
 import 'test_util/test_util.dart';

--- a/pkgs/jni/test/jobject_test.dart
+++ b/pkgs/jni/test/jobject_test.dart
@@ -158,7 +158,7 @@ void run({required TestRunnerCallback testRunner}) {
     final byteClass = JByte.type.jClass;
     final parseByte =
         byteClass.staticMethodId('parseByte', '(Ljava/lang/String;)B');
-    final twelve = parseByte(byteClass, const jbyteType(), ['12'.toJString()]);
+    final twelve = parseByte(byteClass, jbyte.type, ['12'.toJString()]);
     expect(twelve, 12);
     byteClass.release();
   });

--- a/pkgs/jni/test/load_test.dart
+++ b/pkgs/jni/test/load_test.dart
@@ -11,6 +11,7 @@ import 'dart:math';
 
 import 'package:ffi/ffi.dart';
 import 'package:jni/jni.dart';
+import 'package:jni/src/third_party/generated_bindings.dart';
 import 'package:test/test.dart';
 
 import 'test_util/test_util.dart';
@@ -96,7 +97,7 @@ void run({required TestRunnerCallback testRunner}) {
     final random = newRandom();
     final nextInt = randomClass.instanceMethodId('nextInt', '()I');
     for (var i = 0; i < k256; i++) {
-      final rInt = nextInt(random, const jintType(), []);
+      final rInt = nextInt(random, jint.type, []);
       expect(rInt, isA<int>());
     }
   });
@@ -122,7 +123,7 @@ void run({required TestRunnerCallback testRunner}) {
       doGC();
       sleep(Duration(seconds: delayInSeconds));
       expect(
-        nextInt(random, const jintType(), []),
+        nextInt(random, jint.type, []),
         isA<int>(),
       );
       expect(

--- a/pkgs/jni/test/type_test.dart
+++ b/pkgs/jni/test/type_test.dart
@@ -20,10 +20,10 @@ import 'test_util/test_util.dart';
 class A extends JObject {
   A.fromReference(super.reference) : super.fromReference();
   @override
-  JObjType<JObject> get $type => $AType();
+  JType<JObject> get $type => $A$Type$();
 }
 
-final class $ANullableType extends JObjType<A?> {
+final class $A$NullableType$ extends JType<A?> {
   @internal
   @override
   A? fromReference(JReference reference) {
@@ -40,22 +40,22 @@ final class $ANullableType extends JObjType<A?> {
 
   @internal
   @override
-  JObjType<JObject?> get superType => JObject.nullableType;
+  JType<JObject?> get superType => JObject.nullableType;
 
   @internal
   @override
-  JObjType<A?> get nullableType => this;
+  JType<A?> get nullableType => this;
 
   @override
-  int get hashCode => ($ANullableType).hashCode;
+  int get hashCode => ($A$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == $ANullableType && other is $ANullableType;
+    return other.runtimeType == $A$NullableType$ && other is $A$NullableType$;
   }
 }
 
-final class $AType extends JObjType<A> {
+final class $A$Type$ extends JType<A> {
   @internal
   @override
   A fromReference(JReference reference) {
@@ -72,28 +72,28 @@ final class $AType extends JObjType<A> {
 
   @internal
   @override
-  JObjType<JObject> get superType => JObject.type;
+  JType<JObject> get superType => JObject.type;
 
   @internal
   @override
-  JObjType<A?> get nullableType => $ANullableType();
+  JType<A?> get nullableType => $A$NullableType$();
 
   @override
-  int get hashCode => ($AType).hashCode;
+  int get hashCode => ($A$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == $AType && other is $AType;
+    return other.runtimeType == $A$Type$ && other is $A$Type$;
   }
 }
 
 class B extends JObject {
   B.fromReference(super.reference) : super.fromReference();
   @override
-  JObjType<JObject> get $type => $BType();
+  JType<JObject> get $type => $B$Type$();
 }
 
-final class $BNullableType extends JObjType<B?> {
+final class $B$NullableType$ extends JType<B?> {
   @internal
   @override
   B? fromReference(JReference reference) {
@@ -110,22 +110,22 @@ final class $BNullableType extends JObjType<B?> {
 
   @internal
   @override
-  JObjType<JObject?> get superType => JObject.nullableType;
+  JType<JObject?> get superType => JObject.nullableType;
 
   @internal
   @override
-  JObjType<B?> get nullableType => this;
+  JType<B?> get nullableType => this;
 
   @override
-  int get hashCode => ($BNullableType).hashCode;
+  int get hashCode => ($B$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == $BNullableType && other is $BNullableType;
+    return other.runtimeType == $B$NullableType$ && other is $B$NullableType$;
   }
 }
 
-final class $BType extends JObjType<B> {
+final class $B$Type$ extends JType<B> {
   @internal
   @override
   B fromReference(JReference reference) {
@@ -142,18 +142,18 @@ final class $BType extends JObjType<B> {
 
   @internal
   @override
-  JObjType<JObject> get superType => JObject.type;
+  JType<JObject> get superType => JObject.type;
 
   @internal
   @override
-  JObjType<B?> get nullableType => $BNullableType();
+  JType<B?> get nullableType => $B$NullableType$();
 
   @override
-  int get hashCode => ($BType).hashCode;
+  int get hashCode => ($B$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == $BType && other is $BType;
+    return other.runtimeType == $B$Type$ && other is $B$Type$;
   }
 }
 
@@ -161,10 +161,10 @@ class C extends A {
   C.fromReference(super.reference) : super.fromReference();
 
   @override
-  JObjType<JObject> get $type => $CType();
+  JType<JObject> get $type => $C$Type$();
 }
 
-final class $CNullableType extends JObjType<C?> {
+final class $C$NullableType$ extends JType<C?> {
   @internal
   @override
   C? fromReference(JReference reference) {
@@ -181,22 +181,22 @@ final class $CNullableType extends JObjType<C?> {
 
   @internal
   @override
-  JObjType<JObject?> get superType => $ANullableType();
+  JType<JObject?> get superType => $A$NullableType$();
 
   @internal
   @override
-  JObjType<C?> get nullableType => this;
+  JType<C?> get nullableType => this;
 
   @override
-  int get hashCode => ($CNullableType).hashCode;
+  int get hashCode => ($C$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == $CNullableType && other is $CNullableType;
+    return other.runtimeType == $C$NullableType$ && other is $C$NullableType$;
   }
 }
 
-final class $CType extends JObjType<C> {
+final class $C$Type$ extends JType<C> {
   @internal
   @override
   C fromReference(JReference reference) {
@@ -213,18 +213,18 @@ final class $CType extends JObjType<C> {
 
   @internal
   @override
-  JObjType<JObject> get superType => $AType();
+  JType<JObject> get superType => $A$Type$();
 
   @internal
   @override
-  JObjType<C?> get nullableType => $CNullableType();
+  JType<C?> get nullableType => $C$NullableType$();
 
   @override
-  int get hashCode => ($CType).hashCode;
+  int get hashCode => ($C$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == $CType && other is $CType;
+    return other.runtimeType == $C$Type$ && other is $C$Type$;
   }
 }
 
@@ -232,10 +232,10 @@ class D extends A {
   D.fromReference(super.reference) : super.fromReference();
 
   @override
-  JObjType<JObject> get $type => $DType();
+  JType<JObject> get $type => $D$Type$();
 }
 
-final class $DNullableType extends JObjType<D?> {
+final class $D$NullableType$ extends JType<D?> {
   @internal
   @override
   D? fromReference(JReference reference) {
@@ -252,22 +252,22 @@ final class $DNullableType extends JObjType<D?> {
 
   @internal
   @override
-  JObjType<JObject?> get superType => $ANullableType();
+  JType<JObject?> get superType => $A$NullableType$();
 
   @internal
   @override
-  JObjType<D?> get nullableType => this;
+  JType<D?> get nullableType => this;
 
   @override
-  int get hashCode => ($DNullableType).hashCode;
+  int get hashCode => ($D$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == $DNullableType && other is $DNullableType;
+    return other.runtimeType == $D$NullableType$ && other is $D$NullableType$;
   }
 }
 
-final class $DType extends JObjType<D> {
+final class $D$Type$ extends JType<D> {
   @internal
   @override
   D fromReference(JReference reference) {
@@ -284,18 +284,18 @@ final class $DType extends JObjType<D> {
 
   @internal
   @override
-  JObjType<JObject> get superType => $AType();
+  JType<JObject> get superType => $A$Type$();
 
   @internal
   @override
-  JObjType<D?> get nullableType => $DNullableType();
+  JType<D?> get nullableType => $D$NullableType$();
 
   @override
-  int get hashCode => ($DType).hashCode;
+  int get hashCode => ($D$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == $DType && other is $DType;
+    return other.runtimeType == $D$Type$ && other is $D$Type$;
   }
 }
 
@@ -303,10 +303,10 @@ class E extends B {
   E.fromReference(super.reference) : super.fromReference();
 
   @override
-  JObjType<JObject> get $type => $EType();
+  JType<JObject> get $type => $E$Type$();
 }
 
-final class $ENullableType extends JObjType<E?> {
+final class $E$NullableType$ extends JType<E?> {
   @internal
   @override
   E? fromReference(JReference reference) {
@@ -323,22 +323,22 @@ final class $ENullableType extends JObjType<E?> {
 
   @internal
   @override
-  JObjType<JObject?> get superType => $BNullableType();
+  JType<JObject?> get superType => $B$NullableType$();
 
   @internal
   @override
-  JObjType<E?> get nullableType => this;
+  JType<E?> get nullableType => this;
 
   @override
-  int get hashCode => ($ENullableType).hashCode;
+  int get hashCode => ($E$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == $ENullableType && other is $ENullableType;
+    return other.runtimeType == $E$NullableType$ && other is $E$NullableType$;
   }
 }
 
-final class $EType extends JObjType<E> {
+final class $E$Type$ extends JType<E> {
   @internal
   @override
   E fromReference(JReference reference) {
@@ -355,18 +355,18 @@ final class $EType extends JObjType<E> {
 
   @internal
   @override
-  JObjType<JObject> get superType => $BType();
+  JType<JObject> get superType => $B$Type$();
 
   @internal
   @override
-  JObjType<E?> get nullableType => $ENullableType();
+  JType<E?> get nullableType => $E$NullableType$();
 
   @override
-  int get hashCode => ($EType).hashCode;
+  int get hashCode => ($E$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == $EType && other is $EType;
+    return other.runtimeType == $E$Type$ && other is $E$Type$;
   }
 }
 
@@ -374,10 +374,10 @@ class F extends C {
   F.fromReference(super.reference) : super.fromReference();
 
   @override
-  JObjType<JObject> get $type => $FType();
+  JType<JObject> get $type => $F$Type$();
 }
 
-final class $FNullableType extends JObjType<F?> {
+final class $F$NullableType$ extends JType<F?> {
   @internal
   @override
   F? fromReference(JReference reference) {
@@ -394,22 +394,22 @@ final class $FNullableType extends JObjType<F?> {
 
   @internal
   @override
-  JObjType<JObject?> get superType => $CNullableType();
+  JType<JObject?> get superType => $C$NullableType$();
 
   @internal
   @override
-  JObjType<F?> get nullableType => this;
+  JType<F?> get nullableType => this;
 
   @override
-  int get hashCode => ($FNullableType).hashCode;
+  int get hashCode => ($F$NullableType$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == $FNullableType && other is $FNullableType;
+    return other.runtimeType == $F$NullableType$ && other is $F$NullableType$;
   }
 }
 
-final class $FType extends JObjType<F> {
+final class $F$Type$ extends JType<F> {
   @internal
   @override
   F fromReference(JReference reference) {
@@ -426,18 +426,18 @@ final class $FType extends JObjType<F> {
 
   @internal
   @override
-  JObjType<JObject> get superType => $CType();
+  JType<JObject> get superType => $C$Type$();
 
   @internal
   @override
-  JObjType<F?> get nullableType => $FNullableType();
+  JType<F?> get nullableType => $F$NullableType$();
 
   @override
-  int get hashCode => ($FType).hashCode;
+  int get hashCode => ($F$Type$).hashCode;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == $FType && other is $FType;
+    return other.runtimeType == $F$Type$ && other is $F$Type$;
   }
 }
 
@@ -560,17 +560,19 @@ void run({required TestRunnerCallback testRunner}) {
     //    C   D   E
     //   /
     //  F
-    expect(lowestCommonSuperType([$AType(), $BType()]), JObject.type);
-    expect(lowestCommonSuperType([$CType(), $BType()]), JObject.type);
-    expect(lowestCommonSuperType([$FType(), $BType()]), JObject.type);
-    expect(lowestCommonSuperType([$EType(), $CType(), $FType()]), JObject.type);
+    expect(lowestCommonSuperType([$A$Type$(), $B$Type$()]), JObject.type);
+    expect(lowestCommonSuperType([$C$Type$(), $B$Type$()]), JObject.type);
+    expect(lowestCommonSuperType([$F$Type$(), $B$Type$()]), JObject.type);
+    expect(lowestCommonSuperType([$E$Type$(), $C$Type$(), $F$Type$()]),
+        JObject.type);
 
-    expect(lowestCommonSuperType([$CType(), $DType()]), $AType());
-    expect(lowestCommonSuperType([$FType(), $DType()]), $AType());
-    expect(lowestCommonSuperType([$FType(), $CType(), $DType()]), $AType());
+    expect(lowestCommonSuperType([$C$Type$(), $D$Type$()]), $A$Type$());
+    expect(lowestCommonSuperType([$F$Type$(), $D$Type$()]), $A$Type$());
+    expect(lowestCommonSuperType([$F$Type$(), $C$Type$(), $D$Type$()]),
+        $A$Type$());
 
-    expect(lowestCommonSuperType([$EType(), $BType()]), $BType());
-    expect(lowestCommonSuperType([$BType(), $BType()]), $BType());
+    expect(lowestCommonSuperType([$E$Type$(), $B$Type$()]), $B$Type$());
+    expect(lowestCommonSuperType([$B$Type$(), $B$Type$()]), $B$Type$());
   });
 
   testRunner('Mocked nullable type tree', () {
@@ -582,27 +584,27 @@ void run({required TestRunnerCallback testRunner}) {
     //    C   D   E
     //   /
     //  F
-    expect(lowestCommonSuperType([$AType(), $BNullableType()]),
+    expect(lowestCommonSuperType([$A$Type$(), $B$NullableType$()]),
         JObject.nullableType);
-    expect(lowestCommonSuperType([$CNullableType(), $BType()]),
+    expect(lowestCommonSuperType([$C$NullableType$(), $B$Type$()]),
         JObject.nullableType);
-    expect(lowestCommonSuperType([$FNullableType(), $BNullableType()]),
+    expect(lowestCommonSuperType([$F$NullableType$(), $B$NullableType$()]),
         JObject.nullableType);
-    expect(lowestCommonSuperType([$ENullableType(), $CType(), $FType()]),
+    expect(lowestCommonSuperType([$E$NullableType$(), $C$Type$(), $F$Type$()]),
         JObject.nullableType);
 
-    expect(
-        lowestCommonSuperType([$CType(), $DNullableType()]), $ANullableType());
-    expect(
-        lowestCommonSuperType([$FNullableType(), $DType()]), $ANullableType());
-    expect(lowestCommonSuperType([$FType(), $CNullableType(), $DType()]),
-        $ANullableType());
+    expect(lowestCommonSuperType([$C$Type$(), $D$NullableType$()]),
+        $A$NullableType$());
+    expect(lowestCommonSuperType([$F$NullableType$(), $D$Type$()]),
+        $A$NullableType$());
+    expect(lowestCommonSuperType([$F$Type$(), $C$NullableType$(), $D$Type$()]),
+        $A$NullableType$());
 
-    expect(
-        lowestCommonSuperType([$ENullableType(), $BType()]), $BNullableType());
-    expect(
-        lowestCommonSuperType([$BNullableType(), $BType()]), $BNullableType());
-    expect(lowestCommonSuperType([$BNullableType(), $BNullableType()]),
-        $BNullableType());
+    expect(lowestCommonSuperType([$E$NullableType$(), $B$Type$()]),
+        $B$NullableType$());
+    expect(lowestCommonSuperType([$B$NullableType$(), $B$Type$()]),
+        $B$NullableType$());
+    expect(lowestCommonSuperType([$B$NullableType$(), $B$NullableType$()]),
+        $B$NullableType$());
   });
 }

--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.15.0-wip
 
+- Changed the names of internal type classes.
 - **Breaking Change**: Removed `exclude` from config.
 - Update to the latest lints.
 

--- a/pkgs/jnigen/example/in_app_java/lib/android_utils.dart
+++ b/pkgs/jnigen/example/in_app_java/lib/android_utils.dart
@@ -40,7 +40,7 @@ import 'package:jni/jni.dart' as jni$_;
 class R$drawable extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<R$drawable> $type;
+  final jni$_.JType<R$drawable> $type;
 
   @jni$_.internal
   R$drawable.fromReference(
@@ -52,8 +52,11 @@ class R$drawable extends jni$_.JObject {
       jni$_.JClass.forName(r'com/example/in_app_java/R$drawable');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $R$drawable$NullableType();
-  static const type = $R$drawable$Type();
+  static const jni$_.JType<R$drawable?> nullableType =
+      $R$drawable$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<R$drawable> type = $R$drawable$Type$();
   static final _id_launch_background = _class.staticFieldId(
     r'launch_background',
     r'I',
@@ -68,9 +71,9 @@ class R$drawable extends jni$_.JObject {
       _id_launch_background.set(_class, const jni$_.jintType(), value);
 }
 
-final class $R$drawable$NullableType extends jni$_.JObjType<R$drawable?> {
+final class $R$drawable$NullableType$ extends jni$_.JType<R$drawable?> {
   @jni$_.internal
-  const $R$drawable$NullableType();
+  const $R$drawable$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -85,29 +88,29 @@ final class $R$drawable$NullableType extends jni$_.JObjType<R$drawable?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R$drawable?> get nullableType => this;
+  jni$_.JType<R$drawable?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($R$drawable$NullableType).hashCode;
+  int get hashCode => ($R$drawable$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R$drawable$NullableType) &&
-        other is $R$drawable$NullableType;
+    return other.runtimeType == ($R$drawable$NullableType$) &&
+        other is $R$drawable$NullableType$;
   }
 }
 
-final class $R$drawable$Type extends jni$_.JObjType<R$drawable> {
+final class $R$drawable$Type$ extends jni$_.JType<R$drawable> {
   @jni$_.internal
-  const $R$drawable$Type();
+  const $R$drawable$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -121,23 +124,24 @@ final class $R$drawable$Type extends jni$_.JObjType<R$drawable> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R$drawable?> get nullableType =>
-      const $R$drawable$NullableType();
+  jni$_.JType<R$drawable?> get nullableType =>
+      const $R$drawable$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($R$drawable$Type).hashCode;
+  int get hashCode => ($R$drawable$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R$drawable$Type) && other is $R$drawable$Type;
+    return other.runtimeType == ($R$drawable$Type$) &&
+        other is $R$drawable$Type$;
   }
 }
 
@@ -145,7 +149,7 @@ final class $R$drawable$Type extends jni$_.JObjType<R$drawable> {
 class R$mipmap extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<R$mipmap> $type;
+  final jni$_.JType<R$mipmap> $type;
 
   @jni$_.internal
   R$mipmap.fromReference(
@@ -157,8 +161,10 @@ class R$mipmap extends jni$_.JObject {
       jni$_.JClass.forName(r'com/example/in_app_java/R$mipmap');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $R$mipmap$NullableType();
-  static const type = $R$mipmap$Type();
+  static const jni$_.JType<R$mipmap?> nullableType = $R$mipmap$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<R$mipmap> type = $R$mipmap$Type$();
   static final _id_ic_launcher = _class.staticFieldId(
     r'ic_launcher',
     r'I',
@@ -173,9 +179,9 @@ class R$mipmap extends jni$_.JObject {
       _id_ic_launcher.set(_class, const jni$_.jintType(), value);
 }
 
-final class $R$mipmap$NullableType extends jni$_.JObjType<R$mipmap?> {
+final class $R$mipmap$NullableType$ extends jni$_.JType<R$mipmap?> {
   @jni$_.internal
-  const $R$mipmap$NullableType();
+  const $R$mipmap$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -190,29 +196,29 @@ final class $R$mipmap$NullableType extends jni$_.JObjType<R$mipmap?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R$mipmap?> get nullableType => this;
+  jni$_.JType<R$mipmap?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($R$mipmap$NullableType).hashCode;
+  int get hashCode => ($R$mipmap$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R$mipmap$NullableType) &&
-        other is $R$mipmap$NullableType;
+    return other.runtimeType == ($R$mipmap$NullableType$) &&
+        other is $R$mipmap$NullableType$;
   }
 }
 
-final class $R$mipmap$Type extends jni$_.JObjType<R$mipmap> {
+final class $R$mipmap$Type$ extends jni$_.JType<R$mipmap> {
   @jni$_.internal
-  const $R$mipmap$Type();
+  const $R$mipmap$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -225,22 +231,22 @@ final class $R$mipmap$Type extends jni$_.JObjType<R$mipmap> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R$mipmap?> get nullableType => const $R$mipmap$NullableType();
+  jni$_.JType<R$mipmap?> get nullableType => const $R$mipmap$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($R$mipmap$Type).hashCode;
+  int get hashCode => ($R$mipmap$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R$mipmap$Type) && other is $R$mipmap$Type;
+    return other.runtimeType == ($R$mipmap$Type$) && other is $R$mipmap$Type$;
   }
 }
 
@@ -248,7 +254,7 @@ final class $R$mipmap$Type extends jni$_.JObjType<R$mipmap> {
 class R$style extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<R$style> $type;
+  final jni$_.JType<R$style> $type;
 
   @jni$_.internal
   R$style.fromReference(
@@ -260,8 +266,10 @@ class R$style extends jni$_.JObject {
       jni$_.JClass.forName(r'com/example/in_app_java/R$style');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $R$style$NullableType();
-  static const type = $R$style$Type();
+  static const jni$_.JType<R$style?> nullableType = $R$style$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<R$style> type = $R$style$Type$();
   static final _id_LaunchTheme = _class.staticFieldId(
     r'LaunchTheme',
     r'I',
@@ -289,9 +297,9 @@ class R$style extends jni$_.JObject {
       _id_NormalTheme.set(_class, const jni$_.jintType(), value);
 }
 
-final class $R$style$NullableType extends jni$_.JObjType<R$style?> {
+final class $R$style$NullableType$ extends jni$_.JType<R$style?> {
   @jni$_.internal
-  const $R$style$NullableType();
+  const $R$style$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -306,29 +314,29 @@ final class $R$style$NullableType extends jni$_.JObjType<R$style?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R$style?> get nullableType => this;
+  jni$_.JType<R$style?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($R$style$NullableType).hashCode;
+  int get hashCode => ($R$style$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R$style$NullableType) &&
-        other is $R$style$NullableType;
+    return other.runtimeType == ($R$style$NullableType$) &&
+        other is $R$style$NullableType$;
   }
 }
 
-final class $R$style$Type extends jni$_.JObjType<R$style> {
+final class $R$style$Type$ extends jni$_.JType<R$style> {
   @jni$_.internal
-  const $R$style$Type();
+  const $R$style$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -341,22 +349,22 @@ final class $R$style$Type extends jni$_.JObjType<R$style> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R$style?> get nullableType => const $R$style$NullableType();
+  jni$_.JType<R$style?> get nullableType => const $R$style$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($R$style$Type).hashCode;
+  int get hashCode => ($R$style$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R$style$Type) && other is $R$style$Type;
+    return other.runtimeType == ($R$style$Type$) && other is $R$style$Type$;
   }
 }
 
@@ -364,7 +372,7 @@ final class $R$style$Type extends jni$_.JObjType<R$style> {
 class R extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<R> $type;
+  final jni$_.JType<R> $type;
 
   @jni$_.internal
   R.fromReference(
@@ -375,13 +383,15 @@ class R extends jni$_.JObject {
   static final _class = jni$_.JClass.forName(r'com/example/in_app_java/R');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $R$NullableType();
-  static const type = $R$Type();
+  static const jni$_.JType<R?> nullableType = $R$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<R> type = $R$Type$();
 }
 
-final class $R$NullableType extends jni$_.JObjType<R?> {
+final class $R$NullableType$ extends jni$_.JType<R?> {
   @jni$_.internal
-  const $R$NullableType();
+  const $R$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -396,28 +406,28 @@ final class $R$NullableType extends jni$_.JObjType<R?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R?> get nullableType => this;
+  jni$_.JType<R?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($R$NullableType).hashCode;
+  int get hashCode => ($R$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R$NullableType) && other is $R$NullableType;
+    return other.runtimeType == ($R$NullableType$) && other is $R$NullableType$;
   }
 }
 
-final class $R$Type extends jni$_.JObjType<R> {
+final class $R$Type$ extends jni$_.JType<R> {
   @jni$_.internal
-  const $R$Type();
+  const $R$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -430,22 +440,22 @@ final class $R$Type extends jni$_.JObjType<R> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R?> get nullableType => const $R$NullableType();
+  jni$_.JType<R?> get nullableType => const $R$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($R$Type).hashCode;
+  int get hashCode => ($R$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R$Type) && other is $R$Type;
+    return other.runtimeType == ($R$Type$) && other is $R$Type$;
   }
 }
 
@@ -453,7 +463,7 @@ final class $R$Type extends jni$_.JObjType<R> {
 class EmojiCompat$CodepointSequenceMatchResult extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat$CodepointSequenceMatchResult> $type;
+  final jni$_.JType<EmojiCompat$CodepointSequenceMatchResult> $type;
 
   @jni$_.internal
   EmojiCompat$CodepointSequenceMatchResult.fromReference(
@@ -465,9 +475,12 @@ class EmojiCompat$CodepointSequenceMatchResult extends jni$_.JObject {
       r'androidx/emoji2/text/EmojiCompat$CodepointSequenceMatchResult');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType =
-      $EmojiCompat$CodepointSequenceMatchResult$NullableType();
-  static const type = $EmojiCompat$CodepointSequenceMatchResult$Type();
+  static const jni$_.JType<EmojiCompat$CodepointSequenceMatchResult?>
+      nullableType = $EmojiCompat$CodepointSequenceMatchResult$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<EmojiCompat$CodepointSequenceMatchResult> type =
+      $EmojiCompat$CodepointSequenceMatchResult$Type$();
 
   /// Maps a specific port to the implemented interface.
   static final core$_.Map<int, $EmojiCompat$CodepointSequenceMatchResult>
@@ -552,10 +565,10 @@ final class _$EmojiCompat$CodepointSequenceMatchResult
   _$EmojiCompat$CodepointSequenceMatchResult();
 }
 
-final class $EmojiCompat$CodepointSequenceMatchResult$NullableType
-    extends jni$_.JObjType<EmojiCompat$CodepointSequenceMatchResult?> {
+final class $EmojiCompat$CodepointSequenceMatchResult$NullableType$
+    extends jni$_.JType<EmojiCompat$CodepointSequenceMatchResult?> {
   @jni$_.internal
-  const $EmojiCompat$CodepointSequenceMatchResult$NullableType();
+  const $EmojiCompat$CodepointSequenceMatchResult$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -573,11 +586,11 @@ final class $EmojiCompat$CodepointSequenceMatchResult$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$CodepointSequenceMatchResult?> get nullableType =>
+  jni$_.JType<EmojiCompat$CodepointSequenceMatchResult?> get nullableType =>
       this;
 
   @jni$_.internal
@@ -586,20 +599,20 @@ final class $EmojiCompat$CodepointSequenceMatchResult$NullableType
 
   @core$_.override
   int get hashCode =>
-      ($EmojiCompat$CodepointSequenceMatchResult$NullableType).hashCode;
+      ($EmojiCompat$CodepointSequenceMatchResult$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($EmojiCompat$CodepointSequenceMatchResult$NullableType) &&
-        other is $EmojiCompat$CodepointSequenceMatchResult$NullableType;
+            ($EmojiCompat$CodepointSequenceMatchResult$NullableType$) &&
+        other is $EmojiCompat$CodepointSequenceMatchResult$NullableType$;
   }
 }
 
-final class $EmojiCompat$CodepointSequenceMatchResult$Type
-    extends jni$_.JObjType<EmojiCompat$CodepointSequenceMatchResult> {
+final class $EmojiCompat$CodepointSequenceMatchResult$Type$
+    extends jni$_.JType<EmojiCompat$CodepointSequenceMatchResult> {
   @jni$_.internal
-  const $EmojiCompat$CodepointSequenceMatchResult$Type();
+  const $EmojiCompat$CodepointSequenceMatchResult$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -615,25 +628,26 @@ final class $EmojiCompat$CodepointSequenceMatchResult$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$CodepointSequenceMatchResult?> get nullableType =>
-      const $EmojiCompat$CodepointSequenceMatchResult$NullableType();
+  jni$_.JType<EmojiCompat$CodepointSequenceMatchResult?> get nullableType =>
+      const $EmojiCompat$CodepointSequenceMatchResult$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$CodepointSequenceMatchResult$Type).hashCode;
+  int get hashCode =>
+      ($EmojiCompat$CodepointSequenceMatchResult$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($EmojiCompat$CodepointSequenceMatchResult$Type) &&
-        other is $EmojiCompat$CodepointSequenceMatchResult$Type;
+            ($EmojiCompat$CodepointSequenceMatchResult$Type$) &&
+        other is $EmojiCompat$CodepointSequenceMatchResult$Type$;
   }
 }
 
@@ -641,7 +655,7 @@ final class $EmojiCompat$CodepointSequenceMatchResult$Type
 class EmojiCompat$Config extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat$Config> $type;
+  final jni$_.JType<EmojiCompat$Config> $type;
 
   @jni$_.internal
   EmojiCompat$Config.fromReference(
@@ -653,8 +667,12 @@ class EmojiCompat$Config extends jni$_.JObject {
       jni$_.JClass.forName(r'androidx/emoji2/text/EmojiCompat$Config');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat$Config$NullableType();
-  static const type = $EmojiCompat$Config$Type();
+  static const jni$_.JType<EmojiCompat$Config?> nullableType =
+      $EmojiCompat$Config$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<EmojiCompat$Config> type =
+      $EmojiCompat$Config$Type$();
   static final _id_registerInitCallback = _class.instanceMethodId(
     r'registerInitCallback',
     r'(Landroidx/emoji2/text/EmojiCompat$InitCallback;)Landroidx/emoji2/text/EmojiCompat$Config;',
@@ -681,7 +699,7 @@ class EmojiCompat$Config extends jni$_.JObject {
             reference.pointer,
             _id_registerInitCallback as jni$_.JMethodIDPtr,
             _$initCallback.pointer)
-        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type());
+        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type$());
   }
 
   static final _id_unregisterInitCallback = _class.instanceMethodId(
@@ -710,7 +728,7 @@ class EmojiCompat$Config extends jni$_.JObject {
             reference.pointer,
             _id_unregisterInitCallback as jni$_.JMethodIDPtr,
             _$initCallback.pointer)
-        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type());
+        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type$());
   }
 
   static final _id_setReplaceAll = _class.instanceMethodId(
@@ -735,7 +753,7 @@ class EmojiCompat$Config extends jni$_.JObject {
   ) {
     return _setReplaceAll(reference.pointer,
             _id_setReplaceAll as jni$_.JMethodIDPtr, z ? 1 : 0)
-        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type());
+        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type$());
   }
 
   static final _id_setUseEmojiAsDefaultStyle = _class.instanceMethodId(
@@ -760,7 +778,7 @@ class EmojiCompat$Config extends jni$_.JObject {
   ) {
     return _setUseEmojiAsDefaultStyle(reference.pointer,
             _id_setUseEmojiAsDefaultStyle as jni$_.JMethodIDPtr, z ? 1 : 0)
-        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type());
+        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type$());
   }
 
   static final _id_setUseEmojiAsDefaultStyle$1 = _class.instanceMethodId(
@@ -795,7 +813,7 @@ class EmojiCompat$Config extends jni$_.JObject {
             _id_setUseEmojiAsDefaultStyle$1 as jni$_.JMethodIDPtr,
             z ? 1 : 0,
             _$list.pointer)
-        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type());
+        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type$());
   }
 
   static final _id_setEmojiSpanIndicatorEnabled = _class.instanceMethodId(
@@ -820,7 +838,7 @@ class EmojiCompat$Config extends jni$_.JObject {
   ) {
     return _setEmojiSpanIndicatorEnabled(reference.pointer,
             _id_setEmojiSpanIndicatorEnabled as jni$_.JMethodIDPtr, z ? 1 : 0)
-        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type());
+        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type$());
   }
 
   static final _id_setEmojiSpanIndicatorColor = _class.instanceMethodId(
@@ -845,7 +863,7 @@ class EmojiCompat$Config extends jni$_.JObject {
   ) {
     return _setEmojiSpanIndicatorColor(reference.pointer,
             _id_setEmojiSpanIndicatorColor as jni$_.JMethodIDPtr, i)
-        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type());
+        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type$());
   }
 
   static final _id_setMetadataLoadStrategy = _class.instanceMethodId(
@@ -870,7 +888,7 @@ class EmojiCompat$Config extends jni$_.JObject {
   ) {
     return _setMetadataLoadStrategy(reference.pointer,
             _id_setMetadataLoadStrategy as jni$_.JMethodIDPtr, i)
-        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type());
+        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type$());
   }
 
   static final _id_setSpanFactory = _class.instanceMethodId(
@@ -897,7 +915,7 @@ class EmojiCompat$Config extends jni$_.JObject {
     final _$spanFactory = spanFactory.reference;
     return _setSpanFactory(reference.pointer,
             _id_setSpanFactory as jni$_.JMethodIDPtr, _$spanFactory.pointer)
-        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type());
+        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type$());
   }
 
   static final _id_setGlyphChecker = _class.instanceMethodId(
@@ -924,14 +942,14 @@ class EmojiCompat$Config extends jni$_.JObject {
     final _$glyphChecker = glyphChecker.reference;
     return _setGlyphChecker(reference.pointer,
             _id_setGlyphChecker as jni$_.JMethodIDPtr, _$glyphChecker.pointer)
-        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type());
+        .object<EmojiCompat$Config>(const $EmojiCompat$Config$Type$());
   }
 }
 
-final class $EmojiCompat$Config$NullableType
-    extends jni$_.JObjType<EmojiCompat$Config?> {
+final class $EmojiCompat$Config$NullableType$
+    extends jni$_.JType<EmojiCompat$Config?> {
   @jni$_.internal
-  const $EmojiCompat$Config$NullableType();
+  const $EmojiCompat$Config$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -947,30 +965,29 @@ final class $EmojiCompat$Config$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$Config?> get nullableType => this;
+  jni$_.JType<EmojiCompat$Config?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$Config$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$Config$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat$Config$NullableType) &&
-        other is $EmojiCompat$Config$NullableType;
+    return other.runtimeType == ($EmojiCompat$Config$NullableType$) &&
+        other is $EmojiCompat$Config$NullableType$;
   }
 }
 
-final class $EmojiCompat$Config$Type
-    extends jni$_.JObjType<EmojiCompat$Config> {
+final class $EmojiCompat$Config$Type$ extends jni$_.JType<EmojiCompat$Config> {
   @jni$_.internal
-  const $EmojiCompat$Config$Type();
+  const $EmojiCompat$Config$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -984,24 +1001,24 @@ final class $EmojiCompat$Config$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$Config?> get nullableType =>
-      const $EmojiCompat$Config$NullableType();
+  jni$_.JType<EmojiCompat$Config?> get nullableType =>
+      const $EmojiCompat$Config$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$Config$Type).hashCode;
+  int get hashCode => ($EmojiCompat$Config$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat$Config$Type) &&
-        other is $EmojiCompat$Config$Type;
+    return other.runtimeType == ($EmojiCompat$Config$Type$) &&
+        other is $EmojiCompat$Config$Type$;
   }
 }
 
@@ -1009,7 +1026,7 @@ final class $EmojiCompat$Config$Type
 class EmojiCompat$DefaultSpanFactory extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat$DefaultSpanFactory> $type;
+  final jni$_.JType<EmojiCompat$DefaultSpanFactory> $type;
 
   @jni$_.internal
   EmojiCompat$DefaultSpanFactory.fromReference(
@@ -1021,8 +1038,12 @@ class EmojiCompat$DefaultSpanFactory extends jni$_.JObject {
       r'androidx/emoji2/text/EmojiCompat$DefaultSpanFactory');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat$DefaultSpanFactory$NullableType();
-  static const type = $EmojiCompat$DefaultSpanFactory$Type();
+  static const jni$_.JType<EmojiCompat$DefaultSpanFactory?> nullableType =
+      $EmojiCompat$DefaultSpanFactory$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<EmojiCompat$DefaultSpanFactory> type =
+      $EmojiCompat$DefaultSpanFactory$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -1071,14 +1092,14 @@ class EmojiCompat$DefaultSpanFactory extends jni$_.JObject {
     final _$typefaceEmojiRasterizer = typefaceEmojiRasterizer.reference;
     return _createSpan(reference.pointer, _id_createSpan as jni$_.JMethodIDPtr,
             _$typefaceEmojiRasterizer.pointer)
-        .object<jni$_.JObject>(const jni$_.JObjectType());
+        .object<jni$_.JObject>(const jni$_.$JObject$Type$());
   }
 }
 
-final class $EmojiCompat$DefaultSpanFactory$NullableType
-    extends jni$_.JObjType<EmojiCompat$DefaultSpanFactory?> {
+final class $EmojiCompat$DefaultSpanFactory$NullableType$
+    extends jni$_.JType<EmojiCompat$DefaultSpanFactory?> {
   @jni$_.internal
-  const $EmojiCompat$DefaultSpanFactory$NullableType();
+  const $EmojiCompat$DefaultSpanFactory$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -1095,31 +1116,31 @@ final class $EmojiCompat$DefaultSpanFactory$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$DefaultSpanFactory?> get nullableType => this;
+  jni$_.JType<EmojiCompat$DefaultSpanFactory?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$DefaultSpanFactory$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$DefaultSpanFactory$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($EmojiCompat$DefaultSpanFactory$NullableType) &&
-        other is $EmojiCompat$DefaultSpanFactory$NullableType;
+            ($EmojiCompat$DefaultSpanFactory$NullableType$) &&
+        other is $EmojiCompat$DefaultSpanFactory$NullableType$;
   }
 }
 
-final class $EmojiCompat$DefaultSpanFactory$Type
-    extends jni$_.JObjType<EmojiCompat$DefaultSpanFactory> {
+final class $EmojiCompat$DefaultSpanFactory$Type$
+    extends jni$_.JType<EmojiCompat$DefaultSpanFactory> {
   @jni$_.internal
-  const $EmojiCompat$DefaultSpanFactory$Type();
+  const $EmojiCompat$DefaultSpanFactory$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -1134,24 +1155,24 @@ final class $EmojiCompat$DefaultSpanFactory$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$DefaultSpanFactory?> get nullableType =>
-      const $EmojiCompat$DefaultSpanFactory$NullableType();
+  jni$_.JType<EmojiCompat$DefaultSpanFactory?> get nullableType =>
+      const $EmojiCompat$DefaultSpanFactory$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$DefaultSpanFactory$Type).hashCode;
+  int get hashCode => ($EmojiCompat$DefaultSpanFactory$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat$DefaultSpanFactory$Type) &&
-        other is $EmojiCompat$DefaultSpanFactory$Type;
+    return other.runtimeType == ($EmojiCompat$DefaultSpanFactory$Type$) &&
+        other is $EmojiCompat$DefaultSpanFactory$Type$;
   }
 }
 
@@ -1159,7 +1180,7 @@ final class $EmojiCompat$DefaultSpanFactory$Type
 class EmojiCompat$GlyphChecker extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat$GlyphChecker> $type;
+  final jni$_.JType<EmojiCompat$GlyphChecker> $type;
 
   @jni$_.internal
   EmojiCompat$GlyphChecker.fromReference(
@@ -1171,8 +1192,12 @@ class EmojiCompat$GlyphChecker extends jni$_.JObject {
       jni$_.JClass.forName(r'androidx/emoji2/text/EmojiCompat$GlyphChecker');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat$GlyphChecker$NullableType();
-  static const type = $EmojiCompat$GlyphChecker$Type();
+  static const jni$_.JType<EmojiCompat$GlyphChecker?> nullableType =
+      $EmojiCompat$GlyphChecker$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<EmojiCompat$GlyphChecker> type =
+      $EmojiCompat$GlyphChecker$Type$();
   static final _id_hasGlyph = _class.instanceMethodId(
     r'hasGlyph',
     r'(Ljava/lang/CharSequence;III)Z',
@@ -1239,15 +1264,15 @@ class EmojiCompat$GlyphChecker extends jni$_.JObject {
       final $a = $i.args;
       if ($d == r'hasGlyph(Ljava/lang/CharSequence;III)Z') {
         final $r = _$impls[$p]!.hasGlyph(
-          $a![0]!.as(const jni$_.JObjectType(), releaseOriginal: true),
+          $a![0]!.as(const jni$_.$JObject$Type$(), releaseOriginal: true),
           $a![1]!
-              .as(const jni$_.JIntegerType(), releaseOriginal: true)
+              .as(const jni$_.$JInteger$Type$(), releaseOriginal: true)
               .intValue(releaseOriginal: true),
           $a![2]!
-              .as(const jni$_.JIntegerType(), releaseOriginal: true)
+              .as(const jni$_.$JInteger$Type$(), releaseOriginal: true)
               .intValue(releaseOriginal: true),
           $a![3]!
-              .as(const jni$_.JIntegerType(), releaseOriginal: true)
+              .as(const jni$_.$JInteger$Type$(), releaseOriginal: true)
               .intValue(releaseOriginal: true),
         );
         return jni$_.JBoolean($r).reference.toPointer();
@@ -1317,10 +1342,10 @@ final class _$EmojiCompat$GlyphChecker with $EmojiCompat$GlyphChecker {
   }
 }
 
-final class $EmojiCompat$GlyphChecker$NullableType
-    extends jni$_.JObjType<EmojiCompat$GlyphChecker?> {
+final class $EmojiCompat$GlyphChecker$NullableType$
+    extends jni$_.JType<EmojiCompat$GlyphChecker?> {
   @jni$_.internal
-  const $EmojiCompat$GlyphChecker$NullableType();
+  const $EmojiCompat$GlyphChecker$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -1336,30 +1361,30 @@ final class $EmojiCompat$GlyphChecker$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$GlyphChecker?> get nullableType => this;
+  jni$_.JType<EmojiCompat$GlyphChecker?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$GlyphChecker$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$GlyphChecker$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat$GlyphChecker$NullableType) &&
-        other is $EmojiCompat$GlyphChecker$NullableType;
+    return other.runtimeType == ($EmojiCompat$GlyphChecker$NullableType$) &&
+        other is $EmojiCompat$GlyphChecker$NullableType$;
   }
 }
 
-final class $EmojiCompat$GlyphChecker$Type
-    extends jni$_.JObjType<EmojiCompat$GlyphChecker> {
+final class $EmojiCompat$GlyphChecker$Type$
+    extends jni$_.JType<EmojiCompat$GlyphChecker> {
   @jni$_.internal
-  const $EmojiCompat$GlyphChecker$Type();
+  const $EmojiCompat$GlyphChecker$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -1373,24 +1398,24 @@ final class $EmojiCompat$GlyphChecker$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$GlyphChecker?> get nullableType =>
-      const $EmojiCompat$GlyphChecker$NullableType();
+  jni$_.JType<EmojiCompat$GlyphChecker?> get nullableType =>
+      const $EmojiCompat$GlyphChecker$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$GlyphChecker$Type).hashCode;
+  int get hashCode => ($EmojiCompat$GlyphChecker$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat$GlyphChecker$Type) &&
-        other is $EmojiCompat$GlyphChecker$Type;
+    return other.runtimeType == ($EmojiCompat$GlyphChecker$Type$) &&
+        other is $EmojiCompat$GlyphChecker$Type$;
   }
 }
 
@@ -1398,7 +1423,7 @@ final class $EmojiCompat$GlyphChecker$Type
 class EmojiCompat$InitCallback extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat$InitCallback> $type;
+  final jni$_.JType<EmojiCompat$InitCallback> $type;
 
   @jni$_.internal
   EmojiCompat$InitCallback.fromReference(
@@ -1410,8 +1435,12 @@ class EmojiCompat$InitCallback extends jni$_.JObject {
       jni$_.JClass.forName(r'androidx/emoji2/text/EmojiCompat$InitCallback');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat$InitCallback$NullableType();
-  static const type = $EmojiCompat$InitCallback$Type();
+  static const jni$_.JType<EmojiCompat$InitCallback?> nullableType =
+      $EmojiCompat$InitCallback$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<EmojiCompat$InitCallback> type =
+      $EmojiCompat$InitCallback$Type$();
   static final _id_onInitialized = _class.instanceMethodId(
     r'onInitialized',
     r'()V',
@@ -1462,10 +1491,10 @@ class EmojiCompat$InitCallback extends jni$_.JObject {
   }
 }
 
-final class $EmojiCompat$InitCallback$NullableType
-    extends jni$_.JObjType<EmojiCompat$InitCallback?> {
+final class $EmojiCompat$InitCallback$NullableType$
+    extends jni$_.JType<EmojiCompat$InitCallback?> {
   @jni$_.internal
-  const $EmojiCompat$InitCallback$NullableType();
+  const $EmojiCompat$InitCallback$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -1481,30 +1510,30 @@ final class $EmojiCompat$InitCallback$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$InitCallback?> get nullableType => this;
+  jni$_.JType<EmojiCompat$InitCallback?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$InitCallback$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$InitCallback$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat$InitCallback$NullableType) &&
-        other is $EmojiCompat$InitCallback$NullableType;
+    return other.runtimeType == ($EmojiCompat$InitCallback$NullableType$) &&
+        other is $EmojiCompat$InitCallback$NullableType$;
   }
 }
 
-final class $EmojiCompat$InitCallback$Type
-    extends jni$_.JObjType<EmojiCompat$InitCallback> {
+final class $EmojiCompat$InitCallback$Type$
+    extends jni$_.JType<EmojiCompat$InitCallback> {
   @jni$_.internal
-  const $EmojiCompat$InitCallback$Type();
+  const $EmojiCompat$InitCallback$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -1518,24 +1547,24 @@ final class $EmojiCompat$InitCallback$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$InitCallback?> get nullableType =>
-      const $EmojiCompat$InitCallback$NullableType();
+  jni$_.JType<EmojiCompat$InitCallback?> get nullableType =>
+      const $EmojiCompat$InitCallback$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$InitCallback$Type).hashCode;
+  int get hashCode => ($EmojiCompat$InitCallback$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat$InitCallback$Type) &&
-        other is $EmojiCompat$InitCallback$Type;
+    return other.runtimeType == ($EmojiCompat$InitCallback$Type$) &&
+        other is $EmojiCompat$InitCallback$Type$;
   }
 }
 
@@ -1543,7 +1572,7 @@ final class $EmojiCompat$InitCallback$Type
 class EmojiCompat$LoadStrategy extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat$LoadStrategy> $type;
+  final jni$_.JType<EmojiCompat$LoadStrategy> $type;
 
   @jni$_.internal
   EmojiCompat$LoadStrategy.fromReference(
@@ -1555,8 +1584,12 @@ class EmojiCompat$LoadStrategy extends jni$_.JObject {
       jni$_.JClass.forName(r'androidx/emoji2/text/EmojiCompat$LoadStrategy');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat$LoadStrategy$NullableType();
-  static const type = $EmojiCompat$LoadStrategy$Type();
+  static const jni$_.JType<EmojiCompat$LoadStrategy?> nullableType =
+      $EmojiCompat$LoadStrategy$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<EmojiCompat$LoadStrategy> type =
+      $EmojiCompat$LoadStrategy$Type$();
 
   /// Maps a specific port to the implemented interface.
   static final core$_.Map<int, $EmojiCompat$LoadStrategy> _$impls = {};
@@ -1638,10 +1671,10 @@ final class _$EmojiCompat$LoadStrategy with $EmojiCompat$LoadStrategy {
   _$EmojiCompat$LoadStrategy();
 }
 
-final class $EmojiCompat$LoadStrategy$NullableType
-    extends jni$_.JObjType<EmojiCompat$LoadStrategy?> {
+final class $EmojiCompat$LoadStrategy$NullableType$
+    extends jni$_.JType<EmojiCompat$LoadStrategy?> {
   @jni$_.internal
-  const $EmojiCompat$LoadStrategy$NullableType();
+  const $EmojiCompat$LoadStrategy$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -1657,30 +1690,30 @@ final class $EmojiCompat$LoadStrategy$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$LoadStrategy?> get nullableType => this;
+  jni$_.JType<EmojiCompat$LoadStrategy?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$LoadStrategy$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$LoadStrategy$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat$LoadStrategy$NullableType) &&
-        other is $EmojiCompat$LoadStrategy$NullableType;
+    return other.runtimeType == ($EmojiCompat$LoadStrategy$NullableType$) &&
+        other is $EmojiCompat$LoadStrategy$NullableType$;
   }
 }
 
-final class $EmojiCompat$LoadStrategy$Type
-    extends jni$_.JObjType<EmojiCompat$LoadStrategy> {
+final class $EmojiCompat$LoadStrategy$Type$
+    extends jni$_.JType<EmojiCompat$LoadStrategy> {
   @jni$_.internal
-  const $EmojiCompat$LoadStrategy$Type();
+  const $EmojiCompat$LoadStrategy$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -1694,24 +1727,24 @@ final class $EmojiCompat$LoadStrategy$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$LoadStrategy?> get nullableType =>
-      const $EmojiCompat$LoadStrategy$NullableType();
+  jni$_.JType<EmojiCompat$LoadStrategy?> get nullableType =>
+      const $EmojiCompat$LoadStrategy$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$LoadStrategy$Type).hashCode;
+  int get hashCode => ($EmojiCompat$LoadStrategy$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat$LoadStrategy$Type) &&
-        other is $EmojiCompat$LoadStrategy$Type;
+    return other.runtimeType == ($EmojiCompat$LoadStrategy$Type$) &&
+        other is $EmojiCompat$LoadStrategy$Type$;
   }
 }
 
@@ -1719,7 +1752,7 @@ final class $EmojiCompat$LoadStrategy$Type
 class EmojiCompat$MetadataRepoLoader extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat$MetadataRepoLoader> $type;
+  final jni$_.JType<EmojiCompat$MetadataRepoLoader> $type;
 
   @jni$_.internal
   EmojiCompat$MetadataRepoLoader.fromReference(
@@ -1731,8 +1764,12 @@ class EmojiCompat$MetadataRepoLoader extends jni$_.JObject {
       r'androidx/emoji2/text/EmojiCompat$MetadataRepoLoader');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat$MetadataRepoLoader$NullableType();
-  static const type = $EmojiCompat$MetadataRepoLoader$Type();
+  static const jni$_.JType<EmojiCompat$MetadataRepoLoader?> nullableType =
+      $EmojiCompat$MetadataRepoLoader$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<EmojiCompat$MetadataRepoLoader> type =
+      $EmojiCompat$MetadataRepoLoader$Type$();
   static final _id_load = _class.instanceMethodId(
     r'load',
     r'(Landroidx/emoji2/text/EmojiCompat$MetadataRepoLoaderCallback;)V',
@@ -1792,7 +1829,7 @@ class EmojiCompat$MetadataRepoLoader extends jni$_.JObject {
       if ($d ==
           r'load(Landroidx/emoji2/text/EmojiCompat$MetadataRepoLoaderCallback;)V') {
         _$impls[$p]!.load(
-          $a![0]!.as(const $EmojiCompat$MetadataRepoLoaderCallback$Type(),
+          $a![0]!.as(const $EmojiCompat$MetadataRepoLoaderCallback$Type$(),
               releaseOriginal: true),
         );
         return jni$_.nullptr;
@@ -1872,10 +1909,10 @@ final class _$EmojiCompat$MetadataRepoLoader
   }
 }
 
-final class $EmojiCompat$MetadataRepoLoader$NullableType
-    extends jni$_.JObjType<EmojiCompat$MetadataRepoLoader?> {
+final class $EmojiCompat$MetadataRepoLoader$NullableType$
+    extends jni$_.JType<EmojiCompat$MetadataRepoLoader?> {
   @jni$_.internal
-  const $EmojiCompat$MetadataRepoLoader$NullableType();
+  const $EmojiCompat$MetadataRepoLoader$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -1892,31 +1929,31 @@ final class $EmojiCompat$MetadataRepoLoader$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$MetadataRepoLoader?> get nullableType => this;
+  jni$_.JType<EmojiCompat$MetadataRepoLoader?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$MetadataRepoLoader$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$MetadataRepoLoader$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($EmojiCompat$MetadataRepoLoader$NullableType) &&
-        other is $EmojiCompat$MetadataRepoLoader$NullableType;
+            ($EmojiCompat$MetadataRepoLoader$NullableType$) &&
+        other is $EmojiCompat$MetadataRepoLoader$NullableType$;
   }
 }
 
-final class $EmojiCompat$MetadataRepoLoader$Type
-    extends jni$_.JObjType<EmojiCompat$MetadataRepoLoader> {
+final class $EmojiCompat$MetadataRepoLoader$Type$
+    extends jni$_.JType<EmojiCompat$MetadataRepoLoader> {
   @jni$_.internal
-  const $EmojiCompat$MetadataRepoLoader$Type();
+  const $EmojiCompat$MetadataRepoLoader$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -1931,24 +1968,24 @@ final class $EmojiCompat$MetadataRepoLoader$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$MetadataRepoLoader?> get nullableType =>
-      const $EmojiCompat$MetadataRepoLoader$NullableType();
+  jni$_.JType<EmojiCompat$MetadataRepoLoader?> get nullableType =>
+      const $EmojiCompat$MetadataRepoLoader$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$MetadataRepoLoader$Type).hashCode;
+  int get hashCode => ($EmojiCompat$MetadataRepoLoader$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat$MetadataRepoLoader$Type) &&
-        other is $EmojiCompat$MetadataRepoLoader$Type;
+    return other.runtimeType == ($EmojiCompat$MetadataRepoLoader$Type$) &&
+        other is $EmojiCompat$MetadataRepoLoader$Type$;
   }
 }
 
@@ -1956,7 +1993,7 @@ final class $EmojiCompat$MetadataRepoLoader$Type
 class EmojiCompat$MetadataRepoLoaderCallback extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat$MetadataRepoLoaderCallback> $type;
+  final jni$_.JType<EmojiCompat$MetadataRepoLoaderCallback> $type;
 
   @jni$_.internal
   EmojiCompat$MetadataRepoLoaderCallback.fromReference(
@@ -1968,9 +2005,12 @@ class EmojiCompat$MetadataRepoLoaderCallback extends jni$_.JObject {
       r'androidx/emoji2/text/EmojiCompat$MetadataRepoLoaderCallback');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType =
-      $EmojiCompat$MetadataRepoLoaderCallback$NullableType();
-  static const type = $EmojiCompat$MetadataRepoLoaderCallback$Type();
+  static const jni$_.JType<EmojiCompat$MetadataRepoLoaderCallback?>
+      nullableType = $EmojiCompat$MetadataRepoLoaderCallback$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<EmojiCompat$MetadataRepoLoaderCallback> type =
+      $EmojiCompat$MetadataRepoLoaderCallback$Type$();
   static final _id_onLoaded = _class.instanceMethodId(
     r'onLoaded',
     r'(Landroidx/emoji2/text/MetadataRepo;)V',
@@ -2024,10 +2064,10 @@ class EmojiCompat$MetadataRepoLoaderCallback extends jni$_.JObject {
   }
 }
 
-final class $EmojiCompat$MetadataRepoLoaderCallback$NullableType
-    extends jni$_.JObjType<EmojiCompat$MetadataRepoLoaderCallback?> {
+final class $EmojiCompat$MetadataRepoLoaderCallback$NullableType$
+    extends jni$_.JType<EmojiCompat$MetadataRepoLoaderCallback?> {
   @jni$_.internal
-  const $EmojiCompat$MetadataRepoLoaderCallback$NullableType();
+  const $EmojiCompat$MetadataRepoLoaderCallback$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -2045,12 +2085,11 @@ final class $EmojiCompat$MetadataRepoLoaderCallback$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$MetadataRepoLoaderCallback?> get nullableType =>
-      this;
+  jni$_.JType<EmojiCompat$MetadataRepoLoaderCallback?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
@@ -2058,20 +2097,20 @@ final class $EmojiCompat$MetadataRepoLoaderCallback$NullableType
 
   @core$_.override
   int get hashCode =>
-      ($EmojiCompat$MetadataRepoLoaderCallback$NullableType).hashCode;
+      ($EmojiCompat$MetadataRepoLoaderCallback$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($EmojiCompat$MetadataRepoLoaderCallback$NullableType) &&
-        other is $EmojiCompat$MetadataRepoLoaderCallback$NullableType;
+            ($EmojiCompat$MetadataRepoLoaderCallback$NullableType$) &&
+        other is $EmojiCompat$MetadataRepoLoaderCallback$NullableType$;
   }
 }
 
-final class $EmojiCompat$MetadataRepoLoaderCallback$Type
-    extends jni$_.JObjType<EmojiCompat$MetadataRepoLoaderCallback> {
+final class $EmojiCompat$MetadataRepoLoaderCallback$Type$
+    extends jni$_.JType<EmojiCompat$MetadataRepoLoaderCallback> {
   @jni$_.internal
-  const $EmojiCompat$MetadataRepoLoaderCallback$Type();
+  const $EmojiCompat$MetadataRepoLoaderCallback$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -2087,25 +2126,25 @@ final class $EmojiCompat$MetadataRepoLoaderCallback$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$MetadataRepoLoaderCallback?> get nullableType =>
-      const $EmojiCompat$MetadataRepoLoaderCallback$NullableType();
+  jni$_.JType<EmojiCompat$MetadataRepoLoaderCallback?> get nullableType =>
+      const $EmojiCompat$MetadataRepoLoaderCallback$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$MetadataRepoLoaderCallback$Type).hashCode;
+  int get hashCode => ($EmojiCompat$MetadataRepoLoaderCallback$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($EmojiCompat$MetadataRepoLoaderCallback$Type) &&
-        other is $EmojiCompat$MetadataRepoLoaderCallback$Type;
+            ($EmojiCompat$MetadataRepoLoaderCallback$Type$) &&
+        other is $EmojiCompat$MetadataRepoLoaderCallback$Type$;
   }
 }
 
@@ -2113,7 +2152,7 @@ final class $EmojiCompat$MetadataRepoLoaderCallback$Type
 class EmojiCompat$ReplaceStrategy extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat$ReplaceStrategy> $type;
+  final jni$_.JType<EmojiCompat$ReplaceStrategy> $type;
 
   @jni$_.internal
   EmojiCompat$ReplaceStrategy.fromReference(
@@ -2125,8 +2164,12 @@ class EmojiCompat$ReplaceStrategy extends jni$_.JObject {
       jni$_.JClass.forName(r'androidx/emoji2/text/EmojiCompat$ReplaceStrategy');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat$ReplaceStrategy$NullableType();
-  static const type = $EmojiCompat$ReplaceStrategy$Type();
+  static const jni$_.JType<EmojiCompat$ReplaceStrategy?> nullableType =
+      $EmojiCompat$ReplaceStrategy$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<EmojiCompat$ReplaceStrategy> type =
+      $EmojiCompat$ReplaceStrategy$Type$();
 
   /// Maps a specific port to the implemented interface.
   static final core$_.Map<int, $EmojiCompat$ReplaceStrategy> _$impls = {};
@@ -2208,10 +2251,10 @@ final class _$EmojiCompat$ReplaceStrategy with $EmojiCompat$ReplaceStrategy {
   _$EmojiCompat$ReplaceStrategy();
 }
 
-final class $EmojiCompat$ReplaceStrategy$NullableType
-    extends jni$_.JObjType<EmojiCompat$ReplaceStrategy?> {
+final class $EmojiCompat$ReplaceStrategy$NullableType$
+    extends jni$_.JType<EmojiCompat$ReplaceStrategy?> {
   @jni$_.internal
-  const $EmojiCompat$ReplaceStrategy$NullableType();
+  const $EmojiCompat$ReplaceStrategy$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -2227,30 +2270,30 @@ final class $EmojiCompat$ReplaceStrategy$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$ReplaceStrategy?> get nullableType => this;
+  jni$_.JType<EmojiCompat$ReplaceStrategy?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$ReplaceStrategy$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$ReplaceStrategy$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat$ReplaceStrategy$NullableType) &&
-        other is $EmojiCompat$ReplaceStrategy$NullableType;
+    return other.runtimeType == ($EmojiCompat$ReplaceStrategy$NullableType$) &&
+        other is $EmojiCompat$ReplaceStrategy$NullableType$;
   }
 }
 
-final class $EmojiCompat$ReplaceStrategy$Type
-    extends jni$_.JObjType<EmojiCompat$ReplaceStrategy> {
+final class $EmojiCompat$ReplaceStrategy$Type$
+    extends jni$_.JType<EmojiCompat$ReplaceStrategy> {
   @jni$_.internal
-  const $EmojiCompat$ReplaceStrategy$Type();
+  const $EmojiCompat$ReplaceStrategy$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -2264,24 +2307,24 @@ final class $EmojiCompat$ReplaceStrategy$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$ReplaceStrategy?> get nullableType =>
-      const $EmojiCompat$ReplaceStrategy$NullableType();
+  jni$_.JType<EmojiCompat$ReplaceStrategy?> get nullableType =>
+      const $EmojiCompat$ReplaceStrategy$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$ReplaceStrategy$Type).hashCode;
+  int get hashCode => ($EmojiCompat$ReplaceStrategy$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat$ReplaceStrategy$Type) &&
-        other is $EmojiCompat$ReplaceStrategy$Type;
+    return other.runtimeType == ($EmojiCompat$ReplaceStrategy$Type$) &&
+        other is $EmojiCompat$ReplaceStrategy$Type$;
   }
 }
 
@@ -2289,7 +2332,7 @@ final class $EmojiCompat$ReplaceStrategy$Type
 class EmojiCompat$SpanFactory extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat$SpanFactory> $type;
+  final jni$_.JType<EmojiCompat$SpanFactory> $type;
 
   @jni$_.internal
   EmojiCompat$SpanFactory.fromReference(
@@ -2301,8 +2344,12 @@ class EmojiCompat$SpanFactory extends jni$_.JObject {
       jni$_.JClass.forName(r'androidx/emoji2/text/EmojiCompat$SpanFactory');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat$SpanFactory$NullableType();
-  static const type = $EmojiCompat$SpanFactory$Type();
+  static const jni$_.JType<EmojiCompat$SpanFactory?> nullableType =
+      $EmojiCompat$SpanFactory$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<EmojiCompat$SpanFactory> type =
+      $EmojiCompat$SpanFactory$Type$();
   static final _id_createSpan = _class.instanceMethodId(
     r'createSpan',
     r'(Landroidx/emoji2/text/TypefaceEmojiRasterizer;)Landroidx/emoji2/text/EmojiSpan;',
@@ -2327,7 +2374,7 @@ class EmojiCompat$SpanFactory extends jni$_.JObject {
     final _$typefaceEmojiRasterizer = typefaceEmojiRasterizer.reference;
     return _createSpan(reference.pointer, _id_createSpan as jni$_.JMethodIDPtr,
             _$typefaceEmojiRasterizer.pointer)
-        .object<jni$_.JObject>(const jni$_.JObjectType());
+        .object<jni$_.JObject>(const jni$_.$JObject$Type$());
   }
 
   /// Maps a specific port to the implemented interface.
@@ -2363,10 +2410,10 @@ class EmojiCompat$SpanFactory extends jni$_.JObject {
       if ($d ==
           r'createSpan(Landroidx/emoji2/text/TypefaceEmojiRasterizer;)Landroidx/emoji2/text/EmojiSpan;') {
         final $r = _$impls[$p]!.createSpan(
-          $a![0]!.as(const jni$_.JObjectType(), releaseOriginal: true),
+          $a![0]!.as(const jni$_.$JObject$Type$(), releaseOriginal: true),
         );
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
@@ -2436,10 +2483,10 @@ final class _$EmojiCompat$SpanFactory with $EmojiCompat$SpanFactory {
   }
 }
 
-final class $EmojiCompat$SpanFactory$NullableType
-    extends jni$_.JObjType<EmojiCompat$SpanFactory?> {
+final class $EmojiCompat$SpanFactory$NullableType$
+    extends jni$_.JType<EmojiCompat$SpanFactory?> {
   @jni$_.internal
-  const $EmojiCompat$SpanFactory$NullableType();
+  const $EmojiCompat$SpanFactory$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -2455,30 +2502,30 @@ final class $EmojiCompat$SpanFactory$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$SpanFactory?> get nullableType => this;
+  jni$_.JType<EmojiCompat$SpanFactory?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$SpanFactory$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$SpanFactory$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat$SpanFactory$NullableType) &&
-        other is $EmojiCompat$SpanFactory$NullableType;
+    return other.runtimeType == ($EmojiCompat$SpanFactory$NullableType$) &&
+        other is $EmojiCompat$SpanFactory$NullableType$;
   }
 }
 
-final class $EmojiCompat$SpanFactory$Type
-    extends jni$_.JObjType<EmojiCompat$SpanFactory> {
+final class $EmojiCompat$SpanFactory$Type$
+    extends jni$_.JType<EmojiCompat$SpanFactory> {
   @jni$_.internal
-  const $EmojiCompat$SpanFactory$Type();
+  const $EmojiCompat$SpanFactory$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -2492,24 +2539,24 @@ final class $EmojiCompat$SpanFactory$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat$SpanFactory?> get nullableType =>
-      const $EmojiCompat$SpanFactory$NullableType();
+  jni$_.JType<EmojiCompat$SpanFactory?> get nullableType =>
+      const $EmojiCompat$SpanFactory$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$SpanFactory$Type).hashCode;
+  int get hashCode => ($EmojiCompat$SpanFactory$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat$SpanFactory$Type) &&
-        other is $EmojiCompat$SpanFactory$Type;
+    return other.runtimeType == ($EmojiCompat$SpanFactory$Type$) &&
+        other is $EmojiCompat$SpanFactory$Type$;
   }
 }
 
@@ -2517,7 +2564,7 @@ final class $EmojiCompat$SpanFactory$Type
 class EmojiCompat extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<EmojiCompat> $type;
+  final jni$_.JType<EmojiCompat> $type;
 
   @jni$_.internal
   EmojiCompat.fromReference(
@@ -2529,8 +2576,11 @@ class EmojiCompat extends jni$_.JObject {
       jni$_.JClass.forName(r'androidx/emoji2/text/EmojiCompat');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $EmojiCompat$NullableType();
-  static const type = $EmojiCompat$Type();
+  static const jni$_.JType<EmojiCompat?> nullableType =
+      $EmojiCompat$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<EmojiCompat> type = $EmojiCompat$Type$();
   static final _id_EDITOR_INFO_METAVERSION_KEY = _class.staticFieldId(
     r'EDITOR_INFO_METAVERSION_KEY',
     r'Ljava/lang/String;',
@@ -2540,7 +2590,7 @@ class EmojiCompat extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get EDITOR_INFO_METAVERSION_KEY =>
       _id_EDITOR_INFO_METAVERSION_KEY.get(
-          _class, const jni$_.JStringNullableType());
+          _class, const jni$_.$JString$NullableType$());
 
   static final _id_EDITOR_INFO_REPLACE_ALL_KEY = _class.staticFieldId(
     r'EDITOR_INFO_REPLACE_ALL_KEY',
@@ -2551,7 +2601,7 @@ class EmojiCompat extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get EDITOR_INFO_REPLACE_ALL_KEY =>
       _id_EDITOR_INFO_REPLACE_ALL_KEY.get(
-          _class, const jni$_.JStringNullableType());
+          _class, const jni$_.$JString$NullableType$());
 
   /// from: `static public final int LOAD_STATE_DEFAULT`
   static const LOAD_STATE_DEFAULT = 3;
@@ -2612,7 +2662,7 @@ class EmojiCompat extends jni$_.JObject {
     final _$context = context.reference;
     return _init(_class.reference.pointer, _id_init as jni$_.JMethodIDPtr,
             _$context.pointer)
-        .object<EmojiCompat?>(const $EmojiCompat$NullableType());
+        .object<EmojiCompat?>(const $EmojiCompat$NullableType$());
   }
 
   static final _id_init$1 = _class.staticMethodId(
@@ -2649,7 +2699,7 @@ class EmojiCompat extends jni$_.JObject {
         defaultEmojiCompatConfigFactory?.reference ?? jni$_.jNullReference;
     return _init$1(_class.reference.pointer, _id_init$1 as jni$_.JMethodIDPtr,
             _$context.pointer, _$defaultEmojiCompatConfigFactory.pointer)
-        .object<EmojiCompat?>(const $EmojiCompat$NullableType());
+        .object<EmojiCompat?>(const $EmojiCompat$NullableType$());
   }
 
   static final _id_init$2 = _class.staticMethodId(
@@ -2676,7 +2726,7 @@ class EmojiCompat extends jni$_.JObject {
     final _$config = config.reference;
     return _init$2(_class.reference.pointer, _id_init$2 as jni$_.JMethodIDPtr,
             _$config.pointer)
-        .object<EmojiCompat>(const $EmojiCompat$Type());
+        .object<EmojiCompat>(const $EmojiCompat$Type$());
   }
 
   static final _id_isConfigured = _class.staticMethodId(
@@ -2727,7 +2777,7 @@ class EmojiCompat extends jni$_.JObject {
     final _$config = config.reference;
     return _reset(_class.reference.pointer, _id_reset as jni$_.JMethodIDPtr,
             _$config.pointer)
-        .object<EmojiCompat>(const $EmojiCompat$Type());
+        .object<EmojiCompat>(const $EmojiCompat$Type$());
   }
 
   static final _id_reset$1 = _class.staticMethodId(
@@ -2754,7 +2804,7 @@ class EmojiCompat extends jni$_.JObject {
     final _$emojiCompat = emojiCompat?.reference ?? jni$_.jNullReference;
     return _reset$1(_class.reference.pointer, _id_reset$1 as jni$_.JMethodIDPtr,
             _$emojiCompat.pointer)
-        .object<EmojiCompat?>(const $EmojiCompat$NullableType());
+        .object<EmojiCompat?>(const $EmojiCompat$NullableType$());
   }
 
   static final _id_skipDefaultConfigurationLookup = _class.staticMethodId(
@@ -2802,7 +2852,7 @@ class EmojiCompat extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   static EmojiCompat get() {
     return _get(_class.reference.pointer, _id_get as jni$_.JMethodIDPtr)
-        .object<EmojiCompat>(const $EmojiCompat$Type());
+        .object<EmojiCompat>(const $EmojiCompat$Type$());
   }
 
   static final _id_load = _class.instanceMethodId(
@@ -3213,7 +3263,7 @@ class EmojiCompat extends jni$_.JObject {
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
     return _process(reference.pointer, _id_process as jni$_.JMethodIDPtr,
             _$charSequence.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_process$1 = _class.instanceMethodId(
@@ -3246,7 +3296,7 @@ class EmojiCompat extends jni$_.JObject {
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
     return _process$1(reference.pointer, _id_process$1 as jni$_.JMethodIDPtr,
             _$charSequence.pointer, i, i1)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_process$2 = _class.instanceMethodId(
@@ -3281,7 +3331,7 @@ class EmojiCompat extends jni$_.JObject {
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
     return _process$2(reference.pointer, _id_process$2 as jni$_.JMethodIDPtr,
             _$charSequence.pointer, i, i1, i2)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_process$3 = _class.instanceMethodId(
@@ -3324,7 +3374,7 @@ class EmojiCompat extends jni$_.JObject {
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
     return _process$3(reference.pointer, _id_process$3 as jni$_.JMethodIDPtr,
             _$charSequence.pointer, i, i1, i2, i3)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getAssetSignature = _class.instanceMethodId(
@@ -3349,7 +3399,7 @@ class EmojiCompat extends jni$_.JObject {
   jni$_.JString getAssetSignature() {
     return _getAssetSignature(
             reference.pointer, _id_getAssetSignature as jni$_.JMethodIDPtr)
-        .object<jni$_.JString>(const jni$_.JStringType());
+        .object<jni$_.JString>(const jni$_.$JString$Type$());
   }
 
   static final _id_updateEditorInfo = _class.instanceMethodId(
@@ -3379,9 +3429,9 @@ class EmojiCompat extends jni$_.JObject {
   }
 }
 
-final class $EmojiCompat$NullableType extends jni$_.JObjType<EmojiCompat?> {
+final class $EmojiCompat$NullableType$ extends jni$_.JType<EmojiCompat?> {
   @jni$_.internal
-  const $EmojiCompat$NullableType();
+  const $EmojiCompat$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -3396,29 +3446,29 @@ final class $EmojiCompat$NullableType extends jni$_.JObjType<EmojiCompat?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat?> get nullableType => this;
+  jni$_.JType<EmojiCompat?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$NullableType).hashCode;
+  int get hashCode => ($EmojiCompat$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat$NullableType) &&
-        other is $EmojiCompat$NullableType;
+    return other.runtimeType == ($EmojiCompat$NullableType$) &&
+        other is $EmojiCompat$NullableType$;
   }
 }
 
-final class $EmojiCompat$Type extends jni$_.JObjType<EmojiCompat> {
+final class $EmojiCompat$Type$ extends jni$_.JType<EmojiCompat> {
   @jni$_.internal
-  const $EmojiCompat$Type();
+  const $EmojiCompat$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -3432,24 +3482,24 @@ final class $EmojiCompat$Type extends jni$_.JObjType<EmojiCompat> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<EmojiCompat?> get nullableType =>
-      const $EmojiCompat$NullableType();
+  jni$_.JType<EmojiCompat?> get nullableType =>
+      const $EmojiCompat$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($EmojiCompat$Type).hashCode;
+  int get hashCode => ($EmojiCompat$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($EmojiCompat$Type) &&
-        other is $EmojiCompat$Type;
+    return other.runtimeType == ($EmojiCompat$Type$) &&
+        other is $EmojiCompat$Type$;
   }
 }
 
@@ -3458,7 +3508,7 @@ class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory
     extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory>
+  final jni$_.JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory>
       $type;
 
   @jni$_.internal
@@ -3471,10 +3521,15 @@ class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory
       r'androidx/emoji2/text/DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType =
-      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType();
-  static const type =
-      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type();
+  static const jni$_
+      .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory?>
+      nullableType =
+      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_
+      .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory> type =
+      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type$();
   static final _id_new$ = _class.constructorId(
     r'(Landroidx/emoji2/text/DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper;)V',
   );
@@ -3530,15 +3585,15 @@ class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory
     final _$context = context.reference;
     return _create(reference.pointer, _id_create as jni$_.JMethodIDPtr,
             _$context.pointer)
-        .object<EmojiCompat$Config?>(const $EmojiCompat$Config$NullableType());
+        .object<EmojiCompat$Config?>(const $EmojiCompat$Config$NullableType$());
   }
 }
 
-final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType
+final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType$
     extends jni$_
-    .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory?> {
+    .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory?> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType();
+  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -3557,11 +3612,11 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableTy
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory?>
+  jni$_.JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory?>
       get nullableType => this;
 
   @jni$_.internal
@@ -3570,23 +3625,23 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableTy
 
   @core$_.override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType)
+      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType$)
           .hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType) &&
+            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType$) &&
         other
-            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType;
+            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType$;
   }
 }
 
-final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type
+final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type$
     extends jni$_
-    .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory> {
+    .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type();
+  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -3602,13 +3657,13 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory?>
+  jni$_.JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory?>
       get nullableType =>
-          const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType();
+          const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -3616,13 +3671,15 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type
 
   @core$_.override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type).hashCode;
+      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type$)
+          .hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type) &&
-        other is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type;
+            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type$) &&
+        other
+            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$Type$;
   }
 }
 
@@ -3631,7 +3688,7 @@ class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper
     extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper>
+  final jni$_.JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper>
       $type;
 
   @jni$_.internal
@@ -3644,10 +3701,15 @@ class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper
       r'androidx/emoji2/text/DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType =
-      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType();
-  static const type =
-      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type();
+  static const jni$_
+      .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper?>
+      nullableType =
+      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_
+      .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper> type =
+      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -3709,8 +3771,8 @@ class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper
             _$packageManager.pointer,
             _$string.pointer)
         .object<jni$_.JArray<jni$_.JObject?>>(
-            const jni$_.JArrayType<jni$_.JObject?>(
-                jni$_.JObjectNullableType()));
+            const jni$_.$JArray$Type$<jni$_.JObject?>(
+                jni$_.$JObject$NullableType$()));
   }
 
   static final _id_queryIntentContentProviders = _class.instanceMethodId(
@@ -3754,7 +3816,8 @@ class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper
             _$intent.pointer,
             i)
         .object<jni$_.JList<jni$_.JObject?>>(
-            const jni$_.JListType<jni$_.JObject?>(jni$_.JObjectNullableType()));
+            const jni$_.$JList$Type$<jni$_.JObject?>(
+                jni$_.$JObject$NullableType$()));
   }
 
   static final _id_getProviderInfo = _class.instanceMethodId(
@@ -3781,15 +3844,15 @@ class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper
     final _$resolveInfo = resolveInfo.reference;
     return _getProviderInfo(reference.pointer,
             _id_getProviderInfo as jni$_.JMethodIDPtr, _$resolveInfo.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 }
 
-final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType
+final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType$
     extends jni$_
-    .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper?> {
+    .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper?> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType();
+  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -3808,11 +3871,11 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableTyp
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper?>
+  jni$_.JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper?>
       get nullableType => this;
 
   @jni$_.internal
@@ -3821,23 +3884,23 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableTyp
 
   @core$_.override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType)
+      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType$)
           .hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType) &&
+            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType$) &&
         other
-            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType;
+            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType$;
   }
 }
 
-final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type
+final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type$
     extends jni$_
-    .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper> {
+    .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type();
+  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -3853,13 +3916,13 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper?>
+  jni$_.JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper?>
       get nullableType =>
-          const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType();
+          const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -3867,13 +3930,13 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type
 
   @core$_.override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type).hashCode;
+      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type) &&
-        other is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type;
+            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type$) &&
+        other is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$Type$;
   }
 }
 
@@ -3883,7 +3946,7 @@ class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19
   @jni$_.internal
   @core$_.override
   final jni$_
-      .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19>
+      .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19>
       $type;
 
   @jni$_.internal
@@ -3896,10 +3959,16 @@ class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19
       r'androidx/emoji2/text/DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType =
-      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType();
-  static const type =
-      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type();
+  static const jni$_
+      .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19?>
+      nullableType =
+      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_
+      .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19>
+      type =
+      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -3966,7 +4035,8 @@ class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19
             _$intent.pointer,
             i)
         .object<jni$_.JList<jni$_.JObject?>>(
-            const jni$_.JListType<jni$_.JObject?>(jni$_.JObjectNullableType()));
+            const jni$_.$JList$Type$<jni$_.JObject?>(
+                jni$_.$JObject$NullableType$()));
   }
 
   static final _id_getProviderInfo = _class.instanceMethodId(
@@ -3993,15 +4063,15 @@ class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19
     final _$resolveInfo = resolveInfo.reference;
     return _getProviderInfo(reference.pointer,
             _id_getProviderInfo as jni$_.JMethodIDPtr, _$resolveInfo.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 }
 
-final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType
+final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType$
     extends jni$_
-    .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19?> {
+    .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19?> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType();
+  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -4020,12 +4090,12 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Nulla
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType =>
-      const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType();
+  jni$_.JType get superType =>
+      const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19?>
+  jni$_.JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19?>
       get nullableType => this;
 
   @jni$_.internal
@@ -4034,23 +4104,23 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Nulla
 
   @core$_.override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType)
+      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType$)
           .hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType) &&
+            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType$) &&
         other
-            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType;
+            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType$;
   }
 }
 
-final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type
+final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type$
     extends jni$_
-    .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19> {
+    .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type();
+  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -4067,14 +4137,14 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType =>
-      const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType();
+  jni$_.JType get superType =>
+      const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19?>
+  jni$_.JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19?>
       get nullableType =>
-          const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType();
+          const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -4082,15 +4152,15 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type
 
   @core$_.override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type)
+      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type$)
           .hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type) &&
+            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type$) &&
         other
-            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type;
+            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$Type$;
   }
 }
 
@@ -4100,7 +4170,7 @@ class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28
   @jni$_.internal
   @core$_.override
   final jni$_
-      .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28>
+      .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28>
       $type;
 
   @jni$_.internal
@@ -4113,10 +4183,16 @@ class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28
       r'androidx/emoji2/text/DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType =
-      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType();
-  static const type =
-      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type();
+  static const jni$_
+      .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28?>
+      nullableType =
+      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_
+      .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28>
+      type =
+      $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -4178,16 +4254,16 @@ class DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28
             _$packageManager.pointer,
             _$string.pointer)
         .object<jni$_.JArray<jni$_.JObject?>>(
-            const jni$_.JArrayType<jni$_.JObject?>(
-                jni$_.JObjectNullableType()));
+            const jni$_.$JArray$Type$<jni$_.JObject?>(
+                jni$_.$JObject$NullableType$()));
   }
 }
 
-final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType
+final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType$
     extends jni$_
-    .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28?> {
+    .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28?> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType();
+  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -4206,12 +4282,12 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Nulla
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType =>
-      const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType();
+  jni$_.JType get superType =>
+      const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28?>
+  jni$_.JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28?>
       get nullableType => this;
 
   @jni$_.internal
@@ -4220,23 +4296,23 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Nulla
 
   @core$_.override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType)
+      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType$)
           .hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType) &&
+            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType$) &&
         other
-            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType;
+            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType$;
   }
 }
 
-final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type
+final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type$
     extends jni$_
-    .JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28> {
+    .JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type();
+  const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -4253,14 +4329,14 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType =>
-      const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType();
+  jni$_.JType get superType =>
+      const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28?>
+  jni$_.JType<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28?>
       get nullableType =>
-          const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType();
+          const $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -4268,15 +4344,15 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type
 
   @core$_.override
   int get hashCode =>
-      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type)
+      ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type$)
           .hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type) &&
+            ($DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type$) &&
         other
-            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type;
+            is $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type$;
   }
 }
 
@@ -4284,7 +4360,7 @@ final class $DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$Type
 class DefaultEmojiCompatConfig extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<DefaultEmojiCompatConfig> $type;
+  final jni$_.JType<DefaultEmojiCompatConfig> $type;
 
   @jni$_.internal
   DefaultEmojiCompatConfig.fromReference(
@@ -4296,8 +4372,12 @@ class DefaultEmojiCompatConfig extends jni$_.JObject {
       jni$_.JClass.forName(r'androidx/emoji2/text/DefaultEmojiCompatConfig');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $DefaultEmojiCompatConfig$NullableType();
-  static const type = $DefaultEmojiCompatConfig$Type();
+  static const jni$_.JType<DefaultEmojiCompatConfig?> nullableType =
+      $DefaultEmojiCompatConfig$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<DefaultEmojiCompatConfig> type =
+      $DefaultEmojiCompatConfig$Type$();
   static final _id_create = _class.staticMethodId(
     r'create',
     r'(Landroid/content/Context;)Landroidx/emoji2/text/FontRequestEmojiCompatConfig;',
@@ -4322,14 +4402,14 @@ class DefaultEmojiCompatConfig extends jni$_.JObject {
     final _$context = context.reference;
     return _create(_class.reference.pointer, _id_create as jni$_.JMethodIDPtr,
             _$context.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 }
 
-final class $DefaultEmojiCompatConfig$NullableType
-    extends jni$_.JObjType<DefaultEmojiCompatConfig?> {
+final class $DefaultEmojiCompatConfig$NullableType$
+    extends jni$_.JType<DefaultEmojiCompatConfig?> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig$NullableType();
+  const $DefaultEmojiCompatConfig$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -4345,30 +4425,30 @@ final class $DefaultEmojiCompatConfig$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig?> get nullableType => this;
+  jni$_.JType<DefaultEmojiCompatConfig?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($DefaultEmojiCompatConfig$NullableType).hashCode;
+  int get hashCode => ($DefaultEmojiCompatConfig$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($DefaultEmojiCompatConfig$NullableType) &&
-        other is $DefaultEmojiCompatConfig$NullableType;
+    return other.runtimeType == ($DefaultEmojiCompatConfig$NullableType$) &&
+        other is $DefaultEmojiCompatConfig$NullableType$;
   }
 }
 
-final class $DefaultEmojiCompatConfig$Type
-    extends jni$_.JObjType<DefaultEmojiCompatConfig> {
+final class $DefaultEmojiCompatConfig$Type$
+    extends jni$_.JType<DefaultEmojiCompatConfig> {
   @jni$_.internal
-  const $DefaultEmojiCompatConfig$Type();
+  const $DefaultEmojiCompatConfig$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -4382,24 +4462,24 @@ final class $DefaultEmojiCompatConfig$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DefaultEmojiCompatConfig?> get nullableType =>
-      const $DefaultEmojiCompatConfig$NullableType();
+  jni$_.JType<DefaultEmojiCompatConfig?> get nullableType =>
+      const $DefaultEmojiCompatConfig$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($DefaultEmojiCompatConfig$Type).hashCode;
+  int get hashCode => ($DefaultEmojiCompatConfig$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($DefaultEmojiCompatConfig$Type) &&
-        other is $DefaultEmojiCompatConfig$Type;
+    return other.runtimeType == ($DefaultEmojiCompatConfig$Type$) &&
+        other is $DefaultEmojiCompatConfig$Type$;
   }
 }
 
@@ -4407,7 +4487,7 @@ final class $DefaultEmojiCompatConfig$Type
 class Build$Partition extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Build$Partition> $type;
+  final jni$_.JType<Build$Partition> $type;
 
   @jni$_.internal
   Build$Partition.fromReference(
@@ -4418,8 +4498,11 @@ class Build$Partition extends jni$_.JObject {
   static final _class = jni$_.JClass.forName(r'android/os/Build$Partition');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Build$Partition$NullableType();
-  static const type = $Build$Partition$Type();
+  static const jni$_.JType<Build$Partition?> nullableType =
+      $Build$Partition$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Build$Partition> type = $Build$Partition$Type$();
   static final _id_PARTITION_NAME_SYSTEM = _class.staticFieldId(
     r'PARTITION_NAME_SYSTEM',
     r'Ljava/lang/String;',
@@ -4427,8 +4510,8 @@ class Build$Partition extends jni$_.JObject {
 
   /// from: `static public final java.lang.String PARTITION_NAME_SYSTEM`
   /// The returned object must be released after use, by calling the [release] method.
-  static jni$_.JString? get PARTITION_NAME_SYSTEM =>
-      _id_PARTITION_NAME_SYSTEM.get(_class, const jni$_.JStringNullableType());
+  static jni$_.JString? get PARTITION_NAME_SYSTEM => _id_PARTITION_NAME_SYSTEM
+      .get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_getName = _class.instanceMethodId(
     r'getName',
@@ -4451,7 +4534,7 @@ class Build$Partition extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? getName() {
     return _getName(reference.pointer, _id_getName as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_getFingerprint = _class.instanceMethodId(
@@ -4476,7 +4559,7 @@ class Build$Partition extends jni$_.JObject {
   jni$_.JString? getFingerprint() {
     return _getFingerprint(
             reference.pointer, _id_getFingerprint as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_getBuildTimeMillis = _class.instanceMethodId(
@@ -4553,10 +4636,10 @@ class Build$Partition extends jni$_.JObject {
   }
 }
 
-final class $Build$Partition$NullableType
-    extends jni$_.JObjType<Build$Partition?> {
+final class $Build$Partition$NullableType$
+    extends jni$_.JType<Build$Partition?> {
   @jni$_.internal
-  const $Build$Partition$NullableType();
+  const $Build$Partition$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -4571,29 +4654,29 @@ final class $Build$Partition$NullableType
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Build$Partition?> get nullableType => this;
+  jni$_.JType<Build$Partition?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Build$Partition$NullableType).hashCode;
+  int get hashCode => ($Build$Partition$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Build$Partition$NullableType) &&
-        other is $Build$Partition$NullableType;
+    return other.runtimeType == ($Build$Partition$NullableType$) &&
+        other is $Build$Partition$NullableType$;
   }
 }
 
-final class $Build$Partition$Type extends jni$_.JObjType<Build$Partition> {
+final class $Build$Partition$Type$ extends jni$_.JType<Build$Partition> {
   @jni$_.internal
-  const $Build$Partition$Type();
+  const $Build$Partition$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -4607,24 +4690,24 @@ final class $Build$Partition$Type extends jni$_.JObjType<Build$Partition> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Build$Partition?> get nullableType =>
-      const $Build$Partition$NullableType();
+  jni$_.JType<Build$Partition?> get nullableType =>
+      const $Build$Partition$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Build$Partition$Type).hashCode;
+  int get hashCode => ($Build$Partition$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Build$Partition$Type) &&
-        other is $Build$Partition$Type;
+    return other.runtimeType == ($Build$Partition$Type$) &&
+        other is $Build$Partition$Type$;
   }
 }
 
@@ -4632,7 +4715,7 @@ final class $Build$Partition$Type extends jni$_.JObjType<Build$Partition> {
 class Build$VERSION extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Build$VERSION> $type;
+  final jni$_.JType<Build$VERSION> $type;
 
   @jni$_.internal
   Build$VERSION.fromReference(
@@ -4643,8 +4726,11 @@ class Build$VERSION extends jni$_.JObject {
   static final _class = jni$_.JClass.forName(r'android/os/Build$VERSION');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Build$VERSION$NullableType();
-  static const type = $Build$VERSION$Type();
+  static const jni$_.JType<Build$VERSION?> nullableType =
+      $Build$VERSION$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Build$VERSION> type = $Build$VERSION$Type$();
   static final _id_BASE_OS = _class.staticFieldId(
     r'BASE_OS',
     r'Ljava/lang/String;',
@@ -4653,7 +4739,7 @@ class Build$VERSION extends jni$_.JObject {
   /// from: `static public final java.lang.String BASE_OS`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get BASE_OS =>
-      _id_BASE_OS.get(_class, const jni$_.JStringNullableType());
+      _id_BASE_OS.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_CODENAME = _class.staticFieldId(
     r'CODENAME',
@@ -4663,7 +4749,7 @@ class Build$VERSION extends jni$_.JObject {
   /// from: `static public final java.lang.String CODENAME`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get CODENAME =>
-      _id_CODENAME.get(_class, const jni$_.JStringNullableType());
+      _id_CODENAME.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_INCREMENTAL = _class.staticFieldId(
     r'INCREMENTAL',
@@ -4673,7 +4759,7 @@ class Build$VERSION extends jni$_.JObject {
   /// from: `static public final java.lang.String INCREMENTAL`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get INCREMENTAL =>
-      _id_INCREMENTAL.get(_class, const jni$_.JStringNullableType());
+      _id_INCREMENTAL.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_MEDIA_PERFORMANCE_CLASS = _class.staticFieldId(
     r'MEDIA_PERFORMANCE_CLASS',
@@ -4701,7 +4787,7 @@ class Build$VERSION extends jni$_.JObject {
   /// from: `static public final java.lang.String RELEASE`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get RELEASE =>
-      _id_RELEASE.get(_class, const jni$_.JStringNullableType());
+      _id_RELEASE.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_RELEASE_OR_CODENAME = _class.staticFieldId(
     r'RELEASE_OR_CODENAME',
@@ -4711,7 +4797,7 @@ class Build$VERSION extends jni$_.JObject {
   /// from: `static public final java.lang.String RELEASE_OR_CODENAME`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get RELEASE_OR_CODENAME =>
-      _id_RELEASE_OR_CODENAME.get(_class, const jni$_.JStringNullableType());
+      _id_RELEASE_OR_CODENAME.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_RELEASE_OR_PREVIEW_DISPLAY = _class.staticFieldId(
     r'RELEASE_OR_PREVIEW_DISPLAY',
@@ -4722,7 +4808,7 @@ class Build$VERSION extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get RELEASE_OR_PREVIEW_DISPLAY =>
       _id_RELEASE_OR_PREVIEW_DISPLAY.get(
-          _class, const jni$_.JStringNullableType());
+          _class, const jni$_.$JString$NullableType$());
 
   static final _id_SDK = _class.staticFieldId(
     r'SDK',
@@ -4732,7 +4818,7 @@ class Build$VERSION extends jni$_.JObject {
   /// from: `static public final java.lang.String SDK`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get SDK =>
-      _id_SDK.get(_class, const jni$_.JStringNullableType());
+      _id_SDK.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_SDK_INT = _class.staticFieldId(
     r'SDK_INT',
@@ -4750,7 +4836,7 @@ class Build$VERSION extends jni$_.JObject {
   /// from: `static public final java.lang.String SECURITY_PATCH`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get SECURITY_PATCH =>
-      _id_SECURITY_PATCH.get(_class, const jni$_.JStringNullableType());
+      _id_SECURITY_PATCH.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_new$ = _class.constructorId(
     r'()V',
@@ -4777,9 +4863,9 @@ class Build$VERSION extends jni$_.JObject {
   }
 }
 
-final class $Build$VERSION$NullableType extends jni$_.JObjType<Build$VERSION?> {
+final class $Build$VERSION$NullableType$ extends jni$_.JType<Build$VERSION?> {
   @jni$_.internal
-  const $Build$VERSION$NullableType();
+  const $Build$VERSION$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -4794,29 +4880,29 @@ final class $Build$VERSION$NullableType extends jni$_.JObjType<Build$VERSION?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Build$VERSION?> get nullableType => this;
+  jni$_.JType<Build$VERSION?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Build$VERSION$NullableType).hashCode;
+  int get hashCode => ($Build$VERSION$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Build$VERSION$NullableType) &&
-        other is $Build$VERSION$NullableType;
+    return other.runtimeType == ($Build$VERSION$NullableType$) &&
+        other is $Build$VERSION$NullableType$;
   }
 }
 
-final class $Build$VERSION$Type extends jni$_.JObjType<Build$VERSION> {
+final class $Build$VERSION$Type$ extends jni$_.JType<Build$VERSION> {
   @jni$_.internal
-  const $Build$VERSION$Type();
+  const $Build$VERSION$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -4830,24 +4916,24 @@ final class $Build$VERSION$Type extends jni$_.JObjType<Build$VERSION> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Build$VERSION?> get nullableType =>
-      const $Build$VERSION$NullableType();
+  jni$_.JType<Build$VERSION?> get nullableType =>
+      const $Build$VERSION$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Build$VERSION$Type).hashCode;
+  int get hashCode => ($Build$VERSION$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Build$VERSION$Type) &&
-        other is $Build$VERSION$Type;
+    return other.runtimeType == ($Build$VERSION$Type$) &&
+        other is $Build$VERSION$Type$;
   }
 }
 
@@ -4855,7 +4941,7 @@ final class $Build$VERSION$Type extends jni$_.JObjType<Build$VERSION> {
 class Build$VERSION_CODES extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Build$VERSION_CODES> $type;
+  final jni$_.JType<Build$VERSION_CODES> $type;
 
   @jni$_.internal
   Build$VERSION_CODES.fromReference(
@@ -4866,8 +4952,12 @@ class Build$VERSION_CODES extends jni$_.JObject {
   static final _class = jni$_.JClass.forName(r'android/os/Build$VERSION_CODES');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Build$VERSION_CODES$NullableType();
-  static const type = $Build$VERSION_CODES$Type();
+  static const jni$_.JType<Build$VERSION_CODES?> nullableType =
+      $Build$VERSION_CODES$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Build$VERSION_CODES> type =
+      $Build$VERSION_CODES$Type$();
 
   /// from: `static public final int BASE`
   static const BASE = 1;
@@ -5001,10 +5091,10 @@ class Build$VERSION_CODES extends jni$_.JObject {
   }
 }
 
-final class $Build$VERSION_CODES$NullableType
-    extends jni$_.JObjType<Build$VERSION_CODES?> {
+final class $Build$VERSION_CODES$NullableType$
+    extends jni$_.JType<Build$VERSION_CODES?> {
   @jni$_.internal
-  const $Build$VERSION_CODES$NullableType();
+  const $Build$VERSION_CODES$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -5020,30 +5110,30 @@ final class $Build$VERSION_CODES$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Build$VERSION_CODES?> get nullableType => this;
+  jni$_.JType<Build$VERSION_CODES?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Build$VERSION_CODES$NullableType).hashCode;
+  int get hashCode => ($Build$VERSION_CODES$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Build$VERSION_CODES$NullableType) &&
-        other is $Build$VERSION_CODES$NullableType;
+    return other.runtimeType == ($Build$VERSION_CODES$NullableType$) &&
+        other is $Build$VERSION_CODES$NullableType$;
   }
 }
 
-final class $Build$VERSION_CODES$Type
-    extends jni$_.JObjType<Build$VERSION_CODES> {
+final class $Build$VERSION_CODES$Type$
+    extends jni$_.JType<Build$VERSION_CODES> {
   @jni$_.internal
-  const $Build$VERSION_CODES$Type();
+  const $Build$VERSION_CODES$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -5057,24 +5147,24 @@ final class $Build$VERSION_CODES$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Build$VERSION_CODES?> get nullableType =>
-      const $Build$VERSION_CODES$NullableType();
+  jni$_.JType<Build$VERSION_CODES?> get nullableType =>
+      const $Build$VERSION_CODES$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Build$VERSION_CODES$Type).hashCode;
+  int get hashCode => ($Build$VERSION_CODES$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Build$VERSION_CODES$Type) &&
-        other is $Build$VERSION_CODES$Type;
+    return other.runtimeType == ($Build$VERSION_CODES$Type$) &&
+        other is $Build$VERSION_CODES$Type$;
   }
 }
 
@@ -5082,7 +5172,7 @@ final class $Build$VERSION_CODES$Type
 class Build extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Build> $type;
+  final jni$_.JType<Build> $type;
 
   @jni$_.internal
   Build.fromReference(
@@ -5093,8 +5183,10 @@ class Build extends jni$_.JObject {
   static final _class = jni$_.JClass.forName(r'android/os/Build');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Build$NullableType();
-  static const type = $Build$Type();
+  static const jni$_.JType<Build?> nullableType = $Build$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Build> type = $Build$Type$();
   static final _id_BOARD = _class.staticFieldId(
     r'BOARD',
     r'Ljava/lang/String;',
@@ -5103,7 +5195,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String BOARD`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get BOARD =>
-      _id_BOARD.get(_class, const jni$_.JStringNullableType());
+      _id_BOARD.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_BOOTLOADER = _class.staticFieldId(
     r'BOOTLOADER',
@@ -5113,7 +5205,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String BOOTLOADER`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get BOOTLOADER =>
-      _id_BOOTLOADER.get(_class, const jni$_.JStringNullableType());
+      _id_BOOTLOADER.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_BRAND = _class.staticFieldId(
     r'BRAND',
@@ -5123,7 +5215,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String BRAND`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get BRAND =>
-      _id_BRAND.get(_class, const jni$_.JStringNullableType());
+      _id_BRAND.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_CPU_ABI = _class.staticFieldId(
     r'CPU_ABI',
@@ -5133,7 +5225,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String CPU_ABI`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get CPU_ABI =>
-      _id_CPU_ABI.get(_class, const jni$_.JStringNullableType());
+      _id_CPU_ABI.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_CPU_ABI2 = _class.staticFieldId(
     r'CPU_ABI2',
@@ -5143,7 +5235,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String CPU_ABI2`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get CPU_ABI2 =>
-      _id_CPU_ABI2.get(_class, const jni$_.JStringNullableType());
+      _id_CPU_ABI2.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_DEVICE = _class.staticFieldId(
     r'DEVICE',
@@ -5153,7 +5245,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String DEVICE`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get DEVICE =>
-      _id_DEVICE.get(_class, const jni$_.JStringNullableType());
+      _id_DEVICE.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_DISPLAY = _class.staticFieldId(
     r'DISPLAY',
@@ -5163,7 +5255,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String DISPLAY`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get DISPLAY =>
-      _id_DISPLAY.get(_class, const jni$_.JStringNullableType());
+      _id_DISPLAY.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_FINGERPRINT = _class.staticFieldId(
     r'FINGERPRINT',
@@ -5173,7 +5265,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String FINGERPRINT`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get FINGERPRINT =>
-      _id_FINGERPRINT.get(_class, const jni$_.JStringNullableType());
+      _id_FINGERPRINT.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_HARDWARE = _class.staticFieldId(
     r'HARDWARE',
@@ -5183,7 +5275,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String HARDWARE`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get HARDWARE =>
-      _id_HARDWARE.get(_class, const jni$_.JStringNullableType());
+      _id_HARDWARE.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_HOST = _class.staticFieldId(
     r'HOST',
@@ -5193,7 +5285,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String HOST`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get HOST =>
-      _id_HOST.get(_class, const jni$_.JStringNullableType());
+      _id_HOST.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_ID = _class.staticFieldId(
     r'ID',
@@ -5203,7 +5295,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String ID`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get ID =>
-      _id_ID.get(_class, const jni$_.JStringNullableType());
+      _id_ID.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_MANUFACTURER = _class.staticFieldId(
     r'MANUFACTURER',
@@ -5213,7 +5305,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String MANUFACTURER`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get MANUFACTURER =>
-      _id_MANUFACTURER.get(_class, const jni$_.JStringNullableType());
+      _id_MANUFACTURER.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_MODEL = _class.staticFieldId(
     r'MODEL',
@@ -5223,7 +5315,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String MODEL`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get MODEL =>
-      _id_MODEL.get(_class, const jni$_.JStringNullableType());
+      _id_MODEL.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_ODM_SKU = _class.staticFieldId(
     r'ODM_SKU',
@@ -5233,7 +5325,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String ODM_SKU`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get ODM_SKU =>
-      _id_ODM_SKU.get(_class, const jni$_.JStringNullableType());
+      _id_ODM_SKU.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_PRODUCT = _class.staticFieldId(
     r'PRODUCT',
@@ -5243,7 +5335,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String PRODUCT`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get PRODUCT =>
-      _id_PRODUCT.get(_class, const jni$_.JStringNullableType());
+      _id_PRODUCT.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_RADIO = _class.staticFieldId(
     r'RADIO',
@@ -5253,7 +5345,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String RADIO`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get RADIO =>
-      _id_RADIO.get(_class, const jni$_.JStringNullableType());
+      _id_RADIO.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_SERIAL = _class.staticFieldId(
     r'SERIAL',
@@ -5263,7 +5355,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String SERIAL`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get SERIAL =>
-      _id_SERIAL.get(_class, const jni$_.JStringNullableType());
+      _id_SERIAL.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_SKU = _class.staticFieldId(
     r'SKU',
@@ -5273,7 +5365,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String SKU`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get SKU =>
-      _id_SKU.get(_class, const jni$_.JStringNullableType());
+      _id_SKU.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_SOC_MANUFACTURER = _class.staticFieldId(
     r'SOC_MANUFACTURER',
@@ -5283,7 +5375,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String SOC_MANUFACTURER`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get SOC_MANUFACTURER =>
-      _id_SOC_MANUFACTURER.get(_class, const jni$_.JStringNullableType());
+      _id_SOC_MANUFACTURER.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_SOC_MODEL = _class.staticFieldId(
     r'SOC_MODEL',
@@ -5293,7 +5385,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String SOC_MODEL`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get SOC_MODEL =>
-      _id_SOC_MODEL.get(_class, const jni$_.JStringNullableType());
+      _id_SOC_MODEL.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_SUPPORTED_32_BIT_ABIS = _class.staticFieldId(
     r'SUPPORTED_32_BIT_ABIS',
@@ -5305,8 +5397,8 @@ class Build extends jni$_.JObject {
   static jni$_.JArray<jni$_.JString?>? get SUPPORTED_32_BIT_ABIS =>
       _id_SUPPORTED_32_BIT_ABIS.get(
           _class,
-          const jni$_.JArrayNullableType<jni$_.JString?>(
-              jni$_.JStringNullableType()));
+          const jni$_.$JArray$NullableType$<jni$_.JString?>(
+              jni$_.$JString$NullableType$()));
 
   static final _id_SUPPORTED_64_BIT_ABIS = _class.staticFieldId(
     r'SUPPORTED_64_BIT_ABIS',
@@ -5318,8 +5410,8 @@ class Build extends jni$_.JObject {
   static jni$_.JArray<jni$_.JString?>? get SUPPORTED_64_BIT_ABIS =>
       _id_SUPPORTED_64_BIT_ABIS.get(
           _class,
-          const jni$_.JArrayNullableType<jni$_.JString?>(
-              jni$_.JStringNullableType()));
+          const jni$_.$JArray$NullableType$<jni$_.JString?>(
+              jni$_.$JString$NullableType$()));
 
   static final _id_SUPPORTED_ABIS = _class.staticFieldId(
     r'SUPPORTED_ABIS',
@@ -5331,8 +5423,8 @@ class Build extends jni$_.JObject {
   static jni$_.JArray<jni$_.JString?>? get SUPPORTED_ABIS => _id_SUPPORTED_ABIS
       .get(
           _class,
-          const jni$_.JArrayNullableType<jni$_.JString?>(
-              jni$_.JStringNullableType()));
+          const jni$_.$JArray$NullableType$<jni$_.JString?>(
+              jni$_.$JString$NullableType$()));
 
   static final _id_TAGS = _class.staticFieldId(
     r'TAGS',
@@ -5342,7 +5434,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String TAGS`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get TAGS =>
-      _id_TAGS.get(_class, const jni$_.JStringNullableType());
+      _id_TAGS.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_TIME = _class.staticFieldId(
     r'TIME',
@@ -5360,7 +5452,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String TYPE`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get TYPE =>
-      _id_TYPE.get(_class, const jni$_.JStringNullableType());
+      _id_TYPE.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_UNKNOWN = _class.staticFieldId(
     r'UNKNOWN',
@@ -5370,7 +5462,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String UNKNOWN`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get UNKNOWN =>
-      _id_UNKNOWN.get(_class, const jni$_.JStringNullableType());
+      _id_UNKNOWN.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_USER = _class.staticFieldId(
     r'USER',
@@ -5380,7 +5472,7 @@ class Build extends jni$_.JObject {
   /// from: `static public final java.lang.String USER`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get USER =>
-      _id_USER.get(_class, const jni$_.JStringNullableType());
+      _id_USER.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_new$ = _class.constructorId(
     r'()V',
@@ -5428,7 +5520,7 @@ class Build extends jni$_.JObject {
   static jni$_.JString? getSerial() {
     return _getSerial(
             _class.reference.pointer, _id_getSerial as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_getFingerprintedPartitions = _class.staticMethodId(
@@ -5455,8 +5547,8 @@ class Build extends jni$_.JObject {
     return _getFingerprintedPartitions(_class.reference.pointer,
             _id_getFingerprintedPartitions as jni$_.JMethodIDPtr)
         .object<jni$_.JList<Build$Partition?>?>(
-            const jni$_.JListNullableType<Build$Partition?>(
-                $Build$Partition$NullableType()));
+            const jni$_.$JList$NullableType$<Build$Partition?>(
+                $Build$Partition$NullableType$()));
   }
 
   static final _id_getRadioVersion = _class.staticMethodId(
@@ -5481,13 +5573,13 @@ class Build extends jni$_.JObject {
   static jni$_.JString? getRadioVersion() {
     return _getRadioVersion(
             _class.reference.pointer, _id_getRadioVersion as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 }
 
-final class $Build$NullableType extends jni$_.JObjType<Build?> {
+final class $Build$NullableType$ extends jni$_.JType<Build?> {
   @jni$_.internal
-  const $Build$NullableType();
+  const $Build$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -5502,29 +5594,29 @@ final class $Build$NullableType extends jni$_.JObjType<Build?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Build?> get nullableType => this;
+  jni$_.JType<Build?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Build$NullableType).hashCode;
+  int get hashCode => ($Build$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Build$NullableType) &&
-        other is $Build$NullableType;
+    return other.runtimeType == ($Build$NullableType$) &&
+        other is $Build$NullableType$;
   }
 }
 
-final class $Build$Type extends jni$_.JObjType<Build> {
+final class $Build$Type$ extends jni$_.JType<Build> {
   @jni$_.internal
-  const $Build$Type();
+  const $Build$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -5537,22 +5629,22 @@ final class $Build$Type extends jni$_.JObjType<Build> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Build?> get nullableType => const $Build$NullableType();
+  jni$_.JType<Build?> get nullableType => const $Build$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Build$Type).hashCode;
+  int get hashCode => ($Build$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Build$Type) && other is $Build$Type;
+    return other.runtimeType == ($Build$Type$) && other is $Build$Type$;
   }
 }
 
@@ -5561,13 +5653,13 @@ class HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<HashMap<$K, $V>> $type;
+  final jni$_.JType<HashMap<$K, $V>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$K> K;
+  final jni$_.JType<$K> K;
 
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
   HashMap.fromReference(
@@ -5580,23 +5672,24 @@ class HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   static final _class = jni$_.JClass.forName(r'java/util/HashMap');
 
   /// The type which includes information such as the signature of this class.
-  static $HashMap$NullableType<$K, $V>
+  static jni$_.JType<HashMap<$K, $V>?>
       nullableType<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
-    jni$_.JObjType<$K> K,
-    jni$_.JObjType<$V> V,
+    jni$_.JType<$K> K,
+    jni$_.JType<$V> V,
   ) {
-    return $HashMap$NullableType<$K, $V>(
+    return $HashMap$NullableType$<$K, $V>(
       K,
       V,
     );
   }
 
-  static $HashMap$Type<$K, $V>
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<HashMap<$K, $V>>
       type<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
-    jni$_.JObjType<$K> K,
-    jni$_.JObjType<$V> V,
+    jni$_.JType<$K> K,
+    jni$_.JType<$V> V,
   ) {
-    return $HashMap$Type<$K, $V>(
+    return $HashMap$Type$<$K, $V>(
       K,
       V,
     );
@@ -5622,8 +5715,8 @@ class HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   factory HashMap(
     int i,
     double f, {
-    required jni$_.JObjType<$K> K,
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$K> K,
+    required jni$_.JType<$V> V,
   }) {
     return HashMap<$K, $V>.fromReference(
         K,
@@ -5650,8 +5743,8 @@ class HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   /// The returned object must be released after use, by calling the [release] method.
   factory HashMap.new$1(
     int i, {
-    required jni$_.JObjType<$K> K,
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$K> K,
+    required jni$_.JType<$V> V,
   }) {
     return HashMap<$K, $V>.fromReference(
         K,
@@ -5679,8 +5772,8 @@ class HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory HashMap.new$2({
-    required jni$_.JObjType<$K> K,
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$K> K,
+    required jni$_.JType<$V> V,
   }) {
     return HashMap<$K, $V>.fromReference(
         K,
@@ -5708,8 +5801,8 @@ class HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   /// The returned object must be released after use, by calling the [release] method.
   factory HashMap.new$3(
     jni$_.JMap<$K?, $V?>? map, {
-    required jni$_.JObjType<$K> K,
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$K> K,
+    required jni$_.JType<$V> V,
   }) {
     final _$map = map?.reference ?? jni$_.jNullReference;
     return HashMap<$K, $V>.fromReference(
@@ -5974,7 +6067,8 @@ class HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JSet<$K?>? keySet() {
     return _keySet(reference.pointer, _id_keySet as jni$_.JMethodIDPtr)
-        .object<jni$_.JSet<$K?>?>(jni$_.JSetNullableType<$K?>(K.nullableType));
+        .object<jni$_.JSet<$K?>?>(
+            jni$_.$JSet$NullableType$<$K?>(K.nullableType));
   }
 
   static final _id_values = _class.instanceMethodId(
@@ -5998,7 +6092,7 @@ class HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? values() {
     return _values(reference.pointer, _id_values as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_entrySet = _class.instanceMethodId(
@@ -6023,8 +6117,8 @@ class HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   jni$_.JSet<jni$_.JObject?>? entrySet() {
     return _entrySet(reference.pointer, _id_entrySet as jni$_.JMethodIDPtr)
         .object<jni$_.JSet<jni$_.JObject?>?>(
-            const jni$_.JSetNullableType<jni$_.JObject?>(
-                jni$_.JObjectNullableType()));
+            const jni$_.$JSet$NullableType$<jni$_.JObject?>(
+                jni$_.$JObject$NullableType$()));
   }
 
   static final _id_getOrDefault = _class.instanceMethodId(
@@ -6433,7 +6527,7 @@ class HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? clone() {
     return _clone(reference.pointer, _id_clone as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_newHashMap = _class.staticMethodId(
@@ -6455,26 +6549,26 @@ class HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   static HashMap<$K?, $V?>?
       newHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
     int i, {
-    required jni$_.JObjType<$K> K,
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$K> K,
+    required jni$_.JType<$V> V,
   }) {
     return _newHashMap(
             _class.reference.pointer, _id_newHashMap as jni$_.JMethodIDPtr, i)
         .object<HashMap<$K?, $V?>?>(
-            $HashMap$NullableType<$K?, $V?>(K.nullableType, V.nullableType));
+            $HashMap$NullableType$<$K?, $V?>(K.nullableType, V.nullableType));
   }
 }
 
-final class $HashMap$NullableType<$K extends jni$_.JObject?,
-    $V extends jni$_.JObject?> extends jni$_.JObjType<HashMap<$K, $V>?> {
+final class $HashMap$NullableType$<$K extends jni$_.JObject?,
+    $V extends jni$_.JObject?> extends jni$_.JType<HashMap<$K, $V>?> {
   @jni$_.internal
-  final jni$_.JObjType<$K> K;
+  final jni$_.JType<$K> K;
 
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
-  const $HashMap$NullableType(
+  const $HashMap$NullableType$(
     this.K,
     this.V,
   );
@@ -6494,38 +6588,38 @@ final class $HashMap$NullableType<$K extends jni$_.JObject?,
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<HashMap<$K, $V>?> get nullableType => this;
+  jni$_.JType<HashMap<$K, $V>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($HashMap$NullableType, K, V);
+  int get hashCode => Object.hash($HashMap$NullableType$, K, V);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($HashMap$NullableType<$K, $V>) &&
-        other is $HashMap$NullableType<$K, $V> &&
+    return other.runtimeType == ($HashMap$NullableType$<$K, $V>) &&
+        other is $HashMap$NullableType$<$K, $V> &&
         K == other.K &&
         V == other.V;
   }
 }
 
-final class $HashMap$Type<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
-    extends jni$_.JObjType<HashMap<$K, $V>> {
+final class $HashMap$Type$<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
+    extends jni$_.JType<HashMap<$K, $V>> {
   @jni$_.internal
-  final jni$_.JObjType<$K> K;
+  final jni$_.JType<$K> K;
 
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
-  const $HashMap$Type(
+  const $HashMap$Type$(
     this.K,
     this.V,
   );
@@ -6544,24 +6638,24 @@ final class $HashMap$Type<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<HashMap<$K, $V>?> get nullableType =>
-      $HashMap$NullableType<$K, $V>(K, V);
+  jni$_.JType<HashMap<$K, $V>?> get nullableType =>
+      $HashMap$NullableType$<$K, $V>(K, V);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($HashMap$Type, K, V);
+  int get hashCode => Object.hash($HashMap$Type$, K, V);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($HashMap$Type<$K, $V>) &&
-        other is $HashMap$Type<$K, $V> &&
+    return other.runtimeType == ($HashMap$Type$<$K, $V>) &&
+        other is $HashMap$Type$<$K, $V> &&
         K == other.K &&
         V == other.V;
   }
@@ -6571,7 +6665,7 @@ final class $HashMap$Type<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
 class AndroidUtils extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<AndroidUtils> $type;
+  final jni$_.JType<AndroidUtils> $type;
 
   @jni$_.internal
   AndroidUtils.fromReference(
@@ -6583,8 +6677,11 @@ class AndroidUtils extends jni$_.JObject {
       jni$_.JClass.forName(r'com/example/in_app_java/AndroidUtils');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $AndroidUtils$NullableType();
-  static const type = $AndroidUtils$Type();
+  static const jni$_.JType<AndroidUtils?> nullableType =
+      $AndroidUtils$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<AndroidUtils> type = $AndroidUtils$Type$();
   static final _id_showToast = _class.staticMethodId(
     r'showToast',
     r'(Landroid/app/Activity;Ljava/lang/CharSequence;I)V',
@@ -6623,9 +6720,9 @@ class AndroidUtils extends jni$_.JObject {
   }
 }
 
-final class $AndroidUtils$NullableType extends jni$_.JObjType<AndroidUtils?> {
+final class $AndroidUtils$NullableType$ extends jni$_.JType<AndroidUtils?> {
   @jni$_.internal
-  const $AndroidUtils$NullableType();
+  const $AndroidUtils$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -6640,29 +6737,29 @@ final class $AndroidUtils$NullableType extends jni$_.JObjType<AndroidUtils?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<AndroidUtils?> get nullableType => this;
+  jni$_.JType<AndroidUtils?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($AndroidUtils$NullableType).hashCode;
+  int get hashCode => ($AndroidUtils$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($AndroidUtils$NullableType) &&
-        other is $AndroidUtils$NullableType;
+    return other.runtimeType == ($AndroidUtils$NullableType$) &&
+        other is $AndroidUtils$NullableType$;
   }
 }
 
-final class $AndroidUtils$Type extends jni$_.JObjType<AndroidUtils> {
+final class $AndroidUtils$Type$ extends jni$_.JType<AndroidUtils> {
   @jni$_.internal
-  const $AndroidUtils$Type();
+  const $AndroidUtils$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -6676,23 +6773,23 @@ final class $AndroidUtils$Type extends jni$_.JObjType<AndroidUtils> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<AndroidUtils?> get nullableType =>
-      const $AndroidUtils$NullableType();
+  jni$_.JType<AndroidUtils?> get nullableType =>
+      const $AndroidUtils$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($AndroidUtils$Type).hashCode;
+  int get hashCode => ($AndroidUtils$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($AndroidUtils$Type) &&
-        other is $AndroidUtils$Type;
+    return other.runtimeType == ($AndroidUtils$Type$) &&
+        other is $AndroidUtils$Type$;
   }
 }

--- a/pkgs/jnigen/example/in_app_java/lib/main.dart
+++ b/pkgs/jnigen/example/in_app_java/lib/main.dart
@@ -27,8 +27,10 @@ const sunglassEmoji = "😎";
 /// Display device model number and the number of times this was called
 /// as Toast.
 void showToast() {
-  final toastCount =
-      hashmap.getOrDefault("toastCount".toJString(), 0.toJString());
+  final toastCount = hashmap.getOrDefault(
+    "toastCount".toJString(),
+    0.toJString(),
+  );
   final newToastCount = (int.parse(toastCount!.toDartString()) + 1).toJString();
   hashmap.put("toastCount".toJString(), newToastCount);
   final emoji = emojiCompat.hasEmojiGlyph(sunglassEmoji.toJString())
@@ -51,9 +53,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
-      theme: ThemeData(
-        primarySwatch: Colors.teal,
-      ),
+      theme: ThemeData(primarySwatch: Colors.teal),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
   }
@@ -67,9 +67,7 @@ class MyHomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text(title),
-      ),
+      appBar: AppBar(title: Text(title)),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/pkgs/jnigen/example/kotlin_plugin/lib/kotlin_bindings.dart
+++ b/pkgs/jnigen/example/kotlin_plugin/lib/kotlin_bindings.dart
@@ -40,7 +40,7 @@ import 'package:jni/jni.dart' as jni$_;
 class Example extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Example> $type;
+  final jni$_.JType<Example> $type;
 
   @jni$_.internal
   Example.fromReference(
@@ -51,8 +51,10 @@ class Example extends jni$_.JObject {
   static final _class = jni$_.JClass.forName(r'Example');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Example$NullableType();
-  static const type = $Example$Type();
+  static const jni$_.JType<Example?> nullableType = $Example$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Example> type = $Example$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -103,7 +105,7 @@ class Example extends jni$_.JObject {
             reference.pointer,
             _id_thinkBeforeAnswering as jni$_.JMethodIDPtr,
             _$continuation.pointer)
-        .object<jni$_.JObject>(const jni$_.JObjectType());
+        .object<jni$_.JObject>(const jni$_.$JObject$Type$());
     _$continuation.release();
     final jni$_.JObject $o;
     if ($r.isInstanceOf(jni$_.coroutineSingletonsClass)) {
@@ -113,7 +115,7 @@ class Example extends jni$_.JObject {
           jni$_.JGlobalReference(jni$_.JObjectPtr.fromAddress($a)));
       if ($o.isInstanceOf(jni$_.result$FailureClass)) {
         final $e =
-            jni$_.failureExceptionField.get($o, const jni$_.JObjectType());
+            jni$_.failureExceptionField.get($o, const jni$_.$JObject$Type$());
         $o.release();
         jni$_.Jni.throwException($e.reference.toPointer());
       }
@@ -121,15 +123,15 @@ class Example extends jni$_.JObject {
       $o = $r;
     }
     return $o.as<jni$_.JString>(
-      const jni$_.JStringType(),
+      const jni$_.$JString$Type$(),
       releaseOriginal: true,
     );
   }
 }
 
-final class $Example$NullableType extends jni$_.JObjType<Example?> {
+final class $Example$NullableType$ extends jni$_.JType<Example?> {
   @jni$_.internal
-  const $Example$NullableType();
+  const $Example$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -144,29 +146,29 @@ final class $Example$NullableType extends jni$_.JObjType<Example?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example?> get nullableType => this;
+  jni$_.JType<Example?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example$NullableType).hashCode;
+  int get hashCode => ($Example$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example$NullableType) &&
-        other is $Example$NullableType;
+    return other.runtimeType == ($Example$NullableType$) &&
+        other is $Example$NullableType$;
   }
 }
 
-final class $Example$Type extends jni$_.JObjType<Example> {
+final class $Example$Type$ extends jni$_.JType<Example> {
   @jni$_.internal
-  const $Example$Type();
+  const $Example$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -179,21 +181,21 @@ final class $Example$Type extends jni$_.JObjType<Example> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example?> get nullableType => const $Example$NullableType();
+  jni$_.JType<Example?> get nullableType => const $Example$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example$Type).hashCode;
+  int get hashCode => ($Example$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example$Type) && other is $Example$Type;
+    return other.runtimeType == ($Example$Type$) && other is $Example$Type$;
   }
 }

--- a/pkgs/jnigen/example/notification_plugin/lib/notifications.dart
+++ b/pkgs/jnigen/example/notification_plugin/lib/notifications.dart
@@ -44,7 +44,7 @@ import 'package:jni/jni.dart' as jni$_;
 class Notifications extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Notifications> $type;
+  final jni$_.JType<Notifications> $type;
 
   @jni$_.internal
   Notifications.fromReference(
@@ -56,8 +56,11 @@ class Notifications extends jni$_.JObject {
       jni$_.JClass.forName(r'com/example/notification_plugin/Notifications');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Notifications$NullableType();
-  static const type = $Notifications$Type();
+  static const jni$_.JType<Notifications?> nullableType =
+      $Notifications$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Notifications> type = $Notifications$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -129,9 +132,9 @@ class Notifications extends jni$_.JObject {
   }
 }
 
-final class $Notifications$NullableType extends jni$_.JObjType<Notifications?> {
+final class $Notifications$NullableType$ extends jni$_.JType<Notifications?> {
   @jni$_.internal
-  const $Notifications$NullableType();
+  const $Notifications$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -146,29 +149,29 @@ final class $Notifications$NullableType extends jni$_.JObjType<Notifications?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Notifications?> get nullableType => this;
+  jni$_.JType<Notifications?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Notifications$NullableType).hashCode;
+  int get hashCode => ($Notifications$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Notifications$NullableType) &&
-        other is $Notifications$NullableType;
+    return other.runtimeType == ($Notifications$NullableType$) &&
+        other is $Notifications$NullableType$;
   }
 }
 
-final class $Notifications$Type extends jni$_.JObjType<Notifications> {
+final class $Notifications$Type$ extends jni$_.JType<Notifications> {
   @jni$_.internal
-  const $Notifications$Type();
+  const $Notifications$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -182,23 +185,23 @@ final class $Notifications$Type extends jni$_.JObjType<Notifications> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Notifications?> get nullableType =>
-      const $Notifications$NullableType();
+  jni$_.JType<Notifications?> get nullableType =>
+      const $Notifications$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Notifications$Type).hashCode;
+  int get hashCode => ($Notifications$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Notifications$Type) &&
-        other is $Notifications$Type;
+    return other.runtimeType == ($Notifications$Type$) &&
+        other is $Notifications$Type$;
   }
 }

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
@@ -64,7 +64,7 @@ import 'PDDocumentInformation.dart' as pddocumentinformation$_;
 class PDDocument extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<PDDocument> $type;
+  final jni$_.JType<PDDocument> $type;
 
   @jni$_.internal
   PDDocument.fromReference(
@@ -76,8 +76,11 @@ class PDDocument extends jni$_.JObject {
       jni$_.JClass.forName(r'org/apache/pdfbox/pdmodel/PDDocument');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $PDDocument$NullableType();
-  static const type = $PDDocument$Type();
+  static const jni$_.JType<PDDocument?> nullableType =
+      $PDDocument$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<PDDocument> type = $PDDocument$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -620,7 +623,7 @@ class PDDocument extends jni$_.JObject {
     final _$page = page?.reference ?? jni$_.jNullReference;
     return _importPage(reference.pointer, _id_importPage as jni$_.JMethodIDPtr,
             _$page.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getDocument = _class.instanceMethodId(
@@ -648,7 +651,7 @@ class PDDocument extends jni$_.JObject {
   jni$_.JObject? getDocument() {
     return _getDocument(
             reference.pointer, _id_getDocument as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getDocumentInformation = _class.instanceMethodId(
@@ -683,7 +686,7 @@ class PDDocument extends jni$_.JObject {
             reference.pointer, _id_getDocumentInformation as jni$_.JMethodIDPtr)
         .object<pddocumentinformation$_.PDDocumentInformation?>(
             const pddocumentinformation$_
-                .$PDDocumentInformation$NullableType());
+                .$PDDocumentInformation$NullableType$());
   }
 
   static final _id_setDocumentInformation = _class.instanceMethodId(
@@ -744,7 +747,7 @@ class PDDocument extends jni$_.JObject {
   jni$_.JObject? getDocumentCatalog() {
     return _getDocumentCatalog(
             reference.pointer, _id_getDocumentCatalog as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_isEncrypted = _class.instanceMethodId(
@@ -802,7 +805,7 @@ class PDDocument extends jni$_.JObject {
   jni$_.JObject? getEncryption() {
     return _getEncryption(
             reference.pointer, _id_getEncryption as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_setEncryptionDictionary = _class.instanceMethodId(
@@ -865,7 +868,7 @@ class PDDocument extends jni$_.JObject {
   jni$_.JObject? getLastSignatureDictionary() {
     return _getLastSignatureDictionary(reference.pointer,
             _id_getLastSignatureDictionary as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getSignatureFields = _class.instanceMethodId(
@@ -895,8 +898,8 @@ class PDDocument extends jni$_.JObject {
     return _getSignatureFields(
             reference.pointer, _id_getSignatureFields as jni$_.JMethodIDPtr)
         .object<jni$_.JList<jni$_.JObject?>?>(
-            const jni$_.JListNullableType<jni$_.JObject?>(
-                jni$_.JObjectNullableType()));
+            const jni$_.$JList$NullableType$<jni$_.JObject?>(
+                jni$_.$JObject$NullableType$()));
   }
 
   static final _id_getSignatureDictionaries = _class.instanceMethodId(
@@ -926,8 +929,8 @@ class PDDocument extends jni$_.JObject {
     return _getSignatureDictionaries(reference.pointer,
             _id_getSignatureDictionaries as jni$_.JMethodIDPtr)
         .object<jni$_.JList<jni$_.JObject?>?>(
-            const jni$_.JListNullableType<jni$_.JObject?>(
-                jni$_.JObjectNullableType()));
+            const jni$_.$JList$NullableType$<jni$_.JObject?>(
+                jni$_.$JObject$NullableType$()));
   }
 
   static final _id_registerTrueTypeFontForClosing = _class.instanceMethodId(
@@ -994,7 +997,7 @@ class PDDocument extends jni$_.JObject {
     final _$file = file?.reference ?? jni$_.jNullReference;
     return _load(_class.reference.pointer, _id_load as jni$_.JMethodIDPtr,
             _$file.pointer)
-        .object<PDDocument?>(const $PDDocument$NullableType());
+        .object<PDDocument?>(const $PDDocument$NullableType$());
   }
 
   static final _id_load$1 = _class.staticMethodId(
@@ -1037,7 +1040,7 @@ class PDDocument extends jni$_.JObject {
         memUsageSetting?.reference ?? jni$_.jNullReference;
     return _load$1(_class.reference.pointer, _id_load$1 as jni$_.JMethodIDPtr,
             _$file.pointer, _$memUsageSetting.pointer)
-        .object<PDDocument?>(const $PDDocument$NullableType());
+        .object<PDDocument?>(const $PDDocument$NullableType$());
   }
 
   static final _id_load$2 = _class.staticMethodId(
@@ -1079,7 +1082,7 @@ class PDDocument extends jni$_.JObject {
     final _$password = password?.reference ?? jni$_.jNullReference;
     return _load$2(_class.reference.pointer, _id_load$2 as jni$_.JMethodIDPtr,
             _$file.pointer, _$password.pointer)
-        .object<PDDocument?>(const $PDDocument$NullableType());
+        .object<PDDocument?>(const $PDDocument$NullableType$());
   }
 
   static final _id_load$3 = _class.staticMethodId(
@@ -1127,7 +1130,7 @@ class PDDocument extends jni$_.JObject {
         memUsageSetting?.reference ?? jni$_.jNullReference;
     return _load$3(_class.reference.pointer, _id_load$3 as jni$_.JMethodIDPtr,
             _$file.pointer, _$password.pointer, _$memUsageSetting.pointer)
-        .object<PDDocument?>(const $PDDocument$NullableType());
+        .object<PDDocument?>(const $PDDocument$NullableType$());
   }
 
   static final _id_load$4 = _class.staticMethodId(
@@ -1183,7 +1186,7 @@ class PDDocument extends jni$_.JObject {
             _$password.pointer,
             _$keyStore.pointer,
             _$alias.pointer)
-        .object<PDDocument?>(const $PDDocument$NullableType());
+        .object<PDDocument?>(const $PDDocument$NullableType$());
   }
 
   static final _id_load$5 = _class.staticMethodId(
@@ -1246,7 +1249,7 @@ class PDDocument extends jni$_.JObject {
             _$keyStore.pointer,
             _$alias.pointer,
             _$memUsageSetting.pointer)
-        .object<PDDocument?>(const $PDDocument$NullableType());
+        .object<PDDocument?>(const $PDDocument$NullableType$());
   }
 
   static final _id_load$6 = _class.staticMethodId(
@@ -1280,7 +1283,7 @@ class PDDocument extends jni$_.JObject {
     final _$input = input?.reference ?? jni$_.jNullReference;
     return _load$6(_class.reference.pointer, _id_load$6 as jni$_.JMethodIDPtr,
             _$input.pointer)
-        .object<PDDocument?>(const $PDDocument$NullableType());
+        .object<PDDocument?>(const $PDDocument$NullableType$());
   }
 
   static final _id_load$7 = _class.staticMethodId(
@@ -1324,7 +1327,7 @@ class PDDocument extends jni$_.JObject {
         memUsageSetting?.reference ?? jni$_.jNullReference;
     return _load$7(_class.reference.pointer, _id_load$7 as jni$_.JMethodIDPtr,
             _$input.pointer, _$memUsageSetting.pointer)
-        .object<PDDocument?>(const $PDDocument$NullableType());
+        .object<PDDocument?>(const $PDDocument$NullableType$());
   }
 
   static final _id_load$8 = _class.staticMethodId(
@@ -1367,7 +1370,7 @@ class PDDocument extends jni$_.JObject {
     final _$password = password?.reference ?? jni$_.jNullReference;
     return _load$8(_class.reference.pointer, _id_load$8 as jni$_.JMethodIDPtr,
             _$input.pointer, _$password.pointer)
-        .object<PDDocument?>(const $PDDocument$NullableType());
+        .object<PDDocument?>(const $PDDocument$NullableType$());
   }
 
   static final _id_load$9 = _class.staticMethodId(
@@ -1424,7 +1427,7 @@ class PDDocument extends jni$_.JObject {
             _$password.pointer,
             _$keyStore.pointer,
             _$alias.pointer)
-        .object<PDDocument?>(const $PDDocument$NullableType());
+        .object<PDDocument?>(const $PDDocument$NullableType$());
   }
 
   static final _id_load$10 = _class.staticMethodId(
@@ -1473,7 +1476,7 @@ class PDDocument extends jni$_.JObject {
         memUsageSetting?.reference ?? jni$_.jNullReference;
     return _load$10(_class.reference.pointer, _id_load$10 as jni$_.JMethodIDPtr,
             _$input.pointer, _$password.pointer, _$memUsageSetting.pointer)
-        .object<PDDocument?>(const $PDDocument$NullableType());
+        .object<PDDocument?>(const $PDDocument$NullableType$());
   }
 
   static final _id_load$11 = _class.staticMethodId(
@@ -1538,7 +1541,7 @@ class PDDocument extends jni$_.JObject {
             _$keyStore.pointer,
             _$alias.pointer,
             _$memUsageSetting.pointer)
-        .object<PDDocument?>(const $PDDocument$NullableType());
+        .object<PDDocument?>(const $PDDocument$NullableType$());
   }
 
   static final _id_load$12 = _class.staticMethodId(
@@ -1571,7 +1574,7 @@ class PDDocument extends jni$_.JObject {
     final _$input = input?.reference ?? jni$_.jNullReference;
     return _load$12(_class.reference.pointer, _id_load$12 as jni$_.JMethodIDPtr,
             _$input.pointer)
-        .object<PDDocument?>(const $PDDocument$NullableType());
+        .object<PDDocument?>(const $PDDocument$NullableType$());
   }
 
   static final _id_load$13 = _class.staticMethodId(
@@ -1613,7 +1616,7 @@ class PDDocument extends jni$_.JObject {
     final _$password = password?.reference ?? jni$_.jNullReference;
     return _load$13(_class.reference.pointer, _id_load$13 as jni$_.JMethodIDPtr,
             _$input.pointer, _$password.pointer)
-        .object<PDDocument?>(const $PDDocument$NullableType());
+        .object<PDDocument?>(const $PDDocument$NullableType$());
   }
 
   static final _id_load$14 = _class.staticMethodId(
@@ -1670,7 +1673,7 @@ class PDDocument extends jni$_.JObject {
             _$password.pointer,
             _$keyStore.pointer,
             _$alias.pointer)
-        .object<PDDocument?>(const $PDDocument$NullableType());
+        .object<PDDocument?>(const $PDDocument$NullableType$());
   }
 
   static final _id_load$15 = _class.staticMethodId(
@@ -1734,7 +1737,7 @@ class PDDocument extends jni$_.JObject {
             _$keyStore.pointer,
             _$alias.pointer,
             _$memUsageSetting.pointer)
-        .object<PDDocument?>(const $PDDocument$NullableType());
+        .object<PDDocument?>(const $PDDocument$NullableType$());
   }
 
   static final _id_save = _class.instanceMethodId(
@@ -1999,7 +2002,7 @@ class PDDocument extends jni$_.JObject {
             reference.pointer,
             _id_saveIncrementalForExternalSigning as jni$_.JMethodIDPtr,
             _$output.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getPage = _class.instanceMethodId(
@@ -2032,7 +2035,7 @@ class PDDocument extends jni$_.JObject {
   ) {
     return _getPage(
             reference.pointer, _id_getPage as jni$_.JMethodIDPtr, pageIndex)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getPages = _class.instanceMethodId(
@@ -2059,7 +2062,7 @@ class PDDocument extends jni$_.JObject {
   ///@return the page tree
   jni$_.JObject? getPages() {
     return _getPages(reference.pointer, _id_getPages as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getNumberOfPages = _class.instanceMethodId(
@@ -2180,7 +2183,7 @@ class PDDocument extends jni$_.JObject {
   jni$_.JObject? getCurrentAccessPermission() {
     return _getCurrentAccessPermission(reference.pointer,
             _id_getCurrentAccessPermission as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_isAllSecurityToBeRemoved = _class.instanceMethodId(
@@ -2264,7 +2267,7 @@ class PDDocument extends jni$_.JObject {
   jni$_.JLong? getDocumentId() {
     return _getDocumentId(
             reference.pointer, _id_getDocumentId as jni$_.JMethodIDPtr)
-        .object<jni$_.JLong?>(const jni$_.JLongNullableType());
+        .object<jni$_.JLong?>(const jni$_.$JLong$NullableType$());
   }
 
   static final _id_setDocumentId = _class.instanceMethodId(
@@ -2374,7 +2377,7 @@ class PDDocument extends jni$_.JObject {
   jni$_.JObject? getResourceCache() {
     return _getResourceCache(
             reference.pointer, _id_getResourceCache as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_setResourceCache = _class.instanceMethodId(
@@ -2407,9 +2410,9 @@ class PDDocument extends jni$_.JObject {
   }
 }
 
-final class $PDDocument$NullableType extends jni$_.JObjType<PDDocument?> {
+final class $PDDocument$NullableType$ extends jni$_.JType<PDDocument?> {
   @jni$_.internal
-  const $PDDocument$NullableType();
+  const $PDDocument$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -2424,29 +2427,29 @@ final class $PDDocument$NullableType extends jni$_.JObjType<PDDocument?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<PDDocument?> get nullableType => this;
+  jni$_.JType<PDDocument?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($PDDocument$NullableType).hashCode;
+  int get hashCode => ($PDDocument$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($PDDocument$NullableType) &&
-        other is $PDDocument$NullableType;
+    return other.runtimeType == ($PDDocument$NullableType$) &&
+        other is $PDDocument$NullableType$;
   }
 }
 
-final class $PDDocument$Type extends jni$_.JObjType<PDDocument> {
+final class $PDDocument$Type$ extends jni$_.JType<PDDocument> {
   @jni$_.internal
-  const $PDDocument$Type();
+  const $PDDocument$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -2460,22 +2463,23 @@ final class $PDDocument$Type extends jni$_.JObjType<PDDocument> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<PDDocument?> get nullableType =>
-      const $PDDocument$NullableType();
+  jni$_.JType<PDDocument?> get nullableType =>
+      const $PDDocument$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($PDDocument$Type).hashCode;
+  int get hashCode => ($PDDocument$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($PDDocument$Type) && other is $PDDocument$Type;
+    return other.runtimeType == ($PDDocument$Type$) &&
+        other is $PDDocument$Type$;
   }
 }

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocumentInformation.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocumentInformation.dart
@@ -64,7 +64,7 @@ import 'package:jni/jni.dart' as jni$_;
 class PDDocumentInformation extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<PDDocumentInformation> $type;
+  final jni$_.JType<PDDocumentInformation> $type;
 
   @jni$_.internal
   PDDocumentInformation.fromReference(
@@ -76,8 +76,12 @@ class PDDocumentInformation extends jni$_.JObject {
       jni$_.JClass.forName(r'org/apache/pdfbox/pdmodel/PDDocumentInformation');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $PDDocumentInformation$NullableType();
-  static const type = $PDDocumentInformation$Type();
+  static const jni$_.JType<PDDocumentInformation?> nullableType =
+      $PDDocumentInformation$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<PDDocumentInformation> type =
+      $PDDocumentInformation$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -158,7 +162,7 @@ class PDDocumentInformation extends jni$_.JObject {
   jni$_.JObject? getCOSObject() {
     return _getCOSObject(
             reference.pointer, _id_getCOSObject as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getPropertyStringValue = _class.instanceMethodId(
@@ -196,7 +200,7 @@ class PDDocumentInformation extends jni$_.JObject {
             reference.pointer,
             _id_getPropertyStringValue as jni$_.JMethodIDPtr,
             _$propertyKey.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getTitle = _class.instanceMethodId(
@@ -223,7 +227,7 @@ class PDDocumentInformation extends jni$_.JObject {
   ///@return The title of the document.
   jni$_.JString? getTitle() {
     return _getTitle(reference.pointer, _id_getTitle as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_setTitle = _class.instanceMethodId(
@@ -279,7 +283,7 @@ class PDDocumentInformation extends jni$_.JObject {
   ///@return The author of the document.
   jni$_.JString? getAuthor() {
     return _getAuthor(reference.pointer, _id_getAuthor as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_setAuthor = _class.instanceMethodId(
@@ -335,7 +339,7 @@ class PDDocumentInformation extends jni$_.JObject {
   ///@return The subject of the document.
   jni$_.JString? getSubject() {
     return _getSubject(reference.pointer, _id_getSubject as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_setSubject = _class.instanceMethodId(
@@ -392,7 +396,7 @@ class PDDocumentInformation extends jni$_.JObject {
   jni$_.JString? getKeywords() {
     return _getKeywords(
             reference.pointer, _id_getKeywords as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_setKeywords = _class.instanceMethodId(
@@ -448,7 +452,7 @@ class PDDocumentInformation extends jni$_.JObject {
   ///@return The creator of the document.
   jni$_.JString? getCreator() {
     return _getCreator(reference.pointer, _id_getCreator as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_setCreator = _class.instanceMethodId(
@@ -505,7 +509,7 @@ class PDDocumentInformation extends jni$_.JObject {
   jni$_.JString? getProducer() {
     return _getProducer(
             reference.pointer, _id_getProducer as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_setProducer = _class.instanceMethodId(
@@ -562,7 +566,7 @@ class PDDocumentInformation extends jni$_.JObject {
   jni$_.JObject? getCreationDate() {
     return _getCreationDate(
             reference.pointer, _id_getCreationDate as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_setCreationDate = _class.instanceMethodId(
@@ -619,7 +623,7 @@ class PDDocumentInformation extends jni$_.JObject {
   jni$_.JObject? getModificationDate() {
     return _getModificationDate(
             reference.pointer, _id_getModificationDate as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_setModificationDate = _class.instanceMethodId(
@@ -676,7 +680,7 @@ class PDDocumentInformation extends jni$_.JObject {
   ///@return The trapped value for the document.
   jni$_.JString? getTrapped() {
     return _getTrapped(reference.pointer, _id_getTrapped as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_getMetadataKeys = _class.instanceMethodId(
@@ -706,8 +710,8 @@ class PDDocumentInformation extends jni$_.JObject {
     return _getMetadataKeys(
             reference.pointer, _id_getMetadataKeys as jni$_.JMethodIDPtr)
         .object<jni$_.JSet<jni$_.JString?>?>(
-            const jni$_.JSetNullableType<jni$_.JString?>(
-                jni$_.JStringNullableType()));
+            const jni$_.$JSet$NullableType$<jni$_.JString?>(
+                jni$_.$JString$NullableType$()));
   }
 
   static final _id_getCustomMetadataValue = _class.instanceMethodId(
@@ -741,7 +745,7 @@ class PDDocumentInformation extends jni$_.JObject {
             reference.pointer,
             _id_getCustomMetadataValue as jni$_.JMethodIDPtr,
             _$fieldName.pointer)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_setCustomMetadataValue = _class.instanceMethodId(
@@ -817,10 +821,10 @@ class PDDocumentInformation extends jni$_.JObject {
   }
 }
 
-final class $PDDocumentInformation$NullableType
-    extends jni$_.JObjType<PDDocumentInformation?> {
+final class $PDDocumentInformation$NullableType$
+    extends jni$_.JType<PDDocumentInformation?> {
   @jni$_.internal
-  const $PDDocumentInformation$NullableType();
+  const $PDDocumentInformation$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -836,30 +840,30 @@ final class $PDDocumentInformation$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<PDDocumentInformation?> get nullableType => this;
+  jni$_.JType<PDDocumentInformation?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($PDDocumentInformation$NullableType).hashCode;
+  int get hashCode => ($PDDocumentInformation$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($PDDocumentInformation$NullableType) &&
-        other is $PDDocumentInformation$NullableType;
+    return other.runtimeType == ($PDDocumentInformation$NullableType$) &&
+        other is $PDDocumentInformation$NullableType$;
   }
 }
 
-final class $PDDocumentInformation$Type
-    extends jni$_.JObjType<PDDocumentInformation> {
+final class $PDDocumentInformation$Type$
+    extends jni$_.JType<PDDocumentInformation> {
   @jni$_.internal
-  const $PDDocumentInformation$Type();
+  const $PDDocumentInformation$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -873,23 +877,23 @@ final class $PDDocumentInformation$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<PDDocumentInformation?> get nullableType =>
-      const $PDDocumentInformation$NullableType();
+  jni$_.JType<PDDocumentInformation?> get nullableType =>
+      const $PDDocumentInformation$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($PDDocumentInformation$Type).hashCode;
+  int get hashCode => ($PDDocumentInformation$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($PDDocumentInformation$Type) &&
-        other is $PDDocumentInformation$Type;
+    return other.runtimeType == ($PDDocumentInformation$Type$) &&
+        other is $PDDocumentInformation$Type$;
   }
 }

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/text/PDFTextStripper.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/text/PDFTextStripper.dart
@@ -68,7 +68,7 @@ import '../pdmodel/PDDocument.dart' as pddocument$_;
 class PDFTextStripper extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<PDFTextStripper> $type;
+  final jni$_.JType<PDFTextStripper> $type;
 
   @jni$_.internal
   PDFTextStripper.fromReference(
@@ -80,8 +80,11 @@ class PDFTextStripper extends jni$_.JObject {
       jni$_.JClass.forName(r'org/apache/pdfbox/text/PDFTextStripper');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $PDFTextStripper$NullableType();
-  static const type = $PDFTextStripper$Type();
+  static const jni$_.JType<PDFTextStripper?> nullableType =
+      $PDFTextStripper$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<PDFTextStripper> type = $PDFTextStripper$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -144,7 +147,7 @@ class PDFTextStripper extends jni$_.JObject {
     final _$doc = doc?.reference ?? jni$_.jNullReference;
     return _getText(
             reference.pointer, _id_getText as jni$_.JMethodIDPtr, _$doc.pointer)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_writeText = _class.instanceMethodId(
@@ -382,7 +385,7 @@ class PDFTextStripper extends jni$_.JObject {
   jni$_.JString? getLineSeparator() {
     return _getLineSeparator(
             reference.pointer, _id_getLineSeparator as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_getWordSeparator = _class.instanceMethodId(
@@ -410,7 +413,7 @@ class PDFTextStripper extends jni$_.JObject {
   jni$_.JString? getWordSeparator() {
     return _getWordSeparator(
             reference.pointer, _id_getWordSeparator as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_setWordSeparator = _class.instanceMethodId(
@@ -586,7 +589,7 @@ class PDFTextStripper extends jni$_.JObject {
   jni$_.JObject? getEndBookmark() {
     return _getEndBookmark(
             reference.pointer, _id_getEndBookmark as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_setEndBookmark = _class.instanceMethodId(
@@ -643,7 +646,7 @@ class PDFTextStripper extends jni$_.JObject {
   jni$_.JObject? getStartBookmark() {
     return _getStartBookmark(
             reference.pointer, _id_getStartBookmark as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_setStartBookmark = _class.instanceMethodId(
@@ -1052,7 +1055,7 @@ class PDFTextStripper extends jni$_.JObject {
   jni$_.JString? getParagraphStart() {
     return _getParagraphStart(
             reference.pointer, _id_getParagraphStart as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_setParagraphStart = _class.instanceMethodId(
@@ -1109,7 +1112,7 @@ class PDFTextStripper extends jni$_.JObject {
   jni$_.JString? getParagraphEnd() {
     return _getParagraphEnd(
             reference.pointer, _id_getParagraphEnd as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_setParagraphEnd = _class.instanceMethodId(
@@ -1166,7 +1169,7 @@ class PDFTextStripper extends jni$_.JObject {
   jni$_.JString? getPageStart() {
     return _getPageStart(
             reference.pointer, _id_getPageStart as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_setPageStart = _class.instanceMethodId(
@@ -1222,7 +1225,7 @@ class PDFTextStripper extends jni$_.JObject {
   ///@return the page end string
   jni$_.JString? getPageEnd() {
     return _getPageEnd(reference.pointer, _id_getPageEnd as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_setPageEnd = _class.instanceMethodId(
@@ -1279,7 +1282,7 @@ class PDFTextStripper extends jni$_.JObject {
   jni$_.JString? getArticleStart() {
     return _getArticleStart(
             reference.pointer, _id_getArticleStart as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_setArticleStart = _class.instanceMethodId(
@@ -1339,7 +1342,7 @@ class PDFTextStripper extends jni$_.JObject {
   jni$_.JString? getArticleEnd() {
     return _getArticleEnd(
             reference.pointer, _id_getArticleEnd as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_setArticleEnd = _class.instanceMethodId(
@@ -1373,10 +1376,10 @@ class PDFTextStripper extends jni$_.JObject {
   }
 }
 
-final class $PDFTextStripper$NullableType
-    extends jni$_.JObjType<PDFTextStripper?> {
+final class $PDFTextStripper$NullableType$
+    extends jni$_.JType<PDFTextStripper?> {
   @jni$_.internal
-  const $PDFTextStripper$NullableType();
+  const $PDFTextStripper$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -1391,29 +1394,29 @@ final class $PDFTextStripper$NullableType
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<PDFTextStripper?> get nullableType => this;
+  jni$_.JType<PDFTextStripper?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($PDFTextStripper$NullableType).hashCode;
+  int get hashCode => ($PDFTextStripper$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($PDFTextStripper$NullableType) &&
-        other is $PDFTextStripper$NullableType;
+    return other.runtimeType == ($PDFTextStripper$NullableType$) &&
+        other is $PDFTextStripper$NullableType$;
   }
 }
 
-final class $PDFTextStripper$Type extends jni$_.JObjType<PDFTextStripper> {
+final class $PDFTextStripper$Type$ extends jni$_.JType<PDFTextStripper> {
   @jni$_.internal
-  const $PDFTextStripper$Type();
+  const $PDFTextStripper$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -1427,23 +1430,23 @@ final class $PDFTextStripper$Type extends jni$_.JObjType<PDFTextStripper> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<PDFTextStripper?> get nullableType =>
-      const $PDFTextStripper$NullableType();
+  jni$_.JType<PDFTextStripper?> get nullableType =>
+      const $PDFTextStripper$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($PDFTextStripper$Type).hashCode;
+  int get hashCode => ($PDFTextStripper$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($PDFTextStripper$Type) &&
-        other is $PDFTextStripper$Type;
+    return other.runtimeType == ($PDFTextStripper$Type$) &&
+        other is $PDFTextStripper$Type$;
   }
 }

--- a/pkgs/jnigen/lib/src/bindings/dart_generator.dart
+++ b/pkgs/jnigen/lib/src/bindings/dart_generator.dart
@@ -27,12 +27,14 @@ const _core = r'core$_';
 const _override = '@$_core.override';
 
 // package:jni types.
-const _jType = '$_jni.JObjType';
+const _jType = '$_jni.JType';
 const _jPointer = '$_jni.JObjectPtr';
 const _jReference = '$_jni.JReference';
 const _jGlobalReference = '$_jni.JGlobalReference';
 const _jArray = '$_jni.JArray';
+const _jArrayTypePrefix = '$_jni.\$JArray\$';
 const _jObject = '$_jni.JObject';
+const _jObjectTypePrefix = '$_jni.\$JObject\$';
 const _jResult = '$_jni.JniResult';
 const _jThrowable = '$_jni.JThrowablePtr';
 const _methodInvocation = '$_jni.MethodInvocation';
@@ -419,19 +421,19 @@ class $name$typeParamsDef extends $superName {
     final classRef = writeClassRef(node);
 
     // Static TypeClass getter.
-    s.writeln(
-      '  /// The type which includes information such as the signature of this class.',
-    );
     void generateTypeClassGetter({required bool isNullable}) {
+      s.writeln(
+        '  /// The type which includes information such as the signature of this class.',
+      );
       final typeClassName =
           isNullable ? node.nullableTypeClassName : node.typeClassName;
       final typeClassGetterName =
           isNullable ? 'nullableType' : staticTypeGetter;
+      final questionMark = isNullable ? '?' : '';
       if (typeParams.isEmpty) {
-        s.writeln(
-          'static const $typeClassGetterName = '
-          '$typeClassName$typeParamsCall();',
-        );
+        s.write('''
+  static const $_jType<$name$typeParamsCall$questionMark> $typeClassGetterName = $typeClassName$typeParamsCall();
+''');
       } else {
         final staticTypeGetterTypeClassesDef = typeParams
             .map(
@@ -442,7 +444,7 @@ class $name$typeParamsDef extends $superName {
             .map((typeParam) => '$typeParam,')
             .join(_newLine(depth: 3));
         s.write('''
-  static $typeClassName$typeParamsCall $typeClassGetterName$typeParamsDef(
+  static $_jType<$name$typeParamsCall$questionMark> $typeClassGetterName$typeParamsDef(
     $staticTypeGetterTypeClassesDef
   ) {
     return $typeClassName$typeParamsCall(
@@ -972,12 +974,12 @@ class _TypeClassGenerator extends TypeVisitor<_TypeClass> {
         : 'Type';
     if (node.elementType is PrimitiveType) {
       return _TypeClass(
-        '$ifConst$_jni.J${innerType}Array$type()',
+        '$ifConst$_jni.\$J${innerType}Array\$$type\$()',
         innerTypeClass.canBeConst,
       );
     }
     return _TypeClass(
-      '$ifConst$_jArray$type<$innerType>(${innerTypeClass.name})',
+      '$ifConst$_jArrayTypePrefix$type\$<$innerType>(${innerTypeClass.name})',
       innerTypeClass.canBeConst,
     );
   }
@@ -1039,8 +1041,10 @@ class _TypeClassGenerator extends TypeVisitor<_TypeClass> {
   @override
   _TypeClass visitPrimitiveType(PrimitiveType node) {
     final ifConst = isConst ? 'const ' : '';
-    final name = boxPrimitives ? 'J${node.boxedName}' : 'j${node.name}';
-    return _TypeClass('$ifConst$_jni.${name}Type()', true);
+    final name = boxPrimitives
+        ? '$_jni.\$J${node.boxedName}\$Type\$'
+        : '$_jni.j${node.name}Type';
+    return _TypeClass('$ifConst$name()', true);
   }
 
   @override
@@ -1056,7 +1060,7 @@ class _TypeClassGenerator extends TypeVisitor<_TypeClass> {
             : '';
     if (typeErasure) {
       final ifConst = isConst ? 'const ' : '';
-      return _TypeClass('$ifConst$_jObject$type()', true);
+      return _TypeClass('$ifConst$_jObjectTypePrefix$type\$()', true);
     }
     if (forInterfaceImplementation) {
       if (node.origin.parent is ClassDecl) {
@@ -1066,7 +1070,7 @@ class _TypeClassGenerator extends TypeVisitor<_TypeClass> {
         );
       }
       final ifConst = isConst ? 'const ' : '';
-      return _TypeClass('$ifConst$_jObject$type()', true);
+      return _TypeClass('$ifConst$_jObjectTypePrefix$type\$()', true);
     }
     return _TypeClass('${node.name}$convertToNullable', false);
   }
@@ -1097,7 +1101,7 @@ class _TypeClassGenerator extends TypeVisitor<_TypeClass> {
     final type = includeNullability && node.isNullable && isTopTypeNullable
         ? 'NullableType'
         : 'Type';
-    return _TypeClass('$ifConst$_jObject$type()', true);
+    return _TypeClass('$ifConst$_jObjectTypePrefix$type\$()', true);
   }
 }
 
@@ -1490,7 +1494,7 @@ ${modifier}final _$name = $_protectedExtension
           $_jGlobalReference($_jPointer.fromAddress(\$a)));
       if (${isNullable ? '\$o != null && ' : ''}\$o.isInstanceOf($_jni.result\$FailureClass)) {
         final \$e =
-            $_jni.failureExceptionField.get(\$o, const ${_jObject}Type());
+            $_jni.failureExceptionField.get(\$o, const ${_jObjectTypePrefix}Type\$());
         \$o.release();
         $_jni.Jni.throwException(\$e.reference.toPointer());
       }
@@ -2047,7 +2051,7 @@ class _InterfaceReturnBox extends TypeVisitor<String> {
     // Casting is done to create a new global reference. The user might
     // use the original reference elsewhere and so the original object
     // should not be `setAsReleased`.
-    return '(\$r as $_jObject?)?.as(const ${_jObject}Type())'
+    return '(\$r as $_jObject?)?.as(const ${_jObjectTypePrefix}Type\$())'
         '.reference.toPointer() ?? $_jni.nullptr';
   }
 

--- a/pkgs/jnigen/lib/src/bindings/renamer.dart
+++ b/pkgs/jnigen/lib/src/bindings/renamer.dart
@@ -200,8 +200,6 @@ class _ClassRenamer implements Visitor<ClassDecl, void> {
     node.finalName = uniquifyName
         ? _renameConflict(topLevelNameCounts, className, _ElementKind.klass)
         : className;
-    node.typeClassName = '\$${node.finalName}\$Type';
-    node.nullableTypeClassName = '\$${node.finalName}\$NullableType';
 
     if (node.userDefinedName == null ||
         node.userDefinedName == node.finalName) {

--- a/pkgs/jnigen/lib/src/config/config_types.dart
+++ b/pkgs/jnigen/lib/src/config/config_types.dart
@@ -400,8 +400,6 @@ class Config {
           )
             ..path = '$importPath/$filePath'
             ..finalName = decl['name'] as String
-            ..typeClassName = decl['type_class'] as String
-            ..nullableTypeClassName = decl['nullable_type_class'] as String
             ..superCount = decl['super_count'] as int
             ..allTypeParams = []
             // TODO(https://github.com/dart-lang/native/issues/746): include

--- a/pkgs/jnigen/lib/src/elements/elements.dart
+++ b/pkgs/jnigen/lib/src/elements/elements.dart
@@ -146,16 +146,11 @@ class ClassDecl with ClassMember, Annotated implements Element<ClassDecl> {
   late String finalName;
 
   /// Name of the type class.
-  ///
-  /// Populated by [Renamer].
   @JsonKey(includeFromJson: false)
-  late String typeClassName;
+  String get typeClassName => '\$$finalName\$Type\$';
 
   /// Name of the nullable type class.
-  ///
-  /// Populated by [Renamer].
-  @JsonKey(includeFromJson: false)
-  late String nullableTypeClassName;
+  String get nullableTypeClassName => '\$$finalName\$NullableType\$';
 
   /// Type parameters including the ones from its outer classes.
   ///

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
@@ -62,7 +62,7 @@ import 'JsonParser.dart' as jsonparser$_;
 class JsonFactory$Feature extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<JsonFactory$Feature> $type;
+  final jni$_.JType<JsonFactory$Feature> $type;
 
   @jni$_.internal
   JsonFactory$Feature.fromReference(
@@ -74,8 +74,12 @@ class JsonFactory$Feature extends jni$_.JObject {
       jni$_.JClass.forName(r'com/fasterxml/jackson/core/JsonFactory$Feature');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $JsonFactory$Feature$NullableType();
-  static const type = $JsonFactory$Feature$Type();
+  static const jni$_.JType<JsonFactory$Feature?> nullableType =
+      $JsonFactory$Feature$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<JsonFactory$Feature> type =
+      $JsonFactory$Feature$Type$();
   static final _id_INTERN_FIELD_NAMES = _class.staticFieldId(
     r'INTERN_FIELD_NAMES',
     r'Lcom/fasterxml/jackson/core/JsonFactory$Feature;',
@@ -98,7 +102,7 @@ class JsonFactory$Feature extends jni$_.JObject {
   ///
   /// This setting is enabled by default.
   static JsonFactory$Feature get INTERN_FIELD_NAMES =>
-      _id_INTERN_FIELD_NAMES.get(_class, const $JsonFactory$Feature$Type());
+      _id_INTERN_FIELD_NAMES.get(_class, const $JsonFactory$Feature$Type$());
 
   static final _id_CANONICALIZE_FIELD_NAMES = _class.staticFieldId(
     r'CANONICALIZE_FIELD_NAMES',
@@ -116,7 +120,7 @@ class JsonFactory$Feature extends jni$_.JObject {
   /// This setting is enabled by default.
   static JsonFactory$Feature get CANONICALIZE_FIELD_NAMES =>
       _id_CANONICALIZE_FIELD_NAMES.get(
-          _class, const $JsonFactory$Feature$Type());
+          _class, const $JsonFactory$Feature$Type$());
 
   static final _id_FAIL_ON_SYMBOL_HASH_OVERFLOW = _class.staticFieldId(
     r'FAIL_ON_SYMBOL_HASH_OVERFLOW',
@@ -139,7 +143,7 @@ class JsonFactory$Feature extends jni$_.JObject {
   ///@since 2.4
   static JsonFactory$Feature get FAIL_ON_SYMBOL_HASH_OVERFLOW =>
       _id_FAIL_ON_SYMBOL_HASH_OVERFLOW.get(
-          _class, const $JsonFactory$Feature$Type());
+          _class, const $JsonFactory$Feature$Type$());
 
   static final _id_USE_THREAD_LOCAL_FOR_BUFFER_RECYCLING = _class.staticFieldId(
     r'USE_THREAD_LOCAL_FOR_BUFFER_RECYCLING',
@@ -163,7 +167,7 @@ class JsonFactory$Feature extends jni$_.JObject {
   ///@since 2.6
   static JsonFactory$Feature get USE_THREAD_LOCAL_FOR_BUFFER_RECYCLING =>
       _id_USE_THREAD_LOCAL_FOR_BUFFER_RECYCLING.get(
-          _class, const $JsonFactory$Feature$Type());
+          _class, const $JsonFactory$Feature$Type$());
 
   static final _id_values = _class.staticMethodId(
     r'values',
@@ -187,8 +191,8 @@ class JsonFactory$Feature extends jni$_.JObject {
   static jni$_.JArray<JsonFactory$Feature?>? values() {
     return _values(_class.reference.pointer, _id_values as jni$_.JMethodIDPtr)
         .object<jni$_.JArray<JsonFactory$Feature?>?>(
-            const jni$_.JArrayNullableType<JsonFactory$Feature?>(
-                $JsonFactory$Feature$NullableType()));
+            const jni$_.$JArray$NullableType$<JsonFactory$Feature?>(
+                $JsonFactory$Feature$NullableType$()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -216,7 +220,7 @@ class JsonFactory$Feature extends jni$_.JObject {
     return _valueOf(_class.reference.pointer, _id_valueOf as jni$_.JMethodIDPtr,
             _$name.pointer)
         .object<JsonFactory$Feature?>(
-            const $JsonFactory$Feature$NullableType());
+            const $JsonFactory$Feature$NullableType$());
   }
 
   static final _id_collectDefaults = _class.staticMethodId(
@@ -320,10 +324,10 @@ class JsonFactory$Feature extends jni$_.JObject {
   }
 }
 
-final class $JsonFactory$Feature$NullableType
-    extends jni$_.JObjType<JsonFactory$Feature?> {
+final class $JsonFactory$Feature$NullableType$
+    extends jni$_.JType<JsonFactory$Feature?> {
   @jni$_.internal
-  const $JsonFactory$Feature$NullableType();
+  const $JsonFactory$Feature$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -339,30 +343,30 @@ final class $JsonFactory$Feature$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonFactory$Feature?> get nullableType => this;
+  jni$_.JType<JsonFactory$Feature?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonFactory$Feature$NullableType).hashCode;
+  int get hashCode => ($JsonFactory$Feature$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonFactory$Feature$NullableType) &&
-        other is $JsonFactory$Feature$NullableType;
+    return other.runtimeType == ($JsonFactory$Feature$NullableType$) &&
+        other is $JsonFactory$Feature$NullableType$;
   }
 }
 
-final class $JsonFactory$Feature$Type
-    extends jni$_.JObjType<JsonFactory$Feature> {
+final class $JsonFactory$Feature$Type$
+    extends jni$_.JType<JsonFactory$Feature> {
   @jni$_.internal
-  const $JsonFactory$Feature$Type();
+  const $JsonFactory$Feature$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -376,24 +380,24 @@ final class $JsonFactory$Feature$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonFactory$Feature?> get nullableType =>
-      const $JsonFactory$Feature$NullableType();
+  jni$_.JType<JsonFactory$Feature?> get nullableType =>
+      const $JsonFactory$Feature$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonFactory$Feature$Type).hashCode;
+  int get hashCode => ($JsonFactory$Feature$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonFactory$Feature$Type) &&
-        other is $JsonFactory$Feature$Type;
+    return other.runtimeType == ($JsonFactory$Feature$Type$) &&
+        other is $JsonFactory$Feature$Type$;
   }
 }
 
@@ -419,7 +423,7 @@ final class $JsonFactory$Feature$Type
 class JsonFactory extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<JsonFactory> $type;
+  final jni$_.JType<JsonFactory> $type;
 
   @jni$_.internal
   JsonFactory.fromReference(
@@ -431,8 +435,11 @@ class JsonFactory extends jni$_.JObject {
       jni$_.JClass.forName(r'com/fasterxml/jackson/core/JsonFactory');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $JsonFactory$NullableType();
-  static const type = $JsonFactory$Type();
+  static const jni$_.JType<JsonFactory?> nullableType =
+      $JsonFactory$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<JsonFactory> type = $JsonFactory$Type$();
   static final _id_FORMAT_NAME_JSON = _class.staticFieldId(
     r'FORMAT_NAME_JSON',
     r'Ljava/lang/String;',
@@ -444,7 +451,7 @@ class JsonFactory extends jni$_.JObject {
   /// Name used to identify JSON format
   /// (and returned by \#getFormatName()
   static jni$_.JString? get FORMAT_NAME_JSON =>
-      _id_FORMAT_NAME_JSON.get(_class, const jni$_.JStringNullableType());
+      _id_FORMAT_NAME_JSON.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_DEFAULT_ROOT_VALUE_SEPARATOR = _class.staticFieldId(
     r'DEFAULT_ROOT_VALUE_SEPARATOR',
@@ -455,7 +462,7 @@ class JsonFactory extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JObject? get DEFAULT_ROOT_VALUE_SEPARATOR =>
       _id_DEFAULT_ROOT_VALUE_SEPARATOR.get(
-          _class, const jni$_.JObjectNullableType());
+          _class, const jni$_.$JObject$NullableType$());
 
   /// from: `static public final char DEFAULT_QUOTE_CHAR`
   ///
@@ -576,7 +583,7 @@ class JsonFactory extends jni$_.JObject {
   ///@since 2.10
   jni$_.JObject? rebuild() {
     return _rebuild(reference.pointer, _id_rebuild as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_builder = _class.staticMethodId(
@@ -609,7 +616,7 @@ class JsonFactory extends jni$_.JObject {
   ///@return Builder instance to use
   static jni$_.JObject? builder() {
     return _builder(_class.reference.pointer, _id_builder as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_copy = _class.instanceMethodId(
@@ -646,7 +653,7 @@ class JsonFactory extends jni$_.JObject {
   ///@since 2.1
   JsonFactory? copy() {
     return _copy(reference.pointer, _id_copy as jni$_.JMethodIDPtr)
-        .object<JsonFactory?>(const $JsonFactory$NullableType());
+        .object<JsonFactory?>(const $JsonFactory$NullableType$());
   }
 
   static final _id_requiresPropertyOrdering = _class.instanceMethodId(
@@ -814,7 +821,7 @@ class JsonFactory extends jni$_.JObject {
   jni$_.JObject? getFormatReadFeatureType() {
     return _getFormatReadFeatureType(reference.pointer,
             _id_getFormatReadFeatureType as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getFormatWriteFeatureType = _class.instanceMethodId(
@@ -839,7 +846,7 @@ class JsonFactory extends jni$_.JObject {
   jni$_.JObject? getFormatWriteFeatureType() {
     return _getFormatWriteFeatureType(reference.pointer,
             _id_getFormatWriteFeatureType as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_canUseSchema = _class.instanceMethodId(
@@ -907,7 +914,7 @@ class JsonFactory extends jni$_.JObject {
   jni$_.JString? getFormatName() {
     return _getFormatName(
             reference.pointer, _id_getFormatName as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_hasFormat = _class.instanceMethodId(
@@ -934,7 +941,7 @@ class JsonFactory extends jni$_.JObject {
     final _$acc = acc?.reference ?? jni$_.jNullReference;
     return _hasFormat(reference.pointer, _id_hasFormat as jni$_.JMethodIDPtr,
             _$acc.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_requiresCustomCodec = _class.instanceMethodId(
@@ -992,7 +999,7 @@ class JsonFactory extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? version() {
     return _version(reference.pointer, _id_version as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_configure = _class.instanceMethodId(
@@ -1028,7 +1035,7 @@ class JsonFactory extends jni$_.JObject {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _configure(reference.pointer, _id_configure as jni$_.JMethodIDPtr,
             _$f.pointer, state ? 1 : 0)
-        .object<JsonFactory?>(const $JsonFactory$NullableType());
+        .object<JsonFactory?>(const $JsonFactory$NullableType$());
   }
 
   static final _id_enable = _class.instanceMethodId(
@@ -1061,7 +1068,7 @@ class JsonFactory extends jni$_.JObject {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _enable(
             reference.pointer, _id_enable as jni$_.JMethodIDPtr, _$f.pointer)
-        .object<JsonFactory?>(const $JsonFactory$NullableType());
+        .object<JsonFactory?>(const $JsonFactory$NullableType$());
   }
 
   static final _id_disable = _class.instanceMethodId(
@@ -1094,7 +1101,7 @@ class JsonFactory extends jni$_.JObject {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _disable(
             reference.pointer, _id_disable as jni$_.JMethodIDPtr, _$f.pointer)
-        .object<JsonFactory?>(const $JsonFactory$NullableType());
+        .object<JsonFactory?>(const $JsonFactory$NullableType$());
   }
 
   static final _id_isEnabled = _class.instanceMethodId(
@@ -1256,7 +1263,7 @@ class JsonFactory extends jni$_.JObject {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _configure$1(reference.pointer,
             _id_configure$1 as jni$_.JMethodIDPtr, _$f.pointer, state ? 1 : 0)
-        .object<JsonFactory?>(const $JsonFactory$NullableType());
+        .object<JsonFactory?>(const $JsonFactory$NullableType$());
   }
 
   static final _id_enable$1 = _class.instanceMethodId(
@@ -1288,7 +1295,7 @@ class JsonFactory extends jni$_.JObject {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _enable$1(
             reference.pointer, _id_enable$1 as jni$_.JMethodIDPtr, _$f.pointer)
-        .object<JsonFactory?>(const $JsonFactory$NullableType());
+        .object<JsonFactory?>(const $JsonFactory$NullableType$());
   }
 
   static final _id_disable$1 = _class.instanceMethodId(
@@ -1320,7 +1327,7 @@ class JsonFactory extends jni$_.JObject {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _disable$1(
             reference.pointer, _id_disable$1 as jni$_.JMethodIDPtr, _$f.pointer)
-        .object<JsonFactory?>(const $JsonFactory$NullableType());
+        .object<JsonFactory?>(const $JsonFactory$NullableType$());
   }
 
   static final _id_isEnabled$1 = _class.instanceMethodId(
@@ -1410,7 +1417,7 @@ class JsonFactory extends jni$_.JObject {
   jni$_.JObject? getInputDecorator() {
     return _getInputDecorator(
             reference.pointer, _id_getInputDecorator as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_setInputDecorator = _class.instanceMethodId(
@@ -1442,7 +1449,7 @@ class JsonFactory extends jni$_.JObject {
     final _$d = d?.reference ?? jni$_.jNullReference;
     return _setInputDecorator(reference.pointer,
             _id_setInputDecorator as jni$_.JMethodIDPtr, _$d.pointer)
-        .object<JsonFactory?>(const $JsonFactory$NullableType());
+        .object<JsonFactory?>(const $JsonFactory$NullableType$());
   }
 
   static final _id_configure$2 = _class.instanceMethodId(
@@ -1477,7 +1484,7 @@ class JsonFactory extends jni$_.JObject {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _configure$2(reference.pointer,
             _id_configure$2 as jni$_.JMethodIDPtr, _$f.pointer, state ? 1 : 0)
-        .object<JsonFactory?>(const $JsonFactory$NullableType());
+        .object<JsonFactory?>(const $JsonFactory$NullableType$());
   }
 
   static final _id_enable$2 = _class.instanceMethodId(
@@ -1509,7 +1516,7 @@ class JsonFactory extends jni$_.JObject {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _enable$2(
             reference.pointer, _id_enable$2 as jni$_.JMethodIDPtr, _$f.pointer)
-        .object<JsonFactory?>(const $JsonFactory$NullableType());
+        .object<JsonFactory?>(const $JsonFactory$NullableType$());
   }
 
   static final _id_disable$2 = _class.instanceMethodId(
@@ -1541,7 +1548,7 @@ class JsonFactory extends jni$_.JObject {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _disable$2(
             reference.pointer, _id_disable$2 as jni$_.JMethodIDPtr, _$f.pointer)
-        .object<JsonFactory?>(const $JsonFactory$NullableType());
+        .object<JsonFactory?>(const $JsonFactory$NullableType$());
   }
 
   static final _id_isEnabled$3 = _class.instanceMethodId(
@@ -1631,7 +1638,7 @@ class JsonFactory extends jni$_.JObject {
   jni$_.JObject? getCharacterEscapes() {
     return _getCharacterEscapes(
             reference.pointer, _id_getCharacterEscapes as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_setCharacterEscapes = _class.instanceMethodId(
@@ -1663,7 +1670,7 @@ class JsonFactory extends jni$_.JObject {
     final _$esc = esc?.reference ?? jni$_.jNullReference;
     return _setCharacterEscapes(reference.pointer,
             _id_setCharacterEscapes as jni$_.JMethodIDPtr, _$esc.pointer)
-        .object<JsonFactory?>(const $JsonFactory$NullableType());
+        .object<JsonFactory?>(const $JsonFactory$NullableType$());
   }
 
   static final _id_getOutputDecorator = _class.instanceMethodId(
@@ -1693,7 +1700,7 @@ class JsonFactory extends jni$_.JObject {
   jni$_.JObject? getOutputDecorator() {
     return _getOutputDecorator(
             reference.pointer, _id_getOutputDecorator as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_setOutputDecorator = _class.instanceMethodId(
@@ -1725,7 +1732,7 @@ class JsonFactory extends jni$_.JObject {
     final _$d = d?.reference ?? jni$_.jNullReference;
     return _setOutputDecorator(reference.pointer,
             _id_setOutputDecorator as jni$_.JMethodIDPtr, _$d.pointer)
-        .object<JsonFactory?>(const $JsonFactory$NullableType());
+        .object<JsonFactory?>(const $JsonFactory$NullableType$());
   }
 
   static final _id_setRootValueSeparator = _class.instanceMethodId(
@@ -1758,7 +1765,7 @@ class JsonFactory extends jni$_.JObject {
     final _$sep = sep?.reference ?? jni$_.jNullReference;
     return _setRootValueSeparator(reference.pointer,
             _id_setRootValueSeparator as jni$_.JMethodIDPtr, _$sep.pointer)
-        .object<JsonFactory?>(const $JsonFactory$NullableType());
+        .object<JsonFactory?>(const $JsonFactory$NullableType$());
   }
 
   static final _id_getRootValueSeparator = _class.instanceMethodId(
@@ -1785,7 +1792,7 @@ class JsonFactory extends jni$_.JObject {
   jni$_.JString? getRootValueSeparator() {
     return _getRootValueSeparator(
             reference.pointer, _id_getRootValueSeparator as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_setCodec = _class.instanceMethodId(
@@ -1820,7 +1827,7 @@ class JsonFactory extends jni$_.JObject {
     final _$oc = oc?.reference ?? jni$_.jNullReference;
     return _setCodec(
             reference.pointer, _id_setCodec as jni$_.JMethodIDPtr, _$oc.pointer)
-        .object<JsonFactory?>(const $JsonFactory$NullableType());
+        .object<JsonFactory?>(const $JsonFactory$NullableType$());
   }
 
   static final _id_getCodec = _class.instanceMethodId(
@@ -1844,7 +1851,7 @@ class JsonFactory extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? getCodec() {
     return _getCodec(reference.pointer, _id_getCodec as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_createParser = _class.instanceMethodId(
@@ -1889,7 +1896,7 @@ class JsonFactory extends jni$_.JObject {
     return _createParser(reference.pointer,
             _id_createParser as jni$_.JMethodIDPtr, _$f.pointer)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createParser$1 = _class.instanceMethodId(
@@ -1932,7 +1939,7 @@ class JsonFactory extends jni$_.JObject {
     return _createParser$1(reference.pointer,
             _id_createParser$1 as jni$_.JMethodIDPtr, _$url.pointer)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createParser$2 = _class.instanceMethodId(
@@ -1978,7 +1985,7 @@ class JsonFactory extends jni$_.JObject {
     return _createParser$2(reference.pointer,
             _id_createParser$2 as jni$_.JMethodIDPtr, _$in$.pointer)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createParser$3 = _class.instanceMethodId(
@@ -2017,7 +2024,7 @@ class JsonFactory extends jni$_.JObject {
     return _createParser$3(reference.pointer,
             _id_createParser$3 as jni$_.JMethodIDPtr, _$r.pointer)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createParser$4 = _class.instanceMethodId(
@@ -2049,7 +2056,7 @@ class JsonFactory extends jni$_.JObject {
     return _createParser$4(reference.pointer,
             _id_createParser$4 as jni$_.JMethodIDPtr, _$data.pointer)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createParser$5 = _class.instanceMethodId(
@@ -2094,7 +2101,7 @@ class JsonFactory extends jni$_.JObject {
             offset,
             len)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createParser$6 = _class.instanceMethodId(
@@ -2126,7 +2133,7 @@ class JsonFactory extends jni$_.JObject {
     return _createParser$6(reference.pointer,
             _id_createParser$6 as jni$_.JMethodIDPtr, _$content.pointer)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createParser$7 = _class.instanceMethodId(
@@ -2158,7 +2165,7 @@ class JsonFactory extends jni$_.JObject {
     return _createParser$7(reference.pointer,
             _id_createParser$7 as jni$_.JMethodIDPtr, _$content.pointer)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createParser$8 = _class.instanceMethodId(
@@ -2199,7 +2206,7 @@ class JsonFactory extends jni$_.JObject {
             offset,
             len)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createParser$9 = _class.instanceMethodId(
@@ -2234,7 +2241,7 @@ class JsonFactory extends jni$_.JObject {
     return _createParser$9(reference.pointer,
             _id_createParser$9 as jni$_.JMethodIDPtr, _$in$.pointer)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createNonBlockingByteArrayParser = _class.instanceMethodId(
@@ -2275,7 +2282,7 @@ class JsonFactory extends jni$_.JObject {
     return _createNonBlockingByteArrayParser(reference.pointer,
             _id_createNonBlockingByteArrayParser as jni$_.JMethodIDPtr)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createGenerator = _class.instanceMethodId(
@@ -2332,7 +2339,7 @@ class JsonFactory extends jni$_.JObject {
             _id_createGenerator as jni$_.JMethodIDPtr,
             _$out.pointer,
             _$enc.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_createGenerator$1 = _class.instanceMethodId(
@@ -2365,7 +2372,7 @@ class JsonFactory extends jni$_.JObject {
     final _$out = out?.reference ?? jni$_.jNullReference;
     return _createGenerator$1(reference.pointer,
             _id_createGenerator$1 as jni$_.JMethodIDPtr, _$out.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_createGenerator$2 = _class.instanceMethodId(
@@ -2404,7 +2411,7 @@ class JsonFactory extends jni$_.JObject {
     final _$w = w?.reference ?? jni$_.jNullReference;
     return _createGenerator$2(reference.pointer,
             _id_createGenerator$2 as jni$_.JMethodIDPtr, _$w.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_createGenerator$3 = _class.instanceMethodId(
@@ -2455,7 +2462,7 @@ class JsonFactory extends jni$_.JObject {
             _id_createGenerator$3 as jni$_.JMethodIDPtr,
             _$f.pointer,
             _$enc.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_createGenerator$4 = _class.instanceMethodId(
@@ -2497,7 +2504,7 @@ class JsonFactory extends jni$_.JObject {
             _id_createGenerator$4 as jni$_.JMethodIDPtr,
             _$out.pointer,
             _$enc.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_createGenerator$5 = _class.instanceMethodId(
@@ -2530,7 +2537,7 @@ class JsonFactory extends jni$_.JObject {
     final _$out = out?.reference ?? jni$_.jNullReference;
     return _createGenerator$5(reference.pointer,
             _id_createGenerator$5 as jni$_.JMethodIDPtr, _$out.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_createJsonParser = _class.instanceMethodId(
@@ -2577,7 +2584,7 @@ class JsonFactory extends jni$_.JObject {
     return _createJsonParser(reference.pointer,
             _id_createJsonParser as jni$_.JMethodIDPtr, _$f.pointer)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createJsonParser$1 = _class.instanceMethodId(
@@ -2623,7 +2630,7 @@ class JsonFactory extends jni$_.JObject {
     return _createJsonParser$1(reference.pointer,
             _id_createJsonParser$1 as jni$_.JMethodIDPtr, _$url.pointer)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createJsonParser$2 = _class.instanceMethodId(
@@ -2672,7 +2679,7 @@ class JsonFactory extends jni$_.JObject {
     return _createJsonParser$2(reference.pointer,
             _id_createJsonParser$2 as jni$_.JMethodIDPtr, _$in$.pointer)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createJsonParser$3 = _class.instanceMethodId(
@@ -2714,7 +2721,7 @@ class JsonFactory extends jni$_.JObject {
     return _createJsonParser$3(reference.pointer,
             _id_createJsonParser$3 as jni$_.JMethodIDPtr, _$r.pointer)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createJsonParser$4 = _class.instanceMethodId(
@@ -2749,7 +2756,7 @@ class JsonFactory extends jni$_.JObject {
     return _createJsonParser$4(reference.pointer,
             _id_createJsonParser$4 as jni$_.JMethodIDPtr, _$data.pointer)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createJsonParser$5 = _class.instanceMethodId(
@@ -2797,7 +2804,7 @@ class JsonFactory extends jni$_.JObject {
             offset,
             len)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createJsonParser$6 = _class.instanceMethodId(
@@ -2833,7 +2840,7 @@ class JsonFactory extends jni$_.JObject {
     return _createJsonParser$6(reference.pointer,
             _id_createJsonParser$6 as jni$_.JMethodIDPtr, _$content.pointer)
         .object<jsonparser$_.JsonParser?>(
-            const jsonparser$_.$JsonParser$NullableType());
+            const jsonparser$_.$JsonParser$NullableType$());
   }
 
   static final _id_createJsonGenerator = _class.instanceMethodId(
@@ -2892,7 +2899,7 @@ class JsonFactory extends jni$_.JObject {
             _id_createJsonGenerator as jni$_.JMethodIDPtr,
             _$out.pointer,
             _$enc.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_createJsonGenerator$1 = _class.instanceMethodId(
@@ -2933,7 +2940,7 @@ class JsonFactory extends jni$_.JObject {
     final _$out = out?.reference ?? jni$_.jNullReference;
     return _createJsonGenerator$1(reference.pointer,
             _id_createJsonGenerator$1 as jni$_.JMethodIDPtr, _$out.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_createJsonGenerator$2 = _class.instanceMethodId(
@@ -2969,7 +2976,7 @@ class JsonFactory extends jni$_.JObject {
     final _$out = out?.reference ?? jni$_.jNullReference;
     return _createJsonGenerator$2(reference.pointer,
             _id_createJsonGenerator$2 as jni$_.JMethodIDPtr, _$out.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_$_getBufferRecycler = _class.instanceMethodId(
@@ -3000,13 +3007,13 @@ class JsonFactory extends jni$_.JObject {
   jni$_.JObject? $_getBufferRecycler() {
     return _$_getBufferRecycler(
             reference.pointer, _id_$_getBufferRecycler as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 }
 
-final class $JsonFactory$NullableType extends jni$_.JObjType<JsonFactory?> {
+final class $JsonFactory$NullableType$ extends jni$_.JType<JsonFactory?> {
   @jni$_.internal
-  const $JsonFactory$NullableType();
+  const $JsonFactory$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -3021,29 +3028,29 @@ final class $JsonFactory$NullableType extends jni$_.JObjType<JsonFactory?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonFactory?> get nullableType => this;
+  jni$_.JType<JsonFactory?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonFactory$NullableType).hashCode;
+  int get hashCode => ($JsonFactory$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonFactory$NullableType) &&
-        other is $JsonFactory$NullableType;
+    return other.runtimeType == ($JsonFactory$NullableType$) &&
+        other is $JsonFactory$NullableType$;
   }
 }
 
-final class $JsonFactory$Type extends jni$_.JObjType<JsonFactory> {
+final class $JsonFactory$Type$ extends jni$_.JType<JsonFactory> {
   @jni$_.internal
-  const $JsonFactory$Type();
+  const $JsonFactory$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -3057,23 +3064,23 @@ final class $JsonFactory$Type extends jni$_.JObjType<JsonFactory> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonFactory?> get nullableType =>
-      const $JsonFactory$NullableType();
+  jni$_.JType<JsonFactory?> get nullableType =>
+      const $JsonFactory$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonFactory$Type).hashCode;
+  int get hashCode => ($JsonFactory$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonFactory$Type) &&
-        other is $JsonFactory$Type;
+    return other.runtimeType == ($JsonFactory$Type$) &&
+        other is $JsonFactory$Type$;
   }
 }

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonParser.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonParser.dart
@@ -61,7 +61,7 @@ import 'JsonToken.dart' as jsontoken$_;
 class JsonParser$Feature extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<JsonParser$Feature> $type;
+  final jni$_.JType<JsonParser$Feature> $type;
 
   @jni$_.internal
   JsonParser$Feature.fromReference(
@@ -73,8 +73,12 @@ class JsonParser$Feature extends jni$_.JObject {
       jni$_.JClass.forName(r'com/fasterxml/jackson/core/JsonParser$Feature');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $JsonParser$Feature$NullableType();
-  static const type = $JsonParser$Feature$Type();
+  static const jni$_.JType<JsonParser$Feature?> nullableType =
+      $JsonParser$Feature$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<JsonParser$Feature> type =
+      $JsonParser$Feature$Type$();
   static final _id_AUTO_CLOSE_SOURCE = _class.staticFieldId(
     r'AUTO_CLOSE_SOURCE',
     r'Lcom/fasterxml/jackson/core/JsonParser$Feature;',
@@ -94,7 +98,7 @@ class JsonParser$Feature extends jni$_.JObject {
   ///
   /// Feature is enabled by default.
   static JsonParser$Feature get AUTO_CLOSE_SOURCE =>
-      _id_AUTO_CLOSE_SOURCE.get(_class, const $JsonParser$Feature$Type());
+      _id_AUTO_CLOSE_SOURCE.get(_class, const $JsonParser$Feature$Type$());
 
   static final _id_ALLOW_COMMENTS = _class.staticFieldId(
     r'ALLOW_COMMENTS',
@@ -118,7 +122,7 @@ class JsonParser$Feature extends jni$_.JObject {
   /// NOTE: while not technically deprecated, since 2.10 recommended to use
   /// com.fasterxml.jackson.core.json.JsonReadFeature\#ALLOW_JAVA_COMMENTS instead.
   static JsonParser$Feature get ALLOW_COMMENTS =>
-      _id_ALLOW_COMMENTS.get(_class, const $JsonParser$Feature$Type());
+      _id_ALLOW_COMMENTS.get(_class, const $JsonParser$Feature$Type$());
 
   static final _id_ALLOW_YAML_COMMENTS = _class.staticFieldId(
     r'ALLOW_YAML_COMMENTS',
@@ -142,7 +146,7 @@ class JsonParser$Feature extends jni$_.JObject {
   /// NOTE: while not technically deprecated, since 2.10 recommended to use
   /// com.fasterxml.jackson.core.json.JsonReadFeature\#ALLOW_YAML_COMMENTS instead.
   static JsonParser$Feature get ALLOW_YAML_COMMENTS =>
-      _id_ALLOW_YAML_COMMENTS.get(_class, const $JsonParser$Feature$Type());
+      _id_ALLOW_YAML_COMMENTS.get(_class, const $JsonParser$Feature$Type$());
 
   static final _id_ALLOW_UNQUOTED_FIELD_NAMES = _class.staticFieldId(
     r'ALLOW_UNQUOTED_FIELD_NAMES',
@@ -164,7 +168,7 @@ class JsonParser$Feature extends jni$_.JObject {
   /// com.fasterxml.jackson.core.json.JsonReadFeature\#ALLOW_UNQUOTED_FIELD_NAMES instead.
   static JsonParser$Feature get ALLOW_UNQUOTED_FIELD_NAMES =>
       _id_ALLOW_UNQUOTED_FIELD_NAMES.get(
-          _class, const $JsonParser$Feature$Type());
+          _class, const $JsonParser$Feature$Type$());
 
   static final _id_ALLOW_SINGLE_QUOTES = _class.staticFieldId(
     r'ALLOW_SINGLE_QUOTES',
@@ -187,7 +191,7 @@ class JsonParser$Feature extends jni$_.JObject {
   /// NOTE: while not technically deprecated, since 2.10 recommended to use
   /// com.fasterxml.jackson.core.json.JsonReadFeature\#ALLOW_SINGLE_QUOTES instead.
   static JsonParser$Feature get ALLOW_SINGLE_QUOTES =>
-      _id_ALLOW_SINGLE_QUOTES.get(_class, const $JsonParser$Feature$Type());
+      _id_ALLOW_SINGLE_QUOTES.get(_class, const $JsonParser$Feature$Type$());
 
   static final _id_ALLOW_UNQUOTED_CONTROL_CHARS = _class.staticFieldId(
     r'ALLOW_UNQUOTED_CONTROL_CHARS',
@@ -209,7 +213,7 @@ class JsonParser$Feature extends jni$_.JObject {
   ///@deprecated Since 2.10 use com.fasterxml.jackson.core.json.JsonReadFeature\#ALLOW_UNESCAPED_CONTROL_CHARS instead
   static JsonParser$Feature get ALLOW_UNQUOTED_CONTROL_CHARS =>
       _id_ALLOW_UNQUOTED_CONTROL_CHARS.get(
-          _class, const $JsonParser$Feature$Type());
+          _class, const $JsonParser$Feature$Type$());
 
   static final _id_ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER =
       _class.staticFieldId(
@@ -230,7 +234,7 @@ class JsonParser$Feature extends jni$_.JObject {
   ///@deprecated Since 2.10 use com.fasterxml.jackson.core.json.JsonReadFeature\#ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER instead
   static JsonParser$Feature get ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER =>
       _id_ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER.get(
-          _class, const $JsonParser$Feature$Type());
+          _class, const $JsonParser$Feature$Type$());
 
   static final _id_ALLOW_NUMERIC_LEADING_ZEROS = _class.staticFieldId(
     r'ALLOW_NUMERIC_LEADING_ZEROS',
@@ -251,7 +255,7 @@ class JsonParser$Feature extends jni$_.JObject {
   ///@deprecated Since 2.10 use com.fasterxml.jackson.core.json.JsonReadFeature\#ALLOW_LEADING_ZEROS_FOR_NUMBERS instead
   static JsonParser$Feature get ALLOW_NUMERIC_LEADING_ZEROS =>
       _id_ALLOW_NUMERIC_LEADING_ZEROS.get(
-          _class, const $JsonParser$Feature$Type());
+          _class, const $JsonParser$Feature$Type$());
 
   static final _id_ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS =
       _class.staticFieldId(
@@ -265,7 +269,7 @@ class JsonParser$Feature extends jni$_.JObject {
   /// @deprecated Use com.fasterxml.jackson.core.json.JsonReadFeature\#ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS instead
   static JsonParser$Feature get ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS =>
       _id_ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS.get(
-          _class, const $JsonParser$Feature$Type());
+          _class, const $JsonParser$Feature$Type$());
 
   static final _id_ALLOW_NON_NUMERIC_NUMBERS = _class.staticFieldId(
     r'ALLOW_NON_NUMERIC_NUMBERS',
@@ -294,7 +298,7 @@ class JsonParser$Feature extends jni$_.JObject {
   ///@deprecated Since 2.10 use com.fasterxml.jackson.core.json.JsonReadFeature\#ALLOW_NON_NUMERIC_NUMBERS instead
   static JsonParser$Feature get ALLOW_NON_NUMERIC_NUMBERS =>
       _id_ALLOW_NON_NUMERIC_NUMBERS.get(
-          _class, const $JsonParser$Feature$Type());
+          _class, const $JsonParser$Feature$Type$());
 
   static final _id_ALLOW_MISSING_VALUES = _class.staticFieldId(
     r'ALLOW_MISSING_VALUES',
@@ -319,7 +323,7 @@ class JsonParser$Feature extends jni$_.JObject {
   ///@since 2.8
   ///@deprecated Since 2.10 use com.fasterxml.jackson.core.json.JsonReadFeature\#ALLOW_MISSING_VALUES instead
   static JsonParser$Feature get ALLOW_MISSING_VALUES =>
-      _id_ALLOW_MISSING_VALUES.get(_class, const $JsonParser$Feature$Type());
+      _id_ALLOW_MISSING_VALUES.get(_class, const $JsonParser$Feature$Type$());
 
   static final _id_ALLOW_TRAILING_COMMA = _class.staticFieldId(
     r'ALLOW_TRAILING_COMMA',
@@ -349,7 +353,7 @@ class JsonParser$Feature extends jni$_.JObject {
   ///@since 2.9
   ///@deprecated Since 2.10 use com.fasterxml.jackson.core.json.JsonReadFeature\#ALLOW_TRAILING_COMMA instead
   static JsonParser$Feature get ALLOW_TRAILING_COMMA =>
-      _id_ALLOW_TRAILING_COMMA.get(_class, const $JsonParser$Feature$Type());
+      _id_ALLOW_TRAILING_COMMA.get(_class, const $JsonParser$Feature$Type$());
 
   static final _id_STRICT_DUPLICATE_DETECTION = _class.staticFieldId(
     r'STRICT_DUPLICATE_DETECTION',
@@ -374,7 +378,7 @@ class JsonParser$Feature extends jni$_.JObject {
   ///@since 2.3
   static JsonParser$Feature get STRICT_DUPLICATE_DETECTION =>
       _id_STRICT_DUPLICATE_DETECTION.get(
-          _class, const $JsonParser$Feature$Type());
+          _class, const $JsonParser$Feature$Type$());
 
   static final _id_IGNORE_UNDEFINED = _class.staticFieldId(
     r'IGNORE_UNDEFINED',
@@ -404,7 +408,7 @@ class JsonParser$Feature extends jni$_.JObject {
   /// property will result in a JsonProcessingException
   ///@since 2.6
   static JsonParser$Feature get IGNORE_UNDEFINED =>
-      _id_IGNORE_UNDEFINED.get(_class, const $JsonParser$Feature$Type());
+      _id_IGNORE_UNDEFINED.get(_class, const $JsonParser$Feature$Type$());
 
   static final _id_INCLUDE_SOURCE_IN_LOCATION = _class.staticFieldId(
     r'INCLUDE_SOURCE_IN_LOCATION',
@@ -432,7 +436,7 @@ class JsonParser$Feature extends jni$_.JObject {
   ///@since 2.9
   static JsonParser$Feature get INCLUDE_SOURCE_IN_LOCATION =>
       _id_INCLUDE_SOURCE_IN_LOCATION.get(
-          _class, const $JsonParser$Feature$Type());
+          _class, const $JsonParser$Feature$Type$());
 
   static final _id_values = _class.staticMethodId(
     r'values',
@@ -456,8 +460,8 @@ class JsonParser$Feature extends jni$_.JObject {
   static jni$_.JArray<JsonParser$Feature?>? values() {
     return _values(_class.reference.pointer, _id_values as jni$_.JMethodIDPtr)
         .object<jni$_.JArray<JsonParser$Feature?>?>(
-            const jni$_.JArrayNullableType<JsonParser$Feature?>(
-                $JsonParser$Feature$NullableType()));
+            const jni$_.$JArray$NullableType$<JsonParser$Feature?>(
+                $JsonParser$Feature$NullableType$()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -484,7 +488,7 @@ class JsonParser$Feature extends jni$_.JObject {
     final _$name = name?.reference ?? jni$_.jNullReference;
     return _valueOf(_class.reference.pointer, _id_valueOf as jni$_.JMethodIDPtr,
             _$name.pointer)
-        .object<JsonParser$Feature?>(const $JsonParser$Feature$NullableType());
+        .object<JsonParser$Feature?>(const $JsonParser$Feature$NullableType$());
   }
 
   static final _id_collectDefaults = _class.staticMethodId(
@@ -588,10 +592,10 @@ class JsonParser$Feature extends jni$_.JObject {
   }
 }
 
-final class $JsonParser$Feature$NullableType
-    extends jni$_.JObjType<JsonParser$Feature?> {
+final class $JsonParser$Feature$NullableType$
+    extends jni$_.JType<JsonParser$Feature?> {
   @jni$_.internal
-  const $JsonParser$Feature$NullableType();
+  const $JsonParser$Feature$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -607,30 +611,29 @@ final class $JsonParser$Feature$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonParser$Feature?> get nullableType => this;
+  jni$_.JType<JsonParser$Feature?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonParser$Feature$NullableType).hashCode;
+  int get hashCode => ($JsonParser$Feature$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonParser$Feature$NullableType) &&
-        other is $JsonParser$Feature$NullableType;
+    return other.runtimeType == ($JsonParser$Feature$NullableType$) &&
+        other is $JsonParser$Feature$NullableType$;
   }
 }
 
-final class $JsonParser$Feature$Type
-    extends jni$_.JObjType<JsonParser$Feature> {
+final class $JsonParser$Feature$Type$ extends jni$_.JType<JsonParser$Feature> {
   @jni$_.internal
-  const $JsonParser$Feature$Type();
+  const $JsonParser$Feature$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -644,24 +647,24 @@ final class $JsonParser$Feature$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonParser$Feature?> get nullableType =>
-      const $JsonParser$Feature$NullableType();
+  jni$_.JType<JsonParser$Feature?> get nullableType =>
+      const $JsonParser$Feature$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonParser$Feature$Type).hashCode;
+  int get hashCode => ($JsonParser$Feature$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonParser$Feature$Type) &&
-        other is $JsonParser$Feature$Type;
+    return other.runtimeType == ($JsonParser$Feature$Type$) &&
+        other is $JsonParser$Feature$Type$;
   }
 }
 
@@ -672,7 +675,7 @@ final class $JsonParser$Feature$Type
 class JsonParser$NumberType extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<JsonParser$NumberType> $type;
+  final jni$_.JType<JsonParser$NumberType> $type;
 
   @jni$_.internal
   JsonParser$NumberType.fromReference(
@@ -684,8 +687,12 @@ class JsonParser$NumberType extends jni$_.JObject {
       jni$_.JClass.forName(r'com/fasterxml/jackson/core/JsonParser$NumberType');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $JsonParser$NumberType$NullableType();
-  static const type = $JsonParser$NumberType$Type();
+  static const jni$_.JType<JsonParser$NumberType?> nullableType =
+      $JsonParser$NumberType$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<JsonParser$NumberType> type =
+      $JsonParser$NumberType$Type$();
   static final _id_INT = _class.staticFieldId(
     r'INT',
     r'Lcom/fasterxml/jackson/core/JsonParser$NumberType;',
@@ -694,7 +701,7 @@ class JsonParser$NumberType extends jni$_.JObject {
   /// from: `static public final com.fasterxml.jackson.core.JsonParser$NumberType INT`
   /// The returned object must be released after use, by calling the [release] method.
   static JsonParser$NumberType get INT =>
-      _id_INT.get(_class, const $JsonParser$NumberType$Type());
+      _id_INT.get(_class, const $JsonParser$NumberType$Type$());
 
   static final _id_LONG = _class.staticFieldId(
     r'LONG',
@@ -704,7 +711,7 @@ class JsonParser$NumberType extends jni$_.JObject {
   /// from: `static public final com.fasterxml.jackson.core.JsonParser$NumberType LONG`
   /// The returned object must be released after use, by calling the [release] method.
   static JsonParser$NumberType get LONG =>
-      _id_LONG.get(_class, const $JsonParser$NumberType$Type());
+      _id_LONG.get(_class, const $JsonParser$NumberType$Type$());
 
   static final _id_BIG_INTEGER = _class.staticFieldId(
     r'BIG_INTEGER',
@@ -714,7 +721,7 @@ class JsonParser$NumberType extends jni$_.JObject {
   /// from: `static public final com.fasterxml.jackson.core.JsonParser$NumberType BIG_INTEGER`
   /// The returned object must be released after use, by calling the [release] method.
   static JsonParser$NumberType get BIG_INTEGER =>
-      _id_BIG_INTEGER.get(_class, const $JsonParser$NumberType$Type());
+      _id_BIG_INTEGER.get(_class, const $JsonParser$NumberType$Type$());
 
   static final _id_FLOAT = _class.staticFieldId(
     r'FLOAT',
@@ -724,7 +731,7 @@ class JsonParser$NumberType extends jni$_.JObject {
   /// from: `static public final com.fasterxml.jackson.core.JsonParser$NumberType FLOAT`
   /// The returned object must be released after use, by calling the [release] method.
   static JsonParser$NumberType get FLOAT =>
-      _id_FLOAT.get(_class, const $JsonParser$NumberType$Type());
+      _id_FLOAT.get(_class, const $JsonParser$NumberType$Type$());
 
   static final _id_DOUBLE = _class.staticFieldId(
     r'DOUBLE',
@@ -734,7 +741,7 @@ class JsonParser$NumberType extends jni$_.JObject {
   /// from: `static public final com.fasterxml.jackson.core.JsonParser$NumberType DOUBLE`
   /// The returned object must be released after use, by calling the [release] method.
   static JsonParser$NumberType get DOUBLE =>
-      _id_DOUBLE.get(_class, const $JsonParser$NumberType$Type());
+      _id_DOUBLE.get(_class, const $JsonParser$NumberType$Type$());
 
   static final _id_BIG_DECIMAL = _class.staticFieldId(
     r'BIG_DECIMAL',
@@ -744,7 +751,7 @@ class JsonParser$NumberType extends jni$_.JObject {
   /// from: `static public final com.fasterxml.jackson.core.JsonParser$NumberType BIG_DECIMAL`
   /// The returned object must be released after use, by calling the [release] method.
   static JsonParser$NumberType get BIG_DECIMAL =>
-      _id_BIG_DECIMAL.get(_class, const $JsonParser$NumberType$Type());
+      _id_BIG_DECIMAL.get(_class, const $JsonParser$NumberType$Type$());
 
   static final _id_values = _class.staticMethodId(
     r'values',
@@ -768,8 +775,8 @@ class JsonParser$NumberType extends jni$_.JObject {
   static jni$_.JArray<JsonParser$NumberType?>? values() {
     return _values(_class.reference.pointer, _id_values as jni$_.JMethodIDPtr)
         .object<jni$_.JArray<JsonParser$NumberType?>?>(
-            const jni$_.JArrayNullableType<JsonParser$NumberType?>(
-                $JsonParser$NumberType$NullableType()));
+            const jni$_.$JArray$NullableType$<JsonParser$NumberType?>(
+                $JsonParser$NumberType$NullableType$()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -797,14 +804,14 @@ class JsonParser$NumberType extends jni$_.JObject {
     return _valueOf(_class.reference.pointer, _id_valueOf as jni$_.JMethodIDPtr,
             _$name.pointer)
         .object<JsonParser$NumberType?>(
-            const $JsonParser$NumberType$NullableType());
+            const $JsonParser$NumberType$NullableType$());
   }
 }
 
-final class $JsonParser$NumberType$NullableType
-    extends jni$_.JObjType<JsonParser$NumberType?> {
+final class $JsonParser$NumberType$NullableType$
+    extends jni$_.JType<JsonParser$NumberType?> {
   @jni$_.internal
-  const $JsonParser$NumberType$NullableType();
+  const $JsonParser$NumberType$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -820,30 +827,30 @@ final class $JsonParser$NumberType$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonParser$NumberType?> get nullableType => this;
+  jni$_.JType<JsonParser$NumberType?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonParser$NumberType$NullableType).hashCode;
+  int get hashCode => ($JsonParser$NumberType$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonParser$NumberType$NullableType) &&
-        other is $JsonParser$NumberType$NullableType;
+    return other.runtimeType == ($JsonParser$NumberType$NullableType$) &&
+        other is $JsonParser$NumberType$NullableType$;
   }
 }
 
-final class $JsonParser$NumberType$Type
-    extends jni$_.JObjType<JsonParser$NumberType> {
+final class $JsonParser$NumberType$Type$
+    extends jni$_.JType<JsonParser$NumberType> {
   @jni$_.internal
-  const $JsonParser$NumberType$Type();
+  const $JsonParser$NumberType$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -857,24 +864,24 @@ final class $JsonParser$NumberType$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonParser$NumberType?> get nullableType =>
-      const $JsonParser$NumberType$NullableType();
+  jni$_.JType<JsonParser$NumberType?> get nullableType =>
+      const $JsonParser$NumberType$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonParser$NumberType$Type).hashCode;
+  int get hashCode => ($JsonParser$NumberType$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonParser$NumberType$Type) &&
-        other is $JsonParser$NumberType$Type;
+    return other.runtimeType == ($JsonParser$NumberType$Type$) &&
+        other is $JsonParser$NumberType$Type$;
   }
 }
 
@@ -887,7 +894,7 @@ final class $JsonParser$NumberType$Type
 class JsonParser extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<JsonParser> $type;
+  final jni$_.JType<JsonParser> $type;
 
   @jni$_.internal
   JsonParser.fromReference(
@@ -899,8 +906,11 @@ class JsonParser extends jni$_.JObject {
       jni$_.JClass.forName(r'com/fasterxml/jackson/core/JsonParser');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $JsonParser$NullableType();
-  static const type = $JsonParser$Type();
+  static const jni$_.JType<JsonParser?> nullableType =
+      $JsonParser$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<JsonParser> type = $JsonParser$Type$();
   static final _id_getCodec = _class.instanceMethodId(
     r'getCodec',
     r'()Lcom/fasterxml/jackson/core/ObjectCodec;',
@@ -927,7 +937,7 @@ class JsonParser extends jni$_.JObject {
   ///@return Codec assigned to this parser, if any; {@code null} if none
   jni$_.JObject? getCodec() {
     return _getCodec(reference.pointer, _id_getCodec as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_setCodec = _class.instanceMethodId(
@@ -998,7 +1008,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JObject? getInputSource() {
     return _getInputSource(
             reference.pointer, _id_getInputSource as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_setRequestPayloadOnError = _class.instanceMethodId(
@@ -1172,7 +1182,7 @@ class JsonParser extends jni$_.JObject {
   ///@since 2.1
   jni$_.JObject? getSchema() {
     return _getSchema(reference.pointer, _id_getSchema as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_canUseSchema = _class.instanceMethodId(
@@ -1303,7 +1313,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JObject? getNonBlockingInputFeeder() {
     return _getNonBlockingInputFeeder(reference.pointer,
             _id_getNonBlockingInputFeeder as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getReadCapabilities = _class.instanceMethodId(
@@ -1333,7 +1343,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JObject? getReadCapabilities() {
     return _getReadCapabilities(
             reference.pointer, _id_getReadCapabilities as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_version = _class.instanceMethodId(
@@ -1362,7 +1372,7 @@ class JsonParser extends jni$_.JObject {
   ///   {@code jackson-core} jar that contains the class
   jni$_.JObject? version() {
     return _version(reference.pointer, _id_version as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_close = _class.instanceMethodId(
@@ -1465,7 +1475,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JObject? getParsingContext() {
     return _getParsingContext(
             reference.pointer, _id_getParsingContext as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_currentLocation = _class.instanceMethodId(
@@ -1503,7 +1513,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JObject? currentLocation() {
     return _currentLocation(
             reference.pointer, _id_currentLocation as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_currentTokenLocation = _class.instanceMethodId(
@@ -1541,7 +1551,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JObject? currentTokenLocation() {
     return _currentTokenLocation(
             reference.pointer, _id_currentTokenLocation as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getCurrentLocation = _class.instanceMethodId(
@@ -1570,7 +1580,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JObject? getCurrentLocation() {
     return _getCurrentLocation(
             reference.pointer, _id_getCurrentLocation as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getTokenLocation = _class.instanceMethodId(
@@ -1599,7 +1609,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JObject? getTokenLocation() {
     return _getTokenLocation(
             reference.pointer, _id_getTokenLocation as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_currentValue = _class.instanceMethodId(
@@ -1636,7 +1646,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JObject? currentValue() {
     return _currentValue(
             reference.pointer, _id_currentValue as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_assignCurrentValue = _class.instanceMethodId(
@@ -1698,7 +1708,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JObject? getCurrentValue() {
     return _getCurrentValue(
             reference.pointer, _id_getCurrentValue as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_setCurrentValue = _class.instanceMethodId(
@@ -1837,7 +1847,7 @@ class JsonParser extends jni$_.JObject {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _enable(
             reference.pointer, _id_enable as jni$_.JMethodIDPtr, _$f.pointer)
-        .object<JsonParser?>(const $JsonParser$NullableType());
+        .object<JsonParser?>(const $JsonParser$NullableType$());
   }
 
   static final _id_disable = _class.instanceMethodId(
@@ -1869,7 +1879,7 @@ class JsonParser extends jni$_.JObject {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _disable(
             reference.pointer, _id_disable as jni$_.JMethodIDPtr, _$f.pointer)
-        .object<JsonParser?>(const $JsonParser$NullableType());
+        .object<JsonParser?>(const $JsonParser$NullableType$());
   }
 
   static final _id_configure = _class.instanceMethodId(
@@ -1904,7 +1914,7 @@ class JsonParser extends jni$_.JObject {
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _configure(reference.pointer, _id_configure as jni$_.JMethodIDPtr,
             _$f.pointer, state ? 1 : 0)
-        .object<JsonParser?>(const $JsonParser$NullableType());
+        .object<JsonParser?>(const $JsonParser$NullableType$());
   }
 
   static final _id_isEnabled = _class.instanceMethodId(
@@ -2024,7 +2034,7 @@ class JsonParser extends jni$_.JObject {
   ) {
     return _setFeatureMask(
             reference.pointer, _id_setFeatureMask as jni$_.JMethodIDPtr, mask)
-        .object<JsonParser?>(const $JsonParser$NullableType());
+        .object<JsonParser?>(const $JsonParser$NullableType$());
   }
 
   static final _id_overrideStdFeatures = _class.instanceMethodId(
@@ -2064,7 +2074,7 @@ class JsonParser extends jni$_.JObject {
   ) {
     return _overrideStdFeatures(reference.pointer,
             _id_overrideStdFeatures as jni$_.JMethodIDPtr, values, mask)
-        .object<JsonParser?>(const $JsonParser$NullableType());
+        .object<JsonParser?>(const $JsonParser$NullableType$());
   }
 
   static final _id_getFormatFeatures = _class.instanceMethodId(
@@ -2131,7 +2141,7 @@ class JsonParser extends jni$_.JObject {
   ) {
     return _overrideFormatFeatures(reference.pointer,
             _id_overrideFormatFeatures as jni$_.JMethodIDPtr, values, mask)
-        .object<JsonParser?>(const $JsonParser$NullableType());
+        .object<JsonParser?>(const $JsonParser$NullableType$());
   }
 
   static final _id_nextToken = _class.instanceMethodId(
@@ -2165,7 +2175,7 @@ class JsonParser extends jni$_.JObject {
   jsontoken$_.JsonToken? nextToken() {
     return _nextToken(reference.pointer, _id_nextToken as jni$_.JMethodIDPtr)
         .object<jsontoken$_.JsonToken?>(
-            const jsontoken$_.$JsonToken$NullableType());
+            const jsontoken$_.$JsonToken$NullableType$());
   }
 
   static final _id_nextValue = _class.instanceMethodId(
@@ -2207,7 +2217,7 @@ class JsonParser extends jni$_.JObject {
   jsontoken$_.JsonToken? nextValue() {
     return _nextValue(reference.pointer, _id_nextValue as jni$_.JMethodIDPtr)
         .object<jsontoken$_.JsonToken?>(
-            const jsontoken$_.$JsonToken$NullableType());
+            const jsontoken$_.$JsonToken$NullableType$());
   }
 
   static final _id_nextFieldName = _class.instanceMethodId(
@@ -2283,7 +2293,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JString? nextFieldName$1() {
     return _nextFieldName$1(
             reference.pointer, _id_nextFieldName$1 as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_nextTextValue = _class.instanceMethodId(
@@ -2322,7 +2332,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JString? nextTextValue() {
     return _nextTextValue(
             reference.pointer, _id_nextTextValue as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_nextIntValue = _class.instanceMethodId(
@@ -2448,7 +2458,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JBoolean? nextBooleanValue() {
     return _nextBooleanValue(
             reference.pointer, _id_nextBooleanValue as jni$_.JMethodIDPtr)
-        .object<jni$_.JBoolean?>(const jni$_.JBooleanNullableType());
+        .object<jni$_.JBoolean?>(const jni$_.$JBoolean$NullableType$());
   }
 
   static final _id_skipChildren = _class.instanceMethodId(
@@ -2489,7 +2499,7 @@ class JsonParser extends jni$_.JObject {
   JsonParser? skipChildren() {
     return _skipChildren(
             reference.pointer, _id_skipChildren as jni$_.JMethodIDPtr)
-        .object<JsonParser?>(const $JsonParser$NullableType());
+        .object<JsonParser?>(const $JsonParser$NullableType$());
   }
 
   static final _id_finishToken = _class.instanceMethodId(
@@ -2562,7 +2572,7 @@ class JsonParser extends jni$_.JObject {
     return _currentToken(
             reference.pointer, _id_currentToken as jni$_.JMethodIDPtr)
         .object<jsontoken$_.JsonToken?>(
-            const jsontoken$_.$JsonToken$NullableType());
+            const jsontoken$_.$JsonToken$NullableType$());
   }
 
   static final _id_currentTokenId = _class.instanceMethodId(
@@ -2627,7 +2637,7 @@ class JsonParser extends jni$_.JObject {
     return _getCurrentToken(
             reference.pointer, _id_getCurrentToken as jni$_.JMethodIDPtr)
         .object<jsontoken$_.JsonToken?>(
-            const jsontoken$_.$JsonToken$NullableType());
+            const jsontoken$_.$JsonToken$NullableType$());
   }
 
   static final _id_getCurrentTokenId = _class.instanceMethodId(
@@ -2975,7 +2985,7 @@ class JsonParser extends jni$_.JObject {
     return _getLastClearedToken(
             reference.pointer, _id_getLastClearedToken as jni$_.JMethodIDPtr)
         .object<jsontoken$_.JsonToken?>(
-            const jsontoken$_.$JsonToken$NullableType());
+            const jsontoken$_.$JsonToken$NullableType$());
   }
 
   static final _id_overrideCurrentName = _class.instanceMethodId(
@@ -3040,7 +3050,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JString? getCurrentName() {
     return _getCurrentName(
             reference.pointer, _id_getCurrentName as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_currentName = _class.instanceMethodId(
@@ -3075,7 +3085,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JString? currentName() {
     return _currentName(
             reference.pointer, _id_currentName as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_getText = _class.instanceMethodId(
@@ -3108,7 +3118,7 @@ class JsonParser extends jni$_.JObject {
   ///   JsonParseException for decoding problems
   jni$_.JString? getText() {
     return _getText(reference.pointer, _id_getText as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_getText$1 = _class.instanceMethodId(
@@ -3203,7 +3213,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JCharArray? getTextCharacters() {
     return _getTextCharacters(
             reference.pointer, _id_getTextCharacters as jni$_.JMethodIDPtr)
-        .object<jni$_.JCharArray?>(const jni$_.JCharArrayNullableType());
+        .object<jni$_.JCharArray?>(const jni$_.$JCharArray$NullableType$());
   }
 
   static final _id_getTextLength = _class.instanceMethodId(
@@ -3342,7 +3352,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JNumber? getNumberValue() {
     return _getNumberValue(
             reference.pointer, _id_getNumberValue as jni$_.JMethodIDPtr)
-        .object<jni$_.JNumber?>(const jni$_.JNumberNullableType());
+        .object<jni$_.JNumber?>(const jni$_.$JNumber$NullableType$());
   }
 
   static final _id_getNumberValueExact = _class.instanceMethodId(
@@ -3382,7 +3392,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JNumber? getNumberValueExact() {
     return _getNumberValueExact(
             reference.pointer, _id_getNumberValueExact as jni$_.JMethodIDPtr)
-        .object<jni$_.JNumber?>(const jni$_.JNumberNullableType());
+        .object<jni$_.JNumber?>(const jni$_.$JNumber$NullableType$());
   }
 
   static final _id_getNumberType = _class.instanceMethodId(
@@ -3416,7 +3426,7 @@ class JsonParser extends jni$_.JObject {
     return _getNumberType(
             reference.pointer, _id_getNumberType as jni$_.JMethodIDPtr)
         .object<JsonParser$NumberType?>(
-            const $JsonParser$NumberType$NullableType());
+            const $JsonParser$NumberType$NullableType$());
   }
 
   static final _id_getByteValue = _class.instanceMethodId(
@@ -3619,7 +3629,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JObject? getBigIntegerValue() {
     return _getBigIntegerValue(
             reference.pointer, _id_getBigIntegerValue as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getFloatValue = _class.instanceMethodId(
@@ -3733,7 +3743,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JObject? getDecimalValue() {
     return _getDecimalValue(
             reference.pointer, _id_getDecimalValue as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getBooleanValue = _class.instanceMethodId(
@@ -3809,7 +3819,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JObject? getEmbeddedObject() {
     return _getEmbeddedObject(
             reference.pointer, _id_getEmbeddedObject as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getBinaryValue = _class.instanceMethodId(
@@ -3857,7 +3867,7 @@ class JsonParser extends jni$_.JObject {
     final _$bv = bv?.reference ?? jni$_.jNullReference;
     return _getBinaryValue(reference.pointer,
             _id_getBinaryValue as jni$_.JMethodIDPtr, _$bv.pointer)
-        .object<jni$_.JByteArray?>(const jni$_.JByteArrayNullableType());
+        .object<jni$_.JByteArray?>(const jni$_.$JByteArray$NullableType$());
   }
 
   static final _id_getBinaryValue$1 = _class.instanceMethodId(
@@ -3889,7 +3899,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JByteArray? getBinaryValue$1() {
     return _getBinaryValue$1(
             reference.pointer, _id_getBinaryValue$1 as jni$_.JMethodIDPtr)
-        .object<jni$_.JByteArray?>(const jni$_.JByteArrayNullableType());
+        .object<jni$_.JByteArray?>(const jni$_.$JByteArray$NullableType$());
   }
 
   static final _id_readBinaryValue = _class.instanceMethodId(
@@ -4316,7 +4326,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JString? getValueAsString() {
     return _getValueAsString(
             reference.pointer, _id_getValueAsString as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_getValueAsString$1 = _class.instanceMethodId(
@@ -4356,7 +4366,7 @@ class JsonParser extends jni$_.JObject {
     final _$def = def?.reference ?? jni$_.jNullReference;
     return _getValueAsString$1(reference.pointer,
             _id_getValueAsString$1 as jni$_.JMethodIDPtr, _$def.pointer)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_canReadObjectId = _class.instanceMethodId(
@@ -4467,7 +4477,7 @@ class JsonParser extends jni$_.JObject {
   jni$_.JObject? getObjectId() {
     return _getObjectId(
             reference.pointer, _id_getObjectId as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getTypeId = _class.instanceMethodId(
@@ -4505,7 +4515,7 @@ class JsonParser extends jni$_.JObject {
   ///@since 2.3
   jni$_.JObject? getTypeId() {
     return _getTypeId(reference.pointer, _id_getTypeId as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_readValueAs = _class.instanceMethodId(
@@ -4554,7 +4564,7 @@ class JsonParser extends jni$_.JObject {
   ///    issue at format layer
   $T? readValueAs<$T extends jni$_.JObject?>(
     jni$_.JObject? valueType, {
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     final _$valueType = valueType?.reference ?? jni$_.jNullReference;
     return _readValueAs(reference.pointer,
@@ -4605,7 +4615,7 @@ class JsonParser extends jni$_.JObject {
   ///    issue at format layer
   $T? readValueAs$1<$T extends jni$_.JObject?>(
     jni$_.JObject? valueTypeRef, {
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     final _$valueTypeRef = valueTypeRef?.reference ?? jni$_.jNullReference;
     return _readValueAs$1(reference.pointer,
@@ -4642,13 +4652,13 @@ class JsonParser extends jni$_.JObject {
   ///    issue at format layer
   jni$_.JIterator<$T?>? readValuesAs<$T extends jni$_.JObject?>(
     jni$_.JObject? valueType, {
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     final _$valueType = valueType?.reference ?? jni$_.jNullReference;
     return _readValuesAs(reference.pointer,
             _id_readValuesAs as jni$_.JMethodIDPtr, _$valueType.pointer)
         .object<jni$_.JIterator<$T?>?>(
-            jni$_.JIteratorNullableType<$T?>(T.nullableType));
+            jni$_.$JIterator$NullableType$<$T?>(T.nullableType));
   }
 
   static final _id_readValuesAs$1 = _class.instanceMethodId(
@@ -4680,13 +4690,13 @@ class JsonParser extends jni$_.JObject {
   ///    issue at format layer
   jni$_.JIterator<$T?>? readValuesAs$1<$T extends jni$_.JObject?>(
     jni$_.JObject? valueTypeRef, {
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     final _$valueTypeRef = valueTypeRef?.reference ?? jni$_.jNullReference;
     return _readValuesAs$1(reference.pointer,
             _id_readValuesAs$1 as jni$_.JMethodIDPtr, _$valueTypeRef.pointer)
         .object<jni$_.JIterator<$T?>?>(
-            jni$_.JIteratorNullableType<$T?>(T.nullableType));
+            jni$_.$JIterator$NullableType$<$T?>(T.nullableType));
   }
 
   static final _id_readValueAsTree = _class.instanceMethodId(
@@ -4719,7 +4729,7 @@ class JsonParser extends jni$_.JObject {
   ///@throws IOException if there is either an underlying I/O problem or decoding
   ///    issue at format layer
   $T? readValueAsTree<$T extends jni$_.JObject?>({
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     return _readValueAsTree(
             reference.pointer, _id_readValueAsTree as jni$_.JMethodIDPtr)
@@ -4727,9 +4737,9 @@ class JsonParser extends jni$_.JObject {
   }
 }
 
-final class $JsonParser$NullableType extends jni$_.JObjType<JsonParser?> {
+final class $JsonParser$NullableType$ extends jni$_.JType<JsonParser?> {
   @jni$_.internal
-  const $JsonParser$NullableType();
+  const $JsonParser$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -4744,29 +4754,29 @@ final class $JsonParser$NullableType extends jni$_.JObjType<JsonParser?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonParser?> get nullableType => this;
+  jni$_.JType<JsonParser?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonParser$NullableType).hashCode;
+  int get hashCode => ($JsonParser$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonParser$NullableType) &&
-        other is $JsonParser$NullableType;
+    return other.runtimeType == ($JsonParser$NullableType$) &&
+        other is $JsonParser$NullableType$;
   }
 }
 
-final class $JsonParser$Type extends jni$_.JObjType<JsonParser> {
+final class $JsonParser$Type$ extends jni$_.JType<JsonParser> {
   @jni$_.internal
-  const $JsonParser$Type();
+  const $JsonParser$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -4780,22 +4790,23 @@ final class $JsonParser$Type extends jni$_.JObjType<JsonParser> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonParser?> get nullableType =>
-      const $JsonParser$NullableType();
+  jni$_.JType<JsonParser?> get nullableType =>
+      const $JsonParser$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonParser$Type).hashCode;
+  int get hashCode => ($JsonParser$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonParser$Type) && other is $JsonParser$Type;
+    return other.runtimeType == ($JsonParser$Type$) &&
+        other is $JsonParser$Type$;
   }
 }

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonToken.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonToken.dart
@@ -60,7 +60,7 @@ import 'package:jni/jni.dart' as jni$_;
 class JsonToken extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<JsonToken> $type;
+  final jni$_.JType<JsonToken> $type;
 
   @jni$_.internal
   JsonToken.fromReference(
@@ -72,8 +72,11 @@ class JsonToken extends jni$_.JObject {
       jni$_.JClass.forName(r'com/fasterxml/jackson/core/JsonToken');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $JsonToken$NullableType();
-  static const type = $JsonToken$Type();
+  static const jni$_.JType<JsonToken?> nullableType =
+      $JsonToken$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<JsonToken> type = $JsonToken$Type$();
   static final _id_NOT_AVAILABLE = _class.staticFieldId(
     r'NOT_AVAILABLE',
     r'Lcom/fasterxml/jackson/core/JsonToken;',
@@ -90,7 +93,7 @@ class JsonToken extends jni$_.JObject {
   /// they can not block to wait for more data to parse and
   /// must return something.
   static JsonToken get NOT_AVAILABLE =>
-      _id_NOT_AVAILABLE.get(_class, const $JsonToken$Type());
+      _id_NOT_AVAILABLE.get(_class, const $JsonToken$Type$());
 
   static final _id_START_OBJECT = _class.staticFieldId(
     r'START_OBJECT',
@@ -103,7 +106,7 @@ class JsonToken extends jni$_.JObject {
   /// START_OBJECT is returned when encountering '{'
   /// which signals starting of an Object value.
   static JsonToken get START_OBJECT =>
-      _id_START_OBJECT.get(_class, const $JsonToken$Type());
+      _id_START_OBJECT.get(_class, const $JsonToken$Type$());
 
   static final _id_END_OBJECT = _class.staticFieldId(
     r'END_OBJECT',
@@ -116,7 +119,7 @@ class JsonToken extends jni$_.JObject {
   /// END_OBJECT is returned when encountering '}'
   /// which signals ending of an Object value
   static JsonToken get END_OBJECT =>
-      _id_END_OBJECT.get(_class, const $JsonToken$Type());
+      _id_END_OBJECT.get(_class, const $JsonToken$Type$());
 
   static final _id_START_ARRAY = _class.staticFieldId(
     r'START_ARRAY',
@@ -129,7 +132,7 @@ class JsonToken extends jni$_.JObject {
   /// START_ARRAY is returned when encountering '['
   /// which signals starting of an Array value
   static JsonToken get START_ARRAY =>
-      _id_START_ARRAY.get(_class, const $JsonToken$Type());
+      _id_START_ARRAY.get(_class, const $JsonToken$Type$());
 
   static final _id_END_ARRAY = _class.staticFieldId(
     r'END_ARRAY',
@@ -142,7 +145,7 @@ class JsonToken extends jni$_.JObject {
   /// END_ARRAY is returned when encountering ']'
   /// which signals ending of an Array value
   static JsonToken get END_ARRAY =>
-      _id_END_ARRAY.get(_class, const $JsonToken$Type());
+      _id_END_ARRAY.get(_class, const $JsonToken$Type$());
 
   static final _id_FIELD_NAME = _class.staticFieldId(
     r'FIELD_NAME',
@@ -155,7 +158,7 @@ class JsonToken extends jni$_.JObject {
   /// FIELD_NAME is returned when a String token is encountered
   /// as a field name (same lexical value, different function)
   static JsonToken get FIELD_NAME =>
-      _id_FIELD_NAME.get(_class, const $JsonToken$Type());
+      _id_FIELD_NAME.get(_class, const $JsonToken$Type$());
 
   static final _id_VALUE_EMBEDDED_OBJECT = _class.staticFieldId(
     r'VALUE_EMBEDDED_OBJECT',
@@ -174,7 +177,7 @@ class JsonToken extends jni$_.JObject {
   /// only by readers that expose other kinds of source (like
   /// <code>JsonNode</code>-based JSON trees, Maps, Lists and such).
   static JsonToken get VALUE_EMBEDDED_OBJECT =>
-      _id_VALUE_EMBEDDED_OBJECT.get(_class, const $JsonToken$Type());
+      _id_VALUE_EMBEDDED_OBJECT.get(_class, const $JsonToken$Type$());
 
   static final _id_VALUE_STRING = _class.staticFieldId(
     r'VALUE_STRING',
@@ -188,7 +191,7 @@ class JsonToken extends jni$_.JObject {
   /// in value context (array element, field value, or root-level
   /// stand-alone value)
   static JsonToken get VALUE_STRING =>
-      _id_VALUE_STRING.get(_class, const $JsonToken$Type());
+      _id_VALUE_STRING.get(_class, const $JsonToken$Type$());
 
   static final _id_VALUE_NUMBER_INT = _class.staticFieldId(
     r'VALUE_NUMBER_INT',
@@ -205,7 +208,7 @@ class JsonToken extends jni$_.JObject {
   /// or, for binary formats, is indicated as integral number
   /// by internal representation).
   static JsonToken get VALUE_NUMBER_INT =>
-      _id_VALUE_NUMBER_INT.get(_class, const $JsonToken$Type());
+      _id_VALUE_NUMBER_INT.get(_class, const $JsonToken$Type$());
 
   static final _id_VALUE_NUMBER_FLOAT = _class.staticFieldId(
     r'VALUE_NUMBER_FLOAT',
@@ -221,7 +224,7 @@ class JsonToken extends jni$_.JObject {
   /// to one or more digits (or, for non-textual formats,
   /// has internal floating-point representation).
   static JsonToken get VALUE_NUMBER_FLOAT =>
-      _id_VALUE_NUMBER_FLOAT.get(_class, const $JsonToken$Type());
+      _id_VALUE_NUMBER_FLOAT.get(_class, const $JsonToken$Type$());
 
   static final _id_VALUE_TRUE = _class.staticFieldId(
     r'VALUE_TRUE',
@@ -234,7 +237,7 @@ class JsonToken extends jni$_.JObject {
   /// VALUE_TRUE is returned when encountering literal "true" in
   /// value context
   static JsonToken get VALUE_TRUE =>
-      _id_VALUE_TRUE.get(_class, const $JsonToken$Type());
+      _id_VALUE_TRUE.get(_class, const $JsonToken$Type$());
 
   static final _id_VALUE_FALSE = _class.staticFieldId(
     r'VALUE_FALSE',
@@ -247,7 +250,7 @@ class JsonToken extends jni$_.JObject {
   /// VALUE_FALSE is returned when encountering literal "false" in
   /// value context
   static JsonToken get VALUE_FALSE =>
-      _id_VALUE_FALSE.get(_class, const $JsonToken$Type());
+      _id_VALUE_FALSE.get(_class, const $JsonToken$Type$());
 
   static final _id_VALUE_NULL = _class.staticFieldId(
     r'VALUE_NULL',
@@ -260,7 +263,7 @@ class JsonToken extends jni$_.JObject {
   /// VALUE_NULL is returned when encountering literal "null" in
   /// value context
   static JsonToken get VALUE_NULL =>
-      _id_VALUE_NULL.get(_class, const $JsonToken$Type());
+      _id_VALUE_NULL.get(_class, const $JsonToken$Type$());
 
   static final _id_values = _class.staticMethodId(
     r'values',
@@ -284,8 +287,8 @@ class JsonToken extends jni$_.JObject {
   static jni$_.JArray<JsonToken?>? values() {
     return _values(_class.reference.pointer, _id_values as jni$_.JMethodIDPtr)
         .object<jni$_.JArray<JsonToken?>?>(
-            const jni$_.JArrayNullableType<JsonToken?>(
-                $JsonToken$NullableType()));
+            const jni$_.$JArray$NullableType$<JsonToken?>(
+                $JsonToken$NullableType$()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -312,7 +315,7 @@ class JsonToken extends jni$_.JObject {
     final _$name = name?.reference ?? jni$_.jNullReference;
     return _valueOf(_class.reference.pointer, _id_valueOf as jni$_.JMethodIDPtr,
             _$name.pointer)
-        .object<JsonToken?>(const $JsonToken$NullableType());
+        .object<JsonToken?>(const $JsonToken$NullableType$());
   }
 
   static final _id_id = _class.instanceMethodId(
@@ -358,7 +361,7 @@ class JsonToken extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? asString() {
     return _asString(reference.pointer, _id_asString as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_asCharArray = _class.instanceMethodId(
@@ -383,7 +386,7 @@ class JsonToken extends jni$_.JObject {
   jni$_.JCharArray? asCharArray() {
     return _asCharArray(
             reference.pointer, _id_asCharArray as jni$_.JMethodIDPtr)
-        .object<jni$_.JCharArray?>(const jni$_.JCharArrayNullableType());
+        .object<jni$_.JCharArray?>(const jni$_.$JCharArray$NullableType$());
   }
 
   static final _id_asByteArray = _class.instanceMethodId(
@@ -408,7 +411,7 @@ class JsonToken extends jni$_.JObject {
   jni$_.JByteArray? asByteArray() {
     return _asByteArray(
             reference.pointer, _id_asByteArray as jni$_.JMethodIDPtr)
-        .object<jni$_.JByteArray?>(const jni$_.JByteArrayNullableType());
+        .object<jni$_.JByteArray?>(const jni$_.$JByteArray$NullableType$());
   }
 
   static final _id_isNumeric = _class.instanceMethodId(
@@ -559,9 +562,9 @@ class JsonToken extends jni$_.JObject {
   }
 }
 
-final class $JsonToken$NullableType extends jni$_.JObjType<JsonToken?> {
+final class $JsonToken$NullableType$ extends jni$_.JType<JsonToken?> {
   @jni$_.internal
-  const $JsonToken$NullableType();
+  const $JsonToken$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -576,29 +579,29 @@ final class $JsonToken$NullableType extends jni$_.JObjType<JsonToken?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonToken?> get nullableType => this;
+  jni$_.JType<JsonToken?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonToken$NullableType).hashCode;
+  int get hashCode => ($JsonToken$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonToken$NullableType) &&
-        other is $JsonToken$NullableType;
+    return other.runtimeType == ($JsonToken$NullableType$) &&
+        other is $JsonToken$NullableType$;
   }
 }
 
-final class $JsonToken$Type extends jni$_.JObjType<JsonToken> {
+final class $JsonToken$Type$ extends jni$_.JType<JsonToken> {
   @jni$_.internal
-  const $JsonToken$Type();
+  const $JsonToken$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -612,22 +615,21 @@ final class $JsonToken$Type extends jni$_.JObjType<JsonToken> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonToken?> get nullableType =>
-      const $JsonToken$NullableType();
+  jni$_.JType<JsonToken?> get nullableType => const $JsonToken$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonToken$Type).hashCode;
+  int get hashCode => ($JsonToken$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonToken$Type) && other is $JsonToken$Type;
+    return other.runtimeType == ($JsonToken$Type$) && other is $JsonToken$Type$;
   }
 }

--- a/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
+++ b/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
@@ -44,7 +44,7 @@ import 'package:jni/jni.dart' as jni$_;
 class CanDoA extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<CanDoA> $type;
+  final jni$_.JType<CanDoA> $type;
 
   @jni$_.internal
   CanDoA.fromReference(
@@ -56,8 +56,10 @@ class CanDoA extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/CanDoA');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $CanDoA$NullableType();
-  static const type = $CanDoA$Type();
+  static const jni$_.JType<CanDoA?> nullableType = $CanDoA$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<CanDoA> type = $CanDoA$Type$();
   static final _id_doA = _class.instanceMethodId(
     r'doA',
     r'()V',
@@ -182,9 +184,9 @@ final class _$CanDoA with $CanDoA {
   }
 }
 
-final class $CanDoA$NullableType extends jni$_.JObjType<CanDoA?> {
+final class $CanDoA$NullableType$ extends jni$_.JType<CanDoA?> {
   @jni$_.internal
-  const $CanDoA$NullableType();
+  const $CanDoA$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -199,29 +201,29 @@ final class $CanDoA$NullableType extends jni$_.JObjType<CanDoA?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<CanDoA?> get nullableType => this;
+  jni$_.JType<CanDoA?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($CanDoA$NullableType).hashCode;
+  int get hashCode => ($CanDoA$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($CanDoA$NullableType) &&
-        other is $CanDoA$NullableType;
+    return other.runtimeType == ($CanDoA$NullableType$) &&
+        other is $CanDoA$NullableType$;
   }
 }
 
-final class $CanDoA$Type extends jni$_.JObjType<CanDoA> {
+final class $CanDoA$Type$ extends jni$_.JType<CanDoA> {
   @jni$_.internal
-  const $CanDoA$Type();
+  const $CanDoA$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -234,22 +236,22 @@ final class $CanDoA$Type extends jni$_.JObjType<CanDoA> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<CanDoA?> get nullableType => const $CanDoA$NullableType();
+  jni$_.JType<CanDoA?> get nullableType => const $CanDoA$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($CanDoA$Type).hashCode;
+  int get hashCode => ($CanDoA$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($CanDoA$Type) && other is $CanDoA$Type;
+    return other.runtimeType == ($CanDoA$Type$) && other is $CanDoA$Type$;
   }
 }
 
@@ -257,7 +259,7 @@ final class $CanDoA$Type extends jni$_.JObjType<CanDoA> {
 class CanDoB extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<CanDoB> $type;
+  final jni$_.JType<CanDoB> $type;
 
   @jni$_.internal
   CanDoB.fromReference(
@@ -269,8 +271,10 @@ class CanDoB extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/CanDoB');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $CanDoB$NullableType();
-  static const type = $CanDoB$Type();
+  static const jni$_.JType<CanDoB?> nullableType = $CanDoB$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<CanDoB> type = $CanDoB$Type$();
   static final _id_doB = _class.instanceMethodId(
     r'doB',
     r'()V',
@@ -395,9 +399,9 @@ final class _$CanDoB with $CanDoB {
   }
 }
 
-final class $CanDoB$NullableType extends jni$_.JObjType<CanDoB?> {
+final class $CanDoB$NullableType$ extends jni$_.JType<CanDoB?> {
   @jni$_.internal
-  const $CanDoB$NullableType();
+  const $CanDoB$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -412,29 +416,29 @@ final class $CanDoB$NullableType extends jni$_.JObjType<CanDoB?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<CanDoB?> get nullableType => this;
+  jni$_.JType<CanDoB?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($CanDoB$NullableType).hashCode;
+  int get hashCode => ($CanDoB$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($CanDoB$NullableType) &&
-        other is $CanDoB$NullableType;
+    return other.runtimeType == ($CanDoB$NullableType$) &&
+        other is $CanDoB$NullableType$;
   }
 }
 
-final class $CanDoB$Type extends jni$_.JObjType<CanDoB> {
+final class $CanDoB$Type$ extends jni$_.JType<CanDoB> {
   @jni$_.internal
-  const $CanDoB$Type();
+  const $CanDoB$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -447,22 +451,22 @@ final class $CanDoB$Type extends jni$_.JObjType<CanDoB> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<CanDoB?> get nullableType => const $CanDoB$NullableType();
+  jni$_.JType<CanDoB?> get nullableType => const $CanDoB$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($CanDoB$Type).hashCode;
+  int get hashCode => ($CanDoB$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($CanDoB$Type) && other is $CanDoB$Type;
+    return other.runtimeType == ($CanDoB$Type$) && other is $CanDoB$Type$;
   }
 }
 
@@ -470,10 +474,10 @@ final class $CanDoB$Type extends jni$_.JObjType<CanDoB> {
 class Measure<$T extends jni$_.JObject> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Measure<$T>> $type;
+  final jni$_.JType<Measure<$T>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
   Measure.fromReference(
@@ -486,18 +490,19 @@ class Measure<$T extends jni$_.JObject> extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/Measure');
 
   /// The type which includes information such as the signature of this class.
-  static $Measure$NullableType<$T> nullableType<$T extends jni$_.JObject>(
-    jni$_.JObjType<$T> T,
+  static jni$_.JType<Measure<$T>?> nullableType<$T extends jni$_.JObject>(
+    jni$_.JType<$T> T,
   ) {
-    return $Measure$NullableType<$T>(
+    return $Measure$NullableType$<$T>(
       T,
     );
   }
 
-  static $Measure$Type<$T> type<$T extends jni$_.JObject>(
-    jni$_.JObjType<$T> T,
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<Measure<$T>> type<$T extends jni$_.JObject>(
+    jni$_.JType<$T> T,
   ) {
-    return $Measure$Type<$T>(
+    return $Measure$Type$<$T>(
       T,
     );
   }
@@ -576,13 +581,13 @@ class Measure<$T extends jni$_.JObject> extends jni$_.JObject {
   }
 }
 
-final class $Measure$NullableType<$T extends jni$_.JObject>
-    extends jni$_.JObjType<Measure<$T>?> {
+final class $Measure$NullableType$<$T extends jni$_.JObject>
+    extends jni$_.JType<Measure<$T>?> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $Measure$NullableType(
+  const $Measure$NullableType$(
     this.T,
   );
 
@@ -600,34 +605,34 @@ final class $Measure$NullableType<$T extends jni$_.JObject>
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Measure<$T>?> get nullableType => this;
+  jni$_.JType<Measure<$T>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($Measure$NullableType, T);
+  int get hashCode => Object.hash($Measure$NullableType$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Measure$NullableType<$T>) &&
-        other is $Measure$NullableType<$T> &&
+    return other.runtimeType == ($Measure$NullableType$<$T>) &&
+        other is $Measure$NullableType$<$T> &&
         T == other.T;
   }
 }
 
-final class $Measure$Type<$T extends jni$_.JObject>
-    extends jni$_.JObjType<Measure<$T>> {
+final class $Measure$Type$<$T extends jni$_.JObject>
+    extends jni$_.JType<Measure<$T>> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $Measure$Type(
+  const $Measure$Type$(
     this.T,
   );
 
@@ -644,23 +649,23 @@ final class $Measure$Type<$T extends jni$_.JObject>
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Measure<$T>?> get nullableType => $Measure$NullableType<$T>(T);
+  jni$_.JType<Measure<$T>?> get nullableType => $Measure$NullableType$<$T>(T);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($Measure$Type, T);
+  int get hashCode => Object.hash($Measure$Type$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Measure$Type<$T>) &&
-        other is $Measure$Type<$T> &&
+    return other.runtimeType == ($Measure$Type$<$T>) &&
+        other is $Measure$Type$<$T> &&
         T == other.T;
   }
 }
@@ -669,7 +674,7 @@ final class $Measure$Type<$T extends jni$_.JObject>
 class MeasureUnit extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<MeasureUnit> $type;
+  final jni$_.JType<MeasureUnit> $type;
 
   @jni$_.internal
   MeasureUnit.fromReference(
@@ -681,8 +686,11 @@ class MeasureUnit extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/MeasureUnit');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $MeasureUnit$NullableType();
-  static const type = $MeasureUnit$Type();
+  static const jni$_.JType<MeasureUnit?> nullableType =
+      $MeasureUnit$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<MeasureUnit> type = $MeasureUnit$Type$();
   static final _id_getSign = _class.instanceMethodId(
     r'getSign',
     r'()Ljava/lang/String;',
@@ -704,7 +712,7 @@ class MeasureUnit extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString getSign() {
     return _getSign(reference.pointer, _id_getSign as jni$_.JMethodIDPtr)
-        .object<jni$_.JString>(const jni$_.JStringType());
+        .object<jni$_.JString>(const jni$_.$JString$Type$());
   }
 
   static final _id_getCoefficient = _class.instanceMethodId(
@@ -764,7 +772,7 @@ class MeasureUnit extends jni$_.JObject {
       if ($d == r'getSign()Ljava/lang/String;') {
         final $r = _$impls[$p]!.getSign();
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
@@ -844,9 +852,9 @@ final class _$MeasureUnit with $MeasureUnit {
   }
 }
 
-final class $MeasureUnit$NullableType extends jni$_.JObjType<MeasureUnit?> {
+final class $MeasureUnit$NullableType$ extends jni$_.JType<MeasureUnit?> {
   @jni$_.internal
-  const $MeasureUnit$NullableType();
+  const $MeasureUnit$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -861,29 +869,29 @@ final class $MeasureUnit$NullableType extends jni$_.JObjType<MeasureUnit?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MeasureUnit?> get nullableType => this;
+  jni$_.JType<MeasureUnit?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($MeasureUnit$NullableType).hashCode;
+  int get hashCode => ($MeasureUnit$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MeasureUnit$NullableType) &&
-        other is $MeasureUnit$NullableType;
+    return other.runtimeType == ($MeasureUnit$NullableType$) &&
+        other is $MeasureUnit$NullableType$;
   }
 }
 
-final class $MeasureUnit$Type extends jni$_.JObjType<MeasureUnit> {
+final class $MeasureUnit$Type$ extends jni$_.JType<MeasureUnit> {
   @jni$_.internal
-  const $MeasureUnit$Type();
+  const $MeasureUnit$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -897,24 +905,24 @@ final class $MeasureUnit$Type extends jni$_.JObjType<MeasureUnit> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MeasureUnit?> get nullableType =>
-      const $MeasureUnit$NullableType();
+  jni$_.JType<MeasureUnit?> get nullableType =>
+      const $MeasureUnit$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($MeasureUnit$Type).hashCode;
+  int get hashCode => ($MeasureUnit$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MeasureUnit$Type) &&
-        other is $MeasureUnit$Type;
+    return other.runtimeType == ($MeasureUnit$Type$) &&
+        other is $MeasureUnit$Type$;
   }
 }
 
@@ -923,16 +931,16 @@ class Nullability$InnerClass<$T extends jni$_.JObject?,
     $U extends jni$_.JObject, $V extends jni$_.JObject?> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Nullability$InnerClass<$T, $U, $V>> $type;
+  final jni$_.JType<Nullability$InnerClass<$T, $U, $V>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
   Nullability$InnerClass.fromReference(
@@ -947,30 +955,31 @@ class Nullability$InnerClass<$T extends jni$_.JObject?,
       r'com/github/dart_lang/jnigen/Nullability$InnerClass');
 
   /// The type which includes information such as the signature of this class.
-  static $Nullability$InnerClass$NullableType<$T, $U, $V> nullableType<
+  static jni$_.JType<Nullability$InnerClass<$T, $U, $V>?> nullableType<
       $T extends jni$_.JObject?,
       $U extends jni$_.JObject,
       $V extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
-    jni$_.JObjType<$U> U,
-    jni$_.JObjType<$V> V,
+    jni$_.JType<$T> T,
+    jni$_.JType<$U> U,
+    jni$_.JType<$V> V,
   ) {
-    return $Nullability$InnerClass$NullableType<$T, $U, $V>(
+    return $Nullability$InnerClass$NullableType$<$T, $U, $V>(
       T,
       U,
       V,
     );
   }
 
-  static $Nullability$InnerClass$Type<$T, $U, $V> type<
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<Nullability$InnerClass<$T, $U, $V>> type<
       $T extends jni$_.JObject?,
       $U extends jni$_.JObject,
       $V extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
-    jni$_.JObjType<$U> U,
-    jni$_.JObjType<$V> V,
+    jni$_.JType<$T> T,
+    jni$_.JType<$U> U,
+    jni$_.JType<$V> V,
   ) {
-    return $Nullability$InnerClass$Type<$T, $U, $V>(
+    return $Nullability$InnerClass$Type$<$T, $U, $V>(
       T,
       U,
       V,
@@ -996,18 +1005,18 @@ class Nullability$InnerClass<$T extends jni$_.JObject?,
   /// The returned object must be released after use, by calling the [release] method.
   factory Nullability$InnerClass(
     Nullability<$T?, $U> $outerClass, {
-    jni$_.JObjType<$T>? T,
-    jni$_.JObjType<$U>? U,
-    required jni$_.JObjType<$V> V,
+    jni$_.JType<$T>? T,
+    jni$_.JType<$U>? U,
+    required jni$_.JType<$V> V,
   }) {
     T ??= jni$_.lowestCommonSuperType([
-      ($outerClass.$type as $Nullability$Type<core$_.dynamic, core$_.dynamic>)
+      ($outerClass.$type as $Nullability$Type$<core$_.dynamic, core$_.dynamic>)
           .T,
-    ]) as jni$_.JObjType<$T>;
+    ]) as jni$_.JType<$T>;
     U ??= jni$_.lowestCommonSuperType([
-      ($outerClass.$type as $Nullability$Type<core$_.dynamic, core$_.dynamic>)
+      ($outerClass.$type as $Nullability$Type$<core$_.dynamic, core$_.dynamic>)
           .U,
-    ]) as jni$_.JObjType<$U>;
+    ]) as jni$_.JType<$U>;
     final _$$outerClass = $outerClass.reference;
     return Nullability$InnerClass<$T, $U, $V>.fromReference(
         T,
@@ -1057,20 +1066,20 @@ class Nullability$InnerClass<$T extends jni$_.JObject?,
   }
 }
 
-final class $Nullability$InnerClass$NullableType<$T extends jni$_.JObject?,
+final class $Nullability$InnerClass$NullableType$<$T extends jni$_.JObject?,
         $U extends jni$_.JObject, $V extends jni$_.JObject?>
-    extends jni$_.JObjType<Nullability$InnerClass<$T, $U, $V>?> {
+    extends jni$_.JType<Nullability$InnerClass<$T, $U, $V>?> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
-  const $Nullability$InnerClass$NullableType(
+  const $Nullability$InnerClass$NullableType$(
     this.T,
     this.U,
     this.V,
@@ -1095,11 +1104,11 @@ final class $Nullability$InnerClass$NullableType<$T extends jni$_.JObject?,
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Nullability$InnerClass<$T, $U, $V>?> get nullableType => this;
+  jni$_.JType<Nullability$InnerClass<$T, $U, $V>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
@@ -1107,33 +1116,33 @@ final class $Nullability$InnerClass$NullableType<$T extends jni$_.JObject?,
 
   @core$_.override
   int get hashCode =>
-      Object.hash($Nullability$InnerClass$NullableType, T, U, V);
+      Object.hash($Nullability$InnerClass$NullableType$, T, U, V);
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($Nullability$InnerClass$NullableType<$T, $U, $V>) &&
-        other is $Nullability$InnerClass$NullableType<$T, $U, $V> &&
+            ($Nullability$InnerClass$NullableType$<$T, $U, $V>) &&
+        other is $Nullability$InnerClass$NullableType$<$T, $U, $V> &&
         T == other.T &&
         U == other.U &&
         V == other.V;
   }
 }
 
-final class $Nullability$InnerClass$Type<$T extends jni$_.JObject?,
+final class $Nullability$InnerClass$Type$<$T extends jni$_.JObject?,
         $U extends jni$_.JObject, $V extends jni$_.JObject?>
-    extends jni$_.JObjType<Nullability$InnerClass<$T, $U, $V>> {
+    extends jni$_.JType<Nullability$InnerClass<$T, $U, $V>> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
-  const $Nullability$InnerClass$Type(
+  const $Nullability$InnerClass$Type$(
     this.T,
     this.U,
     this.V,
@@ -1156,24 +1165,24 @@ final class $Nullability$InnerClass$Type<$T extends jni$_.JObject?,
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Nullability$InnerClass<$T, $U, $V>?> get nullableType =>
-      $Nullability$InnerClass$NullableType<$T, $U, $V>(T, U, V);
+  jni$_.JType<Nullability$InnerClass<$T, $U, $V>?> get nullableType =>
+      $Nullability$InnerClass$NullableType$<$T, $U, $V>(T, U, V);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($Nullability$InnerClass$Type, T, U, V);
+  int get hashCode => Object.hash($Nullability$InnerClass$Type$, T, U, V);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Nullability$InnerClass$Type<$T, $U, $V>) &&
-        other is $Nullability$InnerClass$Type<$T, $U, $V> &&
+    return other.runtimeType == ($Nullability$InnerClass$Type$<$T, $U, $V>) &&
+        other is $Nullability$InnerClass$Type$<$T, $U, $V> &&
         T == other.T &&
         U == other.U &&
         V == other.V;
@@ -1185,13 +1194,13 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
     extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Nullability<$T, $U>> $type;
+  final jni$_.JType<Nullability<$T, $U>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
   Nullability.fromReference(
@@ -1205,23 +1214,24 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/Nullability');
 
   /// The type which includes information such as the signature of this class.
-  static $Nullability$NullableType<$T, $U>
+  static jni$_.JType<Nullability<$T, $U>?>
       nullableType<$T extends jni$_.JObject?, $U extends jni$_.JObject>(
-    jni$_.JObjType<$T> T,
-    jni$_.JObjType<$U> U,
+    jni$_.JType<$T> T,
+    jni$_.JType<$U> U,
   ) {
-    return $Nullability$NullableType<$T, $U>(
+    return $Nullability$NullableType$<$T, $U>(
       T,
       U,
     );
   }
 
-  static $Nullability$Type<$T, $U>
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<Nullability<$T, $U>>
       type<$T extends jni$_.JObject?, $U extends jni$_.JObject>(
-    jni$_.JObjType<$T> T,
-    jni$_.JObjType<$U> U,
+    jni$_.JType<$T> T,
+    jni$_.JType<$U> U,
   ) {
-    return $Nullability$Type<$T, $U>(
+    return $Nullability$Type$<$T, $U>(
       T,
       U,
     );
@@ -1256,12 +1266,12 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
     $T object,
     $U object1,
     $U? object2, {
-    required jni$_.JObjType<$T> T,
-    jni$_.JObjType<$U>? U,
+    required jni$_.JType<$T> T,
+    jni$_.JType<$U>? U,
   }) {
     U ??= jni$_.lowestCommonSuperType([
       object1.$type,
-    ]) as jni$_.JObjType<$U>;
+    ]) as jni$_.JType<$U>;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1.reference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -1394,8 +1404,8 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
   Nullability<jni$_.JObject?, jni$_.JObject> self() {
     return _self(reference.pointer, _id_self as jni$_.JMethodIDPtr)
         .object<Nullability<jni$_.JObject?, jni$_.JObject>>(
-            const $Nullability$Type<jni$_.JObject?, jni$_.JObject>(
-                jni$_.JObjectNullableType(), jni$_.JObjectType()));
+            const $Nullability$Type$<jni$_.JObject?, jni$_.JObject>(
+                jni$_.$JObject$NullableType$(), jni$_.$JObject$Type$()));
   }
 
   static final _id_hello = _class.instanceMethodId(
@@ -1419,7 +1429,7 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString hello() {
     return _hello(reference.pointer, _id_hello as jni$_.JMethodIDPtr)
-        .object<jni$_.JString>(const jni$_.JStringType());
+        .object<jni$_.JString>(const jni$_.$JString$Type$());
   }
 
   static final _id_nullableHello = _class.instanceMethodId(
@@ -1444,7 +1454,7 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
   ) {
     return _nullableHello(reference.pointer,
             _id_nullableHello as jni$_.JMethodIDPtr, z ? 1 : 0)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_list = _class.instanceMethodId(
@@ -1469,7 +1479,8 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
   jni$_.JList<jni$_.JObject?> list() {
     return _list(reference.pointer, _id_list as jni$_.JMethodIDPtr)
         .object<jni$_.JList<jni$_.JObject?>>(
-            const jni$_.JListType<jni$_.JObject?>(jni$_.JObjectNullableType()));
+            const jni$_.$JList$Type$<jni$_.JObject?>(
+                jni$_.$JObject$NullableType$()));
   }
 
   static final _id_methodGenericEcho = _class.instanceMethodId(
@@ -1492,11 +1503,11 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
   /// The returned object must be released after use, by calling the [release] method.
   $V methodGenericEcho<$V extends jni$_.JObject>(
     $V object, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
       object.$type,
-    ]) as jni$_.JObjType<$V>;
+    ]) as jni$_.JType<$V>;
     final _$object = object.reference;
     return _methodGenericEcho(reference.pointer,
             _id_methodGenericEcho as jni$_.JMethodIDPtr, _$object.pointer)
@@ -1523,7 +1534,7 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
   /// The returned object must be released after use, by calling the [release] method.
   $V methodGenericNullableEcho<$V extends jni$_.JObject?>(
     $V object, {
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$V> V,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _methodGenericNullableEcho(
@@ -1613,7 +1624,7 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
     final _$list = list.reference;
     return _firstOf(reference.pointer, _id_firstOf as jni$_.JMethodIDPtr,
             _$list.pointer)
-        .object<jni$_.JString>(const jni$_.JStringType());
+        .object<jni$_.JString>(const jni$_.$JString$Type$());
   }
 
   static final _id_firstOfNullable = _class.instanceMethodId(
@@ -1640,7 +1651,7 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
     final _$list = list.reference;
     return _firstOfNullable(reference.pointer,
             _id_firstOfNullable as jni$_.JMethodIDPtr, _$list.pointer)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_classGenericFirstOf = _class.instanceMethodId(
@@ -1720,11 +1731,11 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
   /// The returned object must be released after use, by calling the [release] method.
   $V methodGenericFirstOf<$V extends jni$_.JObject>(
     jni$_.JList<$V> list, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
-      (list.$type as jni$_.JListType<core$_.dynamic>).E,
-    ]) as jni$_.JObjType<$V>;
+      (list.$type as jni$_.$JList$Type$<core$_.dynamic>).E,
+    ]) as jni$_.JType<$V>;
     final _$list = list.reference;
     return _methodGenericFirstOf(reference.pointer,
             _id_methodGenericFirstOf as jni$_.JMethodIDPtr, _$list.pointer)
@@ -1752,11 +1763,11 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
   /// The returned object must be released after use, by calling the [release] method.
   $V methodGenericFirstOfNullable<$V extends jni$_.JObject?>(
     jni$_.JList<$V> list, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
-      (list.$type as jni$_.JListType<core$_.dynamic>).E,
-    ]) as jni$_.JObjType<$V>;
+      (list.$type as jni$_.$JList$Type$<core$_.dynamic>).E,
+    ]) as jni$_.JType<$V>;
     final _$list = list.reference;
     return _methodGenericFirstOfNullable(
             reference.pointer,
@@ -1790,7 +1801,7 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
     return _stringListOf(reference.pointer,
             _id_stringListOf as jni$_.JMethodIDPtr, _$string.pointer)
         .object<jni$_.JList<jni$_.JString>>(
-            const jni$_.JListType<jni$_.JString>(jni$_.JStringType()));
+            const jni$_.$JList$Type$<jni$_.JString>(jni$_.$JString$Type$()));
   }
 
   static final _id_nullableListOf = _class.instanceMethodId(
@@ -1818,7 +1829,8 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
     return _nullableListOf(reference.pointer,
             _id_nullableListOf as jni$_.JMethodIDPtr, _$string.pointer)
         .object<jni$_.JList<jni$_.JString?>>(
-            const jni$_.JListType<jni$_.JString?>(jni$_.JStringNullableType()));
+            const jni$_.$JList$Type$<jni$_.JString?>(
+                jni$_.$JString$NullableType$()));
   }
 
   static final _id_classGenericListOf = _class.instanceMethodId(
@@ -1845,7 +1857,7 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
     final _$object = object.reference;
     return _classGenericListOf(reference.pointer,
             _id_classGenericListOf as jni$_.JMethodIDPtr, _$object.pointer)
-        .object<jni$_.JList<$U>>(jni$_.JListType<$U>(U));
+        .object<jni$_.JList<$U>>(jni$_.$JList$Type$<$U>(U));
   }
 
   static final _id_classGenericNullableListOf = _class.instanceMethodId(
@@ -1875,7 +1887,7 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
             reference.pointer,
             _id_classGenericNullableListOf as jni$_.JMethodIDPtr,
             _$object.pointer)
-        .object<jni$_.JList<$T>>(jni$_.JListType<$T>(T));
+        .object<jni$_.JList<$T>>(jni$_.$JList$Type$<$T>(T));
   }
 
   static final _id_methodGenericListOf = _class.instanceMethodId(
@@ -1898,15 +1910,15 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<$V> methodGenericListOf<$V extends jni$_.JObject>(
     $V object, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
       object.$type,
-    ]) as jni$_.JObjType<$V>;
+    ]) as jni$_.JType<$V>;
     final _$object = object.reference;
     return _methodGenericListOf(reference.pointer,
             _id_methodGenericListOf as jni$_.JMethodIDPtr, _$object.pointer)
-        .object<jni$_.JList<$V>>(jni$_.JListType<$V>(V));
+        .object<jni$_.JList<$V>>(jni$_.$JList$Type$<$V>(V));
   }
 
   static final _id_methodGenericNullableListOf = _class.instanceMethodId(
@@ -1930,14 +1942,14 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<$V> methodGenericNullableListOf<$V extends jni$_.JObject?>(
     $V object, {
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$V> V,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _methodGenericNullableListOf(
             reference.pointer,
             _id_methodGenericNullableListOf as jni$_.JMethodIDPtr,
             _$object.pointer)
-        .object<jni$_.JList<$V>>(jni$_.JListType<$V>(V));
+        .object<jni$_.JList<$V>>(jni$_.$JList$Type$<$V>(V));
   }
 
   static final _id_methodWithVarArgs = _class.instanceMethodId(
@@ -1985,11 +1997,11 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
   /// from: `public fun <V> methodWithWhere(element: V): kotlin.Int where V : com.github.dart_lang.jnigen.CanDoA, V : com.github.dart_lang.jnigen.CanDoB`
   int methodWithWhere<$V extends jni$_.JObject>(
     $V canDoA, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
       canDoA.$type,
-    ]) as jni$_.JObjType<$V>;
+    ]) as jni$_.JType<$V>;
     final _$canDoA = canDoA.reference;
     return _methodWithWhere(reference.pointer,
             _id_methodWithWhere as jni$_.JMethodIDPtr, _$canDoA.pointer)
@@ -1997,16 +2009,16 @@ class Nullability<$T extends jni$_.JObject?, $U extends jni$_.JObject>
   }
 }
 
-final class $Nullability$NullableType<$T extends jni$_.JObject?,
-    $U extends jni$_.JObject> extends jni$_.JObjType<Nullability<$T, $U>?> {
+final class $Nullability$NullableType$<$T extends jni$_.JObject?,
+    $U extends jni$_.JObject> extends jni$_.JType<Nullability<$T, $U>?> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
-  const $Nullability$NullableType(
+  const $Nullability$NullableType$(
     this.T,
     this.U,
   );
@@ -2027,38 +2039,38 @@ final class $Nullability$NullableType<$T extends jni$_.JObject?,
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Nullability<$T, $U>?> get nullableType => this;
+  jni$_.JType<Nullability<$T, $U>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($Nullability$NullableType, T, U);
+  int get hashCode => Object.hash($Nullability$NullableType$, T, U);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Nullability$NullableType<$T, $U>) &&
-        other is $Nullability$NullableType<$T, $U> &&
+    return other.runtimeType == ($Nullability$NullableType$<$T, $U>) &&
+        other is $Nullability$NullableType$<$T, $U> &&
         T == other.T &&
         U == other.U;
   }
 }
 
-final class $Nullability$Type<$T extends jni$_.JObject?,
-    $U extends jni$_.JObject> extends jni$_.JObjType<Nullability<$T, $U>> {
+final class $Nullability$Type$<$T extends jni$_.JObject?,
+    $U extends jni$_.JObject> extends jni$_.JType<Nullability<$T, $U>> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
-  const $Nullability$Type(
+  const $Nullability$Type$(
     this.T,
     this.U,
   );
@@ -2077,24 +2089,24 @@ final class $Nullability$Type<$T extends jni$_.JObject?,
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Nullability<$T, $U>?> get nullableType =>
-      $Nullability$NullableType<$T, $U>(T, U);
+  jni$_.JType<Nullability<$T, $U>?> get nullableType =>
+      $Nullability$NullableType$<$T, $U>(T, U);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($Nullability$Type, T, U);
+  int get hashCode => Object.hash($Nullability$Type$, T, U);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Nullability$Type<$T, $U>) &&
-        other is $Nullability$Type<$T, $U> &&
+    return other.runtimeType == ($Nullability$Type$<$T, $U>) &&
+        other is $Nullability$Type$<$T, $U> &&
         T == other.T &&
         U == other.U;
   }
@@ -2104,7 +2116,7 @@ final class $Nullability$Type<$T extends jni$_.JObject?,
 class Operators extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Operators> $type;
+  final jni$_.JType<Operators> $type;
 
   @jni$_.internal
   Operators.fromReference(
@@ -2116,8 +2128,11 @@ class Operators extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/Operators');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Operators$NullableType();
-  static const type = $Operators$Type();
+  static const jni$_.JType<Operators?> nullableType =
+      $Operators$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Operators> type = $Operators$Type$();
   static final _id_new$ = _class.constructorId(
     r'(I)V',
   );
@@ -2211,7 +2226,7 @@ class Operators extends jni$_.JObject {
     final _$operators = operators.reference;
     return _plus(reference.pointer, _id_plus as jni$_.JMethodIDPtr,
             _$operators.pointer)
-        .object<Operators>(const $Operators$Type());
+        .object<Operators>(const $Operators$Type$());
   }
 
   static final _id_plus$1 = _class.instanceMethodId(
@@ -2235,7 +2250,7 @@ class Operators extends jni$_.JObject {
     int i,
   ) {
     return _plus$1(reference.pointer, _id_plus$1 as jni$_.JMethodIDPtr, i)
-        .object<Operators>(const $Operators$Type());
+        .object<Operators>(const $Operators$Type$());
   }
 
   static final _id_minus = _class.instanceMethodId(
@@ -2262,7 +2277,7 @@ class Operators extends jni$_.JObject {
     final _$operators = operators.reference;
     return _minus(reference.pointer, _id_minus as jni$_.JMethodIDPtr,
             _$operators.pointer)
-        .object<Operators>(const $Operators$Type());
+        .object<Operators>(const $Operators$Type$());
   }
 
   static final _id_times = _class.instanceMethodId(
@@ -2289,7 +2304,7 @@ class Operators extends jni$_.JObject {
     final _$operators = operators.reference;
     return _times(reference.pointer, _id_times as jni$_.JMethodIDPtr,
             _$operators.pointer)
-        .object<Operators>(const $Operators$Type());
+        .object<Operators>(const $Operators$Type$());
   }
 
   static final _id_div = _class.instanceMethodId(
@@ -2316,7 +2331,7 @@ class Operators extends jni$_.JObject {
     final _$operators = operators.reference;
     return _div(reference.pointer, _id_div as jni$_.JMethodIDPtr,
             _$operators.pointer)
-        .object<Operators>(const $Operators$Type());
+        .object<Operators>(const $Operators$Type$());
   }
 
   static final _id_rem = _class.instanceMethodId(
@@ -2343,7 +2358,7 @@ class Operators extends jni$_.JObject {
     final _$operators = operators.reference;
     return _rem(reference.pointer, _id_rem as jni$_.JMethodIDPtr,
             _$operators.pointer)
-        .object<Operators>(const $Operators$Type());
+        .object<Operators>(const $Operators$Type$());
   }
 
   static final _id_get = _class.instanceMethodId(
@@ -2465,9 +2480,9 @@ class Operators extends jni$_.JObject {
   }
 }
 
-final class $Operators$NullableType extends jni$_.JObjType<Operators?> {
+final class $Operators$NullableType$ extends jni$_.JType<Operators?> {
   @jni$_.internal
-  const $Operators$NullableType();
+  const $Operators$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -2482,29 +2497,29 @@ final class $Operators$NullableType extends jni$_.JObjType<Operators?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Operators?> get nullableType => this;
+  jni$_.JType<Operators?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Operators$NullableType).hashCode;
+  int get hashCode => ($Operators$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Operators$NullableType) &&
-        other is $Operators$NullableType;
+    return other.runtimeType == ($Operators$NullableType$) &&
+        other is $Operators$NullableType$;
   }
 }
 
-final class $Operators$Type extends jni$_.JObjType<Operators> {
+final class $Operators$Type$ extends jni$_.JType<Operators> {
   @jni$_.internal
-  const $Operators$Type();
+  const $Operators$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -2518,23 +2533,22 @@ final class $Operators$Type extends jni$_.JObjType<Operators> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Operators?> get nullableType =>
-      const $Operators$NullableType();
+  jni$_.JType<Operators?> get nullableType => const $Operators$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Operators$Type).hashCode;
+  int get hashCode => ($Operators$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Operators$Type) && other is $Operators$Type;
+    return other.runtimeType == ($Operators$Type$) && other is $Operators$Type$;
   }
 }
 
@@ -2542,20 +2556,22 @@ final class $Operators$Type extends jni$_.JObjType<Operators> {
 class Speed extends Measure<SpeedUnit> {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Speed> $type;
+  final jni$_.JType<Speed> $type;
 
   @jni$_.internal
   Speed.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
-        super.fromReference(const $SpeedUnit$Type(), reference);
+        super.fromReference(const $SpeedUnit$Type$(), reference);
 
   static final _class =
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/Speed');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Speed$NullableType();
-  static const type = $Speed$Type();
+  static const jni$_.JType<Speed?> nullableType = $Speed$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Speed> type = $Speed$Type$();
   static final _id_new$ = _class.constructorId(
     r'(FLcom/github/dart_lang/jnigen/SpeedUnit;)V',
   );
@@ -2630,7 +2646,7 @@ class Speed extends Measure<SpeedUnit> {
   /// The returned object must be released after use, by calling the [release] method.
   SpeedUnit getUnit$1() {
     return _getUnit$1(reference.pointer, _id_getUnit$1 as jni$_.JMethodIDPtr)
-        .object<SpeedUnit>(const $SpeedUnit$Type());
+        .object<SpeedUnit>(const $SpeedUnit$Type$());
   }
 
   static final _id_toString$1 = _class.instanceMethodId(
@@ -2654,7 +2670,7 @@ class Speed extends Measure<SpeedUnit> {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString toString$1() {
     return _toString$1(reference.pointer, _id_toString$1 as jni$_.JMethodIDPtr)
-        .object<jni$_.JString>(const jni$_.JStringType());
+        .object<jni$_.JString>(const jni$_.$JString$Type$());
   }
 
   static final _id_component1 = _class.instanceMethodId(
@@ -2701,7 +2717,7 @@ class Speed extends Measure<SpeedUnit> {
   /// The returned object must be released after use, by calling the [release] method.
   SpeedUnit component2() {
     return _component2(reference.pointer, _id_component2 as jni$_.JMethodIDPtr)
-        .object<SpeedUnit>(const $SpeedUnit$Type());
+        .object<SpeedUnit>(const $SpeedUnit$Type$());
   }
 
   static final _id_copy = _class.instanceMethodId(
@@ -2732,7 +2748,7 @@ class Speed extends Measure<SpeedUnit> {
     final _$speedUnit = speedUnit.reference;
     return _copy(reference.pointer, _id_copy as jni$_.JMethodIDPtr, f,
             _$speedUnit.pointer)
-        .object<Speed>(const $Speed$Type());
+        .object<Speed>(const $Speed$Type$());
   }
 
   static final _id_hashCode$1 = _class.instanceMethodId(
@@ -2785,9 +2801,9 @@ class Speed extends Measure<SpeedUnit> {
   }
 }
 
-final class $Speed$NullableType extends jni$_.JObjType<Speed?> {
+final class $Speed$NullableType$ extends jni$_.JType<Speed?> {
   @jni$_.internal
-  const $Speed$NullableType();
+  const $Speed$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -2802,30 +2818,30 @@ final class $Speed$NullableType extends jni$_.JObjType<Speed?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType =>
-      const $Measure$Type<SpeedUnit>($SpeedUnit$Type());
+  jni$_.JType get superType =>
+      const $Measure$Type$<SpeedUnit>($SpeedUnit$Type$());
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Speed?> get nullableType => this;
+  jni$_.JType<Speed?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 2;
 
   @core$_.override
-  int get hashCode => ($Speed$NullableType).hashCode;
+  int get hashCode => ($Speed$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Speed$NullableType) &&
-        other is $Speed$NullableType;
+    return other.runtimeType == ($Speed$NullableType$) &&
+        other is $Speed$NullableType$;
   }
 }
 
-final class $Speed$Type extends jni$_.JObjType<Speed> {
+final class $Speed$Type$ extends jni$_.JType<Speed> {
   @jni$_.internal
-  const $Speed$Type();
+  const $Speed$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -2838,23 +2854,23 @@ final class $Speed$Type extends jni$_.JObjType<Speed> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType =>
-      const $Measure$Type<SpeedUnit>($SpeedUnit$Type());
+  jni$_.JType get superType =>
+      const $Measure$Type$<SpeedUnit>($SpeedUnit$Type$());
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Speed?> get nullableType => const $Speed$NullableType();
+  jni$_.JType<Speed?> get nullableType => const $Speed$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 2;
 
   @core$_.override
-  int get hashCode => ($Speed$Type).hashCode;
+  int get hashCode => ($Speed$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Speed$Type) && other is $Speed$Type;
+    return other.runtimeType == ($Speed$Type$) && other is $Speed$Type$;
   }
 }
 
@@ -2862,7 +2878,7 @@ final class $Speed$Type extends jni$_.JObjType<Speed> {
 class SpeedUnit extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<SpeedUnit> $type;
+  final jni$_.JType<SpeedUnit> $type;
 
   @jni$_.internal
   SpeedUnit.fromReference(
@@ -2874,8 +2890,11 @@ class SpeedUnit extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/SpeedUnit');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $SpeedUnit$NullableType();
-  static const type = $SpeedUnit$Type();
+  static const jni$_.JType<SpeedUnit?> nullableType =
+      $SpeedUnit$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<SpeedUnit> type = $SpeedUnit$Type$();
   static final _id_KmPerHour = _class.staticFieldId(
     r'KmPerHour',
     r'Lcom/github/dart_lang/jnigen/SpeedUnit;',
@@ -2884,7 +2903,7 @@ class SpeedUnit extends jni$_.JObject {
   /// from: `static public final com.github.dart_lang.jnigen.SpeedUnit KmPerHour`
   /// The returned object must be released after use, by calling the [release] method.
   static SpeedUnit get KmPerHour =>
-      _id_KmPerHour.get(_class, const $SpeedUnit$Type());
+      _id_KmPerHour.get(_class, const $SpeedUnit$Type$());
 
   static final _id_MetrePerSec = _class.staticFieldId(
     r'MetrePerSec',
@@ -2894,7 +2913,7 @@ class SpeedUnit extends jni$_.JObject {
   /// from: `static public final com.github.dart_lang.jnigen.SpeedUnit MetrePerSec`
   /// The returned object must be released after use, by calling the [release] method.
   static SpeedUnit get MetrePerSec =>
-      _id_MetrePerSec.get(_class, const $SpeedUnit$Type());
+      _id_MetrePerSec.get(_class, const $SpeedUnit$Type$());
 
   static final _id_getSign = _class.instanceMethodId(
     r'getSign',
@@ -2917,7 +2936,7 @@ class SpeedUnit extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString getSign() {
     return _getSign(reference.pointer, _id_getSign as jni$_.JMethodIDPtr)
-        .object<jni$_.JString>(const jni$_.JStringType());
+        .object<jni$_.JString>(const jni$_.$JString$Type$());
   }
 
   static final _id_getCoefficient = _class.instanceMethodId(
@@ -2966,8 +2985,8 @@ class SpeedUnit extends jni$_.JObject {
   static jni$_.JArray<SpeedUnit?>? values() {
     return _values(_class.reference.pointer, _id_values as jni$_.JMethodIDPtr)
         .object<jni$_.JArray<SpeedUnit?>?>(
-            const jni$_.JArrayNullableType<SpeedUnit?>(
-                $SpeedUnit$NullableType()));
+            const jni$_.$JArray$NullableType$<SpeedUnit?>(
+                $SpeedUnit$NullableType$()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -2994,13 +3013,13 @@ class SpeedUnit extends jni$_.JObject {
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _valueOf(_class.reference.pointer, _id_valueOf as jni$_.JMethodIDPtr,
             _$string.pointer)
-        .object<SpeedUnit?>(const $SpeedUnit$NullableType());
+        .object<SpeedUnit?>(const $SpeedUnit$NullableType$());
   }
 }
 
-final class $SpeedUnit$NullableType extends jni$_.JObjType<SpeedUnit?> {
+final class $SpeedUnit$NullableType$ extends jni$_.JType<SpeedUnit?> {
   @jni$_.internal
-  const $SpeedUnit$NullableType();
+  const $SpeedUnit$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -3015,29 +3034,29 @@ final class $SpeedUnit$NullableType extends jni$_.JObjType<SpeedUnit?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<SpeedUnit?> get nullableType => this;
+  jni$_.JType<SpeedUnit?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($SpeedUnit$NullableType).hashCode;
+  int get hashCode => ($SpeedUnit$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($SpeedUnit$NullableType) &&
-        other is $SpeedUnit$NullableType;
+    return other.runtimeType == ($SpeedUnit$NullableType$) &&
+        other is $SpeedUnit$NullableType$;
   }
 }
 
-final class $SpeedUnit$Type extends jni$_.JObjType<SpeedUnit> {
+final class $SpeedUnit$Type$ extends jni$_.JType<SpeedUnit> {
   @jni$_.internal
-  const $SpeedUnit$Type();
+  const $SpeedUnit$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -3051,23 +3070,22 @@ final class $SpeedUnit$Type extends jni$_.JObjType<SpeedUnit> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<SpeedUnit?> get nullableType =>
-      const $SpeedUnit$NullableType();
+  jni$_.JType<SpeedUnit?> get nullableType => const $SpeedUnit$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($SpeedUnit$Type).hashCode;
+  int get hashCode => ($SpeedUnit$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($SpeedUnit$Type) && other is $SpeedUnit$Type;
+    return other.runtimeType == ($SpeedUnit$Type$) && other is $SpeedUnit$Type$;
   }
 }
 
@@ -3075,7 +3093,7 @@ final class $SpeedUnit$Type extends jni$_.JObjType<SpeedUnit> {
 class SuspendFun extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<SuspendFun> $type;
+  final jni$_.JType<SuspendFun> $type;
 
   @jni$_.internal
   SuspendFun.fromReference(
@@ -3087,8 +3105,11 @@ class SuspendFun extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/SuspendFun');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $SuspendFun$NullableType();
-  static const type = $SuspendFun$Type();
+  static const jni$_.JType<SuspendFun?> nullableType =
+      $SuspendFun$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<SuspendFun> type = $SuspendFun$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -3139,7 +3160,7 @@ class SuspendFun extends jni$_.JObject {
             reference.pointer,
             _id_sayHelloWithoutDelay as jni$_.JMethodIDPtr,
             _$continuation.pointer)
-        .object<jni$_.JObject>(const jni$_.JObjectType());
+        .object<jni$_.JObject>(const jni$_.$JObject$Type$());
     _$continuation.release();
     final jni$_.JObject $o;
     if ($r.isInstanceOf(jni$_.coroutineSingletonsClass)) {
@@ -3149,7 +3170,7 @@ class SuspendFun extends jni$_.JObject {
           jni$_.JGlobalReference(jni$_.JObjectPtr.fromAddress($a)));
       if ($o.isInstanceOf(jni$_.result$FailureClass)) {
         final $e =
-            jni$_.failureExceptionField.get($o, const jni$_.JObjectType());
+            jni$_.failureExceptionField.get($o, const jni$_.$JObject$Type$());
         $o.release();
         jni$_.Jni.throwException($e.reference.toPointer());
       }
@@ -3157,7 +3178,7 @@ class SuspendFun extends jni$_.JObject {
       $o = $r;
     }
     return $o.as<jni$_.JString>(
-      const jni$_.JStringType(),
+      const jni$_.$JString$Type$(),
       releaseOriginal: true,
     );
   }
@@ -3186,7 +3207,7 @@ class SuspendFun extends jni$_.JObject {
 
     final $r = _failWithoutDelay(reference.pointer,
             _id_failWithoutDelay as jni$_.JMethodIDPtr, _$continuation.pointer)
-        .object<jni$_.JObject>(const jni$_.JObjectType());
+        .object<jni$_.JObject>(const jni$_.$JObject$Type$());
     _$continuation.release();
     final jni$_.JObject $o;
     if ($r.isInstanceOf(jni$_.coroutineSingletonsClass)) {
@@ -3196,7 +3217,7 @@ class SuspendFun extends jni$_.JObject {
           jni$_.JGlobalReference(jni$_.JObjectPtr.fromAddress($a)));
       if ($o.isInstanceOf(jni$_.result$FailureClass)) {
         final $e =
-            jni$_.failureExceptionField.get($o, const jni$_.JObjectType());
+            jni$_.failureExceptionField.get($o, const jni$_.$JObject$Type$());
         $o.release();
         jni$_.Jni.throwException($e.reference.toPointer());
       }
@@ -3204,7 +3225,7 @@ class SuspendFun extends jni$_.JObject {
       $o = $r;
     }
     return $o.as<jni$_.JString>(
-      const jni$_.JStringType(),
+      const jni$_.$JString$Type$(),
       releaseOriginal: true,
     );
   }
@@ -3233,7 +3254,7 @@ class SuspendFun extends jni$_.JObject {
 
     final $r = _fail(reference.pointer, _id_fail as jni$_.JMethodIDPtr,
             _$continuation.pointer)
-        .object<jni$_.JObject>(const jni$_.JObjectType());
+        .object<jni$_.JObject>(const jni$_.$JObject$Type$());
     _$continuation.release();
     final jni$_.JObject $o;
     if ($r.isInstanceOf(jni$_.coroutineSingletonsClass)) {
@@ -3243,7 +3264,7 @@ class SuspendFun extends jni$_.JObject {
           jni$_.JGlobalReference(jni$_.JObjectPtr.fromAddress($a)));
       if ($o.isInstanceOf(jni$_.result$FailureClass)) {
         final $e =
-            jni$_.failureExceptionField.get($o, const jni$_.JObjectType());
+            jni$_.failureExceptionField.get($o, const jni$_.$JObject$Type$());
         $o.release();
         jni$_.Jni.throwException($e.reference.toPointer());
       }
@@ -3251,7 +3272,7 @@ class SuspendFun extends jni$_.JObject {
       $o = $r;
     }
     return $o.as<jni$_.JString>(
-      const jni$_.JStringType(),
+      const jni$_.$JString$Type$(),
       releaseOriginal: true,
     );
   }
@@ -3280,7 +3301,7 @@ class SuspendFun extends jni$_.JObject {
 
     final $r = _sayHello(reference.pointer, _id_sayHello as jni$_.JMethodIDPtr,
             _$continuation.pointer)
-        .object<jni$_.JObject>(const jni$_.JObjectType());
+        .object<jni$_.JObject>(const jni$_.$JObject$Type$());
     _$continuation.release();
     final jni$_.JObject $o;
     if ($r.isInstanceOf(jni$_.coroutineSingletonsClass)) {
@@ -3290,7 +3311,7 @@ class SuspendFun extends jni$_.JObject {
           jni$_.JGlobalReference(jni$_.JObjectPtr.fromAddress($a)));
       if ($o.isInstanceOf(jni$_.result$FailureClass)) {
         final $e =
-            jni$_.failureExceptionField.get($o, const jni$_.JObjectType());
+            jni$_.failureExceptionField.get($o, const jni$_.$JObject$Type$());
         $o.release();
         jni$_.Jni.throwException($e.reference.toPointer());
       }
@@ -3298,7 +3319,7 @@ class SuspendFun extends jni$_.JObject {
       $o = $r;
     }
     return $o.as<jni$_.JString>(
-      const jni$_.JStringType(),
+      const jni$_.$JString$Type$(),
       releaseOriginal: true,
     );
   }
@@ -3338,7 +3359,7 @@ class SuspendFun extends jni$_.JObject {
             _id_sayHello$1 as jni$_.JMethodIDPtr,
             _$string.pointer,
             _$continuation.pointer)
-        .object<jni$_.JObject>(const jni$_.JObjectType());
+        .object<jni$_.JObject>(const jni$_.$JObject$Type$());
     _$continuation.release();
     final jni$_.JObject $o;
     if ($r.isInstanceOf(jni$_.coroutineSingletonsClass)) {
@@ -3348,7 +3369,7 @@ class SuspendFun extends jni$_.JObject {
           jni$_.JGlobalReference(jni$_.JObjectPtr.fromAddress($a)));
       if ($o.isInstanceOf(jni$_.result$FailureClass)) {
         final $e =
-            jni$_.failureExceptionField.get($o, const jni$_.JObjectType());
+            jni$_.failureExceptionField.get($o, const jni$_.$JObject$Type$());
         $o.release();
         jni$_.Jni.throwException($e.reference.toPointer());
       }
@@ -3356,7 +3377,7 @@ class SuspendFun extends jni$_.JObject {
       $o = $r;
     }
     return $o.as<jni$_.JString>(
-      const jni$_.JStringType(),
+      const jni$_.$JString$Type$(),
       releaseOriginal: true,
     );
   }
@@ -3391,7 +3412,7 @@ class SuspendFun extends jni$_.JObject {
             _id_nullableHello as jni$_.JMethodIDPtr,
             z ? 1 : 0,
             _$continuation.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
     _$continuation.release();
     final jni$_.JObject? $o;
     if ($r != null && $r.isInstanceOf(jni$_.coroutineSingletonsClass)) {
@@ -3403,7 +3424,7 @@ class SuspendFun extends jni$_.JObject {
               jni$_.JGlobalReference(jni$_.JObjectPtr.fromAddress($a)));
       if ($o != null && $o.isInstanceOf(jni$_.result$FailureClass)) {
         final $e =
-            jni$_.failureExceptionField.get($o, const jni$_.JObjectType());
+            jni$_.failureExceptionField.get($o, const jni$_.$JObject$Type$());
         $o.release();
         jni$_.Jni.throwException($e.reference.toPointer());
       }
@@ -3411,7 +3432,7 @@ class SuspendFun extends jni$_.JObject {
       $o = $r;
     }
     return $o?.as<jni$_.JString?>(
-      const jni$_.JStringNullableType(),
+      const jni$_.$JString$NullableType$(),
       releaseOriginal: true,
     );
   }
@@ -3446,7 +3467,7 @@ class SuspendFun extends jni$_.JObject {
             _id_nullableHelloWithoutDelay as jni$_.JMethodIDPtr,
             z ? 1 : 0,
             _$continuation.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
     _$continuation.release();
     final jni$_.JObject? $o;
     if ($r != null && $r.isInstanceOf(jni$_.coroutineSingletonsClass)) {
@@ -3458,7 +3479,7 @@ class SuspendFun extends jni$_.JObject {
               jni$_.JGlobalReference(jni$_.JObjectPtr.fromAddress($a)));
       if ($o != null && $o.isInstanceOf(jni$_.result$FailureClass)) {
         final $e =
-            jni$_.failureExceptionField.get($o, const jni$_.JObjectType());
+            jni$_.failureExceptionField.get($o, const jni$_.$JObject$Type$());
         $o.release();
         jni$_.Jni.throwException($e.reference.toPointer());
       }
@@ -3466,15 +3487,15 @@ class SuspendFun extends jni$_.JObject {
       $o = $r;
     }
     return $o?.as<jni$_.JString?>(
-      const jni$_.JStringNullableType(),
+      const jni$_.$JString$NullableType$(),
       releaseOriginal: true,
     );
   }
 }
 
-final class $SuspendFun$NullableType extends jni$_.JObjType<SuspendFun?> {
+final class $SuspendFun$NullableType$ extends jni$_.JType<SuspendFun?> {
   @jni$_.internal
-  const $SuspendFun$NullableType();
+  const $SuspendFun$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -3489,29 +3510,29 @@ final class $SuspendFun$NullableType extends jni$_.JObjType<SuspendFun?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<SuspendFun?> get nullableType => this;
+  jni$_.JType<SuspendFun?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($SuspendFun$NullableType).hashCode;
+  int get hashCode => ($SuspendFun$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($SuspendFun$NullableType) &&
-        other is $SuspendFun$NullableType;
+    return other.runtimeType == ($SuspendFun$NullableType$) &&
+        other is $SuspendFun$NullableType$;
   }
 }
 
-final class $SuspendFun$Type extends jni$_.JObjType<SuspendFun> {
+final class $SuspendFun$Type$ extends jni$_.JType<SuspendFun> {
   @jni$_.internal
-  const $SuspendFun$Type();
+  const $SuspendFun$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -3525,23 +3546,24 @@ final class $SuspendFun$Type extends jni$_.JObjType<SuspendFun> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectType();
+  jni$_.JType get superType => const jni$_.$JObject$Type$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<SuspendFun?> get nullableType =>
-      const $SuspendFun$NullableType();
+  jni$_.JType<SuspendFun?> get nullableType =>
+      const $SuspendFun$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($SuspendFun$Type).hashCode;
+  int get hashCode => ($SuspendFun$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($SuspendFun$Type) && other is $SuspendFun$Type;
+    return other.runtimeType == ($SuspendFun$Type$) &&
+        other is $SuspendFun$Type$;
   }
 }
 

--- a/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
@@ -44,7 +44,7 @@ import 'package:jni/jni.dart' as jni$_;
 class Example$Nested$NestedTwice extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Example$Nested$NestedTwice> $type;
+  final jni$_.JType<Example$Nested$NestedTwice> $type;
 
   @jni$_.internal
   Example$Nested$NestedTwice.fromReference(
@@ -56,8 +56,12 @@ class Example$Nested$NestedTwice extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/simple_package/Example$Nested$NestedTwice');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Example$Nested$NestedTwice$NullableType();
-  static const type = $Example$Nested$NestedTwice$Type();
+  static const jni$_.JType<Example$Nested$NestedTwice?> nullableType =
+      $Example$Nested$NestedTwice$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Example$Nested$NestedTwice> type =
+      $Example$Nested$NestedTwice$Type$();
   static final _id_ZERO = _class.staticFieldId(
     r'ZERO',
     r'I',
@@ -95,10 +99,10 @@ class Example$Nested$NestedTwice extends jni$_.JObject {
   }
 }
 
-final class $Example$Nested$NestedTwice$NullableType
-    extends jni$_.JObjType<Example$Nested$NestedTwice?> {
+final class $Example$Nested$NestedTwice$NullableType$
+    extends jni$_.JType<Example$Nested$NestedTwice?> {
   @jni$_.internal
-  const $Example$Nested$NestedTwice$NullableType();
+  const $Example$Nested$NestedTwice$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -115,30 +119,30 @@ final class $Example$Nested$NestedTwice$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example$Nested$NestedTwice?> get nullableType => this;
+  jni$_.JType<Example$Nested$NestedTwice?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example$Nested$NestedTwice$NullableType).hashCode;
+  int get hashCode => ($Example$Nested$NestedTwice$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example$Nested$NestedTwice$NullableType) &&
-        other is $Example$Nested$NestedTwice$NullableType;
+    return other.runtimeType == ($Example$Nested$NestedTwice$NullableType$) &&
+        other is $Example$Nested$NestedTwice$NullableType$;
   }
 }
 
-final class $Example$Nested$NestedTwice$Type
-    extends jni$_.JObjType<Example$Nested$NestedTwice> {
+final class $Example$Nested$NestedTwice$Type$
+    extends jni$_.JType<Example$Nested$NestedTwice> {
   @jni$_.internal
-  const $Example$Nested$NestedTwice$Type();
+  const $Example$Nested$NestedTwice$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -153,24 +157,24 @@ final class $Example$Nested$NestedTwice$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example$Nested$NestedTwice?> get nullableType =>
-      const $Example$Nested$NestedTwice$NullableType();
+  jni$_.JType<Example$Nested$NestedTwice?> get nullableType =>
+      const $Example$Nested$NestedTwice$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example$Nested$NestedTwice$Type).hashCode;
+  int get hashCode => ($Example$Nested$NestedTwice$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example$Nested$NestedTwice$Type) &&
-        other is $Example$Nested$NestedTwice$Type;
+    return other.runtimeType == ($Example$Nested$NestedTwice$Type$) &&
+        other is $Example$Nested$NestedTwice$Type$;
   }
 }
 
@@ -178,7 +182,7 @@ final class $Example$Nested$NestedTwice$Type
 class Example$Nested extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Example$Nested> $type;
+  final jni$_.JType<Example$Nested> $type;
 
   @jni$_.internal
   Example$Nested.fromReference(
@@ -190,8 +194,11 @@ class Example$Nested extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/simple_package/Example$Nested');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Example$Nested$NullableType();
-  static const type = $Example$Nested$Type();
+  static const jni$_.JType<Example$Nested?> nullableType =
+      $Example$Nested$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Example$Nested> type = $Example$Nested$Type$();
   static final _id_new$ = _class.constructorId(
     r'(Z)V',
   );
@@ -287,10 +294,9 @@ class Example$Nested extends jni$_.JObject {
   }
 }
 
-final class $Example$Nested$NullableType
-    extends jni$_.JObjType<Example$Nested?> {
+final class $Example$Nested$NullableType$ extends jni$_.JType<Example$Nested?> {
   @jni$_.internal
-  const $Example$Nested$NullableType();
+  const $Example$Nested$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -306,29 +312,29 @@ final class $Example$Nested$NullableType
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example$Nested?> get nullableType => this;
+  jni$_.JType<Example$Nested?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example$Nested$NullableType).hashCode;
+  int get hashCode => ($Example$Nested$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example$Nested$NullableType) &&
-        other is $Example$Nested$NullableType;
+    return other.runtimeType == ($Example$Nested$NullableType$) &&
+        other is $Example$Nested$NullableType$;
   }
 }
 
-final class $Example$Nested$Type extends jni$_.JObjType<Example$Nested> {
+final class $Example$Nested$Type$ extends jni$_.JType<Example$Nested> {
   @jni$_.internal
-  const $Example$Nested$Type();
+  const $Example$Nested$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -343,24 +349,24 @@ final class $Example$Nested$Type extends jni$_.JObjType<Example$Nested> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example$Nested?> get nullableType =>
-      const $Example$Nested$NullableType();
+  jni$_.JType<Example$Nested?> get nullableType =>
+      const $Example$Nested$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example$Nested$Type).hashCode;
+  int get hashCode => ($Example$Nested$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example$Nested$Type) &&
-        other is $Example$Nested$Type;
+    return other.runtimeType == ($Example$Nested$Type$) &&
+        other is $Example$Nested$Type$;
   }
 }
 
@@ -368,7 +374,7 @@ final class $Example$Nested$Type extends jni$_.JObjType<Example$Nested> {
 class Example$NonStaticNested extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Example$NonStaticNested> $type;
+  final jni$_.JType<Example$NonStaticNested> $type;
 
   @jni$_.internal
   Example$NonStaticNested.fromReference(
@@ -380,8 +386,12 @@ class Example$NonStaticNested extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/simple_package/Example$NonStaticNested');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Example$NonStaticNested$NullableType();
-  static const type = $Example$NonStaticNested$Type();
+  static const jni$_.JType<Example$NonStaticNested?> nullableType =
+      $Example$NonStaticNested$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Example$NonStaticNested> type =
+      $Example$NonStaticNested$Type$();
   static final _id_ok = _class.instanceFieldId(
     r'ok',
     r'Z',
@@ -420,10 +430,10 @@ class Example$NonStaticNested extends jni$_.JObject {
   }
 }
 
-final class $Example$NonStaticNested$NullableType
-    extends jni$_.JObjType<Example$NonStaticNested?> {
+final class $Example$NonStaticNested$NullableType$
+    extends jni$_.JType<Example$NonStaticNested?> {
   @jni$_.internal
-  const $Example$NonStaticNested$NullableType();
+  const $Example$NonStaticNested$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -440,30 +450,30 @@ final class $Example$NonStaticNested$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example$NonStaticNested?> get nullableType => this;
+  jni$_.JType<Example$NonStaticNested?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example$NonStaticNested$NullableType).hashCode;
+  int get hashCode => ($Example$NonStaticNested$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example$NonStaticNested$NullableType) &&
-        other is $Example$NonStaticNested$NullableType;
+    return other.runtimeType == ($Example$NonStaticNested$NullableType$) &&
+        other is $Example$NonStaticNested$NullableType$;
   }
 }
 
-final class $Example$NonStaticNested$Type
-    extends jni$_.JObjType<Example$NonStaticNested> {
+final class $Example$NonStaticNested$Type$
+    extends jni$_.JType<Example$NonStaticNested> {
   @jni$_.internal
-  const $Example$NonStaticNested$Type();
+  const $Example$NonStaticNested$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -478,24 +488,24 @@ final class $Example$NonStaticNested$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example$NonStaticNested?> get nullableType =>
-      const $Example$NonStaticNested$NullableType();
+  jni$_.JType<Example$NonStaticNested?> get nullableType =>
+      const $Example$NonStaticNested$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example$NonStaticNested$Type).hashCode;
+  int get hashCode => ($Example$NonStaticNested$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example$NonStaticNested$Type) &&
-        other is $Example$NonStaticNested$Type;
+    return other.runtimeType == ($Example$NonStaticNested$Type$) &&
+        other is $Example$NonStaticNested$Type$;
   }
 }
 
@@ -503,7 +513,7 @@ final class $Example$NonStaticNested$Type
 class Example extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Example> $type;
+  final jni$_.JType<Example> $type;
 
   @jni$_.internal
   Example.fromReference(
@@ -515,8 +525,10 @@ class Example extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/simple_package/Example');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Example$NullableType();
-  static const type = $Example$Type();
+  static const jni$_.JType<Example?> nullableType = $Example$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Example> type = $Example$Type$();
 
   /// from: `static public final int ON`
   static const ON = 1;
@@ -537,7 +549,7 @@ class Example extends jni$_.JObject {
   /// from: `static public final java.lang.String SEMICOLON_STRING`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get SEMICOLON_STRING =>
-      _id_SEMICOLON_STRING.get(_class, const jni$_.JStringNullableType());
+      _id_SEMICOLON_STRING.get(_class, const jni$_.$JString$NullableType$());
 
   static final _id_unusedRandom = _class.staticFieldId(
     r'unusedRandom',
@@ -547,7 +559,7 @@ class Example extends jni$_.JObject {
   /// from: `static public final java.util.Random unusedRandom`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JObject? get unusedRandom =>
-      _id_unusedRandom.get(_class, const jni$_.JObjectNullableType());
+      _id_unusedRandom.get(_class, const jni$_.$JObject$NullableType$());
 
   static final _id_getAmount = _class.staticMethodId(
     r'getAmount',
@@ -641,7 +653,7 @@ class Example extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? getName() {
     return _getName(_class.reference.pointer, _id_getName as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_getNestedInstance = _class.staticMethodId(
@@ -666,7 +678,7 @@ class Example extends jni$_.JObject {
   static Example$Nested? getNestedInstance() {
     return _getNestedInstance(_class.reference.pointer,
             _id_getNestedInstance as jni$_.JMethodIDPtr)
-        .object<Example$Nested?>(const $Example$Nested$NullableType());
+        .object<Example$Nested?>(const $Example$Nested$NullableType$());
   }
 
   static final _id_setAmount = _class.staticMethodId(
@@ -931,7 +943,7 @@ class Example extends jni$_.JObject {
   jni$_.JString? getCodename() {
     return _getCodename(
             reference.pointer, _id_getCodename as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_setCodename = _class.instanceMethodId(
@@ -981,7 +993,7 @@ class Example extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? getRandom() {
     return _getRandom(reference.pointer, _id_getRandom as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_setRandom = _class.instanceMethodId(
@@ -1132,7 +1144,7 @@ class Example extends jni$_.JObject {
     final _$random = random?.reference ?? jni$_.jNullReference;
     return _getRandomNumericString(reference.pointer,
             _id_getRandomNumericString as jni$_.JMethodIDPtr, _$random.pointer)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_finalMethod = _class.instanceMethodId(
@@ -1180,8 +1192,8 @@ class Example extends jni$_.JObject {
   jni$_.JList<jni$_.JString?>? getList() {
     return _getList(reference.pointer, _id_getList as jni$_.JMethodIDPtr)
         .object<jni$_.JList<jni$_.JString?>?>(
-            const jni$_.JListNullableType<jni$_.JString?>(
-                jni$_.JStringNullableType()));
+            const jni$_.$JList$NullableType$<jni$_.JString?>(
+                jni$_.$JString$NullableType$()));
   }
 
   static final _id_joinStrings = _class.instanceMethodId(
@@ -1219,7 +1231,7 @@ class Example extends jni$_.JObject {
             _id_joinStrings as jni$_.JMethodIDPtr,
             _$list.pointer,
             _$string.pointer)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_methodWithSeveralParams = _class.instanceMethodId(
@@ -1260,7 +1272,7 @@ class Example extends jni$_.JObject {
     $T? charSequence,
     jni$_.JList<$T?>? list,
     jni$_.JMap<jni$_.JString?, jni$_.JObject?>? map, {
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$is$ = is$?.reference ?? jni$_.jNullReference;
@@ -1497,7 +1509,7 @@ class Example extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JIntArray? getArr() {
     return _getArr(_class.reference.pointer, _id_getArr as jni$_.JMethodIDPtr)
-        .object<jni$_.JIntArray?>(const jni$_.JIntArrayNullableType());
+        .object<jni$_.JIntArray?>(const jni$_.$JIntArray$NullableType$());
   }
 
   static final _id_addAll = _class.staticMethodId(
@@ -1547,7 +1559,7 @@ class Example extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   Example? getSelf() {
     return _getSelf(reference.pointer, _id_getSelf as jni$_.JMethodIDPtr)
-        .object<Example?>(const $Example$NullableType());
+        .object<Example?>(const $Example$NullableType$());
   }
 
   static final _id_throwException = _class.staticMethodId(
@@ -1709,9 +1721,9 @@ class Example extends jni$_.JObject {
   }
 }
 
-final class $Example$NullableType extends jni$_.JObjType<Example?> {
+final class $Example$NullableType$ extends jni$_.JType<Example?> {
   @jni$_.internal
-  const $Example$NullableType();
+  const $Example$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -1727,29 +1739,29 @@ final class $Example$NullableType extends jni$_.JObjType<Example?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example?> get nullableType => this;
+  jni$_.JType<Example?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example$NullableType).hashCode;
+  int get hashCode => ($Example$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example$NullableType) &&
-        other is $Example$NullableType;
+    return other.runtimeType == ($Example$NullableType$) &&
+        other is $Example$NullableType$;
   }
 }
 
-final class $Example$Type extends jni$_.JObjType<Example> {
+final class $Example$Type$ extends jni$_.JType<Example> {
   @jni$_.internal
-  const $Example$Type();
+  const $Example$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -1763,22 +1775,22 @@ final class $Example$Type extends jni$_.JObjType<Example> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example?> get nullableType => const $Example$NullableType();
+  jni$_.JType<Example?> get nullableType => const $Example$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example$Type).hashCode;
+  int get hashCode => ($Example$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example$Type) && other is $Example$Type;
+    return other.runtimeType == ($Example$Type$) && other is $Example$Type$;
   }
 }
 
@@ -1786,7 +1798,7 @@ final class $Example$Type extends jni$_.JObjType<Example> {
 class Exceptions extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Exceptions> $type;
+  final jni$_.JType<Exceptions> $type;
 
   @jni$_.internal
   Exceptions.fromReference(
@@ -1798,8 +1810,11 @@ class Exceptions extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/simple_package/Exceptions');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Exceptions$NullableType();
-  static const type = $Exceptions$Type();
+  static const jni$_.JType<Exceptions?> nullableType =
+      $Exceptions$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Exceptions> type = $Exceptions$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -1907,7 +1922,7 @@ class Exceptions extends jni$_.JObject {
   static jni$_.JObject? staticObjectMethod() {
     return _staticObjectMethod(_class.reference.pointer,
             _id_staticObjectMethod as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_staticIntMethod = _class.staticMethodId(
@@ -1957,8 +1972,8 @@ class Exceptions extends jni$_.JObject {
     return _staticObjectArrayMethod(_class.reference.pointer,
             _id_staticObjectArrayMethod as jni$_.JMethodIDPtr)
         .object<jni$_.JArray<jni$_.JObject?>?>(
-            const jni$_.JArrayNullableType<jni$_.JObject?>(
-                jni$_.JObjectNullableType()));
+            const jni$_.$JArray$NullableType$<jni$_.JObject?>(
+                jni$_.$JObject$NullableType$()));
   }
 
   static final _id_staticIntArrayMethod = _class.staticMethodId(
@@ -1983,7 +1998,7 @@ class Exceptions extends jni$_.JObject {
   static jni$_.JIntArray? staticIntArrayMethod() {
     return _staticIntArrayMethod(_class.reference.pointer,
             _id_staticIntArrayMethod as jni$_.JMethodIDPtr)
-        .object<jni$_.JIntArray?>(const jni$_.JIntArrayNullableType());
+        .object<jni$_.JIntArray?>(const jni$_.$JIntArray$NullableType$());
   }
 
   static final _id_objectMethod = _class.instanceMethodId(
@@ -2008,7 +2023,7 @@ class Exceptions extends jni$_.JObject {
   jni$_.JObject? objectMethod() {
     return _objectMethod(
             reference.pointer, _id_objectMethod as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_intMethod = _class.instanceMethodId(
@@ -2057,8 +2072,8 @@ class Exceptions extends jni$_.JObject {
     return _objectArrayMethod(
             reference.pointer, _id_objectArrayMethod as jni$_.JMethodIDPtr)
         .object<jni$_.JArray<jni$_.JObject?>?>(
-            const jni$_.JArrayNullableType<jni$_.JObject?>(
-                jni$_.JObjectNullableType()));
+            const jni$_.$JArray$NullableType$<jni$_.JObject?>(
+                jni$_.$JObject$NullableType$()));
   }
 
   static final _id_intArrayMethod = _class.instanceMethodId(
@@ -2083,7 +2098,7 @@ class Exceptions extends jni$_.JObject {
   jni$_.JIntArray? intArrayMethod() {
     return _intArrayMethod(
             reference.pointer, _id_intArrayMethod as jni$_.JMethodIDPtr)
-        .object<jni$_.JIntArray?>(const jni$_.JIntArrayNullableType());
+        .object<jni$_.JIntArray?>(const jni$_.$JIntArray$NullableType$());
   }
 
   static final _id_throwNullPointerException = _class.instanceMethodId(
@@ -2133,7 +2148,7 @@ class Exceptions extends jni$_.JObject {
   jni$_.JObject? throwFileNotFoundException() {
     return _throwFileNotFoundException(reference.pointer,
             _id_throwFileNotFoundException as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_throwClassCastException = _class.instanceMethodId(
@@ -2158,7 +2173,7 @@ class Exceptions extends jni$_.JObject {
   jni$_.JObject? throwClassCastException() {
     return _throwClassCastException(reference.pointer,
             _id_throwClassCastException as jni$_.JMethodIDPtr)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_throwArrayIndexException = _class.instanceMethodId(
@@ -2234,9 +2249,9 @@ class Exceptions extends jni$_.JObject {
   }
 }
 
-final class $Exceptions$NullableType extends jni$_.JObjType<Exceptions?> {
+final class $Exceptions$NullableType$ extends jni$_.JType<Exceptions?> {
   @jni$_.internal
-  const $Exceptions$NullableType();
+  const $Exceptions$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -2252,29 +2267,29 @@ final class $Exceptions$NullableType extends jni$_.JObjType<Exceptions?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Exceptions?> get nullableType => this;
+  jni$_.JType<Exceptions?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Exceptions$NullableType).hashCode;
+  int get hashCode => ($Exceptions$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Exceptions$NullableType) &&
-        other is $Exceptions$NullableType;
+    return other.runtimeType == ($Exceptions$NullableType$) &&
+        other is $Exceptions$NullableType$;
   }
 }
 
-final class $Exceptions$Type extends jni$_.JObjType<Exceptions> {
+final class $Exceptions$Type$ extends jni$_.JType<Exceptions> {
   @jni$_.internal
-  const $Exceptions$Type();
+  const $Exceptions$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -2289,23 +2304,24 @@ final class $Exceptions$Type extends jni$_.JObjType<Exceptions> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Exceptions?> get nullableType =>
-      const $Exceptions$NullableType();
+  jni$_.JType<Exceptions?> get nullableType =>
+      const $Exceptions$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Exceptions$Type).hashCode;
+  int get hashCode => ($Exceptions$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Exceptions$Type) && other is $Exceptions$Type;
+    return other.runtimeType == ($Exceptions$Type$) &&
+        other is $Exceptions$Type$;
   }
 }
 
@@ -2313,7 +2329,7 @@ final class $Exceptions$Type extends jni$_.JObjType<Exceptions> {
 class Fields$Nested extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Fields$Nested> $type;
+  final jni$_.JType<Fields$Nested> $type;
 
   @jni$_.internal
   Fields$Nested.fromReference(
@@ -2325,8 +2341,11 @@ class Fields$Nested extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/simple_package/Fields$Nested');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Fields$Nested$NullableType();
-  static const type = $Fields$Nested$Type();
+  static const jni$_.JType<Fields$Nested?> nullableType =
+      $Fields$Nested$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Fields$Nested> type = $Fields$Nested$Type$();
   static final _id_hundred = _class.instanceFieldId(
     r'hundred',
     r'J',
@@ -2347,12 +2366,12 @@ class Fields$Nested extends jni$_.JObject {
   /// from: `static public java.lang.String BEST_GOD`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get BEST_GOD =>
-      _id_BEST_GOD.get(_class, const jni$_.JStringNullableType());
+      _id_BEST_GOD.get(_class, const jni$_.$JString$NullableType$());
 
   /// from: `static public java.lang.String BEST_GOD`
   /// The returned object must be released after use, by calling the [release] method.
   static set BEST_GOD(jni$_.JString? value) =>
-      _id_BEST_GOD.set(_class, const jni$_.JStringNullableType(), value);
+      _id_BEST_GOD.set(_class, const jni$_.$JString$NullableType$(), value);
 
   static final _id_new$ = _class.constructorId(
     r'()V',
@@ -2379,9 +2398,9 @@ class Fields$Nested extends jni$_.JObject {
   }
 }
 
-final class $Fields$Nested$NullableType extends jni$_.JObjType<Fields$Nested?> {
+final class $Fields$Nested$NullableType$ extends jni$_.JType<Fields$Nested?> {
   @jni$_.internal
-  const $Fields$Nested$NullableType();
+  const $Fields$Nested$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -2397,29 +2416,29 @@ final class $Fields$Nested$NullableType extends jni$_.JObjType<Fields$Nested?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Fields$Nested?> get nullableType => this;
+  jni$_.JType<Fields$Nested?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Fields$Nested$NullableType).hashCode;
+  int get hashCode => ($Fields$Nested$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Fields$Nested$NullableType) &&
-        other is $Fields$Nested$NullableType;
+    return other.runtimeType == ($Fields$Nested$NullableType$) &&
+        other is $Fields$Nested$NullableType$;
   }
 }
 
-final class $Fields$Nested$Type extends jni$_.JObjType<Fields$Nested> {
+final class $Fields$Nested$Type$ extends jni$_.JType<Fields$Nested> {
   @jni$_.internal
-  const $Fields$Nested$Type();
+  const $Fields$Nested$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -2434,24 +2453,24 @@ final class $Fields$Nested$Type extends jni$_.JObjType<Fields$Nested> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Fields$Nested?> get nullableType =>
-      const $Fields$Nested$NullableType();
+  jni$_.JType<Fields$Nested?> get nullableType =>
+      const $Fields$Nested$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Fields$Nested$Type).hashCode;
+  int get hashCode => ($Fields$Nested$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Fields$Nested$Type) &&
-        other is $Fields$Nested$Type;
+    return other.runtimeType == ($Fields$Nested$Type$) &&
+        other is $Fields$Nested$Type$;
   }
 }
 
@@ -2459,7 +2478,7 @@ final class $Fields$Nested$Type extends jni$_.JObjType<Fields$Nested> {
 class Fields extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Fields> $type;
+  final jni$_.JType<Fields> $type;
 
   @jni$_.internal
   Fields.fromReference(
@@ -2471,8 +2490,10 @@ class Fields extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/simple_package/Fields');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Fields$NullableType();
-  static const type = $Fields$Type();
+  static const jni$_.JType<Fields?> nullableType = $Fields$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Fields> type = $Fields$Type$();
   static final _id_amount = _class.staticFieldId(
     r'amount',
     r'I',
@@ -2517,12 +2538,12 @@ class Fields extends jni$_.JObject {
   /// from: `static public java.lang.String name`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get name =>
-      _id_name.get(_class, const jni$_.JStringNullableType());
+      _id_name.get(_class, const jni$_.$JString$NullableType$());
 
   /// from: `static public java.lang.String name`
   /// The returned object must be released after use, by calling the [release] method.
   static set name(jni$_.JString? value) =>
-      _id_name.set(_class, const jni$_.JStringNullableType(), value);
+      _id_name.set(_class, const jni$_.$JString$NullableType$(), value);
 
   static final _id_i = _class.instanceFieldId(
     r'i',
@@ -2531,12 +2552,13 @@ class Fields extends jni$_.JObject {
 
   /// from: `public java.lang.Integer i`
   /// The returned object must be released after use, by calling the [release] method.
-  jni$_.JInteger? get i => _id_i.get(this, const jni$_.JIntegerNullableType());
+  jni$_.JInteger? get i =>
+      _id_i.get(this, const jni$_.$JInteger$NullableType$());
 
   /// from: `public java.lang.Integer i`
   /// The returned object must be released after use, by calling the [release] method.
   set i(jni$_.JInteger? value) =>
-      _id_i.set(this, const jni$_.JIntegerNullableType(), value);
+      _id_i.set(this, const jni$_.$JInteger$NullableType$(), value);
 
   static final _id_trillion = _class.instanceFieldId(
     r'trillion',
@@ -2571,12 +2593,12 @@ class Fields extends jni$_.JObject {
   /// from: `public java.lang.String bestFighterInGreece`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? get bestFighterInGreece =>
-      _id_bestFighterInGreece.get(this, const jni$_.JStringNullableType());
+      _id_bestFighterInGreece.get(this, const jni$_.$JString$NullableType$());
 
   /// from: `public java.lang.String bestFighterInGreece`
   /// The returned object must be released after use, by calling the [release] method.
   set bestFighterInGreece(jni$_.JString? value) => _id_bestFighterInGreece.set(
-      this, const jni$_.JStringNullableType(), value);
+      this, const jni$_.$JString$NullableType$(), value);
 
   static final _id_random = _class.instanceFieldId(
     r'random',
@@ -2586,12 +2608,12 @@ class Fields extends jni$_.JObject {
   /// from: `public java.util.Random random`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? get random =>
-      _id_random.get(this, const jni$_.JObjectNullableType());
+      _id_random.get(this, const jni$_.$JObject$NullableType$());
 
   /// from: `public java.util.Random random`
   /// The returned object must be released after use, by calling the [release] method.
   set random(jni$_.JObject? value) =>
-      _id_random.set(this, const jni$_.JObjectNullableType(), value);
+      _id_random.set(this, const jni$_.$JObject$NullableType$(), value);
 
   static final _id_euroSymbol = _class.staticFieldId(
     r'euroSymbol',
@@ -2631,9 +2653,9 @@ class Fields extends jni$_.JObject {
   }
 }
 
-final class $Fields$NullableType extends jni$_.JObjType<Fields?> {
+final class $Fields$NullableType$ extends jni$_.JType<Fields?> {
   @jni$_.internal
-  const $Fields$NullableType();
+  const $Fields$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -2649,29 +2671,29 @@ final class $Fields$NullableType extends jni$_.JObjType<Fields?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Fields?> get nullableType => this;
+  jni$_.JType<Fields?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Fields$NullableType).hashCode;
+  int get hashCode => ($Fields$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Fields$NullableType) &&
-        other is $Fields$NullableType;
+    return other.runtimeType == ($Fields$NullableType$) &&
+        other is $Fields$NullableType$;
   }
 }
 
-final class $Fields$Type extends jni$_.JObjType<Fields> {
+final class $Fields$Type$ extends jni$_.JType<Fields> {
   @jni$_.internal
-  const $Fields$Type();
+  const $Fields$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -2685,22 +2707,22 @@ final class $Fields$Type extends jni$_.JObjType<Fields> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Fields?> get nullableType => const $Fields$NullableType();
+  jni$_.JType<Fields?> get nullableType => const $Fields$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Fields$Type).hashCode;
+  int get hashCode => ($Fields$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Fields$Type) && other is $Fields$Type;
+    return other.runtimeType == ($Fields$Type$) && other is $Fields$Type$;
   }
 }
 
@@ -2708,7 +2730,7 @@ final class $Fields$Type extends jni$_.JObjType<Fields> {
 class C2 extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<C2> $type;
+  final jni$_.JType<C2> $type;
 
   @jni$_.internal
   C2.fromReference(
@@ -2720,8 +2742,10 @@ class C2 extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/pkg2/C2');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $C2$NullableType();
-  static const type = $C2$Type();
+  static const jni$_.JType<C2?> nullableType = $C2$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<C2> type = $C2$Type$();
   static final _id_CONSTANT = _class.staticFieldId(
     r'CONSTANT',
     r'I',
@@ -2759,9 +2783,9 @@ class C2 extends jni$_.JObject {
   }
 }
 
-final class $C2$NullableType extends jni$_.JObjType<C2?> {
+final class $C2$NullableType$ extends jni$_.JType<C2?> {
   @jni$_.internal
-  const $C2$NullableType();
+  const $C2$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -2776,28 +2800,29 @@ final class $C2$NullableType extends jni$_.JObjType<C2?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<C2?> get nullableType => this;
+  jni$_.JType<C2?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($C2$NullableType).hashCode;
+  int get hashCode => ($C2$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($C2$NullableType) && other is $C2$NullableType;
+    return other.runtimeType == ($C2$NullableType$) &&
+        other is $C2$NullableType$;
   }
 }
 
-final class $C2$Type extends jni$_.JObjType<C2> {
+final class $C2$Type$ extends jni$_.JType<C2> {
   @jni$_.internal
-  const $C2$Type();
+  const $C2$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -2810,22 +2835,22 @@ final class $C2$Type extends jni$_.JObjType<C2> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<C2?> get nullableType => const $C2$NullableType();
+  jni$_.JType<C2?> get nullableType => const $C2$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($C2$Type).hashCode;
+  int get hashCode => ($C2$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($C2$Type) && other is $C2$Type;
+    return other.runtimeType == ($C2$Type$) && other is $C2$Type$;
   }
 }
 
@@ -2833,7 +2858,7 @@ final class $C2$Type extends jni$_.JObjType<C2> {
 class Example$1 extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Example$1> $type;
+  final jni$_.JType<Example$1> $type;
 
   @jni$_.internal
   Example$1.fromReference(
@@ -2845,8 +2870,11 @@ class Example$1 extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/pkg2/Example');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Example$1$NullableType();
-  static const type = $Example$1$Type();
+  static const jni$_.JType<Example$1?> nullableType =
+      $Example$1$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Example$1> type = $Example$1$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -2896,9 +2924,9 @@ class Example$1 extends jni$_.JObject {
   }
 }
 
-final class $Example$1$NullableType extends jni$_.JObjType<Example$1?> {
+final class $Example$1$NullableType$ extends jni$_.JType<Example$1?> {
   @jni$_.internal
-  const $Example$1$NullableType();
+  const $Example$1$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -2913,29 +2941,29 @@ final class $Example$1$NullableType extends jni$_.JObjType<Example$1?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example$1?> get nullableType => this;
+  jni$_.JType<Example$1?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example$1$NullableType).hashCode;
+  int get hashCode => ($Example$1$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example$1$NullableType) &&
-        other is $Example$1$NullableType;
+    return other.runtimeType == ($Example$1$NullableType$) &&
+        other is $Example$1$NullableType$;
   }
 }
 
-final class $Example$1$Type extends jni$_.JObjType<Example$1> {
+final class $Example$1$Type$ extends jni$_.JType<Example$1> {
   @jni$_.internal
-  const $Example$1$Type();
+  const $Example$1$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -2949,23 +2977,22 @@ final class $Example$1$Type extends jni$_.JObjType<Example$1> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Example$1?> get nullableType =>
-      const $Example$1$NullableType();
+  jni$_.JType<Example$1?> get nullableType => const $Example$1$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Example$1$Type).hashCode;
+  int get hashCode => ($Example$1$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Example$1$Type) && other is $Example$1$Type;
+    return other.runtimeType == ($Example$1$Type$) && other is $Example$1$Type$;
   }
 }
 
@@ -2973,7 +3000,7 @@ final class $Example$1$Type extends jni$_.JObjType<Example$1> {
 class Colors$RGB extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Colors$RGB> $type;
+  final jni$_.JType<Colors$RGB> $type;
 
   @jni$_.internal
   Colors$RGB.fromReference(
@@ -2985,8 +3012,11 @@ class Colors$RGB extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/enums/Colors$RGB');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Colors$RGB$NullableType();
-  static const type = $Colors$RGB$Type();
+  static const jni$_.JType<Colors$RGB?> nullableType =
+      $Colors$RGB$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Colors$RGB> type = $Colors$RGB$Type$();
   static final _id_red = _class.instanceFieldId(
     r'red',
     r'I',
@@ -3097,9 +3127,9 @@ class Colors$RGB extends jni$_.JObject {
   }
 }
 
-final class $Colors$RGB$NullableType extends jni$_.JObjType<Colors$RGB?> {
+final class $Colors$RGB$NullableType$ extends jni$_.JType<Colors$RGB?> {
   @jni$_.internal
-  const $Colors$RGB$NullableType();
+  const $Colors$RGB$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -3114,29 +3144,29 @@ final class $Colors$RGB$NullableType extends jni$_.JObjType<Colors$RGB?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Colors$RGB?> get nullableType => this;
+  jni$_.JType<Colors$RGB?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Colors$RGB$NullableType).hashCode;
+  int get hashCode => ($Colors$RGB$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Colors$RGB$NullableType) &&
-        other is $Colors$RGB$NullableType;
+    return other.runtimeType == ($Colors$RGB$NullableType$) &&
+        other is $Colors$RGB$NullableType$;
   }
 }
 
-final class $Colors$RGB$Type extends jni$_.JObjType<Colors$RGB> {
+final class $Colors$RGB$Type$ extends jni$_.JType<Colors$RGB> {
   @jni$_.internal
-  const $Colors$RGB$Type();
+  const $Colors$RGB$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -3150,23 +3180,24 @@ final class $Colors$RGB$Type extends jni$_.JObjType<Colors$RGB> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Colors$RGB?> get nullableType =>
-      const $Colors$RGB$NullableType();
+  jni$_.JType<Colors$RGB?> get nullableType =>
+      const $Colors$RGB$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Colors$RGB$Type).hashCode;
+  int get hashCode => ($Colors$RGB$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Colors$RGB$Type) && other is $Colors$RGB$Type;
+    return other.runtimeType == ($Colors$RGB$Type$) &&
+        other is $Colors$RGB$Type$;
   }
 }
 
@@ -3174,7 +3205,7 @@ final class $Colors$RGB$Type extends jni$_.JObjType<Colors$RGB> {
 class Colors extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Colors> $type;
+  final jni$_.JType<Colors> $type;
 
   @jni$_.internal
   Colors.fromReference(
@@ -3186,8 +3217,10 @@ class Colors extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/enums/Colors');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Colors$NullableType();
-  static const type = $Colors$Type();
+  static const jni$_.JType<Colors?> nullableType = $Colors$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Colors> type = $Colors$Type$();
   static final _id_red = _class.staticFieldId(
     r'red',
     r'Lcom/github/dart_lang/jnigen/enums/Colors;',
@@ -3195,7 +3228,7 @@ class Colors extends jni$_.JObject {
 
   /// from: `static public final com.github.dart_lang.jnigen.enums.Colors red`
   /// The returned object must be released after use, by calling the [release] method.
-  static Colors get red => _id_red.get(_class, const $Colors$Type());
+  static Colors get red => _id_red.get(_class, const $Colors$Type$());
 
   static final _id_green = _class.staticFieldId(
     r'green',
@@ -3204,7 +3237,7 @@ class Colors extends jni$_.JObject {
 
   /// from: `static public final com.github.dart_lang.jnigen.enums.Colors green`
   /// The returned object must be released after use, by calling the [release] method.
-  static Colors get green => _id_green.get(_class, const $Colors$Type());
+  static Colors get green => _id_green.get(_class, const $Colors$Type$());
 
   static final _id_blue = _class.staticFieldId(
     r'blue',
@@ -3213,7 +3246,7 @@ class Colors extends jni$_.JObject {
 
   /// from: `static public final com.github.dart_lang.jnigen.enums.Colors blue`
   /// The returned object must be released after use, by calling the [release] method.
-  static Colors get blue => _id_blue.get(_class, const $Colors$Type());
+  static Colors get blue => _id_blue.get(_class, const $Colors$Type$());
 
   static final _id_code = _class.instanceFieldId(
     r'code',
@@ -3245,7 +3278,8 @@ class Colors extends jni$_.JObject {
   static jni$_.JArray<Colors?>? values() {
     return _values(_class.reference.pointer, _id_values as jni$_.JMethodIDPtr)
         .object<jni$_.JArray<Colors?>?>(
-            const jni$_.JArrayNullableType<Colors?>($Colors$NullableType()));
+            const jni$_.$JArray$NullableType$<Colors?>(
+                $Colors$NullableType$()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -3272,7 +3306,7 @@ class Colors extends jni$_.JObject {
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _valueOf(_class.reference.pointer, _id_valueOf as jni$_.JMethodIDPtr,
             _$string.pointer)
-        .object<Colors?>(const $Colors$NullableType());
+        .object<Colors?>(const $Colors$NullableType$());
   }
 
   static final _id_toRGB = _class.instanceMethodId(
@@ -3296,13 +3330,13 @@ class Colors extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   Colors$RGB? toRGB() {
     return _toRGB(reference.pointer, _id_toRGB as jni$_.JMethodIDPtr)
-        .object<Colors$RGB?>(const $Colors$RGB$NullableType());
+        .object<Colors$RGB?>(const $Colors$RGB$NullableType$());
   }
 }
 
-final class $Colors$NullableType extends jni$_.JObjType<Colors?> {
+final class $Colors$NullableType$ extends jni$_.JType<Colors?> {
   @jni$_.internal
-  const $Colors$NullableType();
+  const $Colors$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -3317,29 +3351,29 @@ final class $Colors$NullableType extends jni$_.JObjType<Colors?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Colors?> get nullableType => this;
+  jni$_.JType<Colors?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Colors$NullableType).hashCode;
+  int get hashCode => ($Colors$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Colors$NullableType) &&
-        other is $Colors$NullableType;
+    return other.runtimeType == ($Colors$NullableType$) &&
+        other is $Colors$NullableType$;
   }
 }
 
-final class $Colors$Type extends jni$_.JObjType<Colors> {
+final class $Colors$Type$ extends jni$_.JType<Colors> {
   @jni$_.internal
-  const $Colors$Type();
+  const $Colors$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -3352,22 +3386,22 @@ final class $Colors$Type extends jni$_.JObjType<Colors> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Colors?> get nullableType => const $Colors$NullableType();
+  jni$_.JType<Colors?> get nullableType => const $Colors$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Colors$Type).hashCode;
+  int get hashCode => ($Colors$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Colors$Type) && other is $Colors$Type;
+    return other.runtimeType == ($Colors$Type$) && other is $Colors$Type$;
   }
 }
 
@@ -3376,13 +3410,13 @@ class GenericTypeParams<$S extends jni$_.JObject?, $K extends jni$_.JObject?>
     extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<GenericTypeParams<$S, $K>> $type;
+  final jni$_.JType<GenericTypeParams<$S, $K>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$S> S;
+  final jni$_.JType<$S> S;
 
   @jni$_.internal
-  final jni$_.JObjType<$K> K;
+  final jni$_.JType<$K> K;
 
   @jni$_.internal
   GenericTypeParams.fromReference(
@@ -3396,23 +3430,24 @@ class GenericTypeParams<$S extends jni$_.JObject?, $K extends jni$_.JObject?>
       r'com/github/dart_lang/jnigen/generics/GenericTypeParams');
 
   /// The type which includes information such as the signature of this class.
-  static $GenericTypeParams$NullableType<$S, $K>
+  static jni$_.JType<GenericTypeParams<$S, $K>?>
       nullableType<$S extends jni$_.JObject?, $K extends jni$_.JObject?>(
-    jni$_.JObjType<$S> S,
-    jni$_.JObjType<$K> K,
+    jni$_.JType<$S> S,
+    jni$_.JType<$K> K,
   ) {
-    return $GenericTypeParams$NullableType<$S, $K>(
+    return $GenericTypeParams$NullableType$<$S, $K>(
       S,
       K,
     );
   }
 
-  static $GenericTypeParams$Type<$S, $K>
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<GenericTypeParams<$S, $K>>
       type<$S extends jni$_.JObject?, $K extends jni$_.JObject?>(
-    jni$_.JObjType<$S> S,
-    jni$_.JObjType<$K> K,
+    jni$_.JType<$S> S,
+    jni$_.JType<$K> K,
   ) {
-    return $GenericTypeParams$Type<$S, $K>(
+    return $GenericTypeParams$Type$<$S, $K>(
       S,
       K,
     );
@@ -3437,8 +3472,8 @@ class GenericTypeParams<$S extends jni$_.JObject?, $K extends jni$_.JObject?>
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory GenericTypeParams({
-    required jni$_.JObjType<$S> S,
-    required jni$_.JObjType<$K> K,
+    required jni$_.JType<$S> S,
+    required jni$_.JType<$K> K,
   }) {
     return GenericTypeParams<$S, $K>.fromReference(
         S,
@@ -3448,17 +3483,16 @@ class GenericTypeParams<$S extends jni$_.JObject?, $K extends jni$_.JObject?>
   }
 }
 
-final class $GenericTypeParams$NullableType<$S extends jni$_.JObject?,
-        $K extends jni$_.JObject?>
-    extends jni$_.JObjType<GenericTypeParams<$S, $K>?> {
+final class $GenericTypeParams$NullableType$<$S extends jni$_.JObject?,
+    $K extends jni$_.JObject?> extends jni$_.JType<GenericTypeParams<$S, $K>?> {
   @jni$_.internal
-  final jni$_.JObjType<$S> S;
+  final jni$_.JType<$S> S;
 
   @jni$_.internal
-  final jni$_.JObjType<$K> K;
+  final jni$_.JType<$K> K;
 
   @jni$_.internal
-  const $GenericTypeParams$NullableType(
+  const $GenericTypeParams$NullableType$(
     this.S,
     this.K,
   );
@@ -3480,39 +3514,38 @@ final class $GenericTypeParams$NullableType<$S extends jni$_.JObject?,
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GenericTypeParams<$S, $K>?> get nullableType => this;
+  jni$_.JType<GenericTypeParams<$S, $K>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GenericTypeParams$NullableType, S, K);
+  int get hashCode => Object.hash($GenericTypeParams$NullableType$, S, K);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GenericTypeParams$NullableType<$S, $K>) &&
-        other is $GenericTypeParams$NullableType<$S, $K> &&
+    return other.runtimeType == ($GenericTypeParams$NullableType$<$S, $K>) &&
+        other is $GenericTypeParams$NullableType$<$S, $K> &&
         S == other.S &&
         K == other.K;
   }
 }
 
-final class $GenericTypeParams$Type<$S extends jni$_.JObject?,
-        $K extends jni$_.JObject?>
-    extends jni$_.JObjType<GenericTypeParams<$S, $K>> {
+final class $GenericTypeParams$Type$<$S extends jni$_.JObject?,
+    $K extends jni$_.JObject?> extends jni$_.JType<GenericTypeParams<$S, $K>> {
   @jni$_.internal
-  final jni$_.JObjType<$S> S;
+  final jni$_.JType<$S> S;
 
   @jni$_.internal
-  final jni$_.JObjType<$K> K;
+  final jni$_.JType<$K> K;
 
   @jni$_.internal
-  const $GenericTypeParams$Type(
+  const $GenericTypeParams$Type$(
     this.S,
     this.K,
   );
@@ -3532,24 +3565,24 @@ final class $GenericTypeParams$Type<$S extends jni$_.JObject?,
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GenericTypeParams<$S, $K>?> get nullableType =>
-      $GenericTypeParams$NullableType<$S, $K>(S, K);
+  jni$_.JType<GenericTypeParams<$S, $K>?> get nullableType =>
+      $GenericTypeParams$NullableType$<$S, $K>(S, K);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GenericTypeParams$Type, S, K);
+  int get hashCode => Object.hash($GenericTypeParams$Type$, S, K);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GenericTypeParams$Type<$S, $K>) &&
-        other is $GenericTypeParams$Type<$S, $K> &&
+    return other.runtimeType == ($GenericTypeParams$Type$<$S, $K>) &&
+        other is $GenericTypeParams$Type$<$S, $K> &&
         S == other.S &&
         K == other.K;
   }
@@ -3562,16 +3595,16 @@ class GrandParent$Parent$Child<
     $U extends jni$_.JObject?> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<GrandParent$Parent$Child<$T, $S, $U>> $type;
+  final jni$_.JType<GrandParent$Parent$Child<$T, $S, $U>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$S> S;
+  final jni$_.JType<$S> S;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
   GrandParent$Parent$Child.fromReference(
@@ -3586,30 +3619,31 @@ class GrandParent$Parent$Child<
       r'com/github/dart_lang/jnigen/generics/GrandParent$Parent$Child');
 
   /// The type which includes information such as the signature of this class.
-  static $GrandParent$Parent$Child$NullableType<$T, $S, $U> nullableType<
+  static jni$_.JType<GrandParent$Parent$Child<$T, $S, $U>?> nullableType<
       $T extends jni$_.JObject?,
       $S extends jni$_.JObject?,
       $U extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
-    jni$_.JObjType<$S> S,
-    jni$_.JObjType<$U> U,
+    jni$_.JType<$T> T,
+    jni$_.JType<$S> S,
+    jni$_.JType<$U> U,
   ) {
-    return $GrandParent$Parent$Child$NullableType<$T, $S, $U>(
+    return $GrandParent$Parent$Child$NullableType$<$T, $S, $U>(
       T,
       S,
       U,
     );
   }
 
-  static $GrandParent$Parent$Child$Type<$T, $S, $U> type<
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<GrandParent$Parent$Child<$T, $S, $U>> type<
       $T extends jni$_.JObject?,
       $S extends jni$_.JObject?,
       $U extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
-    jni$_.JObjType<$S> S,
-    jni$_.JObjType<$U> U,
+    jni$_.JType<$T> T,
+    jni$_.JType<$S> S,
+    jni$_.JType<$U> U,
   ) {
-    return $GrandParent$Parent$Child$Type<$T, $S, $U>(
+    return $GrandParent$Parent$Child$Type$<$T, $S, $U>(
       T,
       S,
       U,
@@ -3683,20 +3717,20 @@ class GrandParent$Parent$Child<
   factory GrandParent$Parent$Child(
     GrandParent$Parent<$T?, $S?> $outerClass,
     $U? object, {
-    jni$_.JObjType<$T>? T,
-    jni$_.JObjType<$S>? S,
-    required jni$_.JObjType<$U> U,
+    jni$_.JType<$T>? T,
+    jni$_.JType<$S>? S,
+    required jni$_.JType<$U> U,
   }) {
     T ??= jni$_.lowestCommonSuperType([
       ($outerClass.$type
-              as $GrandParent$Parent$Type<core$_.dynamic, core$_.dynamic>)
+              as $GrandParent$Parent$Type$<core$_.dynamic, core$_.dynamic>)
           .T,
-    ]) as jni$_.JObjType<$T>;
+    ]) as jni$_.JType<$T>;
     S ??= jni$_.lowestCommonSuperType([
       ($outerClass.$type
-              as $GrandParent$Parent$Type<core$_.dynamic, core$_.dynamic>)
+              as $GrandParent$Parent$Type$<core$_.dynamic, core$_.dynamic>)
           .S,
-    ]) as jni$_.JObjType<$S>;
+    ]) as jni$_.JType<$S>;
     final _$$outerClass = $outerClass.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return GrandParent$Parent$Child<$T, $S, $U>.fromReference(
@@ -3709,20 +3743,20 @@ class GrandParent$Parent$Child<
   }
 }
 
-final class $GrandParent$Parent$Child$NullableType<$T extends jni$_.JObject?,
+final class $GrandParent$Parent$Child$NullableType$<$T extends jni$_.JObject?,
         $S extends jni$_.JObject?, $U extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent$Parent$Child<$T, $S, $U>?> {
+    extends jni$_.JType<GrandParent$Parent$Child<$T, $S, $U>?> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$S> S;
+  final jni$_.JType<$S> S;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
-  const $GrandParent$Parent$Child$NullableType(
+  const $GrandParent$Parent$Child$NullableType$(
     this.T,
     this.S,
     this.U,
@@ -3747,12 +3781,11 @@ final class $GrandParent$Parent$Child$NullableType<$T extends jni$_.JObject?,
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent$Parent$Child<$T, $S, $U>?> get nullableType =>
-      this;
+  jni$_.JType<GrandParent$Parent$Child<$T, $S, $U>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
@@ -3760,33 +3793,33 @@ final class $GrandParent$Parent$Child$NullableType<$T extends jni$_.JObject?,
 
   @core$_.override
   int get hashCode =>
-      Object.hash($GrandParent$Parent$Child$NullableType, T, S, U);
+      Object.hash($GrandParent$Parent$Child$NullableType$, T, S, U);
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($GrandParent$Parent$Child$NullableType<$T, $S, $U>) &&
-        other is $GrandParent$Parent$Child$NullableType<$T, $S, $U> &&
+            ($GrandParent$Parent$Child$NullableType$<$T, $S, $U>) &&
+        other is $GrandParent$Parent$Child$NullableType$<$T, $S, $U> &&
         T == other.T &&
         S == other.S &&
         U == other.U;
   }
 }
 
-final class $GrandParent$Parent$Child$Type<$T extends jni$_.JObject?,
+final class $GrandParent$Parent$Child$Type$<$T extends jni$_.JObject?,
         $S extends jni$_.JObject?, $U extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent$Parent$Child<$T, $S, $U>> {
+    extends jni$_.JType<GrandParent$Parent$Child<$T, $S, $U>> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$S> S;
+  final jni$_.JType<$S> S;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
-  const $GrandParent$Parent$Child$Type(
+  const $GrandParent$Parent$Child$Type$(
     this.T,
     this.S,
     this.U,
@@ -3809,24 +3842,24 @@ final class $GrandParent$Parent$Child$Type<$T extends jni$_.JObject?,
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent$Parent$Child<$T, $S, $U>?> get nullableType =>
-      $GrandParent$Parent$Child$NullableType<$T, $S, $U>(T, S, U);
+  jni$_.JType<GrandParent$Parent$Child<$T, $S, $U>?> get nullableType =>
+      $GrandParent$Parent$Child$NullableType$<$T, $S, $U>(T, S, U);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GrandParent$Parent$Child$Type, T, S, U);
+  int get hashCode => Object.hash($GrandParent$Parent$Child$Type$, T, S, U);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent$Parent$Child$Type<$T, $S, $U>) &&
-        other is $GrandParent$Parent$Child$Type<$T, $S, $U> &&
+    return other.runtimeType == ($GrandParent$Parent$Child$Type$<$T, $S, $U>) &&
+        other is $GrandParent$Parent$Child$Type$<$T, $S, $U> &&
         T == other.T &&
         S == other.S &&
         U == other.U;
@@ -3838,13 +3871,13 @@ class GrandParent$Parent<$T extends jni$_.JObject?, $S extends jni$_.JObject?>
     extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<GrandParent$Parent<$T, $S>> $type;
+  final jni$_.JType<GrandParent$Parent<$T, $S>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$S> S;
+  final jni$_.JType<$S> S;
 
   @jni$_.internal
   GrandParent$Parent.fromReference(
@@ -3858,23 +3891,24 @@ class GrandParent$Parent<$T extends jni$_.JObject?, $S extends jni$_.JObject?>
       r'com/github/dart_lang/jnigen/generics/GrandParent$Parent');
 
   /// The type which includes information such as the signature of this class.
-  static $GrandParent$Parent$NullableType<$T, $S>
+  static jni$_.JType<GrandParent$Parent<$T, $S>?>
       nullableType<$T extends jni$_.JObject?, $S extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
-    jni$_.JObjType<$S> S,
+    jni$_.JType<$T> T,
+    jni$_.JType<$S> S,
   ) {
-    return $GrandParent$Parent$NullableType<$T, $S>(
+    return $GrandParent$Parent$NullableType$<$T, $S>(
       T,
       S,
     );
   }
 
-  static $GrandParent$Parent$Type<$T, $S>
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<GrandParent$Parent<$T, $S>>
       type<$T extends jni$_.JObject?, $S extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
-    jni$_.JObjType<$S> S,
+    jni$_.JType<$T> T,
+    jni$_.JType<$S> S,
   ) {
-    return $GrandParent$Parent$Type<$T, $S>(
+    return $GrandParent$Parent$Type$<$T, $S>(
       T,
       S,
     );
@@ -3933,12 +3967,12 @@ class GrandParent$Parent<$T extends jni$_.JObject?, $S extends jni$_.JObject?>
   factory GrandParent$Parent(
     GrandParent<$T?> $outerClass,
     $S? object, {
-    jni$_.JObjType<$T>? T,
-    required jni$_.JObjType<$S> S,
+    jni$_.JType<$T>? T,
+    required jni$_.JType<$S> S,
   }) {
     T ??= jni$_.lowestCommonSuperType([
-      ($outerClass.$type as $GrandParent$Type<core$_.dynamic>).T,
-    ]) as jni$_.JObjType<$T>;
+      ($outerClass.$type as $GrandParent$Type$<core$_.dynamic>).T,
+    ]) as jni$_.JType<$T>;
     final _$$outerClass = $outerClass.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return GrandParent$Parent<$T, $S>.fromReference(
@@ -3950,17 +3984,17 @@ class GrandParent$Parent<$T extends jni$_.JObject?, $S extends jni$_.JObject?>
   }
 }
 
-final class $GrandParent$Parent$NullableType<$T extends jni$_.JObject?,
+final class $GrandParent$Parent$NullableType$<$T extends jni$_.JObject?,
         $S extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent$Parent<$T, $S>?> {
+    extends jni$_.JType<GrandParent$Parent<$T, $S>?> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$S> S;
+  final jni$_.JType<$S> S;
 
   @jni$_.internal
-  const $GrandParent$Parent$NullableType(
+  const $GrandParent$Parent$NullableType$(
     this.T,
     this.S,
   );
@@ -3982,39 +4016,38 @@ final class $GrandParent$Parent$NullableType<$T extends jni$_.JObject?,
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent$Parent<$T, $S>?> get nullableType => this;
+  jni$_.JType<GrandParent$Parent<$T, $S>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GrandParent$Parent$NullableType, T, S);
+  int get hashCode => Object.hash($GrandParent$Parent$NullableType$, T, S);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent$Parent$NullableType<$T, $S>) &&
-        other is $GrandParent$Parent$NullableType<$T, $S> &&
+    return other.runtimeType == ($GrandParent$Parent$NullableType$<$T, $S>) &&
+        other is $GrandParent$Parent$NullableType$<$T, $S> &&
         T == other.T &&
         S == other.S;
   }
 }
 
-final class $GrandParent$Parent$Type<$T extends jni$_.JObject?,
-        $S extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent$Parent<$T, $S>> {
+final class $GrandParent$Parent$Type$<$T extends jni$_.JObject?,
+    $S extends jni$_.JObject?> extends jni$_.JType<GrandParent$Parent<$T, $S>> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$S> S;
+  final jni$_.JType<$S> S;
 
   @jni$_.internal
-  const $GrandParent$Parent$Type(
+  const $GrandParent$Parent$Type$(
     this.T,
     this.S,
   );
@@ -4034,24 +4067,24 @@ final class $GrandParent$Parent$Type<$T extends jni$_.JObject?,
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent$Parent<$T, $S>?> get nullableType =>
-      $GrandParent$Parent$NullableType<$T, $S>(T, S);
+  jni$_.JType<GrandParent$Parent<$T, $S>?> get nullableType =>
+      $GrandParent$Parent$NullableType$<$T, $S>(T, S);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GrandParent$Parent$Type, T, S);
+  int get hashCode => Object.hash($GrandParent$Parent$Type$, T, S);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent$Parent$Type<$T, $S>) &&
-        other is $GrandParent$Parent$Type<$T, $S> &&
+    return other.runtimeType == ($GrandParent$Parent$Type$<$T, $S>) &&
+        other is $GrandParent$Parent$Type$<$T, $S> &&
         T == other.T &&
         S == other.S;
   }
@@ -4062,13 +4095,13 @@ class GrandParent$StaticParent$Child<$S extends jni$_.JObject?,
     $U extends jni$_.JObject?> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<GrandParent$StaticParent$Child<$S, $U>> $type;
+  final jni$_.JType<GrandParent$StaticParent$Child<$S, $U>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$S> S;
+  final jni$_.JType<$S> S;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
   GrandParent$StaticParent$Child.fromReference(
@@ -4082,23 +4115,24 @@ class GrandParent$StaticParent$Child<$S extends jni$_.JObject?,
       r'com/github/dart_lang/jnigen/generics/GrandParent$StaticParent$Child');
 
   /// The type which includes information such as the signature of this class.
-  static $GrandParent$StaticParent$Child$NullableType<$S, $U>
+  static jni$_.JType<GrandParent$StaticParent$Child<$S, $U>?>
       nullableType<$S extends jni$_.JObject?, $U extends jni$_.JObject?>(
-    jni$_.JObjType<$S> S,
-    jni$_.JObjType<$U> U,
+    jni$_.JType<$S> S,
+    jni$_.JType<$U> U,
   ) {
-    return $GrandParent$StaticParent$Child$NullableType<$S, $U>(
+    return $GrandParent$StaticParent$Child$NullableType$<$S, $U>(
       S,
       U,
     );
   }
 
-  static $GrandParent$StaticParent$Child$Type<$S, $U>
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<GrandParent$StaticParent$Child<$S, $U>>
       type<$S extends jni$_.JObject?, $U extends jni$_.JObject?>(
-    jni$_.JObjType<$S> S,
-    jni$_.JObjType<$U> U,
+    jni$_.JType<$S> S,
+    jni$_.JType<$U> U,
   ) {
-    return $GrandParent$StaticParent$Child$Type<$S, $U>(
+    return $GrandParent$StaticParent$Child$Type$<$S, $U>(
       S,
       U,
     );
@@ -4160,12 +4194,12 @@ class GrandParent$StaticParent$Child<$S extends jni$_.JObject?,
     GrandParent$StaticParent<$S?> $outerClass,
     $S? object,
     $U? object1, {
-    jni$_.JObjType<$S>? S,
-    required jni$_.JObjType<$U> U,
+    jni$_.JType<$S>? S,
+    required jni$_.JType<$U> U,
   }) {
     S ??= jni$_.lowestCommonSuperType([
-      ($outerClass.$type as $GrandParent$StaticParent$Type<core$_.dynamic>).S,
-    ]) as jni$_.JObjType<$S>;
+      ($outerClass.$type as $GrandParent$StaticParent$Type$<core$_.dynamic>).S,
+    ]) as jni$_.JType<$S>;
     final _$$outerClass = $outerClass.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
@@ -4178,17 +4212,17 @@ class GrandParent$StaticParent$Child<$S extends jni$_.JObject?,
   }
 }
 
-final class $GrandParent$StaticParent$Child$NullableType<
+final class $GrandParent$StaticParent$Child$NullableType$<
         $S extends jni$_.JObject?, $U extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent$StaticParent$Child<$S, $U>?> {
+    extends jni$_.JType<GrandParent$StaticParent$Child<$S, $U>?> {
   @jni$_.internal
-  final jni$_.JObjType<$S> S;
+  final jni$_.JType<$S> S;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
-  const $GrandParent$StaticParent$Child$NullableType(
+  const $GrandParent$StaticParent$Child$NullableType$(
     this.S,
     this.U,
   );
@@ -4211,12 +4245,11 @@ final class $GrandParent$StaticParent$Child$NullableType<
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent$StaticParent$Child<$S, $U>?> get nullableType =>
-      this;
+  jni$_.JType<GrandParent$StaticParent$Child<$S, $U>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
@@ -4224,29 +4257,29 @@ final class $GrandParent$StaticParent$Child$NullableType<
 
   @core$_.override
   int get hashCode =>
-      Object.hash($GrandParent$StaticParent$Child$NullableType, S, U);
+      Object.hash($GrandParent$StaticParent$Child$NullableType$, S, U);
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($GrandParent$StaticParent$Child$NullableType<$S, $U>) &&
-        other is $GrandParent$StaticParent$Child$NullableType<$S, $U> &&
+            ($GrandParent$StaticParent$Child$NullableType$<$S, $U>) &&
+        other is $GrandParent$StaticParent$Child$NullableType$<$S, $U> &&
         S == other.S &&
         U == other.U;
   }
 }
 
-final class $GrandParent$StaticParent$Child$Type<$S extends jni$_.JObject?,
+final class $GrandParent$StaticParent$Child$Type$<$S extends jni$_.JObject?,
         $U extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent$StaticParent$Child<$S, $U>> {
+    extends jni$_.JType<GrandParent$StaticParent$Child<$S, $U>> {
   @jni$_.internal
-  final jni$_.JObjType<$S> S;
+  final jni$_.JType<$S> S;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
-  const $GrandParent$StaticParent$Child$Type(
+  const $GrandParent$StaticParent$Child$Type$(
     this.S,
     this.U,
   );
@@ -4267,25 +4300,25 @@ final class $GrandParent$StaticParent$Child$Type<$S extends jni$_.JObject?,
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent$StaticParent$Child<$S, $U>?> get nullableType =>
-      $GrandParent$StaticParent$Child$NullableType<$S, $U>(S, U);
+  jni$_.JType<GrandParent$StaticParent$Child<$S, $U>?> get nullableType =>
+      $GrandParent$StaticParent$Child$NullableType$<$S, $U>(S, U);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GrandParent$StaticParent$Child$Type, S, U);
+  int get hashCode => Object.hash($GrandParent$StaticParent$Child$Type$, S, U);
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($GrandParent$StaticParent$Child$Type<$S, $U>) &&
-        other is $GrandParent$StaticParent$Child$Type<$S, $U> &&
+            ($GrandParent$StaticParent$Child$Type$<$S, $U>) &&
+        other is $GrandParent$StaticParent$Child$Type$<$S, $U> &&
         S == other.S &&
         U == other.U;
   }
@@ -4296,10 +4329,10 @@ class GrandParent$StaticParent<$S extends jni$_.JObject?>
     extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<GrandParent$StaticParent<$S>> $type;
+  final jni$_.JType<GrandParent$StaticParent<$S>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$S> S;
+  final jni$_.JType<$S> S;
 
   @jni$_.internal
   GrandParent$StaticParent.fromReference(
@@ -4312,19 +4345,21 @@ class GrandParent$StaticParent<$S extends jni$_.JObject?>
       r'com/github/dart_lang/jnigen/generics/GrandParent$StaticParent');
 
   /// The type which includes information such as the signature of this class.
-  static $GrandParent$StaticParent$NullableType<$S>
+  static jni$_.JType<GrandParent$StaticParent<$S>?>
       nullableType<$S extends jni$_.JObject?>(
-    jni$_.JObjType<$S> S,
+    jni$_.JType<$S> S,
   ) {
-    return $GrandParent$StaticParent$NullableType<$S>(
+    return $GrandParent$StaticParent$NullableType$<$S>(
       S,
     );
   }
 
-  static $GrandParent$StaticParent$Type<$S> type<$S extends jni$_.JObject?>(
-    jni$_.JObjType<$S> S,
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<GrandParent$StaticParent<$S>>
+      type<$S extends jni$_.JObject?>(
+    jni$_.JType<$S> S,
   ) {
-    return $GrandParent$StaticParent$Type<$S>(
+    return $GrandParent$StaticParent$Type$<$S>(
       S,
     );
   }
@@ -4361,7 +4396,7 @@ class GrandParent$StaticParent<$S extends jni$_.JObject?>
   /// The returned object must be released after use, by calling the [release] method.
   factory GrandParent$StaticParent(
     $S? object, {
-    required jni$_.JObjType<$S> S,
+    required jni$_.JType<$S> S,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return GrandParent$StaticParent<$S>.fromReference(
@@ -4372,13 +4407,13 @@ class GrandParent$StaticParent<$S extends jni$_.JObject?>
   }
 }
 
-final class $GrandParent$StaticParent$NullableType<$S extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent$StaticParent<$S>?> {
+final class $GrandParent$StaticParent$NullableType$<$S extends jni$_.JObject?>
+    extends jni$_.JType<GrandParent$StaticParent<$S>?> {
   @jni$_.internal
-  final jni$_.JObjType<$S> S;
+  final jni$_.JType<$S> S;
 
   @jni$_.internal
-  const $GrandParent$StaticParent$NullableType(
+  const $GrandParent$StaticParent$NullableType$(
     this.S,
   );
 
@@ -4398,34 +4433,34 @@ final class $GrandParent$StaticParent$NullableType<$S extends jni$_.JObject?>
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent$StaticParent<$S>?> get nullableType => this;
+  jni$_.JType<GrandParent$StaticParent<$S>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GrandParent$StaticParent$NullableType, S);
+  int get hashCode => Object.hash($GrandParent$StaticParent$NullableType$, S);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent$StaticParent$NullableType<$S>) &&
-        other is $GrandParent$StaticParent$NullableType<$S> &&
+    return other.runtimeType == ($GrandParent$StaticParent$NullableType$<$S>) &&
+        other is $GrandParent$StaticParent$NullableType$<$S> &&
         S == other.S;
   }
 }
 
-final class $GrandParent$StaticParent$Type<$S extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent$StaticParent<$S>> {
+final class $GrandParent$StaticParent$Type$<$S extends jni$_.JObject?>
+    extends jni$_.JType<GrandParent$StaticParent<$S>> {
   @jni$_.internal
-  final jni$_.JObjType<$S> S;
+  final jni$_.JType<$S> S;
 
   @jni$_.internal
-  const $GrandParent$StaticParent$Type(
+  const $GrandParent$StaticParent$Type$(
     this.S,
   );
 
@@ -4443,24 +4478,24 @@ final class $GrandParent$StaticParent$Type<$S extends jni$_.JObject?>
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent$StaticParent<$S>?> get nullableType =>
-      $GrandParent$StaticParent$NullableType<$S>(S);
+  jni$_.JType<GrandParent$StaticParent<$S>?> get nullableType =>
+      $GrandParent$StaticParent$NullableType$<$S>(S);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GrandParent$StaticParent$Type, S);
+  int get hashCode => Object.hash($GrandParent$StaticParent$Type$, S);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent$StaticParent$Type<$S>) &&
-        other is $GrandParent$StaticParent$Type<$S> &&
+    return other.runtimeType == ($GrandParent$StaticParent$Type$<$S>) &&
+        other is $GrandParent$StaticParent$Type$<$S> &&
         S == other.S;
   }
 }
@@ -4469,10 +4504,10 @@ final class $GrandParent$StaticParent$Type<$S extends jni$_.JObject?>
 class GrandParent<$T extends jni$_.JObject?> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<GrandParent<$T>> $type;
+  final jni$_.JType<GrandParent<$T>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
   GrandParent.fromReference(
@@ -4485,18 +4520,19 @@ class GrandParent<$T extends jni$_.JObject?> extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/generics/GrandParent');
 
   /// The type which includes information such as the signature of this class.
-  static $GrandParent$NullableType<$T> nullableType<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+  static jni$_.JType<GrandParent<$T>?> nullableType<$T extends jni$_.JObject?>(
+    jni$_.JType<$T> T,
   ) {
-    return $GrandParent$NullableType<$T>(
+    return $GrandParent$NullableType$<$T>(
       T,
     );
   }
 
-  static $GrandParent$Type<$T> type<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<GrandParent<$T>> type<$T extends jni$_.JObject?>(
+    jni$_.JType<$T> T,
   ) {
-    return $GrandParent$Type<$T>(
+    return $GrandParent$Type$<$T>(
       T,
     );
   }
@@ -4533,7 +4569,7 @@ class GrandParent<$T extends jni$_.JObject?> extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   factory GrandParent(
     $T? object, {
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return GrandParent<$T>.fromReference(
@@ -4566,8 +4602,8 @@ class GrandParent<$T extends jni$_.JObject?> extends jni$_.JObject {
     return _stringParent(
             reference.pointer, _id_stringParent as jni$_.JMethodIDPtr)
         .object<GrandParent$Parent<$T?, jni$_.JString?>?>(
-            $GrandParent$Parent$NullableType<$T?, jni$_.JString?>(
-                T.nullableType, const jni$_.JStringNullableType()));
+            $GrandParent$Parent$NullableType$<$T?, jni$_.JString?>(
+                T.nullableType, const jni$_.$JString$NullableType$()));
   }
 
   static final _id_varParent = _class.instanceMethodId(
@@ -4590,13 +4626,13 @@ class GrandParent<$T extends jni$_.JObject?> extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   GrandParent$Parent<$T?, $S?>? varParent<$S extends jni$_.JObject?>(
     $S? object, {
-    required jni$_.JObjType<$S> S,
+    required jni$_.JType<$S> S,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _varParent(reference.pointer, _id_varParent as jni$_.JMethodIDPtr,
             _$object.pointer)
         .object<GrandParent$Parent<$T?, $S?>?>(
-            $GrandParent$Parent$NullableType<$T?, $S?>(
+            $GrandParent$Parent$NullableType$<$T?, $S?>(
                 T.nullableType, S.nullableType));
   }
 
@@ -4623,8 +4659,8 @@ class GrandParent<$T extends jni$_.JObject?> extends jni$_.JObject {
     return _stringStaticParent(_class.reference.pointer,
             _id_stringStaticParent as jni$_.JMethodIDPtr)
         .object<GrandParent$StaticParent<jni$_.JString?>?>(
-            const $GrandParent$StaticParent$NullableType<jni$_.JString?>(
-                jni$_.JStringNullableType()));
+            const $GrandParent$StaticParent$NullableType$<jni$_.JString?>(
+                jni$_.$JString$NullableType$()));
   }
 
   static final _id_varStaticParent = _class.staticMethodId(
@@ -4648,13 +4684,13 @@ class GrandParent<$T extends jni$_.JObject?> extends jni$_.JObject {
   static GrandParent$StaticParent<$S?>?
       varStaticParent<$S extends jni$_.JObject?>(
     $S? object, {
-    required jni$_.JObjType<$S> S,
+    required jni$_.JType<$S> S,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _varStaticParent(_class.reference.pointer,
             _id_varStaticParent as jni$_.JMethodIDPtr, _$object.pointer)
         .object<GrandParent$StaticParent<$S?>?>(
-            $GrandParent$StaticParent$NullableType<$S?>(S.nullableType));
+            $GrandParent$StaticParent$NullableType$<$S?>(S.nullableType));
   }
 
   static final _id_staticParentWithSameType = _class.instanceMethodId(
@@ -4680,17 +4716,17 @@ class GrandParent<$T extends jni$_.JObject?> extends jni$_.JObject {
     return _staticParentWithSameType(reference.pointer,
             _id_staticParentWithSameType as jni$_.JMethodIDPtr)
         .object<GrandParent$StaticParent<$T?>?>(
-            $GrandParent$StaticParent$NullableType<$T?>(T.nullableType));
+            $GrandParent$StaticParent$NullableType$<$T?>(T.nullableType));
   }
 }
 
-final class $GrandParent$NullableType<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent<$T>?> {
+final class $GrandParent$NullableType$<$T extends jni$_.JObject?>
+    extends jni$_.JType<GrandParent<$T>?> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $GrandParent$NullableType(
+  const $GrandParent$NullableType$(
     this.T,
   );
 
@@ -4708,34 +4744,34 @@ final class $GrandParent$NullableType<$T extends jni$_.JObject?>
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent<$T>?> get nullableType => this;
+  jni$_.JType<GrandParent<$T>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GrandParent$NullableType, T);
+  int get hashCode => Object.hash($GrandParent$NullableType$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent$NullableType<$T>) &&
-        other is $GrandParent$NullableType<$T> &&
+    return other.runtimeType == ($GrandParent$NullableType$<$T>) &&
+        other is $GrandParent$NullableType$<$T> &&
         T == other.T;
   }
 }
 
-final class $GrandParent$Type<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<GrandParent<$T>> {
+final class $GrandParent$Type$<$T extends jni$_.JObject?>
+    extends jni$_.JType<GrandParent<$T>> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $GrandParent$Type(
+  const $GrandParent$Type$(
     this.T,
   );
 
@@ -4752,24 +4788,24 @@ final class $GrandParent$Type<$T extends jni$_.JObject?>
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GrandParent<$T>?> get nullableType =>
-      $GrandParent$NullableType<$T>(T);
+  jni$_.JType<GrandParent<$T>?> get nullableType =>
+      $GrandParent$NullableType$<$T>(T);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GrandParent$Type, T);
+  int get hashCode => Object.hash($GrandParent$Type$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GrandParent$Type<$T>) &&
-        other is $GrandParent$Type<$T> &&
+    return other.runtimeType == ($GrandParent$Type$<$T>) &&
+        other is $GrandParent$Type$<$T> &&
         T == other.T;
   }
 }
@@ -4779,13 +4815,13 @@ class MyMap$MyEntry<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<MyMap$MyEntry<$K, $V>> $type;
+  final jni$_.JType<MyMap$MyEntry<$K, $V>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$K> K;
+  final jni$_.JType<$K> K;
 
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
   MyMap$MyEntry.fromReference(
@@ -4799,23 +4835,24 @@ class MyMap$MyEntry<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
       r'com/github/dart_lang/jnigen/generics/MyMap$MyEntry');
 
   /// The type which includes information such as the signature of this class.
-  static $MyMap$MyEntry$NullableType<$K, $V>
+  static jni$_.JType<MyMap$MyEntry<$K, $V>?>
       nullableType<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
-    jni$_.JObjType<$K> K,
-    jni$_.JObjType<$V> V,
+    jni$_.JType<$K> K,
+    jni$_.JType<$V> V,
   ) {
-    return $MyMap$MyEntry$NullableType<$K, $V>(
+    return $MyMap$MyEntry$NullableType$<$K, $V>(
       K,
       V,
     );
   }
 
-  static $MyMap$MyEntry$Type<$K, $V>
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<MyMap$MyEntry<$K, $V>>
       type<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
-    jni$_.JObjType<$K> K,
-    jni$_.JObjType<$V> V,
+    jni$_.JType<$K> K,
+    jni$_.JType<$V> V,
   ) {
-    return $MyMap$MyEntry$Type<$K, $V>(
+    return $MyMap$MyEntry$Type$<$K, $V>(
       K,
       V,
     );
@@ -4876,15 +4913,15 @@ class MyMap$MyEntry<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     MyMap<$K?, $V?> $outerClass,
     $K? object,
     $V? object1, {
-    jni$_.JObjType<$K>? K,
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$K>? K,
+    jni$_.JType<$V>? V,
   }) {
     K ??= jni$_.lowestCommonSuperType([
-      ($outerClass.$type as $MyMap$Type<core$_.dynamic, core$_.dynamic>).K,
-    ]) as jni$_.JObjType<$K>;
+      ($outerClass.$type as $MyMap$Type$<core$_.dynamic, core$_.dynamic>).K,
+    ]) as jni$_.JType<$K>;
     V ??= jni$_.lowestCommonSuperType([
-      ($outerClass.$type as $MyMap$Type<core$_.dynamic, core$_.dynamic>).V,
-    ]) as jni$_.JObjType<$V>;
+      ($outerClass.$type as $MyMap$Type$<core$_.dynamic, core$_.dynamic>).V,
+    ]) as jni$_.JType<$V>;
     final _$$outerClass = $outerClass.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
@@ -4897,16 +4934,16 @@ class MyMap$MyEntry<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   }
 }
 
-final class $MyMap$MyEntry$NullableType<$K extends jni$_.JObject?,
-    $V extends jni$_.JObject?> extends jni$_.JObjType<MyMap$MyEntry<$K, $V>?> {
+final class $MyMap$MyEntry$NullableType$<$K extends jni$_.JObject?,
+    $V extends jni$_.JObject?> extends jni$_.JType<MyMap$MyEntry<$K, $V>?> {
   @jni$_.internal
-  final jni$_.JObjType<$K> K;
+  final jni$_.JType<$K> K;
 
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
-  const $MyMap$MyEntry$NullableType(
+  const $MyMap$MyEntry$NullableType$(
     this.K,
     this.V,
   );
@@ -4928,38 +4965,38 @@ final class $MyMap$MyEntry$NullableType<$K extends jni$_.JObject?,
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyMap$MyEntry<$K, $V>?> get nullableType => this;
+  jni$_.JType<MyMap$MyEntry<$K, $V>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($MyMap$MyEntry$NullableType, K, V);
+  int get hashCode => Object.hash($MyMap$MyEntry$NullableType$, K, V);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyMap$MyEntry$NullableType<$K, $V>) &&
-        other is $MyMap$MyEntry$NullableType<$K, $V> &&
+    return other.runtimeType == ($MyMap$MyEntry$NullableType$<$K, $V>) &&
+        other is $MyMap$MyEntry$NullableType$<$K, $V> &&
         K == other.K &&
         V == other.V;
   }
 }
 
-final class $MyMap$MyEntry$Type<$K extends jni$_.JObject?,
-    $V extends jni$_.JObject?> extends jni$_.JObjType<MyMap$MyEntry<$K, $V>> {
+final class $MyMap$MyEntry$Type$<$K extends jni$_.JObject?,
+    $V extends jni$_.JObject?> extends jni$_.JType<MyMap$MyEntry<$K, $V>> {
   @jni$_.internal
-  final jni$_.JObjType<$K> K;
+  final jni$_.JType<$K> K;
 
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
-  const $MyMap$MyEntry$Type(
+  const $MyMap$MyEntry$Type$(
     this.K,
     this.V,
   );
@@ -4979,24 +5016,24 @@ final class $MyMap$MyEntry$Type<$K extends jni$_.JObject?,
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyMap$MyEntry<$K, $V>?> get nullableType =>
-      $MyMap$MyEntry$NullableType<$K, $V>(K, V);
+  jni$_.JType<MyMap$MyEntry<$K, $V>?> get nullableType =>
+      $MyMap$MyEntry$NullableType$<$K, $V>(K, V);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($MyMap$MyEntry$Type, K, V);
+  int get hashCode => Object.hash($MyMap$MyEntry$Type$, K, V);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyMap$MyEntry$Type<$K, $V>) &&
-        other is $MyMap$MyEntry$Type<$K, $V> &&
+    return other.runtimeType == ($MyMap$MyEntry$Type$<$K, $V>) &&
+        other is $MyMap$MyEntry$Type$<$K, $V> &&
         K == other.K &&
         V == other.V;
   }
@@ -5007,13 +5044,13 @@ class MyMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<MyMap<$K, $V>> $type;
+  final jni$_.JType<MyMap<$K, $V>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$K> K;
+  final jni$_.JType<$K> K;
 
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
   MyMap.fromReference(
@@ -5027,23 +5064,24 @@ class MyMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/generics/MyMap');
 
   /// The type which includes information such as the signature of this class.
-  static $MyMap$NullableType<$K, $V>
+  static jni$_.JType<MyMap<$K, $V>?>
       nullableType<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
-    jni$_.JObjType<$K> K,
-    jni$_.JObjType<$V> V,
+    jni$_.JType<$K> K,
+    jni$_.JType<$V> V,
   ) {
-    return $MyMap$NullableType<$K, $V>(
+    return $MyMap$NullableType$<$K, $V>(
       K,
       V,
     );
   }
 
-  static $MyMap$Type<$K, $V>
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<MyMap<$K, $V>>
       type<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
-    jni$_.JObjType<$K> K,
-    jni$_.JObjType<$V> V,
+    jni$_.JType<$K> K,
+    jni$_.JType<$V> V,
   ) {
-    return $MyMap$Type<$K, $V>(
+    return $MyMap$Type$<$K, $V>(
       K,
       V,
     );
@@ -5068,8 +5106,8 @@ class MyMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory MyMap({
-    required jni$_.JObjType<$K> K,
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$K> K,
+    required jni$_.JType<$V> V,
   }) {
     return MyMap<$K, $V>.fromReference(
         K,
@@ -5162,22 +5200,22 @@ class MyMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   MyStack<MyMap$MyEntry<$K?, $V?>?>? entryStack() {
     return _entryStack(reference.pointer, _id_entryStack as jni$_.JMethodIDPtr)
         .object<MyStack<MyMap$MyEntry<$K?, $V?>?>?>(
-            $MyStack$NullableType<MyMap$MyEntry<$K?, $V?>?>(
-                $MyMap$MyEntry$NullableType<$K?, $V?>(
+            $MyStack$NullableType$<MyMap$MyEntry<$K?, $V?>?>(
+                $MyMap$MyEntry$NullableType$<$K?, $V?>(
                     K.nullableType, V.nullableType)));
   }
 }
 
-final class $MyMap$NullableType<$K extends jni$_.JObject?,
-    $V extends jni$_.JObject?> extends jni$_.JObjType<MyMap<$K, $V>?> {
+final class $MyMap$NullableType$<$K extends jni$_.JObject?,
+    $V extends jni$_.JObject?> extends jni$_.JType<MyMap<$K, $V>?> {
   @jni$_.internal
-  final jni$_.JObjType<$K> K;
+  final jni$_.JType<$K> K;
 
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
-  const $MyMap$NullableType(
+  const $MyMap$NullableType$(
     this.K,
     this.V,
   );
@@ -5197,38 +5235,38 @@ final class $MyMap$NullableType<$K extends jni$_.JObject?,
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyMap<$K, $V>?> get nullableType => this;
+  jni$_.JType<MyMap<$K, $V>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($MyMap$NullableType, K, V);
+  int get hashCode => Object.hash($MyMap$NullableType$, K, V);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyMap$NullableType<$K, $V>) &&
-        other is $MyMap$NullableType<$K, $V> &&
+    return other.runtimeType == ($MyMap$NullableType$<$K, $V>) &&
+        other is $MyMap$NullableType$<$K, $V> &&
         K == other.K &&
         V == other.V;
   }
 }
 
-final class $MyMap$Type<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
-    extends jni$_.JObjType<MyMap<$K, $V>> {
+final class $MyMap$Type$<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
+    extends jni$_.JType<MyMap<$K, $V>> {
   @jni$_.internal
-  final jni$_.JObjType<$K> K;
+  final jni$_.JType<$K> K;
 
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
-  const $MyMap$Type(
+  const $MyMap$Type$(
     this.K,
     this.V,
   );
@@ -5247,24 +5285,24 @@ final class $MyMap$Type<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyMap<$K, $V>?> get nullableType =>
-      $MyMap$NullableType<$K, $V>(K, V);
+  jni$_.JType<MyMap<$K, $V>?> get nullableType =>
+      $MyMap$NullableType$<$K, $V>(K, V);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($MyMap$Type, K, V);
+  int get hashCode => Object.hash($MyMap$Type$, K, V);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyMap$Type<$K, $V>) &&
-        other is $MyMap$Type<$K, $V> &&
+    return other.runtimeType == ($MyMap$Type$<$K, $V>) &&
+        other is $MyMap$Type$<$K, $V> &&
         K == other.K &&
         V == other.V;
   }
@@ -5274,10 +5312,10 @@ final class $MyMap$Type<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
 class MyStack<$T extends jni$_.JObject?> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<MyStack<$T>> $type;
+  final jni$_.JType<MyStack<$T>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
   MyStack.fromReference(
@@ -5290,18 +5328,19 @@ class MyStack<$T extends jni$_.JObject?> extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/generics/MyStack');
 
   /// The type which includes information such as the signature of this class.
-  static $MyStack$NullableType<$T> nullableType<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+  static jni$_.JType<MyStack<$T>?> nullableType<$T extends jni$_.JObject?>(
+    jni$_.JType<$T> T,
   ) {
-    return $MyStack$NullableType<$T>(
+    return $MyStack$NullableType$<$T>(
       T,
     );
   }
 
-  static $MyStack$Type<$T> type<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<MyStack<$T>> type<$T extends jni$_.JObject?>(
+    jni$_.JType<$T> T,
   ) {
-    return $MyStack$Type<$T>(
+    return $MyStack$Type$<$T>(
       T,
     );
   }
@@ -5325,7 +5364,7 @@ class MyStack<$T extends jni$_.JObject?> extends jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory MyStack({
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     return MyStack<$T>.fromReference(
         T,
@@ -5353,12 +5392,12 @@ class MyStack<$T extends jni$_.JObject?> extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   static MyStack<$T?>? fromArray<$T extends jni$_.JObject?>(
     jni$_.JArray<$T?>? objects, {
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     final _$objects = objects?.reference ?? jni$_.jNullReference;
     return _fromArray(_class.reference.pointer,
             _id_fromArray as jni$_.JMethodIDPtr, _$objects.pointer)
-        .object<MyStack<$T?>?>($MyStack$NullableType<$T?>(T.nullableType));
+        .object<MyStack<$T?>?>($MyStack$NullableType$<$T?>(T.nullableType));
   }
 
   static final _id_fromArrayOfArrayOfGrandParents = _class.staticMethodId(
@@ -5383,14 +5422,14 @@ class MyStack<$T extends jni$_.JObject?> extends jni$_.JObject {
   static MyStack<$S?>?
       fromArrayOfArrayOfGrandParents<$S extends jni$_.JObject?>(
     jni$_.JArray<jni$_.JArray<GrandParent<$S?>?>?>? grandParents, {
-    required jni$_.JObjType<$S> S,
+    required jni$_.JType<$S> S,
   }) {
     final _$grandParents = grandParents?.reference ?? jni$_.jNullReference;
     return _fromArrayOfArrayOfGrandParents(
             _class.reference.pointer,
             _id_fromArrayOfArrayOfGrandParents as jni$_.JMethodIDPtr,
             _$grandParents.pointer)
-        .object<MyStack<$S?>?>($MyStack$NullableType<$S?>(S.nullableType));
+        .object<MyStack<$S?>?>($MyStack$NullableType$<$S?>(S.nullableType));
   }
 
   static final _id_of = _class.staticMethodId(
@@ -5413,10 +5452,10 @@ class MyStack<$T extends jni$_.JObject?> extends jni$_.JObject {
   /// from: `static public com.github.dart_lang.jnigen.generics.MyStack<T> of()`
   /// The returned object must be released after use, by calling the [release] method.
   static MyStack<$T?>? of<$T extends jni$_.JObject?>({
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     return _of(_class.reference.pointer, _id_of as jni$_.JMethodIDPtr)
-        .object<MyStack<$T?>?>($MyStack$NullableType<$T?>(T.nullableType));
+        .object<MyStack<$T?>?>($MyStack$NullableType$<$T?>(T.nullableType));
   }
 
   static final _id_of$1 = _class.staticMethodId(
@@ -5439,12 +5478,12 @@ class MyStack<$T extends jni$_.JObject?> extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   static MyStack<$T?>? of$1<$T extends jni$_.JObject?>(
     $T? object, {
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _of$1(_class.reference.pointer, _id_of$1 as jni$_.JMethodIDPtr,
             _$object.pointer)
-        .object<MyStack<$T?>?>($MyStack$NullableType<$T?>(T.nullableType));
+        .object<MyStack<$T?>?>($MyStack$NullableType$<$T?>(T.nullableType));
   }
 
   static final _id_of$2 = _class.staticMethodId(
@@ -5474,13 +5513,13 @@ class MyStack<$T extends jni$_.JObject?> extends jni$_.JObject {
   static MyStack<$T?>? of$2<$T extends jni$_.JObject?>(
     $T? object,
     $T? object1, {
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     return _of$2(_class.reference.pointer, _id_of$2 as jni$_.JMethodIDPtr,
             _$object.pointer, _$object1.pointer)
-        .object<MyStack<$T?>?>($MyStack$NullableType<$T?>(T.nullableType));
+        .object<MyStack<$T?>?>($MyStack$NullableType$<$T?>(T.nullableType));
   }
 
   static final _id_push = _class.instanceMethodId(
@@ -5555,13 +5594,13 @@ class MyStack<$T extends jni$_.JObject?> extends jni$_.JObject {
   }
 }
 
-final class $MyStack$NullableType<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<MyStack<$T>?> {
+final class $MyStack$NullableType$<$T extends jni$_.JObject?>
+    extends jni$_.JType<MyStack<$T>?> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $MyStack$NullableType(
+  const $MyStack$NullableType$(
     this.T,
   );
 
@@ -5579,34 +5618,34 @@ final class $MyStack$NullableType<$T extends jni$_.JObject?>
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyStack<$T>?> get nullableType => this;
+  jni$_.JType<MyStack<$T>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($MyStack$NullableType, T);
+  int get hashCode => Object.hash($MyStack$NullableType$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyStack$NullableType<$T>) &&
-        other is $MyStack$NullableType<$T> &&
+    return other.runtimeType == ($MyStack$NullableType$<$T>) &&
+        other is $MyStack$NullableType$<$T> &&
         T == other.T;
   }
 }
 
-final class $MyStack$Type<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<MyStack<$T>> {
+final class $MyStack$Type$<$T extends jni$_.JObject?>
+    extends jni$_.JType<MyStack<$T>> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $MyStack$Type(
+  const $MyStack$Type$(
     this.T,
   );
 
@@ -5623,23 +5662,23 @@ final class $MyStack$Type<$T extends jni$_.JObject?>
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyStack<$T>?> get nullableType => $MyStack$NullableType<$T>(T);
+  jni$_.JType<MyStack<$T>?> get nullableType => $MyStack$NullableType$<$T>(T);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($MyStack$Type, T);
+  int get hashCode => Object.hash($MyStack$Type$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyStack$Type<$T>) &&
-        other is $MyStack$Type<$T> &&
+    return other.runtimeType == ($MyStack$Type$<$T>) &&
+        other is $MyStack$Type$<$T> &&
         T == other.T;
   }
 }
@@ -5649,10 +5688,10 @@ class StringKeyedMap<$V extends jni$_.JObject?>
     extends MyMap<jni$_.JString?, $V?> {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<StringKeyedMap<$V>> $type;
+  final jni$_.JType<StringKeyedMap<$V>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
   StringKeyedMap.fromReference(
@@ -5660,25 +5699,26 @@ class StringKeyedMap<$V extends jni$_.JObject?>
     jni$_.JReference reference,
   )   : $type = type<$V>(V),
         super.fromReference(
-            const jni$_.JStringNullableType(), V.nullableType, reference);
+            const jni$_.$JString$NullableType$(), V.nullableType, reference);
 
   static final _class = jni$_.JClass.forName(
       r'com/github/dart_lang/jnigen/generics/StringKeyedMap');
 
   /// The type which includes information such as the signature of this class.
-  static $StringKeyedMap$NullableType<$V>
+  static jni$_.JType<StringKeyedMap<$V>?>
       nullableType<$V extends jni$_.JObject?>(
-    jni$_.JObjType<$V> V,
+    jni$_.JType<$V> V,
   ) {
-    return $StringKeyedMap$NullableType<$V>(
+    return $StringKeyedMap$NullableType$<$V>(
       V,
     );
   }
 
-  static $StringKeyedMap$Type<$V> type<$V extends jni$_.JObject?>(
-    jni$_.JObjType<$V> V,
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<StringKeyedMap<$V>> type<$V extends jni$_.JObject?>(
+    jni$_.JType<$V> V,
   ) {
-    return $StringKeyedMap$Type<$V>(
+    return $StringKeyedMap$Type$<$V>(
       V,
     );
   }
@@ -5702,7 +5742,7 @@ class StringKeyedMap<$V extends jni$_.JObject?>
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory StringKeyedMap({
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$V> V,
   }) {
     return StringKeyedMap<$V>.fromReference(
         V,
@@ -5711,13 +5751,13 @@ class StringKeyedMap<$V extends jni$_.JObject?>
   }
 }
 
-final class $StringKeyedMap$NullableType<$V extends jni$_.JObject?>
-    extends jni$_.JObjType<StringKeyedMap<$V>?> {
+final class $StringKeyedMap$NullableType$<$V extends jni$_.JObject?>
+    extends jni$_.JType<StringKeyedMap<$V>?> {
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
-  const $StringKeyedMap$NullableType(
+  const $StringKeyedMap$NullableType$(
     this.V,
   );
 
@@ -5737,35 +5777,35 @@ final class $StringKeyedMap$NullableType<$V extends jni$_.JObject?>
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => $MyMap$NullableType<jni$_.JString?, $V?>(
-      const jni$_.JStringNullableType(), V.nullableType);
+  jni$_.JType get superType => $MyMap$NullableType$<jni$_.JString?, $V?>(
+      const jni$_.$JString$NullableType$(), V.nullableType);
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<StringKeyedMap<$V>?> get nullableType => this;
+  jni$_.JType<StringKeyedMap<$V>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 2;
 
   @core$_.override
-  int get hashCode => Object.hash($StringKeyedMap$NullableType, V);
+  int get hashCode => Object.hash($StringKeyedMap$NullableType$, V);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($StringKeyedMap$NullableType<$V>) &&
-        other is $StringKeyedMap$NullableType<$V> &&
+    return other.runtimeType == ($StringKeyedMap$NullableType$<$V>) &&
+        other is $StringKeyedMap$NullableType$<$V> &&
         V == other.V;
   }
 }
 
-final class $StringKeyedMap$Type<$V extends jni$_.JObject?>
-    extends jni$_.JObjType<StringKeyedMap<$V>> {
+final class $StringKeyedMap$Type$<$V extends jni$_.JObject?>
+    extends jni$_.JType<StringKeyedMap<$V>> {
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
-  const $StringKeyedMap$Type(
+  const $StringKeyedMap$Type$(
     this.V,
   );
 
@@ -5783,25 +5823,25 @@ final class $StringKeyedMap$Type<$V extends jni$_.JObject?>
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => $MyMap$NullableType<jni$_.JString?, $V?>(
-      const jni$_.JStringNullableType(), V.nullableType);
+  jni$_.JType get superType => $MyMap$NullableType$<jni$_.JString?, $V?>(
+      const jni$_.$JString$NullableType$(), V.nullableType);
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<StringKeyedMap<$V>?> get nullableType =>
-      $StringKeyedMap$NullableType<$V>(V);
+  jni$_.JType<StringKeyedMap<$V>?> get nullableType =>
+      $StringKeyedMap$NullableType$<$V>(V);
 
   @jni$_.internal
   @core$_.override
   final superCount = 2;
 
   @core$_.override
-  int get hashCode => Object.hash($StringKeyedMap$Type, V);
+  int get hashCode => Object.hash($StringKeyedMap$Type$, V);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($StringKeyedMap$Type<$V>) &&
-        other is $StringKeyedMap$Type<$V> &&
+    return other.runtimeType == ($StringKeyedMap$Type$<$V>) &&
+        other is $StringKeyedMap$Type$<$V> &&
         V == other.V;
   }
 }
@@ -5810,20 +5850,23 @@ final class $StringKeyedMap$Type<$V extends jni$_.JObject?>
 class StringMap extends StringKeyedMap<jni$_.JString?> {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<StringMap> $type;
+  final jni$_.JType<StringMap> $type;
 
   @jni$_.internal
   StringMap.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
-        super.fromReference(const jni$_.JStringNullableType(), reference);
+        super.fromReference(const jni$_.$JString$NullableType$(), reference);
 
   static final _class =
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/generics/StringMap');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $StringMap$NullableType();
-  static const type = $StringMap$Type();
+  static const jni$_.JType<StringMap?> nullableType =
+      $StringMap$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<StringMap> type = $StringMap$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -5849,9 +5892,9 @@ class StringMap extends StringKeyedMap<jni$_.JString?> {
   }
 }
 
-final class $StringMap$NullableType extends jni$_.JObjType<StringMap?> {
+final class $StringMap$NullableType$ extends jni$_.JType<StringMap?> {
   @jni$_.internal
-  const $StringMap$NullableType();
+  const $StringMap$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -5866,31 +5909,31 @@ final class $StringMap$NullableType extends jni$_.JObjType<StringMap?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType =>
-      const $StringKeyedMap$NullableType<jni$_.JString?>(
-          jni$_.JStringNullableType());
+  jni$_.JType get superType =>
+      const $StringKeyedMap$NullableType$<jni$_.JString?>(
+          jni$_.$JString$NullableType$());
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<StringMap?> get nullableType => this;
+  jni$_.JType<StringMap?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 3;
 
   @core$_.override
-  int get hashCode => ($StringMap$NullableType).hashCode;
+  int get hashCode => ($StringMap$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($StringMap$NullableType) &&
-        other is $StringMap$NullableType;
+    return other.runtimeType == ($StringMap$NullableType$) &&
+        other is $StringMap$NullableType$;
   }
 }
 
-final class $StringMap$Type extends jni$_.JObjType<StringMap> {
+final class $StringMap$Type$ extends jni$_.JType<StringMap> {
   @jni$_.internal
-  const $StringMap$Type();
+  const $StringMap$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -5904,25 +5947,24 @@ final class $StringMap$Type extends jni$_.JObjType<StringMap> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType =>
-      const $StringKeyedMap$NullableType<jni$_.JString?>(
-          jni$_.JStringNullableType());
+  jni$_.JType get superType =>
+      const $StringKeyedMap$NullableType$<jni$_.JString?>(
+          jni$_.$JString$NullableType$());
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<StringMap?> get nullableType =>
-      const $StringMap$NullableType();
+  jni$_.JType<StringMap?> get nullableType => const $StringMap$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 3;
 
   @core$_.override
-  int get hashCode => ($StringMap$Type).hashCode;
+  int get hashCode => ($StringMap$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($StringMap$Type) && other is $StringMap$Type;
+    return other.runtimeType == ($StringMap$Type$) && other is $StringMap$Type$;
   }
 }
 
@@ -5930,20 +5972,23 @@ final class $StringMap$Type extends jni$_.JObjType<StringMap> {
 class StringStack extends MyStack<jni$_.JString?> {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<StringStack> $type;
+  final jni$_.JType<StringStack> $type;
 
   @jni$_.internal
   StringStack.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
-        super.fromReference(const jni$_.JStringNullableType(), reference);
+        super.fromReference(const jni$_.$JString$NullableType$(), reference);
 
   static final _class =
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/generics/StringStack');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $StringStack$NullableType();
-  static const type = $StringStack$Type();
+  static const jni$_.JType<StringStack?> nullableType =
+      $StringStack$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<StringStack> type = $StringStack$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -5969,9 +6014,9 @@ class StringStack extends MyStack<jni$_.JString?> {
   }
 }
 
-final class $StringStack$NullableType extends jni$_.JObjType<StringStack?> {
+final class $StringStack$NullableType$ extends jni$_.JType<StringStack?> {
   @jni$_.internal
-  const $StringStack$NullableType();
+  const $StringStack$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -5986,30 +6031,30 @@ final class $StringStack$NullableType extends jni$_.JObjType<StringStack?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType =>
-      const $MyStack$NullableType<jni$_.JString?>(jni$_.JStringNullableType());
+  jni$_.JType get superType => const $MyStack$NullableType$<jni$_.JString?>(
+      jni$_.$JString$NullableType$());
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<StringStack?> get nullableType => this;
+  jni$_.JType<StringStack?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 2;
 
   @core$_.override
-  int get hashCode => ($StringStack$NullableType).hashCode;
+  int get hashCode => ($StringStack$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($StringStack$NullableType) &&
-        other is $StringStack$NullableType;
+    return other.runtimeType == ($StringStack$NullableType$) &&
+        other is $StringStack$NullableType$;
   }
 }
 
-final class $StringStack$Type extends jni$_.JObjType<StringStack> {
+final class $StringStack$Type$ extends jni$_.JType<StringStack> {
   @jni$_.internal
-  const $StringStack$Type();
+  const $StringStack$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -6023,25 +6068,25 @@ final class $StringStack$Type extends jni$_.JObjType<StringStack> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType =>
-      const $MyStack$NullableType<jni$_.JString?>(jni$_.JStringNullableType());
+  jni$_.JType get superType => const $MyStack$NullableType$<jni$_.JString?>(
+      jni$_.$JString$NullableType$());
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<StringStack?> get nullableType =>
-      const $StringStack$NullableType();
+  jni$_.JType<StringStack?> get nullableType =>
+      const $StringStack$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 2;
 
   @core$_.override
-  int get hashCode => ($StringStack$Type).hashCode;
+  int get hashCode => ($StringStack$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($StringStack$Type) &&
-        other is $StringStack$Type;
+    return other.runtimeType == ($StringStack$Type$) &&
+        other is $StringStack$Type$;
   }
 }
 
@@ -6050,10 +6095,10 @@ class StringValuedMap<$K extends jni$_.JObject?>
     extends MyMap<$K?, jni$_.JString?> {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<StringValuedMap<$K>> $type;
+  final jni$_.JType<StringValuedMap<$K>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$K> K;
+  final jni$_.JType<$K> K;
 
   @jni$_.internal
   StringValuedMap.fromReference(
@@ -6061,25 +6106,26 @@ class StringValuedMap<$K extends jni$_.JObject?>
     jni$_.JReference reference,
   )   : $type = type<$K>(K),
         super.fromReference(
-            K.nullableType, const jni$_.JStringNullableType(), reference);
+            K.nullableType, const jni$_.$JString$NullableType$(), reference);
 
   static final _class = jni$_.JClass.forName(
       r'com/github/dart_lang/jnigen/generics/StringValuedMap');
 
   /// The type which includes information such as the signature of this class.
-  static $StringValuedMap$NullableType<$K>
+  static jni$_.JType<StringValuedMap<$K>?>
       nullableType<$K extends jni$_.JObject?>(
-    jni$_.JObjType<$K> K,
+    jni$_.JType<$K> K,
   ) {
-    return $StringValuedMap$NullableType<$K>(
+    return $StringValuedMap$NullableType$<$K>(
       K,
     );
   }
 
-  static $StringValuedMap$Type<$K> type<$K extends jni$_.JObject?>(
-    jni$_.JObjType<$K> K,
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<StringValuedMap<$K>> type<$K extends jni$_.JObject?>(
+    jni$_.JType<$K> K,
   ) {
-    return $StringValuedMap$Type<$K>(
+    return $StringValuedMap$Type$<$K>(
       K,
     );
   }
@@ -6103,7 +6149,7 @@ class StringValuedMap<$K extends jni$_.JObject?>
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory StringValuedMap({
-    required jni$_.JObjType<$K> K,
+    required jni$_.JType<$K> K,
   }) {
     return StringValuedMap<$K>.fromReference(
         K,
@@ -6112,13 +6158,13 @@ class StringValuedMap<$K extends jni$_.JObject?>
   }
 }
 
-final class $StringValuedMap$NullableType<$K extends jni$_.JObject?>
-    extends jni$_.JObjType<StringValuedMap<$K>?> {
+final class $StringValuedMap$NullableType$<$K extends jni$_.JObject?>
+    extends jni$_.JType<StringValuedMap<$K>?> {
   @jni$_.internal
-  final jni$_.JObjType<$K> K;
+  final jni$_.JType<$K> K;
 
   @jni$_.internal
-  const $StringValuedMap$NullableType(
+  const $StringValuedMap$NullableType$(
     this.K,
   );
 
@@ -6138,35 +6184,35 @@ final class $StringValuedMap$NullableType<$K extends jni$_.JObject?>
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => $MyMap$NullableType<$K?, jni$_.JString?>(
-      K.nullableType, const jni$_.JStringNullableType());
+  jni$_.JType get superType => $MyMap$NullableType$<$K?, jni$_.JString?>(
+      K.nullableType, const jni$_.$JString$NullableType$());
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<StringValuedMap<$K>?> get nullableType => this;
+  jni$_.JType<StringValuedMap<$K>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 2;
 
   @core$_.override
-  int get hashCode => Object.hash($StringValuedMap$NullableType, K);
+  int get hashCode => Object.hash($StringValuedMap$NullableType$, K);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($StringValuedMap$NullableType<$K>) &&
-        other is $StringValuedMap$NullableType<$K> &&
+    return other.runtimeType == ($StringValuedMap$NullableType$<$K>) &&
+        other is $StringValuedMap$NullableType$<$K> &&
         K == other.K;
   }
 }
 
-final class $StringValuedMap$Type<$K extends jni$_.JObject?>
-    extends jni$_.JObjType<StringValuedMap<$K>> {
+final class $StringValuedMap$Type$<$K extends jni$_.JObject?>
+    extends jni$_.JType<StringValuedMap<$K>> {
   @jni$_.internal
-  final jni$_.JObjType<$K> K;
+  final jni$_.JType<$K> K;
 
   @jni$_.internal
-  const $StringValuedMap$Type(
+  const $StringValuedMap$Type$(
     this.K,
   );
 
@@ -6184,25 +6230,25 @@ final class $StringValuedMap$Type<$K extends jni$_.JObject?>
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => $MyMap$NullableType<$K?, jni$_.JString?>(
-      K.nullableType, const jni$_.JStringNullableType());
+  jni$_.JType get superType => $MyMap$NullableType$<$K?, jni$_.JString?>(
+      K.nullableType, const jni$_.$JString$NullableType$());
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<StringValuedMap<$K>?> get nullableType =>
-      $StringValuedMap$NullableType<$K>(K);
+  jni$_.JType<StringValuedMap<$K>?> get nullableType =>
+      $StringValuedMap$NullableType$<$K>(K);
 
   @jni$_.internal
   @core$_.override
   final superCount = 2;
 
   @core$_.override
-  int get hashCode => Object.hash($StringValuedMap$Type, K);
+  int get hashCode => Object.hash($StringValuedMap$Type$, K);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($StringValuedMap$Type<$K>) &&
-        other is $StringValuedMap$Type<$K> &&
+    return other.runtimeType == ($StringValuedMap$Type$<$K>) &&
+        other is $StringValuedMap$Type$<$K> &&
         K == other.K;
   }
 }
@@ -6211,10 +6257,10 @@ final class $StringValuedMap$Type<$K extends jni$_.JObject?>
 class GenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<GenericInterface<$T>> $type;
+  final jni$_.JType<GenericInterface<$T>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
   GenericInterface.fromReference(
@@ -6227,19 +6273,20 @@ class GenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/interfaces/GenericInterface');
 
   /// The type which includes information such as the signature of this class.
-  static $GenericInterface$NullableType<$T>
+  static jni$_.JType<GenericInterface<$T>?>
       nullableType<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+    jni$_.JType<$T> T,
   ) {
-    return $GenericInterface$NullableType<$T>(
+    return $GenericInterface$NullableType$<$T>(
       T,
     );
   }
 
-  static $GenericInterface$Type<$T> type<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<GenericInterface<$T>> type<$T extends jni$_.JObject?>(
+    jni$_.JType<$T> T,
   ) {
-    return $GenericInterface$Type<$T>(
+    return $GenericInterface$Type$<$T>(
       T,
     );
   }
@@ -6264,13 +6311,13 @@ class GenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JArray<$U?>? genericArrayOf<$U extends jni$_.JObject?>(
     $U? object, {
-    required jni$_.JObjType<$U> U,
+    required jni$_.JType<$U> U,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _genericArrayOf(reference.pointer,
             _id_genericArrayOf as jni$_.JMethodIDPtr, _$object.pointer)
         .object<jni$_.JArray<$U?>?>(
-            jni$_.JArrayNullableType<$U?>(U.nullableType));
+            jni$_.$JArray$NullableType$<$U?>(U.nullableType));
   }
 
   static final _id_arrayOf = _class.instanceMethodId(
@@ -6298,7 +6345,7 @@ class GenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
     return _arrayOf(reference.pointer, _id_arrayOf as jni$_.JMethodIDPtr,
             _$object.pointer)
         .object<jni$_.JArray<$T?>?>(
-            jni$_.JArrayNullableType<$T?>(T.nullableType));
+            jni$_.$JArray$NullableType$<$T?>(T.nullableType));
   }
 
   static final _id_mapOf = _class.instanceMethodId(
@@ -6328,14 +6375,14 @@ class GenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
   jni$_.JMap<$T?, $U?>? mapOf<$U extends jni$_.JObject?>(
     $T? object,
     $U? object1, {
-    required jni$_.JObjType<$U> U,
+    required jni$_.JType<$U> U,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     return _mapOf(reference.pointer, _id_mapOf as jni$_.JMethodIDPtr,
             _$object.pointer, _$object1.pointer)
-        .object<jni$_.JMap<$T?, $U?>?>(
-            jni$_.JMapNullableType<$T?, $U?>(T.nullableType, U.nullableType));
+        .object<jni$_.JMap<$T?, $U?>?>(jni$_.$JMap$NullableType$<$T?, $U?>(
+            T.nullableType, U.nullableType));
   }
 
   static final _id_firstOfGenericArray = _class.instanceMethodId(
@@ -6358,7 +6405,7 @@ class GenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   $U? firstOfGenericArray<$U extends jni$_.JObject?>(
     jni$_.JArray<$U?>? objects, {
-    required jni$_.JObjType<$U> U,
+    required jni$_.JType<$U> U,
   }) {
     final _$objects = objects?.reference ?? jni$_.jNullReference;
     return _firstOfGenericArray(reference.pointer,
@@ -6413,7 +6460,7 @@ class GenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   $T? firstKeyOf<$U extends jni$_.JObject?>(
     jni$_.JMap<$T?, $U?>? map, {
-    required jni$_.JObjType<$U> U,
+    required jni$_.JType<$U> U,
   }) {
     final _$map = map?.reference ?? jni$_.jNullReference;
     return _firstKeyOf(reference.pointer, _id_firstKeyOf as jni$_.JMethodIDPtr,
@@ -6441,7 +6488,7 @@ class GenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   $U? firstValueOf<$U extends jni$_.JObject?>(
     jni$_.JMap<$T?, $U?>? map, {
-    required jni$_.JObjType<$U> U,
+    required jni$_.JType<$U> U,
   }) {
     final _$map = map?.reference ?? jni$_.jNullReference;
     return _firstValueOf(reference.pointer,
@@ -6481,10 +6528,10 @@ class GenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
       final $a = $i.args;
       if ($d == r'genericArrayOf(Ljava/lang/Object;)[Ljava/lang/Object;') {
         final $r = _$impls[$p]!.genericArrayOf(
-          $a![0]?.as(const jni$_.JObjectType(), releaseOriginal: true),
+          $a![0]?.as(const jni$_.$JObject$Type$(), releaseOriginal: true),
         );
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
@@ -6494,7 +6541,7 @@ class GenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
           $a![0]?.as(_$impls[$p]!.T, releaseOriginal: true),
         );
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
@@ -6502,10 +6549,10 @@ class GenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
       if ($d == r'mapOf(Ljava/lang/Object;Ljava/lang/Object;)Ljava/util/Map;') {
         final $r = _$impls[$p]!.mapOf(
           $a![0]?.as(_$impls[$p]!.T, releaseOriginal: true),
-          $a![1]?.as(const jni$_.JObjectType(), releaseOriginal: true),
+          $a![1]?.as(const jni$_.$JObject$Type$(), releaseOriginal: true),
         );
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
@@ -6513,12 +6560,12 @@ class GenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
       if ($d == r'firstOfGenericArray([Ljava/lang/Object;)Ljava/lang/Object;') {
         final $r = _$impls[$p]!.firstOfGenericArray(
           $a![0]?.as(
-              const jni$_.JArrayType<jni$_.JObject?>(
-                  jni$_.JObjectNullableType()),
+              const jni$_.$JArray$Type$<jni$_.JObject?>(
+                  jni$_.$JObject$NullableType$()),
               releaseOriginal: true),
         );
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
@@ -6526,12 +6573,12 @@ class GenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
       if ($d == r'firstOfArray([Ljava/lang/Object;)Ljava/lang/Object;') {
         final $r = _$impls[$p]!.firstOfArray(
           $a![0]?.as(
-              const jni$_.JArrayType<jni$_.JObject?>(
-                  jni$_.JObjectNullableType()),
+              const jni$_.$JArray$Type$<jni$_.JObject?>(
+                  jni$_.$JObject$NullableType$()),
               releaseOriginal: true),
         );
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
@@ -6539,12 +6586,13 @@ class GenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
       if ($d == r'firstKeyOf(Ljava/util/Map;)Ljava/lang/Object;') {
         final $r = _$impls[$p]!.firstKeyOf(
           $a![0]?.as(
-              const jni$_.JMapType<jni$_.JObject?, jni$_.JObject?>(
-                  jni$_.JObjectNullableType(), jni$_.JObjectNullableType()),
+              const jni$_.$JMap$Type$<jni$_.JObject?, jni$_.JObject?>(
+                  jni$_.$JObject$NullableType$(),
+                  jni$_.$JObject$NullableType$()),
               releaseOriginal: true),
         );
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
@@ -6552,12 +6600,13 @@ class GenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
       if ($d == r'firstValueOf(Ljava/util/Map;)Ljava/lang/Object;') {
         final $r = _$impls[$p]!.firstValueOf(
           $a![0]?.as(
-              const jni$_.JMapType<jni$_.JObject?, jni$_.JObject?>(
-                  jni$_.JObjectNullableType(), jni$_.JObjectNullableType()),
+              const jni$_.$JMap$Type$<jni$_.JObject?, jni$_.JObject?>(
+                  jni$_.$JObject$NullableType$(),
+                  jni$_.$JObject$NullableType$()),
               releaseOriginal: true),
         );
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
@@ -6607,7 +6656,7 @@ class GenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
 
 abstract base mixin class $GenericInterface<$T extends jni$_.JObject?> {
   factory $GenericInterface({
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
     required jni$_.JArray<jni$_.JObject?>? Function(jni$_.JObject? object)
         genericArrayOf,
     required jni$_.JArray<jni$_.JObject?>? Function($T? object) arrayOf,
@@ -6624,7 +6673,7 @@ abstract base mixin class $GenericInterface<$T extends jni$_.JObject?> {
         firstValueOf,
   }) = _$GenericInterface<$T>;
 
-  jni$_.JObjType<$T> get T;
+  jni$_.JType<$T> get T;
 
   jni$_.JArray<jni$_.JObject?>? genericArrayOf(jni$_.JObject? object);
   jni$_.JArray<jni$_.JObject?>? arrayOf($T? object);
@@ -6663,7 +6712,7 @@ final class _$GenericInterface<$T extends jni$_.JObject?>
         _firstValueOf = firstValueOf;
 
   @core$_.override
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   final jni$_.JArray<jni$_.JObject?>? Function(jni$_.JObject? object)
       _genericArrayOf;
@@ -6708,13 +6757,13 @@ final class _$GenericInterface<$T extends jni$_.JObject?>
   }
 }
 
-final class $GenericInterface$NullableType<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<GenericInterface<$T>?> {
+final class $GenericInterface$NullableType$<$T extends jni$_.JObject?>
+    extends jni$_.JType<GenericInterface<$T>?> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $GenericInterface$NullableType(
+  const $GenericInterface$NullableType$(
     this.T,
   );
 
@@ -6734,34 +6783,34 @@ final class $GenericInterface$NullableType<$T extends jni$_.JObject?>
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GenericInterface<$T>?> get nullableType => this;
+  jni$_.JType<GenericInterface<$T>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GenericInterface$NullableType, T);
+  int get hashCode => Object.hash($GenericInterface$NullableType$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GenericInterface$NullableType<$T>) &&
-        other is $GenericInterface$NullableType<$T> &&
+    return other.runtimeType == ($GenericInterface$NullableType$<$T>) &&
+        other is $GenericInterface$NullableType$<$T> &&
         T == other.T;
   }
 }
 
-final class $GenericInterface$Type<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<GenericInterface<$T>> {
+final class $GenericInterface$Type$<$T extends jni$_.JObject?>
+    extends jni$_.JType<GenericInterface<$T>> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $GenericInterface$Type(
+  const $GenericInterface$Type$(
     this.T,
   );
 
@@ -6779,24 +6828,24 @@ final class $GenericInterface$Type<$T extends jni$_.JObject?>
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GenericInterface<$T>?> get nullableType =>
-      $GenericInterface$NullableType<$T>(T);
+  jni$_.JType<GenericInterface<$T>?> get nullableType =>
+      $GenericInterface$NullableType$<$T>(T);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($GenericInterface$Type, T);
+  int get hashCode => Object.hash($GenericInterface$Type$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GenericInterface$Type<$T>) &&
-        other is $GenericInterface$Type<$T> &&
+    return other.runtimeType == ($GenericInterface$Type$<$T>) &&
+        other is $GenericInterface$Type$<$T> &&
         T == other.T;
   }
 }
@@ -6805,7 +6854,7 @@ final class $GenericInterface$Type<$T extends jni$_.JObject?>
 class InheritedFromMyInterface extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<InheritedFromMyInterface> $type;
+  final jni$_.JType<InheritedFromMyInterface> $type;
 
   @jni$_.internal
   InheritedFromMyInterface.fromReference(
@@ -6817,8 +6866,12 @@ class InheritedFromMyInterface extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/interfaces/InheritedFromMyInterface');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $InheritedFromMyInterface$NullableType();
-  static const type = $InheritedFromMyInterface$Type();
+  static const jni$_.JType<InheritedFromMyInterface?> nullableType =
+      $InheritedFromMyInterface$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<InheritedFromMyInterface> type =
+      $InheritedFromMyInterface$Type$();
   static final _id_voidCallback = _class.instanceMethodId(
     r'voidCallback',
     r'(Ljava/lang/String;)V',
@@ -6869,7 +6922,7 @@ class InheritedFromMyInterface extends jni$_.JObject {
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _stringCallback(reference.pointer,
             _id_stringCallback as jni$_.JMethodIDPtr, _$string.pointer)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_varCallback = _class.instanceMethodId(
@@ -6896,7 +6949,7 @@ class InheritedFromMyInterface extends jni$_.JObject {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _varCallback(reference.pointer,
             _id_varCallback as jni$_.JMethodIDPtr, _$object.pointer)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_manyPrimitives = _class.instanceMethodId(
@@ -6964,26 +7017,26 @@ class InheritedFromMyInterface extends jni$_.JObject {
       final $a = $i.args;
       if ($d == r'voidCallback(Ljava/lang/String;)V') {
         _$impls[$p]!.voidCallback(
-          $a![0]?.as(const jni$_.JStringType(), releaseOriginal: true),
+          $a![0]?.as(const jni$_.$JString$Type$(), releaseOriginal: true),
         );
         return jni$_.nullptr;
       }
       if ($d == r'stringCallback(Ljava/lang/String;)Ljava/lang/String;') {
         final $r = _$impls[$p]!.stringCallback(
-          $a![0]?.as(const jni$_.JStringType(), releaseOriginal: true),
+          $a![0]?.as(const jni$_.$JString$Type$(), releaseOriginal: true),
         );
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
       }
       if ($d == r'varCallback(Ljava/lang/String;)Ljava/lang/String;') {
         final $r = _$impls[$p]!.varCallback(
-          $a![0]?.as(const jni$_.JStringType(), releaseOriginal: true),
+          $a![0]?.as(const jni$_.$JString$Type$(), releaseOriginal: true),
         );
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
@@ -6991,16 +7044,16 @@ class InheritedFromMyInterface extends jni$_.JObject {
       if ($d == r'manyPrimitives(IZCD)J') {
         final $r = _$impls[$p]!.manyPrimitives(
           $a![0]!
-              .as(const jni$_.JIntegerType(), releaseOriginal: true)
+              .as(const jni$_.$JInteger$Type$(), releaseOriginal: true)
               .intValue(releaseOriginal: true),
           $a![1]!
-              .as(const jni$_.JBooleanType(), releaseOriginal: true)
+              .as(const jni$_.$JBoolean$Type$(), releaseOriginal: true)
               .booleanValue(releaseOriginal: true),
           $a![2]!
-              .as(const jni$_.JCharacterType(), releaseOriginal: true)
+              .as(const jni$_.$JCharacter$Type$(), releaseOriginal: true)
               .charValue(releaseOriginal: true),
           $a![3]!
-              .as(const jni$_.JDoubleType(), releaseOriginal: true)
+              .as(const jni$_.$JDouble$Type$(), releaseOriginal: true)
               .doubleValue(releaseOriginal: true),
         );
         return jni$_.JLong($r).reference.toPointer();
@@ -7100,10 +7153,10 @@ final class _$InheritedFromMyInterface with $InheritedFromMyInterface {
   }
 }
 
-final class $InheritedFromMyInterface$NullableType
-    extends jni$_.JObjType<InheritedFromMyInterface?> {
+final class $InheritedFromMyInterface$NullableType$
+    extends jni$_.JType<InheritedFromMyInterface?> {
   @jni$_.internal
-  const $InheritedFromMyInterface$NullableType();
+  const $InheritedFromMyInterface$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -7120,30 +7173,30 @@ final class $InheritedFromMyInterface$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<InheritedFromMyInterface?> get nullableType => this;
+  jni$_.JType<InheritedFromMyInterface?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($InheritedFromMyInterface$NullableType).hashCode;
+  int get hashCode => ($InheritedFromMyInterface$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($InheritedFromMyInterface$NullableType) &&
-        other is $InheritedFromMyInterface$NullableType;
+    return other.runtimeType == ($InheritedFromMyInterface$NullableType$) &&
+        other is $InheritedFromMyInterface$NullableType$;
   }
 }
 
-final class $InheritedFromMyInterface$Type
-    extends jni$_.JObjType<InheritedFromMyInterface> {
+final class $InheritedFromMyInterface$Type$
+    extends jni$_.JType<InheritedFromMyInterface> {
   @jni$_.internal
-  const $InheritedFromMyInterface$Type();
+  const $InheritedFromMyInterface$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -7158,24 +7211,24 @@ final class $InheritedFromMyInterface$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<InheritedFromMyInterface?> get nullableType =>
-      const $InheritedFromMyInterface$NullableType();
+  jni$_.JType<InheritedFromMyInterface?> get nullableType =>
+      const $InheritedFromMyInterface$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($InheritedFromMyInterface$Type).hashCode;
+  int get hashCode => ($InheritedFromMyInterface$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($InheritedFromMyInterface$Type) &&
-        other is $InheritedFromMyInterface$Type;
+    return other.runtimeType == ($InheritedFromMyInterface$Type$) &&
+        other is $InheritedFromMyInterface$Type$;
   }
 }
 
@@ -7183,7 +7236,7 @@ final class $InheritedFromMyInterface$Type
 class InheritedFromMyRunnable extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<InheritedFromMyRunnable> $type;
+  final jni$_.JType<InheritedFromMyRunnable> $type;
 
   @jni$_.internal
   InheritedFromMyRunnable.fromReference(
@@ -7195,8 +7248,12 @@ class InheritedFromMyRunnable extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/interfaces/InheritedFromMyRunnable');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $InheritedFromMyRunnable$NullableType();
-  static const type = $InheritedFromMyRunnable$Type();
+  static const jni$_.JType<InheritedFromMyRunnable?> nullableType =
+      $InheritedFromMyRunnable$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<InheritedFromMyRunnable> type =
+      $InheritedFromMyRunnable$Type$();
   static final _id_run = _class.instanceMethodId(
     r'run',
     r'()V',
@@ -7321,10 +7378,10 @@ final class _$InheritedFromMyRunnable with $InheritedFromMyRunnable {
   }
 }
 
-final class $InheritedFromMyRunnable$NullableType
-    extends jni$_.JObjType<InheritedFromMyRunnable?> {
+final class $InheritedFromMyRunnable$NullableType$
+    extends jni$_.JType<InheritedFromMyRunnable?> {
   @jni$_.internal
-  const $InheritedFromMyRunnable$NullableType();
+  const $InheritedFromMyRunnable$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -7341,30 +7398,30 @@ final class $InheritedFromMyRunnable$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<InheritedFromMyRunnable?> get nullableType => this;
+  jni$_.JType<InheritedFromMyRunnable?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($InheritedFromMyRunnable$NullableType).hashCode;
+  int get hashCode => ($InheritedFromMyRunnable$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($InheritedFromMyRunnable$NullableType) &&
-        other is $InheritedFromMyRunnable$NullableType;
+    return other.runtimeType == ($InheritedFromMyRunnable$NullableType$) &&
+        other is $InheritedFromMyRunnable$NullableType$;
   }
 }
 
-final class $InheritedFromMyRunnable$Type
-    extends jni$_.JObjType<InheritedFromMyRunnable> {
+final class $InheritedFromMyRunnable$Type$
+    extends jni$_.JType<InheritedFromMyRunnable> {
   @jni$_.internal
-  const $InheritedFromMyRunnable$Type();
+  const $InheritedFromMyRunnable$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -7379,24 +7436,24 @@ final class $InheritedFromMyRunnable$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<InheritedFromMyRunnable?> get nullableType =>
-      const $InheritedFromMyRunnable$NullableType();
+  jni$_.JType<InheritedFromMyRunnable?> get nullableType =>
+      const $InheritedFromMyRunnable$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($InheritedFromMyRunnable$Type).hashCode;
+  int get hashCode => ($InheritedFromMyRunnable$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($InheritedFromMyRunnable$Type) &&
-        other is $InheritedFromMyRunnable$Type;
+    return other.runtimeType == ($InheritedFromMyRunnable$Type$) &&
+        other is $InheritedFromMyRunnable$Type$;
   }
 }
 
@@ -7404,10 +7461,10 @@ final class $InheritedFromMyRunnable$Type
 class MyInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<MyInterface<$T>> $type;
+  final jni$_.JType<MyInterface<$T>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
   MyInterface.fromReference(
@@ -7420,18 +7477,19 @@ class MyInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/interfaces/MyInterface');
 
   /// The type which includes information such as the signature of this class.
-  static $MyInterface$NullableType<$T> nullableType<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+  static jni$_.JType<MyInterface<$T>?> nullableType<$T extends jni$_.JObject?>(
+    jni$_.JType<$T> T,
   ) {
-    return $MyInterface$NullableType<$T>(
+    return $MyInterface$NullableType$<$T>(
       T,
     );
   }
 
-  static $MyInterface$Type<$T> type<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<MyInterface<$T>> type<$T extends jni$_.JObject?>(
+    jni$_.JType<$T> T,
   ) {
-    return $MyInterface$Type<$T>(
+    return $MyInterface$Type$<$T>(
       T,
     );
   }
@@ -7486,7 +7544,7 @@ class MyInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _stringCallback(reference.pointer,
             _id_stringCallback as jni$_.JMethodIDPtr, _$string.pointer)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_varCallback = _class.instanceMethodId(
@@ -7581,16 +7639,16 @@ class MyInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
       final $a = $i.args;
       if ($d == r'voidCallback(Ljava/lang/String;)V') {
         _$impls[$p]!.voidCallback(
-          $a![0]?.as(const jni$_.JStringType(), releaseOriginal: true),
+          $a![0]?.as(const jni$_.$JString$Type$(), releaseOriginal: true),
         );
         return jni$_.nullptr;
       }
       if ($d == r'stringCallback(Ljava/lang/String;)Ljava/lang/String;') {
         final $r = _$impls[$p]!.stringCallback(
-          $a![0]?.as(const jni$_.JStringType(), releaseOriginal: true),
+          $a![0]?.as(const jni$_.$JString$Type$(), releaseOriginal: true),
         );
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
@@ -7600,7 +7658,7 @@ class MyInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
           $a![0]?.as(_$impls[$p]!.T, releaseOriginal: true),
         );
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
@@ -7608,16 +7666,16 @@ class MyInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
       if ($d == r'manyPrimitives(IZCD)J') {
         final $r = _$impls[$p]!.manyPrimitives(
           $a![0]!
-              .as(const jni$_.JIntegerType(), releaseOriginal: true)
+              .as(const jni$_.$JInteger$Type$(), releaseOriginal: true)
               .intValue(releaseOriginal: true),
           $a![1]!
-              .as(const jni$_.JBooleanType(), releaseOriginal: true)
+              .as(const jni$_.$JBoolean$Type$(), releaseOriginal: true)
               .booleanValue(releaseOriginal: true),
           $a![2]!
-              .as(const jni$_.JCharacterType(), releaseOriginal: true)
+              .as(const jni$_.$JCharacter$Type$(), releaseOriginal: true)
               .charValue(releaseOriginal: true),
           $a![3]!
-              .as(const jni$_.JDoubleType(), releaseOriginal: true)
+              .as(const jni$_.$JDouble$Type$(), releaseOriginal: true)
               .doubleValue(releaseOriginal: true),
         );
         return jni$_.JLong($r).reference.toPointer();
@@ -7670,7 +7728,7 @@ class MyInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
 
 abstract base mixin class $MyInterface<$T extends jni$_.JObject?> {
   factory $MyInterface({
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
     required void Function(jni$_.JString? string) voidCallback,
     bool voidCallback$async,
     required jni$_.JString? Function(jni$_.JString? string) stringCallback,
@@ -7678,7 +7736,7 @@ abstract base mixin class $MyInterface<$T extends jni$_.JObject?> {
     required int Function(int i, bool z, int c, double d) manyPrimitives,
   }) = _$MyInterface<$T>;
 
-  jni$_.JObjType<$T> get T;
+  jni$_.JType<$T> get T;
 
   void voidCallback(jni$_.JString? string);
   bool get voidCallback$async => false;
@@ -7701,7 +7759,7 @@ final class _$MyInterface<$T extends jni$_.JObject?> with $MyInterface<$T> {
         _manyPrimitives = manyPrimitives;
 
   @core$_.override
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   final void Function(jni$_.JString? string) _voidCallback;
   final bool voidCallback$async;
@@ -7726,13 +7784,13 @@ final class _$MyInterface<$T extends jni$_.JObject?> with $MyInterface<$T> {
   }
 }
 
-final class $MyInterface$NullableType<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<MyInterface<$T>?> {
+final class $MyInterface$NullableType$<$T extends jni$_.JObject?>
+    extends jni$_.JType<MyInterface<$T>?> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $MyInterface$NullableType(
+  const $MyInterface$NullableType$(
     this.T,
   );
 
@@ -7751,34 +7809,34 @@ final class $MyInterface$NullableType<$T extends jni$_.JObject?>
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyInterface<$T>?> get nullableType => this;
+  jni$_.JType<MyInterface<$T>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($MyInterface$NullableType, T);
+  int get hashCode => Object.hash($MyInterface$NullableType$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyInterface$NullableType<$T>) &&
-        other is $MyInterface$NullableType<$T> &&
+    return other.runtimeType == ($MyInterface$NullableType$<$T>) &&
+        other is $MyInterface$NullableType$<$T> &&
         T == other.T;
   }
 }
 
-final class $MyInterface$Type<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<MyInterface<$T>> {
+final class $MyInterface$Type$<$T extends jni$_.JObject?>
+    extends jni$_.JType<MyInterface<$T>> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $MyInterface$Type(
+  const $MyInterface$Type$(
     this.T,
   );
 
@@ -7796,24 +7854,24 @@ final class $MyInterface$Type<$T extends jni$_.JObject?>
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyInterface<$T>?> get nullableType =>
-      $MyInterface$NullableType<$T>(T);
+  jni$_.JType<MyInterface<$T>?> get nullableType =>
+      $MyInterface$NullableType$<$T>(T);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($MyInterface$Type, T);
+  int get hashCode => Object.hash($MyInterface$Type$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyInterface$Type<$T>) &&
-        other is $MyInterface$Type<$T> &&
+    return other.runtimeType == ($MyInterface$Type$<$T>) &&
+        other is $MyInterface$Type$<$T> &&
         T == other.T;
   }
 }
@@ -7822,7 +7880,7 @@ final class $MyInterface$Type<$T extends jni$_.JObject?>
 class MyInterfaceConsumer extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<MyInterfaceConsumer> $type;
+  final jni$_.JType<MyInterfaceConsumer> $type;
 
   @jni$_.internal
   MyInterfaceConsumer.fromReference(
@@ -7834,8 +7892,12 @@ class MyInterfaceConsumer extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/interfaces/MyInterfaceConsumer');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $MyInterfaceConsumer$NullableType();
-  static const type = $MyInterfaceConsumer$Type();
+  static const jni$_.JType<MyInterfaceConsumer?> nullableType =
+      $MyInterfaceConsumer$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<MyInterfaceConsumer> type =
+      $MyInterfaceConsumer$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -7901,7 +7963,7 @@ class MyInterfaceConsumer extends jni$_.JObject {
     int c,
     double d,
     $T? object, {
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     final _$myInterface = myInterface?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
@@ -7960,7 +8022,7 @@ class MyInterfaceConsumer extends jni$_.JObject {
     int c,
     double d,
     $T? object, {
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     final _$myInterface = myInterface?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
@@ -7979,10 +8041,10 @@ class MyInterfaceConsumer extends jni$_.JObject {
   }
 }
 
-final class $MyInterfaceConsumer$NullableType
-    extends jni$_.JObjType<MyInterfaceConsumer?> {
+final class $MyInterfaceConsumer$NullableType$
+    extends jni$_.JType<MyInterfaceConsumer?> {
   @jni$_.internal
-  const $MyInterfaceConsumer$NullableType();
+  const $MyInterfaceConsumer$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -7999,30 +8061,30 @@ final class $MyInterfaceConsumer$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyInterfaceConsumer?> get nullableType => this;
+  jni$_.JType<MyInterfaceConsumer?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($MyInterfaceConsumer$NullableType).hashCode;
+  int get hashCode => ($MyInterfaceConsumer$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyInterfaceConsumer$NullableType) &&
-        other is $MyInterfaceConsumer$NullableType;
+    return other.runtimeType == ($MyInterfaceConsumer$NullableType$) &&
+        other is $MyInterfaceConsumer$NullableType$;
   }
 }
 
-final class $MyInterfaceConsumer$Type
-    extends jni$_.JObjType<MyInterfaceConsumer> {
+final class $MyInterfaceConsumer$Type$
+    extends jni$_.JType<MyInterfaceConsumer> {
   @jni$_.internal
-  const $MyInterfaceConsumer$Type();
+  const $MyInterfaceConsumer$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -8037,24 +8099,24 @@ final class $MyInterfaceConsumer$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyInterfaceConsumer?> get nullableType =>
-      const $MyInterfaceConsumer$NullableType();
+  jni$_.JType<MyInterfaceConsumer?> get nullableType =>
+      const $MyInterfaceConsumer$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($MyInterfaceConsumer$Type).hashCode;
+  int get hashCode => ($MyInterfaceConsumer$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyInterfaceConsumer$Type) &&
-        other is $MyInterfaceConsumer$Type;
+    return other.runtimeType == ($MyInterfaceConsumer$Type$) &&
+        other is $MyInterfaceConsumer$Type$;
   }
 }
 
@@ -8062,7 +8124,7 @@ final class $MyInterfaceConsumer$Type
 class MyRunnable extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<MyRunnable> $type;
+  final jni$_.JType<MyRunnable> $type;
 
   @jni$_.internal
   MyRunnable.fromReference(
@@ -8074,8 +8136,11 @@ class MyRunnable extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/interfaces/MyRunnable');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $MyRunnable$NullableType();
-  static const type = $MyRunnable$Type();
+  static const jni$_.JType<MyRunnable?> nullableType =
+      $MyRunnable$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<MyRunnable> type = $MyRunnable$Type$();
   static final _id_run = _class.instanceMethodId(
     r'run',
     r'()V',
@@ -8201,9 +8266,9 @@ final class _$MyRunnable with $MyRunnable {
   }
 }
 
-final class $MyRunnable$NullableType extends jni$_.JObjType<MyRunnable?> {
+final class $MyRunnable$NullableType$ extends jni$_.JType<MyRunnable?> {
   @jni$_.internal
-  const $MyRunnable$NullableType();
+  const $MyRunnable$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -8219,29 +8284,29 @@ final class $MyRunnable$NullableType extends jni$_.JObjType<MyRunnable?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyRunnable?> get nullableType => this;
+  jni$_.JType<MyRunnable?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($MyRunnable$NullableType).hashCode;
+  int get hashCode => ($MyRunnable$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyRunnable$NullableType) &&
-        other is $MyRunnable$NullableType;
+    return other.runtimeType == ($MyRunnable$NullableType$) &&
+        other is $MyRunnable$NullableType$;
   }
 }
 
-final class $MyRunnable$Type extends jni$_.JObjType<MyRunnable> {
+final class $MyRunnable$Type$ extends jni$_.JType<MyRunnable> {
   @jni$_.internal
-  const $MyRunnable$Type();
+  const $MyRunnable$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -8256,23 +8321,24 @@ final class $MyRunnable$Type extends jni$_.JObjType<MyRunnable> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyRunnable?> get nullableType =>
-      const $MyRunnable$NullableType();
+  jni$_.JType<MyRunnable?> get nullableType =>
+      const $MyRunnable$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($MyRunnable$Type).hashCode;
+  int get hashCode => ($MyRunnable$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyRunnable$Type) && other is $MyRunnable$Type;
+    return other.runtimeType == ($MyRunnable$Type$) &&
+        other is $MyRunnable$Type$;
   }
 }
 
@@ -8280,7 +8346,7 @@ final class $MyRunnable$Type extends jni$_.JObjType<MyRunnable> {
 class MyRunnableRunner extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<MyRunnableRunner> $type;
+  final jni$_.JType<MyRunnableRunner> $type;
 
   @jni$_.internal
   MyRunnableRunner.fromReference(
@@ -8292,8 +8358,11 @@ class MyRunnableRunner extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/interfaces/MyRunnableRunner');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $MyRunnableRunner$NullableType();
-  static const type = $MyRunnableRunner$Type();
+  static const jni$_.JType<MyRunnableRunner?> nullableType =
+      $MyRunnableRunner$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<MyRunnableRunner> type = $MyRunnableRunner$Type$();
   static final _id_error = _class.instanceFieldId(
     r'error',
     r'Ljava/lang/Throwable;',
@@ -8302,12 +8371,12 @@ class MyRunnableRunner extends jni$_.JObject {
   /// from: `public java.lang.Throwable error`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? get error =>
-      _id_error.get(this, const jni$_.JObjectNullableType());
+      _id_error.get(this, const jni$_.$JObject$NullableType$());
 
   /// from: `public java.lang.Throwable error`
   /// The returned object must be released after use, by calling the [release] method.
   set error(jni$_.JObject? value) =>
-      _id_error.set(this, const jni$_.JObjectNullableType(), value);
+      _id_error.set(this, const jni$_.$JObject$NullableType$(), value);
 
   static final _id_new$ = _class.constructorId(
     r'(Lcom/github/dart_lang/jnigen/interfaces/MyRunnable;)V',
@@ -8408,10 +8477,10 @@ class MyRunnableRunner extends jni$_.JObject {
   }
 }
 
-final class $MyRunnableRunner$NullableType
-    extends jni$_.JObjType<MyRunnableRunner?> {
+final class $MyRunnableRunner$NullableType$
+    extends jni$_.JType<MyRunnableRunner?> {
   @jni$_.internal
-  const $MyRunnableRunner$NullableType();
+  const $MyRunnableRunner$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -8428,29 +8497,29 @@ final class $MyRunnableRunner$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyRunnableRunner?> get nullableType => this;
+  jni$_.JType<MyRunnableRunner?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($MyRunnableRunner$NullableType).hashCode;
+  int get hashCode => ($MyRunnableRunner$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyRunnableRunner$NullableType) &&
-        other is $MyRunnableRunner$NullableType;
+    return other.runtimeType == ($MyRunnableRunner$NullableType$) &&
+        other is $MyRunnableRunner$NullableType$;
   }
 }
 
-final class $MyRunnableRunner$Type extends jni$_.JObjType<MyRunnableRunner> {
+final class $MyRunnableRunner$Type$ extends jni$_.JType<MyRunnableRunner> {
   @jni$_.internal
-  const $MyRunnableRunner$Type();
+  const $MyRunnableRunner$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -8465,24 +8534,24 @@ final class $MyRunnableRunner$Type extends jni$_.JObjType<MyRunnableRunner> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyRunnableRunner?> get nullableType =>
-      const $MyRunnableRunner$NullableType();
+  jni$_.JType<MyRunnableRunner?> get nullableType =>
+      const $MyRunnableRunner$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($MyRunnableRunner$Type).hashCode;
+  int get hashCode => ($MyRunnableRunner$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyRunnableRunner$Type) &&
-        other is $MyRunnableRunner$Type;
+    return other.runtimeType == ($MyRunnableRunner$Type$) &&
+        other is $MyRunnableRunner$Type$;
   }
 }
 
@@ -8490,7 +8559,7 @@ final class $MyRunnableRunner$Type extends jni$_.JObjType<MyRunnableRunner> {
 class StringConversionException extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<StringConversionException> $type;
+  final jni$_.JType<StringConversionException> $type;
 
   @jni$_.internal
   StringConversionException.fromReference(
@@ -8502,8 +8571,12 @@ class StringConversionException extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/interfaces/StringConversionException');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $StringConversionException$NullableType();
-  static const type = $StringConversionException$Type();
+  static const jni$_.JType<StringConversionException?> nullableType =
+      $StringConversionException$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<StringConversionException> type =
+      $StringConversionException$Type$();
   static final _id_new$ = _class.constructorId(
     r'(Ljava/lang/String;)V',
   );
@@ -8533,10 +8606,10 @@ class StringConversionException extends jni$_.JObject {
   }
 }
 
-final class $StringConversionException$NullableType
-    extends jni$_.JObjType<StringConversionException?> {
+final class $StringConversionException$NullableType$
+    extends jni$_.JType<StringConversionException?> {
   @jni$_.internal
-  const $StringConversionException$NullableType();
+  const $StringConversionException$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -8553,30 +8626,30 @@ final class $StringConversionException$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<StringConversionException?> get nullableType => this;
+  jni$_.JType<StringConversionException?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($StringConversionException$NullableType).hashCode;
+  int get hashCode => ($StringConversionException$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($StringConversionException$NullableType) &&
-        other is $StringConversionException$NullableType;
+    return other.runtimeType == ($StringConversionException$NullableType$) &&
+        other is $StringConversionException$NullableType$;
   }
 }
 
-final class $StringConversionException$Type
-    extends jni$_.JObjType<StringConversionException> {
+final class $StringConversionException$Type$
+    extends jni$_.JType<StringConversionException> {
   @jni$_.internal
-  const $StringConversionException$Type();
+  const $StringConversionException$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -8591,24 +8664,24 @@ final class $StringConversionException$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<StringConversionException?> get nullableType =>
-      const $StringConversionException$NullableType();
+  jni$_.JType<StringConversionException?> get nullableType =>
+      const $StringConversionException$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($StringConversionException$Type).hashCode;
+  int get hashCode => ($StringConversionException$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($StringConversionException$Type) &&
-        other is $StringConversionException$Type;
+    return other.runtimeType == ($StringConversionException$Type$) &&
+        other is $StringConversionException$Type$;
   }
 }
 
@@ -8616,7 +8689,7 @@ final class $StringConversionException$Type
 class StringConverter extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<StringConverter> $type;
+  final jni$_.JType<StringConverter> $type;
 
   @jni$_.internal
   StringConverter.fromReference(
@@ -8628,8 +8701,11 @@ class StringConverter extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/interfaces/StringConverter');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $StringConverter$NullableType();
-  static const type = $StringConverter$Type();
+  static const jni$_.JType<StringConverter?> nullableType =
+      $StringConverter$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<StringConverter> type = $StringConverter$Type$();
   static final _id_parseToInt = _class.instanceMethodId(
     r'parseToInt',
     r'(Ljava/lang/String;)I',
@@ -8688,7 +8764,7 @@ class StringConverter extends jni$_.JObject {
       final $a = $i.args;
       if ($d == r'parseToInt(Ljava/lang/String;)I') {
         final $r = _$impls[$p]!.parseToInt(
-          $a![0]?.as(const jni$_.JStringType(), releaseOriginal: true),
+          $a![0]?.as(const jni$_.$JString$Type$(), releaseOriginal: true),
         );
         return jni$_.JInteger($r).reference.toPointer();
       }
@@ -8754,10 +8830,10 @@ final class _$StringConverter with $StringConverter {
   }
 }
 
-final class $StringConverter$NullableType
-    extends jni$_.JObjType<StringConverter?> {
+final class $StringConverter$NullableType$
+    extends jni$_.JType<StringConverter?> {
   @jni$_.internal
-  const $StringConverter$NullableType();
+  const $StringConverter$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -8773,29 +8849,29 @@ final class $StringConverter$NullableType
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<StringConverter?> get nullableType => this;
+  jni$_.JType<StringConverter?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($StringConverter$NullableType).hashCode;
+  int get hashCode => ($StringConverter$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($StringConverter$NullableType) &&
-        other is $StringConverter$NullableType;
+    return other.runtimeType == ($StringConverter$NullableType$) &&
+        other is $StringConverter$NullableType$;
   }
 }
 
-final class $StringConverter$Type extends jni$_.JObjType<StringConverter> {
+final class $StringConverter$Type$ extends jni$_.JType<StringConverter> {
   @jni$_.internal
-  const $StringConverter$Type();
+  const $StringConverter$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -8810,24 +8886,24 @@ final class $StringConverter$Type extends jni$_.JObjType<StringConverter> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<StringConverter?> get nullableType =>
-      const $StringConverter$NullableType();
+  jni$_.JType<StringConverter?> get nullableType =>
+      const $StringConverter$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($StringConverter$Type).hashCode;
+  int get hashCode => ($StringConverter$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($StringConverter$Type) &&
-        other is $StringConverter$Type;
+    return other.runtimeType == ($StringConverter$Type$) &&
+        other is $StringConverter$Type$;
   }
 }
 
@@ -8835,7 +8911,7 @@ final class $StringConverter$Type extends jni$_.JObjType<StringConverter> {
 class StringConverterConsumer extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<StringConverterConsumer> $type;
+  final jni$_.JType<StringConverterConsumer> $type;
 
   @jni$_.internal
   StringConverterConsumer.fromReference(
@@ -8847,8 +8923,12 @@ class StringConverterConsumer extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/interfaces/StringConverterConsumer');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $StringConverterConsumer$NullableType();
-  static const type = $StringConverterConsumer$Type();
+  static const jni$_.JType<StringConverterConsumer?> nullableType =
+      $StringConverterConsumer$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<StringConverterConsumer> type =
+      $StringConverterConsumer$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -8909,7 +8989,7 @@ class StringConverterConsumer extends jni$_.JObject {
             _id_consumeOnSameThread as jni$_.JMethodIDPtr,
             _$stringConverter.pointer,
             _$string.pointer)
-        .object<jni$_.JInteger?>(const jni$_.JIntegerNullableType());
+        .object<jni$_.JInteger?>(const jni$_.$JInteger$NullableType$());
   }
 
   static final _id_consumeOnAnotherThread = _class.staticMethodId(
@@ -8948,14 +9028,14 @@ class StringConverterConsumer extends jni$_.JObject {
             _id_consumeOnAnotherThread as jni$_.JMethodIDPtr,
             _$stringConverter.pointer,
             _$string.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 }
 
-final class $StringConverterConsumer$NullableType
-    extends jni$_.JObjType<StringConverterConsumer?> {
+final class $StringConverterConsumer$NullableType$
+    extends jni$_.JType<StringConverterConsumer?> {
   @jni$_.internal
-  const $StringConverterConsumer$NullableType();
+  const $StringConverterConsumer$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -8972,30 +9052,30 @@ final class $StringConverterConsumer$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<StringConverterConsumer?> get nullableType => this;
+  jni$_.JType<StringConverterConsumer?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($StringConverterConsumer$NullableType).hashCode;
+  int get hashCode => ($StringConverterConsumer$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($StringConverterConsumer$NullableType) &&
-        other is $StringConverterConsumer$NullableType;
+    return other.runtimeType == ($StringConverterConsumer$NullableType$) &&
+        other is $StringConverterConsumer$NullableType$;
   }
 }
 
-final class $StringConverterConsumer$Type
-    extends jni$_.JObjType<StringConverterConsumer> {
+final class $StringConverterConsumer$Type$
+    extends jni$_.JType<StringConverterConsumer> {
   @jni$_.internal
-  const $StringConverterConsumer$Type();
+  const $StringConverterConsumer$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -9010,24 +9090,24 @@ final class $StringConverterConsumer$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<StringConverterConsumer?> get nullableType =>
-      const $StringConverterConsumer$NullableType();
+  jni$_.JType<StringConverterConsumer?> get nullableType =>
+      const $StringConverterConsumer$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($StringConverterConsumer$Type).hashCode;
+  int get hashCode => ($StringConverterConsumer$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($StringConverterConsumer$Type) &&
-        other is $StringConverterConsumer$Type;
+    return other.runtimeType == ($StringConverterConsumer$Type$) &&
+        other is $StringConverterConsumer$Type$;
   }
 }
 
@@ -9035,10 +9115,10 @@ final class $StringConverterConsumer$Type
 class BaseClass<$T extends jni$_.JObject?> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<BaseClass<$T>> $type;
+  final jni$_.JType<BaseClass<$T>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
   BaseClass.fromReference(
@@ -9051,18 +9131,19 @@ class BaseClass<$T extends jni$_.JObject?> extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/inheritance/BaseClass');
 
   /// The type which includes information such as the signature of this class.
-  static $BaseClass$NullableType<$T> nullableType<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+  static jni$_.JType<BaseClass<$T>?> nullableType<$T extends jni$_.JObject?>(
+    jni$_.JType<$T> T,
   ) {
-    return $BaseClass$NullableType<$T>(
+    return $BaseClass$NullableType$<$T>(
       T,
     );
   }
 
-  static $BaseClass$Type<$T> type<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<BaseClass<$T>> type<$T extends jni$_.JObject?>(
+    jni$_.JType<$T> T,
   ) {
-    return $BaseClass$Type<$T>(
+    return $BaseClass$Type$<$T>(
       T,
     );
   }
@@ -9086,7 +9167,7 @@ class BaseClass<$T extends jni$_.JObject?> extends jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory BaseClass({
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     return BaseClass<$T>.fromReference(
         T,
@@ -9095,13 +9176,13 @@ class BaseClass<$T extends jni$_.JObject?> extends jni$_.JObject {
   }
 }
 
-final class $BaseClass$NullableType<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<BaseClass<$T>?> {
+final class $BaseClass$NullableType$<$T extends jni$_.JObject?>
+    extends jni$_.JType<BaseClass<$T>?> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $BaseClass$NullableType(
+  const $BaseClass$NullableType$(
     this.T,
   );
 
@@ -9120,34 +9201,34 @@ final class $BaseClass$NullableType<$T extends jni$_.JObject?>
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<BaseClass<$T>?> get nullableType => this;
+  jni$_.JType<BaseClass<$T>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($BaseClass$NullableType, T);
+  int get hashCode => Object.hash($BaseClass$NullableType$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($BaseClass$NullableType<$T>) &&
-        other is $BaseClass$NullableType<$T> &&
+    return other.runtimeType == ($BaseClass$NullableType$<$T>) &&
+        other is $BaseClass$NullableType$<$T> &&
         T == other.T;
   }
 }
 
-final class $BaseClass$Type<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<BaseClass<$T>> {
+final class $BaseClass$Type$<$T extends jni$_.JObject?>
+    extends jni$_.JType<BaseClass<$T>> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $BaseClass$Type(
+  const $BaseClass$Type$(
     this.T,
   );
 
@@ -9165,24 +9246,24 @@ final class $BaseClass$Type<$T extends jni$_.JObject?>
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<BaseClass<$T>?> get nullableType =>
-      $BaseClass$NullableType<$T>(T);
+  jni$_.JType<BaseClass<$T>?> get nullableType =>
+      $BaseClass$NullableType$<$T>(T);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($BaseClass$Type, T);
+  int get hashCode => Object.hash($BaseClass$Type$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($BaseClass$Type<$T>) &&
-        other is $BaseClass$Type<$T> &&
+    return other.runtimeType == ($BaseClass$Type$<$T>) &&
+        other is $BaseClass$Type$<$T> &&
         T == other.T;
   }
 }
@@ -9191,10 +9272,10 @@ final class $BaseClass$Type<$T extends jni$_.JObject?>
 class BaseGenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<BaseGenericInterface<$T>> $type;
+  final jni$_.JType<BaseGenericInterface<$T>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
   BaseGenericInterface.fromReference(
@@ -9207,19 +9288,20 @@ class BaseGenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/inheritance/BaseGenericInterface');
 
   /// The type which includes information such as the signature of this class.
-  static $BaseGenericInterface$NullableType<$T>
+  static jni$_.JType<BaseGenericInterface<$T>?>
       nullableType<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+    jni$_.JType<$T> T,
   ) {
-    return $BaseGenericInterface$NullableType<$T>(
+    return $BaseGenericInterface$NullableType$<$T>(
       T,
     );
   }
 
-  static $BaseGenericInterface$Type<$T> type<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<BaseGenericInterface<$T>> type<$T extends jni$_.JObject?>(
+    jni$_.JType<$T> T,
   ) {
-    return $BaseGenericInterface$Type<$T>(
+    return $BaseGenericInterface$Type$<$T>(
       T,
     );
   }
@@ -9281,7 +9363,7 @@ class BaseGenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
       if ($d == r'foo()Ljava/lang/Object;') {
         final $r = _$impls[$p]!.foo();
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
@@ -9331,11 +9413,11 @@ class BaseGenericInterface<$T extends jni$_.JObject?> extends jni$_.JObject {
 
 abstract base mixin class $BaseGenericInterface<$T extends jni$_.JObject?> {
   factory $BaseGenericInterface({
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
     required $T? Function() foo,
   }) = _$BaseGenericInterface<$T>;
 
-  jni$_.JObjType<$T> get T;
+  jni$_.JType<$T> get T;
 
   $T? foo();
 }
@@ -9348,7 +9430,7 @@ final class _$BaseGenericInterface<$T extends jni$_.JObject?>
   }) : _foo = foo;
 
   @core$_.override
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   final $T? Function() _foo;
 
@@ -9357,13 +9439,13 @@ final class _$BaseGenericInterface<$T extends jni$_.JObject?>
   }
 }
 
-final class $BaseGenericInterface$NullableType<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<BaseGenericInterface<$T>?> {
+final class $BaseGenericInterface$NullableType$<$T extends jni$_.JObject?>
+    extends jni$_.JType<BaseGenericInterface<$T>?> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $BaseGenericInterface$NullableType(
+  const $BaseGenericInterface$NullableType$(
     this.T,
   );
 
@@ -9383,34 +9465,34 @@ final class $BaseGenericInterface$NullableType<$T extends jni$_.JObject?>
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<BaseGenericInterface<$T>?> get nullableType => this;
+  jni$_.JType<BaseGenericInterface<$T>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($BaseGenericInterface$NullableType, T);
+  int get hashCode => Object.hash($BaseGenericInterface$NullableType$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($BaseGenericInterface$NullableType<$T>) &&
-        other is $BaseGenericInterface$NullableType<$T> &&
+    return other.runtimeType == ($BaseGenericInterface$NullableType$<$T>) &&
+        other is $BaseGenericInterface$NullableType$<$T> &&
         T == other.T;
   }
 }
 
-final class $BaseGenericInterface$Type<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<BaseGenericInterface<$T>> {
+final class $BaseGenericInterface$Type$<$T extends jni$_.JObject?>
+    extends jni$_.JType<BaseGenericInterface<$T>> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $BaseGenericInterface$Type(
+  const $BaseGenericInterface$Type$(
     this.T,
   );
 
@@ -9428,24 +9510,24 @@ final class $BaseGenericInterface$Type<$T extends jni$_.JObject?>
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<BaseGenericInterface<$T>?> get nullableType =>
-      $BaseGenericInterface$NullableType<$T>(T);
+  jni$_.JType<BaseGenericInterface<$T>?> get nullableType =>
+      $BaseGenericInterface$NullableType$<$T>(T);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($BaseGenericInterface$Type, T);
+  int get hashCode => Object.hash($BaseGenericInterface$Type$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($BaseGenericInterface$Type<$T>) &&
-        other is $BaseGenericInterface$Type<$T> &&
+    return other.runtimeType == ($BaseGenericInterface$Type$<$T>) &&
+        other is $BaseGenericInterface$Type$<$T> &&
         T == other.T;
   }
 }
@@ -9454,7 +9536,7 @@ final class $BaseGenericInterface$Type<$T extends jni$_.JObject?>
 class BaseInterface extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<BaseInterface> $type;
+  final jni$_.JType<BaseInterface> $type;
 
   @jni$_.internal
   BaseInterface.fromReference(
@@ -9466,8 +9548,11 @@ class BaseInterface extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/inheritance/BaseInterface');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $BaseInterface$NullableType();
-  static const type = $BaseInterface$Type();
+  static const jni$_.JType<BaseInterface?> nullableType =
+      $BaseInterface$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<BaseInterface> type = $BaseInterface$Type$();
   static final _id_foo = _class.instanceMethodId(
     r'foo',
     r'()Ljava/lang/String;',
@@ -9489,7 +9574,7 @@ class BaseInterface extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? foo() {
     return _foo(reference.pointer, _id_foo as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   /// Maps a specific port to the implemented interface.
@@ -9525,7 +9610,7 @@ class BaseInterface extends jni$_.JObject {
       if ($d == r'foo()Ljava/lang/String;') {
         final $r = _$impls[$p]!.foo();
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
@@ -9592,9 +9677,9 @@ final class _$BaseInterface with $BaseInterface {
   }
 }
 
-final class $BaseInterface$NullableType extends jni$_.JObjType<BaseInterface?> {
+final class $BaseInterface$NullableType$ extends jni$_.JType<BaseInterface?> {
   @jni$_.internal
-  const $BaseInterface$NullableType();
+  const $BaseInterface$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -9610,29 +9695,29 @@ final class $BaseInterface$NullableType extends jni$_.JObjType<BaseInterface?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<BaseInterface?> get nullableType => this;
+  jni$_.JType<BaseInterface?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($BaseInterface$NullableType).hashCode;
+  int get hashCode => ($BaseInterface$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($BaseInterface$NullableType) &&
-        other is $BaseInterface$NullableType;
+    return other.runtimeType == ($BaseInterface$NullableType$) &&
+        other is $BaseInterface$NullableType$;
   }
 }
 
-final class $BaseInterface$Type extends jni$_.JObjType<BaseInterface> {
+final class $BaseInterface$Type$ extends jni$_.JType<BaseInterface> {
   @jni$_.internal
-  const $BaseInterface$Type();
+  const $BaseInterface$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -9647,24 +9732,24 @@ final class $BaseInterface$Type extends jni$_.JObjType<BaseInterface> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<BaseInterface?> get nullableType =>
-      const $BaseInterface$NullableType();
+  jni$_.JType<BaseInterface?> get nullableType =>
+      const $BaseInterface$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($BaseInterface$Type).hashCode;
+  int get hashCode => ($BaseInterface$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($BaseInterface$Type) &&
-        other is $BaseInterface$Type;
+    return other.runtimeType == ($BaseInterface$Type$) &&
+        other is $BaseInterface$Type$;
   }
 }
 
@@ -9672,7 +9757,7 @@ final class $BaseInterface$Type extends jni$_.JObjType<BaseInterface> {
 class DerivedInterface extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<DerivedInterface> $type;
+  final jni$_.JType<DerivedInterface> $type;
 
   @jni$_.internal
   DerivedInterface.fromReference(
@@ -9684,8 +9769,11 @@ class DerivedInterface extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/inheritance/DerivedInterface');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $DerivedInterface$NullableType();
-  static const type = $DerivedInterface$Type();
+  static const jni$_.JType<DerivedInterface?> nullableType =
+      $DerivedInterface$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<DerivedInterface> type = $DerivedInterface$Type$();
   static final _id_foo = _class.instanceMethodId(
     r'foo',
     r'()Ljava/lang/String;',
@@ -9707,7 +9795,7 @@ class DerivedInterface extends jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? foo() {
     return _foo(reference.pointer, _id_foo as jni$_.JMethodIDPtr)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   /// Maps a specific port to the implemented interface.
@@ -9743,7 +9831,7 @@ class DerivedInterface extends jni$_.JObject {
       if ($d == r'foo()Ljava/lang/String;') {
         final $r = _$impls[$p]!.foo();
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
@@ -9810,10 +9898,10 @@ final class _$DerivedInterface with $DerivedInterface {
   }
 }
 
-final class $DerivedInterface$NullableType
-    extends jni$_.JObjType<DerivedInterface?> {
+final class $DerivedInterface$NullableType$
+    extends jni$_.JType<DerivedInterface?> {
   @jni$_.internal
-  const $DerivedInterface$NullableType();
+  const $DerivedInterface$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -9830,29 +9918,29 @@ final class $DerivedInterface$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DerivedInterface?> get nullableType => this;
+  jni$_.JType<DerivedInterface?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($DerivedInterface$NullableType).hashCode;
+  int get hashCode => ($DerivedInterface$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($DerivedInterface$NullableType) &&
-        other is $DerivedInterface$NullableType;
+    return other.runtimeType == ($DerivedInterface$NullableType$) &&
+        other is $DerivedInterface$NullableType$;
   }
 }
 
-final class $DerivedInterface$Type extends jni$_.JObjType<DerivedInterface> {
+final class $DerivedInterface$Type$ extends jni$_.JType<DerivedInterface> {
   @jni$_.internal
-  const $DerivedInterface$Type();
+  const $DerivedInterface$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -9867,24 +9955,24 @@ final class $DerivedInterface$Type extends jni$_.JObjType<DerivedInterface> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<DerivedInterface?> get nullableType =>
-      const $DerivedInterface$NullableType();
+  jni$_.JType<DerivedInterface?> get nullableType =>
+      const $DerivedInterface$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($DerivedInterface$Type).hashCode;
+  int get hashCode => ($DerivedInterface$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($DerivedInterface$Type) &&
-        other is $DerivedInterface$Type;
+    return other.runtimeType == ($DerivedInterface$Type$) &&
+        other is $DerivedInterface$Type$;
   }
 }
 
@@ -9892,10 +9980,10 @@ final class $DerivedInterface$Type extends jni$_.JObjType<DerivedInterface> {
 class GenericDerivedClass<$T extends jni$_.JObject?> extends BaseClass<$T?> {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<GenericDerivedClass<$T>> $type;
+  final jni$_.JType<GenericDerivedClass<$T>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
   GenericDerivedClass.fromReference(
@@ -9908,19 +9996,20 @@ class GenericDerivedClass<$T extends jni$_.JObject?> extends BaseClass<$T?> {
       r'com/github/dart_lang/jnigen/inheritance/GenericDerivedClass');
 
   /// The type which includes information such as the signature of this class.
-  static $GenericDerivedClass$NullableType<$T>
+  static jni$_.JType<GenericDerivedClass<$T>?>
       nullableType<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+    jni$_.JType<$T> T,
   ) {
-    return $GenericDerivedClass$NullableType<$T>(
+    return $GenericDerivedClass$NullableType$<$T>(
       T,
     );
   }
 
-  static $GenericDerivedClass$Type<$T> type<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<GenericDerivedClass<$T>> type<$T extends jni$_.JObject?>(
+    jni$_.JType<$T> T,
   ) {
-    return $GenericDerivedClass$Type<$T>(
+    return $GenericDerivedClass$Type$<$T>(
       T,
     );
   }
@@ -9944,7 +10033,7 @@ class GenericDerivedClass<$T extends jni$_.JObject?> extends BaseClass<$T?> {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory GenericDerivedClass({
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     return GenericDerivedClass<$T>.fromReference(
         T,
@@ -9953,13 +10042,13 @@ class GenericDerivedClass<$T extends jni$_.JObject?> extends BaseClass<$T?> {
   }
 }
 
-final class $GenericDerivedClass$NullableType<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<GenericDerivedClass<$T>?> {
+final class $GenericDerivedClass$NullableType$<$T extends jni$_.JObject?>
+    extends jni$_.JType<GenericDerivedClass<$T>?> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $GenericDerivedClass$NullableType(
+  const $GenericDerivedClass$NullableType$(
     this.T,
   );
 
@@ -9979,34 +10068,34 @@ final class $GenericDerivedClass$NullableType<$T extends jni$_.JObject?>
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => $BaseClass$NullableType<$T?>(T.nullableType);
+  jni$_.JType get superType => $BaseClass$NullableType$<$T?>(T.nullableType);
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GenericDerivedClass<$T>?> get nullableType => this;
+  jni$_.JType<GenericDerivedClass<$T>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 2;
 
   @core$_.override
-  int get hashCode => Object.hash($GenericDerivedClass$NullableType, T);
+  int get hashCode => Object.hash($GenericDerivedClass$NullableType$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GenericDerivedClass$NullableType<$T>) &&
-        other is $GenericDerivedClass$NullableType<$T> &&
+    return other.runtimeType == ($GenericDerivedClass$NullableType$<$T>) &&
+        other is $GenericDerivedClass$NullableType$<$T> &&
         T == other.T;
   }
 }
 
-final class $GenericDerivedClass$Type<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<GenericDerivedClass<$T>> {
+final class $GenericDerivedClass$Type$<$T extends jni$_.JObject?>
+    extends jni$_.JType<GenericDerivedClass<$T>> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $GenericDerivedClass$Type(
+  const $GenericDerivedClass$Type$(
     this.T,
   );
 
@@ -10024,24 +10113,24 @@ final class $GenericDerivedClass$Type<$T extends jni$_.JObject?>
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => $BaseClass$NullableType<$T?>(T.nullableType);
+  jni$_.JType get superType => $BaseClass$NullableType$<$T?>(T.nullableType);
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<GenericDerivedClass<$T>?> get nullableType =>
-      $GenericDerivedClass$NullableType<$T>(T);
+  jni$_.JType<GenericDerivedClass<$T>?> get nullableType =>
+      $GenericDerivedClass$NullableType$<$T>(T);
 
   @jni$_.internal
   @core$_.override
   final superCount = 2;
 
   @core$_.override
-  int get hashCode => Object.hash($GenericDerivedClass$Type, T);
+  int get hashCode => Object.hash($GenericDerivedClass$Type$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($GenericDerivedClass$Type<$T>) &&
-        other is $GenericDerivedClass$Type<$T> &&
+    return other.runtimeType == ($GenericDerivedClass$Type$<$T>) &&
+        other is $GenericDerivedClass$Type$<$T> &&
         T == other.T;
   }
 }
@@ -10050,20 +10139,24 @@ final class $GenericDerivedClass$Type<$T extends jni$_.JObject?>
 class SpecificDerivedClass extends BaseClass<jni$_.JString?> {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<SpecificDerivedClass> $type;
+  final jni$_.JType<SpecificDerivedClass> $type;
 
   @jni$_.internal
   SpecificDerivedClass.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
-        super.fromReference(const jni$_.JStringNullableType(), reference);
+        super.fromReference(const jni$_.$JString$NullableType$(), reference);
 
   static final _class = jni$_.JClass.forName(
       r'com/github/dart_lang/jnigen/inheritance/SpecificDerivedClass');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $SpecificDerivedClass$NullableType();
-  static const type = $SpecificDerivedClass$Type();
+  static const jni$_.JType<SpecificDerivedClass?> nullableType =
+      $SpecificDerivedClass$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<SpecificDerivedClass> type =
+      $SpecificDerivedClass$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -10089,10 +10182,10 @@ class SpecificDerivedClass extends BaseClass<jni$_.JString?> {
   }
 }
 
-final class $SpecificDerivedClass$NullableType
-    extends jni$_.JObjType<SpecificDerivedClass?> {
+final class $SpecificDerivedClass$NullableType$
+    extends jni$_.JType<SpecificDerivedClass?> {
   @jni$_.internal
-  const $SpecificDerivedClass$NullableType();
+  const $SpecificDerivedClass$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -10109,31 +10202,31 @@ final class $SpecificDerivedClass$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const $BaseClass$NullableType<jni$_.JString?>(
-      jni$_.JStringNullableType());
+  jni$_.JType get superType => const $BaseClass$NullableType$<jni$_.JString?>(
+      jni$_.$JString$NullableType$());
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<SpecificDerivedClass?> get nullableType => this;
+  jni$_.JType<SpecificDerivedClass?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 2;
 
   @core$_.override
-  int get hashCode => ($SpecificDerivedClass$NullableType).hashCode;
+  int get hashCode => ($SpecificDerivedClass$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($SpecificDerivedClass$NullableType) &&
-        other is $SpecificDerivedClass$NullableType;
+    return other.runtimeType == ($SpecificDerivedClass$NullableType$) &&
+        other is $SpecificDerivedClass$NullableType$;
   }
 }
 
-final class $SpecificDerivedClass$Type
-    extends jni$_.JObjType<SpecificDerivedClass> {
+final class $SpecificDerivedClass$Type$
+    extends jni$_.JType<SpecificDerivedClass> {
   @jni$_.internal
-  const $SpecificDerivedClass$Type();
+  const $SpecificDerivedClass$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -10148,25 +10241,25 @@ final class $SpecificDerivedClass$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const $BaseClass$NullableType<jni$_.JString?>(
-      jni$_.JStringNullableType());
+  jni$_.JType get superType => const $BaseClass$NullableType$<jni$_.JString?>(
+      jni$_.$JString$NullableType$());
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<SpecificDerivedClass?> get nullableType =>
-      const $SpecificDerivedClass$NullableType();
+  jni$_.JType<SpecificDerivedClass?> get nullableType =>
+      const $SpecificDerivedClass$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 2;
 
   @core$_.override
-  int get hashCode => ($SpecificDerivedClass$Type).hashCode;
+  int get hashCode => ($SpecificDerivedClass$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($SpecificDerivedClass$Type) &&
-        other is $SpecificDerivedClass$Type;
+    return other.runtimeType == ($SpecificDerivedClass$Type$) &&
+        other is $SpecificDerivedClass$Type$;
   }
 }
 
@@ -10175,19 +10268,19 @@ class Annotated$Nested<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     $W extends jni$_.JObject, $V extends jni$_.JObject?> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Annotated$Nested<$T, $U, $W, $V>> $type;
+  final jni$_.JType<Annotated$Nested<$T, $U, $W, $V>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
-  final jni$_.JObjType<$W> W;
+  final jni$_.JType<$W> W;
 
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
   Annotated$Nested.fromReference(
@@ -10203,17 +10296,17 @@ class Annotated$Nested<$T extends jni$_.JObject?, $U extends jni$_.JObject,
       r'com/github/dart_lang/jnigen/annotations/Annotated$Nested');
 
   /// The type which includes information such as the signature of this class.
-  static $Annotated$Nested$NullableType<$T, $U, $W, $V> nullableType<
+  static jni$_.JType<Annotated$Nested<$T, $U, $W, $V>?> nullableType<
       $T extends jni$_.JObject?,
       $U extends jni$_.JObject,
       $W extends jni$_.JObject,
       $V extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
-    jni$_.JObjType<$U> U,
-    jni$_.JObjType<$W> W,
-    jni$_.JObjType<$V> V,
+    jni$_.JType<$T> T,
+    jni$_.JType<$U> U,
+    jni$_.JType<$W> W,
+    jni$_.JType<$V> V,
   ) {
-    return $Annotated$Nested$NullableType<$T, $U, $W, $V>(
+    return $Annotated$Nested$NullableType$<$T, $U, $W, $V>(
       T,
       U,
       W,
@@ -10221,17 +10314,18 @@ class Annotated$Nested<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     );
   }
 
-  static $Annotated$Nested$Type<$T, $U, $W, $V> type<
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<Annotated$Nested<$T, $U, $W, $V>> type<
       $T extends jni$_.JObject?,
       $U extends jni$_.JObject,
       $W extends jni$_.JObject,
       $V extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
-    jni$_.JObjType<$U> U,
-    jni$_.JObjType<$W> W,
-    jni$_.JObjType<$V> V,
+    jni$_.JType<$T> T,
+    jni$_.JType<$U> U,
+    jni$_.JType<$W> W,
+    jni$_.JType<$V> V,
   ) {
-    return $Annotated$Nested$Type<$T, $U, $W, $V>(
+    return $Annotated$Nested$Type$<$T, $U, $W, $V>(
       T,
       U,
       W,
@@ -10291,26 +10385,26 @@ class Annotated$Nested<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   factory Annotated$Nested(
     Annotated<$T?, $U, $W> $outerClass,
     $V? object, {
-    jni$_.JObjType<$T>? T,
-    jni$_.JObjType<$U>? U,
-    jni$_.JObjType<$W>? W,
-    required jni$_.JObjType<$V> V,
+    jni$_.JType<$T>? T,
+    jni$_.JType<$U>? U,
+    jni$_.JType<$W>? W,
+    required jni$_.JType<$V> V,
   }) {
     T ??= jni$_.lowestCommonSuperType([
-      ($outerClass.$type as $Annotated$Type<core$_.dynamic, core$_.dynamic,
+      ($outerClass.$type as $Annotated$Type$<core$_.dynamic, core$_.dynamic,
               core$_.dynamic>)
           .T,
-    ]) as jni$_.JObjType<$T>;
+    ]) as jni$_.JType<$T>;
     U ??= jni$_.lowestCommonSuperType([
-      ($outerClass.$type as $Annotated$Type<core$_.dynamic, core$_.dynamic,
+      ($outerClass.$type as $Annotated$Type$<core$_.dynamic, core$_.dynamic,
               core$_.dynamic>)
           .U,
-    ]) as jni$_.JObjType<$U>;
+    ]) as jni$_.JType<$U>;
     W ??= jni$_.lowestCommonSuperType([
-      ($outerClass.$type as $Annotated$Type<core$_.dynamic, core$_.dynamic,
+      ($outerClass.$type as $Annotated$Type$<core$_.dynamic, core$_.dynamic,
               core$_.dynamic>)
           .W,
-    ]) as jni$_.JObjType<$W>;
+    ]) as jni$_.JType<$W>;
     final _$$outerClass = $outerClass.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return Annotated$Nested<$T, $U, $W, $V>.fromReference(
@@ -10324,26 +10418,26 @@ class Annotated$Nested<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   }
 }
 
-final class $Annotated$Nested$NullableType<
+final class $Annotated$Nested$NullableType$<
         $T extends jni$_.JObject?,
         $U extends jni$_.JObject,
         $W extends jni$_.JObject,
         $V extends jni$_.JObject?>
-    extends jni$_.JObjType<Annotated$Nested<$T, $U, $W, $V>?> {
+    extends jni$_.JType<Annotated$Nested<$T, $U, $W, $V>?> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
-  final jni$_.JObjType<$W> W;
+  final jni$_.JType<$W> W;
 
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
-  const $Annotated$Nested$NullableType(
+  const $Annotated$Nested$NullableType$(
     this.T,
     this.U,
     this.W,
@@ -10369,24 +10463,24 @@ final class $Annotated$Nested$NullableType<
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Annotated$Nested<$T, $U, $W, $V>?> get nullableType => this;
+  jni$_.JType<Annotated$Nested<$T, $U, $W, $V>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($Annotated$Nested$NullableType, T, U, W, V);
+  int get hashCode => Object.hash($Annotated$Nested$NullableType$, T, U, W, V);
 
   @core$_.override
   bool operator ==(Object other) {
     return other.runtimeType ==
-            ($Annotated$Nested$NullableType<$T, $U, $W, $V>) &&
-        other is $Annotated$Nested$NullableType<$T, $U, $W, $V> &&
+            ($Annotated$Nested$NullableType$<$T, $U, $W, $V>) &&
+        other is $Annotated$Nested$NullableType$<$T, $U, $W, $V> &&
         T == other.T &&
         U == other.U &&
         W == other.W &&
@@ -10394,26 +10488,26 @@ final class $Annotated$Nested$NullableType<
   }
 }
 
-final class $Annotated$Nested$Type<
+final class $Annotated$Nested$Type$<
         $T extends jni$_.JObject?,
         $U extends jni$_.JObject,
         $W extends jni$_.JObject,
         $V extends jni$_.JObject?>
-    extends jni$_.JObjType<Annotated$Nested<$T, $U, $W, $V>> {
+    extends jni$_.JType<Annotated$Nested<$T, $U, $W, $V>> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
-  final jni$_.JObjType<$W> W;
+  final jni$_.JType<$W> W;
 
   @jni$_.internal
-  final jni$_.JObjType<$V> V;
+  final jni$_.JType<$V> V;
 
   @jni$_.internal
-  const $Annotated$Nested$Type(
+  const $Annotated$Nested$Type$(
     this.T,
     this.U,
     this.W,
@@ -10437,24 +10531,24 @@ final class $Annotated$Nested$Type<
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Annotated$Nested<$T, $U, $W, $V>?> get nullableType =>
-      $Annotated$Nested$NullableType<$T, $U, $W, $V>(T, U, W, V);
+  jni$_.JType<Annotated$Nested<$T, $U, $W, $V>?> get nullableType =>
+      $Annotated$Nested$NullableType$<$T, $U, $W, $V>(T, U, W, V);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($Annotated$Nested$Type, T, U, W, V);
+  int get hashCode => Object.hash($Annotated$Nested$Type$, T, U, W, V);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Annotated$Nested$Type<$T, $U, $W, $V>) &&
-        other is $Annotated$Nested$Type<$T, $U, $W, $V> &&
+    return other.runtimeType == ($Annotated$Nested$Type$<$T, $U, $W, $V>) &&
+        other is $Annotated$Nested$Type$<$T, $U, $W, $V> &&
         T == other.T &&
         U == other.U &&
         W == other.W &&
@@ -10467,16 +10561,16 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     $W extends jni$_.JObject> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Annotated<$T, $U, $W>> $type;
+  final jni$_.JType<Annotated<$T, $U, $W>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
-  final jni$_.JObjType<$W> W;
+  final jni$_.JType<$W> W;
 
   @jni$_.internal
   Annotated.fromReference(
@@ -10491,28 +10585,29 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
       r'com/github/dart_lang/jnigen/annotations/Annotated');
 
   /// The type which includes information such as the signature of this class.
-  static $Annotated$NullableType<$T, $U, $W> nullableType<
+  static jni$_.JType<Annotated<$T, $U, $W>?> nullableType<
       $T extends jni$_.JObject?,
       $U extends jni$_.JObject,
       $W extends jni$_.JObject>(
-    jni$_.JObjType<$T> T,
-    jni$_.JObjType<$U> U,
-    jni$_.JObjType<$W> W,
+    jni$_.JType<$T> T,
+    jni$_.JType<$U> U,
+    jni$_.JType<$W> W,
   ) {
-    return $Annotated$NullableType<$T, $U, $W>(
+    return $Annotated$NullableType$<$T, $U, $W>(
       T,
       U,
       W,
     );
   }
 
-  static $Annotated$Type<$T, $U, $W> type<$T extends jni$_.JObject?,
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<Annotated<$T, $U, $W>> type<$T extends jni$_.JObject?,
       $U extends jni$_.JObject, $W extends jni$_.JObject>(
-    jni$_.JObjType<$T> T,
-    jni$_.JObjType<$U> U,
-    jni$_.JObjType<$W> W,
+    jni$_.JType<$T> T,
+    jni$_.JType<$U> U,
+    jni$_.JType<$W> W,
   ) {
-    return $Annotated$Type<$T, $U, $W>(
+    return $Annotated$Type$<$T, $U, $W>(
       T,
       U,
       W,
@@ -10587,16 +10682,16 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     $T? object,
     $U object1,
     $W object2, {
-    required jni$_.JObjType<$T> T,
-    jni$_.JObjType<$U>? U,
-    jni$_.JObjType<$W>? W,
+    required jni$_.JType<$T> T,
+    jni$_.JType<$U>? U,
+    jni$_.JType<$W>? W,
   }) {
     U ??= jni$_.lowestCommonSuperType([
       object1.$type,
-    ]) as jni$_.JObjType<$U>;
+    ]) as jni$_.JType<$U>;
     W ??= jni$_.lowestCommonSuperType([
       object2.$type,
-    ]) as jni$_.JObjType<$W>;
+    ]) as jni$_.JType<$W>;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1.reference;
     final _$object2 = object2.reference;
@@ -10631,7 +10726,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   static jni$_.JString staticHello() {
     return _staticHello(
             _class.reference.pointer, _id_staticHello as jni$_.JMethodIDPtr)
-        .object<jni$_.JString>(const jni$_.JStringType());
+        .object<jni$_.JString>(const jni$_.$JString$Type$());
   }
 
   static final _id_hello = _class.instanceMethodId(
@@ -10655,7 +10750,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString hello() {
     return _hello(reference.pointer, _id_hello as jni$_.JMethodIDPtr)
-        .object<jni$_.JString>(const jni$_.JStringType());
+        .object<jni$_.JString>(const jni$_.$JString$Type$());
   }
 
   static final _id_nullableHello = _class.instanceMethodId(
@@ -10680,7 +10775,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   ) {
     return _nullableHello(reference.pointer,
             _id_nullableHello as jni$_.JMethodIDPtr, z ? 1 : 0)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_echo = _class.instanceMethodId(
@@ -10707,7 +10802,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     final _$string = string.reference;
     return _echo(
             reference.pointer, _id_echo as jni$_.JMethodIDPtr, _$string.pointer)
-        .object<jni$_.JString>(const jni$_.JStringType());
+        .object<jni$_.JString>(const jni$_.$JString$Type$());
   }
 
   static final _id_nullableEcho = _class.instanceMethodId(
@@ -10734,7 +10829,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _nullableEcho(reference.pointer,
             _id_nullableEcho as jni$_.JMethodIDPtr, _$string.pointer)
-        .object<jni$_.JString?>(const jni$_.JStringNullableType());
+        .object<jni$_.JString?>(const jni$_.$JString$NullableType$());
   }
 
   static final _id_array = _class.instanceMethodId(
@@ -10759,7 +10854,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   jni$_.JArray<jni$_.JString> array() {
     return _array(reference.pointer, _id_array as jni$_.JMethodIDPtr)
         .object<jni$_.JArray<jni$_.JString>>(
-            const jni$_.JArrayType<jni$_.JString>(jni$_.JStringType()));
+            const jni$_.$JArray$Type$<jni$_.JString>(jni$_.$JString$Type$()));
   }
 
   static final _id_arrayOfNullable = _class.instanceMethodId(
@@ -10785,8 +10880,8 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     return _arrayOfNullable(
             reference.pointer, _id_arrayOfNullable as jni$_.JMethodIDPtr)
         .object<jni$_.JArray<jni$_.JString?>>(
-            const jni$_.JArrayType<jni$_.JString?>(
-                jni$_.JStringNullableType()));
+            const jni$_.$JArray$Type$<jni$_.JString?>(
+                jni$_.$JString$NullableType$()));
   }
 
   static final _id_nullableArray = _class.instanceMethodId(
@@ -10812,7 +10907,8 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     return _nullableArray(reference.pointer,
             _id_nullableArray as jni$_.JMethodIDPtr, z ? 1 : 0)
         .object<jni$_.JArray<jni$_.JString>?>(
-            const jni$_.JArrayNullableType<jni$_.JString>(jni$_.JStringType()));
+            const jni$_.$JArray$NullableType$<jni$_.JString>(
+                jni$_.$JString$Type$()));
   }
 
   static final _id_nullableArrayOfNullable = _class.instanceMethodId(
@@ -10838,8 +10934,8 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     return _nullableArrayOfNullable(reference.pointer,
             _id_nullableArrayOfNullable as jni$_.JMethodIDPtr, z ? 1 : 0)
         .object<jni$_.JArray<jni$_.JString?>?>(
-            const jni$_.JArrayNullableType<jni$_.JString?>(
-                jni$_.JStringNullableType()));
+            const jni$_.$JArray$NullableType$<jni$_.JString?>(
+                jni$_.$JString$NullableType$()));
   }
 
   static final _id_list = _class.instanceMethodId(
@@ -10864,7 +10960,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   jni$_.JList<jni$_.JString> list() {
     return _list(reference.pointer, _id_list as jni$_.JMethodIDPtr)
         .object<jni$_.JList<jni$_.JString>>(
-            const jni$_.JListType<jni$_.JString>(jni$_.JStringType()));
+            const jni$_.$JList$Type$<jni$_.JString>(jni$_.$JString$Type$()));
   }
 
   static final _id_listOfNullable = _class.instanceMethodId(
@@ -10890,7 +10986,8 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     return _listOfNullable(
             reference.pointer, _id_listOfNullable as jni$_.JMethodIDPtr)
         .object<jni$_.JList<jni$_.JString?>>(
-            const jni$_.JListType<jni$_.JString?>(jni$_.JStringNullableType()));
+            const jni$_.$JList$Type$<jni$_.JString?>(
+                jni$_.$JString$NullableType$()));
   }
 
   static final _id_nullableList = _class.instanceMethodId(
@@ -10916,7 +11013,8 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     return _nullableList(reference.pointer,
             _id_nullableList as jni$_.JMethodIDPtr, z ? 1 : 0)
         .object<jni$_.JList<jni$_.JString>?>(
-            const jni$_.JListNullableType<jni$_.JString>(jni$_.JStringType()));
+            const jni$_.$JList$NullableType$<jni$_.JString>(
+                jni$_.$JString$Type$()));
   }
 
   static final _id_nullableListOfNullable = _class.instanceMethodId(
@@ -10942,8 +11040,8 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     return _nullableListOfNullable(reference.pointer,
             _id_nullableListOfNullable as jni$_.JMethodIDPtr, z ? 1 : 0)
         .object<jni$_.JList<jni$_.JString?>?>(
-            const jni$_.JListNullableType<jni$_.JString?>(
-                jni$_.JStringNullableType()));
+            const jni$_.$JList$NullableType$<jni$_.JString?>(
+                jni$_.$JString$NullableType$()));
   }
 
   static final _id_classGenericEcho = _class.instanceMethodId(
@@ -11022,7 +11120,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $V methodGenericEcho<$V extends jni$_.JObject?>(
     $V object, {
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$V> V,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _methodGenericEcho(reference.pointer,
@@ -11050,11 +11148,11 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $V methodGenericEcho2<$V extends jni$_.JObject>(
     $V object, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
       object.$type,
-    ]) as jni$_.JObjType<$V>;
+    ]) as jni$_.JType<$V>;
     final _$object = object.reference;
     return _methodGenericEcho2(reference.pointer,
             _id_methodGenericEcho2 as jni$_.JMethodIDPtr, _$object.pointer)
@@ -11081,11 +11179,11 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $V methodGenericEcho3<$V extends jni$_.JObject>(
     $V object, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
       object.$type,
-    ]) as jni$_.JObjType<$V>;
+    ]) as jni$_.JType<$V>;
     final _$object = object.reference;
     return _methodGenericEcho3(reference.pointer,
             _id_methodGenericEcho3 as jni$_.JMethodIDPtr, _$object.pointer)
@@ -11117,7 +11215,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   $V? nullableReturnMethodGenericEcho<$V extends jni$_.JObject?>(
     $V object,
     bool z, {
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$V> V,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _nullableReturnMethodGenericEcho(
@@ -11153,11 +11251,11 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   $V? nullableReturnMethodGenericEcho2<$V extends jni$_.JObject>(
     $V object,
     bool z, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
       object.$type,
-    ]) as jni$_.JObjType<$V>;
+    ]) as jni$_.JType<$V>;
     final _$object = object.reference;
     return _nullableReturnMethodGenericEcho2(
             reference.pointer,
@@ -11187,7 +11285,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $V nullableMethodGenericEcho<$V extends jni$_.JObject?>(
     $V object, {
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$V> V,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _nullableMethodGenericEcho(
@@ -11218,7 +11316,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $V? noAnnotationMethodGenericEcho<$V extends jni$_.JObject?>(
     $V? object, {
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$V> V,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _noAnnotationMethodGenericEcho(
@@ -11249,7 +11347,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $V nullableArgMethodGenericEcho<$V extends jni$_.JObject>(
     $V? object, {
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$V> V,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _nullableArgMethodGenericEcho(
@@ -11281,7 +11379,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   jni$_.JList<$T> classGenericList() {
     return _classGenericList(
             reference.pointer, _id_classGenericList as jni$_.JMethodIDPtr)
-        .object<jni$_.JList<$T>>(jni$_.JListType<$T>(T));
+        .object<jni$_.JList<$T>>(jni$_.$JList$Type$<$T>(T));
   }
 
   static final _id_classGenericListOfNullable = _class.instanceMethodId(
@@ -11307,7 +11405,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   jni$_.JList<$T?> classGenericListOfNullable() {
     return _classGenericListOfNullable(reference.pointer,
             _id_classGenericListOfNullable as jni$_.JMethodIDPtr)
-        .object<jni$_.JList<$T?>>(jni$_.JListType<$T?>(T.nullableType));
+        .object<jni$_.JList<$T?>>(jni$_.$JList$Type$<$T?>(T.nullableType));
   }
 
   static final _id_nullableClassGenericList = _class.instanceMethodId(
@@ -11332,7 +11430,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   ) {
     return _nullableClassGenericList(reference.pointer,
             _id_nullableClassGenericList as jni$_.JMethodIDPtr, z ? 1 : 0)
-        .object<jni$_.JList<$T>?>(jni$_.JListNullableType<$T>(T));
+        .object<jni$_.JList<$T>?>(jni$_.$JList$NullableType$<$T>(T));
   }
 
   static final _id_nullableClassGenericListOfNullable = _class.instanceMethodId(
@@ -11360,7 +11458,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
             _id_nullableClassGenericListOfNullable as jni$_.JMethodIDPtr,
             z ? 1 : 0)
         .object<jni$_.JList<$T?>?>(
-            jni$_.JListNullableType<$T?>(T.nullableType));
+            jni$_.$JList$NullableType$<$T?>(T.nullableType));
   }
 
   static final _id_methodGenericList = _class.instanceMethodId(
@@ -11383,12 +11481,12 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<$V> methodGenericList<$V extends jni$_.JObject?>(
     $V object, {
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$V> V,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _methodGenericList(reference.pointer,
             _id_methodGenericList as jni$_.JMethodIDPtr, _$object.pointer)
-        .object<jni$_.JList<$V>>(jni$_.JListType<$V>(V));
+        .object<jni$_.JList<$V>>(jni$_.$JList$Type$<$V>(V));
   }
 
   static final _id_methodGenericListOfNullable = _class.instanceMethodId(
@@ -11412,11 +11510,11 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// from: `public java.util.List<V> methodGenericListOfNullable()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<$V?> methodGenericListOfNullable<$V extends jni$_.JObject?>({
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$V> V,
   }) {
     return _methodGenericListOfNullable(reference.pointer,
             _id_methodGenericListOfNullable as jni$_.JMethodIDPtr)
-        .object<jni$_.JList<$V?>>(jni$_.JListType<$V?>(V.nullableType));
+        .object<jni$_.JList<$V?>>(jni$_.$JList$Type$<$V?>(V.nullableType));
   }
 
   static final _id_nullableMethodGenericList = _class.instanceMethodId(
@@ -11441,7 +11539,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   jni$_.JList<$V>? nullableMethodGenericList<$V extends jni$_.JObject?>(
     $V object,
     bool z, {
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$V> V,
   }) {
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _nullableMethodGenericList(
@@ -11449,7 +11547,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
             _id_nullableMethodGenericList as jni$_.JMethodIDPtr,
             _$object.pointer,
             z ? 1 : 0)
-        .object<jni$_.JList<$V>?>(jni$_.JListNullableType<$V>(V));
+        .object<jni$_.JList<$V>?>(jni$_.$JList$NullableType$<$V>(V));
   }
 
   static final _id_nullableMethodGenericListOfNullable =
@@ -11473,14 +11571,14 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   jni$_.JList<$V?>?
       nullableMethodGenericListOfNullable<$V extends jni$_.JObject?>(
     bool z, {
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$V> V,
   }) {
     return _nullableMethodGenericListOfNullable(
             reference.pointer,
             _id_nullableMethodGenericListOfNullable as jni$_.JMethodIDPtr,
             z ? 1 : 0)
         .object<jni$_.JList<$V?>?>(
-            jni$_.JListNullableType<$V?>(V.nullableType));
+            jni$_.$JList$NullableType$<$V?>(V.nullableType));
   }
 
   static final _id_firstOfClassGenericList = _class.instanceMethodId(
@@ -11621,11 +11719,11 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $V? firstOfMethodGenericList<$V extends jni$_.JObject?>(
     jni$_.JList<$V> list, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
-      (list.$type as jni$_.JListType<core$_.dynamic>).E,
-    ]) as jni$_.JObjType<$V>;
+      (list.$type as jni$_.$JList$Type$<core$_.dynamic>).E,
+    ]) as jni$_.JType<$V>;
     final _$list = list.reference;
     return _firstOfMethodGenericList(reference.pointer,
             _id_firstOfMethodGenericList as jni$_.JMethodIDPtr, _$list.pointer)
@@ -11653,7 +11751,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $V? firstOfMethodGenericNullableList<$V extends jni$_.JObject?>(
     jni$_.JList<$V>? list, {
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$V> V,
   }) {
     final _$list = list?.reference ?? jni$_.jNullReference;
     return _firstOfMethodGenericNullableList(
@@ -11684,11 +11782,11 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $V? firstOfMethodGenericListOfNullable<$V extends jni$_.JObject?>(
     jni$_.JList<$V?> list, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
-      (list.$type as jni$_.JListType<core$_.dynamic>).E,
-    ]) as jni$_.JObjType<$V>;
+      (list.$type as jni$_.$JList$Type$<core$_.dynamic>).E,
+    ]) as jni$_.JType<$V>;
     final _$list = list.reference;
     return _firstOfMethodGenericListOfNullable(
             reference.pointer,
@@ -11719,7 +11817,7 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $V? firstOfMethodGenericNullableListOfNullable<$V extends jni$_.JObject?>(
     jni$_.JList<$V?>? list, {
-    required jni$_.JObjType<$V> V,
+    required jni$_.JType<$V> V,
   }) {
     final _$list = list?.reference ?? jni$_.jNullReference;
     return _firstOfMethodGenericNullableListOfNullable(
@@ -11750,11 +11848,11 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $T? firstKeyOfComboMap<$V extends jni$_.JObject?>(
     jni$_.JMap<$T, $V> map, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
-      (map.$type as jni$_.JMapType<core$_.dynamic, core$_.dynamic>).V,
-    ]) as jni$_.JObjType<$V>;
+      (map.$type as jni$_.$JMap$Type$<core$_.dynamic, core$_.dynamic>).V,
+    ]) as jni$_.JType<$V>;
     final _$map = map.reference;
     return _firstKeyOfComboMap(reference.pointer,
             _id_firstKeyOfComboMap as jni$_.JMethodIDPtr, _$map.pointer)
@@ -11781,11 +11879,11 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $V? firstValueOfComboMap<$V extends jni$_.JObject?>(
     jni$_.JMap<$T, $V> map, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
-      (map.$type as jni$_.JMapType<core$_.dynamic, core$_.dynamic>).V,
-    ]) as jni$_.JObjType<$V>;
+      (map.$type as jni$_.$JMap$Type$<core$_.dynamic, core$_.dynamic>).V,
+    ]) as jni$_.JType<$V>;
     final _$map = map.reference;
     return _firstValueOfComboMap(reference.pointer,
             _id_firstValueOfComboMap as jni$_.JMethodIDPtr, _$map.pointer)
@@ -11813,11 +11911,11 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $T? firstKeyOfComboMapNullableKey<$V extends jni$_.JObject?>(
     jni$_.JMap<$T?, $V> map, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
-      (map.$type as jni$_.JMapType<core$_.dynamic, core$_.dynamic>).V,
-    ]) as jni$_.JObjType<$V>;
+      (map.$type as jni$_.$JMap$Type$<core$_.dynamic, core$_.dynamic>).V,
+    ]) as jni$_.JType<$V>;
     final _$map = map.reference;
     return _firstKeyOfComboMapNullableKey(
             reference.pointer,
@@ -11847,11 +11945,11 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $V? firstValueOfComboMapNullableKey<$V extends jni$_.JObject?>(
     jni$_.JMap<$T?, $V> map, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
-      (map.$type as jni$_.JMapType<core$_.dynamic, core$_.dynamic>).V,
-    ]) as jni$_.JObjType<$V>;
+      (map.$type as jni$_.$JMap$Type$<core$_.dynamic, core$_.dynamic>).V,
+    ]) as jni$_.JType<$V>;
     final _$map = map.reference;
     return _firstValueOfComboMapNullableKey(
             reference.pointer,
@@ -11881,11 +11979,11 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $T? firstKeyOfComboMapNullableValue<$V extends jni$_.JObject?>(
     jni$_.JMap<$T, $V?> map, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
-      (map.$type as jni$_.JMapType<core$_.dynamic, core$_.dynamic>).V,
-    ]) as jni$_.JObjType<$V>;
+      (map.$type as jni$_.$JMap$Type$<core$_.dynamic, core$_.dynamic>).V,
+    ]) as jni$_.JType<$V>;
     final _$map = map.reference;
     return _firstKeyOfComboMapNullableValue(
             reference.pointer,
@@ -11915,11 +12013,11 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $V? firstValueOfComboMapNullableValue<$V extends jni$_.JObject?>(
     jni$_.JMap<$T, $V?> map, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
-      (map.$type as jni$_.JMapType<core$_.dynamic, core$_.dynamic>).V,
-    ]) as jni$_.JObjType<$V>;
+      (map.$type as jni$_.$JMap$Type$<core$_.dynamic, core$_.dynamic>).V,
+    ]) as jni$_.JType<$V>;
     final _$map = map.reference;
     return _firstValueOfComboMapNullableValue(
             reference.pointer,
@@ -11950,11 +12048,11 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $T? firstKeyOfComboMapNullableKeyAndValue<$V extends jni$_.JObject?>(
     jni$_.JMap<$T?, $V?> map, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
-      (map.$type as jni$_.JMapType<core$_.dynamic, core$_.dynamic>).V,
-    ]) as jni$_.JObjType<$V>;
+      (map.$type as jni$_.$JMap$Type$<core$_.dynamic, core$_.dynamic>).V,
+    ]) as jni$_.JType<$V>;
     final _$map = map.reference;
     return _firstKeyOfComboMapNullableKeyAndValue(
             reference.pointer,
@@ -11985,11 +12083,11 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   $V? firstValueOfComboMapNullableKeyAndValue<$V extends jni$_.JObject?>(
     jni$_.JMap<$T?, $V?> map, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
-      (map.$type as jni$_.JMapType<core$_.dynamic, core$_.dynamic>).V,
-    ]) as jni$_.JObjType<$V>;
+      (map.$type as jni$_.$JMap$Type$<core$_.dynamic, core$_.dynamic>).V,
+    ]) as jni$_.JType<$V>;
     final _$map = map.reference;
     return _firstValueOfComboMapNullableKeyAndValue(
             reference.pointer,
@@ -12018,15 +12116,15 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? firstEntryOfComboMap<$V extends jni$_.JObject?>(
     jni$_.JMap<$T, $V> map, {
-    jni$_.JObjType<$V>? V,
+    jni$_.JType<$V>? V,
   }) {
     V ??= jni$_.lowestCommonSuperType([
-      (map.$type as jni$_.JMapType<core$_.dynamic, core$_.dynamic>).V,
-    ]) as jni$_.JObjType<$V>;
+      (map.$type as jni$_.$JMap$Type$<core$_.dynamic, core$_.dynamic>).V,
+    ]) as jni$_.JType<$V>;
     final _$map = map.reference;
     return _firstEntryOfComboMap(reference.pointer,
             _id_firstEntryOfComboMap as jni$_.JMethodIDPtr, _$map.pointer)
-        .object<jni$_.JObject?>(const jni$_.JObjectNullableType());
+        .object<jni$_.JObject?>(const jni$_.$JObject$NullableType$());
   }
 
   static final _id_getW = _class.instanceMethodId(
@@ -12100,9 +12198,9 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   jni$_.JList<jni$_.JList<jni$_.JList<$T?>>> list3dOfT() {
     return _list3dOfT(reference.pointer, _id_list3dOfT as jni$_.JMethodIDPtr)
         .object<jni$_.JList<jni$_.JList<jni$_.JList<$T?>>>>(
-            jni$_.JListType<jni$_.JList<jni$_.JList<$T?>>>(
-                jni$_.JListType<jni$_.JList<$T?>>(
-                    jni$_.JListType<$T?>(T.nullableType))));
+            jni$_.$JList$Type$<jni$_.JList<jni$_.JList<$T?>>>(
+                jni$_.$JList$Type$<jni$_.JList<$T?>>(
+                    jni$_.$JList$Type$<$T?>(T.nullableType))));
   }
 
   static final _id_list3dOfU = _class.instanceMethodId(
@@ -12127,8 +12225,8 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   jni$_.JList<jni$_.JList<jni$_.JList<$U>>> list3dOfU() {
     return _list3dOfU(reference.pointer, _id_list3dOfU as jni$_.JMethodIDPtr)
         .object<jni$_.JList<jni$_.JList<jni$_.JList<$U>>>>(
-            jni$_.JListType<jni$_.JList<jni$_.JList<$U>>>(
-                jni$_.JListType<jni$_.JList<$U>>(jni$_.JListType<$U>(U))));
+            jni$_.$JList$Type$<jni$_.JList<jni$_.JList<$U>>>(jni$_
+                .$JList$Type$<jni$_.JList<$U>>(jni$_.$JList$Type$<$U>(U))));
   }
 
   static final _id_list3dOfW = _class.instanceMethodId(
@@ -12153,8 +12251,8 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   jni$_.JList<jni$_.JList<jni$_.JList<$W>>> list3dOfW() {
     return _list3dOfW(reference.pointer, _id_list3dOfW as jni$_.JMethodIDPtr)
         .object<jni$_.JList<jni$_.JList<jni$_.JList<$W>>>>(
-            jni$_.JListType<jni$_.JList<jni$_.JList<$W>>>(
-                jni$_.JListType<jni$_.JList<$W>>(jni$_.JListType<$W>(W))));
+            jni$_.$JList$Type$<jni$_.JList<jni$_.JList<$W>>>(jni$_
+                .$JList$Type$<jni$_.JList<$W>>(jni$_.$JList$Type$<$W>(W))));
   }
 
   static final _id_list3dOfNullableU = _class.instanceMethodId(
@@ -12180,9 +12278,9 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     return _list3dOfNullableU(reference.pointer,
             _id_list3dOfNullableU as jni$_.JMethodIDPtr, z ? 1 : 0)
         .object<jni$_.JList<jni$_.JList<jni$_.JList<$U?>>>>(
-            jni$_.JListType<jni$_.JList<jni$_.JList<$U?>>>(
-                jni$_.JListType<jni$_.JList<$U?>>(
-                    jni$_.JListType<$U?>(U.nullableType))));
+            jni$_.$JList$Type$<jni$_.JList<jni$_.JList<$U?>>>(
+                jni$_.$JList$Type$<jni$_.JList<$U?>>(
+                    jni$_.$JList$Type$<$U?>(U.nullableType))));
   }
 
   static final _id_list3dOfNullableW = _class.instanceMethodId(
@@ -12208,9 +12306,9 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     return _list3dOfNullableW(reference.pointer,
             _id_list3dOfNullableW as jni$_.JMethodIDPtr, z ? 1 : 0)
         .object<jni$_.JList<jni$_.JList<jni$_.JList<$W?>>>>(
-            jni$_.JListType<jni$_.JList<jni$_.JList<$W?>>>(
-                jni$_.JListType<jni$_.JList<$W?>>(
-                    jni$_.JListType<$W?>(W.nullableType))));
+            jni$_.$JList$Type$<jni$_.JList<jni$_.JList<$W?>>>(
+                jni$_.$JList$Type$<jni$_.JList<$W?>>(
+                    jni$_.$JList$Type$<$W?>(W.nullableType))));
   }
 
   static final _id_nested = _class.instanceMethodId(
@@ -12235,8 +12333,8 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   Annotated$Nested<$T?, $U, $W, jni$_.JInteger>? nested() {
     return _nested(reference.pointer, _id_nested as jni$_.JMethodIDPtr)
         .object<Annotated$Nested<$T?, $U, $W, jni$_.JInteger>?>(
-            $Annotated$Nested$NullableType<$T?, $U, $W, jni$_.JInteger>(
-                T.nullableType, U, W, const jni$_.JIntegerType()));
+            $Annotated$Nested$NullableType$<$T?, $U, $W, jni$_.JInteger>(
+                T.nullableType, U, W, const jni$_.$JInteger$Type$()));
   }
 
   static final _id_intList = _class.instanceMethodId(
@@ -12261,25 +12359,25 @@ class Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   jni$_.JList<jni$_.JInteger> intList() {
     return _intList(reference.pointer, _id_intList as jni$_.JMethodIDPtr)
         .object<jni$_.JList<jni$_.JInteger>>(
-            const jni$_.JListType<jni$_.JInteger>(jni$_.JIntegerType()));
+            const jni$_.$JList$Type$<jni$_.JInteger>(jni$_.$JInteger$Type$()));
   }
 }
 
-final class $Annotated$NullableType<
+final class $Annotated$NullableType$<
     $T extends jni$_.JObject?,
     $U extends jni$_.JObject,
-    $W extends jni$_.JObject> extends jni$_.JObjType<Annotated<$T, $U, $W>?> {
+    $W extends jni$_.JObject> extends jni$_.JType<Annotated<$T, $U, $W>?> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
-  final jni$_.JObjType<$W> W;
+  final jni$_.JType<$W> W;
 
   @jni$_.internal
-  const $Annotated$NullableType(
+  const $Annotated$NullableType$(
     this.T,
     this.U,
     this.W,
@@ -12303,42 +12401,44 @@ final class $Annotated$NullableType<
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Annotated<$T, $U, $W>?> get nullableType => this;
+  jni$_.JType<Annotated<$T, $U, $W>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($Annotated$NullableType, T, U, W);
+  int get hashCode => Object.hash($Annotated$NullableType$, T, U, W);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Annotated$NullableType<$T, $U, $W>) &&
-        other is $Annotated$NullableType<$T, $U, $W> &&
+    return other.runtimeType == ($Annotated$NullableType$<$T, $U, $W>) &&
+        other is $Annotated$NullableType$<$T, $U, $W> &&
         T == other.T &&
         U == other.U &&
         W == other.W;
   }
 }
 
-final class $Annotated$Type<$T extends jni$_.JObject?, $U extends jni$_.JObject,
-    $W extends jni$_.JObject> extends jni$_.JObjType<Annotated<$T, $U, $W>> {
+final class $Annotated$Type$<
+    $T extends jni$_.JObject?,
+    $U extends jni$_.JObject,
+    $W extends jni$_.JObject> extends jni$_.JType<Annotated<$T, $U, $W>> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  final jni$_.JObjType<$U> U;
+  final jni$_.JType<$U> U;
 
   @jni$_.internal
-  final jni$_.JObjType<$W> W;
+  final jni$_.JType<$W> W;
 
   @jni$_.internal
-  const $Annotated$Type(
+  const $Annotated$Type$(
     this.T,
     this.U,
     this.W,
@@ -12360,24 +12460,24 @@ final class $Annotated$Type<$T extends jni$_.JObject?, $U extends jni$_.JObject,
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Annotated<$T, $U, $W>?> get nullableType =>
-      $Annotated$NullableType<$T, $U, $W>(T, U, W);
+  jni$_.JType<Annotated<$T, $U, $W>?> get nullableType =>
+      $Annotated$NullableType$<$T, $U, $W>(T, U, W);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($Annotated$Type, T, U, W);
+  int get hashCode => Object.hash($Annotated$Type$, T, U, W);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Annotated$Type<$T, $U, $W>) &&
-        other is $Annotated$Type<$T, $U, $W> &&
+    return other.runtimeType == ($Annotated$Type$<$T, $U, $W>) &&
+        other is $Annotated$Type$<$T, $U, $W> &&
         T == other.T &&
         U == other.U &&
         W == other.W;
@@ -12388,7 +12488,7 @@ final class $Annotated$Type<$T extends jni$_.JObject?, $U extends jni$_.JObject,
 class JsonSerializable$Case extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<JsonSerializable$Case> $type;
+  final jni$_.JType<JsonSerializable$Case> $type;
 
   @jni$_.internal
   JsonSerializable$Case.fromReference(
@@ -12400,8 +12500,12 @@ class JsonSerializable$Case extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/annotations/JsonSerializable$Case');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $JsonSerializable$Case$NullableType();
-  static const type = $JsonSerializable$Case$Type();
+  static const jni$_.JType<JsonSerializable$Case?> nullableType =
+      $JsonSerializable$Case$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<JsonSerializable$Case> type =
+      $JsonSerializable$Case$Type$();
   static final _id_SNAKE_CASE = _class.staticFieldId(
     r'SNAKE_CASE',
     r'Lcom/github/dart_lang/jnigen/annotations/JsonSerializable$Case;',
@@ -12410,7 +12514,7 @@ class JsonSerializable$Case extends jni$_.JObject {
   /// from: `static public final com.github.dart_lang.jnigen.annotations.JsonSerializable$Case SNAKE_CASE`
   /// The returned object must be released after use, by calling the [release] method.
   static JsonSerializable$Case get SNAKE_CASE =>
-      _id_SNAKE_CASE.get(_class, const $JsonSerializable$Case$Type());
+      _id_SNAKE_CASE.get(_class, const $JsonSerializable$Case$Type$());
 
   static final _id_KEBAB_CASE = _class.staticFieldId(
     r'KEBAB_CASE',
@@ -12420,7 +12524,7 @@ class JsonSerializable$Case extends jni$_.JObject {
   /// from: `static public final com.github.dart_lang.jnigen.annotations.JsonSerializable$Case KEBAB_CASE`
   /// The returned object must be released after use, by calling the [release] method.
   static JsonSerializable$Case get KEBAB_CASE =>
-      _id_KEBAB_CASE.get(_class, const $JsonSerializable$Case$Type());
+      _id_KEBAB_CASE.get(_class, const $JsonSerializable$Case$Type$());
 
   static final _id_CAMEL_CASE = _class.staticFieldId(
     r'CAMEL_CASE',
@@ -12430,7 +12534,7 @@ class JsonSerializable$Case extends jni$_.JObject {
   /// from: `static public final com.github.dart_lang.jnigen.annotations.JsonSerializable$Case CAMEL_CASE`
   /// The returned object must be released after use, by calling the [release] method.
   static JsonSerializable$Case get CAMEL_CASE =>
-      _id_CAMEL_CASE.get(_class, const $JsonSerializable$Case$Type());
+      _id_CAMEL_CASE.get(_class, const $JsonSerializable$Case$Type$());
 
   static final _id_values = _class.staticMethodId(
     r'values',
@@ -12454,8 +12558,8 @@ class JsonSerializable$Case extends jni$_.JObject {
   static jni$_.JArray<JsonSerializable$Case?>? values() {
     return _values(_class.reference.pointer, _id_values as jni$_.JMethodIDPtr)
         .object<jni$_.JArray<JsonSerializable$Case?>?>(
-            const jni$_.JArrayNullableType<JsonSerializable$Case?>(
-                $JsonSerializable$Case$NullableType()));
+            const jni$_.$JArray$NullableType$<JsonSerializable$Case?>(
+                $JsonSerializable$Case$NullableType$()));
   }
 
   static final _id_valueOf = _class.staticMethodId(
@@ -12483,14 +12587,14 @@ class JsonSerializable$Case extends jni$_.JObject {
     return _valueOf(_class.reference.pointer, _id_valueOf as jni$_.JMethodIDPtr,
             _$string.pointer)
         .object<JsonSerializable$Case?>(
-            const $JsonSerializable$Case$NullableType());
+            const $JsonSerializable$Case$NullableType$());
   }
 }
 
-final class $JsonSerializable$Case$NullableType
-    extends jni$_.JObjType<JsonSerializable$Case?> {
+final class $JsonSerializable$Case$NullableType$
+    extends jni$_.JType<JsonSerializable$Case?> {
   @jni$_.internal
-  const $JsonSerializable$Case$NullableType();
+  const $JsonSerializable$Case$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -12507,30 +12611,30 @@ final class $JsonSerializable$Case$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonSerializable$Case?> get nullableType => this;
+  jni$_.JType<JsonSerializable$Case?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonSerializable$Case$NullableType).hashCode;
+  int get hashCode => ($JsonSerializable$Case$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonSerializable$Case$NullableType) &&
-        other is $JsonSerializable$Case$NullableType;
+    return other.runtimeType == ($JsonSerializable$Case$NullableType$) &&
+        other is $JsonSerializable$Case$NullableType$;
   }
 }
 
-final class $JsonSerializable$Case$Type
-    extends jni$_.JObjType<JsonSerializable$Case> {
+final class $JsonSerializable$Case$Type$
+    extends jni$_.JType<JsonSerializable$Case> {
   @jni$_.internal
-  const $JsonSerializable$Case$Type();
+  const $JsonSerializable$Case$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -12545,24 +12649,24 @@ final class $JsonSerializable$Case$Type
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonSerializable$Case?> get nullableType =>
-      const $JsonSerializable$Case$NullableType();
+  jni$_.JType<JsonSerializable$Case?> get nullableType =>
+      const $JsonSerializable$Case$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonSerializable$Case$Type).hashCode;
+  int get hashCode => ($JsonSerializable$Case$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonSerializable$Case$Type) &&
-        other is $JsonSerializable$Case$Type;
+    return other.runtimeType == ($JsonSerializable$Case$Type$) &&
+        other is $JsonSerializable$Case$Type$;
   }
 }
 
@@ -12570,7 +12674,7 @@ final class $JsonSerializable$Case$Type
 class JsonSerializable extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<JsonSerializable> $type;
+  final jni$_.JType<JsonSerializable> $type;
 
   @jni$_.internal
   JsonSerializable.fromReference(
@@ -12582,8 +12686,11 @@ class JsonSerializable extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/annotations/JsonSerializable');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $JsonSerializable$NullableType();
-  static const type = $JsonSerializable$Type();
+  static const jni$_.JType<JsonSerializable?> nullableType =
+      $JsonSerializable$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<JsonSerializable> type = $JsonSerializable$Type$();
   static final _id_value = _class.instanceMethodId(
     r'value',
     r'()Lcom/github/dart_lang/jnigen/annotations/JsonSerializable$Case;',
@@ -12606,7 +12713,7 @@ class JsonSerializable extends jni$_.JObject {
   JsonSerializable$Case? value() {
     return _value(reference.pointer, _id_value as jni$_.JMethodIDPtr)
         .object<JsonSerializable$Case?>(
-            const $JsonSerializable$Case$NullableType());
+            const $JsonSerializable$Case$NullableType$());
   }
 
   /// Maps a specific port to the implemented interface.
@@ -12643,7 +12750,7 @@ class JsonSerializable extends jni$_.JObject {
           r'value()Lcom/github/dart_lang/jnigen/annotations/JsonSerializable$Case;') {
         final $r = _$impls[$p]!.value();
         return ($r as jni$_.JObject?)
-                ?.as(const jni$_.JObjectType())
+                ?.as(const jni$_.$JObject$Type$())
                 .reference
                 .toPointer() ??
             jni$_.nullptr;
@@ -12710,10 +12817,10 @@ final class _$JsonSerializable with $JsonSerializable {
   }
 }
 
-final class $JsonSerializable$NullableType
-    extends jni$_.JObjType<JsonSerializable?> {
+final class $JsonSerializable$NullableType$
+    extends jni$_.JType<JsonSerializable?> {
   @jni$_.internal
-  const $JsonSerializable$NullableType();
+  const $JsonSerializable$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -12730,29 +12837,29 @@ final class $JsonSerializable$NullableType
             );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonSerializable?> get nullableType => this;
+  jni$_.JType<JsonSerializable?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonSerializable$NullableType).hashCode;
+  int get hashCode => ($JsonSerializable$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonSerializable$NullableType) &&
-        other is $JsonSerializable$NullableType;
+    return other.runtimeType == ($JsonSerializable$NullableType$) &&
+        other is $JsonSerializable$NullableType$;
   }
 }
 
-final class $JsonSerializable$Type extends jni$_.JObjType<JsonSerializable> {
+final class $JsonSerializable$Type$ extends jni$_.JType<JsonSerializable> {
   @jni$_.internal
-  const $JsonSerializable$Type();
+  const $JsonSerializable$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -12767,24 +12874,24 @@ final class $JsonSerializable$Type extends jni$_.JObjType<JsonSerializable> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<JsonSerializable?> get nullableType =>
-      const $JsonSerializable$NullableType();
+  jni$_.JType<JsonSerializable?> get nullableType =>
+      const $JsonSerializable$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($JsonSerializable$Type).hashCode;
+  int get hashCode => ($JsonSerializable$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($JsonSerializable$Type) &&
-        other is $JsonSerializable$Type;
+    return other.runtimeType == ($JsonSerializable$Type$) &&
+        other is $JsonSerializable$Type$;
   }
 }
 
@@ -12792,7 +12899,7 @@ final class $JsonSerializable$Type extends jni$_.JObjType<JsonSerializable> {
 class MyDataClass extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<MyDataClass> $type;
+  final jni$_.JType<MyDataClass> $type;
 
   @jni$_.internal
   MyDataClass.fromReference(
@@ -12804,8 +12911,11 @@ class MyDataClass extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/annotations/MyDataClass');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $MyDataClass$NullableType();
-  static const type = $MyDataClass$Type();
+  static const jni$_.JType<MyDataClass?> nullableType =
+      $MyDataClass$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<MyDataClass> type = $MyDataClass$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -12831,9 +12941,9 @@ class MyDataClass extends jni$_.JObject {
   }
 }
 
-final class $MyDataClass$NullableType extends jni$_.JObjType<MyDataClass?> {
+final class $MyDataClass$NullableType$ extends jni$_.JType<MyDataClass?> {
   @jni$_.internal
-  const $MyDataClass$NullableType();
+  const $MyDataClass$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -12849,29 +12959,29 @@ final class $MyDataClass$NullableType extends jni$_.JObjType<MyDataClass?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyDataClass?> get nullableType => this;
+  jni$_.JType<MyDataClass?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($MyDataClass$NullableType).hashCode;
+  int get hashCode => ($MyDataClass$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyDataClass$NullableType) &&
-        other is $MyDataClass$NullableType;
+    return other.runtimeType == ($MyDataClass$NullableType$) &&
+        other is $MyDataClass$NullableType$;
   }
 }
 
-final class $MyDataClass$Type extends jni$_.JObjType<MyDataClass> {
+final class $MyDataClass$Type$ extends jni$_.JType<MyDataClass> {
   @jni$_.internal
-  const $MyDataClass$Type();
+  const $MyDataClass$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -12886,24 +12996,24 @@ final class $MyDataClass$Type extends jni$_.JObjType<MyDataClass> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<MyDataClass?> get nullableType =>
-      const $MyDataClass$NullableType();
+  jni$_.JType<MyDataClass?> get nullableType =>
+      const $MyDataClass$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($MyDataClass$Type).hashCode;
+  int get hashCode => ($MyDataClass$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($MyDataClass$Type) &&
-        other is $MyDataClass$Type;
+    return other.runtimeType == ($MyDataClass$Type$) &&
+        other is $MyDataClass$Type$;
   }
 }
 
@@ -12911,7 +13021,7 @@ final class $MyDataClass$Type extends jni$_.JObjType<MyDataClass> {
 class NotNull extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<NotNull> $type;
+  final jni$_.JType<NotNull> $type;
 
   @jni$_.internal
   NotNull.fromReference(
@@ -12923,8 +13033,10 @@ class NotNull extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/annotations/NotNull');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $NotNull$NullableType();
-  static const type = $NotNull$Type();
+  static const jni$_.JType<NotNull?> nullableType = $NotNull$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<NotNull> type = $NotNull$Type$();
 
   /// Maps a specific port to the implemented interface.
   static final core$_.Map<int, $NotNull> _$impls = {};
@@ -13006,9 +13118,9 @@ final class _$NotNull with $NotNull {
   _$NotNull();
 }
 
-final class $NotNull$NullableType extends jni$_.JObjType<NotNull?> {
+final class $NotNull$NullableType$ extends jni$_.JType<NotNull?> {
   @jni$_.internal
-  const $NotNull$NullableType();
+  const $NotNull$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -13023,29 +13135,29 @@ final class $NotNull$NullableType extends jni$_.JObjType<NotNull?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<NotNull?> get nullableType => this;
+  jni$_.JType<NotNull?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($NotNull$NullableType).hashCode;
+  int get hashCode => ($NotNull$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($NotNull$NullableType) &&
-        other is $NotNull$NullableType;
+    return other.runtimeType == ($NotNull$NullableType$) &&
+        other is $NotNull$NullableType$;
   }
 }
 
-final class $NotNull$Type extends jni$_.JObjType<NotNull> {
+final class $NotNull$Type$ extends jni$_.JType<NotNull> {
   @jni$_.internal
-  const $NotNull$Type();
+  const $NotNull$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -13058,22 +13170,22 @@ final class $NotNull$Type extends jni$_.JObjType<NotNull> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<NotNull?> get nullableType => const $NotNull$NullableType();
+  jni$_.JType<NotNull?> get nullableType => const $NotNull$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($NotNull$Type).hashCode;
+  int get hashCode => ($NotNull$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($NotNull$Type) && other is $NotNull$Type;
+    return other.runtimeType == ($NotNull$Type$) && other is $NotNull$Type$;
   }
 }
 
@@ -13081,7 +13193,7 @@ final class $NotNull$Type extends jni$_.JObjType<NotNull> {
 class Nullable extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<Nullable> $type;
+  final jni$_.JType<Nullable> $type;
 
   @jni$_.internal
   Nullable.fromReference(
@@ -13093,8 +13205,10 @@ class Nullable extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/annotations/Nullable');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $Nullable$NullableType();
-  static const type = $Nullable$Type();
+  static const jni$_.JType<Nullable?> nullableType = $Nullable$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<Nullable> type = $Nullable$Type$();
 
   /// Maps a specific port to the implemented interface.
   static final core$_.Map<int, $Nullable> _$impls = {};
@@ -13176,9 +13290,9 @@ final class _$Nullable with $Nullable {
   _$Nullable();
 }
 
-final class $Nullable$NullableType extends jni$_.JObjType<Nullable?> {
+final class $Nullable$NullableType$ extends jni$_.JType<Nullable?> {
   @jni$_.internal
-  const $Nullable$NullableType();
+  const $Nullable$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -13193,29 +13307,29 @@ final class $Nullable$NullableType extends jni$_.JObjType<Nullable?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Nullable?> get nullableType => this;
+  jni$_.JType<Nullable?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Nullable$NullableType).hashCode;
+  int get hashCode => ($Nullable$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Nullable$NullableType) &&
-        other is $Nullable$NullableType;
+    return other.runtimeType == ($Nullable$NullableType$) &&
+        other is $Nullable$NullableType$;
   }
 }
 
-final class $Nullable$Type extends jni$_.JObjType<Nullable> {
+final class $Nullable$Type$ extends jni$_.JType<Nullable> {
   @jni$_.internal
-  const $Nullable$Type();
+  const $Nullable$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -13228,22 +13342,22 @@ final class $Nullable$Type extends jni$_.JObjType<Nullable> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<Nullable?> get nullableType => const $Nullable$NullableType();
+  jni$_.JType<Nullable?> get nullableType => const $Nullable$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($Nullable$Type).hashCode;
+  int get hashCode => ($Nullable$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($Nullable$Type) && other is $Nullable$Type;
+    return other.runtimeType == ($Nullable$Type$) && other is $Nullable$Type$;
   }
 }
 
@@ -13251,7 +13365,7 @@ final class $Nullable$Type extends jni$_.JObjType<Nullable> {
 class R2250$Child extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<R2250$Child> $type;
+  final jni$_.JType<R2250$Child> $type;
 
   @jni$_.internal
   R2250$Child.fromReference(
@@ -13263,8 +13377,11 @@ class R2250$Child extends jni$_.JObject {
       r'com/github/dart_lang/jnigen/regressions/R2250$Child');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $R2250$Child$NullableType();
-  static const type = $R2250$Child$Type();
+  static const jni$_.JType<R2250$Child?> nullableType =
+      $R2250$Child$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<R2250$Child> type = $R2250$Child$Type$();
   static final _id_foo = _class.instanceMethodId(
     r'foo',
     r'(Ljava/lang/Object;)V',
@@ -13322,7 +13439,7 @@ class R2250$Child extends jni$_.JObject {
       final $a = $i.args;
       if ($d == r'foo(Ljava/lang/Object;)V') {
         _$impls[$p]!.foo(
-          $a![0]?.as(const jni$_.JObjectType(), releaseOriginal: true),
+          $a![0]?.as(const jni$_.$JObject$Type$(), releaseOriginal: true),
         );
         return jni$_.nullptr;
       }
@@ -13394,9 +13511,9 @@ final class _$R2250$Child with $R2250$Child {
   }
 }
 
-final class $R2250$Child$NullableType extends jni$_.JObjType<R2250$Child?> {
+final class $R2250$Child$NullableType$ extends jni$_.JType<R2250$Child?> {
   @jni$_.internal
-  const $R2250$Child$NullableType();
+  const $R2250$Child$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -13412,29 +13529,29 @@ final class $R2250$Child$NullableType extends jni$_.JObjType<R2250$Child?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R2250$Child?> get nullableType => this;
+  jni$_.JType<R2250$Child?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($R2250$Child$NullableType).hashCode;
+  int get hashCode => ($R2250$Child$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R2250$Child$NullableType) &&
-        other is $R2250$Child$NullableType;
+    return other.runtimeType == ($R2250$Child$NullableType$) &&
+        other is $R2250$Child$NullableType$;
   }
 }
 
-final class $R2250$Child$Type extends jni$_.JObjType<R2250$Child> {
+final class $R2250$Child$Type$ extends jni$_.JType<R2250$Child> {
   @jni$_.internal
-  const $R2250$Child$Type();
+  const $R2250$Child$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -13449,24 +13566,24 @@ final class $R2250$Child$Type extends jni$_.JObjType<R2250$Child> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R2250$Child?> get nullableType =>
-      const $R2250$Child$NullableType();
+  jni$_.JType<R2250$Child?> get nullableType =>
+      const $R2250$Child$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => ($R2250$Child$Type).hashCode;
+  int get hashCode => ($R2250$Child$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R2250$Child$Type) &&
-        other is $R2250$Child$Type;
+    return other.runtimeType == ($R2250$Child$Type$) &&
+        other is $R2250$Child$Type$;
   }
 }
 
@@ -13474,10 +13591,10 @@ final class $R2250$Child$Type extends jni$_.JObjType<R2250$Child> {
 class R2250<$T extends jni$_.JObject?> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<R2250<$T>> $type;
+  final jni$_.JType<R2250<$T>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
   R2250.fromReference(
@@ -13490,18 +13607,19 @@ class R2250<$T extends jni$_.JObject?> extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/regressions/R2250');
 
   /// The type which includes information such as the signature of this class.
-  static $R2250$NullableType<$T> nullableType<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+  static jni$_.JType<R2250<$T>?> nullableType<$T extends jni$_.JObject?>(
+    jni$_.JType<$T> T,
   ) {
-    return $R2250$NullableType<$T>(
+    return $R2250$NullableType$<$T>(
       T,
     );
   }
 
-  static $R2250$Type<$T> type<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<R2250<$T>> type<$T extends jni$_.JObject?>(
+    jni$_.JType<$T> T,
   ) {
-    return $R2250$Type<$T>(
+    return $R2250$Type$<$T>(
       T,
     );
   }
@@ -13614,12 +13732,12 @@ class R2250<$T extends jni$_.JObject?> extends jni$_.JObject {
 
 abstract base mixin class $R2250<$T extends jni$_.JObject?> {
   factory $R2250({
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
     required void Function($T? object) foo,
     bool foo$async,
   }) = _$R2250<$T>;
 
-  jni$_.JObjType<$T> get T;
+  jni$_.JType<$T> get T;
 
   void foo($T? object);
   bool get foo$async => false;
@@ -13633,7 +13751,7 @@ final class _$R2250<$T extends jni$_.JObject?> with $R2250<$T> {
   }) : _foo = foo;
 
   @core$_.override
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   final void Function($T? object) _foo;
   final bool foo$async;
@@ -13643,13 +13761,13 @@ final class _$R2250<$T extends jni$_.JObject?> with $R2250<$T> {
   }
 }
 
-final class $R2250$NullableType<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<R2250<$T>?> {
+final class $R2250$NullableType$<$T extends jni$_.JObject?>
+    extends jni$_.JType<R2250<$T>?> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $R2250$NullableType(
+  const $R2250$NullableType$(
     this.T,
   );
 
@@ -13667,34 +13785,34 @@ final class $R2250$NullableType<$T extends jni$_.JObject?>
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R2250<$T>?> get nullableType => this;
+  jni$_.JType<R2250<$T>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($R2250$NullableType, T);
+  int get hashCode => Object.hash($R2250$NullableType$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R2250$NullableType<$T>) &&
-        other is $R2250$NullableType<$T> &&
+    return other.runtimeType == ($R2250$NullableType$<$T>) &&
+        other is $R2250$NullableType$<$T> &&
         T == other.T;
   }
 }
 
-final class $R2250$Type<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<R2250<$T>> {
+final class $R2250$Type$<$T extends jni$_.JObject?>
+    extends jni$_.JType<R2250<$T>> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $R2250$Type(
+  const $R2250$Type$(
     this.T,
   );
 
@@ -13711,23 +13829,23 @@ final class $R2250$Type<$T extends jni$_.JObject?>
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R2250<$T>?> get nullableType => $R2250$NullableType<$T>(T);
+  jni$_.JType<R2250<$T>?> get nullableType => $R2250$NullableType$<$T>(T);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($R2250$Type, T);
+  int get hashCode => Object.hash($R2250$Type$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R2250$Type<$T>) &&
-        other is $R2250$Type<$T> &&
+    return other.runtimeType == ($R2250$Type$<$T>) &&
+        other is $R2250$Type$<$T> &&
         T == other.T;
   }
 }
@@ -13736,20 +13854,23 @@ final class $R2250$Type<$T extends jni$_.JObject?>
 class R693$Child extends R693<R693$Child?> {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<R693$Child> $type;
+  final jni$_.JType<R693$Child> $type;
 
   @jni$_.internal
   R693$Child.fromReference(
     jni$_.JReference reference,
   )   : $type = type,
-        super.fromReference(const $R693$Child$NullableType(), reference);
+        super.fromReference(const $R693$Child$NullableType$(), reference);
 
   static final _class = jni$_.JClass.forName(
       r'com/github/dart_lang/jnigen/regressions/R693$Child');
 
   /// The type which includes information such as the signature of this class.
-  static const nullableType = $R693$Child$NullableType();
-  static const type = $R693$Child$Type();
+  static const jni$_.JType<R693$Child?> nullableType =
+      $R693$Child$NullableType$();
+
+  /// The type which includes information such as the signature of this class.
+  static const jni$_.JType<R693$Child> type = $R693$Child$Type$();
   static final _id_new$ = _class.constructorId(
     r'()V',
   );
@@ -13775,9 +13896,9 @@ class R693$Child extends R693<R693$Child?> {
   }
 }
 
-final class $R693$Child$NullableType extends jni$_.JObjType<R693$Child?> {
+final class $R693$Child$NullableType$ extends jni$_.JType<R693$Child?> {
   @jni$_.internal
-  const $R693$Child$NullableType();
+  const $R693$Child$NullableType$();
 
   @jni$_.internal
   @core$_.override
@@ -13793,30 +13914,30 @@ final class $R693$Child$NullableType extends jni$_.JObjType<R693$Child?> {
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType =>
-      const $R693$NullableType<R693$Child?>($R693$Child$NullableType());
+  jni$_.JType get superType =>
+      const $R693$NullableType$<R693$Child?>($R693$Child$NullableType$());
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R693$Child?> get nullableType => this;
+  jni$_.JType<R693$Child?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 2;
 
   @core$_.override
-  int get hashCode => ($R693$Child$NullableType).hashCode;
+  int get hashCode => ($R693$Child$NullableType$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R693$Child$NullableType) &&
-        other is $R693$Child$NullableType;
+    return other.runtimeType == ($R693$Child$NullableType$) &&
+        other is $R693$Child$NullableType$;
   }
 }
 
-final class $R693$Child$Type extends jni$_.JObjType<R693$Child> {
+final class $R693$Child$Type$ extends jni$_.JType<R693$Child> {
   @jni$_.internal
-  const $R693$Child$Type();
+  const $R693$Child$Type$();
 
   @jni$_.internal
   @core$_.override
@@ -13831,24 +13952,25 @@ final class $R693$Child$Type extends jni$_.JObjType<R693$Child> {
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType =>
-      const $R693$NullableType<R693$Child?>($R693$Child$NullableType());
+  jni$_.JType get superType =>
+      const $R693$NullableType$<R693$Child?>($R693$Child$NullableType$());
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R693$Child?> get nullableType =>
-      const $R693$Child$NullableType();
+  jni$_.JType<R693$Child?> get nullableType =>
+      const $R693$Child$NullableType$();
 
   @jni$_.internal
   @core$_.override
   final superCount = 2;
 
   @core$_.override
-  int get hashCode => ($R693$Child$Type).hashCode;
+  int get hashCode => ($R693$Child$Type$).hashCode;
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R693$Child$Type) && other is $R693$Child$Type;
+    return other.runtimeType == ($R693$Child$Type$) &&
+        other is $R693$Child$Type$;
   }
 }
 
@@ -13856,10 +13978,10 @@ final class $R693$Child$Type extends jni$_.JObjType<R693$Child> {
 class R693<$T extends jni$_.JObject?> extends jni$_.JObject {
   @jni$_.internal
   @core$_.override
-  final jni$_.JObjType<R693<$T>> $type;
+  final jni$_.JType<R693<$T>> $type;
 
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
   R693.fromReference(
@@ -13872,18 +13994,19 @@ class R693<$T extends jni$_.JObject?> extends jni$_.JObject {
       jni$_.JClass.forName(r'com/github/dart_lang/jnigen/regressions/R693');
 
   /// The type which includes information such as the signature of this class.
-  static $R693$NullableType<$T> nullableType<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+  static jni$_.JType<R693<$T>?> nullableType<$T extends jni$_.JObject?>(
+    jni$_.JType<$T> T,
   ) {
-    return $R693$NullableType<$T>(
+    return $R693$NullableType$<$T>(
       T,
     );
   }
 
-  static $R693$Type<$T> type<$T extends jni$_.JObject?>(
-    jni$_.JObjType<$T> T,
+  /// The type which includes information such as the signature of this class.
+  static jni$_.JType<R693<$T>> type<$T extends jni$_.JObject?>(
+    jni$_.JType<$T> T,
   ) {
-    return $R693$Type<$T>(
+    return $R693$Type$<$T>(
       T,
     );
   }
@@ -13907,7 +14030,7 @@ class R693<$T extends jni$_.JObject?> extends jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory R693({
-    required jni$_.JObjType<$T> T,
+    required jni$_.JType<$T> T,
   }) {
     return R693<$T>.fromReference(
         T,
@@ -13916,13 +14039,13 @@ class R693<$T extends jni$_.JObject?> extends jni$_.JObject {
   }
 }
 
-final class $R693$NullableType<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<R693<$T>?> {
+final class $R693$NullableType$<$T extends jni$_.JObject?>
+    extends jni$_.JType<R693<$T>?> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $R693$NullableType(
+  const $R693$NullableType$(
     this.T,
   );
 
@@ -13940,34 +14063,34 @@ final class $R693$NullableType<$T extends jni$_.JObject?>
         );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R693<$T>?> get nullableType => this;
+  jni$_.JType<R693<$T>?> get nullableType => this;
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($R693$NullableType, T);
+  int get hashCode => Object.hash($R693$NullableType$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R693$NullableType<$T>) &&
-        other is $R693$NullableType<$T> &&
+    return other.runtimeType == ($R693$NullableType$<$T>) &&
+        other is $R693$NullableType$<$T> &&
         T == other.T;
   }
 }
 
-final class $R693$Type<$T extends jni$_.JObject?>
-    extends jni$_.JObjType<R693<$T>> {
+final class $R693$Type$<$T extends jni$_.JObject?>
+    extends jni$_.JType<R693<$T>> {
   @jni$_.internal
-  final jni$_.JObjType<$T> T;
+  final jni$_.JType<$T> T;
 
   @jni$_.internal
-  const $R693$Type(
+  const $R693$Type$(
     this.T,
   );
 
@@ -13983,23 +14106,23 @@ final class $R693$Type<$T extends jni$_.JObject?>
       );
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType get superType => const jni$_.JObjectNullableType();
+  jni$_.JType get superType => const jni$_.$JObject$NullableType$();
 
   @jni$_.internal
   @core$_.override
-  jni$_.JObjType<R693<$T>?> get nullableType => $R693$NullableType<$T>(T);
+  jni$_.JType<R693<$T>?> get nullableType => $R693$NullableType$<$T>(T);
 
   @jni$_.internal
   @core$_.override
   final superCount = 1;
 
   @core$_.override
-  int get hashCode => Object.hash($R693$Type, T);
+  int get hashCode => Object.hash($R693$Type$, T);
 
   @core$_.override
   bool operator ==(Object other) {
-    return other.runtimeType == ($R693$Type<$T>) &&
-        other is $R693$Type<$T> &&
+    return other.runtimeType == ($R693$Type$<$T>) &&
+        other is $R693$Type$<$T> &&
         T == other.T;
   }
 }

--- a/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
+++ b/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
 
-import 'package:jni/_internal.dart';
 import 'package:jni/jni.dart';
 import 'package:test/test.dart';
 
@@ -294,7 +293,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
             T: JString.type,
           )..releasedBy(arena);
           expect(grandParent, isA<GrandParent<JString>>());
-          expect(grandParent.$type, isA<$GrandParent$Type<JString>>());
+          expect(grandParent.$type, isA<$GrandParent$Type$<JString>>());
           expect(
             grandParent.value!.toDartString(releaseOriginal: true),
             'Hello',
@@ -412,10 +411,15 @@ void registerTests(String groupName, TestRunnerCallback test) {
         });
       });
       test('superclass count', () {
+        // ignore: invalid_use_of_internal_member
         expect(JObject.type.superCount, 0);
+        // ignore: invalid_use_of_internal_member
         expect(MyMap.type(JObject.type, JObject.type).superCount, 1);
+        // ignore: invalid_use_of_internal_member
         expect(StringKeyedMap.type(JObject.type).superCount, 2);
+        // ignore: invalid_use_of_internal_member
         expect(StringValuedMap.type(JObject.type).superCount, 2);
+        // ignore: invalid_use_of_internal_member
         expect(StringMap.type.superCount, 3);
       });
       test('nested generics', () {
@@ -503,7 +507,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
           )!
             ..releasedBy(arena);
           expect(stack, isA<MyStack<JString?>>());
-          expect(stack.$type, isA<$MyStack$Type<JString?>>());
+          expect(stack.$type, isA<$MyStack$Type$<JString?>>());
           expect(stack.pop()!.toDartString(releaseOriginal: true), 'Hello');
         });
       });
@@ -516,7 +520,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
           )!
             ..releasedBy(arena);
           expect(stack, isA<MyStack<JString?>>());
-          expect(stack.$type, isA<$MyStack$Type<JString?>>());
+          expect(stack.$type, isA<$MyStack$Type$<JString?>>());
           expect(stack.pop()!.toDartString(releaseOriginal: true), 'World');
           expect(stack.pop()!.toDartString(releaseOriginal: true), 'Hello');
         });
@@ -532,7 +536,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
           )!
             ..releasedBy(arena);
           expect(stack, isA<MyStack<JObject?>>());
-          expect(stack.$type, isA<$MyStack$Type<JObject?>>());
+          expect(stack.$type, isA<$MyStack$Type$<JObject?>>());
           expect(
             stack
                 .pop()!
@@ -556,7 +560,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
           final stack = MyStack.fromArray(T: JString.type, array)!
             ..releasedBy(arena);
           expect(stack, isA<MyStack<JString?>>());
-          expect(stack.$type, isA<$MyStack$Type<JString?>>());
+          expect(stack.$type, isA<$MyStack$Type$<JString?>>());
           expect(stack.pop()!.toDartString(releaseOriginal: true), 'Hello');
         });
       });
@@ -575,7 +579,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
           )!
             ..releasedBy(arena);
           expect(stack, isA<MyStack<JString?>>());
-          expect(stack.$type, isA<$MyStack$Type<JString?>>());
+          expect(stack.$type, isA<$MyStack$Type$<JString?>>());
           expect(stack.pop()!.toDartString(releaseOriginal: true), 'Hello');
         });
       });
@@ -864,7 +868,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
           Future<$T> toDartFuture<$T extends JObject>(
             JObject future,
             // ignore: invalid_use_of_internal_member
-            JObjType<$T> T,
+            JType<$T> T,
           ) async {
             final receivePort = ReceivePort();
             await Isolate.spawn((sendPort) {
@@ -984,7 +988,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
         isA<
             $R2250<$T> Function<$T extends JObject?>(
                 // ignore: invalid_use_of_internal_member
-                {required JObjType<$T> T,
+                {required JType<$T> T,
                 required void Function($T?) foo,
                 bool foo$async})>(),
       );

--- a/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
+++ b/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
@@ -802,15 +802,10 @@ void registerTests(String groupName, TestRunnerCallback test) {
                 await Future<void>.delayed(const Duration(milliseconds: 100));
               }
               expect(
-                Jni.env.IsInstanceOf(
-                  // ignore: invalid_use_of_internal_member
-                  runner.error!.reference.pointer,
+                runner.error!.isInstanceOf(
                   JClass.forName(
                     'java/lang/reflect/UndeclaredThrowableException',
-                  )
-                      // ignore: invalid_use_of_internal_member
-                      .reference
-                      .pointer,
+                  ),
                 ),
                 isTrue,
               );
@@ -819,15 +814,10 @@ void registerTests(String groupName, TestRunnerCallback test) {
                   .instanceMethodId('getCause', '()Ljava/lang/Throwable;')
                   .call(runner.error!, JObject.type, []);
               expect(
-                Jni.env.IsInstanceOf(
-                  // ignore: invalid_use_of_internal_member
-                  cause.reference.pointer,
+                cause.isInstanceOf(
                   JClass.forName(
                     'com/github/dart_lang/jni/PortProxyBuilder\$DartException',
-                  )
-                      // ignore: invalid_use_of_internal_member
-                      .reference
-                      .pointer,
+                  ),
                 ),
                 isTrue,
               );

--- a/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
+++ b/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
@@ -22,13 +22,12 @@ void _runJavaGC() {
   );
   final bean = managementFactory
       .staticMethodId(
-        'getRuntimeMXBean',
-        '()Ljava/lang/management/RuntimeMXBean;',
-      )
+    'getRuntimeMXBean',
+    '()Ljava/lang/management/RuntimeMXBean;',
+  )
       .call(managementFactory, JObject.type, []);
-  final pid = bean.jClass
-      .instanceMethodId('getPid', '()J')
-      .call(bean, jlong.type, []);
+  final pid =
+      bean.jClass.instanceMethodId('getPid', '()J').call(bean, jlong.type, []);
   ProcessResult result;
   do {
     result = Process.runSync('jcmd', [pid.toString(), 'GC.run']);
@@ -136,9 +135,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
       final rand = e.getRandom();
       expect(rand, isNotNull);
       final _ = e.getRandomLong();
-      final id = e
-          .getRandomNumericString(rand)!
-          .toDartString(releaseOriginal: true);
+      final id =
+          e.getRandomNumericString(rand)!.toDartString(releaseOriginal: true);
       expect(int.parse(id), lessThan(10000));
       e.setNumber(145);
       expect(
@@ -343,13 +341,17 @@ void registerTests(String groupName, TestRunnerCallback test) {
           expect(
             (map.get(
               'Hello'.toJString()..releasedBy(arena),
-            )!..releasedBy(arena)).getNumber(),
+            )!
+                  ..releasedBy(arena))
+                .getNumber(),
             1,
           );
           expect(
             (map.get(
               'World'.toJString()..releasedBy(arena),
-            )!..releasedBy(arena)).getNumber(),
+            )!
+                  ..releasedBy(arena))
+                .getNumber(),
             2,
           );
           expect(
@@ -380,7 +382,9 @@ void registerTests(String groupName, TestRunnerCallback test) {
             expect(
               (map.get(
                 'Hello'.toJString()..releasedBy(arena),
-              )!..releasedBy(arena)).getNumber(),
+              )!
+                    ..releasedBy(arena))
+                  .getNumber(),
               0,
             );
           });
@@ -442,7 +446,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
           final exampleStaticParent = GrandParent.varStaticParent(
             S: Example.type,
             Example()..releasedBy(arena),
-          )!..releasedBy(arena);
+          )!
+            ..releasedBy(arena);
           expect(
             (exampleStaticParent.value!..releasedBy(arena)).getNumber(),
             0,
@@ -460,7 +465,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
           final exampleParent = grandParent.varParent(
             S: Example.type,
             Example()..releasedBy(arena),
-          )!..releasedBy(arena);
+          )!
+            ..releasedBy(arena);
           expect(
             exampleParent.parentValue!
                 .as(JString.type, releaseOriginal: true)
@@ -504,7 +510,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
           final stack = MyStack.of$1(
             'Hello'.toJString()..releasedBy(arena),
             T: JString.type,
-          )!..releasedBy(arena);
+          )!
+            ..releasedBy(arena);
           expect(stack, isA<MyStack<JString?>>());
           expect(stack.$type, isA<$MyStack$Type$<JString?>>());
           expect(stack.pop()!.toDartString(releaseOriginal: true), 'Hello');
@@ -516,7 +523,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
             'Hello'.toJString()..releasedBy(arena),
             'World'.toJString()..releasedBy(arena),
             T: JString.type,
-          )!..releasedBy(arena);
+          )!
+            ..releasedBy(arena);
           expect(stack, isA<MyStack<JString?>>());
           expect(stack.$type, isA<$MyStack$Type$<JString?>>());
           expect(stack.pop()!.toDartString(releaseOriginal: true), 'World');
@@ -531,7 +539,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
             T: JObject.type,
             'Hello'.toJString()..releasedBy(arena),
             array,
-          )!..releasedBy(arena);
+          )!
+            ..releasedBy(arena);
           expect(stack, isA<MyStack<JObject?>>());
           expect(stack.$type, isA<$MyStack$Type$<JObject?>>());
           expect(
@@ -573,7 +582,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
           final stack = MyStack.fromArrayOfArrayOfGrandParents(
             S: JString.type,
             twoDimentionalArray,
-          )!..releasedBy(arena);
+          )!
+            ..releasedBy(arena);
           expect(stack, isA<MyStack<JString?>>());
           expect(stack.$type, isA<$MyStack$Type$<JString?>>());
           expect(stack.pop()!.toDartString(releaseOriginal: true), 'Hello');
@@ -601,8 +611,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
               return (s!.toDartString(releaseOriginal: true) * 2).toJString();
             },
             varCallback: (JInteger? t) {
-              final result = (t!.intValue(releaseOriginal: true) * 2)
-                  .toJInteger();
+              final result =
+                  (t!.intValue(releaseOriginal: true) * 2).toJInteger();
               varCallbackResult.complete(result);
               return result;
             },
@@ -776,7 +786,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
     group('Dart exceptions are handled', () {
       for (final exception in [UnimplementedError(), 'Hello!']) {
         for (final sameThread in [true, false]) {
-          test('on ${sameThread ? 'the same thread' : 'another thread'}'
+          test(
+              'on ${sameThread ? 'the same thread' : 'another thread'}'
               ' throwing $exception', () async {
             await using((arena) async {
               final runnable = MyRunnable.implement(
@@ -882,7 +893,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
             sevenHundred = (await toDartFuture(
               sevenHundredBoxed,
               JInteger.type,
-            )).intValue();
+            ))
+                .intValue();
           }
           expect(sevenHundred, 700);
 
@@ -918,7 +930,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
         )..releasedBy(arena);
         final stringArray = genericInterface.arrayOf(
           'hello'.toJString()..releasedBy(arena),
-        )!..releasedBy(arena);
+        )!
+          ..releasedBy(arena);
         expect(stringArray, hasLength(1));
         expect(stringArray[0]!.toDartString(releaseOriginal: true), 'hello');
         expect(
@@ -931,7 +944,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
         final intArray = genericInterface.genericArrayOf(
           U: JInteger.type,
           42.toJInteger()..releasedBy(arena),
-        )!..releasedBy(arena);
+        )!
+          ..releasedBy(arena);
         expect(
           genericInterface
               .firstOfGenericArray(U: JInteger.type, intArray)!
@@ -943,7 +957,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
           U: JInteger.type,
           'hello'.toJString()..releasedBy(arena),
           42.toJInteger()..releasedBy(arena),
-        )!..releasedBy(arena);
+        )!
+          ..releasedBy(arena);
         expect(
           jmap['hello'.toJString()..releasedBy(arena)]!.intValue(
             releaseOriginal: true,
@@ -969,21 +984,19 @@ void registerTests(String groupName, TestRunnerCallback test) {
       expect(
         $R2250.new,
         isA<
-          $R2250<$T> Function<$T extends JObject?>({
-            required JType<$T> T,
-            required void Function($T?) foo,
-            bool foo$async,
-          })
-        >(),
+            $R2250<$T> Function<$T extends JObject?>({
+              required JType<$T> T,
+              required void Function($T?) foo,
+              bool foo$async,
+            })>(),
       );
       expect(
         $R2250$Child.new,
         isA<
-          $R2250$Child Function({
-            required void Function(JObject?) foo,
-            bool foo$async,
-          })
-        >(),
+            $R2250$Child Function({
+              required void Function(JObject?) foo,
+              bool foo$async,
+            })>(),
       );
     });
   });
@@ -1062,7 +1075,9 @@ void registerTests(String groupName, TestRunnerCallback test) {
         expect(
           (annotated.nullableArray(
             false,
-          )!..releasedBy(arena))[0].toDartString(releaseOriginal: true),
+          )!
+                ..releasedBy(arena))[0]
+              .toDartString(releaseOriginal: true),
           'hello',
         );
         expect(annotated.nullableArrayOfNullable(true), isNull);
@@ -1087,7 +1102,9 @@ void registerTests(String groupName, TestRunnerCallback test) {
         expect(
           (annotated.nullableList(
             false,
-          )!..releasedBy(arena))[0].toDartString(releaseOriginal: true),
+          )!
+                ..releasedBy(arena))[0]
+              .toDartString(releaseOriginal: true),
           'hello',
         );
         expect(annotated.nullableListOfNullable(true), isNull);
@@ -1188,8 +1205,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
         );
         expect(
           annotated
-          // Requires `V`.
-          .nullableReturnMethodGenericEcho(object, true, V: JString.type),
+              // Requires `V`.
+              .nullableReturnMethodGenericEcho(object, true, V: JString.type),
           isNull,
         );
         expect(
@@ -1202,8 +1219,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
         );
         expect(
           annotated
-          // `V` is optional.
-          .nullableReturnMethodGenericEcho2(object, true),
+              // `V` is optional.
+              .nullableReturnMethodGenericEcho2(object, true),
           isNull,
         );
         expect(
@@ -1270,8 +1287,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
         final annotated = newNonNullTestObject(arena);
         expect(
           (annotated.classGenericList()..releasedBy(arena)).first.toDartString(
-            releaseOriginal: true,
-          ),
+                releaseOriginal: true,
+              ),
           'hello',
         );
         expect(
@@ -1282,14 +1299,19 @@ void registerTests(String groupName, TestRunnerCallback test) {
         expect(
           (annotated.nullableClassGenericList(
             false,
-          )!..releasedBy(arena)).first.toDartString(releaseOriginal: true),
+          )!
+                ..releasedBy(arena))
+              .first
+              .toDartString(releaseOriginal: true),
           'hello',
         );
         expect(annotated.nullableClassGenericListOfNullable(true), isNull);
         expect(
           (annotated.nullableClassGenericListOfNullable(
             false,
-          )!..releasedBy(arena)).first,
+          )!
+                ..releasedBy(arena))
+              .first,
           isNull,
         );
       });

--- a/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
+++ b/pkgs/jnigen/test/simple_package_test/runtime_test_registrant.dart
@@ -22,12 +22,13 @@ void _runJavaGC() {
   );
   final bean = managementFactory
       .staticMethodId(
-    'getRuntimeMXBean',
-    '()Ljava/lang/management/RuntimeMXBean;',
-  )
+        'getRuntimeMXBean',
+        '()Ljava/lang/management/RuntimeMXBean;',
+      )
       .call(managementFactory, JObject.type, []);
-  final pid =
-      bean.jClass.instanceMethodId('getPid', '()J').call(bean, jlong.type, []);
+  final pid = bean.jClass
+      .instanceMethodId('getPid', '()J')
+      .call(bean, jlong.type, []);
   ProcessResult result;
   do {
     result = Process.runSync('jcmd', [pid.toString(), 'GC.run']);
@@ -135,8 +136,9 @@ void registerTests(String groupName, TestRunnerCallback test) {
       final rand = e.getRandom();
       expect(rand, isNotNull);
       final _ = e.getRandomLong();
-      final id =
-          e.getRandomNumericString(rand)!.toDartString(releaseOriginal: true);
+      final id = e
+          .getRandomNumericString(rand)!
+          .toDartString(releaseOriginal: true);
       expect(int.parse(id), lessThan(10000));
       e.setNumber(145);
       expect(
@@ -339,15 +341,15 @@ void registerTests(String groupName, TestRunnerCallback test) {
           map.put('Hello'.toJString()..releasedBy(arena), helloExample);
           map.put('World'.toJString()..releasedBy(arena), worldExample);
           expect(
-            (map.get('Hello'.toJString()..releasedBy(arena))!
-                  ..releasedBy(arena))
-                .getNumber(),
+            (map.get(
+              'Hello'.toJString()..releasedBy(arena),
+            )!..releasedBy(arena)).getNumber(),
             1,
           );
           expect(
-            (map.get('World'.toJString()..releasedBy(arena))!
-                  ..releasedBy(arena))
-                .getNumber(),
+            (map.get(
+              'World'.toJString()..releasedBy(arena),
+            )!..releasedBy(arena)).getNumber(),
             2,
           );
           expect(
@@ -376,9 +378,9 @@ void registerTests(String groupName, TestRunnerCallback test) {
             final example = Example()..releasedBy(arena);
             map.put('Hello'.toJString()..releasedBy(arena), example);
             expect(
-              (map.get('Hello'.toJString()..releasedBy(arena))!
-                    ..releasedBy(arena))
-                  .getNumber(),
+              (map.get(
+                'Hello'.toJString()..releasedBy(arena),
+              )!..releasedBy(arena)).getNumber(),
               0,
             );
           });
@@ -440,8 +442,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
           final exampleStaticParent = GrandParent.varStaticParent(
             S: Example.type,
             Example()..releasedBy(arena),
-          )!
-            ..releasedBy(arena);
+          )!..releasedBy(arena);
           expect(
             (exampleStaticParent.value!..releasedBy(arena)).getNumber(),
             0,
@@ -459,8 +460,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
           final exampleParent = grandParent.varParent(
             S: Example.type,
             Example()..releasedBy(arena),
-          )!
-            ..releasedBy(arena);
+          )!..releasedBy(arena);
           expect(
             exampleParent.parentValue!
                 .as(JString.type, releaseOriginal: true)
@@ -504,8 +504,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
           final stack = MyStack.of$1(
             'Hello'.toJString()..releasedBy(arena),
             T: JString.type,
-          )!
-            ..releasedBy(arena);
+          )!..releasedBy(arena);
           expect(stack, isA<MyStack<JString?>>());
           expect(stack.$type, isA<$MyStack$Type$<JString?>>());
           expect(stack.pop()!.toDartString(releaseOriginal: true), 'Hello');
@@ -517,8 +516,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
             'Hello'.toJString()..releasedBy(arena),
             'World'.toJString()..releasedBy(arena),
             T: JString.type,
-          )!
-            ..releasedBy(arena);
+          )!..releasedBy(arena);
           expect(stack, isA<MyStack<JString?>>());
           expect(stack.$type, isA<$MyStack$Type$<JString?>>());
           expect(stack.pop()!.toDartString(releaseOriginal: true), 'World');
@@ -533,8 +531,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
             T: JObject.type,
             'Hello'.toJString()..releasedBy(arena),
             array,
-          )!
-            ..releasedBy(arena);
+          )!..releasedBy(arena);
           expect(stack, isA<MyStack<JObject?>>());
           expect(stack.$type, isA<$MyStack$Type$<JObject?>>());
           expect(
@@ -576,8 +573,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
           final stack = MyStack.fromArrayOfArrayOfGrandParents(
             S: JString.type,
             twoDimentionalArray,
-          )!
-            ..releasedBy(arena);
+          )!..releasedBy(arena);
           expect(stack, isA<MyStack<JString?>>());
           expect(stack.$type, isA<$MyStack$Type$<JString?>>());
           expect(stack.pop()!.toDartString(releaseOriginal: true), 'Hello');
@@ -605,8 +601,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
               return (s!.toDartString(releaseOriginal: true) * 2).toJString();
             },
             varCallback: (JInteger? t) {
-              final result =
-                  (t!.intValue(releaseOriginal: true) * 2).toJInteger();
+              final result = (t!.intValue(releaseOriginal: true) * 2)
+                  .toJInteger();
               varCallbackResult.complete(result);
               return result;
             },
@@ -780,8 +776,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
     group('Dart exceptions are handled', () {
       for (final exception in [UnimplementedError(), 'Hello!']) {
         for (final sameThread in [true, false]) {
-          test(
-              'on ${sameThread ? 'the same thread' : 'another thread'}'
+          test('on ${sameThread ? 'the same thread' : 'another thread'}'
               ' throwing $exception', () async {
             await using((arena) async {
               final runnable = MyRunnable.implement(
@@ -857,7 +852,6 @@ void registerTests(String groupName, TestRunnerCallback test) {
           // TODO(#1213): remove this once we support Java futures.
           Future<$T> toDartFuture<$T extends JObject>(
             JObject future,
-            // ignore: invalid_use_of_internal_member
             JType<$T> T,
           ) async {
             final receivePort = ReceivePort();
@@ -877,8 +871,10 @@ void registerTests(String groupName, TestRunnerCallback test) {
             return (await receivePort.first) as $T;
           }
 
-          final sevenHundredBoxed =
-              consume(stringConverter, '700'.toJString())!;
+          final sevenHundredBoxed = consume(
+            stringConverter,
+            '700'.toJString(),
+          )!;
           final int sevenHundred;
           if (sevenHundredBoxed is JInteger) {
             sevenHundred = sevenHundredBoxed.intValue();
@@ -886,8 +882,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
             sevenHundred = (await toDartFuture(
               sevenHundredBoxed,
               JInteger.type,
-            ))
-                .intValue();
+            )).intValue();
           }
           expect(sevenHundred, 700);
 
@@ -921,9 +916,9 @@ void registerTests(String groupName, TestRunnerCallback test) {
                 JMap.hash(JString.type, JObject.type)..[key!] = value,
           ),
         )..releasedBy(arena);
-        final stringArray = genericInterface
-            .arrayOf('hello'.toJString()..releasedBy(arena))!
-          ..releasedBy(arena);
+        final stringArray = genericInterface.arrayOf(
+          'hello'.toJString()..releasedBy(arena),
+        )!..releasedBy(arena);
         expect(stringArray, hasLength(1));
         expect(stringArray[0]!.toDartString(releaseOriginal: true), 'hello');
         expect(
@@ -936,8 +931,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
         final intArray = genericInterface.genericArrayOf(
           U: JInteger.type,
           42.toJInteger()..releasedBy(arena),
-        )!
-          ..releasedBy(arena);
+        )!..releasedBy(arena);
         expect(
           genericInterface
               .firstOfGenericArray(U: JInteger.type, intArray)!
@@ -949,8 +943,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
           U: JInteger.type,
           'hello'.toJString()..releasedBy(arena),
           42.toJInteger()..releasedBy(arena),
-        )!
-          ..releasedBy(arena);
+        )!..releasedBy(arena);
         expect(
           jmap['hello'.toJString()..releasedBy(arena)]!.intValue(
             releaseOriginal: true,
@@ -976,17 +969,21 @@ void registerTests(String groupName, TestRunnerCallback test) {
       expect(
         $R2250.new,
         isA<
-            $R2250<$T> Function<$T extends JObject?>(
-                // ignore: invalid_use_of_internal_member
-                {required JType<$T> T,
-                required void Function($T?) foo,
-                bool foo$async})>(),
+          $R2250<$T> Function<$T extends JObject?>({
+            required JType<$T> T,
+            required void Function($T?) foo,
+            bool foo$async,
+          })
+        >(),
       );
       expect(
         $R2250$Child.new,
         isA<
-            $R2250$Child Function(
-                {required void Function(JObject?) foo, bool foo$async})>(),
+          $R2250$Child Function({
+            required void Function(JObject?) foo,
+            bool foo$async,
+          })
+        >(),
       );
     });
   });
@@ -1063,9 +1060,9 @@ void registerTests(String groupName, TestRunnerCallback test) {
         expect((annotated.arrayOfNullable()..releasedBy(arena))[0], isNull);
         expect(annotated.nullableArray(true), isNull);
         expect(
-          (annotated.nullableArray(false)!..releasedBy(arena))[0].toDartString(
-            releaseOriginal: true,
-          ),
+          (annotated.nullableArray(
+            false,
+          )!..releasedBy(arena))[0].toDartString(releaseOriginal: true),
           'hello',
         );
         expect(annotated.nullableArrayOfNullable(true), isNull);
@@ -1088,9 +1085,9 @@ void registerTests(String groupName, TestRunnerCallback test) {
         expect((annotated.listOfNullable()..releasedBy(arena))[0], isNull);
         expect(annotated.nullableList(true), isNull);
         expect(
-          (annotated.nullableList(false)!..releasedBy(arena))[0].toDartString(
-            releaseOriginal: true,
-          ),
+          (annotated.nullableList(
+            false,
+          )!..releasedBy(arena))[0].toDartString(releaseOriginal: true),
           'hello',
         );
         expect(annotated.nullableListOfNullable(true), isNull);
@@ -1191,8 +1188,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
         );
         expect(
           annotated
-              // Requires `V`.
-              .nullableReturnMethodGenericEcho(object, true, V: JString.type),
+          // Requires `V`.
+          .nullableReturnMethodGenericEcho(object, true, V: JString.type),
           isNull,
         );
         expect(
@@ -1205,8 +1202,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
         );
         expect(
           annotated
-              // `V` is optional.
-              .nullableReturnMethodGenericEcho2(object, true),
+          // `V` is optional.
+          .nullableReturnMethodGenericEcho2(object, true),
           isNull,
         );
         expect(
@@ -1273,8 +1270,8 @@ void registerTests(String groupName, TestRunnerCallback test) {
         final annotated = newNonNullTestObject(arena);
         expect(
           (annotated.classGenericList()..releasedBy(arena)).first.toDartString(
-                releaseOriginal: true,
-              ),
+            releaseOriginal: true,
+          ),
           'hello',
         );
         expect(
@@ -1283,16 +1280,16 @@ void registerTests(String groupName, TestRunnerCallback test) {
         );
         expect(annotated.nullableClassGenericList(true), isNull);
         expect(
-          (annotated.nullableClassGenericList(false)!..releasedBy(arena))
-              .first
-              .toDartString(releaseOriginal: true),
+          (annotated.nullableClassGenericList(
+            false,
+          )!..releasedBy(arena)).first.toDartString(releaseOriginal: true),
           'hello',
         );
         expect(annotated.nullableClassGenericListOfNullable(true), isNull);
         expect(
-          (annotated.nullableClassGenericListOfNullable(false)!
-                ..releasedBy(arena))
-              .first,
+          (annotated.nullableClassGenericListOfNullable(
+            false,
+          )!..releasedBy(arena)).first,
           isNull,
         );
       });
@@ -1308,12 +1305,18 @@ void registerTests(String groupName, TestRunnerCallback test) {
         expect(red.code, 0xFF0000);
         expect(green.code, 0x00FF00);
         expect(blue.code, 0x0000FF);
-        expect(red.toRGB()!..releasedBy(arena),
-            Colors$RGB(255, 0, 0)..releasedBy(arena));
-        expect(green.toRGB()!..releasedBy(arena),
-            Colors$RGB(0, 255, 0)..releasedBy(arena));
-        expect(blue.toRGB()!..releasedBy(arena),
-            Colors$RGB(0, 0, 255)..releasedBy(arena));
+        expect(
+          red.toRGB()!..releasedBy(arena),
+          Colors$RGB(255, 0, 0)..releasedBy(arena),
+        );
+        expect(
+          green.toRGB()!..releasedBy(arena),
+          Colors$RGB(0, 255, 0)..releasedBy(arena),
+        );
+        expect(
+          blue.toRGB()!..releasedBy(arena),
+          Colors$RGB(0, 0, 255)..releasedBy(arena),
+        );
       });
     });
   });


### PR DESCRIPTION
* Make `Jni.env` internal. We're not even using it in the JNIgen generated bindings. If users want to have a functionality here, they can open an issue. Making this internal heavily discourages use.
* Remove a degree of flexibility for type class naming, any class named `Foo` will have two typeclasses: `$Foo$NullableType$` and `$Foo$Type$` including the classes in `package:jni ` itself. 
* Remove the information about these symbols from `jni_symbols.yaml` (this will be changed again after jnigen transformation PR lands but wanted to land this first to make that PR a bit smaller)
* Same change in JNIgen, this fixes #2493.
* Remove API leaks reported by the health bot (https://github.com/dart-lang/native/pull/2494#issuecomment-3178608339)
* Rename `JObjType` to `JType` and make it not internal. `JType` used to be the union of both primitive types and non-primitive types, however that is rarely used and internal so renamed that to `JTypeBase` and renamed the commonly used `JObjType` to `JType`.
