### PR TITLE
[code_assets] [hooks] [hooks_runner] [data_assets] Publish

### DIFF
--- a/pkgs/code_assets/CHANGELOG.md
+++ b/pkgs/code_assets/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.19.6-wip
+## 0.19.6
 
 - Added a library comment detailing how to use the package.
 - Fixed duplicate asset id detection with assets coming from both build and

--- a/pkgs/code_assets/pubspec.yaml
+++ b/pkgs/code_assets/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   This library contains the hook protocol specification for bundling native code
   with Dart packages.
 
-version: 0.19.6-wip
+version: 0.19.6
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/code_assets
 
@@ -21,7 +21,7 @@ environment:
 
 dependencies:
   collection: ^1.19.1
-  hooks: ^0.20.1-wip
+  hooks: ^0.20.1
 
 dev_dependencies:
   custom_lint: ^0.7.5

--- a/pkgs/data_assets/CHANGELOG.md
+++ b/pkgs/data_assets/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.19.3-wip
+## 0.19.3
 
 - Added a library comment detailing how to use the package.
 

--- a/pkgs/data_assets/pubspec.yaml
+++ b/pkgs/data_assets/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   This library contains the hook protocol specification for bundling data assets
   with Dart packages.
 
-version: 0.19.3-wip
+version: 0.19.3
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/data_assets
 
@@ -17,7 +17,7 @@ environment:
   sdk: '>=3.9.0 <4.0.0'
 
 dependencies:
-  hooks: ^0.20.1-wip
+  hooks: ^0.20.1
 
 dev_dependencies:
   custom_lint: ^0.7.5

--- a/pkgs/hooks/CHANGELOG.md
+++ b/pkgs/hooks/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.20.1-wip
+## 0.20.1
 
 - Update outdated documentation.
 - Deprecate `HookOutputBuilder.addDependency` and

--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A library that contains a Dart API for the JSON-based protocol for
   `hook/build.dart` and `hook/link.dart`.
 
-version: 0.20.1-wip
+version: 0.20.1
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks
 
@@ -29,7 +29,7 @@ dependencies:
 
 dev_dependencies:
   args: ^2.6.0
-  code_assets: ^0.19.6-wip # Used for running tests with real asset types.
+  code_assets: ^0.19.6 # Used for running tests with real asset types.
   custom_lint: ^0.7.5
   dart_flutter_team_lints: ^3.5.2
   data_assets: any # Used for running tests with real asset types.

--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.22.1-wip
+## 0.22.1
 
 * Fix caches not being invalidated on (1) user-defines changing, (2) metadata
   changing, and (3) assets sent to link hooks.

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 0.22.1-wip
+version: 0.22.1
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 


### PR DESCRIPTION
We have landed readme files and examples, publish versions so they become visible on pub.

The breaking change check is reporting `InvalidTypes` (https://github.com/dart-lang/native/issues/2361). I've checked manually, there are no breaking changes.