### PR TITLE
[code_assets] [hooks] Fix process run in test

### DIFF
--- a/pkgs/code_assets/test/example/pub_publish_size_test.dart
+++ b/pkgs/code_assets/test/example/pub_publish_size_test.dart
@@ -15,7 +15,7 @@ void main() {
     final packageRoot = findPackageRoot('code_assets');
 
     final dryRunResult = Process.runSync(
-      'dart',
+      Platform.executable,
       ['pub', 'publish', '--dry-run'],
       workingDirectory: packageRoot.toFilePath(),
       stdoutEncoding: utf8,

--- a/pkgs/hooks/test/example/pub_publish_size_test.dart
+++ b/pkgs/hooks/test/example/pub_publish_size_test.dart
@@ -15,7 +15,7 @@ void main() {
     final packageRoot = findPackageRoot('hooks');
 
     final dryRunResult = Process.runSync(
-      'dart',
+      Platform.executable,
       ['pub', 'publish', '--dry-run'],
       workingDirectory: packageRoot.toFilePath(),
       stdoutEncoding: utf8,


### PR DESCRIPTION
These tests were wrong assuming `dart` to be on `PATH`.

This doesn't fail on GitHub, but it does on the Dart CI: [https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8705372601376369393/+/u/test_results/new_test_failures__logs_](https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8705372601376369393/+/u/test_results/new_test_failures__logs_)

(No changelog or version bump, only needed for Dart CI.)