### PR TITLE
[swift2objc] Built in declarations should only come from the built in module

### DIFF
--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_built_in_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_built_in_declaration.dart
@@ -3,11 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../../../ast/declarations/built_in/built_in_declaration.dart';
-import '../../_core/json.dart';
+import '../../../config.dart';
+import '../../_core/parsed_symbolgraph.dart';
 import '../../_core/utils.dart';
 
-BuiltInDeclaration? tryParseBuiltInDeclaration(Json symbolJson) {
-  final id = parseSymbolId(symbolJson);
+BuiltInDeclaration? tryParseBuiltInDeclaration(ParsedSymbol parsedSymbol) {
+  if (parsedSymbol.source != builtInInputConfig) return null;
+  final id = parseSymbolId(parsedSymbol.json);
   if (!id.startsWith('c:objc(cs)')) return null;
-  return BuiltInDeclaration(id: id, name: parseSymbolName(symbolJson));
+  return BuiltInDeclaration(id: id, name: parseSymbolName(parsedSymbol.json));
 }

--- a/pkgs/swift2objc/lib/src/parser/parsers/parse_declarations.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/parse_declarations.dart
@@ -39,7 +39,7 @@ Declaration parseDeclaration(
 
   final symbolJson = parsedSymbol.json;
 
-  final builtIn = tryParseBuiltInDeclaration(symbolJson);
+  final builtIn = tryParseBuiltInDeclaration(parsedSymbol);
   if (builtIn != null) {
     return parsedSymbol.declaration = builtIn;
   }


### PR DESCRIPTION
Restrict `tryParseBuiltInDeclaration` to symbols that come from the built in `Foundation` module. There are symbols in other modules that have IDs starting with `c:objc(cs)`, so if we treat them all as built in, then users can't actually generate bindings for them.