### PR TITLE
[ffigen] Remove `PackageConfig` from `FfiGen` config

### DIFF
--- a/pkgs/ffigen/lib/src/config_provider/config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:logging/logging.dart';
-import 'package:package_config/package_config.dart';
 
 import '../code_generator.dart';
 import 'config_impl.dart';
@@ -14,9 +13,6 @@ import 'spec_utils.dart';
 abstract interface class FfiGen {
   /// Input config filename, if any.
   Uri? get filename;
-
-  /// Package config.
-  PackageConfig? get packageConfig;
 
   /// Path to the clang library.
   Uri get libclangDylib;
@@ -196,7 +192,6 @@ abstract interface class FfiGen {
   factory FfiGen(
     Logger logger, {
     Uri? filename,
-    PackageConfig? packageConfig,
     Uri? libclangDylib,
     required Uri output,
     Uri? outputObjC,
@@ -252,7 +247,6 @@ abstract interface class FfiGen {
     ExternalVersions externalVersions = const ExternalVersions(),
   }) => ConfigImpl(
     filename: filename == null ? null : Uri.file(filename.toFilePath()),
-    packageConfig: packageConfig,
     libclangDylib: Uri.file(
       libclangDylib?.toFilePath() ?? findDylibAtDefaultLocations(logger),
     ),

--- a/pkgs/ffigen/lib/src/config_provider/config_impl.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config_impl.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:package_config/package_config.dart';
-
 import '../code_generator.dart';
 import 'config.dart';
 import 'config_types.dart';
@@ -11,9 +9,6 @@ import 'config_types.dart';
 class ConfigImpl implements FfiGen {
   @override
   final Uri? filename;
-
-  @override
-  final PackageConfig? packageConfig;
 
   @override
   final Uri libclangDylib;
@@ -189,7 +184,6 @@ class ConfigImpl implements FfiGen {
 
   ConfigImpl({
     required this.filename,
-    required this.packageConfig,
     required this.libclangDylib,
     required this.output,
     required this.outputObjC,

--- a/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
@@ -27,7 +27,6 @@ class YamlConfig implements FfiGen {
   final Uri? filename;
 
   /// Package config.
-  @override
   final PackageConfig? packageConfig;
 
   /// Path to the clang library.


### PR DESCRIPTION
It's only used by the `YamlConfig`. Fixes https://github.com/dart-lang/native/issues/2558