### PR TITLE
[swift2objc] Cleanup API for MVP

### DIFF
--- a/pkgs/swift2objc/lib/src/ast/visitor.dart
+++ b/pkgs/swift2objc/lib/src/ast/visitor.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:logging/logging.dart';
-
+import '../context.dart';
 import '_core/interfaces/compound_declaration.dart';
 import '_core/interfaces/declaration.dart';
 import '_core/interfaces/enum_declaration.dart';
@@ -24,8 +23,6 @@ import 'declarations/enums/raw_value_enum_declaration.dart';
 import 'declarations/globals/globals.dart';
 import 'declarations/typealias_declaration.dart';
 
-final _logger = Logger('swift2objc.visitor');
-
 /// Wrapper around [Visitation] to be used by callers.
 ///
 /// The [Visitor] determines the traversal order of the AST, and has helper
@@ -33,10 +30,12 @@ final _logger = Logger('swift2objc.visitor');
 /// responsible for what happens at each visited node. The [Visitor] is generic
 /// and the [Visitation] contains the specific logic of the traversal.
 final class Visitor {
-  Visitor(this._visitation, {bool debug = false}) : _debug = debug {
+  Visitor(this._context, this._visitation, {bool debug = false})
+    : _debug = debug {
     _visitation.visitor = this;
   }
 
+  final Context _context;
   final Visitation _visitation;
   final _seen = <AstNode>{};
   final bool _debug;
@@ -45,7 +44,7 @@ final class Visitor {
   /// Visits a node.
   void visit(AstNode? node) {
     if (node == null) return;
-    if (_debug) _logger.info('${'  ' * _indentLevel++}$node');
+    if (_debug) _context.logger.info('${'  ' * _indentLevel++}$node');
     if (!_seen.contains(node)) {
       _seen.add(node);
       node.visit(_visitation);
@@ -123,10 +122,11 @@ abstract class Visitation {
 }
 
 T visit<T extends Visitation>(
+  Context context,
   T visitation,
   Iterable<AstNode> roots, {
   bool debug = false,
 }) {
-  Visitor(visitation, debug: debug).visitAll(roots);
+  Visitor(context, visitation, debug: debug).visitAll(roots);
   return visitation;
 }

--- a/pkgs/swift2objc/lib/src/config.dart
+++ b/pkgs/swift2objc/lib/src/config.dart
@@ -17,7 +17,7 @@ class Command {
 }
 
 /// Used to configure Swift2ObjC wrapper generation.
-class Config {
+class Swift2ObjCGenerator {
   /// The inputs to generate a wrapper for.
   /// See `FilesInputConfig` and `ModuleInputConfig`;
   final List<InputConfig> inputs;
@@ -52,14 +52,14 @@ class Config {
 
   static bool _defaultInclude(Declaration _) => true;
 
-  const Config({
+  const Swift2ObjCGenerator({
     required this.inputs,
     required this.outputFile,
     this.target,
     this.sdk,
     this.tempDir,
     this.preamble,
-    this.include = Config._defaultInclude,
+    this.include = Swift2ObjCGenerator._defaultInclude,
   });
 }
 

--- a/pkgs/swift2objc/lib/src/context.dart
+++ b/pkgs/swift2objc/lib/src/context.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:logging/logging.dart';
+
+class Context {
+  final Logger logger;
+
+  Context(this.logger);
+}

--- a/pkgs/swift2objc/lib/src/generate_wrapper.dart
+++ b/pkgs/swift2objc/lib/src/generate_wrapper.dart
@@ -4,16 +4,31 @@
 
 import 'dart:io';
 
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 
 import 'config.dart';
+import 'context.dart';
 import 'generator/generator.dart';
 import 'parser/parser.dart';
 import 'transformer/transform.dart';
 import 'utils.dart';
 
-/// Used to generate the wrapper swift file.
-Future<void> generateWrapper(Config config) async {
+extension Swift2ObjCGeneratorMethod on Swift2ObjCGenerator {
+  /// Used to generate the wrapper swift file.
+  Future<void> generate({required Logger? logger}) => _generateWrapper(
+    this,
+    Context(
+      logger ?? Logger.detached('dev/null')
+        ..level = Level.OFF,
+    ),
+  );
+}
+
+Future<void> _generateWrapper(
+  Swift2ObjCGenerator config,
+  Context context,
+) async {
   final Directory tempDir;
   final bool deleteTempDirWhenDone;
 
@@ -63,8 +78,9 @@ Future<void> generateWrapper(Config config) async {
     mergedSymbolgraph.merge(parseSymbolgraph(input, symbolgraphJson));
   }
 
-  final declarations = parseDeclarations(mergedSymbolgraph);
+  final declarations = parseDeclarations(context, mergedSymbolgraph);
   final transformedDeclarations = transform(
+    context,
     declarations,
     filter: config.include,
   );

--- a/pkgs/swift2objc/lib/src/parser/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/parser/_core/utils.dart
@@ -10,6 +10,7 @@ import '../../ast/_core/interfaces/declaration.dart';
 import '../../ast/_core/interfaces/nestable_declaration.dart';
 import '../../ast/_core/shared/referred_type.dart';
 import '../../ast/declarations/globals/globals.dart';
+import '../../context.dart';
 import '../parsers/parse_type.dart';
 import 'json.dart';
 import 'parsed_symbolgraph.dart';
@@ -121,6 +122,7 @@ extension Deduper<T> on Iterable<T> {
 }
 
 ReferredType parseTypeAfterSeparator(
+  Context context,
   TokenList fragments,
   ParsedSymbolgraph symbolgraph,
 ) {
@@ -129,6 +131,7 @@ ReferredType parseTypeAfterSeparator(
     (token) => matchFragment(token, 'text', ':'),
   );
   final (type, suffix) = parseType(
+    context,
     symbolgraph,
     fragments.slice(separatorIndex + 1),
   );

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_compound_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_compound_declaration.dart
@@ -11,6 +11,7 @@ import '../../../ast/declarations/compounds/members/method_declaration.dart';
 import '../../../ast/declarations/compounds/members/property_declaration.dart';
 import '../../../ast/declarations/compounds/struct_declaration.dart';
 import '../../../config.dart';
+import '../../../context.dart';
 import '../../_core/parsed_symbolgraph.dart';
 import '../../_core/utils.dart';
 import '../parse_declarations.dart';
@@ -28,6 +29,7 @@ typedef CompoundTearOff<T extends CompoundDeclaration> =
     });
 
 T _parseCompoundDeclaration<T extends CompoundDeclaration>(
+  Context context,
   ParsedSymbol symbol,
   CompoundTearOff<T> tearoffConstructor,
   ParsedSymbolgraph symbolgraph,
@@ -62,7 +64,7 @@ T _parseCompoundDeclaration<T extends CompoundDeclaration>(
         if (memberSymbol == null) {
           return null;
         }
-        return tryParseDeclaration(memberSymbol, symbolgraph);
+        return tryParseDeclaration(context, memberSymbol, symbolgraph);
       })
       .nonNulls
       .dedupeBy((decl) => decl.id)
@@ -91,10 +93,12 @@ T _parseCompoundDeclaration<T extends CompoundDeclaration>(
 }
 
 ClassDeclaration parseClassDeclaration(
+  Context context,
   ParsedSymbol classSymbol,
   ParsedSymbolgraph symbolgraph,
 ) {
   return _parseCompoundDeclaration(
+    context,
     classSymbol,
     ClassDeclaration.new,
     symbolgraph,
@@ -102,10 +106,12 @@ ClassDeclaration parseClassDeclaration(
 }
 
 StructDeclaration parseStructDeclaration(
+  Context context,
   ParsedSymbol classSymbol,
   ParsedSymbolgraph symbolgraph,
 ) {
   return _parseCompoundDeclaration(
+    context,
     classSymbol,
     StructDeclaration.new,
     symbolgraph,

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_function_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_function_declaration.dart
@@ -6,6 +6,7 @@ import '../../../ast/_core/shared/parameter.dart';
 import '../../../ast/_core/shared/referred_type.dart';
 import '../../../ast/declarations/compounds/members/method_declaration.dart';
 import '../../../ast/declarations/globals/globals.dart';
+import '../../../context.dart';
 import '../../_core/json.dart';
 import '../../_core/parsed_symbolgraph.dart';
 import '../../_core/token_list.dart';
@@ -13,10 +14,12 @@ import '../../_core/utils.dart';
 import '../parse_type.dart';
 
 GlobalFunctionDeclaration parseGlobalFunctionDeclaration(
+  Context context,
   ParsedSymbol symbol,
   ParsedSymbolgraph symbolgraph,
 ) {
   final info = parseFunctionInfo(
+    context,
     symbol.json['declarationFragments'],
     symbolgraph,
   );
@@ -25,7 +28,7 @@ GlobalFunctionDeclaration parseGlobalFunctionDeclaration(
     name: parseSymbolName(symbol.json),
     source: symbol.source,
     availability: parseAvailability(symbol.json),
-    returnType: _parseFunctionReturnType(symbol.json, symbolgraph),
+    returnType: _parseFunctionReturnType(context, symbol.json, symbolgraph),
     params: info.params,
     throws: info.throws,
     async: info.async,
@@ -33,11 +36,13 @@ GlobalFunctionDeclaration parseGlobalFunctionDeclaration(
 }
 
 MethodDeclaration parseMethodDeclaration(
+  Context context,
   ParsedSymbol symbol,
   ParsedSymbolgraph symbolgraph, {
   bool isStatic = false,
 }) {
   final info = parseFunctionInfo(
+    context,
     symbol.json['declarationFragments'],
     symbolgraph,
   );
@@ -46,7 +51,7 @@ MethodDeclaration parseMethodDeclaration(
     name: parseSymbolName(symbol.json),
     source: symbol.source,
     availability: parseAvailability(symbol.json),
-    returnType: _parseFunctionReturnType(symbol.json, symbolgraph),
+    returnType: _parseFunctionReturnType(context, symbol.json, symbolgraph),
     params: info.params,
     hasObjCAnnotation: parseSymbolHasObjcAnnotation(symbol.json),
     isStatic: isStatic,
@@ -64,6 +69,7 @@ typedef ParsedFunctionInfo = ({
 });
 
 ParsedFunctionInfo parseFunctionInfo(
+  Context context,
   Json declarationFragments,
   ParsedSymbolgraph symbolgraph,
 ) {
@@ -137,7 +143,7 @@ ParsedFunctionInfo parseFunctionInfo(
       }
 
       if (sep != ':') throw malformedInitializerException;
-      final (type, remainingTokens) = parseType(symbolgraph, tokens);
+      final (type, remainingTokens) = parseType(context, symbolgraph, tokens);
       tokens = remainingTokens;
 
       parameters.add(
@@ -171,11 +177,12 @@ ParsedFunctionInfo parseFunctionInfo(
 }
 
 ReferredType _parseFunctionReturnType(
+  Context context,
   Json symbolJson,
   ParsedSymbolgraph symbolgraph,
 ) {
   final returnJson = TokenList(symbolJson['functionSignature']['returns']);
-  final (returnType, unparsed) = parseType(symbolgraph, returnJson);
+  final (returnType, unparsed) = parseType(context, symbolgraph, returnJson);
   assert(unparsed.isEmpty, '$returnJson\n\n$returnType\n\n$unparsed\n');
   return returnType;
 }

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_initializer_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_initializer_declaration.dart
@@ -3,12 +3,14 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../../../ast/declarations/compounds/members/initializer_declaration.dart';
+import '../../../context.dart';
 import '../../_core/json.dart';
 import '../../_core/parsed_symbolgraph.dart';
 import '../../_core/utils.dart';
 import 'parse_function_declaration.dart';
 
 InitializerDeclaration parseInitializerDeclaration(
+  Context context,
   ParsedSymbol symbol,
   ParsedSymbolgraph symbolgraph,
 ) {
@@ -23,7 +25,7 @@ InitializerDeclaration parseInitializerDeclaration(
     throw Exception('Invalid initializer at ${declarationFragments.path}: $id');
   }
 
-  final info = parseFunctionInfo(declarationFragments, symbolgraph);
+  final info = parseFunctionInfo(context, declarationFragments, symbolgraph);
 
   return InitializerDeclaration(
     id: id,

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_typealias_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_typealias_declaration.dart
@@ -3,12 +3,14 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../../../ast/declarations/typealias_declaration.dart';
+import '../../../context.dart';
 import '../../_core/parsed_symbolgraph.dart';
 import '../../_core/token_list.dart';
 import '../../_core/utils.dart';
 import '../parse_type.dart';
 
 TypealiasDeclaration? parseTypealiasDeclaration(
+  Context context,
   ParsedSymbol symbol,
   ParsedSymbolgraph symbolgraph,
 ) {
@@ -26,7 +28,11 @@ TypealiasDeclaration? parseTypealiasDeclaration(
   final equals = tokens.indexWhere((tok) => matchFragment(tok, 'text', '='));
   if (equals == -1) throw malformedException;
 
-  final (target, remaining) = parseType(symbolgraph, tokens.slice(equals + 1));
+  final (target, remaining) = parseType(
+    context,
+    symbolgraph,
+    tokens.slice(equals + 1),
+  );
   if (remaining.isNotEmpty) throw malformedException;
 
   return TypealiasDeclaration(

--- a/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_variable_declaration.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/declaration_parsers/parse_variable_declaration.dart
@@ -5,12 +5,14 @@
 import '../../../ast/_core/shared/referred_type.dart';
 import '../../../ast/declarations/compounds/members/property_declaration.dart';
 import '../../../ast/declarations/globals/globals.dart';
+import '../../../context.dart';
 import '../../_core/json.dart';
 import '../../_core/parsed_symbolgraph.dart';
 import '../../_core/token_list.dart';
 import '../../_core/utils.dart';
 
 PropertyDeclaration parsePropertyDeclaration(
+  Context context,
   ParsedSymbol symbol,
   ParsedSymbolgraph symbolgraph, {
   bool isStatic = false,
@@ -21,7 +23,7 @@ PropertyDeclaration parsePropertyDeclaration(
     name: parseSymbolName(symbol.json),
     source: symbol.source,
     availability: parseAvailability(symbol.json),
-    type: _parseVariableType(symbol.json, symbolgraph),
+    type: _parseVariableType(context, symbol.json, symbolgraph),
     hasObjCAnnotation: parseSymbolHasObjcAnnotation(symbol.json),
     isConstant: info.constant,
     isStatic: isStatic,
@@ -35,6 +37,7 @@ PropertyDeclaration parsePropertyDeclaration(
 }
 
 GlobalVariableDeclaration parseGlobalVariableDeclaration(
+  Context context,
   ParsedSymbol symbol,
   ParsedSymbolgraph symbolgraph, {
   bool isStatic = false,
@@ -45,7 +48,7 @@ GlobalVariableDeclaration parseGlobalVariableDeclaration(
     name: parseSymbolName(symbol.json),
     source: symbol.source,
     availability: parseAvailability(symbol.json),
-    type: _parseVariableType(symbol.json, symbolgraph),
+    type: _parseVariableType(context, symbol.json, symbolgraph),
     isConstant: info.constant || !info.setter,
     throws: info.throws,
     async: info.async,
@@ -53,9 +56,11 @@ GlobalVariableDeclaration parseGlobalVariableDeclaration(
 }
 
 ReferredType _parseVariableType(
+  Context context,
   Json symbolJson,
   ParsedSymbolgraph symbolgraph,
 ) => parseTypeAfterSeparator(
+  context,
   TokenList(symbolJson['names']['subHeading']),
   symbolgraph,
 );

--- a/pkgs/swift2objc/lib/src/parser/parsers/parse_type.dart
+++ b/pkgs/swift2objc/lib/src/parser/parsers/parse_type.dart
@@ -5,6 +5,7 @@
 import '../../ast/_core/interfaces/declaration.dart';
 import '../../ast/_core/shared/referred_type.dart';
 import '../../ast/declarations/built_in/built_in_declaration.dart';
+import '../../context.dart';
 import '../_core/json.dart';
 import '../_core/parsed_symbolgraph.dart';
 import '../_core/token_list.dart';
@@ -15,12 +16,18 @@ import 'parse_declarations.dart';
 /// Returns the parsed type, and a Json slice of the remaining fragments that
 /// weren't part of the type.
 (ReferredType, TokenList) parseType(
+  Context context,
   ParsedSymbolgraph symbolgraph,
   TokenList fragments,
 ) {
-  var (type, suffix) = _parsePrefixTypeExpression(symbolgraph, fragments);
+  var (type, suffix) = _parsePrefixTypeExpression(
+    context,
+    symbolgraph,
+    fragments,
+  );
   while (true) {
     final (nextType, nextSuffix) = _maybeParseSuffixTypeExpression(
+      context,
       symbolgraph,
       type,
       suffix,
@@ -36,19 +43,21 @@ import 'parse_declarations.dart';
 // at the beginning of the list of fragments). If we were parsing a programming
 // language, these would be things like `123` or `-x`.
 (ReferredType, TokenList) _parsePrefixTypeExpression(
+  Context context,
   ParsedSymbolgraph symbolgraph,
   TokenList fragments,
 ) {
   final token = fragments[0];
   final parselet = _prefixParsets[_tokenId(token)];
   if (parselet == null) throw Exception('Invalid type at "${token.path}"');
-  return parselet(symbolgraph, token, fragments.slice(1));
+  return parselet(context, symbolgraph, token, fragments.slice(1));
 }
 
 // Suffix expressions are infix operators or suffix operators (basically
 // anything that isn't a prefix). If we were parsing a programming language,
 // these would be things like `x + y`, `z!`, or even `x ? y : z`.
 (ReferredType?, TokenList) _maybeParseSuffixTypeExpression(
+  Context context,
   ParsedSymbolgraph symbolgraph,
   ReferredType prefixType,
   TokenList fragments,
@@ -57,7 +66,7 @@ import 'parse_declarations.dart';
   final token = fragments[0];
   final parselet = _suffixParsets[_tokenId(token)];
   if (parselet == null) return (null, fragments);
-  return parselet(symbolgraph, prefixType, token, fragments.slice(1));
+  return parselet(context, symbolgraph, prefixType, token, fragments.slice(1));
 }
 
 // For most tokens, we only care about the kind. But some tokens just have a
@@ -73,12 +82,14 @@ String _tokenId(Json token) {
 
 typedef PrefixParselet =
     (ReferredType, TokenList) Function(
+      Context context,
       ParsedSymbolgraph symbolgraph,
       Json token,
       TokenList fragments,
     );
 
 (ReferredType, TokenList) _typeIdentifierParselet(
+  Context context,
   ParsedSymbolgraph symbolgraph,
   Json token,
   TokenList fragments,
@@ -92,11 +103,12 @@ typedef PrefixParselet =
     );
   }
 
-  final type = parseDeclaration(symbol, symbolgraph).asDeclaredType;
+  final type = parseDeclaration(context, symbol, symbolgraph).asDeclaredType;
   return (type, fragments);
 }
 
 (ReferredType, TokenList) _tupleParselet(
+  Context context,
   ParsedSymbolgraph symbolgraph,
   Json token,
   TokenList fragments,
@@ -119,6 +131,7 @@ Map<String, PrefixParselet> _prefixParsets = {
 
 typedef SuffixParselet =
     (ReferredType, TokenList) Function(
+      Context context,
       ParsedSymbolgraph symbolgraph,
       ReferredType prefixType,
       Json token,
@@ -126,6 +139,7 @@ typedef SuffixParselet =
     );
 
 (ReferredType, TokenList) _optionalParselet(
+  Context context,
   ParsedSymbolgraph symbolgraph,
   ReferredType prefixType,
   Json token,
@@ -133,6 +147,7 @@ typedef SuffixParselet =
 ) => (OptionalType(prefixType), fragments);
 
 (ReferredType, TokenList) _nestedTypeParselet(
+  Context context,
   ParsedSymbolgraph symbolgraph,
   ReferredType prefixType,
   Json token,
@@ -141,7 +156,7 @@ typedef SuffixParselet =
   // Parsing Foo.Bar. Foo is in prefixType, and the token is ".". Bar's ID
   // is a globally uniquely identifier. We don't need to use Foo as a namespace.
   // So we can actually completely discard Foo and just parse Bar.
-  return parseType(symbolgraph, fragments);
+  return parseType(context, symbolgraph, fragments);
 }
 
 Map<String, SuffixParselet> _suffixParsets = {

--- a/pkgs/swift2objc/lib/src/transformer/transform.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transform.dart
@@ -11,6 +11,7 @@ import '../ast/declarations/compounds/struct_declaration.dart';
 import '../ast/declarations/globals/globals.dart';
 import '../ast/declarations/typealias_declaration.dart';
 import '../ast/visitor.dart';
+import '../context.dart';
 import '_core/dependencies.dart';
 import '_core/unique_namer.dart';
 import 'transformers/transform_compound.dart';
@@ -30,18 +31,25 @@ class TransformationState {
 
 /// Transforms the given declarations into the desired ObjC wrapped declarations
 List<Declaration> transform(
+  Context context,
   List<Declaration> declarations, {
   required bool Function(Declaration) filter,
 }) {
   final state = TransformationState();
 
-  final includes = visit(FindIncludesVisitation(filter), declarations).includes;
+  final includes = visit(
+    context,
+    FindIncludesVisitation(filter),
+    declarations,
+  ).includes;
   final directTransitives = visit(
+    context,
     FindDirectTransitiveDepsVisitation(includes),
     includes,
   ).directTransitives;
   state.bindings.addAll(includes.union(directTransitives));
   final listDecls = visit(
+    context,
     ListDeclsVisitation(includes, directTransitives),
     state.bindings,
   );

--- a/pkgs/swift2objc/lib/swift2objc.dart
+++ b/pkgs/swift2objc/lib/swift2objc.dart
@@ -4,10 +4,10 @@
 
 export 'src/config.dart'
     show
-        Config,
         FilesInputConfig,
         InputConfig,
         JsonFileInputConfig,
-        ModuleInputConfig;
+        ModuleInputConfig,
+        Swift2ObjCGenerator;
 export 'src/generate_wrapper.dart';
 export 'src/utils.dart';

--- a/pkgs/swift2objc/test/integration/integration_test.dart
+++ b/pkgs/swift2objc/test/integration/integration_test.dart
@@ -62,16 +62,14 @@ void main([List<String>? args]) {
             ? expectedOutputFile
             : path.join(tempDir, '$name$outputSuffix');
 
-        await generateWrapper(
-          Config(
-            inputs: [
-              FilesInputConfig(files: [Uri.file(inputFile)]),
-            ],
-            outputFile: Uri.file(actualOutputFile),
-            tempDir: Directory(tempDir).uri,
-            preamble: '// Test preamble text',
-          ),
-        );
+        await Swift2ObjCGenerator(
+          inputs: [
+            FilesInputConfig(files: [Uri.file(inputFile)]),
+          ],
+          outputFile: Uri.file(actualOutputFile),
+          tempDir: Directory(tempDir).uri,
+          preamble: '// Test preamble text',
+        ).generate(logger: Logger.root);
 
         final actualOutput = await File(actualOutputFile).readAsString();
         final expectedOutput = File(expectedOutputFile).readAsStringSync();

--- a/pkgs/swift2objc/test/unit/filter_test.dart
+++ b/pkgs/swift2objc/test/unit/filter_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:swift2objc/src/ast/_core/interfaces/declaration.dart';
 import 'package:swift2objc/src/ast/declarations/compounds/class_declaration.dart';
@@ -35,17 +36,15 @@ void main([List<String>? args]) {
           '${p.basenameWithoutExtension(output)}.g.swift',
         );
 
-        await generateWrapper(
-          Config(
-            inputs: [
-              FilesInputConfig(files: [Uri.file(inputFile)]),
-            ],
-            outputFile: Uri.file(actualOutputFile),
-            tempDir: Directory(tempDir).uri,
-            preamble: '// Test preamble text',
-            include: include,
-          ),
-        );
+        await Swift2ObjCGenerator(
+          inputs: [
+            FilesInputConfig(files: [Uri.file(inputFile)]),
+          ],
+          outputFile: Uri.file(actualOutputFile),
+          tempDir: Directory(tempDir).uri,
+          preamble: '// Test preamble text',
+          include: include,
+        ).generate(logger: Logger.root);
 
         if (regen) {
           File(actualOutputFile).copySync(output);

--- a/pkgs/swift2objc/test/unit/parse_function_info_test.dart
+++ b/pkgs/swift2objc/test/unit/parse_function_info_test.dart
@@ -4,15 +4,18 @@
 
 import 'dart:convert';
 
+import 'package:logging/logging.dart';
 import 'package:swift2objc/src/ast/_core/shared/parameter.dart';
 import 'package:swift2objc/src/ast/_core/shared/referred_type.dart';
 import 'package:swift2objc/src/ast/declarations/built_in/built_in_declaration.dart';
+import 'package:swift2objc/src/context.dart';
 import 'package:swift2objc/src/parser/_core/json.dart';
 import 'package:swift2objc/src/parser/_core/parsed_symbolgraph.dart';
 import 'package:swift2objc/src/parser/parsers/declaration_parsers/parse_function_declaration.dart';
 import 'package:test/test.dart';
 
 void main() {
+  final context = Context(Logger.root);
   final parsedSymbols = {
     for (final decl in builtInDeclarations)
       decl.id: ParsedSymbol(source: null, json: Json(null), declaration: decl),
@@ -63,7 +66,7 @@ void main() {
         '''),
       );
 
-      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final info = parseFunctionInfo(context, json, emptySymbolgraph);
 
       final expectedParams = [
         Parameter(
@@ -117,7 +120,7 @@ void main() {
         '''),
       );
 
-      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final info = parseFunctionInfo(context, json, emptySymbolgraph);
 
       final expectedParams = [
         Parameter(
@@ -156,7 +159,7 @@ void main() {
         '''),
       );
 
-      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final info = parseFunctionInfo(context, json, emptySymbolgraph);
 
       final expectedParams = [Parameter(name: 'parameter', type: intType)];
 
@@ -175,7 +178,7 @@ void main() {
         '''),
       );
 
-      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final info = parseFunctionInfo(context, json, emptySymbolgraph);
 
       expectEqualParams(info.params, []);
       expect(info.throws, isFalse);
@@ -209,7 +212,7 @@ void main() {
         '''),
       );
 
-      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final info = parseFunctionInfo(context, json, emptySymbolgraph);
 
       final expectedParams = [Parameter(name: 'parameter', type: intType)];
 
@@ -235,7 +238,7 @@ void main() {
         '''),
       );
 
-      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final info = parseFunctionInfo(context, json, emptySymbolgraph);
 
       expectEqualParams(info.params, []);
       expect(info.throws, isFalse);
@@ -254,7 +257,7 @@ void main() {
         '''),
       );
 
-      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final info = parseFunctionInfo(context, json, emptySymbolgraph);
 
       expectEqualParams(info.params, []);
       expect(info.throws, isFalse);
@@ -288,7 +291,7 @@ void main() {
         '''),
       );
 
-      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final info = parseFunctionInfo(context, json, emptySymbolgraph);
 
       final expectedParams = [Parameter(name: 'parameter', type: intType)];
 
@@ -318,7 +321,7 @@ void main() {
         '''),
       );
 
-      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final info = parseFunctionInfo(context, json, emptySymbolgraph);
 
       final expectedParams = [Parameter(name: 'parameter', type: intType)];
 
@@ -340,7 +343,7 @@ void main() {
         '''),
       );
 
-      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final info = parseFunctionInfo(context, json, emptySymbolgraph);
 
       expectEqualParams(info.params, []);
       expect(info.throws, isTrue);
@@ -374,7 +377,7 @@ void main() {
         '''),
       );
 
-      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final info = parseFunctionInfo(context, json, emptySymbolgraph);
 
       final expectedParams = [Parameter(name: 'parameter', type: intType)];
 
@@ -412,7 +415,7 @@ void main() {
         '''),
       );
 
-      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final info = parseFunctionInfo(context, json, emptySymbolgraph);
 
       final expectedParams = [Parameter(name: 'parameter', type: intType)];
 
@@ -507,7 +510,7 @@ void main() {
         '''),
       );
 
-      final info = parseFunctionInfo(json, emptySymbolgraph);
+      final info = parseFunctionInfo(context, json, emptySymbolgraph);
 
       expect(info.throws, isTrue);
       expect(info.mutating, isTrue);
@@ -534,7 +537,7 @@ void main() {
       );
 
       expect(
-        () => parseFunctionInfo(json, emptySymbolgraph),
+        () => parseFunctionInfo(context, json, emptySymbolgraph),
         throwsA(isA<Exception>()),
       );
     });
@@ -554,7 +557,7 @@ void main() {
       );
 
       expect(
-        () => parseFunctionInfo(json, emptySymbolgraph),
+        () => parseFunctionInfo(context, json, emptySymbolgraph),
         throwsA(isA<Exception>()),
       );
     });
@@ -577,7 +580,7 @@ void main() {
       );
 
       expect(
-        () => parseFunctionInfo(json, emptySymbolgraph),
+        () => parseFunctionInfo(context, json, emptySymbolgraph),
         throwsA(isA<Exception>()),
       );
     });

--- a/pkgs/swift2objc/test/unit/parse_type_test.dart
+++ b/pkgs/swift2objc/test/unit/parse_type_test.dart
@@ -4,10 +4,12 @@
 
 import 'dart:convert';
 
+import 'package:logging/logging.dart';
 import 'package:swift2objc/src/ast/_core/interfaces/declaration.dart';
 import 'package:swift2objc/src/ast/_core/shared/referred_type.dart';
 import 'package:swift2objc/src/ast/declarations/built_in/built_in_declaration.dart';
 import 'package:swift2objc/src/ast/declarations/compounds/class_declaration.dart';
+import 'package:swift2objc/src/context.dart';
 import 'package:swift2objc/src/parser/_core/json.dart';
 import 'package:swift2objc/src/parser/_core/parsed_symbolgraph.dart';
 import 'package:swift2objc/src/parser/_core/token_list.dart';
@@ -15,6 +17,8 @@ import 'package:swift2objc/src/parser/parsers/parse_type.dart';
 import 'package:test/test.dart';
 
 void main() {
+  final context = Context(Logger.root);
+
   final classFoo = ClassDeclaration(
     id: 'Foo',
     name: 'Foo',
@@ -53,7 +57,11 @@ void main() {
       '''),
     );
 
-    final (type, remaining) = parseType(parsedSymbols, TokenList(fragments));
+    final (type, remaining) = parseType(
+      context,
+      parsedSymbols,
+      TokenList(fragments),
+    );
 
     expect(type.sameAs(intType), isTrue);
     expect(remaining.length, 0);
@@ -71,7 +79,11 @@ void main() {
       '''),
     );
 
-    final (type, remaining) = parseType(parsedSymbols, TokenList(fragments));
+    final (type, remaining) = parseType(
+      context,
+      parsedSymbols,
+      TokenList(fragments),
+    );
 
     expect(type.sameAs(voidType), isTrue);
     expect(remaining.length, 0);
@@ -94,7 +106,11 @@ void main() {
       '''),
     );
 
-    final (type, remaining) = parseType(parsedSymbols, TokenList(fragments));
+    final (type, remaining) = parseType(
+      context,
+      parsedSymbols,
+      TokenList(fragments),
+    );
 
     expect(type.sameAs(OptionalType(intType)), isTrue);
     expect(remaining.length, 0);
@@ -122,7 +138,11 @@ void main() {
       '''),
     );
 
-    final (type, remaining) = parseType(parsedSymbols, TokenList(fragments));
+    final (type, remaining) = parseType(
+      context,
+      parsedSymbols,
+      TokenList(fragments),
+    );
 
     expect(type.sameAs(classBar.asDeclaredType), isTrue);
     expect(remaining.length, 0);
@@ -157,7 +177,11 @@ void main() {
       '''),
     );
 
-    final (type, remaining) = parseType(parsedSymbols, TokenList(fragments));
+    final (type, remaining) = parseType(
+      context,
+      parsedSymbols,
+      TokenList(fragments),
+    );
 
     expect(type.sameAs(OptionalType(intType)), isFalse);
     expect(
@@ -193,7 +217,11 @@ void main() {
       '''),
     );
 
-    final (type, remaining) = parseType(parsedSymbols, TokenList(fragments));
+    final (type, remaining) = parseType(
+      context,
+      parsedSymbols,
+      TokenList(fragments),
+    );
 
     expect(type.sameAs(OptionalType(intType)), isTrue);
     expect(remaining.length, 2);


### PR DESCRIPTION
- Rename `Config` to `Swift2ObjCGenerator`.
- Make `generateWrapper` an extension method on `Swift2ObjCGenerator` and rename it `generate`.
- Take a `Logger` as input in `generate`.
- Pass the logger throughout the API in a `Context` object.

Fixes https://github.com/dart-lang/native/issues/1143