### PR TITLE
[ffigen] Rename `FfiGen` to `FfiGenerator`

### DIFF
--- a/pkgs/ffigen/lib/ffigen.dart
+++ b/pkgs/ffigen/lib/ffigen.dart
@@ -18,7 +18,7 @@ export 'src/config_provider.dart'
         Declaration,
         DeclarationFilters,
         ExternalVersions,
-        FfiGen,
+        FfiGenerator,
         FfiNativeConfig,
         Language,
         PackingValue,
@@ -27,4 +27,3 @@ export 'src/config_provider.dart'
         Versions,
         YamlConfig,
         defaultCompilerOpts;
-export 'src/ffigen.dart' show FfiGenGenerator;

--- a/pkgs/ffigen/lib/src/config_provider/config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config.dart
@@ -2,11 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:logging/logging.dart';
+
 import '../code_generator.dart';
+import '../ffigen.dart';
 import 'config_types.dart';
 
-/// Provides configurations to other modules.
-final class FfiGen {
+/// The generator that generates bindings for `dart:ffi` from C and Objective-C
+/// headers.
+// TODO: Add a code snippet example.
+final class FfiGenerator {
   /// Input config filename, if any.
   final Uri? filename;
 
@@ -240,7 +245,7 @@ final class FfiGen {
   /// before this version will not be generated.
   final ExternalVersions externalVersions;
 
-  FfiGen({
+  FfiGenerator({
     this.filename,
     required this.output,
     this.outputObjC,
@@ -295,9 +300,16 @@ final class FfiGen {
     this.externalVersions = const ExternalVersions(),
     @Deprecated('Only visible for YamlConfig plumbing.') this.libclangDylib,
   });
+
+  /// Run this generator.
+  void generate({required Logger? logger, Uri? libclangDylib}) {
+    return FfiGenGenerator(
+      this,
+    ).generate(logger: logger, libclangDylib: libclangDylib);
+  }
 }
 
-extension type Config(FfiGen ffiGen) implements FfiGen {
+extension type Config(FfiGenerator ffiGen) implements FfiGenerator {
   Map<String, LibraryImport> get libraryImports => ffiGen._libraryImports;
 
   Map<String, ImportedType> get typedefTypeMappings =>

--- a/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/yaml_config.dart
@@ -1236,7 +1236,7 @@ final class YamlConfig {
     );
   }
 
-  FfiGen configAdapter() => FfiGen(
+  FfiGenerator configAdapter() => FfiGenerator(
     output: output,
     filename: filename,
     outputObjC: outputObjC,

--- a/pkgs/ffigen/lib/src/context.dart
+++ b/pkgs/ffigen/lib/src/context.dart
@@ -37,15 +37,15 @@ class Context {
 
   late final compilerOpts = config.compilerOpts ?? defaultCompilerOpts(logger);
 
-  Context(this.logger, FfiGen config, {Uri? libclangDylib})
-    : config = Config(config),
+  Context(this.logger, FfiGenerator generator, {Uri? libclangDylib})
+    : config = Config(generator),
       cursorIndex = CursorIndex(logger),
       objCBuiltInFunctions = ObjCBuiltInFunctions(
-        config.wrapperName,
-        config.generateForPackageObjectiveC,
+        generator.wrapperName,
+        generator.generateForPackageObjectiveC,
       ) {
     final libclangDylibPath =
-        config.libclangDylib?.toFilePath() ??
+        generator.libclangDylib?.toFilePath() ??
         libclangDylib?.toFilePath() ??
         findDylibAtDefaultLocations(logger);
     _clang ??= Clang(DynamicLibrary.open(libclangDylibPath));

--- a/pkgs/ffigen/lib/src/executables/ffigen.dart
+++ b/pkgs/ffigen/lib/src/executables/ffigen.dart
@@ -49,18 +49,21 @@ Future<void> main(List<String> args) async {
   Logger.root.level = _parseLogLevel(argResult);
 
   // Create a config object.
-  FfiGen config;
+  FfiGenerator generator;
   try {
-    config = getConfig(argResult, await findPackageConfig(Directory.current));
+    generator = getGenerator(
+      argResult,
+      await findPackageConfig(Directory.current),
+    );
   } on FormatException {
     logger.severe('Please fix configuration errors and re-run the tool.');
     exit(1);
   }
 
-  config.generate(logger: logger);
+  generator.generate(logger: logger);
 }
 
-FfiGen getConfig(ArgResults result, PackageConfig? packageConfig) {
+FfiGenerator getGenerator(ArgResults result, PackageConfig? packageConfig) {
   logger.info('Running in ${Directory.current}');
   YamlConfig config;
 

--- a/pkgs/ffigen/lib/src/ffigen.dart
+++ b/pkgs/ffigen/lib/src/ffigen.dart
@@ -7,13 +7,13 @@ import 'dart:io';
 import 'package:cli_util/cli_logging.dart' show Ansi;
 import 'package:logging/logging.dart';
 
-import 'config_provider.dart' show Config, FfiGen;
+import 'config_provider.dart' show Config, FfiGenerator;
 import 'context.dart';
 import 'header_parser.dart' show parse;
 
 final _ansi = Ansi(Ansi.terminalSupportsAnsi);
 
-extension FfiGenGenerator on FfiGen {
+extension FfiGenGenerator on FfiGenerator {
   /// Runs the entire generation pipeline for the given config.
   void generate({required Logger? logger, Uri? libclangDylib}) {
     logger ??= Logger.detached('dev/null')..level = Level.OFF;

--- a/pkgs/ffigen/test/code_generator_tests/code_generator_test.dart
+++ b/pkgs/ffigen/test/code_generator_tests/code_generator_test.dart
@@ -40,7 +40,10 @@ void main() {
     ) {
       final library = Library(
         context: testContext(
-          FfiGen(ffiNativeConfig: nativeConfig, output: Uri.file('unused')),
+          FfiGenerator(
+            ffiNativeConfig: nativeConfig,
+            output: Uri.file('unused'),
+          ),
         ),
         name: 'Bindings',
         header: licenseHeader,

--- a/pkgs/ffigen/test/collision_tests/decl_decl_collision_test.dart
+++ b/pkgs/ffigen/test/collision_tests/decl_decl_collision_test.dart
@@ -15,7 +15,7 @@ void main() {
       logWarnings(Level.SEVERE);
     });
     test('declaration conflict', () {
-      final config = FfiGen(
+      final generator = FfiGenerator(
         entryPoints: [],
         output: Uri(),
         functionDecl: DeclarationFilters.includeAll,
@@ -81,7 +81,7 @@ void main() {
             name: 'ffi\$1',
             returnType: NativeType(SupportedNativeType.voidType),
           ),
-        ], testContext(config)),
+        ], testContext(generator)),
       );
       matchLibraryWithExpected(
         library,

--- a/pkgs/ffigen/test/collision_tests/reserved_keyword_collision_test.dart
+++ b/pkgs/ffigen/test/collision_tests/reserved_keyword_collision_test.dart
@@ -18,7 +18,7 @@ void main() {
     test('reserved keyword collision', () {
       final library = parser.parse(
         testContext(
-          FfiGen(
+          FfiGenerator(
             output: Uri.file('unused'),
             entryPoints: [
               Uri.file(

--- a/pkgs/ffigen/test/config_tests/include_exclude_test.dart
+++ b/pkgs/ffigen/test/config_tests/include_exclude_test.dart
@@ -43,7 +43,7 @@ void main() {
   });
 }
 
-FfiGen _makeFieldIncludeExcludeConfig({
+FfiGenerator _makeFieldIncludeExcludeConfig({
   required String field,
   String? include,
   String? exclude,

--- a/pkgs/ffigen/test/example_tests/libclang_example_test.dart
+++ b/pkgs/ffigen/test/example_tests/libclang_example_test.dart
@@ -27,15 +27,15 @@ void main() {
           'config.yaml',
         ),
       ).absolute;
-      late FfiGen config;
+      late FfiGenerator generator;
       late Library library;
       withChDir(configYaml.path, () {
-        config = testConfigFromPath(configYaml.path);
-        library = parse(testContext(config));
+        generator = testConfigFromPath(configYaml.path);
+        library = parse(testContext(generator));
       });
 
       matchLibraryWithExpected(library, 'example_libclang.dart', [
-        config.output.toFilePath(),
+        generator.output.toFilePath(),
       ]);
     });
   });

--- a/pkgs/ffigen/test/header_parser_tests/separate_definition_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/separate_definition_test.dart
@@ -32,7 +32,7 @@ void main() {
   });
 }
 
-FfiGen _makeConfig(List<String> entryPoints) {
+FfiGenerator _makeConfig(List<String> entryPoints) {
   final entryPointBuilder = StringBuffer();
   for (final ep in entryPoints) {
     entryPointBuilder.writeln('    - $ep');

--- a/pkgs/ffigen/test/header_parser_tests/sort_test.dart
+++ b/pkgs/ffigen/test/header_parser_tests/sort_test.dart
@@ -18,7 +18,7 @@ void main() {
       logWarnings();
       actual = parser.parse(
         testContext(
-          FfiGen(
+          FfiGenerator(
             output: Uri.file('unused'),
             entryPoints: [
               Uri.file(

--- a/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
+++ b/pkgs/ffigen/test/large_integration_tests/large_objc_test.dart
@@ -71,7 +71,7 @@ void main() {
     // TODO(https://github.com/dart-lang/native/issues/2517): Remove this.
     const forceIncludedProtocols = {'NSTextLocation'};
 
-    final config = FfiGen(
+    final generator = FfiGenerator(
       wrapperName: 'LargeObjCLibrary',
       language: Language.objc,
       output: Uri.file(outFile),
@@ -114,7 +114,7 @@ void main() {
     );
 
     final timer = Stopwatch()..start();
-    config.generate(
+    generator.generate(
       logger: Logger.root
         ..level = Level.SEVERE
         ..onRecord.listen((record) {

--- a/pkgs/ffigen/test/large_integration_tests/large_test.dart
+++ b/pkgs/ffigen/test/large_integration_tests/large_test.dart
@@ -26,7 +26,7 @@ void main() {
       );
       final logArr = <String>[];
       logToArray(logArr, Level.SEVERE);
-      final config = FfiGen(
+      final generator = FfiGenerator(
         wrapperName: 'LibClang',
         wrapperDocComment: 'Bindings to LibClang.',
         output: Uri.file('unused'),
@@ -68,7 +68,7 @@ void main() {
 // ignore_for_file: camel_case_types, non_constant_identifier_names
 ''',
       );
-      final library = parse(testContext(config));
+      final library = parse(testContext(generator));
 
       matchLibraryWithExpected(
         library,
@@ -120,7 +120,7 @@ void main() {
     });
 
     test('CJSON test', () {
-      final config = FfiGen(
+      final generator = FfiGenerator(
         wrapperName: 'CJson',
         wrapperDocComment: 'Bindings to Cjson.',
         output: Uri.file('unused'),
@@ -144,7 +144,7 @@ void main() {
 // ignore_for_file: camel_case_types, non_constant_identifier_names
 ''',
       );
-      final library = parse(testContext(config));
+      final library = parse(testContext(generator));
 
       matchLibraryWithExpected(library, 'large_test_cjson.dart', [
         'test',
@@ -156,7 +156,7 @@ void main() {
     test('SQLite test', () {
       // Excluding functions that use 'va_list' because it can either be a
       // Pointer<__va_list_tag> or int depending on the OS.
-      final config = FfiGen(
+      final generator = FfiGenerator(
         wrapperName: 'SQLite',
         wrapperDocComment: 'Bindings to SQLite.',
         output: Uri.file('unused'),
@@ -188,7 +188,7 @@ void main() {
 // ignore_for_file: camel_case_types, non_constant_identifier_names
 ''',
       );
-      final library = parse(testContext(config));
+      final library = parse(testContext(generator));
 
       matchLibraryWithExpected(library, 'large_test_sqlite.dart', [
         'test',

--- a/pkgs/ffigen/test/native_objc_test/deprecated_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/deprecated_test.dart
@@ -16,7 +16,7 @@ import 'package:test/test.dart';
 import '../test_utils.dart';
 
 String bindingsForVersion({Versions? iosVers, Versions? macosVers}) {
-  FfiGen(
+  FfiGenerator(
     wrapperName: 'DeprecatedTestObjCLibrary',
     wrapperDocComment: 'Tests API deprecation',
     language: Language.objc,

--- a/pkgs/ffigen/test/native_objc_test/ns_range_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/ns_range_test.dart
@@ -18,7 +18,7 @@ void main() {
   group('NSRange', () {
     late final String bindings;
     setUpAll(() {
-      FfiGen(
+      FfiGenerator(
         wrapperName: 'NSRangeTestObjCLibrary',
         language: Language.objc,
         output: Uri.file(

--- a/pkgs/ffigen/test/native_objc_test/transitive_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/transitive_test.dart
@@ -19,7 +19,7 @@ String generate({
   bool includeTransitiveObjCProtocols = false,
   bool includeTransitiveObjCCategories = false,
 }) {
-  FfiGen(
+  FfiGenerator(
     wrapperName: 'TransitiveTestObjCLibrary',
     wrapperDocComment: 'Tests transitive inclusion',
     language: Language.objc,

--- a/pkgs/ffigen/test/native_test/native_test.dart
+++ b/pkgs/ffigen/test/native_test/native_test.dart
@@ -42,7 +42,7 @@ void main() {
         ),
       ).absolute;
 
-      late FfiGen config;
+      late FfiGenerator config;
       withChDir(configFile.path, () {
         config = testConfigFromPath(configFile.path);
       });

--- a/pkgs/ffigen/test/regen.dart
+++ b/pkgs/ffigen/test/regen.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:ffigen/ffigen.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'test_utils.dart';

--- a/pkgs/ffigen/test/test_utils.dart
+++ b/pkgs/ffigen/test/test_utils.dart
@@ -17,8 +17,8 @@ import 'package:yaml/yaml.dart' as yaml;
 
 export 'package:ffigen/src/config_provider/utils.dart';
 
-Context testContext([FfiGen? config]) =>
-    Context(Logger.root, config ?? FfiGen(output: Uri.file('unused')));
+Context testContext([FfiGenerator? generator]) =>
+    Context(Logger.root, generator ?? FfiGenerator(output: Uri.file('unused')));
 
 extension LibraryTestExt on Library {
   /// Get a [Binding]'s generated string with a given name.
@@ -173,7 +173,7 @@ Logger logToArray(List<String> logArr, Level level) {
   return logger;
 }
 
-FfiGen testConfig(String yamlBody, {String? filename, Logger? logger}) {
+FfiGenerator testConfig(String yamlBody, {String? filename, Logger? logger}) {
   return YamlConfig.fromYaml(
     yaml.loadYaml(yamlBody) as yaml.YamlMap,
     logger ?? Logger.root,
@@ -189,7 +189,7 @@ FfiGen testConfig(String yamlBody, {String? filename, Logger? logger}) {
   ).configAdapter();
 }
 
-FfiGen testConfigFromPath(String path) {
+FfiGenerator testConfigFromPath(String path) {
   final file = File(path);
   final yamlBody = file.readAsStringSync();
   return testConfig(yamlBody, filename: path);

--- a/pkgs/jni/tool/wrapper_generators/ffigen_util.dart
+++ b/pkgs/jni/tool/wrapper_generators/ffigen_util.dart
@@ -17,7 +17,7 @@ final dummyWriter = Writer(
   silenceEnumWarning: true,
   generateForPackageObjectiveC: false,
   nativeAssetId: null,
-  context: Context(Logger.root, FfiGen(output: Uri.file('unused'))),
+  context: Context(Logger.root, FfiGenerator(output: Uri.file('unused'))),
 );
 
 /// Find compound having [name] in [library].

--- a/pkgs/swiftgen/lib/src/config.dart
+++ b/pkgs/swiftgen/lib/src/config.dart
@@ -58,69 +58,69 @@ class ObjCCompatibleSwiftFileInput implements SwiftGenInput {
   Iterable<String> get compileArgs => const <String>[];
 }
 
-/// Selected options from [ffigen.FfiGen].
+/// Selected options from [ffigen.FfiGenerator].
 class FfiGenConfig {
-  /// [ffigen.FfiGen.output]
+  /// [ffigen.FfiGenerator.output]
   final Uri output;
 
-  /// [ffigen.FfiGen.outputObjC]
+  /// [ffigen.FfiGenerator.outputObjC]
   final Uri outputObjC;
 
-  /// [ffigen.FfiGen.wrapperName]
+  /// [ffigen.FfiGenerator.wrapperName]
   /// Defaults to the swift module name.
   final String? wrapperName;
 
-  /// [ffigen.FfiGen.wrapperDocComment]
+  /// [ffigen.FfiGenerator.wrapperDocComment]
   final String? wrapperDocComment;
 
-  /// [ffigen.FfiGen.preamble]
+  /// [ffigen.FfiGenerator.preamble]
   final String? preamble;
 
-  /// [ffigen.FfiGen.functionDecl]
+  /// [ffigen.FfiGenerator.functionDecl]
   /// Defaults to [ffigen.DeclarationFilters.excludeAll]
   final ffigen.DeclarationFilters? functionDecl;
 
-  /// [ffigen.FfiGen.structDecl]
+  /// [ffigen.FfiGenerator.structDecl]
   /// Defaults to [ffigen.DeclarationFilters.excludeAll]
   final ffigen.DeclarationFilters? structDecl;
 
-  /// [ffigen.FfiGen.unionDecl]
+  /// [ffigen.FfiGenerator.unionDecl]
   /// Defaults to [ffigen.DeclarationFilters.excludeAll]
   final ffigen.DeclarationFilters? unionDecl;
 
-  /// [ffigen.FfiGen.enumClassDecl]
+  /// [ffigen.FfiGenerator.enumClassDecl]
   /// Defaults to [ffigen.DeclarationFilters.excludeAll]
   final ffigen.DeclarationFilters? enumClassDecl;
 
-  /// [ffigen.FfiGen.unnamedEnumConstants]
+  /// [ffigen.FfiGenerator.unnamedEnumConstants]
   /// Defaults to [ffigen.DeclarationFilters.excludeAll]
   final ffigen.DeclarationFilters? unnamedEnumConstants;
 
-  /// [ffigen.FfiGen.globals]
+  /// [ffigen.FfiGenerator.globals]
   /// Defaults to [ffigen.DeclarationFilters.excludeAll]
   final ffigen.DeclarationFilters? globals;
 
-  /// [ffigen.FfiGen.macroDecl]
+  /// [ffigen.FfiGenerator.macroDecl]
   /// Defaults to [ffigen.DeclarationFilters.excludeAll]
   final ffigen.DeclarationFilters? macroDecl;
 
-  /// [ffigen.FfiGen.typedefs]
+  /// [ffigen.FfiGenerator.typedefs]
   /// Defaults to [ffigen.DeclarationFilters.excludeAll]
   final ffigen.DeclarationFilters? typedefs;
 
-  /// [ffigen.FfiGen.objcInterfaces]
+  /// [ffigen.FfiGenerator.objcInterfaces]
   /// Defaults to [ffigen.DeclarationFilters.excludeAll]
   final ffigen.DeclarationFilters? objcInterfaces;
 
-  /// [ffigen.FfiGen.objcProtocols]
+  /// [ffigen.FfiGenerator.objcProtocols]
   /// Defaults to [ffigen.DeclarationFilters.excludeAll]
   final ffigen.DeclarationFilters? objcProtocols;
 
-  /// [ffigen.FfiGen.objcCategories]
+  /// [ffigen.FfiGenerator.objcCategories]
   /// Defaults to [ffigen.DeclarationFilters.excludeAll]
   final ffigen.DeclarationFilters? objcCategories;
 
-  /// [ffigen.FfiGen.externalVersions]
+  /// [ffigen.FfiGenerator.externalVersions]
   final ffigen.ExternalVersions externalVersions;
 
   FfiGenConfig({

--- a/pkgs/swiftgen/lib/src/generator.dart
+++ b/pkgs/swiftgen/lib/src/generator.dart
@@ -37,7 +37,7 @@ extension SwiftGenGenerator on SwiftGen {
   ], absTempDir);
 
   void _generateDartFile(Logger logger) {
-    fg.FfiGen(
+    fg.FfiGenerator(
       language: fg.Language.objc,
       output: ffigen.output,
       outputObjC: ffigen.outputObjC,


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/2567

Renames  `FfiGen` to `FfiGenerator` and makes `generate` a method.

The internals of FFIgen should to be refactored a bit more to make the generator only a public class and the `Config` the only internal class. But I'm aiming to get the public API in shape right now.