### PR TITLE
[objective_c]: `ns_number.m` not included in iOS/macOS `objective_c.m` file causes `NSNumber.isFloat` crash due to selector missing at runtime

### DIFF
--- a/pkgs/objective_c/ios/Classes/objective_c.m
+++ b/pkgs/objective_c/ios/Classes/objective_c.m
@@ -7,5 +7,6 @@
 #include "../../src/input_stream_adapter.m"
 #include "../../src/objective_c.m"
 #include "../../src/objective_c_bindings_generated.m"
+#include "../../src/ns_number.m"
 #include "../../src/observer.m"
 #include "../../src/protocol.m"

--- a/pkgs/objective_c/macos/Classes/objective_c.m
+++ b/pkgs/objective_c/macos/Classes/objective_c.m
@@ -7,5 +7,6 @@
 #include "../../src/input_stream_adapter.m"
 #include "../../src/objective_c.m"
 #include "../../src/objective_c_bindings_generated.m"
+#include "../../src/ns_number.m"
 #include "../../src/observer.m"
 #include "../../src/protocol.m"


### PR DESCRIPTION
## Issue

The `NSNumber` (NSNumberIsFloat) category exists but is not compiled into the iOS/macOS plugin targets, so the `isFloat` selector is absent at runtime and can crash when used via generated bindings.

I observed this when executing `toDartMap()` on a `NSDictionary`.

Why tests didn’t catch it: the test in `setup.dart` compiles `ns_number.m` directly

Crash report from Sentry:
<img width="620" height="78" alt="image" src="https://github.com/user-attachments/assets/8313545a-99b4-407c-b22f-c7885699867c" />

## Proposed solution

Include `ns_number.m` in both iOS and macOS 

## Testing

I manually tested it but if needed I can look into improving the test suite

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
