### PR TITLE
[native_doc_dartifier] Improve Fixing Dart Code

### DIFF
--- a/pkgs/native_doc_dartifier/lib/src/code_processor.dart
+++ b/pkgs/native_doc_dartifier/lib/src/code_processor.dart
@@ -15,7 +15,7 @@ class CodeProcessor {
     }
   }
 
-  Future<String> analyzeCode(String mainCode, String helperCode) async {
+  Future<List<String>> analyzeCode(String mainCode, String helperCode) async {
     await _saveCodeToFile(mainCode, helperCode);
     final dartifiedFile = File('${_tempDir.path}/$_dartifiedCodeFileName');
     final analysisResult = await Process.run('dart', [
@@ -23,16 +23,12 @@ class CodeProcessor {
       dartifiedFile.absolute.path,
     ], runInShell: true);
 
-    var errorMessage = '';
-
     final allLines = analysisResult.stdout.toString().trim().split('\n');
     final errorLines =
         allLines.where((line) => line.trim().startsWith('error -')).toList();
 
-    errorMessage = errorLines.join('\n');
-
     await _cleanUp();
-    return errorMessage;
+    return errorLines;
   }
 
   Future<void> _saveCodeToFile(String mainCode, String helperCode) async {

--- a/pkgs/native_doc_dartifier/lib/src/prompts.dart
+++ b/pkgs/native_doc_dartifier/lib/src/prompts.dart
@@ -154,7 +154,7 @@ also provide your thinking process. Explain your approach to fixing the errors, 
 1.  **Use Previous Bindings:** Please use the JNIgen bindings to correctly resolve the remaining errors, for example use the correct class name, or use the correct method with the given number and types of parameters.
 2.  **Prioritize Helper File:** Make changes to the **helper Dart file** first.
 3.  **Modify Main File as a Last Resort:** Only alter the **main Dart file** if the problems cannot be resolved within the helper file.
-4.  **Minimalist Fixes:** Add only the code necessary to fix the remaining errors in the **helper Dart file**. Do not write a complete or fully initialized implementation.
+4.  **Minimalist Fixes:** Add only the code necessary to fix the remaining errors in the **helper Dart file**. Do not write a complete or fully initialized implementation for example you can initialize missing declerations like (late final Foo;).
 5.  **Valid Dart Syntax:** Ensure all generated Dart code is valid. Avoid using backslashes (`\\`) before dollar signs (`\$`).
 
 ---

--- a/pkgs/native_doc_dartifier/lib/src/prompts.dart
+++ b/pkgs/native_doc_dartifier/lib/src/prompts.dart
@@ -135,6 +135,7 @@ class FixPrompt implements Prompt {
   final String _schema = '''
 Output the response in JSON format:
 {
+  "thinking": "Your thinking process here",
   "mainDartCode": "Dart code here",
   "helperDartCode": "Dart code here"
 }
@@ -142,22 +143,33 @@ Output the response in JSON format:
 
   @override
   String get prompt => '''
-  You are an expert Dart code fixer. Your task is to fix the provided main Dart code based on the analysis results.
-  Here is the main Dart file code that needs fixing:
-  $mainDartCode
-  Here is the helper Dart file that you can use to add initialization code or other necessary imports to fix the issues in the main Dart code file:
-  $helperDartCode
-  Here are the issues found in the main Dart code:
-  $analysisResult
+I need your help fixing some analyzer errors in the Dart code you generated for me.
 
-  $_schema
+also provide your thinking process. Explain your approach to fixing the errors, identify the specific issues, and describe how you will use the previously shared bindings and code to solve them.
 
-  try to add initialization or imports or whatever in the helper Dart file to fix the errors as the main Dart file import this helper Dart file.
-  change the main Dart file only if you can't fix the issues by adding code to the helper Dart file.
-  do not make a full initializaiton or completed code in the helper Dart file, just add the necessary code to fix the issues in the main Dart file even if not complete.
+---
 
-  Make sure to not use a backslash (`\\`) before Dollar sign ('\$') in the Dart code, as it is not a valid Dart.
-  ''';
+**Instructions:**
+
+1.  **Use Previous Bindings:** Please use the JNIgen bindings to correctly resolve the remaining errors, for example use the correct class name, or use the correct method with the given number and types of parameters.
+2.  **Prioritize Helper File:** Make changes to the **helper Dart file** first.
+3.  **Modify Main File as a Last Resort:** Only alter the **main Dart file** if the problems cannot be resolved within the helper file.
+4.  **Minimalist Fixes:** Add only the code necessary to fix the remaining errors in the **helper Dart file**. Do not write a complete or fully initialized implementation.
+5.  **Valid Dart Syntax:** Ensure all generated Dart code is valid. Avoid using backslashes (`\\`) before dollar signs (`\$`).
+
+---
+
+Here is the main Dart file code that needs fixing:
+$mainDartCode
+
+Here is the helper Dart file that you can use to add initialization code or other necessary imports to fix the issues in the main Dart code file:
+$helperDartCode
+
+Here are the issues found in the main Dart code:
+$analysisResult
+
+$_schema
+''';
 
   @override
   FixResponse getParsedResponse(String response) {


### PR DESCRIPTION
CI output: marshelino-maged/native#17
closes: #2490
closes: #2442

## Summary
- Return the Dart code with the **fewest** analyzer errors from the loop  
- Updated fix prompt with clearer instructions.
- Switched to the Single-Prompt **Chain-of-Thought** Approach: model first **plans (think)**, then **applies the fix** — which is equivalent to making the LLM think in one prompt and fix in another ... it is like the Teacher Learner Model.

---

CC @HosseinYousefi 
- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.