### PR TITLE
[ffigen] [objective_c] Publish v20 and v9 dev releases

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 20.0.0-wip
+## 20.0.0-dev.0
 
 - __Breaking change__: Completely rewrite the public Dart API for FFIgen.
   The new API is focused on a declartive configuration: `FfiGenerate(...)` with

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: ffigen
-version: 20.0.0-wip
+version: 20.0.0-dev.0
 description: >
   Generator for FFI bindings, using LibClang to parse C, Objective-C, and Swift
   files.
@@ -40,7 +40,7 @@ dev_dependencies:
   dart_flutter_team_lints: ^3.5.2
   json_schema: ^5.1.1
   leak_tracker: ^10.0.7
-  objective_c: ^8.1.0
+  objective_c: ^9.0.0-dev.0
   test: ^1.16.2
 
 dependency_overrides:

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 9.0.0-wip
+## 9.0.0-dev.0
 
 - Use ffigen 20.0.0
 - Fix missing `NSNumber` category includes in iOS and macOS `objective_c.m` files

--- a/pkgs/objective_c/pubspec.yaml
+++ b/pkgs/objective_c/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: objective_c
 description: 'A library to access Objective C from Flutter that acts as a support library for package:ffigen.'
-version: 9.0.0-wip
+version: 9.0.0-dev.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/objective_c
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aobjective_c
 
@@ -27,7 +27,7 @@ dependencies:
 dev_dependencies:
   args: ^2.6.0
   dart_flutter_team_lints: ^3.5.2
-  ffigen: ^19.1.0
+  ffigen: ^20.0.0-dev.0
   flutter_test:
     sdk: flutter
   native_test_helpers:


### PR DESCRIPTION
Let's publish a dev release so that the samples of `code_assets` can import that, but we can still iterate on the Dart API before we make a stable release.