### PR TITLE
[ffigen] Add another `libclang` discovery mechanism

### DIFF
--- a/pkgs/ffigen/lib/src/config_provider/spec_utils.dart
+++ b/pkgs/ffigen/lib/src/config_provider/spec_utils.dart
@@ -4,7 +4,6 @@
 
 import 'dart:io';
 
-import 'package:ffigen/src/strings.dart';
 import 'package:file/local.dart';
 import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
@@ -418,7 +417,7 @@ String findDylibAtDefaultLocations(Logger logger) {
   }
 
   final clangPrintFileNameResult = Process.runSync('clang', [
-    '-print-file-name=$dylibFileName',
+    '-print-file-name=${strings.dylibFileName}',
   ]);
   if (clangPrintFileNameResult.exitCode == 0) {
     final path = (clangPrintFileNameResult.stdout as String).trim();


### PR DESCRIPTION
This PR adds another discovery mechanism for the `libclang` dynamic library.

In certain environments (specifically, I ran into this in a Nix-based setup), the current `libclang` discovery mechanisms aren't able to find the copy of `libclang.so`.

After tinkering for a bit, the mechanism introduced in this PR seemed fairly reliable across operating systems when `clang` is on the path. Worked for both nix and home-brew installed LLVM + Clang.

When the clang installation can't find the dynamic library, it just echos back the name of the file. But when it does work, it prints out an absolute path to the file (thus, the file exists check).


CC @dcharkes since it looks like you did some similar work a bit ago: https://github.com/dart-lang/native/commit/153aad5cab417fd86691a8cd07f960419fa1411b

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
