### PR TITLE
[swiftgen] Allow user to use custom module function

### DIFF
--- a/pkgs/ffigen/lib/src/config_provider/config.dart
+++ b/pkgs/ffigen/lib/src/config_provider/config.dart
@@ -504,8 +504,6 @@ final class Interfaces extends Declarations {
   /// The module that the Objective-C interface belongs to.
   final String? Function(Declaration declaration) module;
 
-  static String? _moduleDefault(Declaration declaration) => null;
-
   const Interfaces({
     super.include,
     super.includeMember,
@@ -513,7 +511,7 @@ final class Interfaces extends Declarations {
     super.rename,
     super.renameMember,
     this.includeTransitive = false,
-    this.module = _moduleDefault,
+    this.module = noModule,
   });
 
   static const excludeAll = Interfaces(include: _excludeAll);
@@ -523,6 +521,8 @@ final class Interfaces extends Declarations {
   static Interfaces includeSet(Set<String> names) => Interfaces(
     include: (Declaration decl) => names.contains(decl.originalName),
   );
+
+  static String? noModule(Declaration declaration) => null;
 }
 
 /// Configuration for Objective-C protocols.
@@ -536,8 +536,6 @@ final class Protocols extends Declarations {
   /// The module that the Objective-C protocol belongs to.
   final String? Function(Declaration declaration) module;
 
-  static String? _moduleDefault(Declaration declaration) => null;
-
   const Protocols({
     super.include,
     super.includeMember,
@@ -545,7 +543,7 @@ final class Protocols extends Declarations {
     super.rename,
     super.renameMember,
     this.includeTransitive = false,
-    this.module = _moduleDefault,
+    this.module = noModule,
   });
 
   static const excludeAll = Protocols(include: _excludeAll);
@@ -555,6 +553,8 @@ final class Protocols extends Declarations {
   static Protocols includeSet(Set<String> names) => Protocols(
     include: (Declaration decl) => names.contains(decl.originalName),
   );
+
+  static String? noModule(Declaration declaration) => null;
 }
 
 /// Configuration for outputting bindings.
@@ -696,6 +696,8 @@ extension type Config(FfiGenerator ffiGen) implements FfiGenerator {
   Uri get output => ffiGen.output.dartFile;
 
   Uri get outputObjC => ffiGen.output._objectiveCFile;
+
+  BindingStyle get outputStyle => ffiGen.output.style;
 
   SymbolFile? get symbolFile => ffiGen.output.symbolFile;
 

--- a/pkgs/swiftgen/CHANGELOG.md
+++ b/pkgs/swiftgen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1
+
+- Fix bug where `SwiftGenerator.ffigen.objectiveC.(interfaces|protocols).module`
+  is ignored.
+
 ## 0.1.0
 
 - MVP version.

--- a/pkgs/swiftgen/lib/src/generator.dart
+++ b/pkgs/swiftgen/lib/src/generator.dart
@@ -76,6 +76,8 @@ extension SwiftGenGenerator on SwiftGenerator {
   ], absTempDir);
 
   void _generateDartFile(Logger logger, String objcHeader) {
+    final interfaces = ffigen.objectiveC.interfaces;
+    final protocols = ffigen.objectiveC.protocols;
     fg.FfiGenerator(
       output: fg.Output(
         dartFile: output.dartFile,
@@ -98,24 +100,26 @@ extension SwiftGenGenerator on SwiftGenerator {
       typedefs: ffigen.typedefs,
       objectiveC: fg.ObjectiveC(
         interfaces: fg.Interfaces(
-          include: ffigen.objectiveC.interfaces.include,
-          includeMember: ffigen.objectiveC.interfaces.includeMember,
-          includeSymbolAddress:
-              ffigen.objectiveC.interfaces.includeSymbolAddress,
-          rename: ffigen.objectiveC.interfaces.rename,
-          renameMember: ffigen.objectiveC.interfaces.renameMember,
-          includeTransitive: ffigen.objectiveC.interfaces.includeTransitive,
-          module: (_) => output.module,
+          include: interfaces.include,
+          includeMember: interfaces.includeMember,
+          includeSymbolAddress: interfaces.includeSymbolAddress,
+          rename: interfaces.rename,
+          renameMember: interfaces.renameMember,
+          includeTransitive: interfaces.includeTransitive,
+          module: interfaces.module != fg.Interfaces.noModule
+              ? interfaces.module
+              : (_) => output.module,
         ),
         protocols: fg.Protocols(
-          include: ffigen.objectiveC.protocols.include,
-          includeMember: ffigen.objectiveC.protocols.includeMember,
-          includeSymbolAddress:
-              ffigen.objectiveC.protocols.includeSymbolAddress,
-          rename: ffigen.objectiveC.protocols.rename,
-          renameMember: ffigen.objectiveC.protocols.renameMember,
-          includeTransitive: ffigen.objectiveC.protocols.includeTransitive,
-          module: (_) => output.module,
+          include: protocols.include,
+          includeMember: protocols.includeMember,
+          includeSymbolAddress: protocols.includeSymbolAddress,
+          rename: protocols.rename,
+          renameMember: protocols.renameMember,
+          includeTransitive: protocols.includeTransitive,
+          module: protocols.module != fg.Protocols.noModule
+              ? protocols.module
+              : (_) => output.module,
         ),
         categories: ffigen.objectiveC.categories,
         externalVersions: ffigen.objectiveC.externalVersions,

--- a/pkgs/swiftgen/pubspec.yaml
+++ b/pkgs/swiftgen/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: swiftgen
 description: 'A tool for generating bindings that allow interop between Dart and Swift code.'
-version: 0.1.0
+version: 0.1.1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/swiftgen
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aswiftgen
 


### PR DESCRIPTION
At the moment we ignore the user's `SwiftGenerator.ffigen.objectiveC.(interfaces|protocols).module` and just always assume the classes should be loaded from `SwiftGenerator.output.module`. Instead we should use their function if they set one.

Related to https://github.com/dart-lang/native/issues/2629. Tarrin wants to generate bindings for some Foundation classes that are missing from package:objective_c. He can generate those bindings, but at the moment it's trying to load them from the swift2objc output module, rather than the Foundation module.