### PR TITLE
[swiftgen] remove Required from Logger in generate method

### DIFF
--- a/pkgs/swiftgen/CHANGELOG.md
+++ b/pkgs/swiftgen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Removes `Required` keyword from `logger` parameter in `generate` method.
+
 ## 0.1.0
 
 - MVP version.

--- a/pkgs/swiftgen/lib/src/generator.dart
+++ b/pkgs/swiftgen/lib/src/generator.dart
@@ -13,7 +13,7 @@ import 'config.dart';
 import 'util.dart';
 
 extension SwiftGenGenerator on SwiftGenerator {
-  Future<void> generate({required Logger? logger, Uri? tempDirectory}) async {
+  Future<void> generate({Logger? logger, Uri? tempDirectory}) async {
     logger ??= Logger.detached('dev/null')..level = Level.OFF;
     tempDirectory ??= createTempDirectory();
     final absTempDir = p.absolute(tempDirectory.toFilePath());


### PR DESCRIPTION
Seems unnecessary to force users to pass null here. So I removed the Required keyword.

Also, if there's a reason it is the way it is, feel free to just close this :)

Let me know if there are parts of the pr process missing, I read the guide but wasn't sure how much applies to this repo.