### PR TITLE
[hooks_runner] Pass `NIX_` environment variables through in hooks_runner

### DIFF
--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.23.0
+
+- **Breaking change**: Replaced `NativeAssetsBuildRunner.hookEnvironmentVariablesFilter`
+  with `NativeAssetsBuildRunner.includeHookEnvironmentVariable` to account for
+  environment variables that start with a particular prefix (i.e., `NIX_`).
+
 ## 0.22.1
 
 * Fix caches not being invalidated on (1) user-defines changing, (2) metadata

--- a/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
@@ -80,7 +80,7 @@ class NativeAssetsBuildRunner {
        singleHookTimeout = singleHookTimeout ?? const Duration(minutes: 5),
        hookEnvironment =
            hookEnvironment ??
-           filteredEnvironment(hookEnvironmentVariablesFilter) {
+           filteredEnvironment(includeHookEnvironmentVariable) {
     _fileSystem = TracingFileSystem(fileSystem, _task);
   }
 
@@ -538,23 +538,27 @@ class NativeAssetsBuildRunner {
     ),
   );
 
-  /// The list of environment variables used if [hookEnvironment] is not passed
-  /// in.
-  /// This allowlist lists environment variables needed to run mainstream
-  /// compilers.
-  static const hookEnvironmentVariablesFilter = {
-    'ANDROID_HOME', // Needed for the NDK.
-    'HOME', // Needed to find tools in default install locations.
-    'PATH', // Needed to invoke native tools.
-    'PROGRAMDATA', // Needed for vswhere.exe.
-    'SYSTEMDRIVE', // Needed for CMake.
-    'SYSTEMROOT', // Needed for process invocations on Windows.
-    'TEMP', // Needed for temp dirs in Dart process.
-    'TMP', // Needed for temp dirs in Dart process.
-    'TMPDIR', // Needed for temp dirs in Dart process.
-    'USERPROFILE', // Needed to find tools in default install locations.
-    'WINDIR', // Needed for CMake.
-  };
+  /// Determines whether to allow an environment variable through
+  /// if [hookEnvironment] is not passed in.
+  ///
+  /// This allows environment variables needed to run mainstream compilers.
+  static bool includeHookEnvironmentVariable(String environmentVariableName) {
+    const staticVariablesFilter = {
+      'ANDROID_HOME', // Needed for the NDK.
+      'HOME', // Needed to find tools in default install locations.
+      'PATH', // Needed to invoke native tools.
+      'PROGRAMDATA', // Needed for vswhere.exe.
+      'SYSTEMDRIVE', // Needed for CMake.
+      'SYSTEMROOT', // Needed for process invocations on Windows.
+      'TEMP', // Needed for temp dirs in Dart process.
+      'TMP', // Needed for temp dirs in Dart process.
+      'TMPDIR', // Needed for temp dirs in Dart process.
+      'USERPROFILE', // Needed to find tools in default install locations.
+      'WINDIR', // Needed for CMake.
+    };
+    return staticVariablesFilter.contains(environmentVariableName) ||
+        environmentVariableName.startsWith('NIX_');
+  }
 
   Future<Result<HookOutput, HooksRunnerFailure>> _runHookForPackage(
     Hook hook,
@@ -1198,7 +1202,7 @@ Future<List<Uri>> _readDepFile(File depFile) async {
 }
 
 @internal
-Map<String, String> filteredEnvironment(Set<String> allowList) => {
+Map<String, String> filteredEnvironment(bool Function(String) include) => {
   for (final entry in Platform.environment.entries)
-    if (allowList.contains(entry.key.toUpperCase())) entry.key: entry.value,
+    if (include(entry.key.toUpperCase())) entry.key: entry.value,
 };

--- a/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
@@ -556,8 +556,12 @@ class NativeAssetsBuildRunner {
       'USERPROFILE', // Needed to find tools in default install locations.
       'WINDIR', // Needed for CMake.
     };
+    const variablePrefixesFilter = {
+      'NIX_', // Needed for Nix-installed toolchains.
+    };
+
     return staticVariablesFilter.contains(environmentVariableName) ||
-        environmentVariableName.startsWith('NIX_');
+        variablePrefixesFilter.any(environmentVariableName.startsWith);
   }
 
   Future<Result<HookOutput, HooksRunnerFailure>> _runHookForPackage(

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 0.22.1
+version: 0.23.0
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 

--- a/pkgs/hooks_runner/test/build_runner/build_runner_caching_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/build_runner_caching_test.dart
@@ -276,7 +276,7 @@ void main() async {
           hookEnvironment: modifiedEnvKey == 'PATH'
               ? null
               : filteredEnvironment(
-                  NativeAssetsBuildRunner.hookEnvironmentVariablesFilter,
+                  NativeAssetsBuildRunner.includeHookEnvironmentVariable,
                 ),
         )).success;
         logMessages.clear();


### PR DESCRIPTION
Allows environment variables starting with `NIX_` to pass through in `hooks_runner`. This fixes failing builds when using Nix-installed LLVM.

Fixes #2623 