### PR TITLE
[native_toolchain_c] Broaden compiler tool discovery

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Made `CBuilder.run` `Logger` argument optional. It now defaults to a logger
   printing to stdout and stderr. (Technically this is a breaking change on
   passing `null` explicitly, but I doubt anyone is using it like that.)
+- Broaden compiler tool discovery
 
 ## 0.17.1
 

--- a/pkgs/native_toolchain_c/lib/src/native_toolchain/clang.dart
+++ b/pkgs/native_toolchain_c/lib/src/native_toolchain/clang.dart
@@ -48,6 +48,11 @@ final Tool llvmAr = Tool(
         wrappedResolver: clang.defaultResolver!,
         relativePath: Uri.file(OS.current.executableFileName('llvm-ar')),
       ),
+      RelativeToolResolver(
+        toolName: 'LLVM archiver',
+        wrappedResolver: clang.defaultResolver!,
+        relativePath: Uri.file(OS.current.executableFileName('ar')),
+      ),
       PathToolResolver(
         toolName: 'LLVM archiver',
         executableName: OS.current.executableFileName('llvm-ar'),
@@ -67,6 +72,11 @@ final Tool lld = Tool(
         toolName: 'LLD',
         wrappedResolver: clang.defaultResolver!,
         relativePath: Uri.file(OS.current.executableFileName('ld.lld')),
+      ),
+      RelativeToolResolver(
+        toolName: 'LLD',
+        wrappedResolver: clang.defaultResolver!,
+        relativePath: Uri.file(OS.current.executableFileName('ld')),
       ),
       PathToolResolver(
         toolName: 'LLD',


### PR DESCRIPTION
This change:
1. Also looks for `ld` and `ar` in the same directory as `clang`, since `llvm-ar` and `ld.lld` are not always the binary names in certain toolchain installations.
2. Adds tool fallback support in case the desired tool is not found (currently just `clang` is used as a fallback in case `appleClang` cannot be resolved on macOS).

Both of these changes are needed to support running in a Nix-like environment (on both Linux + macOS).

Fixes #2647

CC @dcharkes 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
