### PR TITLE
[infra] Enable the Dart MCP server by default in Gemini CLI

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "dart": {
+      "command": "dart",
+      "args": [
+        "mcp-server"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I am reluctant to commit any opinionated rule sets for AI to the repo, as I have no idea what's good or not. However, enabling the MCP server seems good always.