### PR TITLE
[swift2objc] Generate initializers as public

### DIFF
--- a/pkgs/swift2objc/lib/src/generator/generators/class_generator.dart
+++ b/pkgs/swift2objc/lib/src/generator/generators/class_generator.dart
@@ -72,35 +72,28 @@ String? _generateClassWrappedInstance(ClassDeclaration declaration) {
 }
 
 List<String> _generateInitializers(ClassDeclaration declaration) {
-  final initializers = [
-    declaration.wrapperInitializer,
-    ...declaration.initializers,
-  ].nonNulls;
-  return [for (final init in initializers) ..._generateInitializer(init)];
+  return [
+    ..._generateInitializer(declaration.wrapperInitializer, isPublic: false),
+    for (final init in declaration.initializers)
+        ..._generateInitializer(init, isPublic: true),
+  ];
 }
 
-List<String> _generateInitializer(InitializerDeclaration initializer) {
-  final header = StringBuffer();
-
-  if (initializer.hasObjCAnnotation) {
-    header.write('@objc ');
-  }
-
-  if (initializer.isOverriding) {
-    header.write('override ');
-  }
-
-  header.write('init');
-
-  if (initializer.isFailable) {
-    header.write('?');
-  }
-
-  header.write('(${generateParameters(initializer.params)})');
+List<String> _generateInitializer(InitializerDeclaration? initializer, {required bool isPublic}) {
+  if (initializer == null) return [];
+  final header = [
+    if (initializer.hasObjCAnnotation) '@objc ',
+    if (initializer.isOverriding) 'override ',
+    if (isPublic) 'public ',
+    'init',
+    if (initializer.isFailable) '?',
+    '(${generateParameters(initializer.params)}) ',
+    '${generateAnnotations(initializer)}{',
+  ].join('');
 
   return [
     ...generateAvailability(initializer),
-    '$header ${generateAnnotations(initializer)}{',
+    header,
     ...initializer.statements.indent(),
     '}\n',
   ];

--- a/pkgs/swift2objc/test/integration/async_init_output.swift
+++ b/pkgs/swift2objc/test/integration/async_init_output.swift
@@ -9,7 +9,7 @@ import Foundation
     self.wrappedInstance = wrappedInstance
   }
 
-  @objc override init() {
+  @objc override public init() {
     wrappedInstance = MyClass()
   }
 

--- a/pkgs/swift2objc/test/integration/available_output.swift
+++ b/pkgs/swift2objc/test/integration/available_output.swift
@@ -55,7 +55,7 @@ import Foundation
 
   @available(macOS, introduced: 456)
   @available(iOS, introduced: 101)
-  @objc init(x: Int) {
+  @objc public init(x: Int) {
     wrappedInstance = NewApi(x: x)
   }
 

--- a/pkgs/swift2objc/test/integration/classes_and_initializers_output.swift
+++ b/pkgs/swift2objc/test/integration/classes_and_initializers_output.swift
@@ -30,11 +30,11 @@ import Foundation
     self.wrappedInstance = wrappedInstance
   }
 
-  @objc init(outerLabel representableProperty: Int, customProperty: MyOtherClassWrapper) {
+  @objc public init(outerLabel representableProperty: Int, customProperty: MyOtherClassWrapper) {
     wrappedInstance = MyClass(outerLabel: representableProperty, customProperty: customProperty.wrappedInstance)
   }
 
-  @objc init?(outerLabel x: Int) {
+  @objc public init?(outerLabel x: Int) {
     if let instance = MyClass(outerLabel: x) {
       wrappedInstance = instance
     } else {
@@ -42,7 +42,7 @@ import Foundation
     }
   }
 
-  @objc init(label1 name1: Int, label2: Int, _ name3: Int) {
+  @objc public init(label1 name1: Int, label2: Int, _ name3: Int) {
     wrappedInstance = MyClass(label1: name1, label2: label2, name3)
   }
 

--- a/pkgs/swift2objc/test/integration/optional_output.swift
+++ b/pkgs/swift2objc/test/integration/optional_output.swift
@@ -53,11 +53,11 @@ import Foundation
     self.wrappedInstance = wrappedInstance
   }
 
-  @objc init(label param: MyClassWrapper?) {
+  @objc public init(label param: MyClassWrapper?) {
     wrappedInstance = MyClass(label: param?.wrappedInstance)
   }
 
-  @objc init(label1 param1: MyClassWrapper?, label2: Int, label3 param3: MyStructWrapper?) {
+  @objc public init(label1 param1: MyClassWrapper?, label2: Int, label3 param3: MyStructWrapper?) {
     wrappedInstance = MyClass(label1: param1?.wrappedInstance, label2: label2, label3: param3?.wrappedInstance)
   }
 
@@ -88,7 +88,7 @@ import Foundation
     self.wrappedInstance = wrappedInstance
   }
 
-  @objc init(label param: MyClassWrapper?) {
+  @objc public init(label param: MyClassWrapper?) {
     wrappedInstance = MyStruct(label: param?.wrappedInstance)
   }
 

--- a/pkgs/swift2objc/test/integration/structs_and_initializers_output.swift
+++ b/pkgs/swift2objc/test/integration/structs_and_initializers_output.swift
@@ -30,11 +30,11 @@ import Foundation
     self.wrappedInstance = wrappedInstance
   }
 
-  @objc init(outerLabel representableProperty: Int, customProperty: MyOtherStructWrapper) {
+  @objc public init(outerLabel representableProperty: Int, customProperty: MyOtherStructWrapper) {
     wrappedInstance = MyStruct(outerLabel: representableProperty, customProperty: customProperty.wrappedInstance)
   }
 
-  @objc init?(outerLabel x: Int) {
+  @objc public init?(outerLabel x: Int) {
     if let instance = MyStruct(outerLabel: x) {
       wrappedInstance = instance
     } else {
@@ -42,7 +42,7 @@ import Foundation
     }
   }
 
-  @objc init(label1 name1: Int, label2: Int, _ name3: Int) {
+  @objc public init(label1 name1: Int, label2: Int, _ name3: Int) {
     wrappedInstance = MyStruct(label1: name1, label2: label2, name3)
   }
 

--- a/pkgs/swift2objc/test/integration/throwing_getters_output.swift
+++ b/pkgs/swift2objc/test/integration/throwing_getters_output.swift
@@ -31,7 +31,7 @@ import Foundation
     self.wrappedInstance = wrappedInstance
   }
 
-  @objc init(y: Int) throws {
+  @objc public init(y: Int) throws {
     wrappedInstance = try MyClass(y: y)
   }
 

--- a/pkgs/swift2objc/test/integration/throws_output.swift
+++ b/pkgs/swift2objc/test/integration/throws_output.swift
@@ -21,7 +21,7 @@ import Foundation
     self.wrappedInstance = wrappedInstance
   }
 
-  @objc init(y: Int) throws {
+  @objc public init(y: Int) throws {
     wrappedInstance = try MyClass(y: y)
   }
 


### PR DESCRIPTION
Generate initializers as public, except for the internal `wrapperInitializer`.

Fixes https://github.com/dart-lang/native/issues/2666