### PR TITLE
[hooks] Point to code assets examples

### DIFF
--- a/pkgs/hooks/example/README.md
+++ b/pkgs/hooks/example/README.md
@@ -1,4 +1,23 @@
-These are examples for using the hooks defined in `package:hooks`.
+# Examples
+
+The examples in `package:hooks` show how to use `package:hooks` and
+`package:code_assets` in build hooks to bundle native code with Dart and Flutter
+applications.
+
+| Example                                                        | Use Case             | Used Features                                                                                                             |
+| :------------------------------------------------------------- | :------------------- | :------------------------------------------------------------------------------------------------------------------------ |
+| [`host_name`](../../code_assets/example/host_name)             | Get the hostname.    | - Accessing a system library with `DynamicLoadingSystem` and `LookupInProcess`.<br/>- OS-specific differences.            |
+| [`mini_audio`](../../code_assets/example/mini_audio)           | Play audio.          | - C library built from source with `package:native_toolchain_c`.<br/>- Bundled with `DynamicLoadingBundled`.              |
+| [`sqlite`](../../code_assets/example/sqlite)                   | Database access.     | - C library built from source with `package:native_toolchain_c`.<br/>- Bundled with `DynamicLoadingBundled`.              |
+| [`sqlite_prebuilt`](../../code_assets/example/sqlite_prebuilt) | Database access.     | - Pre-built binary downloaded from the internet or available on host machine.<br/>- Bundled with `DynamicLoadingBundled`. |
+| [`stb_image`](../../code_assets/example/stb_image)             | Read image metadata. | - C library built from source with `package:native_toolchain_c`.<br/>- Bundled with `DynamicLoadingBundled`.              |
+
+<!--
+The above samples are use-case driven, not feature driven.
+When adding new features to hooks, we will update the samples accordingly.
+-->
+
+The following examples showcase individual features of of `package:hooks`:
 
 * [build/](build/) contains examples on how to use `hook/build.dart` to build
   and bundle code assets, such as C libraries, into Dart applications.


### PR DESCRIPTION
Make the `examples/README.md` of `package:hooks` point to the examples from `package:code_assets`.

Note: I don't know if the relative paths to _outside_ the package work properly, if not we'll need to use absolute URLs.

Bug:

* https://github.com/dart-lang/native/issues/2686