### PR TITLE
[hooks] `LinkInput` Mark the record uses file as experimental

### DIFF
--- a/pkgs/hooks/lib/src/config.dart
+++ b/pkgs/hooks/lib/src/config.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart' show sha256;
+import 'package:meta/meta.dart';
 
 import 'api/build_and_link.dart';
 import 'encoded_asset.dart';
@@ -346,6 +347,12 @@ final class LinkInput extends HookInput {
   List<EncodedAsset> get _encodedAssets => assets.encodedAssets;
 
   /// The file containing recorded usages, if any.
+  ///
+  /// Experimental: The record uses feature needs to be enabled as experiment.
+  /// The experiment is only available in the Dart SDK, not in Flutter. We
+  /// reserve the right to break this API at any point without respecting
+  /// semantic versioning of this package.
+  @experimental
   Uri? get recordedUsagesFile => _syntaxLinkInput.resourceIdentifiers;
 
   @override


### PR DESCRIPTION
I'm not convinced that we'll keep the current API (a file path) for record use.

* We might want to simply have the Dart API directly. (Possibly async via a future. Possibly as an extension method on top of the `LinkInput` in `package:record_use`.)
  * Then we could solve caching transparently (https://github.com/dart-lang/native/issues/1178)
  * Then we could have a clearer story about the versioning of the API and JSON

Let's just mark it experimental for now, then we are allowed to change it and break people who rely on it.