### PR TITLE
[hooks] [code_assets] Publish new docs

### DIFF
--- a/pkgs/code_assets/CHANGELOG.md
+++ b/pkgs/code_assets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.19.8
+
+- Polished README.md, Dartdocs, and examples.
+
 ## 0.19.7
 
 - Bump examples to use `package:ffigen` 20.0.0-dev.0.

--- a/pkgs/code_assets/pubspec.yaml
+++ b/pkgs/code_assets/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   This library contains the hook protocol specification for bundling native code
   with Dart packages.
 
-version: 0.19.7
+version: 0.19.8
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/code_assets
 

--- a/pkgs/hooks/CHANGELOG.md
+++ b/pkgs/hooks/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.20.3
+
+- Polished README.md, Dartdocs, and examples.
+
 ## 0.20.2
 
 - Change the length of the checksum used for `outputDirectory` to 10 hexadecimal

--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A library that contains a Dart API for the JSON-based protocol for
   `hook/build.dart` and `hook/link.dart`.
 
-version: 0.20.2
+version: 0.20.3
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks
 


### PR DESCRIPTION
Publish the readmes and Dart API docs on pub.dev.