### PR TITLE
[infra] add 'publish_to: none' to workspace

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,5 @@
 name: dart_lang_native_workspace
+# TODO(goderbauer): reevaluate after https://github.com/dart-lang/ecosystem/issues/377 is resolved.
 publish_to: none
 
 environment:


### PR DESCRIPTION
The publish check is complaining about this missing in https://github.com/dart-lang/native/actions/runs/18460902655/job/52591942525?pr=2694.