### PR TITLE
[hooks_runner] Don't time out on missing `output.json`

### DIFF
--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- Ensure build fails if a build hook does not produce an output file.
+
 ## 1.0.0
 
 - Stable release.

--- a/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
@@ -961,7 +961,17 @@ ${e.message}''');
     String packageName,
   ) async {
     final file = hookOutputFile;
-    final fileContents = await file.readAsString();
+    final String fileContents;
+    try {
+      fileContents = await file.readAsString();
+    } on FileSystemException catch (e) {
+      logger.severe('''
+Building assets for package:$packageName failed.
+Error reading ${hookOutputFile.uri.toFilePath()}.
+
+${e.message}''');
+      return const Failure(HooksRunnerFailure.hookRun);
+    }
     logger.info('output.json contents:\n$fileContents');
     final Map<String, Object?> hookOutputJson;
     try {

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 1.0.0
+version: 1.0.1
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 

--- a/pkgs/hooks_runner/test/build_runner/no_build_output_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/no_build_output_test.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+
+import '../helpers.dart';
+import 'helpers.dart';
+
+const Timeout longTimeout = Timeout(Duration(minutes: 5));
+
+void main() async {
+  test('no build output', timeout: longTimeout, () async {
+    await inTempDir((tempUri) async {
+      await copyTestProjects(targetUri: tempUri);
+      final packageUri = tempUri.resolve('no_build_output/');
+
+      await runPubGet(workingDirectory: packageUri, logger: logger);
+
+      final logMessages = <String>[];
+      final result = await build(
+        packageUri,
+        createCapturingLogger(logMessages, level: Level.SEVERE),
+        dartExecutable,
+        buildAssetTypes: [],
+      );
+      expect(result.isFailure, isTrue);
+      final fullLog = logMessages.join('\n');
+      expect(fullLog, contains('Error reading'));
+      expect(fullLog, contains('output.json'));
+    });
+  });
+}

--- a/pkgs/hooks_runner/test_data/manifest.yaml
+++ b/pkgs/hooks_runner/test_data/manifest.yaml
@@ -139,6 +139,8 @@
 - native_subtract/src/native_subtract.h
 - no_asset_for_link/hook/link.dart
 - no_asset_for_link/pubspec.yaml
+- no_build_output/hook/build.dart
+- no_build_output/pubspec.yaml
 - no_hook/lib/no_hook.dart
 - no_hook/pubspec.yaml
 - package_reading_metadata/hook/build.dart

--- a/pkgs/hooks_runner/test_data/no_build_output/hook/build.dart
+++ b/pkgs/hooks_runner/test_data/no_build_output/hook/build.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+void main(List<String> arguments) {
+  // This hook does nothing, and doesn't write an output file.
+}

--- a/pkgs/hooks_runner/test_data/no_build_output/pubspec.yaml
+++ b/pkgs/hooks_runner/test_data/no_build_output/pubspec.yaml
@@ -1,0 +1,13 @@
+name: no_build_output
+description: A package with a build hook that does not produce any output.
+version: 0.1.0
+
+publish_to: none
+
+resolution: workspace
+
+environment:
+  sdk: '>=3.9.0 <4.0.0'
+
+dependencies:
+  hooks: any


### PR DESCRIPTION
If build hooks didn't output an `output.json` the build hooks runner would think it failed to acquire a file lock.

This PR fixes this by checking that the file system exceptions from locks are not mixed up with other file system exceptions, and adds an integration test.

I presume everyone is using the `build` and `link` methods from `package:hooks`, so I think it's unlikely anyone runs into this.