### PR TITLE
[infra] bump dependencies

### DIFF
--- a/pkgs/code_assets/pubspec.yaml
+++ b/pkgs/code_assets/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   hooks: ^1.0.0
 
 dev_dependencies:
-  custom_lint: ^0.7.5
+  custom_lint: ^0.8.1
   dart_flutter_team_lints: ^3.5.2
   json_schema: ^5.2.0 # May only be used in tool/ and test/json_schema/.
   native_test_helpers:

--- a/pkgs/data_assets/pubspec.yaml
+++ b/pkgs/data_assets/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   hooks: ^1.0.0
 
 dev_dependencies:
-  custom_lint: ^0.7.5
+  custom_lint: ^0.8.1
   dart_flutter_team_lints: ^3.5.2
   json_schema: ^5.2.0 # May only be used in tool/ and test/json_schema/.
   native_test_helpers:

--- a/pkgs/ffigen/example/objective_c/pubspec.yaml
+++ b/pkgs/ffigen/example/objective_c/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   args: ^2.6.0
   ffi: ^2.0.1
   logging: ^1.3.0
-  objective_c: ^0.0.1
+  objective_c: ^9.2.1
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.5.2

--- a/pkgs/ffigen/example/swift/pubspec.yaml
+++ b/pkgs/ffigen/example/swift/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   args: ^2.6.0
   ffi: ^2.0.1
-  objective_c: ^0.0.1
+  objective_c: ^9.2.1
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.5.2

--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -39,8 +39,8 @@ dev_dependencies:
   async: ^2.11.0
   dart_flutter_team_lints: ^3.5.2
   json_schema: ^5.1.1
-  leak_tracker: ^10.0.7
-  objective_c: ^9.2.0
+  leak_tracker: ^11.0.2
+  objective_c: ^9.2.1
   test: ^1.26.2
 
 dependency_overrides:

--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
 dev_dependencies:
   args: ^2.6.0
   code_assets: ^1.0.0 # Used for running tests with real asset types.
-  custom_lint: ^0.7.5
+  custom_lint: ^0.8.1
   dart_flutter_team_lints: ^3.5.2
   data_assets: any # Used for running tests with real asset types.
   file_testing: ^3.0.2

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
 
 dev_dependencies:
   args: any
-  custom_lint: ^0.7.5
+  custom_lint: ^0.8.1
   dart_flutter_team_lints: ^3.5.2
   data_assets: any # Used in tests.
   file_testing: ^3.0.2

--- a/pkgs/jnigen/pubspec.yaml
+++ b/pkgs/jnigen/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.4.12
   dart_flutter_team_lints: ^3.5.2
-  jni: ^0.14.0
+  jni: ^0.15.2
   json_serializable: ^6.8.0
   test: ^1.25.8
 

--- a/pkgs/json_syntax_generator/pubspec.yaml
+++ b/pkgs/json_syntax_generator/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   json_schema: ^5.2.0
 
 dev_dependencies:
-  custom_lint: ^0.7.5
+  custom_lint: ^0.8.1
   dart_flutter_team_lints: ^3.5.2
   native_test_helpers:
     path: ../native_test_helpers/

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
 
 dev_dependencies:
   collection: ^1.19.1
-  custom_lint: ^0.7.5
+  custom_lint: ^0.8.1
   dart_flutter_team_lints: ^3.5.2
   native_test_helpers:
     path: ../native_test_helpers/

--- a/pkgs/objective_c/example/command_line/pubspec.yaml
+++ b/pkgs/objective_c/example/command_line/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
     path: ../..
 
 dev_dependencies:
-  lints: ^5.0.0
+  lints: ^6.0.0
   test: ^1.27.0

--- a/pkgs/objective_c/pubspec.yaml
+++ b/pkgs/objective_c/pubspec.yaml
@@ -18,18 +18,18 @@ environment:
   sdk: '>=3.10.0 <4.0.0'
 
 dependencies:
-  code_assets: ^0.19.0
+  code_assets: ^1.0.0
   collection: ^1.19.1
   ffi: ^2.1.0
-  hooks: ^0.20.5
+  hooks: ^1.0.0
   logging: ^1.3.0
-  native_toolchain_c: ^0.17.2
+  native_toolchain_c: ^0.17.4
   pub_semver: ^2.1.4
 
 dev_dependencies:
   args: ^2.6.0
   dart_flutter_team_lints: ^3.5.2
-  ffigen: ^20.1.0
+  ffigen: ^20.1.1
   native_test_helpers:
     path: ../native_test_helpers/
   path: ^1.9.0

--- a/pkgs/repo_lint_rules/lib/src/avoid_import_outside_src_rule.dart
+++ b/pkgs/repo_lint_rules/lib/src/avoid_import_outside_src_rule.dart
@@ -20,7 +20,7 @@ class AvoidImportOutsideSrcRule extends DartLintRule {
   @override
   void run(
     CustomLintResolver resolver,
-    ErrorReporter reporter,
+    DiagnosticReporter reporter,
     CustomLintContext context,
   ) {
     context.registry.addImportDirective((node) {

--- a/pkgs/repo_lint_rules/pubspec.yaml
+++ b/pkgs/repo_lint_rules/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
   sdk: '>=3.9.0 <4.0.0'
 
 dependencies:
-  analyzer: ^7.3.0
-  custom_lint_builder: ^0.7.5
+  analyzer: ^8.4.0
+  custom_lint_builder: ^0.8.1
   dart_flutter_team_lints: ^3.5.2
   path: ^1.9.1
 
 dev_dependencies:
-  custom_lint: ^0.7.5
+  custom_lint: ^0.8.1

--- a/pkgs/swiftgen/example/pubspec.yaml
+++ b/pkgs/swiftgen/example/pubspec.yaml
@@ -12,9 +12,9 @@ environment:
 
 dependencies:
   ffi: ^2.1.0
-  ffigen: ^20.0.0
+  ffigen: ^20.1.1
   logging: ^1.3.0
-  objective_c: ^9.1.0-dev
+  objective_c: ^9.2.1
   pub_semver: ^2.2.0
   swift2objc: ^0.1.0
   swiftgen:

--- a/pkgs/swiftgen/pubspec.yaml
+++ b/pkgs/swiftgen/pubspec.yaml
@@ -19,9 +19,9 @@ environment:
 
 dependencies:
   ffi: ^2.1.0
-  ffigen: ^20.0.0-dev.1
+  ffigen: ^20.1.1
   logging: ^1.3.0
-  objective_c: ^8.0.0
+  objective_c: ^9.2.1
   package_config: ^2.2.0
   path: ^1.9.1
   swift2objc: ^0.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,15 @@ workspace:
   - pkgs/code_assets/example/stb_image
   - pkgs/data_assets
   - pkgs/hooks
+  - pkgs/hooks/example/build/download_asset
+  - pkgs/hooks/example/build/local_asset
+  - pkgs/hooks/example/build/native_add_app
+  - pkgs/hooks/example/build/native_add_library
+  - pkgs/hooks/example/build/native_dynamic_linking
+  - pkgs/hooks/example/build/system_library
+  - pkgs/hooks/example/build/use_dart_api
+  - pkgs/hooks/example/link/app_with_asset_treeshaking
+  - pkgs/hooks/example/link/package_with_assets
   - pkgs/hooks_runner
   - pkgs/hooks_runner/test_data/add_asset_link
   - pkgs/hooks_runner/test_data/complex_link
@@ -45,6 +54,7 @@ workspace:
   - pkgs/hooks_runner/test_data/native_dynamic_linking
   - pkgs/hooks_runner/test_data/native_subtract
   - pkgs/hooks_runner/test_data/no_asset_for_link
+  - pkgs/hooks_runner/test_data/no_build_output
   - pkgs/hooks_runner/test_data/no_hook
   - pkgs/hooks_runner/test_data/package_reading_metadata
   - pkgs/hooks_runner/test_data/package_with_metadata
@@ -64,15 +74,6 @@ workspace:
   - pkgs/hooks_runner/test_data/wrong_build_output_3
   - pkgs/hooks_runner/test_data/wrong_linker
   - pkgs/hooks_runner/test_data/wrong_namespace_asset
-  - pkgs/hooks/example/build/download_asset
-  - pkgs/hooks/example/build/local_asset
-  - pkgs/hooks/example/build/native_add_app
-  - pkgs/hooks/example/build/native_add_library
-  - pkgs/hooks/example/build/native_dynamic_linking
-  - pkgs/hooks/example/build/system_library
-  - pkgs/hooks/example/build/use_dart_api
-  - pkgs/hooks/example/link/app_with_asset_treeshaking
-  - pkgs/hooks/example/link/package_with_assets
   - pkgs/json_syntax_generator
   - pkgs/native_test_helpers
   - pkgs/native_toolchain_c


### PR DESCRIPTION
Bumping dependencies of native_doc_dartifier was excluded from this because of https://github.com/dart-lang/native/issues/2839.