### PR TITLE
[ffigen] Remove `Parameter.isCovariant`

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/func.dart
+++ b/pkgs/ffigen/lib/src/code_generator/func.dart
@@ -239,7 +239,6 @@ class Parameter extends AstNode {
   final String originalName;
   Type type;
   final bool objCConsumed;
-  bool isCovariant = false;
 
   Symbol symbol;
   String get name => symbol.name;


### PR DESCRIPTION
Since we migrated to extension methods, this isn't necessary anymore (in fact we're not actually using it at all).