### PR TITLE
[ffigen] Make regen.dart output visible and include ffinative config

### DIFF
--- a/pkgs/ffigen/test/regen.dart
+++ b/pkgs/ffigen/test/regen.dart
@@ -20,10 +20,12 @@ $ dart run test/setup.dart && dart run test/regen.dart && dart test
 ''';
 
 void _regenConfig(Logger logger, String yamlConfigPath) {
+  logger.info('Regenerating: $yamlConfigPath');
   final path = p.join(packagePathForTests, yamlConfigPath);
   Directory.current = File(path).parent;
   testConfigFromPath(path, logger: logger).generate(logger: logger);
 }
+
 
 Future<void> main(List<String> args) async {
   final parser = ArgParser();
@@ -44,9 +46,14 @@ Future<void> main(List<String> args) async {
     exit(1);
   }
 
-  final logger = Logger.root..level = Level.WARNING;
+  final logger = Logger.root..level = Level.INFO;
+
+logger.onRecord.listen((record) {
+  print('${record.level.name}: ${record.message}');
+});
 
   _regenConfig(logger, 'test/native_test/config.yaml');
+_regenConfig(logger, 'example/ffinative/config.yaml');
   _regenConfig(logger, 'example/libclang-example/config.yaml');
   _regenConfig(logger, 'example/simple/config.yaml');
   _regenConfig(logger, 'example/c_json/config.yaml');
@@ -55,3 +62,6 @@ Future<void> main(List<String> args) async {
     example_objective_c.main();
   }
 }
+
+
+


### PR DESCRIPTION
### Summary

This PR improves the `ffigen` regeneration script (`test/regen.dart`) by making its behavior more complete and observable.

Changes included:
- Adds regeneration for the previously omitted `example/ffinative/config.yaml`
- Adds explicit logging so it is clear which configs are regenerated, improving debuggability and CI visibility

### Verification

Verified locally on Linux by running:
- `dart run test/setup.dart`
- `dart run test/regen.dart`

The script now clearly logs each regenerated configuration and successfully regenerates all example and test bindings.

Fixes #862
- [ ✔️] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

