### PR TITLE
[record_use] Document compiler differences

### DIFF
--- a/pkgs/record_use/doc/compiler_differences.md
+++ b/pkgs/record_use/doc/compiler_differences.md
@@ -14,7 +14,7 @@ The following compiler optimizations can influence the recorded API usage:
     example, `dart compile exe` might tree-shake a call, while `dart2js` might
     not.
 *   **Constant propagation and inlining:** Constant propagation and inlining of
-    other code might lead to `record-use` annotated API calls receiving more
+    other code might lead to record-use annotated API calls receiving more
     constant arguments or being promoted to static calls. These optimizations
     might also lead to tearoffs being promoted to static calls or const values
     showing up for call sites that were propagated there by the compiler. (The


### PR DESCRIPTION
Compilers can have small differences:

* https://github.com/dart-lang/native/issues/2889

This PR documents some possible differences and how they show up.

A follow up PR should add this kind of docs to a logical place in the Dartdoc (maybe the library dartdoc and the readme).

Another follow up PR should add a `semanticEquals` method so we can test that the output of two compilers is semantically identical:

* https://github.com/dart-lang/native/issues/2897

