### PR TITLE
[native_toolchain_c] Make timeouts consistent

### DIFF
--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -2,9 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Timeout.factor(4)
-library;
-
 import 'dart:io';
 
 import 'package:code_assets/code_assets.dart';
@@ -13,6 +10,8 @@ import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:test/test.dart';
 
 import '../helpers.dart';
+
+const Timeout longTimeout = Timeout(Duration(minutes: 5));
 
 void main() {
   const targets = [
@@ -36,26 +35,30 @@ void main() {
         final optimizationLevel = optimizationLevels[selectOptimizationLevel];
         selectOptimizationLevel =
             (selectOptimizationLevel + 1) % optimizationLevels.length;
-        test('CBuilder $linkMode library $target minSdkVersion $apiLevel '
-            '$optimizationLevel', () async {
-          final tempUri = await tempDirForTest();
-          final libUri = await buildLib(
-            tempUri,
-            target,
-            apiLevel,
-            linkMode,
-            optimizationLevel: optimizationLevel,
-          );
-          await expectMachineArchitecture(libUri, target, OS.android);
-          if (linkMode == DynamicLoadingBundled()) {
-            await expectPageSize(libUri, 16 * 1024);
-          }
-        });
+        test(
+          'CBuilder $linkMode library $target minSdkVersion $apiLevel '
+          '$optimizationLevel',
+          timeout: longTimeout,
+          () async {
+            final tempUri = await tempDirForTest();
+            final libUri = await buildLib(
+              tempUri,
+              target,
+              apiLevel,
+              linkMode,
+              optimizationLevel: optimizationLevel,
+            );
+            await expectMachineArchitecture(libUri, target, OS.android);
+            if (linkMode == DynamicLoadingBundled()) {
+              await expectPageSize(libUri, 16 * 1024);
+            }
+          },
+        );
       }
     }
   }
 
-  test('CBuilder API levels binary difference', () async {
+  test('CBuilder API levels binary difference', timeout: longTimeout, () async {
     const target = Architecture.arm64;
     final linkMode = DynamicLoadingBundled();
     const apiLevel1 = flutterAndroidNdkVersionLowestSupported;
@@ -79,7 +82,7 @@ void main() {
     expect(bytes2, bytes3);
   });
 
-  test('page size override', () async {
+  test('page size override', timeout: longTimeout, () async {
     const target = Architecture.arm64;
     final linkMode = DynamicLoadingBundled();
     const apiLevel1 = flutterAndroidNdkVersionLowestSupported;


### PR DESCRIPTION
Use consistent syntax for test outputs. And use a syntax that also works when running the test _not_ via `dart test` (locally or on the Dart SDK CI).

And, increase the timeout further, 2 minutes didn't seem enough on https://github.com/dart-lang/native/actions/runs/20713316970/job/59458655551

(Background: our code sees many NDKs on the GitHub bots since https://github.com/dart-lang/native/pull/2736)