### PR TITLE
[swift2objc] Add configurable wrapperSuffix parameter

### DIFF
--- a/pkgs/swift2objc/lib/src/config.dart
+++ b/pkgs/swift2objc/lib/src/config.dart
@@ -50,6 +50,19 @@ class Swift2ObjCGenerator {
   /// Includes all declarations by default
   final bool Function(Declaration declaration) include;
 
+  ///Suffix to append to wrapper class names.
+  ///
+  /// For example, with the default suffix of 'Wrapper', a Swift class named
+  /// `MyClass` will generate a wrapper class named `MyClassWrapper`.
+  ///
+  /// You can customize this to use different naming conventions:
+  /// - `'ObjC'` -> `MyClassObjC`
+  /// - `'_Wrapper'` -> `MyClass_Wrapper`
+  /// - `''` -> `MyClass` (no suffix, may cause naming conflicts)
+  ///
+  /// Defaults to 'Wrapper' for backward compatibility.
+  final String wrapperSuffix;
+
   static bool _defaultInclude(Declaration _) => true;
 
   const Swift2ObjCGenerator({
@@ -60,6 +73,7 @@ class Swift2ObjCGenerator {
     this.tempDir,
     this.preamble,
     this.include = Swift2ObjCGenerator._defaultInclude,
+    this.wrapperSuffix = 'Wrapper',
   });
 }
 

--- a/pkgs/swift2objc/lib/src/generate_wrapper.dart
+++ b/pkgs/swift2objc/lib/src/generate_wrapper.dart
@@ -80,6 +80,7 @@ Future<void> _generateWrapper(
     context,
     declarations,
     filter: config.include,
+    wrapperSuffix: config.wrapperSuffix,
   );
   final wrapperCode = generate(
     transformedDeclarations,

--- a/pkgs/swift2objc/lib/src/transformer/transform.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transform.dart
@@ -24,6 +24,9 @@ class TransformationState {
 
   // All the bindings to be generated.
   final bindings = <Declaration>{};
+  // Suffix to append to wrapper class names.
+  final String wrapperSuffix;
+  TransformationState({this.wrapperSuffix = 'Wrapper'});
 
   // Bindings that will be generated as stubs.
   final stubs = <Declaration>{};
@@ -34,6 +37,7 @@ List<Declaration> transform(
   Context context,
   List<Declaration> declarations, {
   required bool Function(Declaration) filter,
+  String wrapperSuffix = 'Wrapper',
 }) {
   final state = TransformationState();
 

--- a/pkgs/swift2objc/lib/src/transformer/transformers/transform_compound.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transformers/transform_compound.dart
@@ -36,7 +36,9 @@ ClassDeclaration transformCompound(
 
   final transformedCompound = ClassDeclaration(
     id: originalCompound.id.addIdSuffix('wrapper'),
-    name: parentNamer.makeUnique('${originalCompound.name}Wrapper'),
+    name: parentNamer.makeUnique(
+      '${originalCompound.name}${state.wrapperSuffix}',
+    ),
     source: originalCompound.source,
     availability: originalCompound.availability,
     hasObjCAnnotation: true,


### PR DESCRIPTION
## Summary
Adds a `wrapperSuffix` to `Swift2ObjCGenerator` so users can customize the suffix appended to wrapper class names. Default remains `'Wrapper'` for backward compatibility.
**Issue:** #2509
---

## Key Changes
* `config.dart`: Added `wrapperSuffix` parameter
* `transform.dart` & `transform_compound.dart`: Use `state.wrapperSuffix` instead of hardcoded `'Wrapper'`
* `generate_wrapper.dart`: Pass config value to transform pipeline
---

## Why This Approach
* **Better than module namespacing or nested wrappers:** Objective-C interop remains intact
* **Cleaner than hardcoded `'Wrapper'`:** Users can choose any suffix
* **No Dart-side tricks needed:** Swift/ObjC API is clean and predictable
* **Backward-compatible:** Default behavior unchanged
---

## Example

```dart
// Default
wrapperSuffix: 'Wrapper'   // VehicleWrapper, CarWrapper

// Custom
wrapperSuffix: 'ObjC'       // VehicleObjC, CarObjC

// Empty suffix (advanced)
wrapperSuffix: ''           // Vehicle, Car (may cause conflicts, so be careful that will not cause any collisions when use it )
```


