### PR TITLE
[infra] Remove outdated TODO from root pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,4 @@
 name: dart_lang_native_workspace
-# TODO(goderbauer): reevaluate after https://github.com/dart-lang/ecosystem/issues/377 is resolved.
 publish_to: none
 
 environment:


### PR DESCRIPTION
https://github.com/dart-lang/ecosystem/issues/377 is closed. `publish_to: none` is the way to go.