### PR TITLE
[record_use] Use `snake_case` in JSON

### DIFF
--- a/pkgs/record_use/doc/schema/record_use.schema.json
+++ b/pkgs/record_use/doc/schema/record_use.schema.json
@@ -65,13 +65,13 @@
           "anyOf": [
             {
               "enum": [
-                "Instance",
-                "Null",
-                "String",
                 "bool",
+                "instance",
                 "int",
                 "list",
-                "map"
+                "map",
+                "null",
+                "string"
               ]
             },
             {
@@ -84,58 +84,6 @@
         "type"
       ],
       "allOf": [
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "Instance"
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "value": {
-                "type": "object",
-                "additionalProperties": true
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "Null"
-              }
-            }
-          },
-          "then": {
-            "not": {
-              "required": [
-                "value"
-              ]
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "String"
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "value": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "value"
-            ]
-          }
-        },
         {
           "if": {
             "properties": {
@@ -153,6 +101,23 @@
             "required": [
               "value"
             ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "instance"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
           }
         },
         {
@@ -206,6 +171,41 @@
               "value": {
                 "type": "object",
                 "additionalProperties": true
+              }
+            },
+            "required": [
+              "value"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "null"
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "required": [
+                "value"
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "string"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "type": "string"
               }
             },
             "required": [

--- a/pkgs/record_use/lib/src/constant.dart
+++ b/pkgs/record_use/lib/src/constant.dart
@@ -68,7 +68,9 @@ sealed class Constant {
         (key, value) => MapEntry(key, constants[value as int]),
       ),
     ),
-    _ => throw UnimplementedError('This type is not a supported constant'),
+    _ => throw UnimplementedError(
+      '"${syntax.type}" is not a supported constant type',
+    ),
   };
 }
 

--- a/pkgs/record_use/lib/src/syntax.g.dart
+++ b/pkgs/record_use/lib/src/syntax.g.dart
@@ -125,17 +125,11 @@ class ConstantSyntax extends JsonObjectSyntax {
     List<Object> path = const [],
   }) {
     final result = ConstantSyntax._fromJson(json, path: path);
-    if (result.isInstanceConstant) {
-      return result.asInstanceConstant;
-    }
-    if (result.isNullConstant) {
-      return result.asNullConstant;
-    }
-    if (result.isStringConstant) {
-      return result.asStringConstant;
-    }
     if (result.isBoolConstant) {
       return result.asBoolConstant;
+    }
+    if (result.isInstanceConstant) {
+      return result.asInstanceConstant;
     }
     if (result.isIntConstant) {
       return result.asIntConstant;
@@ -145,6 +139,12 @@ class ConstantSyntax extends JsonObjectSyntax {
     }
     if (result.isMapConstant) {
       return result.asMapConstant;
+    }
+    if (result.isNullConstant) {
+      return result.asNullConstant;
+    }
+    if (result.isStringConstant) {
+      return result.asStringConstant;
     }
     return result;
   }
@@ -344,7 +344,7 @@ class InstanceConstantSyntax extends ConstantSyntax {
   }) : super._fromJson();
 
   InstanceConstantSyntax({JsonObjectSyntax? value, super.path = const []})
-    : super(type: 'Instance') {
+    : super(type: 'instance') {
     _value = value;
     json.sortOnKey();
   }
@@ -382,7 +382,7 @@ class InstanceConstantSyntax extends ConstantSyntax {
 }
 
 extension InstanceConstantSyntaxExtension on ConstantSyntax {
-  bool get isInstanceConstant => type == 'Instance';
+  bool get isInstanceConstant => type == 'instance';
 
   InstanceConstantSyntax get asInstanceConstant =>
       InstanceConstantSyntax.fromJson(json, path: path);
@@ -624,7 +624,7 @@ class NullConstantSyntax extends ConstantSyntax {
     super.path,
   }) : super._fromJson();
 
-  NullConstantSyntax({super.path = const []}) : super(type: 'Null');
+  NullConstantSyntax({super.path = const []}) : super(type: 'null');
 
   @override
   List<String> validate() => [
@@ -636,7 +636,7 @@ class NullConstantSyntax extends ConstantSyntax {
 }
 
 extension NullConstantSyntaxExtension on ConstantSyntax {
-  bool get isNullConstant => type == 'Null';
+  bool get isNullConstant => type == 'null';
 
   NullConstantSyntax get asNullConstant =>
       NullConstantSyntax.fromJson(json, path: path);
@@ -916,7 +916,7 @@ class StringConstantSyntax extends ConstantSyntax {
   }) : super._fromJson();
 
   StringConstantSyntax({required String value, super.path = const []})
-    : super(type: 'String') {
+    : super(type: 'string') {
     _value = value;
     json.sortOnKey();
   }
@@ -944,7 +944,7 @@ class StringConstantSyntax extends ConstantSyntax {
 }
 
 extension StringConstantSyntaxExtension on ConstantSyntax {
-  bool get isStringConstant => type == 'String';
+  bool get isStringConstant => type == 'string';
 
   StringConstantSyntax get asStringConstant =>
       StringConstantSyntax.fromJson(json, path: path);

--- a/pkgs/record_use/test/test_data.dart
+++ b/pkgs/record_use/test/test_data.dart
@@ -112,7 +112,7 @@ const recordedUsesJson = '''{
   },
   "constants": [
     {
-      "type": "String",
+      "type": "string",
       "value": "lib_SHA1"
     },
     {
@@ -124,11 +124,11 @@ const recordedUsesJson = '''{
       "value": 1
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "mercury"
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "jenkins"
     },
     {
@@ -142,15 +142,15 @@ const recordedUsesJson = '''{
       }
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "camus"
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "einstein"
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "insert"
     },
     {
@@ -178,17 +178,17 @@ const recordedUsesJson = '''{
       "value": 42
     },
     {
-      "type": "Null"
+      "type": "null"
     },
     {
-      "type": "Instance",
+      "type": "instance",
       "value": {
         "a": 13,
         "b": 14
       }
     },
     {
-      "type": "Instance"
+      "type": "instance"
     }
   ],
   "locations": [
@@ -283,7 +283,7 @@ const recordedUsesJson2 = '''{
       "value": 1
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "mercury"
     },
     {

--- a/pkgs/record_use/test_data/json/extension.json
+++ b/pkgs/record_use/test_data/json/extension.json
@@ -2,7 +2,7 @@
   "$schema": "../../doc/schema/record_use.schema.json",
   "constants": [
     {
-      "type": "String",
+      "type": "string",
       "value": "42"
     }
   ],

--- a/pkgs/record_use/test_data/json/instance_class.json
+++ b/pkgs/record_use/test_data/json/instance_class.json
@@ -6,7 +6,7 @@
       "value": 42
     },
     {
-      "type": "Instance",
+      "type": "instance",
       "value": {
         "i": 0
       }

--- a/pkgs/record_use/test_data/json/instance_complex.json
+++ b/pkgs/record_use/test_data/json/instance_complex.json
@@ -6,7 +6,7 @@
       "value": 15
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "s"
     },
     {
@@ -40,10 +40,10 @@
       ]
     },
     {
-      "type": "Null"
+      "type": "null"
     },
     {
-      "type": "Instance",
+      "type": "instance",
       "value": {
         "i": 0,
         "s": 1,

--- a/pkgs/record_use/test_data/json/instance_duplicates.json
+++ b/pkgs/record_use/test_data/json/instance_duplicates.json
@@ -6,7 +6,7 @@
       "value": 42
     },
     {
-      "type": "Instance",
+      "type": "instance",
       "value": {
         "i": 0
       }
@@ -16,7 +16,7 @@
       "value": 43
     },
     {
-      "type": "Instance",
+      "type": "instance",
       "value": {
         "i": 2
       }

--- a/pkgs/record_use/test_data/json/instance_method.json
+++ b/pkgs/record_use/test_data/json/instance_method.json
@@ -6,7 +6,7 @@
       "value": 42
     },
     {
-      "type": "Instance",
+      "type": "instance",
       "value": {
         "i": 0
       }

--- a/pkgs/record_use/test_data/json/instance_not_annotation.json
+++ b/pkgs/record_use/test_data/json/instance_not_annotation.json
@@ -2,7 +2,7 @@
   "$schema": "../../doc/schema/record_use.schema.json",
   "constants": [
     {
-      "type": "Instance"
+      "type": "instance"
     }
   ],
   "locations": [

--- a/pkgs/record_use/test_data/json/named_and_positional.json
+++ b/pkgs/record_use/test_data/json/named_and_positional.json
@@ -6,7 +6,7 @@
       "value": 3
     },
     {
-      "type": "Null"
+      "type": "null"
     },
     {
       "type": "int",

--- a/pkgs/record_use/test_data/json/named_both.json
+++ b/pkgs/record_use/test_data/json/named_both.json
@@ -6,7 +6,7 @@
       "value": 3
     },
     {
-      "type": "Null"
+      "type": "null"
     },
     {
       "type": "int",

--- a/pkgs/record_use/test_data/json/named_with_function_arg.json
+++ b/pkgs/record_use/test_data/json/named_with_function_arg.json
@@ -2,7 +2,7 @@
   "$schema": "../../doc/schema/record_use.schema.json",
   "constants": [
     {
-      "type": "String",
+      "type": "string",
       "value": "hello-world"
     }
   ],

--- a/pkgs/record_use/test_data/json/nested.json
+++ b/pkgs/record_use/test_data/json/nested.json
@@ -6,23 +6,23 @@
       "value": 42
     },
     {
-      "type": "Instance",
+      "type": "instance",
       "value": {
         "i": 0
       }
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "test"
     },
     {
-      "type": "Instance",
+      "type": "instance",
       "value": {
         "i": 2
       }
     },
     {
-      "type": "Instance"
+      "type": "instance"
     }
   ],
   "locations": [

--- a/pkgs/record_use/test_data/json/record_enum.json
+++ b/pkgs/record_use/test_data/json/record_enum.json
@@ -6,18 +6,18 @@
       "value": 0
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "a"
     },
     {
-      "type": "Instance",
+      "type": "instance",
       "value": {
         "index": 0,
         "_name": 1
       }
     },
     {
-      "type": "Instance",
+      "type": "instance",
       "value": {
         "a": 2
       }

--- a/pkgs/record_use/test_data/json/record_instance_constant.json
+++ b/pkgs/record_use/test_data/json/record_instance_constant.json
@@ -6,13 +6,13 @@
       "value": 42
     },
     {
-      "type": "Instance",
+      "type": "instance",
       "value": {
         "i": 0
       }
     },
     {
-      "type": "Instance",
+      "type": "instance",
       "value": {
         "a": 1
       }

--- a/pkgs/record_use/test_data/json/record_instance_constant_empty.json
+++ b/pkgs/record_use/test_data/json/record_instance_constant_empty.json
@@ -2,10 +2,10 @@
   "$schema": "../../doc/schema/record_use.schema.json",
   "constants": [
     {
-      "type": "Instance"
+      "type": "instance"
     },
     {
-      "type": "Instance",
+      "type": "instance",
       "value": {
         "a": 0
       }

--- a/pkgs/record_use/test_data/json/recorded_uses.json
+++ b/pkgs/record_use/test_data/json/recorded_uses.json
@@ -2,7 +2,7 @@
   "$schema": "../../doc/schema/record_use.schema.json",
   "constants": [
     {
-      "type": "String",
+      "type": "string",
       "value": "42"
     },
     {
@@ -16,14 +16,14 @@
       }
     },
     {
-      "type": "Null"
+      "type": "null"
     },
     {
       "type": "int",
       "value": 42
     },
     {
-      "type": "Instance",
+      "type": "instance",
       "value": {
         "i": 4
       }

--- a/pkgs/record_use/test_data/json/types_of_arguments.json
+++ b/pkgs/record_use/test_data/json/types_of_arguments.json
@@ -6,10 +6,10 @@
       "value": 42
     },
     {
-      "type": "Null"
+      "type": "null"
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "s"
     },
     {
@@ -17,11 +17,11 @@
       "value": true
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "a1"
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "a2"
     },
     {
@@ -32,11 +32,11 @@
       ]
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "b1"
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "b2"
     },
     {

--- a/pkgs/record_use/test_data/json_dart2js/complex.json
+++ b/pkgs/record_use/test_data/json_dart2js/complex.json
@@ -1,7 +1,7 @@
 {
   "constants": [
     {
-      "type": "String",
+      "type": "string",
       "value": "somestring"
     },
     {

--- a/pkgs/record_use/test_data/json_dart2js/extension.json
+++ b/pkgs/record_use/test_data/json_dart2js/extension.json
@@ -1,7 +1,7 @@
 {
   "constants": [
     {
-      "type": "String",
+      "type": "string",
       "value": "42"
     }
   ],

--- a/pkgs/record_use/test_data/json_dart2js/loading_units_multiple.json
+++ b/pkgs/record_use/test_data/json_dart2js/loading_units_multiple.json
@@ -5,11 +5,11 @@
       "value": 42
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "helper"
     },
     {
-      "type": "String",
+      "type": "string",
       "value": ""
     }
   ],

--- a/pkgs/record_use/test_data/json_dart2js/loading_units_simple.json
+++ b/pkgs/record_use/test_data/json_dart2js/loading_units_simple.json
@@ -5,11 +5,11 @@
       "value": 42
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "helper"
     },
     {
-      "type": "String",
+      "type": "string",
       "value": ""
     }
   ],

--- a/pkgs/record_use/test_data/json_dart2js/named_and_positional.json
+++ b/pkgs/record_use/test_data/json_dart2js/named_and_positional.json
@@ -5,7 +5,7 @@
       "value": 3
     },
     {
-      "type": "Null"
+      "type": "null"
     },
     {
       "type": "int",

--- a/pkgs/record_use/test_data/json_dart2js/named_both.json
+++ b/pkgs/record_use/test_data/json_dart2js/named_both.json
@@ -5,7 +5,7 @@
       "value": 3
     },
     {
-      "type": "Null"
+      "type": "null"
     },
     {
       "type": "int",

--- a/pkgs/record_use/test_data/json_dart2js/types_of_arguments.json
+++ b/pkgs/record_use/test_data/json_dart2js/types_of_arguments.json
@@ -5,10 +5,10 @@
       "value": 42
     },
     {
-      "type": "Null"
+      "type": "null"
     },
     {
-      "type": "String",
+      "type": "string",
       "value": "s"
     },
     {


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/2887

This is a non-backwards compatible change. The Dart SDK has expect files which need to be updated when rolling this in, but all other places should only use the Dart API. Let's use this simple change to see if we got everything.