### PR TITLE
[record_use] Remove internal `fromJson` and `toJson`

### DIFF
--- a/pkgs/record_use/lib/src/constant.dart
+++ b/pkgs/record_use/lib/src/constant.dart
@@ -16,13 +16,6 @@ sealed class Constant {
   /// Creates a [Constant] object.
   const Constant();
 
-  /// Converts this [Constant] object to a JSON representation.
-  ///
-  /// [constants] needs to be passed, as the [Constant]s are normalized and
-  /// stored separately in the JSON.
-  Map<String, Object?> toJson(Map<Constant, int> constants) =>
-      _toSyntax(constants).json;
-
   /// Converts this [Constant] object to a syntax representation.
   ConstantSyntax _toSyntax(Map<Constant, int> constants);
 
@@ -38,15 +31,6 @@ sealed class Constant {
       (key, value) => MapEntry(key, value.toValue()),
     ),
   };
-
-  /// Creates a [Constant] object from its JSON representation.
-  ///
-  /// [constants] needs to be passed, as the [Constant]s are normalized and
-  /// stored separately in the JSON.
-  static Constant fromJson(
-    Map<String, Object?> value,
-    List<Constant> constants,
-  ) => _fromSyntax(ConstantSyntax.fromJson(value), constants);
 
   /// Creates a [Constant] object from its syntax representation.
   static Constant _fromSyntax(

--- a/pkgs/record_use/lib/src/definition.dart
+++ b/pkgs/record_use/lib/src/definition.dart
@@ -14,15 +14,10 @@ class Definition {
 
   const Definition({required this.identifier, this.loadingUnit});
 
-  factory Definition.fromJson(Map<String, Object?> json) =>
-      Definition._fromSyntax(DefinitionSyntax.fromJson(json));
-
   factory Definition._fromSyntax(DefinitionSyntax syntax) => Definition(
     identifier: IdentifierProtected.fromSyntax(syntax.identifier),
     loadingUnit: syntax.loadingUnit,
   );
-
-  Map<String, Object?> toJson() => _toSyntax().json;
 
   DefinitionSyntax _toSyntax() => DefinitionSyntax(
     identifier: identifier.toSyntax(),

--- a/pkgs/record_use/lib/src/identifier.dart
+++ b/pkgs/record_use/lib/src/identifier.dart
@@ -39,16 +39,9 @@ class Identifier {
   /// [name] is the name of the element.
   const Identifier({required this.importUri, this.scope, required this.name});
 
-  /// Creates an [Identifier] object from its JSON representation.
-  factory Identifier.fromJson(Map<String, Object?> json) =>
-      Identifier._fromSyntax(IdentifierSyntax.fromJson(json));
-
   /// Creates an [Identifier] object from its syntax representation.
   factory Identifier._fromSyntax(IdentifierSyntax syntax) =>
       Identifier(importUri: syntax.uri, scope: syntax.scope, name: syntax.name);
-
-  /// Converts this [Identifier] object to a JSON representation.
-  Map<String, Object?> toJson() => _toSyntax().json;
 
   /// Converts this [Identifier] object to a syntax representation.
   IdentifierSyntax _toSyntax() =>

--- a/pkgs/record_use/lib/src/location.dart
+++ b/pkgs/record_use/lib/src/location.dart
@@ -13,13 +13,8 @@ class Location {
 
   const Location({required this.uri, this.line, this.column});
 
-  factory Location.fromJson(Map<String, Object?> map) =>
-      Location._fromSyntax(LocationSyntax.fromJson(map));
-
   factory Location._fromSyntax(LocationSyntax syntax) =>
       Location(uri: syntax.uri, line: syntax.line, column: syntax.column);
-
-  Map<String, Object?> toJson() => _toSyntax().json;
 
   LocationSyntax _toSyntax() =>
       LocationSyntax(uri: uri, line: line, column: column);

--- a/pkgs/record_use/lib/src/metadata.dart
+++ b/pkgs/record_use/lib/src/metadata.dart
@@ -17,8 +17,21 @@ class Metadata {
 
   const Metadata._(this._syntax);
 
-  factory Metadata.fromJson(Map<String, Object?> json) =>
-      Metadata._(MetadataSyntax.fromJson(json));
+  factory Metadata({
+    required Version version,
+    required String comment,
+    Map<String, Object?>? extension,
+  }) {
+    final syntax = MetadataSyntax(
+      comment: comment,
+      version: version.toString(),
+    );
+    // TODO(https://github.com/dart-lang/native/issues/2984): Nest extension
+    // fields.
+    return Metadata._(
+      MetadataSyntax.fromJson({...syntax.json, ...?extension}),
+    );
+  }
 
   /// The underlying data.
   ///
@@ -27,10 +40,19 @@ class Metadata {
   /// VM.
   Map<String, Object?> get json => _syntax.json;
 
-  Map<String, Object?> toJson() => _syntax.json;
-
   Version get version => Version.parse(_syntax.version);
+
   String get comment => _syntax.comment;
+
+  Map<String, Object?>? get extension {
+    // TODO(https://github.com/dart-lang/native/issues/2984): Nest extension
+    // fields.
+    final dummy = MetadataSyntax(comment: comment, version: version.toString());
+    return {
+      for (final entry in _syntax.json.entries)
+        if (!dummy.json.keys.contains(entry.key)) entry.key: entry.value,
+    };
+  }
 
   @override
   bool operator ==(covariant Metadata other) {

--- a/pkgs/record_use/lib/src/reference.dart
+++ b/pkgs/record_use/lib/src/reference.dart
@@ -35,16 +35,6 @@ sealed class Reference {
   @override
   int get hashCode => Object.hash(loadingUnit, location);
 
-  Map<String, Object?> toJson(
-    Map<Constant, int> constants,
-    Map<Location, int> locations,
-  ) => _toSyntax(constants, locations).json;
-
-  JsonObjectSyntax _toSyntax(
-    Map<Constant, int> constants,
-    Map<Location, int> locations,
-  );
-
   bool _semanticEqualsShared(
     Reference other,
     bool allowLocationNull, {
@@ -81,12 +71,6 @@ sealed class Reference {
 sealed class CallReference extends Reference {
   const CallReference({required super.loadingUnit, required super.location});
 
-  static CallReference fromJson(
-    Map<String, Object?> json,
-    List<Constant> constants,
-    List<Location> locations,
-  ) => _fromSyntax(CallSyntax.fromJson(json), constants, locations);
-
   static CallReference _fromSyntax(
     CallSyntax syntax,
     List<Constant> constants,
@@ -121,7 +105,6 @@ sealed class CallReference extends Reference {
     };
   }
 
-  @override
   CallSyntax _toSyntax(
     Map<Constant, int> constants,
     Map<Location, int> locations,
@@ -296,12 +279,6 @@ final class InstanceReference extends Reference {
     required super.location,
   });
 
-  factory InstanceReference.fromJson(
-    Map<String, Object?> json,
-    List<Constant> constants,
-    List<Location> locations,
-  ) => _fromSyntax(InstanceSyntax.fromJson(json), constants, locations);
-
   static InstanceReference _fromSyntax(
     InstanceSyntax syntax,
     List<Constant> constants,
@@ -316,7 +293,6 @@ final class InstanceReference extends Reference {
     );
   }
 
-  @override
   InstanceSyntax _toSyntax(
     Map<Constant, int> constants,
     Map<Location, int> locations,

--- a/pkgs/record_use/test/semantic_equality_test.dart
+++ b/pkgs/record_use/test/semantic_equality_test.dart
@@ -63,10 +63,10 @@ void main() {
     loadingUnit: null,
     location: Location(uri: 'memory:a/a.dart', line: 1, column: 1),
   );
-  final metadata = Metadata.fromJson({
-    'version': Version(1, 0, 0).toString(),
-    'comment': '',
-  });
+  final metadata = Metadata(
+    version: Version(1, 0, 0),
+    comment: '',
+  );
 
   test('Definition semantic equality', () {
     expect(definition1.semanticEquals(definition1), isTrue);

--- a/pkgs/record_use/test/test_data.dart
+++ b/pkgs/record_use/test/test_data.dart
@@ -20,12 +20,12 @@ final instanceId = Identifier(
 );
 
 final recordedUses = Recordings(
-  metadata: Metadata.fromJson({
-    'version': Version(1, 6, 2, pre: 'wip', build: '5.-.2.z').toString(),
-    'comment':
+  metadata: Metadata(
+    version: Version(1, 6, 2, pre: 'wip', build: '5.-.2.z'),
+    comment:
         'Recorded references at compile time and their argument values, as'
         ' far as known, to definitions annotated with @RecordUse',
-  }),
+  ),
   callsForDefinition: {
     Definition(identifier: callId, loadingUnit: 'part_15.js'): [
       const CallWithArguments(
@@ -83,12 +83,12 @@ final recordedUses = Recordings(
 );
 
 final recordedUses2 = Recordings(
-  metadata: Metadata.fromJson({
-    'version': Version(1, 6, 2, pre: 'wip', build: '5.-.2.z').toString(),
-    'comment':
+  metadata: Metadata(
+    version: Version(1, 6, 2, pre: 'wip', build: '5.-.2.z'),
+    comment:
         'Recorded references at compile time and their argument values, as'
         ' far as known, to definitions annotated with @RecordUse',
-  }),
+  ),
   callsForDefinition: {
     Definition(identifier: callId, loadingUnit: 'part_15.js'): [
       const CallWithArguments(


### PR DESCRIPTION
This PR only leaves the top level `Recordings` and `RecordedUsages` JSON APIs. All internal from and to json have been removed.

The format uses normalization (with constant indices), which means the to and from JSON of parts of the format are not useful by themselves. Users should not try to use JSON serialization of parts of the format, only the full format.

Closes: https://github.com/dart-lang/native/issues/2901

This will require a manual roll into the Dart SDK to migrate `Metadata.fromJson` constructor calls.

