### PR TITLE
[objective_c] Fix path resolving for test files on MacOS

### DIFF
--- a/pkgs/objective_c/hook/build.dart
+++ b/pkgs/objective_c/hook/build.dart
@@ -63,7 +63,9 @@ void main(List<String> args) async {
     // aren't supported on iOS, like mach_vm_region. We don't need them on iOS
     // anyway since we only run memory tests on mac.
     if (os == OS.macOS) {
-      cFiles.addAll(testFiles.map((f) => File.fromUri(input.packageRoot.resolve(f)).path));
+      cFiles.addAll(
+        testFiles.map((f) => File.fromUri(input.packageRoot.resolve(f)).path),
+      );
     }
 
     final sysroot = sdkPath(codeConfig);


### PR DESCRIPTION
**Description** 
This PR fixes a build failure introduced in version 9.2.0 (native assets migration) when the package is fetched from a custom pub repository (e.g., Artifactory).

**Issue** 
When using a custom pub host, the pub cache directory often contains URL-encoded characters (e.g., %47 or %25). The hook/build.dart script was handling file paths inconsistently:

- Source files (src/): Were retrieved using Directory.listSync(). The file.path property correctly returned the decoded OS file system path.

- Test files (test/util.c): Were retrieved using uri.resolve(path).path. This returned the encoded URI path (e.g., retaining %2547), causing clang to fail with no such file or directory.

**Fix**
I updated the resolution of testFiles to use File.fromUri(...).path. This ensures that the path is correctly decoded to the OS file system format, matching the behavior used for the source files.

fixes: https://github.com/dart-lang/native/issues/2990

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
