### PR TITLE
[objective_c] Make autoReleasePool return callback value

### DIFF
--- a/pkgs/objective_c/lib/src/autorelease.dart
+++ b/pkgs/objective_c/lib/src/autorelease.dart
@@ -35,10 +35,10 @@ import 'runtime_bindings_generated.dart';
 /// here (the [Future] it returns will not be awaited). Objective-C autorelease
 /// pools form a strict stack, and allowing async execution gaps inside the pool
 /// scope could easily break this nesting, so async functions are not supported.
-void autoReleasePool(void Function() function) {
+T autoReleasePool<T>(T Function() function) {
   final pool = autoreleasePoolPush();
   try {
-    function();
+    return function();
   } finally {
     autoreleasePoolPop(pool);
   }


### PR DESCRIPTION
This updates `autoReleasePool` so it returns the value produced by the callback instead of always returning `void`.

Returning a value makes it easier to use `autoReleasePool` in expressions, while keeping the same behavior for managing the Objective-C autorelease pool.
The pool is still always popped using `try/finally`, so the semantics and safety stay the same. Existing call sites don’t need to change.. the return value can just be ignored if not needed.
Tests in `package:objective_c` pass locally.

[x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
Closes #3006 
