### PR TITLE
[objective_c] Make autoReleasePool return callback value

### DIFF
--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 9.3.0
+- `autoReleasePool` now returns the value produced by its callback.
+
 ## 9.2.5
 - Fix a [bug](https://github.com/dart-lang/native/issues/3011) by adding
   minimum OS version flags to the build script.

--- a/pkgs/objective_c/lib/src/autorelease.dart
+++ b/pkgs/objective_c/lib/src/autorelease.dart
@@ -35,10 +35,10 @@ import 'runtime_bindings_generated.dart';
 /// here (the [Future] it returns will not be awaited). Objective-C autorelease
 /// pools form a strict stack, and allowing async execution gaps inside the pool
 /// scope could easily break this nesting, so async functions are not supported.
-void autoReleasePool(void Function() function) {
+T autoReleasePool<T>(T Function() function) {
   final pool = autoreleasePoolPush();
   try {
-    function();
+    return function();
   } finally {
     autoreleasePoolPop(pool);
   }

--- a/pkgs/objective_c/pubspec.yaml
+++ b/pkgs/objective_c/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: objective_c
 description: 'A library to access Objective C from Flutter that acts as a support library for package:ffigen.'
-version: 9.2.5
+version: 9.3.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/objective_c
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aobjective_c
 

--- a/pkgs/objective_c/test/autorelease_test.dart
+++ b/pkgs/objective_c/test/autorelease_test.dart
@@ -56,5 +56,25 @@ void main() {
 
       expect(objectRetainCount(pointer), 0);
     });
+
+    test('returns callback value', () async {
+      late Pointer<ObjCObjectImpl> pointer;
+
+      final returnedPointer = autoReleasePool(() {
+        final object = NSObject();
+        pointer = object.ref.retainAndAutorelease();
+        return pointer;
+      });
+
+      // Returned value should be exactly what the callback returned
+      expect(returnedPointer, same(pointer));
+
+      doGC();
+      await Future<void>.delayed(Duration.zero);
+      doGC();
+
+      // Object should be released once the pool is popped
+      expect(objectRetainCount(pointer), 0);
+    });
   });
 }


### PR DESCRIPTION
This PR updates `autoReleasePool` to return the value produced by its callback, while preserving existing autorelease semantics.

Changes included:
- Ensure the callback is invoked exactly once
- Return the callback value from `autoReleasePool`
- Add a test verifying the return value while preserving autorelease behavior
- Update the changelog and bump the package version

Tests:
- Ran `dart test` locally on Windows (tests skipped as expected)
- CI should run tests on macOS

[x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
