### PR TITLE
[native_toolchain_c] Don't require lld on `PATH` for MacOS -> Linux

### DIFF
--- a/pkgs/native_toolchain_c/lib/src/native_toolchain/clang.dart
+++ b/pkgs/native_toolchain_c/lib/src/native_toolchain/clang.dart
@@ -78,6 +78,15 @@ final Tool lld = Tool(
         wrappedResolver: clang.defaultResolver!,
         relativePath: Uri.file(OS.current.executableFileName('ld')),
       ),
+      InstallLocationResolver(
+        toolName: 'LLD',
+        paths: [
+          '/opt/homebrew/opt/lld/bin/ld.lld',
+          '/opt/homebrew/bin/ld.lld',
+          '/usr/local/opt/lld/bin/ld.lld',
+          '/usr/local/bin/ld.lld',
+        ],
+      ),
       PathToolResolver(
         toolName: 'LLD',
         executableName: OS.current.executableFileName('ld.lld'),


### PR DESCRIPTION
This PR fixes the `cbuilder_cross_macos_host_test.dart` tests which were failing on macOS environments where `ld.lld` (required for cross-compiling to Linux) was not in the system PATH.

## Changes

- **`pkgs/native_toolchain_c/lib/src/native_toolchain/clang.dart`**: 
  - Updated the `lld` tool definition to explicitly check standard Homebrew install locations (e.g., `/opt/homebrew/opt/lld/bin/ld.lld`). This ensures `lld` can be found even if it is installed as a keg-only formula (like `llvm`) or not linked to the main PATH.

- **`pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart`**:
  - Updated `main()` to properly resolve `lld` using the `native_toolchain_c` tool resolver.
  - Added a warning to `stderr` if `lld` is not found, advising the user to install it via `brew install lld`. The tests will now fail with a clear error message instead of an obscure process failure if the tool is missing.
  - Updated the test configuration to use the fully resolved `lld` path passed to the linker flags.

## Context

The test `pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart` was originally added in #3005.
