### PR TITLE
[record_use] Add constructor invocations to recorded instances

### DIFF
--- a/pkgs/record_use/doc/schema/record_use.schema.json
+++ b/pkgs/record_use/doc/schema/record_use.schema.json
@@ -235,16 +235,77 @@
     "Instance": {
       "type": "object",
       "properties": {
-        "constant_index": {
-          "type": "integer"
+        "type": {
+          "type": "string",
+          "anyOf": [
+            {
+              "enum": [
+                "constant",
+                "creation",
+                "tearoff"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "loading_unit": {
           "type": "string"
         }
       },
       "required": [
-        "constant_index",
-        "loading_unit"
+        "loading_unit",
+        "type"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "constant"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "constant_index": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "constant_index"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "creation"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "named": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "integer"
+                }
+              },
+              "positional": {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        }
       ]
     },
     "MapEntry": {

--- a/pkgs/record_use/lib/record_use_internal.dart
+++ b/pkgs/record_use/lib/record_use_internal.dart
@@ -20,5 +20,12 @@ export 'src/record_use.dart' show RecordedUsages;
 export 'src/recordings.dart'
     show FlattenConstantsExtension, MapifyIterableExtension, Recordings;
 export 'src/reference.dart'
-    show CallReference, CallTearOff, CallWithArguments, InstanceReference;
+    show
+        CallReference,
+        CallTearoff,
+        CallWithArguments,
+        ConstructorTearoffReference,
+        InstanceConstantReference,
+        InstanceCreationReference,
+        InstanceReference;
 export 'src/version.dart' show version;

--- a/pkgs/record_use/lib/src/record_use.dart
+++ b/pkgs/record_use/lib/src/record_use.dart
@@ -108,9 +108,11 @@ extension type RecordedUsages._(Recordings _recordings) {
   /// What kinds of fields can be recorded depends on the implementation of
   /// https://dart-review.googlesource.com/c/sdk/+/369620/13/pkg/vm/lib/transformations/record_use/record_instance.dart
   Iterable<ConstantInstance> constantsOf(Identifier identifier) =>
-      _recordings.instances[identifier]?.map(
-        (reference) => ConstantInstance(reference.instanceConstant.fields),
-      ) ??
+      _recordings.instances[identifier]
+          ?.whereType<InstanceConstantReference>()
+          .map(
+            (reference) => ConstantInstance(reference.instanceConstant.fields),
+          ) ??
       [];
 
   /// Checks if any call to [identifier] has non-const arguments, or if any
@@ -124,7 +126,7 @@ extension type RecordedUsages._(Recordings _recordings) {
   bool hasNonConstArguments(Identifier identifier) =>
       (_recordings.calls[identifier] ?? []).any(
         (element) => switch (element) {
-          CallTearOff() => true,
+          CallTearoff() => true,
           final CallWithArguments call => call.positionalArguments.any(
             (argument) => argument == null,
           ),

--- a/pkgs/record_use/lib/src/recordings.dart
+++ b/pkgs/record_use/lib/src/recordings.dart
@@ -134,9 +134,17 @@ Error: $e
       ...instancesForDefinition.values
           .expand((instances) => instances)
           .expand(
-            (instance) => {
-              ...instance.instanceConstant.fields.values,
-              instance.instanceConstant,
+            (instance) => switch (instance) {
+              InstanceConstantReference(:final instanceConstant) => {
+                ...instanceConstant.fields.values,
+                instanceConstant,
+              },
+              InstanceCreationReference(
+                :final positionalArguments,
+                :final namedArguments,
+              ) =>
+                [...positionalArguments, ...namedArguments.values].nonNulls,
+              ConstructorTearoffReference() => <Constant>[],
             },
           ),
     }.flatten().asMapToIndices;
@@ -218,7 +226,7 @@ Error: $e
   /// a usage from [expected] cannot be found in `this`, simulating the effect
   /// of a compiler optimizing away a call entirely.
   ///
-  /// If [allowTearOffToStaticPromotion] is `true`, allows an [expected]
+  /// If [allowTearoffToStaticPromotion] is `true`, allows an [expected]
   /// function tear-off to match an `actual` static call.
   ///
   /// If [allowDefinitionLoadingUnitNull] is `true`, allows a definition's
@@ -237,7 +245,7 @@ Error: $e
     Recordings expected, {
     bool expectedIsSubset = false,
     bool allowDeadCodeElimination = false,
-    bool allowTearOffToStaticPromotion = false,
+    bool allowTearoffToStaticPromotion = false,
     bool allowDefinitionLoadingUnitNull = false,
     bool allowMoreConstArguments = false,
     bool allowMetadataMismatch = false,
@@ -264,7 +272,7 @@ Error: $e
       // ignore: invalid_use_of_visible_for_testing_member
       referenceMatches: (CallReference a, CallReference b) => a.semanticEquals(
         b,
-        allowTearOffToStaticPromotion: allowTearOffToStaticPromotion,
+        allowTearoffToStaticPromotion: allowTearoffToStaticPromotion,
         allowMoreConstArguments: allowMoreConstArguments,
         uriMapping: uriMapping,
         loadingUnitMapping: loadingUnitMapping,
@@ -285,6 +293,7 @@ Error: $e
             b,
             uriMapping: uriMapping,
             loadingUnitMapping: loadingUnitMapping,
+            allowMoreConstArguments: allowMoreConstArguments,
           ),
     )) {
       return false;

--- a/pkgs/record_use/lib/src/syntax.g.dart
+++ b/pkgs/record_use/lib/src/syntax.g.dart
@@ -163,6 +163,121 @@ class ConstantSyntax extends JsonObjectSyntax {
   String toString() => 'ConstantSyntax($json)';
 }
 
+class ConstantInstanceSyntax extends InstanceSyntax {
+  ConstantInstanceSyntax.fromJson(
+    super.json, {
+    super.path,
+  }) : super._fromJson();
+
+  ConstantInstanceSyntax({
+    required int constantIndex,
+    required super.loadingUnit,
+    super.path = const [],
+  }) : super(type: 'constant') {
+    _constantIndex = constantIndex;
+    json.sortOnKey();
+  }
+
+  /// Setup all fields for [ConstantInstanceSyntax] that are not in
+  /// [InstanceSyntax].
+  void setup({required int constantIndex}) {
+    _constantIndex = constantIndex;
+    json.sortOnKey();
+  }
+
+  int get constantIndex => _reader.get<int>('constant_index');
+
+  set _constantIndex(int value) {
+    json.setOrRemove('constant_index', value);
+  }
+
+  List<String> _validateConstantIndex() =>
+      _reader.validate<int>('constant_index');
+
+  @override
+  List<String> validate() => [...super.validate(), ..._validateConstantIndex()];
+
+  @override
+  String toString() => 'ConstantInstanceSyntax($json)';
+}
+
+extension ConstantInstanceSyntaxExtension on InstanceSyntax {
+  bool get isConstantInstance => type == 'constant';
+
+  ConstantInstanceSyntax get asConstantInstance =>
+      ConstantInstanceSyntax.fromJson(json, path: path);
+}
+
+class CreationInstanceSyntax extends InstanceSyntax {
+  CreationInstanceSyntax.fromJson(
+    super.json, {
+    super.path,
+  }) : super._fromJson();
+
+  CreationInstanceSyntax({
+    required super.loadingUnit,
+    Map<String, int>? named,
+    List<int?>? positional,
+    super.path = const [],
+  }) : super(type: 'creation') {
+    _named = named;
+    _positional = positional;
+    json.sortOnKey();
+  }
+
+  /// Setup all fields for [CreationInstanceSyntax] that are not in
+  /// [InstanceSyntax].
+  void setup({
+    required Map<String, int>? named,
+    required List<int?>? positional,
+  }) {
+    _named = named;
+    _positional = positional;
+    json.sortOnKey();
+  }
+
+  Map<String, int>? get named => _reader.optionalMap<int>(
+    'named',
+  );
+
+  set _named(Map<String, int>? value) {
+    _checkArgumentMapKeys(
+      value,
+    );
+    json.setOrRemove('named', value);
+  }
+
+  List<String> _validateNamed() => _reader.validateMap<int>(
+    'named',
+  );
+
+  List<int?>? get positional => _reader.optionalList<int?>('positional');
+
+  set _positional(List<int?>? value) {
+    json.setOrRemove('positional', value);
+  }
+
+  List<String> _validatePositional() =>
+      _reader.validateOptionalList<int?>('positional');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateNamed(),
+    ..._validatePositional(),
+  ];
+
+  @override
+  String toString() => 'CreationInstanceSyntax($json)';
+}
+
+extension CreationInstanceSyntaxExtension on InstanceSyntax {
+  bool get isCreationInstance => type == 'creation';
+
+  CreationInstanceSyntax get asCreationInstance =>
+      CreationInstanceSyntax.fromJson(json, path: path);
+}
+
 class DefinitionSyntax extends JsonObjectSyntax {
   DefinitionSyntax.fromJson(
     super.json, {
@@ -271,29 +386,37 @@ class IdentifierSyntax extends JsonObjectSyntax {
 }
 
 class InstanceSyntax extends JsonObjectSyntax {
-  InstanceSyntax.fromJson(
+  factory InstanceSyntax.fromJson(
+    Map<String, Object?> json, {
+    List<Object> path = const [],
+  }) {
+    final result = InstanceSyntax._fromJson(json, path: path);
+    if (result.isConstantInstance) {
+      return result.asConstantInstance;
+    }
+    if (result.isCreationInstance) {
+      return result.asCreationInstance;
+    }
+    if (result.isTearoffInstance) {
+      return result.asTearoffInstance;
+    }
+    return result;
+  }
+
+  InstanceSyntax._fromJson(
     super.json, {
     super.path = const [],
   }) : super.fromJson();
 
   InstanceSyntax({
-    required int constantIndex,
     required String loadingUnit,
+    required String type,
     super.path = const [],
   }) : super() {
-    _constantIndex = constantIndex;
     _loadingUnit = loadingUnit;
+    _type = type;
     json.sortOnKey();
   }
-
-  int get constantIndex => _reader.get<int>('constant_index');
-
-  set _constantIndex(int value) {
-    json.setOrRemove('constant_index', value);
-  }
-
-  List<String> _validateConstantIndex() =>
-      _reader.validate<int>('constant_index');
 
   String get loadingUnit => _reader.get<String>('loading_unit');
 
@@ -304,11 +427,19 @@ class InstanceSyntax extends JsonObjectSyntax {
   List<String> _validateLoadingUnit() =>
       _reader.validate<String>('loading_unit');
 
+  String get type => _reader.get<String>('type');
+
+  set _type(String value) {
+    json.setOrRemove('type', value);
+  }
+
+  List<String> _validateType() => _reader.validate<String>('type');
+
   @override
   List<String> validate() => [
     ...super.validate(),
-    ..._validateConstantIndex(),
     ..._validateLoadingUnit(),
+    ..._validateType(),
   ];
 
   @override
@@ -911,6 +1042,31 @@ extension TearoffCallSyntaxExtension on CallSyntax {
 
   TearoffCallSyntax get asTearoffCall =>
       TearoffCallSyntax.fromJson(json, path: path);
+}
+
+class TearoffInstanceSyntax extends InstanceSyntax {
+  TearoffInstanceSyntax.fromJson(
+    super.json, {
+    super.path,
+  }) : super._fromJson();
+
+  TearoffInstanceSyntax({required super.loadingUnit, super.path = const []})
+    : super(type: 'tearoff');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+  ];
+
+  @override
+  String toString() => 'TearoffInstanceSyntax($json)';
+}
+
+extension TearoffInstanceSyntaxExtension on InstanceSyntax {
+  bool get isTearoffInstance => type == 'tearoff';
+
+  TearoffInstanceSyntax get asTearoffInstance =>
+      TearoffInstanceSyntax.fromJson(json, path: path);
 }
 
 class WithArgumentsCallSyntax extends CallSyntax {

--- a/pkgs/record_use/test/instance_references_test.dart
+++ b/pkgs/record_use/test/instance_references_test.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_semver/pub_semver.dart';
+import 'package:record_use/record_use_internal.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const identifier = Identifier(
+    importUri: 'package:test/test.dart',
+    name: 'MyClass',
+  );
+
+  final metadata = Metadata(
+    version: Version(1, 0, 0),
+    comment: 'Test for new instance formats',
+  );
+
+  final recordings = Recordings(
+    metadata: metadata,
+    callsForDefinition: {},
+    instancesForDefinition: {
+      const Definition(identifier: identifier, loadingUnit: 'root'): [
+        const InstanceCreationReference(
+          positionalArguments: [IntConstant(1), IntConstant(2)],
+          namedArguments: {'param': StringConstant('named_arg_value')},
+          loadingUnit: 'root',
+        ),
+        const ConstructorTearoffReference(loadingUnit: 'other'),
+      ],
+    },
+  );
+
+  test('Deserialize creation and tearoff instances', () {
+    final instances = recordings.instances[identifier];
+    expect(instances, isNotNull);
+    expect(instances, hasLength(2));
+
+    final creation = instances![0];
+    expect(creation, isA<InstanceCreationReference>());
+    if (creation is InstanceCreationReference) {
+      expect(creation.loadingUnit, 'root');
+      expect(creation.positionalArguments, hasLength(2));
+      expect(creation.positionalArguments[0], isA<IntConstant>());
+      expect((creation.positionalArguments[0] as IntConstant).value, 1);
+      expect((creation.positionalArguments[1] as IntConstant).value, 2);
+      expect(creation.namedArguments, hasLength(1));
+      expect(creation.namedArguments['param'], isA<StringConstant>());
+      expect(
+        (creation.namedArguments['param'] as StringConstant).value,
+        'named_arg_value',
+      );
+    }
+
+    final tearoff = instances[1];
+    expect(tearoff, isA<ConstructorTearoffReference>());
+    if (tearoff is ConstructorTearoffReference) {
+      expect(tearoff.loadingUnit, 'other');
+    }
+  });
+
+  test('Round trip serialization', () {
+    final serializedJson = recordings.toJson();
+    final roundTrippedRecordings = Recordings.fromJson(serializedJson);
+    expect(roundTrippedRecordings, equals(recordings));
+  });
+
+  test('constantsOf filters out creation and tearoff', () {
+    // We need to construct RecordedUsages from Recordings, but RecordedUsages
+    // doesn't expose a constructor taking Recordings directly publicly?
+    // It does via `RecordedUsages._(Recordings _recordings)`.
+    // But we can go via JSON.
+    final usages = RecordedUsages.fromJson(recordings.toJson());
+
+    final constants = usages.constantsOf(identifier);
+    expect(constants, isEmpty);
+  });
+}

--- a/pkgs/record_use/test/json_schema/schema_test.dart
+++ b/pkgs/record_use/test/json_schema/schema_test.dart
@@ -33,6 +33,20 @@ void main() {
       missingExpectations: field.$2,
     );
   }
+
+  final constructorInvocationDataUri = testDataUri.resolve(
+    'constructor_invocation.json',
+  );
+  for (final field in constructorInvocationFields) {
+    testField(
+      schemaUri: schemaUri,
+      dataUri: constructorInvocationDataUri,
+      schema: schema,
+      data: allTestData[constructorInvocationDataUri]!,
+      field: field.$1,
+      missingExpectations: field.$2,
+    );
+  }
 }
 
 const constNullIndex = 4;
@@ -87,6 +101,7 @@ recordUseFields = [
   (['recordings', 0, 'calls', 0, 'positional', 0], expectOptionalFieldMissing),
   (['recordings', 0, 'calls', 0, 'loading_unit'], expectRequiredFieldMissing),
   (['recordings', 1, 'instances'], expectOptionalFieldMissing),
+  (['recordings', 1, 'instances', 0, 'type'], expectRequiredFieldMissing),
   (
     ['recordings', 1, 'instances', 0, 'constant_index'],
     expectRequiredFieldMissing,
@@ -94,6 +109,26 @@ recordUseFields = [
   (
     ['recordings', 1, 'instances', 0, 'loading_unit'],
     expectRequiredFieldMissing,
+  ),
+];
+
+List<(List<Object>, void Function(ValidationResults result))>
+constructorInvocationFields = [
+  (
+    ['recordings', 0, 'instances', 0, 'loading_unit'],
+    expectRequiredFieldMissing,
+  ),
+  (
+    ['recordings', 0, 'instances', 0, 'type'],
+    expectRequiredFieldMissing,
+  ),
+  (
+    ['recordings', 0, 'instances', 0, 'positional'],
+    expectOptionalFieldMissing,
+  ),
+  (
+    ['recordings', 0, 'instances', 0, 'named'],
+    expectOptionalFieldMissing,
   ),
 ];
 

--- a/pkgs/record_use/test/semantic_equality_golden_test.dart
+++ b/pkgs/record_use/test/semantic_equality_golden_test.dart
@@ -70,7 +70,7 @@ void main() {
         // https://github.com/dart-lang/native/issues/2890
         allowDefinitionLoadingUnitNull: true,
         allowMoreConstArguments: true,
-        allowTearOffToStaticPromotion: true,
+        allowTearoffToStaticPromotion: true,
         expectedIsSubset: dart2jsDeferLoadedLibrary.contains(fileName),
         uriMapping: (String uri) =>
             uri.replaceFirst('memory:sdk/tests/web/native/', ''),

--- a/pkgs/record_use/test/semantic_equality_test.dart
+++ b/pkgs/record_use/test/semantic_equality_test.dart
@@ -46,7 +46,7 @@ void main() {
     namedArguments: {},
     loadingUnit: null,
   );
-  const callDefinition1TearOff = CallTearOff(
+  const callDefinition1Tearoff = CallTearoff(
     loadingUnit: null,
   );
   const definition1differentUri2 = Definition(
@@ -192,7 +192,7 @@ void main() {
     );
   });
 
-  test('allowTearOffToStaticPromotion', () {
+  test('allowTearoffToStaticPromotion', () {
     final recordings1 = Recordings(
       metadata: metadata,
       callsForDefinition: {
@@ -203,21 +203,21 @@ void main() {
     final recordings2 = Recordings(
       metadata: metadata,
       callsForDefinition: {
-        definition1: [callDefinition1TearOff],
+        definition1: [callDefinition1Tearoff],
       },
       instancesForDefinition: const {},
     );
     expect(
       recordings1.semanticEquals(
         recordings2,
-        allowTearOffToStaticPromotion: true,
+        allowTearoffToStaticPromotion: true,
       ),
       isTrue,
     );
     expect(
       recordings1.semanticEquals(
         recordings2,
-        allowTearOffToStaticPromotion: false,
+        allowTearoffToStaticPromotion: false,
       ),
       isFalse,
     );
@@ -225,7 +225,7 @@ void main() {
     expect(
       recordings2.semanticEquals(
         recordings1,
-        allowTearOffToStaticPromotion: true,
+        allowTearoffToStaticPromotion: true,
       ),
       isFalse,
     );

--- a/pkgs/record_use/test/test_data.dart
+++ b/pkgs/record_use/test/test_data.dart
@@ -66,13 +66,13 @@ final recordedUses = Recordings(
   },
   instancesForDefinition: {
     Definition(identifier: instanceId): [
-      const InstanceReference(
+      const InstanceConstantReference(
         instanceConstant: InstanceConstant(
           fields: {'a': IntConstant(42), 'b': NullConstant()},
         ),
         loadingUnit: '3',
       ),
-      const InstanceReference(
+      const InstanceConstantReference(
         instanceConstant: InstanceConstant(fields: {}),
         loadingUnit: '3',
       ),
@@ -243,10 +243,12 @@ const recordedUsesJson = '''{
       },
       "instances": [
         {
+          "type": "constant",
           "constant_index": 16,
           "loading_unit": "3"
         },
         {
+          "type": "constant",
           "constant_index": 17,
           "loading_unit": "3"
         }

--- a/pkgs/record_use/test/usage_test.dart
+++ b/pkgs/record_use/test/usage_test.dart
@@ -45,6 +45,7 @@ void main() {
             .first;
     final instanceMap = recordedUses.instancesForDefinition.values
         .expand((usage) => usage)
+        .whereType<InstanceConstantReference>()
         .map(
           (instance) => instance.instanceConstant.fields.map(
             (key, constant) => MapEntry(key, constant.toValue()),

--- a/pkgs/record_use/test_data/json/constructor_invocation.json
+++ b/pkgs/record_use/test_data/json/constructor_invocation.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "../../doc/schema/record_use.schema.json",
+  "constants": [
+    {
+      "type": "int",
+      "value": 1
+    },
+    {
+      "type": "int",
+      "value": 2
+    },
+    {
+      "type": "string",
+      "value": "named_arg_value"
+    }
+  ],
+  "metadata": {
+    "comment": "Constructor invocation recording",
+    "version": "1.0.0"
+  },
+  "recordings": [
+    {
+      "definition": {
+        "identifier": {
+          "name": "MyClass",
+          "uri": "package:test/test.dart"
+        },
+        "loading_unit": "root"
+      },
+      "instances": [
+        {
+          "loading_unit": "root",
+          "named": {
+            "param": 2
+          },
+          "positional": [
+            0,
+            1
+          ],
+          "type": "creation"
+        }
+      ]
+    }
+  ]
+}

--- a/pkgs/record_use/test_data/json/instance_class.json
+++ b/pkgs/record_use/test_data/json/instance_class.json
@@ -28,7 +28,8 @@
       "instances": [
         {
           "constant_index": 1,
-          "loading_unit": "1"
+          "loading_unit": "1",
+          "type": "constant"
         }
       ]
     }

--- a/pkgs/record_use/test_data/json/instance_complex.json
+++ b/pkgs/record_use/test_data/json/instance_complex.json
@@ -84,7 +84,8 @@
       "instances": [
         {
           "constant_index": 11,
-          "loading_unit": "1"
+          "loading_unit": "1",
+          "type": "constant"
         }
       ]
     }

--- a/pkgs/record_use/test_data/json/instance_duplicates.json
+++ b/pkgs/record_use/test_data/json/instance_duplicates.json
@@ -38,11 +38,13 @@
       "instances": [
         {
           "constant_index": 1,
-          "loading_unit": "1"
+          "loading_unit": "1",
+          "type": "constant"
         },
         {
           "constant_index": 3,
-          "loading_unit": "1"
+          "loading_unit": "1",
+          "type": "constant"
         }
       ]
     }

--- a/pkgs/record_use/test_data/json/instance_method.json
+++ b/pkgs/record_use/test_data/json/instance_method.json
@@ -28,7 +28,8 @@
       "instances": [
         {
           "constant_index": 1,
-          "loading_unit": "1"
+          "loading_unit": "1",
+          "type": "constant"
         }
       ]
     }

--- a/pkgs/record_use/test_data/json/instance_not_annotation.json
+++ b/pkgs/record_use/test_data/json/instance_not_annotation.json
@@ -21,7 +21,8 @@
       "instances": [
         {
           "constant_index": 0,
-          "loading_unit": "1"
+          "loading_unit": "1",
+          "type": "constant"
         }
       ]
     }

--- a/pkgs/record_use/test_data/json/nested.json
+++ b/pkgs/record_use/test_data/json/nested.json
@@ -41,11 +41,13 @@
       "instances": [
         {
           "constant_index": 1,
-          "loading_unit": "1"
+          "loading_unit": "1",
+          "type": "constant"
         },
         {
           "constant_index": 3,
-          "loading_unit": "1"
+          "loading_unit": "1",
+          "type": "constant"
         }
       ]
     },
@@ -60,7 +62,8 @@
       "instances": [
         {
           "constant_index": 4,
-          "loading_unit": "1"
+          "loading_unit": "1",
+          "type": "constant"
         }
       ]
     }

--- a/pkgs/record_use/test_data/json/record_enum.json
+++ b/pkgs/record_use/test_data/json/record_enum.json
@@ -39,7 +39,8 @@
       "instances": [
         {
           "constant_index": 3,
-          "loading_unit": "1"
+          "loading_unit": "1",
+          "type": "constant"
         }
       ]
     }

--- a/pkgs/record_use/test_data/json/record_instance_constant.json
+++ b/pkgs/record_use/test_data/json/record_instance_constant.json
@@ -34,7 +34,8 @@
       "instances": [
         {
           "constant_index": 2,
-          "loading_unit": "1"
+          "loading_unit": "1",
+          "type": "constant"
         }
       ]
     }

--- a/pkgs/record_use/test_data/json/record_instance_constant_empty.json
+++ b/pkgs/record_use/test_data/json/record_instance_constant_empty.json
@@ -27,7 +27,8 @@
       "instances": [
         {
           "constant_index": 1,
-          "loading_unit": "1"
+          "loading_unit": "1",
+          "type": "constant"
         }
       ]
     }

--- a/pkgs/record_use/test_data/json/recorded_uses.json
+++ b/pkgs/record_use/test_data/json/recorded_uses.json
@@ -88,7 +88,8 @@
       "instances": [
         {
           "constant_index": 6,
-          "loading_unit": "1"
+          "loading_unit": "1",
+          "type": "constant"
         }
       ]
     }


### PR DESCRIPTION
Refactored `InstanceReference` into a sealed class hierarchy to support constructor invocations and tear-offs alongside constant instances.

### Changes
- **Hierarchy:** Introduced `InstanceConstantReference`, `InstanceCreationReference`, and `ConstructorTearoffReference`.
- **Schema:** Updated `record_use.schema.json` with a `type` discriminator for instances and regenerated `syntax.g.dart`.
- **API:** Updated `Recordings` and `RecordedUsages` to handle the polymorphic types and improved semantic equality comparison.
- **Migration:** Updated all JSON test data to include the required `"type": "constant"` field and ensured trailing newlines.
- **Testing:** Added `test/instance_references_test.dart` and updated schema validation tests.

Relevant issues:

* https://github.com/dart-lang/native/issues/2907
* https://github.com/dart-lang/native/issues/2911