### PR TITLE
[record_use] Support unsupported constants

### DIFF
--- a/pkgs/hooks_runner/test_data/pirate_speak/hook/link.dart
+++ b/pkgs/hooks_runner/test_data/pirate_speak/hook/link.dart
@@ -59,9 +59,8 @@ Set<String> _extractUsedPhrases(Recordings recordings) {
 
   for (final call in usages.constArgumentsFor(pirateSpeakId)) {
     if (call.positional.isNotEmpty) {
-      final phrase = call.positional.first;
-      if (phrase is String) {
-        usedPhrases.add(phrase);
+      if (call.positional.first case StringConstant(:final value)) {
+        usedPhrases.add(value);
       }
     }
   }

--- a/pkgs/json_syntax_generator/lib/src/parser/schema_analyzer.dart
+++ b/pkgs/json_syntax_generator/lib/src/parser/schema_analyzer.dart
@@ -339,11 +339,12 @@ class SchemaAnalyzer {
             isNullable: false,
             pattern: schemas.patternPropertiesSchemas.keys.firstOrNull,
           );
-          final additionalPropertiesType = additionalPropertiesSchema.type;
+          final (additionalPropertiesType, additionalNullable) =
+              additionalPropertiesSchema.typeAndNullable;
           switch (additionalPropertiesType) {
             case SchemaType.array:
               final items = additionalPropertiesSchema.items;
-              final itemType = items.type;
+              final (itemType, itemNullable) = items.typeAndNullable;
               switch (itemType) {
                 case SchemaType.object:
                   _analyzeClass(items);
@@ -353,9 +354,9 @@ class SchemaAnalyzer {
                     valueType: ListDartType(
                       itemType: ClassDartType(
                         classInfo: itemClass,
-                        isNullable: false,
+                        isNullable: itemNullable,
                       ),
-                      isNullable: false,
+                      isNullable: additionalNullable,
                     ),
                     isNullable: isNullable,
                   );
@@ -370,15 +371,18 @@ class SchemaAnalyzer {
                 final clazz = _classes[additionalPropertiesSchema.className]!;
                 dartType = MapDartType(
                   keyType: keyDartType,
-                  valueType: ClassDartType(classInfo: clazz, isNullable: false),
+                  valueType: ClassDartType(
+                    classInfo: clazz,
+                    isNullable: additionalNullable,
+                  ),
                   isNullable: isNullable,
                 );
               } else {
                 dartType = MapDartType(
                   keyType: keyDartType,
-                  valueType: const MapDartType(
-                    valueType: ObjectDartType(isNullable: true),
-                    isNullable: false,
+                  valueType: MapDartType(
+                    valueType: const ObjectDartType(isNullable: true),
+                    isNullable: additionalNullable,
                   ),
                   isNullable: isNullable,
                 );
@@ -431,13 +435,13 @@ class SchemaAnalyzer {
             case SchemaType.string:
               dartType = MapDartType(
                 keyType: keyDartType,
-                valueType: const StringDartType(isNullable: false),
+                valueType: StringDartType(isNullable: additionalNullable),
                 isNullable: isNullable,
               );
             case SchemaType.integer:
               dartType = MapDartType(
                 keyType: keyDartType,
-                valueType: const IntDartType(isNullable: false),
+                valueType: IntDartType(isNullable: additionalNullable),
                 isNullable: isNullable,
               );
             default:

--- a/pkgs/record_use/doc/schema/record_use.schema.json
+++ b/pkgs/record_use/doc/schema/record_use.schema.json
@@ -39,7 +39,10 @@
           "named": {
             "type": "object",
             "additionalProperties": {
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           "positional": {
@@ -68,7 +71,8 @@
                 "list",
                 "map",
                 "null",
-                "string"
+                "string",
+                "unsupported"
               ]
             },
             {
@@ -211,6 +215,25 @@
               "value"
             ]
           }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "unsupported"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          }
         }
       ]
     },
@@ -291,7 +314,10 @@
               "named": {
                 "type": "object",
                 "additionalProperties": {
-                  "type": "integer"
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
                 }
               },
               "positional": {

--- a/pkgs/record_use/lib/record_use.dart
+++ b/pkgs/record_use/lib/record_use.dart
@@ -2,7 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+export 'src/constant.dart'
+    show
+        BoolConstant,
+        Constant,
+        InstanceConstant,
+        IntConstant,
+        ListConstant,
+        MapConstant,
+        MaybeConstant,
+        NonConstant,
+        NullConstant,
+        StringConstant,
+        UnsupportedConstant;
 export 'src/identifier.dart' show Identifier;
 export 'src/metadata.dart' show Metadata;
-export 'src/record_use.dart' show ConstantInstance, RecordedUsages;
+export 'src/record_use.dart' show RecordedUsages;
 export 'src/recorded_usage_from_file.dart' show parseFromFile;

--- a/pkgs/record_use/lib/record_use_internal.dart
+++ b/pkgs/record_use/lib/record_use_internal.dart
@@ -10,9 +10,11 @@ export 'src/constant.dart'
         IntConstant,
         ListConstant,
         MapConstant,
+        MaybeConstant,
+        NonConstant,
         NullConstant,
-        PrimitiveConstant,
-        StringConstant;
+        StringConstant,
+        UnsupportedConstant;
 export 'src/definition.dart' show Definition;
 export 'src/identifier.dart' show Identifier;
 export 'src/metadata.dart' show Metadata;

--- a/pkgs/record_use/lib/src/identifier.dart
+++ b/pkgs/record_use/lib/src/identifier.dart
@@ -6,7 +6,7 @@ import 'package:meta/meta.dart';
 
 import 'syntax.g.dart';
 
-/// Represents a unique identifier for a code element, such as a class, method,
+/// A unique identifier for a code element, such as a class, method,
 /// or field, within a Dart program.
 ///
 /// An [Identifier] is used to pinpoint a specific element based on its

--- a/pkgs/record_use/lib/src/syntax.g.dart
+++ b/pkgs/record_use/lib/src/syntax.g.dart
@@ -135,6 +135,9 @@ class ConstantSyntax extends JsonObjectSyntax {
     if (result.isStringConstant) {
       return result.asStringConstant;
     }
+    if (result.isUnsupportedConstant) {
+      return result.asUnsupportedConstant;
+    }
     return result;
   }
 
@@ -216,7 +219,7 @@ class CreationInstanceSyntax extends InstanceSyntax {
 
   CreationInstanceSyntax({
     required super.loadingUnit,
-    Map<String, int>? named,
+    Map<String, int?>? named,
     List<int?>? positional,
     super.path = const [],
   }) : super(type: 'creation') {
@@ -228,7 +231,7 @@ class CreationInstanceSyntax extends InstanceSyntax {
   /// Setup all fields for [CreationInstanceSyntax] that are not in
   /// [InstanceSyntax].
   void setup({
-    required Map<String, int>? named,
+    required Map<String, int?>? named,
     required List<int?>? positional,
   }) {
     _named = named;
@@ -236,18 +239,18 @@ class CreationInstanceSyntax extends InstanceSyntax {
     json.sortOnKey();
   }
 
-  Map<String, int>? get named => _reader.optionalMap<int>(
+  Map<String, int?>? get named => _reader.optionalMap<int?>(
     'named',
   );
 
-  set _named(Map<String, int>? value) {
+  set _named(Map<String, int?>? value) {
     _checkArgumentMapKeys(
       value,
     );
     json.setOrRemove('named', value);
   }
 
-  List<String> _validateNamed() => _reader.validateMap<int>(
+  List<String> _validateNamed() => _reader.validateOptionalMap<int?>(
     'named',
   );
 
@@ -1069,6 +1072,47 @@ extension TearoffInstanceSyntaxExtension on InstanceSyntax {
       TearoffInstanceSyntax.fromJson(json, path: path);
 }
 
+class UnsupportedConstantSyntax extends ConstantSyntax {
+  UnsupportedConstantSyntax.fromJson(
+    super.json, {
+    super.path,
+  }) : super._fromJson();
+
+  UnsupportedConstantSyntax({required String message, super.path = const []})
+    : super(type: 'unsupported') {
+    _message = message;
+    json.sortOnKey();
+  }
+
+  /// Setup all fields for [UnsupportedConstantSyntax] that are not in
+  /// [ConstantSyntax].
+  void setup({required String message}) {
+    _message = message;
+    json.sortOnKey();
+  }
+
+  String get message => _reader.get<String>('message');
+
+  set _message(String value) {
+    json.setOrRemove('message', value);
+  }
+
+  List<String> _validateMessage() => _reader.validate<String>('message');
+
+  @override
+  List<String> validate() => [...super.validate(), ..._validateMessage()];
+
+  @override
+  String toString() => 'UnsupportedConstantSyntax($json)';
+}
+
+extension UnsupportedConstantSyntaxExtension on ConstantSyntax {
+  bool get isUnsupportedConstant => type == 'unsupported';
+
+  UnsupportedConstantSyntax get asUnsupportedConstant =>
+      UnsupportedConstantSyntax.fromJson(json, path: path);
+}
+
 class WithArgumentsCallSyntax extends CallSyntax {
   WithArgumentsCallSyntax.fromJson(
     super.json, {
@@ -1077,7 +1121,7 @@ class WithArgumentsCallSyntax extends CallSyntax {
 
   WithArgumentsCallSyntax({
     required super.loadingUnit,
-    Map<String, int>? named,
+    Map<String, int?>? named,
     List<int?>? positional,
     super.path = const [],
   }) : super(type: 'with_arguments') {
@@ -1089,7 +1133,7 @@ class WithArgumentsCallSyntax extends CallSyntax {
   /// Setup all fields for [WithArgumentsCallSyntax] that are not in
   /// [CallSyntax].
   void setup({
-    required Map<String, int>? named,
+    required Map<String, int?>? named,
     required List<int?>? positional,
   }) {
     _named = named;
@@ -1097,18 +1141,18 @@ class WithArgumentsCallSyntax extends CallSyntax {
     json.sortOnKey();
   }
 
-  Map<String, int>? get named => _reader.optionalMap<int>(
+  Map<String, int?>? get named => _reader.optionalMap<int?>(
     'named',
   );
 
-  set _named(Map<String, int>? value) {
+  set _named(Map<String, int?>? value) {
     _checkArgumentMapKeys(
       value,
     );
     json.setOrRemove('named', value);
   }
 
-  List<String> _validateNamed() => _reader.validateMap<int>(
+  List<String> _validateNamed() => _reader.validateOptionalMap<int?>(
     'named',
   );
 

--- a/pkgs/record_use/test/complex_keys_test.dart
+++ b/pkgs/record_use/test/complex_keys_test.dart
@@ -49,7 +49,7 @@ void main() {
     expect(backAgain, recordings);
   });
 
-  test('toValue() with InstanceConstant keys', () {
+  test('MapConstant equality with InstanceConstant keys', () {
     const instanceKey = InstanceConstant(
       fields: {
         'id': IntConstant(1),
@@ -61,13 +61,16 @@ void main() {
       MapEntry(instanceKey, StringConstant('value')),
     ]);
 
-    final mapValue = mapConstant.toValue() as Map;
-
-    expect(mapValue.keys.first, {
-      'id': 1,
-      'tag': 'key',
-    });
-    expect(mapValue.values.first, 'value');
+    expect(
+      mapConstant.entries.first.key,
+      const InstanceConstant(
+        fields: {
+          'id': IntConstant(1),
+          'tag': StringConstant('key'),
+        },
+      ),
+    );
+    expect(mapConstant.entries.first.value, const StringConstant('value'));
   });
 
   test('Deeply nested MapConstant with complex keys round-trip', () {
@@ -111,7 +114,7 @@ void main() {
     expect(backAgain, recordings);
   });
 
-  test('toValue() with deeply nested complex keys', () {
+  test('Deeply nested complex keys structure', () {
     const listKey = ListConstant([IntConstant(1), IntConstant(2)]);
     const mapKey = MapConstant([
       MapEntry(StringConstant('inner'), IntConstant(3)),
@@ -122,12 +125,27 @@ void main() {
       MapEntry(mapKey, listKey),
     ]);
 
-    final mapValue = complexMap.toValue() as Map;
-    expect(mapValue.length, 2);
-    final entries = mapValue.entries.toList();
-    expect(entries[0].key, [1, 2]);
-    expect(entries[0].value, {'inner': 3});
-    expect(entries[1].key, {'inner': 3});
-    expect(entries[1].value, [1, 2]);
+    expect(complexMap.entries, hasLength(2));
+    final entries = complexMap.entries;
+    expect(
+      entries[0].key,
+      const ListConstant([IntConstant(1), IntConstant(2)]),
+    );
+    expect(
+      entries[0].value,
+      const MapConstant([
+        MapEntry(StringConstant('inner'), IntConstant(3)),
+      ]),
+    );
+    expect(
+      entries[1].key,
+      const MapConstant([
+        MapEntry(StringConstant('inner'), IntConstant(3)),
+      ]),
+    );
+    expect(
+      entries[1].value,
+      const ListConstant([IntConstant(1), IntConstant(2)]),
+    );
   });
 }

--- a/pkgs/record_use/test/maybe_constant_test.dart
+++ b/pkgs/record_use/test/maybe_constant_test.dart
@@ -1,0 +1,149 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:record_use/record_use_internal.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('MaybeConstant arguments in JSON', () {
+    const json = {
+      'metadata': {'version': '1.0.0', 'comment': 'test'},
+      'constants': [
+        {'type': 'int', 'value': 42},
+        {'type': 'unsupported', 'message': 'Record'},
+      ],
+      'recordings': [
+        {
+          'definition': {
+            'identifier': {'uri': 'package:a/a.dart', 'name': 'foo'},
+          },
+          'calls': [
+            {
+              'type': 'with_arguments',
+              'loading_unit': '1',
+              'positional': [0, 1, null],
+              'named': {'a': 0, 'b': 1, 'c': null},
+            },
+          ],
+        },
+      ],
+    };
+
+    final recordings = Recordings.fromJson(json);
+    const identifier = Identifier(importUri: 'package:a/a.dart', name: 'foo');
+    final calls = recordings.calls[identifier]!;
+    final call = calls[0] as CallWithArguments;
+
+    expect(call.positionalArguments, hasLength(3));
+    expect(call.positionalArguments[0], const IntConstant(42));
+    expect(call.positionalArguments[1], const UnsupportedConstant('Record'));
+    expect(call.positionalArguments[2], const NonConstant());
+
+    expect(call.namedArguments, hasLength(3));
+    expect(call.namedArguments['a'], const IntConstant(42));
+    expect(call.namedArguments['b'], const UnsupportedConstant('Record'));
+    expect(call.namedArguments['c'], const NonConstant());
+  });
+
+  test('MaybeConstant serialization round-trip', () {
+    const identifier = Identifier(importUri: 'package:a/a.dart', name: 'foo');
+    const definition = Definition(identifier: identifier, loadingUnit: '1');
+    final recordings = Recordings(
+      metadata: Metadata(version: version, comment: 'test'),
+      callsForDefinition: {
+        definition: [
+          const CallWithArguments(
+            positionalArguments: [
+              IntConstant(42),
+              UnsupportedConstant('Record'),
+              NonConstant(),
+            ],
+            namedArguments: {
+              'a': IntConstant(42),
+              'b': UnsupportedConstant('Record'),
+              'c': NonConstant(),
+            },
+            loadingUnit: '1',
+          ),
+        ],
+      },
+      instancesForDefinition: {},
+    );
+
+    final json = recordings.toJson();
+    final roundTripped = Recordings.fromJson(json);
+
+    expect(roundTripped, equals(recordings));
+
+    // Verify JSON structure specifically for named nulls
+    final recordingsJson = json['recordings'] as List;
+    final recording = recordingsJson[0] as Map;
+    final call = (recording['calls'] as List)[0] as Map;
+    final named = call['named'] as Map;
+    expect(named.containsKey('c'), isTrue);
+    expect(named['c'], isNull);
+  });
+
+  test('allowPromotionOfUnsupported semantic equality', () {
+    const identifier = Identifier(importUri: 'package:a/a.dart', name: 'foo');
+    const definition = Definition(identifier: identifier, loadingUnit: '1');
+
+    final actualRecordings = Recordings(
+      metadata: Metadata(version: version, comment: 'actual'),
+      callsForDefinition: {
+        definition: [
+          const CallWithArguments(
+            positionalArguments: [IntConstant(42)],
+            namedArguments: {'a': StringConstant('bar')},
+            loadingUnit: '1',
+          ),
+        ],
+      },
+      instancesForDefinition: {},
+    );
+
+    final expectedRecordings = Recordings(
+      metadata: Metadata(version: version, comment: 'expected'),
+      callsForDefinition: {
+        definition: [
+          const CallWithArguments(
+            positionalArguments: [UnsupportedConstant('Record')],
+            namedArguments: {'a': UnsupportedConstant('Record')},
+            loadingUnit: '1',
+          ),
+        ],
+      },
+      instancesForDefinition: {},
+    );
+
+    // Should not match by default.
+    expect(
+      actualRecordings.semanticEquals(
+        expectedRecordings,
+        allowMetadataMismatch: true,
+      ),
+      isFalse,
+    );
+
+    // Should match when promotion is allowed.
+    expect(
+      actualRecordings.semanticEquals(
+        expectedRecordings,
+        allowMetadataMismatch: true,
+        allowPromotionOfUnsupported: true,
+      ),
+      isTrue,
+    );
+
+    // Verify it doesn't work the other way around (actual is less specific).
+    expect(
+      expectedRecordings.semanticEquals(
+        actualRecordings,
+        allowMetadataMismatch: true,
+        allowPromotionOfUnsupported: true,
+      ),
+      isFalse,
+    );
+  });
+}

--- a/pkgs/record_use/test/test_data.dart
+++ b/pkgs/record_use/test/test_data.dart
@@ -43,7 +43,7 @@ final recordedUses = Recordings(
       const CallWithArguments(
         positionalArguments: [
           StringConstant('lib_SHA1'),
-          MapConstant<StringConstant, IntConstant>([
+          MapConstant([
             MapEntry(StringConstant('key'), IntConstant(99)),
           ]),
           ListConstant([

--- a/pkgs/record_use/test/to_string_test.dart
+++ b/pkgs/record_use/test/to_string_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:record_use/src/reference.dart';
+import 'package:record_use/record_use_internal.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -21,14 +21,18 @@ void main() {
 
     test('CallWithArguments with multiple args', () {
       const call = CallWithArguments(
-        positionalArguments: [null, null],
-        namedArguments: {'bar': null, 'baz': null},
+        positionalArguments: [NonConstant(), NonConstant()],
+        namedArguments: {
+          'bar': NonConstant(),
+          'baz': NonConstant(),
+        },
         loadingUnit: 'dart.foo',
       );
       expect(
         call.toString(),
-        'CallWithArguments(positional: null, null, named: bar=null, baz=null, '
-        'loadingUnit: dart.foo)',
+        'CallWithArguments(positional: NonConstant(), '
+        'NonConstant(), named: bar=NonConstant(), '
+        'baz=NonConstant(), loadingUnit: dart.foo)',
       );
     });
   });

--- a/pkgs/record_use/test/usage_test.dart
+++ b/pkgs/record_use/test/usage_test.dart
@@ -43,17 +43,12 @@ void main() {
               ),
             )
             .first;
-    final instanceMap = recordedUses.instancesForDefinition.values
-        .expand((usage) => usage)
-        .whereType<InstanceConstantReference>()
-        .map(
-          (instance) => instance.instanceConstant.fields.map(
-            (key, constant) => MapEntry(key, constant.toValue()),
-          ),
-        )
-        .first;
-    for (final entry in instanceMap.entries) {
-      expect(instance[entry.key], entry.value);
+    final instances = recordedUses.instances[instanceId]!
+        .whereType<InstanceConstantReference>();
+    final instance0 = instances.first.instanceConstant;
+    for (final entry in instance0.fields.entries) {
+      final field = instance.fields[entry.key];
+      expect(field, equals(entry.value));
     }
   });
 
@@ -73,19 +68,25 @@ void main() {
             )
             .toList();
     final (named: named0, positional: positional0) = arguments[0];
-    expect(named0, const {'freddy': 'mercury', 'leroy': 'jenkins'});
-    expect(positional0, const ['lib_SHA1', false, 1]);
-    final (named: named1, positional: positional1) = arguments[1];
-    expect(named1, const {'freddy': 0, 'leroy': 'jenkins'});
-    expect(positional1, const [
-      'lib_SHA1',
-      {'key': 99},
-      [
-        'camus',
-        ['einstein', 'insert', false],
-        'einstein',
-      ],
+    expect(named0, {
+      'freddy': const StringConstant('mercury'),
+      'leroy': const StringConstant('jenkins'),
+    });
+    expect(positional0, const [
+      StringConstant('lib_SHA1'),
+      BoolConstant(false),
+      IntConstant(1),
     ]);
+    final (named: named1, positional: positional1) = arguments[1];
+    expect(named1, {
+      'freddy': const IntConstant(0),
+      'leroy': const StringConstant('jenkins'),
+    });
+    expect(positional1[0], const StringConstant('lib_SHA1'));
+    expect(positional1[1], isA<MapConstant>());
+    final map = positional1[1] as MapConstant;
+    expect(map.entries[0].key, const StringConstant('key'));
+    expect(map.entries[0].value, const IntConstant(99));
   });
 
   test('Specific API instances', () {
@@ -102,8 +103,8 @@ void main() {
               ),
             )
             .first;
-    expect(instance['a'], 42);
-    expect(instance['b'], null);
+    expect(instance.fields['a'], const IntConstant(42));
+    expect(instance.fields['b'], isA<NullConstant>());
   });
 
   test('HasNonConstInstance', () {

--- a/pkgs/record_use/test_data/drop_data_asset/hook/link.dart
+++ b/pkgs/record_use/test_data/drop_data_asset/hook/link.dart
@@ -38,10 +38,14 @@ void main(List<String> arguments) async {
       );
       print('Checking calls to $methodName...');
       for (final call in calls) {
-        print(
-          'A call was made to "$methodName" with the arguments ('
-          '${call.positional[0] as int},${call.positional[1] as int})',
-        );
+        if (call.positional case [
+          IntConstant(value: final v0),
+          IntConstant(value: final v1),
+        ]) {
+          print(
+            'A call was made to "$methodName" with the arguments ($v0,$v1)',
+          );
+        }
         symbols.add(methodName);
       }
     }

--- a/pkgs/record_use/test_data/drop_dylib_recording/hook/link.dart
+++ b/pkgs/record_use/test_data/drop_dylib_recording/hook/link.dart
@@ -41,10 +41,14 @@ void main(List<String> arguments) async {
         ),
       );
       for (final call in calls) {
-        dataLines.add(
-          'A call was made to "$methodName" with the arguments ('
-          '${call.positional[0] as int},${call.positional[1] as int})',
-        );
+        if (call.positional case [
+          IntConstant(value: final v0),
+          IntConstant(value: final v1),
+        ]) {
+          dataLines.add(
+            'A call was made to "$methodName" with the arguments ($v0,$v1)',
+          );
+        }
         symbols.add(methodName);
       }
     }

--- a/pkgs/record_use/test_data/json/constructor_invocation.json
+++ b/pkgs/record_use/test_data/json/constructor_invocation.json
@@ -31,6 +31,7 @@
         {
           "loading_unit": "root",
           "named": {
+            "other": null,
             "param": 2
           },
           "positional": [

--- a/pkgs/record_use/test_data/json/recorded_uses.json
+++ b/pkgs/record_use/test_data/json/recorded_uses.json
@@ -40,6 +40,10 @@
       "value": [
         5
       ]
+    },
+    {
+      "message": "Record",
+      "type": "unsupported"
     }
   ],
   "metadata": {
@@ -54,7 +58,8 @@
           "named": {
             "a": 0,
             "b": 2,
-            "c": 5
+            "c": 5,
+            "d": null
           },
           "positional": [
             0,
@@ -63,7 +68,8 @@
             null,
             5,
             6,
-            7
+            7,
+            8
           ],
           "type": "with_arguments"
         }


### PR DESCRIPTION
### Problem

Currently, `package:record_use` conflates several states when a recorded argument is not a supported constant. Both "non-constant" values and "unsupported constants" (constant values the compiler or `record_use` doesn't yet handle) are represented as `null`.

This ambiguity leads to confusing error messages for link hook authors. For example, a tool might report that a value "is not a constant" when the user knows it is, but the tool simply doesn't support that specific constant type (e.g., a new language feature).

* https://github.com/dart-lang/native/issues/2899

### Solution

This PR introduces a tri-state representation using a sealed hierarchy to distinguish between:
1.  **Supported Constants**: Constants whose structure and value are known (e.g., `IntConstant`, `StringConstant`).
2.  **Unsupported Constants**: Values that are definitely constants in Dart, but `record_use` cannot yet extract their value. These include a `message` explaining why.
3.  **Non-Constants**: Values provided at a call site that are not constant expressions.

### Key Changes

*   **Refactored `Constant` Hierarchy**:
    *   Introduced `MaybeConstant` as the sealed root.
    *   `NonConstant` represents non-constant values.
    *   `Constant` is the abstract base for all constants (including `UnsupportedConstant`). This enables having complex constants that somewhere deeply nested have an unsupported constant.
*   **Safe-by-Design API**:
    *   Removed the `toValue()` method and top-level getters from the base classes. This forces users to use **pattern matching**, ensuring they explicitly handle the `UnsupportedConstant` and `NonConstant` cases rather than writing code that silently fails or crashes on non-happy paths.
    *   Refined API precision: `constArgumentsFor` returns `MaybeConstant` (tri-state), while instance field access returns `Constant` (bi-state), as instance fields are guaranteed to be constants.
    * In a follow up PR we'll likely get rid of the whole current public API when addressing https://github.com/dart-lang/native/issues/2718
*   **Future-Proofing**: `UnsupportedConstant` allows the system to gracefully handle new Dart constant types. Link hooks can now report "Unsupported constant type: Record" instead of a misleading "Value is not a constant" error.
*   **Simplified Collections**: Removed generic type arguments from `ListConstant` and `MapConstant` to match the reality of the serialization format and simplify consumer code. (Closes https://github.com/dart-lang/native/issues/3036)
*   **Improved Semantic Equality**: Moved `semanticEquals` logic into the models and added an `allowPromotionOfUnsupported` flag. This allows an "expected" unsupported constant to match a more specific "actual" constant, which is useful when comparing results across different compiler versions.

This is a breaking change, will require manual rolling into the Dart SDK and g3.