### PR TITLE
[record_use] Require `package:` URIs in schema

### DIFF
--- a/pkgs/record_use/doc/schema/record_use.schema.json
+++ b/pkgs/record_use/doc/schema/record_use.schema.json
@@ -247,7 +247,8 @@
           "type": "string"
         },
         "uri": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^package:"
         }
       },
       "required": [

--- a/pkgs/record_use/lib/src/syntax.g.dart
+++ b/pkgs/record_use/lib/src/syntax.g.dart
@@ -315,13 +315,22 @@ class IdentifierSyntax extends JsonObjectSyntax {
 
   List<String> _validateScope() => _reader.validate<String?>('scope');
 
-  String get uri => _reader.get<String>('uri');
+  static final _uriPattern = RegExp(r'^package:');
+
+  String get uri => _reader.string('uri', _uriPattern);
 
   set _uri(String value) {
+    if (!_uriPattern.hasMatch(value)) {
+      throw ArgumentError.value(
+        value,
+        'value',
+        'Value does not satisify pattern: ${_uriPattern.pattern}.',
+      );
+    }
     json.setOrRemove('uri', value);
   }
 
-  List<String> _validateUri() => _reader.validate<String>('uri');
+  List<String> _validateUri() => _reader.validateString('uri', _uriPattern);
 
   @override
   List<String> validate() => [

--- a/pkgs/record_use/test/json_schema/uri_pattern_test.dart
+++ b/pkgs/record_use/test/json_schema/uri_pattern_test.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:json_schema/json_schema.dart';
+import 'package:native_test_helpers/native_test_helpers.dart';
+import 'package:test/test.dart';
+
+import '../test_data.dart';
+
+void main() {
+  final schemaUri = packageUri.resolve('doc/schema/record_use.schema.json');
+  final schemaJson =
+      jsonDecode(File.fromUri(schemaUri).readAsStringSync())
+          as Map<String, Object?>;
+  final schema = JsonSchema.create(schemaJson);
+
+  group('Identifier.uri pattern', () {
+    test('JSON schema validation succeeds for package URI', () {
+      final json = recordedUses.toJson();
+      final result = schema.validate(json);
+      expect(result.isValid, isTrue);
+    });
+
+    test('JSON schema validation fails for non-package URI', () {
+      final json = recordedUses.toJson();
+      // Modify the first recording's identifier URI to be invalid.
+      final recordings = json['recordings'] as List;
+      final recording = recordings[0] as Map;
+      final identifier = recording['identifier'] as Map;
+      identifier['uri'] = 'dart:core'; // Should start with package:
+
+      final result = schema.validate(json);
+      expect(result.isValid, isFalse);
+      expect(
+        result.errors.any((e) => e.message.contains('pattern')),
+        isTrue,
+      );
+    });
+  });
+}
+
+Uri packageUri = findPackageRoot('record_use');

--- a/pkgs/record_use/test/syntax/uri_pattern_test.dart
+++ b/pkgs/record_use/test/syntax/uri_pattern_test.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:record_use/record_use_internal.dart';
+import 'package:test/test.dart';
+
+import '../test_data.dart';
+
+void main() {
+  group('Identifier.uri pattern', () {
+    test('Recordings.fromJson fails for non-package URI', () {
+      final json = recordedUses.toJson();
+      // Modify the first recording's identifier URI to be invalid.
+      final recordings = json['recordings'] as List;
+      final recording = recordings[0] as Map;
+      final identifier = recording['identifier'] as Map;
+      identifier['uri'] = 'file:///foo.dart'; // Should start with package:
+
+      expect(
+        () => Recordings.fromJson(json),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('Expected a String satisfying ^package:'),
+          ),
+        ),
+      );
+    });
+
+    test('RecordedUsages.fromJson fails for non-package URI', () {
+      final json = recordedUses.toJson();
+      // Modify the first recording's identifier URI to be invalid.
+      final recordings = json['recordings'] as List;
+      final recording = recordings[0] as Map;
+      final identifier = recording['identifier'] as Map;
+      identifier['uri'] = 'file:///foo.dart'; // Should start with package:
+
+      expect(
+        () => RecordedUsages.fromJson(json),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('Expected a String satisfying ^package:'),
+          ),
+        ),
+      );
+    });
+
+    test('Identifier constructor does not throw (currently)', () {
+      // The Identifier class itself doesn't have the regex check in its
+      // constructor, only the generated syntax class has it.
+      expect(
+        () => const Identifier(importUri: 'dart:core', name: 'foo'),
+        returnsNormally,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Add `package:` library check to the json schema and validator.

Follow up of:

* https://github.com/dart-lang/native/pull/3069
* https://github.com/dart-lang/native/issues/2891