### PR TITLE
[record_use] Rework `Definition`s

### DIFF
--- a/pkgs/hooks/example/link/package_with_assets/hook/link.dart
+++ b/pkgs/hooks/example/link/package_with_assets/hook/link.dart
@@ -12,13 +12,13 @@ import 'package:hooks/hooks.dart';
 import 'package:record_use/record_use.dart';
 
 const someMethodDefinition = Definition(
-  importUri: 'package:package_with_assets/package_with_assets.dart',
-  name: 'someMethod',
+  'package:package_with_assets/package_with_assets.dart',
+  [Name('someMethod')],
 );
 
 const someOtherMethodDefinition = Definition(
-  importUri: 'package:package_with_assets/package_with_assets.dart',
-  name: 'someOtherMethod',
+  'package:package_with_assets/package_with_assets.dart',
+  [Name('someOtherMethod')],
 );
 
 final assetMapping = {

--- a/pkgs/hooks_runner/test/build_runner/resources_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/resources_test.dart
@@ -121,10 +121,9 @@ void main() async {
 final _pirateAdventureRecordings = Recordings(
   metadata: Metadata(version: Version(1, 0, 0), comment: 'Filtering test'),
   calls: {
-    const Definition(
-      importUri: 'package:pirate_speak/src/definitions.dart',
-      name: 'pirateSpeak',
-    ): [
+    const Definition('package:pirate_speak/src/definitions.dart', [
+      Name('pirateSpeak'),
+    ]): [
       const CallWithArguments(
         loadingUnit: 'root',
         positionalArguments: [StringConstant('Hello')],
@@ -136,10 +135,9 @@ final _pirateAdventureRecordings = Recordings(
         namedArguments: {},
       ),
     ],
-    const Definition(
-      importUri: 'package:pirate_technology/src/definitions.dart',
-      name: 'useCannon',
-    ): [
+    const Definition('package:pirate_technology/src/definitions.dart', [
+      Name('useCannon'),
+    ]): [
       const CallWithArguments(
         loadingUnit: 'root',
         positionalArguments: [],

--- a/pkgs/hooks_runner/test_data/pirate_speak/hook/link.dart
+++ b/pkgs/hooks_runner/test_data/pirate_speak/hook/link.dart
@@ -53,8 +53,8 @@ Set<String> _extractUsedPhrases(Recordings recordings) {
   final usages = RecordedUsages.fromJson(recordings.toJson());
   final usedPhrases = <String>{};
   const pirateSpeakDef = Definition(
-    importUri: 'package:pirate_speak/src/definitions.dart',
-    name: 'pirateSpeak',
+    'package:pirate_speak/src/definitions.dart',
+    [Name('pirateSpeak')],
   );
 
   for (final call in usages.constArgumentsFor(pirateSpeakDef)) {

--- a/pkgs/hooks_runner/test_data/pirate_technology/hook/link.dart
+++ b/pkgs/hooks_runner/test_data/pirate_technology/hook/link.dart
@@ -50,11 +50,11 @@ Future<Recordings> _loadRecordings(Uri file) async {
 Set<String> _extractUsedTechnologies(Recordings recordings) {
   final usedTechnologies = <String>{};
   for (final definition in recordings.calls.keys) {
-    if (definition.importUri ==
+    if (definition.library ==
         'package:pirate_technology/src/definitions.dart') {
       // Map function name to tech key (simple capitalization)
       // e.g. useCannon -> Cannon
-      final name = definition.name;
+      final name = definition.path.last.name;
       if (name.startsWith('use')) {
         usedTechnologies.add(name.substring(3));
       }

--- a/pkgs/record_use/README.md
+++ b/pkgs/record_use/README.md
@@ -78,13 +78,13 @@ import 'package:hooks/hooks.dart';
 import 'package:record_use/record_use_internal.dart';
 
 final methodId = Definition(
-  importUri: 'myfile.dart',
-  name: 'myMethod',
+  'package:mypackage/myfile.dart',
+  [Name('myMethod')],
 );
 
 final classId = Definition(
-  importUri: 'myfile.dart',
-  name: 'myClass',
+  'package:mypackage/myfile.dart',
+  [Name('myClass')],
 );
 
 void main(List<String> arguments){

--- a/pkgs/record_use/lib/record_use.dart
+++ b/pkgs/record_use/lib/record_use.dart
@@ -15,7 +15,8 @@ export 'src/constant.dart'
         NullConstant,
         StringConstant,
         UnsupportedConstant;
-export 'src/definition.dart' show Definition;
+export 'src/definition.dart'
+    show Definition, DefinitionDisambiguator, DefinitionKind, Name;
 export 'src/metadata.dart' show Metadata;
 export 'src/record_use.dart' show RecordedUsages;
 export 'src/recorded_usage_from_file.dart' show parseFromFile;

--- a/pkgs/record_use/lib/record_use_internal.dart
+++ b/pkgs/record_use/lib/record_use_internal.dart
@@ -15,7 +15,8 @@ export 'src/constant.dart'
         NullConstant,
         StringConstant,
         UnsupportedConstant;
-export 'src/definition.dart' show Definition;
+export 'src/definition.dart'
+    show Definition, DefinitionDisambiguator, DefinitionKind, Name;
 export 'src/metadata.dart' show Metadata;
 export 'src/record_use.dart' show RecordedUsages;
 export 'src/recordings.dart'

--- a/pkgs/record_use/lib/src/definition.dart
+++ b/pkgs/record_use/lib/src/definition.dart
@@ -10,80 +10,199 @@ import 'syntax.g.dart';
 /// or field, within a Dart program.
 ///
 /// A [Definition] is used to pinpoint a specific element based on its
-/// location and name. It consists of:
-///
-/// - `importUri`: The URI of the library where the element is defined.
-/// - `parent`: The name of the parent element (e.g., the class name for a
-///   method or field). This is optional, as not all elements have parents (e.g.
-///   top-level functions).
-/// - `name`: The name of the element itself.
-// TODO(https://github.com/dart-lang/native/issues/2888): Rename to Definition.
+/// location and name.
+// TODO(https://github.com/dart-lang/native/issues/3062): Make this API more
+// kind-centric, after we've added support for kinds and disambiguators in the
+// compilers.
 class Definition {
   /// The URI of the library where the element is defined.
   ///
-  /// This is given in the form of its package import uri, so that it is OS- and
-  /// user independent.
+  /// This must be a `package:` URI, so that it is OS- and user independent.
   ///
   /// For elements annotated with `@RecordUse`, this URI will always point to a
   /// file in the `lib/` directory of a package.
-  final String importUri;
+  final String library;
 
-  /// The name of the parent element (e.g., the class name for a method or
-  /// field). This is optional, as not all elements have parents (e.g. top-level
-  /// functions).
-  final String? scope;
-
-  /// The name of the element itself.
-  final String name;
+  /// The hierarchical path to the element within the library.
+  final List<Name> path;
 
   /// Creates a [Definition] object.
-  ///
-  /// [importUri] is the URI of the library where the element is defined.
-  /// [scope] is the optional name of the parent element.
-  /// [name] is the name of the element.
-  const Definition({required this.importUri, this.scope, required this.name});
+  const Definition(this.library, this.path);
 
   /// Creates a [Definition] object from its syntax representation.
-  factory Definition._fromSyntax(DefinitionSyntax syntax) =>
-      Definition(importUri: syntax.uri, scope: syntax.scope, name: syntax.name);
+  static Definition _fromSyntax(DefinitionSyntax syntax) {
+    final path = <Name>[];
+    if (syntax.scope != null) {
+      path.add(Name(syntax.scope!));
+    }
+    path.add(Name(syntax.name));
+    return Definition(syntax.uri, path);
+  }
 
   /// Converts this [Definition] object to a syntax representation.
-  DefinitionSyntax _toSyntax() =>
-      DefinitionSyntax(uri: importUri, scope: scope, name: name);
+  DefinitionSyntax _toSyntax() {
+    if (path.length > 2) {
+      throw StateError(
+        'DefinitionSyntax only supports up to two levels of nesting. '
+        'Found ${path.length} levels: $path',
+      );
+    }
+    String? scope;
+    if (path.length > 1) {
+      scope = path.first.name;
+    }
+    final name = path.last.name;
+    return DefinitionSyntax(uri: library, scope: scope, name: name);
+  }
+
+  /// The parent, if it exists.
+  Definition? get parent => path.length > 1
+      ? Definition(library, path.sublist(0, path.length - 1))
+      : null;
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
 
-    return other is Definition &&
-        other.importUri == importUri &&
-        other.scope == scope &&
-        other.name == name;
+    if (other is! Definition) return false;
+    if (other.library != library) return false;
+    if (other.path.length != path.length) return false;
+    for (var i = 0; i < path.length; i++) {
+      if (other.path[i] != path[i]) return false;
+    }
+    return true;
   }
 
   @override
-  int get hashCode => Object.hash(importUri, scope, name);
+  int get hashCode => Object.hash(library, Object.hashAll(path));
+
+  /// Returns a URI representation of this definition.
+  ///
+  /// The [library] is the base URI and the [path] is the fragment.
+  /// [Name]s in the [path] are separated by `::`.
+  @override
+  String toString() => '$library#${path.join('::')}';
 
   /// Compares this [Definition] with [other] for semantic equality.
   ///
-  /// The [importUri] can be mapped using [uriMapping] before comparison.
+  /// The [library] can be mapped using [uriMapping] before comparison.
   @visibleForTesting
   bool semanticEquals(
     Definition other, {
     String Function(String)? uriMapping,
   }) {
-    if (other.scope != scope) return false;
+    if (other.path.length != path.length) return false;
+    for (var i = 0; i < path.length; i++) {
+      if (other.path[i] != path[i]) return false;
+    }
+    final mappedLibrary = uriMapping == null ? library : uriMapping(library);
+    return mappedLibrary == other.library;
+  }
+}
+
+/// A component of a [Definition] path.
+class Name {
+  /// The name of the element itself.
+  final String name;
+
+  /// The kind of the element.
+  ///
+  /// TODO(https://github.com/dart-lang/native/issues/2888): Make this
+  /// non-nullable.
+  final DefinitionKind? kind;
+
+  /// Optional disambiguators (e.g. to distinguish between static and instance
+  /// members in extensions and extension types).
+  final Set<DefinitionDisambiguator> disambiguators;
+
+  const Name(
+    this.name, {
+    this.kind,
+    this.disambiguators = const {},
+  });
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    if (other is! Name) return false;
     if (other.name != name) return false;
-    final mappedImportUri = uriMapping == null
-        ? importUri
-        : uriMapping(importUri);
-    return mappedImportUri == other.importUri;
+    if (other.kind != kind) return false;
+    if (other.disambiguators.length != disambiguators.length) return false;
+    return disambiguators.every(other.disambiguators.contains);
   }
 
   @override
-  String toString() => scope == null
-      ? 'Definition($importUri, $name)'
-      : 'Definition($importUri, $scope, $name)';
+  int get hashCode => Object.hash(
+    name,
+    kind,
+    Object.hashAllUnordered(disambiguators),
+  );
+
+  /// Returns a string representation of this name that can be used as a part of
+  /// a URI fragment.
+  ///
+  /// The format is `kind:name@disambiguator1@disambiguator2`.
+  /// Disambiguators are sorted alphabetically.
+  @override
+  String toString() {
+    final buffer = StringBuffer();
+    if (kind != null) {
+      buffer.write('$kind:');
+    }
+    buffer.write(name);
+    if (disambiguators.isNotEmpty) {
+      final sorted = disambiguators.toList()
+        ..sort((a, b) => a.toString().compareTo(b.toString()));
+      for (final disambiguator in sorted) {
+        buffer.write('@$disambiguator');
+      }
+    }
+    return buffer.toString();
+  }
+}
+
+/// The kind of code element represented by a [Name].
+final class DefinitionKind {
+  final String _name;
+  const DefinitionKind._(this._name);
+
+  static const classKind = DefinitionKind._('class');
+  static const mixinKind = DefinitionKind._('mixin');
+  static const enumKind = DefinitionKind._('enum');
+  static const extensionKind = DefinitionKind._('extension');
+  static const extensionTypeKind = DefinitionKind._('extension_type');
+  static const methodKind = DefinitionKind._('method');
+  static const getterKind = DefinitionKind._('getter');
+  static const setterKind = DefinitionKind._('setter');
+  static const operatorKind = DefinitionKind._('operator');
+  static const constructorKind = DefinitionKind._('constructor');
+
+  @override
+  String toString() => _name;
+}
+
+/// Extra metadata to disambiguate between elements that might have the same
+/// name and kind.
+final class DefinitionDisambiguator {
+  final String _name;
+  const DefinitionDisambiguator._(this._name);
+
+  /// Applied to members that are static (e.g. a static method in a class).
+  ///
+  /// Only applies to [DefinitionKind.methodKind], [DefinitionKind.getterKind],
+  /// [DefinitionKind.setterKind], and [DefinitionKind.operatorKind].
+  static const staticDisambiguator = DefinitionDisambiguator._('static');
+
+  /// Applied to members that are instance members (e.g. an instance method in a
+  /// class or extension).
+  ///
+  /// Only applies to [DefinitionKind.methodKind], [DefinitionKind.getterKind],
+  /// [DefinitionKind.setterKind], and [DefinitionKind.operatorKind].
+  static const instanceDisambiguator = DefinitionDisambiguator._('instance');
+
+  @override
+  String toString() => _name;
 }
 
 /// Package private (protected) methods for [Definition].

--- a/pkgs/record_use/lib/src/record_use.dart
+++ b/pkgs/record_use/lib/src/record_use.dart
@@ -48,9 +48,8 @@ extension type RecordedUsages._(Recordings _recordings) {
   /// ```
   /// constArgumentsFor(
   ///           Definition(
-  ///             importUri: 'path/to/file.dart',
-  ///             scope: 'SomeClass',
-  ///             name: 'someStaticMethod',
+  ///             'package:my_package/file.dart',
+  ///             [Name('SomeClass'), Name('someStaticMethod')],
   ///           ),
   ///         ).first.positional[0] is IntConstant
   /// ```
@@ -96,8 +95,8 @@ extension type RecordedUsages._(Recordings _recordings) {
   /// ```
   /// constantsOf(
   ///       Definition(
-  ///           importUri: 'path/to/file.dart',
-  ///           name: 'AnnotationClass'),
+  ///           'package:my_package/file.dart',
+  ///           [Name('AnnotationClass')]),
   ///       ).first.fields['s'] is StringConstant;
   /// ```
   ///

--- a/pkgs/record_use/lib/src/recordings.dart
+++ b/pkgs/record_use/lib/src/recordings.dart
@@ -414,7 +414,7 @@ Error: $e
   Recordings filter({String? definitionPackageName}) {
     bool belongsToPackage(Definition definition) {
       if (definitionPackageName == null) return true;
-      final uri = definition.importUri;
+      final uri = definition.library;
       return uri.startsWith('package:$definitionPackageName/');
     }
 

--- a/pkgs/record_use/test/complex_keys_test.dart
+++ b/pkgs/record_use/test/complex_keys_test.dart
@@ -20,8 +20,8 @@ void main() {
     ]);
 
     const definition = Definition(
-      importUri: 'package:test/test.dart',
-      name: 'testMethod',
+      'package:test/test.dart',
+      [Name('testMethod')],
     );
 
     final recordings = Recordings(
@@ -83,8 +83,8 @@ void main() {
     ]);
 
     const definition = Definition(
-      importUri: 'package:test/test.dart',
-      name: 'complexMethod',
+      'package:test/test.dart',
+      [Name('complexMethod')],
     );
 
     final recordings = Recordings(

--- a/pkgs/record_use/test/instance_references_test.dart
+++ b/pkgs/record_use/test/instance_references_test.dart
@@ -8,8 +8,8 @@ import 'package:test/test.dart';
 
 void main() {
   const definition = Definition(
-    importUri: 'package:test/test.dart',
-    name: 'MyClass',
+    'package:test/test.dart',
+    [Name('MyClass')],
   );
 
   final metadata = Metadata(

--- a/pkgs/record_use/test/maybe_constant_test.dart
+++ b/pkgs/record_use/test/maybe_constant_test.dart
@@ -29,7 +29,7 @@ void main() {
     };
 
     final recordings = Recordings.fromJson(json);
-    const definition = Definition(importUri: 'package:a/a.dart', name: 'foo');
+    const definition = Definition('package:a/a.dart', [Name('foo')]);
     final calls = recordings.calls[definition]!;
     final call = calls[0] as CallWithArguments;
 
@@ -45,7 +45,7 @@ void main() {
   });
 
   test('MaybeConstant serialization round-trip', () {
-    const definition = Definition(importUri: 'package:a/a.dart', name: 'foo');
+    const definition = Definition('package:a/a.dart', [Name('foo')]);
     final recordings = Recordings(
       metadata: Metadata(version: version, comment: 'test'),
       calls: {
@@ -83,7 +83,7 @@ void main() {
   });
 
   test('allowPromotionOfUnsupported semantic equality', () {
-    const definition = Definition(importUri: 'package:a/a.dart', name: 'foo');
+    const definition = Definition('package:a/a.dart', [Name('foo')]);
 
     final actualRecordings = Recordings(
       metadata: Metadata(version: version, comment: 'actual'),

--- a/pkgs/record_use/test/semantic_equality_test.dart
+++ b/pkgs/record_use/test/semantic_equality_test.dart
@@ -8,21 +8,20 @@ import 'package:test/test.dart';
 
 void main() {
   const definition1 = Definition(
-    importUri: 'package:a/a.dart',
-    name: 'definition1',
+    'package:a/a.dart',
+    [Name('definition1')],
   );
   const definition2 = Definition(
-    importUri: 'package:a/a.dart',
-    name: 'definition2',
+    'package:a/a.dart',
+    [Name('definition2')],
   );
-  const definition1differentUri = Definition(
-    importUri: 'package:a/b.dart',
-    name: 'definition1',
+  const definition1differentLibrary = Definition(
+    'package:a/b.dart',
+    [Name('definition1')],
   );
   const definition3 = Definition(
-    importUri: 'package:a/a.dart',
-    scope: 'SomeClass',
-    name: 'definition1',
+    'package:a/a.dart',
+    [Name('SomeClass'), Name('definition1')],
   );
   const callDefintion1Static = CallWithArguments(
     positionalArguments: [],
@@ -42,9 +41,9 @@ void main() {
   const callDefinition1Tearoff = CallTearoff(
     loadingUnit: null,
   );
-  const definition1differentUri2 = Definition(
-    importUri: 'memory:a/a.dart',
-    name: 'definition1',
+  const definition1differentLibrary2 = Definition(
+    'memory:a/a.dart',
+    [Name('definition1')],
   );
   const callDefintion1StaticDifferentUri = CallWithArguments(
     positionalArguments: [],
@@ -59,10 +58,10 @@ void main() {
   test('Definition semantic equality', () {
     expect(definition1.semanticEquals(definition1), isTrue);
     expect(definition1.semanticEquals(definition2), isFalse);
-    expect(definition1.semanticEquals(definition1differentUri), isFalse);
+    expect(definition1.semanticEquals(definition1differentLibrary), isFalse);
     expect(
       definition1.semanticEquals(
-        definition1differentUri,
+        definition1differentLibrary,
         uriMapping: (uri) => uri.replaceFirst('a.dart', 'b.dart'),
       ),
       isTrue,
@@ -225,7 +224,7 @@ void main() {
     final recordings2 = Recordings(
       metadata: metadata,
       calls: {
-        definition1differentUri2: [
+        definition1differentLibrary2: [
           callDefintion1StaticDifferentUri,
         ],
       },

--- a/pkgs/record_use/test/syntax/uri_pattern_test.dart
+++ b/pkgs/record_use/test/syntax/uri_pattern_test.dart
@@ -53,7 +53,7 @@ void main() {
       // The Definition class itself doesn't have the regex check in its
       // constructor, only the generated syntax class has it.
       expect(
-        () => const Definition(importUri: 'dart:core', name: 'foo'),
+        () => const Definition('dart:core', [Name('foo')]),
         returnsNormally,
       );
     });

--- a/pkgs/record_use/test/test_data.dart
+++ b/pkgs/record_use/test/test_data.dart
@@ -6,13 +6,12 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:record_use/record_use_internal.dart';
 
 const callId = Definition(
-  importUri: 'package:js_runtime/js_helper.dart',
-  scope: 'MyClass',
-  name: 'get:loadDeferredLibrary',
+  'package:js_runtime/js_helper.dart',
+  [Name('MyClass'), Name('get:loadDeferredLibrary')],
 );
 const instanceId = Definition(
-  importUri: 'package:js_runtime/js_helper.dart',
-  name: 'MyAnnotation',
+  'package:js_runtime/js_helper.dart',
+  [Name('MyAnnotation')],
 );
 
 final recordedUses = Recordings(

--- a/pkgs/record_use/test/usage_test.dart
+++ b/pkgs/record_use/test/usage_test.dart
@@ -17,9 +17,8 @@ void main() {
           )
           .constArgumentsFor(
             const Definition(
-              importUri: 'package:js_runtime/js_helper.dart',
-              scope: 'MyClass',
-              name: 'get:loadDeferredLibrary',
+              'package:js_runtime/js_helper.dart',
+              [Name('MyClass'), Name('get:loadDeferredLibrary')],
             ),
           )
           .length,
@@ -34,8 +33,8 @@ void main() {
             )
             .constantsOf(
               const Definition(
-                importUri: 'package:js_runtime/js_helper.dart',
-                name: 'MyAnnotation',
+                'package:js_runtime/js_helper.dart',
+                [Name('MyAnnotation')],
               ),
             )
             .first;
@@ -55,9 +54,8 @@ void main() {
             )
             .constArgumentsFor(
               const Definition(
-                importUri: 'package:js_runtime/js_helper.dart',
-                scope: 'MyClass',
-                name: 'get:loadDeferredLibrary',
+                'package:js_runtime/js_helper.dart',
+                [Name('MyClass'), Name('get:loadDeferredLibrary')],
               ),
             )
             .toList();
@@ -90,8 +88,8 @@ void main() {
             )
             .constantsOf(
               const Definition(
-                importUri: 'package:js_runtime/js_helper.dart',
-                name: 'MyAnnotation',
+                'package:js_runtime/js_helper.dart',
+                [Name('MyAnnotation')],
               ),
             )
             .first;
@@ -105,9 +103,8 @@ void main() {
         jsonDecode(recordedUsesJson2) as Map<String, Object?>,
       ).hasNonConstArguments(
         const Definition(
-          importUri:
-              'package:drop_dylib_recording/src/drop_dylib_recording.dart',
-          name: 'getMathMethod',
+          'package:drop_dylib_recording/src/drop_dylib_recording.dart',
+          [Name('getMathMethod')],
         ),
       ),
       false,

--- a/pkgs/record_use/test_data/drop_data_asset/hook/link.dart
+++ b/pkgs/record_use/test_data/drop_data_asset/hook/link.dart
@@ -30,10 +30,8 @@ void main(List<String> arguments) async {
     for (final methodName in ['add', 'multiply']) {
       final calls = usages.constArgumentsFor(
         Definition(
-          importUri:
-              'package:${input.packageName}/src/${input.packageName}.dart',
-          scope: 'MyMath',
-          name: methodName,
+          'package:${input.packageName}/src/${input.packageName}.dart',
+          [const Name('MyMath'), Name(methodName)],
         ),
       );
       print('Checking calls to $methodName...');
@@ -54,9 +52,8 @@ void main(List<String> arguments) async {
     for (final className in ['Double', 'Square']) {
       final instances = usages.constantsOf(
         Definition(
-          importUri:
-              'package:${input.packageName}/src/${input.packageName}.dart',
-          name: className,
+          'package:${input.packageName}/src/${input.packageName}.dart',
+          [Name(className)],
         ),
       );
       print('Checking instances of $className...');

--- a/pkgs/record_use/test_data/drop_dylib_recording/hook/link.dart
+++ b/pkgs/record_use/test_data/drop_dylib_recording/hook/link.dart
@@ -34,10 +34,8 @@ void main(List<String> arguments) async {
     for (final methodName in ['add', 'multiply']) {
       final calls = usages.constArgumentsFor(
         Definition(
-          importUri:
-              'package:drop_dylib_recording/src/drop_dylib_recording.dart',
-          scope: 'MyMath',
-          name: methodName,
+          'package:drop_dylib_recording/src/drop_dylib_recording.dart',
+          [const Name('MyMath'), Name(methodName)],
         ),
       );
       for (final call in calls) {
@@ -59,9 +57,8 @@ void main(List<String> arguments) async {
     for (final className in ['Double', 'Square']) {
       final instances = usages.constantsOf(
         Definition(
-          importUri:
-              'package:drop_dylib_recording/src/drop_dylib_recording.dart',
-          name: className,
+          'package:drop_dylib_recording/src/drop_dylib_recording.dart',
+          [Name(className)],
         ),
       );
       for (final instance in instances) {

--- a/pkgs/record_use/test_data/library_uris/hook/link.dart
+++ b/pkgs/record_use/test_data/library_uris/hook/link.dart
@@ -25,28 +25,28 @@ void main(List<String> arguments) async {
 
       // This package.
       final myMethodDefinition = recordings.calls.keys.firstWhere(
-        (i) => i.name == 'myMethod',
+        (i) => i.path.last.name == 'myMethod',
       );
       expect(
-        myMethodDefinition.importUri,
+        myMethodDefinition.library,
         'package:library_uris/src/definition.dart',
       );
 
       // The helper package.
       final helperMethodDefinition = recordings.calls.keys.firstWhere(
-        (i) => i.name == 'methodInHelper',
+        (i) => i.path.last.name == 'methodInHelper',
       );
       expect(
-        helperMethodDefinition.importUri,
+        helperMethodDefinition.library,
         'package:library_uris_helper/src/helper_definition.dart',
       );
 
       // Outside the lib dir, no package: uri.
       final methodInBinDefinition = recordings.calls.keys.firstWhere(
-        (i) => i.name == 'methodInBin',
+        (i) => i.path.last.name == 'methodInBin',
       );
       expect(
-        methodInBinDefinition.importUri,
+        methodInBinDefinition.library,
         // TODO(https://github.com/dart-lang/native/issues/2891): What should
         // this be? We don't have library uris for bin.
         'package:library_uris/../bin/my_bin.dart',


### PR DESCRIPTION
This change addresses the ambiguity issues in how we identify Dart definitions. The new API ensures we can unambiguously capture and reference all kinds of statically resolved symbols across classes, extensions, and extension types.

Related bugs:

* https://github.com/dart-lang/native/issues/2888
* https://github.com/dart-lang/native/issues/3062

### Key Changes

#### 1. Structured `Name` with Kinds and Disambiguators
Each segment in the path is now a `Name` object containing:
* `name`: The string identifier.
* `kind`: A `DefinitionKind` (e.g., `classKind`, `methodKind`, `getterKind`, `setterKind`, `operatorKind`).
* `disambiguators`: A `Set<DefinitionDisambiguator>` used to distinguish between `static` and `instance` members, which is critical for extensions and extension types.

The `kind` and `disambiguators` are null. Setting them non-null will be done in a follow up PR.

#### 2. Canonical URI `toString()`
Implemented a "smart" `toString()` that produces valid, URI-friendly strings for use in tooling and documentation.
* **Format:** `library#kind:name@disambiguator::kind:name`
* **Example:** `package:my_pkg/foo.dart#class:MyClass::method:myMethod@static`

(Taken from discussions on https://github.com/dart-lang/language/issues/4616)