### PR TITLE
[record_use] Rename `Identifier` to `Definition`

### DIFF
--- a/pkgs/data_assets/lib/src/data_assets/data_asset.dart
+++ b/pkgs/data_assets/lib/src/data_assets/data_asset.dart
@@ -13,7 +13,7 @@ import 'syntax.g.dart';
 /// asset at runtime, the [id] is used. This enables access to the asset
 /// irrespective of how and where the application is run.
 ///
-/// An data asset must provide a [DataAsset.file]. The Dart and Flutter SDK will
+/// A data asset must provide a [DataAsset.file]. The Dart and Flutter SDK will
 /// bundle this code in the final application.
 final class DataAsset {
   /// The file to be bundled with the Dart or Flutter application.
@@ -32,7 +32,7 @@ final class DataAsset {
 
   /// The identifier for this data asset.
   ///
-  /// An [DataAsset] has a string identifier called "asset id". Dart code that
+  /// A [DataAsset] has a string identifier called "asset id". Dart code that
   /// uses an asset references the asset using this asset id.
   ///
   /// An asset identifier consists of two elements, the `package` and `name`,

--- a/pkgs/hooks/example/link/package_with_assets/hook/link.dart
+++ b/pkgs/hooks/example/link/package_with_assets/hook/link.dart
@@ -11,19 +11,19 @@ import 'package:data_assets/data_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:record_use/record_use.dart';
 
-const someMethodIdentifier = Identifier(
+const someMethodDefinition = Definition(
   importUri: 'package:package_with_assets/package_with_assets.dart',
   name: 'someMethod',
 );
 
-const someOtherMethodIdentifier = Identifier(
+const someOtherMethodDefinition = Definition(
   importUri: 'package:package_with_assets/package_with_assets.dart',
   name: 'someOtherMethod',
 );
 
 final assetMapping = {
-  someMethodIdentifier: 'assets/used_asset.json',
-  someOtherMethodIdentifier: 'assets/unused_asset.json',
+  someMethodDefinition: 'assets/used_asset.json',
+  someOtherMethodDefinition: 'assets/unused_asset.json',
 };
 
 void main(List<String> args) async {

--- a/pkgs/hooks_runner/lib/src/model/target.dart
+++ b/pkgs/hooks_runner/lib/src/model/target.dart
@@ -145,7 +145,7 @@ final class Target implements Comparable<Target> {
 
   /// Compares `this` to [other].
   ///
-  /// If [other] is also an [Target], consistent with sorting on [toString].
+  /// If [other] is also a [Target], consistent with sorting on [toString].
   @override
   int compareTo(Target other) => toString().compareTo(other.toString());
 

--- a/pkgs/hooks_runner/test/build_runner/resources_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/resources_test.dart
@@ -121,7 +121,7 @@ void main() async {
 final _pirateAdventureRecordings = Recordings(
   metadata: Metadata(version: Version(1, 0, 0), comment: 'Filtering test'),
   calls: {
-    const Identifier(
+    const Definition(
       importUri: 'package:pirate_speak/src/definitions.dart',
       name: 'pirateSpeak',
     ): [
@@ -136,7 +136,7 @@ final _pirateAdventureRecordings = Recordings(
         namedArguments: {},
       ),
     ],
-    const Identifier(
+    const Definition(
       importUri: 'package:pirate_technology/src/definitions.dart',
       name: 'useCannon',
     ): [

--- a/pkgs/hooks_runner/test_data/pirate_speak/hook/link.dart
+++ b/pkgs/hooks_runner/test_data/pirate_speak/hook/link.dart
@@ -52,12 +52,12 @@ Future<Recordings> _loadRecordings(Uri file) async {
 Set<String> _extractUsedPhrases(Recordings recordings) {
   final usages = RecordedUsages.fromJson(recordings.toJson());
   final usedPhrases = <String>{};
-  const pirateSpeakId = Identifier(
+  const pirateSpeakDef = Definition(
     importUri: 'package:pirate_speak/src/definitions.dart',
     name: 'pirateSpeak',
   );
 
-  for (final call in usages.constArgumentsFor(pirateSpeakId)) {
+  for (final call in usages.constArgumentsFor(pirateSpeakDef)) {
     if (call.positional.isNotEmpty) {
       if (call.positional.first case StringConstant(:final value)) {
         usedPhrases.add(value);

--- a/pkgs/hooks_runner/test_data/pirate_technology/hook/link.dart
+++ b/pkgs/hooks_runner/test_data/pirate_technology/hook/link.dart
@@ -49,12 +49,12 @@ Future<Recordings> _loadRecordings(Uri file) async {
 
 Set<String> _extractUsedTechnologies(Recordings recordings) {
   final usedTechnologies = <String>{};
-  for (final identifier in recordings.calls.keys) {
-    if (identifier.importUri ==
+  for (final definition in recordings.calls.keys) {
+    if (definition.importUri ==
         'package:pirate_technology/src/definitions.dart') {
       // Map function name to tech key (simple capitalization)
       // e.g. useCannon -> Cannon
-      final name = identifier.name;
+      final name = definition.name;
       if (name.startsWith('use')) {
         usedTechnologies.add(name.substring(3));
       }

--- a/pkgs/record_use/README.md
+++ b/pkgs/record_use/README.md
@@ -77,12 +77,12 @@ import 'dart:convert';
 import 'package:hooks/hooks.dart';
 import 'package:record_use/record_use_internal.dart';
 
-final methodId = Identifier(
+final methodId = Definition(
   importUri: 'myfile.dart',
   name: 'myMethod',
 );
 
-final classId = Identifier(
+final classId = Definition(
   importUri: 'myfile.dart',
   name: 'myClass',
 );

--- a/pkgs/record_use/doc/schema/record_use.schema.json
+++ b/pkgs/record_use/doc/schema/record_use.schema.json
@@ -237,7 +237,7 @@
         }
       ]
     },
-    "Identifier": {
+    "Definition": {
       "type": "object",
       "properties": {
         "name": {
@@ -395,7 +395,7 @@
           }
         },
         "identifier": {
-          "$ref": "#/definitions/Identifier"
+          "$ref": "#/definitions/Definition"
         },
         "instances": {
           "type": "array",

--- a/pkgs/record_use/doc/use_cases/jnigen.md
+++ b/pkgs/record_use/doc/use_cases/jnigen.md
@@ -88,7 +88,7 @@ const dartToJava = {
     importUrl: 'package:foo/foo.dart',
     name: 'Bar',
     methodName: 'baz',
-  ) : JavaMethodIdentifier(
+  ) : JavaMethodDefinition(
     qualifiedImport: 'org.foo.foo',
     name: 'Bar',
     methodName: 'baz',

--- a/pkgs/record_use/lib/record_use.dart
+++ b/pkgs/record_use/lib/record_use.dart
@@ -15,7 +15,7 @@ export 'src/constant.dart'
         NullConstant,
         StringConstant,
         UnsupportedConstant;
-export 'src/identifier.dart' show Identifier;
+export 'src/definition.dart' show Definition;
 export 'src/metadata.dart' show Metadata;
 export 'src/record_use.dart' show RecordedUsages;
 export 'src/recorded_usage_from_file.dart' show parseFromFile;

--- a/pkgs/record_use/lib/record_use_internal.dart
+++ b/pkgs/record_use/lib/record_use_internal.dart
@@ -15,7 +15,7 @@ export 'src/constant.dart'
         NullConstant,
         StringConstant,
         UnsupportedConstant;
-export 'src/identifier.dart' show Identifier;
+export 'src/definition.dart' show Definition;
 export 'src/metadata.dart' show Metadata;
 export 'src/record_use.dart' show RecordedUsages;
 export 'src/recordings.dart'

--- a/pkgs/record_use/lib/src/definition.dart
+++ b/pkgs/record_use/lib/src/definition.dart
@@ -9,7 +9,7 @@ import 'syntax.g.dart';
 /// A unique identifier for a code element, such as a class, method,
 /// or field, within a Dart program.
 ///
-/// An [Identifier] is used to pinpoint a specific element based on its
+/// A [Definition] is used to pinpoint a specific element based on its
 /// location and name. It consists of:
 ///
 /// - `importUri`: The URI of the library where the element is defined.
@@ -18,7 +18,7 @@ import 'syntax.g.dart';
 ///   top-level functions).
 /// - `name`: The name of the element itself.
 // TODO(https://github.com/dart-lang/native/issues/2888): Rename to Definition.
-class Identifier {
+class Definition {
   /// The URI of the library where the element is defined.
   ///
   /// This is given in the form of its package import uri, so that it is OS- and
@@ -36,26 +36,26 @@ class Identifier {
   /// The name of the element itself.
   final String name;
 
-  /// Creates an [Identifier] object.
+  /// Creates a [Definition] object.
   ///
   /// [importUri] is the URI of the library where the element is defined.
   /// [scope] is the optional name of the parent element.
   /// [name] is the name of the element.
-  const Identifier({required this.importUri, this.scope, required this.name});
+  const Definition({required this.importUri, this.scope, required this.name});
 
-  /// Creates an [Identifier] object from its syntax representation.
-  factory Identifier._fromSyntax(IdentifierSyntax syntax) =>
-      Identifier(importUri: syntax.uri, scope: syntax.scope, name: syntax.name);
+  /// Creates a [Definition] object from its syntax representation.
+  factory Definition._fromSyntax(DefinitionSyntax syntax) =>
+      Definition(importUri: syntax.uri, scope: syntax.scope, name: syntax.name);
 
-  /// Converts this [Identifier] object to a syntax representation.
-  IdentifierSyntax _toSyntax() =>
-      IdentifierSyntax(uri: importUri, scope: scope, name: name);
+  /// Converts this [Definition] object to a syntax representation.
+  DefinitionSyntax _toSyntax() =>
+      DefinitionSyntax(uri: importUri, scope: scope, name: name);
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
 
-    return other is Identifier &&
+    return other is Definition &&
         other.importUri == importUri &&
         other.scope == scope &&
         other.name == name;
@@ -64,12 +64,12 @@ class Identifier {
   @override
   int get hashCode => Object.hash(importUri, scope, name);
 
-  /// Compares this [Identifier] with [other] for semantic equality.
+  /// Compares this [Definition] with [other] for semantic equality.
   ///
   /// The [importUri] can be mapped using [uriMapping] before comparison.
   @visibleForTesting
   bool semanticEquals(
-    Identifier other, {
+    Definition other, {
     String Function(String)? uriMapping,
   }) {
     if (other.scope != scope) return false;
@@ -82,17 +82,17 @@ class Identifier {
 
   @override
   String toString() => scope == null
-      ? 'Identifier($importUri, $name)'
-      : 'Identifier($importUri, $scope, $name)';
+      ? 'Definition($importUri, $name)'
+      : 'Definition($importUri, $scope, $name)';
 }
 
-/// Package private (protected) methods for [Identifier].
+/// Package private (protected) methods for [Definition].
 ///
 /// This avoids bloating the public API and public API docs and prevents
 /// internal types from leaking from the API.
-extension IdentifierProtected on Identifier {
-  IdentifierSyntax toSyntax() => _toSyntax();
+extension DefinitionProtected on Definition {
+  DefinitionSyntax toSyntax() => _toSyntax();
 
-  static Identifier fromSyntax(IdentifierSyntax syntax) =>
-      Identifier._fromSyntax(syntax);
+  static Definition fromSyntax(DefinitionSyntax syntax) =>
+      Definition._fromSyntax(syntax);
 }

--- a/pkgs/record_use/lib/src/record_use.dart
+++ b/pkgs/record_use/lib/src/record_use.dart
@@ -7,7 +7,7 @@ import '../record_use_internal.dart';
 /// Holds all information recorded during compilation.
 ///
 /// This can be queried using the methods provided, which each take an
-/// [Identifier] which must be annotated with `@RecordUse` from `package:meta`.
+/// [Definition] which must be annotated with `@RecordUse` from `package:meta`.
 ///
 /// The definition annotated with `@RecordUse` must be inside the `lib/`
 /// directory of the package. If the definition is a member of a class (e.g. a
@@ -19,7 +19,7 @@ extension type RecordedUsages._(Recordings _recordings) {
   /// Show the metadata for this recording of usages.
   Metadata get metadata => _recordings.metadata;
 
-  /// Finds all recorded arguments for calls to the [identifier].
+  /// Finds all recorded arguments for calls to the [definition].
   ///
   /// The definition must be annotated with `@RecordUse()`. The definition (and
   /// its enclosing class, if any) must be in the `lib/` directory of the
@@ -47,7 +47,7 @@ extension type RecordedUsages._(Recordings _recordings) {
   /// Would mean that
   /// ```
   /// constArgumentsFor(
-  ///           Identifier(
+  ///           Definition(
   ///             importUri: 'path/to/file.dart',
   ///             scope: 'SomeClass',
   ///             name: 'someStaticMethod',
@@ -55,8 +55,8 @@ extension type RecordedUsages._(Recordings _recordings) {
   ///         ).first.positional[0] is IntConstant
   /// ```
   Iterable<({Map<String, MaybeConstant> named, List<MaybeConstant> positional})>
-  constArgumentsFor(Identifier identifier) =>
-      _recordings.calls[identifier]?.whereType<CallWithArguments>().map(
+  constArgumentsFor(Definition definition) =>
+      _recordings.calls[definition]?.whereType<CallWithArguments>().map(
         (call) => (
           named: call.namedArguments,
           positional: call.positionalArguments,
@@ -64,7 +64,7 @@ extension type RecordedUsages._(Recordings _recordings) {
       ) ??
       [];
 
-  /// Finds all constant instances of the class [identifier].
+  /// Finds all constant instances of the class [definition].
   ///
   /// The definition must be annotated with `@RecordUse()`. The definition (and
   /// its enclosing class, if any) must be in the `lib/` directory of the
@@ -95,7 +95,7 @@ extension type RecordedUsages._(Recordings _recordings) {
   /// Would mean that
   /// ```
   /// constantsOf(
-  ///       Identifier(
+  ///       Definition(
   ///           importUri: 'path/to/file.dart',
   ///           name: 'AnnotationClass'),
   ///       ).first.fields['s'] is StringConstant;
@@ -103,13 +103,13 @@ extension type RecordedUsages._(Recordings _recordings) {
   ///
   /// What kinds of fields can be recorded depends on the implementation of
   /// https://dart-review.googlesource.com/c/sdk/+/369620/13/pkg/vm/lib/transformations/record_use/record_instance.dart
-  Iterable<InstanceConstant> constantsOf(Identifier identifier) =>
-      _recordings.instances[identifier]
+  Iterable<InstanceConstant> constantsOf(Definition definition) =>
+      _recordings.instances[definition]
           ?.whereType<InstanceConstantReference>()
           .map((reference) => reference.instanceConstant) ??
       [];
 
-  /// Checks if any call to [identifier] has non-const arguments, or if any
+  /// Checks if any call to [definition] has non-const arguments, or if any
   /// tear-off was recorded.
   ///
   /// The definition must be annotated with `@RecordUse()`. The definition (and
@@ -117,8 +117,8 @@ extension type RecordedUsages._(Recordings _recordings) {
   /// package. If there are no calls to the definition, either because it was
   /// treeshaken, because it was not annotated, or because it does not exist,
   /// this method returns `false`.
-  bool hasNonConstArguments(Identifier identifier) =>
-      (_recordings.calls[identifier] ?? []).any(
+  bool hasNonConstArguments(Definition definition) =>
+      (_recordings.calls[definition] ?? []).any(
         (element) => switch (element) {
           CallTearoff() => true,
           final CallWithArguments call =>

--- a/pkgs/record_use/lib/src/reference.dart
+++ b/pkgs/record_use/lib/src/reference.dart
@@ -5,8 +5,8 @@
 import 'package:meta/meta.dart';
 
 import 'constant.dart';
+import 'definition.dart';
 import 'helper.dart';
-import 'identifier.dart';
 import 'syntax.g.dart';
 
 /// A reference to *something*.
@@ -42,7 +42,7 @@ sealed class Reference {
       other.loadingUnit;
 }
 
-/// A reference to a call to some [Identifier].
+/// A reference to a call to some [Definition].
 ///
 /// This might be an actual call, in which case we record the arguments, or a
 /// tear-off, in which case we can't record the arguments.
@@ -104,7 +104,7 @@ sealed class CallReference extends Reference {
   });
 }
 
-/// A reference to a call to some [Identifier] with [positionalArguments] and
+/// A reference to a call to some [Definition] with [positionalArguments] and
 /// [namedArguments].
 final class CallWithArguments extends CallReference {
   final List<MaybeConstant> positionalArguments;
@@ -231,7 +231,7 @@ final class CallWithArguments extends CallReference {
   }
 }
 
-/// A reference to a tear-off use of the [Identifier]. This means that we can't
+/// A reference to a tear-off use of the [Definition]. This means that we can't
 /// record the arguments possibly passed to the method somewhere else.
 final class CallTearoff extends CallReference {
   const CallTearoff({required super.loadingUnit});

--- a/pkgs/record_use/lib/src/syntax.g.dart
+++ b/pkgs/record_use/lib/src/syntax.g.dart
@@ -281,13 +281,13 @@ extension CreationInstanceSyntaxExtension on InstanceSyntax {
       CreationInstanceSyntax.fromJson(json, path: path);
 }
 
-class IdentifierSyntax extends JsonObjectSyntax {
-  IdentifierSyntax.fromJson(
+class DefinitionSyntax extends JsonObjectSyntax {
+  DefinitionSyntax.fromJson(
     super.json, {
     super.path = const [],
   }) : super.fromJson();
 
-  IdentifierSyntax({
+  DefinitionSyntax({
     required String name,
     String? scope,
     required String uri,
@@ -341,7 +341,7 @@ class IdentifierSyntax extends JsonObjectSyntax {
   ];
 
   @override
-  String toString() => 'IdentifierSyntax($json)';
+  String toString() => 'DefinitionSyntax($json)';
 }
 
 class InstanceSyntax extends JsonObjectSyntax {
@@ -830,7 +830,7 @@ class RecordingSyntax extends JsonObjectSyntax {
 
   RecordingSyntax({
     List<CallSyntax>? calls,
-    required IdentifierSyntax identifier,
+    required DefinitionSyntax identifier,
     List<InstanceSyntax>? instances,
     super.path = const [],
   }) : super() {
@@ -874,12 +874,12 @@ class RecordingSyntax extends JsonObjectSyntax {
     return [for (final element in elements) ...element.validate()];
   }
 
-  IdentifierSyntax get identifier {
+  DefinitionSyntax get identifier {
     final jsonValue = _reader.map$('identifier');
-    return IdentifierSyntax.fromJson(jsonValue, path: [...path, 'identifier']);
+    return DefinitionSyntax.fromJson(jsonValue, path: [...path, 'identifier']);
   }
 
-  set _identifier(IdentifierSyntax value) {
+  set _identifier(DefinitionSyntax value) {
     json['identifier'] = value.json;
   }
 

--- a/pkgs/record_use/test/complex_keys_test.dart
+++ b/pkgs/record_use/test/complex_keys_test.dart
@@ -19,7 +19,7 @@ void main() {
       MapEntry(instanceKey, StringConstant('value')),
     ]);
 
-    const identifier = Identifier(
+    const definition = Definition(
       importUri: 'package:test/test.dart',
       name: 'testMethod',
     );
@@ -30,7 +30,7 @@ void main() {
         comment: 'Test complex keys',
       ),
       calls: {
-        identifier: [
+        definition: [
           const CallWithArguments(
             positionalArguments: [mapConstant],
             namedArguments: {},
@@ -82,7 +82,7 @@ void main() {
       MapEntry(mapKey, listKey),
     ]);
 
-    const identifier = Identifier(
+    const definition = Definition(
       importUri: 'package:test/test.dart',
       name: 'complexMethod',
     );
@@ -93,7 +93,7 @@ void main() {
         comment: 'Test deeply nested complex keys',
       ),
       calls: {
-        identifier: [
+        definition: [
           const CallWithArguments(
             positionalArguments: [complexMap],
             namedArguments: {},

--- a/pkgs/record_use/test/instance_references_test.dart
+++ b/pkgs/record_use/test/instance_references_test.dart
@@ -7,7 +7,7 @@ import 'package:record_use/record_use_internal.dart';
 import 'package:test/test.dart';
 
 void main() {
-  const identifier = Identifier(
+  const definition = Definition(
     importUri: 'package:test/test.dart',
     name: 'MyClass',
   );
@@ -21,7 +21,7 @@ void main() {
     metadata: metadata,
     calls: {},
     instances: {
-      identifier: [
+      definition: [
         const InstanceCreationReference(
           positionalArguments: [IntConstant(1), IntConstant(2)],
           namedArguments: {'param': StringConstant('named_arg_value')},
@@ -33,7 +33,7 @@ void main() {
   );
 
   test('Deserialize creation and tearoff instances', () {
-    final instances = recordings.instances[identifier];
+    final instances = recordings.instances[definition];
     expect(instances, isNotNull);
     expect(instances, hasLength(2));
 
@@ -73,7 +73,7 @@ void main() {
     // But we can go via JSON.
     final usages = RecordedUsages.fromJson(recordings.toJson());
 
-    final constants = usages.constantsOf(identifier);
+    final constants = usages.constantsOf(definition);
     expect(constants, isEmpty);
   });
 }

--- a/pkgs/record_use/test/json_schema/uri_pattern_test.dart
+++ b/pkgs/record_use/test/json_schema/uri_pattern_test.dart
@@ -18,7 +18,7 @@ void main() {
           as Map<String, Object?>;
   final schema = JsonSchema.create(schemaJson);
 
-  group('Identifier.uri pattern', () {
+  group('Definition.uri pattern', () {
     test('JSON schema validation succeeds for package URI', () {
       final json = recordedUses.toJson();
       final result = schema.validate(json);

--- a/pkgs/record_use/test/maybe_constant_test.dart
+++ b/pkgs/record_use/test/maybe_constant_test.dart
@@ -29,8 +29,8 @@ void main() {
     };
 
     final recordings = Recordings.fromJson(json);
-    const identifier = Identifier(importUri: 'package:a/a.dart', name: 'foo');
-    final calls = recordings.calls[identifier]!;
+    const definition = Definition(importUri: 'package:a/a.dart', name: 'foo');
+    final calls = recordings.calls[definition]!;
     final call = calls[0] as CallWithArguments;
 
     expect(call.positionalArguments, hasLength(3));
@@ -45,11 +45,11 @@ void main() {
   });
 
   test('MaybeConstant serialization round-trip', () {
-    const identifier = Identifier(importUri: 'package:a/a.dart', name: 'foo');
+    const definition = Definition(importUri: 'package:a/a.dart', name: 'foo');
     final recordings = Recordings(
       metadata: Metadata(version: version, comment: 'test'),
       calls: {
-        identifier: [
+        definition: [
           const CallWithArguments(
             positionalArguments: [
               IntConstant(42),
@@ -83,12 +83,12 @@ void main() {
   });
 
   test('allowPromotionOfUnsupported semantic equality', () {
-    const identifier = Identifier(importUri: 'package:a/a.dart', name: 'foo');
+    const definition = Definition(importUri: 'package:a/a.dart', name: 'foo');
 
     final actualRecordings = Recordings(
       metadata: Metadata(version: version, comment: 'actual'),
       calls: {
-        identifier: [
+        definition: [
           const CallWithArguments(
             positionalArguments: [IntConstant(42)],
             namedArguments: {'a': StringConstant('bar')},
@@ -102,7 +102,7 @@ void main() {
     final expectedRecordings = Recordings(
       metadata: Metadata(version: version, comment: 'expected'),
       calls: {
-        identifier: [
+        definition: [
           const CallWithArguments(
             positionalArguments: [UnsupportedConstant('Record')],
             namedArguments: {'a': UnsupportedConstant('Record')},

--- a/pkgs/record_use/test/semantic_equality_test.dart
+++ b/pkgs/record_use/test/semantic_equality_test.dart
@@ -7,19 +7,19 @@ import 'package:record_use/record_use_internal.dart';
 import 'package:test/test.dart';
 
 void main() {
-  const identifier1 = Identifier(
+  const definition1 = Definition(
     importUri: 'package:a/a.dart',
     name: 'definition1',
   );
-  const identifier2 = Identifier(
+  const definition2 = Definition(
     importUri: 'package:a/a.dart',
     name: 'definition2',
   );
-  const identifier1differentUri = Identifier(
+  const definition1differentUri = Definition(
     importUri: 'package:a/b.dart',
     name: 'definition1',
   );
-  const identifier3 = Identifier(
+  const definition3 = Definition(
     importUri: 'package:a/a.dart',
     scope: 'SomeClass',
     name: 'definition1',
@@ -42,7 +42,7 @@ void main() {
   const callDefinition1Tearoff = CallTearoff(
     loadingUnit: null,
   );
-  const identifier1differentUri2 = Identifier(
+  const definition1differentUri2 = Definition(
     importUri: 'memory:a/a.dart',
     name: 'definition1',
   );
@@ -56,41 +56,41 @@ void main() {
     comment: '',
   );
 
-  test('Identifier semantic equality', () {
-    expect(identifier1.semanticEquals(identifier1), isTrue);
-    expect(identifier1.semanticEquals(identifier2), isFalse);
-    expect(identifier1.semanticEquals(identifier1differentUri), isFalse);
+  test('Definition semantic equality', () {
+    expect(definition1.semanticEquals(definition1), isTrue);
+    expect(definition1.semanticEquals(definition2), isFalse);
+    expect(definition1.semanticEquals(definition1differentUri), isFalse);
     expect(
-      identifier1.semanticEquals(
-        identifier1differentUri,
+      definition1.semanticEquals(
+        definition1differentUri,
         uriMapping: (uri) => uri.replaceFirst('a.dart', 'b.dart'),
       ),
       isTrue,
     );
-    expect(identifier1.semanticEquals(identifier3), isFalse);
+    expect(definition1.semanticEquals(definition3), isFalse);
   });
 
   test('Strict equality', () {
     final recordings1 = Recordings(
       metadata: metadata,
       calls: {
-        identifier1: [callDefintion1Static, callDefintion1Static2],
-        identifier2: [callDefinition2Static],
+        definition1: [callDefintion1Static, callDefintion1Static2],
+        definition2: [callDefinition2Static],
       },
       instances: const {},
     );
     final recordings2 = Recordings(
       metadata: metadata,
       calls: {
-        identifier2: [callDefinition2Static],
-        identifier1: [callDefintion1Static2, callDefintion1Static],
+        definition2: [callDefinition2Static],
+        definition1: [callDefintion1Static2, callDefintion1Static],
       },
       instances: const {},
     );
     final recordings3 = Recordings(
       metadata: metadata,
       calls: {
-        identifier1: [callDefintion1Static],
+        definition1: [callDefintion1Static],
       },
       instances: const {},
     );
@@ -106,15 +106,15 @@ void main() {
     final recordings1 = Recordings(
       metadata: metadata,
       calls: {
-        identifier1: [callDefintion1Static],
-        identifier2: [callDefinition2Static],
+        definition1: [callDefintion1Static],
+        definition2: [callDefinition2Static],
       },
       instances: const {},
     );
     final recordings2 = Recordings(
       metadata: metadata,
       calls: {
-        identifier1: [callDefintion1Static],
+        definition1: [callDefintion1Static],
       },
       instances: const {},
     );
@@ -137,15 +137,15 @@ void main() {
     final recordings1 = Recordings(
       metadata: metadata,
       calls: {
-        identifier1: [callDefintion1Static],
+        definition1: [callDefintion1Static],
       },
       instances: const {},
     );
     final recordings2 = Recordings(
       metadata: metadata,
       calls: {
-        identifier1: [callDefintion1Static],
-        identifier2: [callDefinition2Static],
+        definition1: [callDefintion1Static],
+        definition2: [callDefinition2Static],
       },
       instances: const {},
     );
@@ -177,14 +177,14 @@ void main() {
     final recordings1 = Recordings(
       metadata: metadata,
       calls: {
-        identifier1: [callDefintion1Static],
+        definition1: [callDefintion1Static],
       },
       instances: const {},
     );
     final recordings2 = Recordings(
       metadata: metadata,
       calls: {
-        identifier1: [callDefinition1Tearoff],
+        definition1: [callDefinition1Tearoff],
       },
       instances: const {},
     );
@@ -216,7 +216,7 @@ void main() {
     final recordings1 = Recordings(
       metadata: metadata,
       calls: {
-        identifier1: [
+        definition1: [
           callDefintion1Static,
         ],
       },
@@ -225,7 +225,7 @@ void main() {
     final recordings2 = Recordings(
       metadata: metadata,
       calls: {
-        identifier1differentUri2: [
+        definition1differentUri2: [
           callDefintion1StaticDifferentUri,
         ],
       },
@@ -248,7 +248,7 @@ void main() {
     final recordings1 = Recordings(
       metadata: metadata,
       calls: {
-        identifier1: [
+        definition1: [
           const CallWithArguments(
             positionalArguments: [IntConstant(1)],
             namedArguments: {},
@@ -261,7 +261,7 @@ void main() {
     final recordings2 = Recordings(
       metadata: metadata,
       calls: {
-        identifier1: [
+        definition1: [
           const CallWithArguments(
             positionalArguments: [IntConstant(1), IntConstant(2)],
             namedArguments: {},

--- a/pkgs/record_use/test/syntax/uri_pattern_test.dart
+++ b/pkgs/record_use/test/syntax/uri_pattern_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 import '../test_data.dart';
 
 void main() {
-  group('Identifier.uri pattern', () {
+  group('Definition.uri pattern', () {
     test('Recordings.fromJson fails for non-package URI', () {
       final json = recordedUses.toJson();
       // Modify the first recording's identifier URI to be invalid.
@@ -49,11 +49,11 @@ void main() {
       );
     });
 
-    test('Identifier constructor does not throw (currently)', () {
-      // The Identifier class itself doesn't have the regex check in its
+    test('Definition constructor does not throw (currently)', () {
+      // The Definition class itself doesn't have the regex check in its
       // constructor, only the generated syntax class has it.
       expect(
-        () => const Identifier(importUri: 'dart:core', name: 'foo'),
+        () => const Definition(importUri: 'dart:core', name: 'foo'),
         returnsNormally,
       );
     });

--- a/pkgs/record_use/test/test_data.dart
+++ b/pkgs/record_use/test/test_data.dart
@@ -5,12 +5,12 @@
 import 'package:pub_semver/pub_semver.dart';
 import 'package:record_use/record_use_internal.dart';
 
-const callId = Identifier(
+const callId = Definition(
   importUri: 'package:js_runtime/js_helper.dart',
   scope: 'MyClass',
   name: 'get:loadDeferredLibrary',
 );
-const instanceId = Identifier(
+const instanceId = Definition(
   importUri: 'package:js_runtime/js_helper.dart',
   name: 'MyAnnotation',
 );

--- a/pkgs/record_use/test/usage_test.dart
+++ b/pkgs/record_use/test/usage_test.dart
@@ -16,7 +16,7 @@ void main() {
             jsonDecode(recordedUsesJson) as Map<String, Object?>,
           )
           .constArgumentsFor(
-            const Identifier(
+            const Definition(
               importUri: 'package:js_runtime/js_helper.dart',
               scope: 'MyClass',
               name: 'get:loadDeferredLibrary',
@@ -33,7 +33,7 @@ void main() {
               jsonDecode(recordedUsesJson) as Map<String, Object?>,
             )
             .constantsOf(
-              const Identifier(
+              const Definition(
                 importUri: 'package:js_runtime/js_helper.dart',
                 name: 'MyAnnotation',
               ),
@@ -54,7 +54,7 @@ void main() {
               jsonDecode(recordedUsesJson) as Map<String, Object?>,
             )
             .constArgumentsFor(
-              const Identifier(
+              const Definition(
                 importUri: 'package:js_runtime/js_helper.dart',
                 scope: 'MyClass',
                 name: 'get:loadDeferredLibrary',
@@ -89,7 +89,7 @@ void main() {
               jsonDecode(recordedUsesJson) as Map<String, Object?>,
             )
             .constantsOf(
-              const Identifier(
+              const Definition(
                 importUri: 'package:js_runtime/js_helper.dart',
                 name: 'MyAnnotation',
               ),
@@ -104,7 +104,7 @@ void main() {
       RecordedUsages.fromJson(
         jsonDecode(recordedUsesJson2) as Map<String, Object?>,
       ).hasNonConstArguments(
-        const Identifier(
+        const Definition(
           importUri:
               'package:drop_dylib_recording/src/drop_dylib_recording.dart',
           name: 'getMathMethod',

--- a/pkgs/record_use/test_data/drop_data_asset/hook/link.dart
+++ b/pkgs/record_use/test_data/drop_data_asset/hook/link.dart
@@ -29,7 +29,7 @@ void main(List<String> arguments) async {
     // Tree-shake unused assets using calls
     for (final methodName in ['add', 'multiply']) {
       final calls = usages.constArgumentsFor(
-        Identifier(
+        Definition(
           importUri:
               'package:${input.packageName}/src/${input.packageName}.dart',
           scope: 'MyMath',
@@ -53,7 +53,7 @@ void main(List<String> arguments) async {
     // Tree-shake unused assets using instances
     for (final className in ['Double', 'Square']) {
       final instances = usages.constantsOf(
-        Identifier(
+        Definition(
           importUri:
               'package:${input.packageName}/src/${input.packageName}.dart',
           name: className,

--- a/pkgs/record_use/test_data/drop_dylib_recording/hook/link.dart
+++ b/pkgs/record_use/test_data/drop_dylib_recording/hook/link.dart
@@ -33,7 +33,7 @@ void main(List<String> arguments) async {
     // Tree-shake unused assets using calls
     for (final methodName in ['add', 'multiply']) {
       final calls = usages.constArgumentsFor(
-        Identifier(
+        Definition(
           importUri:
               'package:drop_dylib_recording/src/drop_dylib_recording.dart',
           scope: 'MyMath',
@@ -58,7 +58,7 @@ void main(List<String> arguments) async {
     // Tree-shake unused assets using instances
     for (final className in ['Double', 'Square']) {
       final instances = usages.constantsOf(
-        Identifier(
+        Definition(
           importUri:
               'package:drop_dylib_recording/src/drop_dylib_recording.dart',
           name: className,

--- a/pkgs/record_use/test_data/library_uris/hook/link.dart
+++ b/pkgs/record_use/test_data/library_uris/hook/link.dart
@@ -24,29 +24,29 @@ void main(List<String> arguments) async {
       final recordings = await readUsagesFile(recordedUsagesFile);
 
       // This package.
-      final myMethodIdentifier = recordings.calls.keys.firstWhere(
+      final myMethodDefinition = recordings.calls.keys.firstWhere(
         (i) => i.name == 'myMethod',
       );
       expect(
-        myMethodIdentifier.importUri,
+        myMethodDefinition.importUri,
         'package:library_uris/src/definition.dart',
       );
 
       // The helper package.
-      final helperMethodIdentifier = recordings.calls.keys.firstWhere(
+      final helperMethodDefinition = recordings.calls.keys.firstWhere(
         (i) => i.name == 'methodInHelper',
       );
       expect(
-        helperMethodIdentifier.importUri,
+        helperMethodDefinition.importUri,
         'package:library_uris_helper/src/helper_definition.dart',
       );
 
       // Outside the lib dir, no package: uri.
-      final methodInBinIdentifer = recordings.calls.keys.firstWhere(
+      final methodInBinDefinition = recordings.calls.keys.firstWhere(
         (i) => i.name == 'methodInBin',
       );
       expect(
-        methodInBinIdentifer.importUri,
+        methodInBinDefinition.importUri,
         // TODO(https://github.com/dart-lang/native/issues/2891): What should
         // this be? We don't have library uris for bin.
         'package:library_uris/../bin/my_bin.dart',


### PR DESCRIPTION
Now that we've removed loading units, `Identifier` can be renamed to `Definition`. This is the `package:record_use`. And the uses refer to uses of definitions. So definition is the better name.

