### PR TITLE
[record_use] Run validation in `Recordings.fromJson`

### DIFF
--- a/pkgs/record_use/lib/src/recordings.dart
+++ b/pkgs/record_use/lib/src/recordings.dart
@@ -47,6 +47,13 @@ class Recordings {
   factory Recordings.fromJson(Map<String, Object?> json) {
     try {
       final syntax = RecordedUsesSyntax.fromJson(json);
+      final syntaxErrors = syntax.validate();
+      if (syntaxErrors.isNotEmpty) {
+        final errorsString = syntaxErrors.map((e) => ' - $e').join('\n');
+        throw FormatException(
+          'Validation errors for record use file:\n$errorsString\n',
+        );
+      }
       return Recordings._fromSyntax(syntax);
     } on FormatException catch (e) {
       throw FormatException('''

--- a/pkgs/record_use/test/syntax/validation_test.dart
+++ b/pkgs/record_use/test/syntax/validation_test.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:record_use/record_use_internal.dart';
+import 'package:test/test.dart';
+
+import '../test_data.dart';
+
+void main() {
+  group('Recordings.fromJson validation', () {
+    test('Recordings.fromJson fails for invalid JSON', () {
+      final json = recordedUses.toJson();
+      // Modify the first recording's identifier URI to be an invalid type.
+      final recordings = json['recordings'] as List;
+      final recording = recordings[0] as Map;
+      final identifier = recording['identifier'] as Map;
+      identifier['uri'] = 123; // Should be a string
+
+      expect(
+        () => Recordings.fromJson(json),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('Validation errors for record use file:'),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
https://github.com/dart-lang/native/pull/3064 revealed we weren't ever running the validator.

Refiling of:

* https://github.com/dart-lang/native/pull/3070