### PR TITLE
[ffi] Export leaked types

### DIFF
--- a/pkgs/ffi/CHANGELOG.md
+++ b/pkgs/ffi/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+- Export leaked types.
+
 ## 2.1.5
 
 - Update to the latest lints.

--- a/pkgs/ffi/lib/ffi.dart
+++ b/pkgs/ffi/lib/ffi.dart
@@ -2,7 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/allocation.dart' show calloc, malloc;
+export 'src/allocation.dart'
+    show CallocAllocator, MallocAllocator, calloc, malloc;
 export 'src/arena.dart';
 export 'src/utf16.dart';
 export 'src/utf8.dart';

--- a/pkgs/ffi/pubspec.yaml
+++ b/pkgs/ffi/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ffi
-version: 2.1.5
+version: 2.2.0
 description: Utilities for working with Foreign Function Interface (FFI) code.
 repository: https://github.com/dart-lang/native/tree/main/pkgs/ffi
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Affi


### PR DESCRIPTION
This is causing flags on Dart API Tool runs. We should just export them.