### PR TITLE
[pub_formats] Add analysis options

### DIFF
--- a/pkgs/pub_formats/analysis_options.yaml
+++ b/pkgs/pub_formats/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/pkgs/pub_formats/test/helpers.dart
+++ b/pkgs/pub_formats/test/helpers.dart
@@ -19,7 +19,7 @@ Map<String, Object?> loadYamlAsJson(String relativePath) {
   final packageRoot = findPackageRoot('pub_formats');
   final pubspecFile = File.fromUri(packageRoot.resolve(relativePath));
   final json = convertYamlMapToJsonMap(
-    loadYaml(pubspecFile.readAsStringSync()),
+    loadYaml(pubspecFile.readAsStringSync()) as YamlMap,
   );
   return json;
 }

--- a/pkgs/pub_formats/test/package_graph_test.dart
+++ b/pkgs/pub_formats/test/package_graph_test.dart
@@ -15,7 +15,7 @@ void main() {
     expect(errors, isEmpty);
     expect(
       parsed.roots,
-      equals(["add_asset_link", "app_with_asset_treeshaking"]),
+      equals(['add_asset_link', 'app_with_asset_treeshaking']),
     );
     final somePackage = parsed.packages.firstWhere(
       (e) => e.name == 'code_assets',

--- a/pkgs/pub_formats/test/pubspec_lock_test.dart
+++ b/pkgs/pub_formats/test/pubspec_lock_test.dart
@@ -41,8 +41,12 @@ void main() {
     expect(
       errorsDescription,
       equals([
-        "Unexpected value 'not a valid name' (String) for 'dart_apitool.description.name'. Expected a String satisfying ^[a-zA-Z_]\\w*\$.",
-        "Unexpected value 'not a valid sha' (String) for 'dart_apitool.description.sha256'. Expected a String satisfying ^[a-f0-9]{64}\$.",
+        "Unexpected value 'not a valid name' (String) "
+            "for 'dart_apitool.description.name'. "
+            'Expected a String satisfying ^[a-zA-Z_]\\w*\$.',
+        "Unexpected value 'not a valid sha' (String) "
+            "for 'dart_apitool.description.sha256'. "
+            'Expected a String satisfying ^[a-f0-9]{64}\$.',
       ]),
     );
     expect(() => description.sha256, throwsFormatException);

--- a/pkgs/pub_formats/test/pubspec_test.dart
+++ b/pkgs/pub_formats/test/pubspec_test.dart
@@ -95,7 +95,8 @@ void main() {
     expect(
       syntaxError1.validate(),
       equals([
-        "Unexpected value 'not a map' (String) for 'executables'. Expected a Map<String, Object?>?.",
+        "Unexpected value 'not a map' (String) for 'executables'. "
+            'Expected a Map<String, Object?>?.',
       ]),
     );
     expect(() => syntaxError1.executables, throwsFormatException);

--- a/pkgs/pub_formats/tool/generate.dart
+++ b/pkgs/pub_formats/tool/generate.dart
@@ -40,10 +40,10 @@ void main(List<String> args) {
     'pubspec',
   ]) {
     final schemaFile = File.fromUri(
-      packageRoot.resolve('doc/schema/${name}.schema.json'),
+      packageRoot.resolve('doc/schema/$name.schema.json'),
     );
     final schemaJson = jsonDecode(schemaFile.readAsStringSync());
-    final schema = JsonSchema.create(schemaJson);
+    final schema = JsonSchema.create(schemaJson as Object);
 
     final analyzedSchema = SchemaAnalyzer(
       schema,


### PR DESCRIPTION
I noticed this while trying to play around with the new analyzer plugins (which need to be at the root of the workspace).