### PR TITLE
[record_use] Use `update_snippets.dart`

### DIFF
--- a/pkgs/record_use/README.md
+++ b/pkgs/record_use/README.md
@@ -12,8 +12,7 @@ being recorded.
 - If placed on a static method, the annotation means that arguments passed to
 the method will be recorded, as far as they can be inferred at compile time.
 - If placed on a class with a constant constructor, the annotation means that
-any constant instance of the class will be recorded. This is particularly useful
-when using the class as an annotation.
+any constant instance of the class will be recorded.
 
 > [!NOTE]
 > The `@RecordUse` annotation is only allowed on definitions within a package's
@@ -22,102 +21,62 @@ when using the class as an annotation.
 
 ## Example
 
+<!-- file://./example/api/usage.dart#usage -->
 ```dart
-import 'package:meta/meta.dart' show RecordUse;
-
 void main() {
-  print(SomeClass.stringMetadata(42));
-  print(SomeClass.doubleMetadata(42));
-  print(SomeClass.intMetadata(42));
-  print(SomeClass.boolMetadata(42));
+  PirateTranslator.speak('Hello');
+  print(const PirateShip('Black Pearl', 50));
 }
 
-class SomeClass {
-  @RecordMetadata('leroyjenkins')
+abstract class PirateTranslator {
   @RecordUse()
-  static stringMetadata(int i) {
-    return i + 1;
-  }
-
-  @RecordMetadata(3.14)
-  @RecordUse()
-  static doubleMetadata(int i) {
-    return i + 1;
-  }
-
-  @RecordMetadata(42)
-  @RecordUse()
-  static intMetadata(int i) {
-    return i + 1;
-  }
-
-  @RecordMetadata(true)
-  @RecordUse()
-  static boolMetadata(int i) {
-    return i + 1;
-  }
+  static String speak(String english) => 'Ahoy $english';
 }
 
 @RecordUse()
-class RecordMetadata {
-  final Object metadata;
+class PirateShip {
+  final String name;
+  final int cannons;
 
-  const RecordMetadata(this.metadata);
+  const PirateShip(this.name, this.cannons);
 }
-
 ```
-This code will generate a data file that contains both the `metadata` values of
-the `RecordMetadata` instances, as well as the arguments for the different
-methods annotated with `@RecordUse()`.
+This code will generate a data file that contains both the field values of
+the `PirateShip` instances, as well as the arguments for the `speak`
+method annotated with `@RecordUse()`.
 
 This information can then be accessed in a link hook as follows:
+<!-- file://./example/api/usage_link.dart#link -->
 ```dart
-import 'dart:convert';
-
-import 'package:hooks/hooks.dart';
-import 'package:record_use/record_use_internal.dart';
-
-final methodId = Definition(
-  'package:mypackage/myfile.dart',
-  [Name('myMethod')],
-);
-
-final classId = Definition(
-  'package:mypackage/myfile.dart',
-  [Name('myClass')],
-);
-
-void main(List<String> arguments){
+void main(List<String> arguments) {
   link(arguments, (input, output) async {
     final usesUri = input.recordedUsagesFile;
     if (usesUri == null) return;
     final usesJson = await File.fromUri(usesUri).readAsString();
-    final uses = RecordedUsages.fromJson(jsonDecode(usesJson));
+    final uses = RecordedUsages.fromJson(
+      jsonDecode(usesJson) as Map<String, Object?>,
+    );
 
     final args = uses.constArgumentsFor(methodId);
-    //[args] is an iterable of arguments, in this case containing "42"
+    for (final arg in args) {
+      if (arg.positional[0] case StringConstant(value: final english)) {
+        print('Translating to pirate: $english');
+        // Shrink a translations file based on all the different translation
+        // keys.
+      }
+    }
 
-    final fields = uses.constantsOf(classId);
-    //[fields] is an iterable of the constants of the class, in this case
-    //containing
-    // {"metadata": "leroyjenkins"}
-    // {"metadata": 3.14}
-    // {"metadata": 42}
-    // {"metadata": true}
-
-    ... // Do something with the information, such as tree-shaking native assets
+    final ships = uses.constantsOf(classId);
+    for (final ship in ships) {
+      if (ship.fields['name'] case StringConstant(value: final name)) {
+        print('Pirate ship found: $name');
+        // Include the 3d model for this ship in the application but not
+        // bundle the other ships.
+      }
+    }
   });
 }
 ```
-
-## Limitations
-As this is designed to work on both web and native platforms, we have to adapt 
-to the platform pecularities. One of them is that javascript does not support
-named arguments, so the dart2js compiler rewrites functions to only accept named
-parameters.
-While you can use named parameters to record functions, we advise caution as the
-retrieval behavior might change once we work around this dart2js limitation and
-implement separate positional and named parameters.
 
 ## Contributing
 Contributions are welcome! Please open an issue or submit a pull request.

--- a/pkgs/record_use/doc/use_cases/icon_data.md
+++ b/pkgs/record_use/doc/use_cases/icon_data.md
@@ -6,6 +6,7 @@ package.
 
 Dart API and use:
 
+<!-- no-source-file -->
 ```dart
 class IconData {
   const IconData(
@@ -18,6 +19,7 @@ class IconData {
 }
 ```
 
+<!-- no-source-file -->
 ```dart
 abstract final class GalleryIcons {
   static const IconData tooltip = IconData(0xe900, fontFamily: 'GalleryIcons');
@@ -45,6 +47,7 @@ the const instances.
 Since this API is already in active use, we cannot simply change the API to
 static getters, as that would prevent const:
 
+<!-- no-source-file -->
 ```dart
 abstract final class GalleryIcons {
   static IconData get tooltip => IconData(0xe900, fontFamily: 'GalleryIcons');

--- a/pkgs/record_use/doc/use_cases/icu4x.md
+++ b/pkgs/record_use/doc/use_cases/icu4x.md
@@ -8,6 +8,7 @@ MBs.
 
 The native symbols that are reachable:
 
+<!-- no-source-file -->
 ```dart
 @ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Size, ffi.Size)>(
   symbol: 'diplomat_alloc',
@@ -28,6 +29,7 @@ The file containing the external static functions is a generated file.
 
 The link hook could import a generated file that contains the mapping:
 
+<!-- no-source-file -->
 ```dart
 const dartStaticCallToNativeSymbol = {
     'diplomat_alloc': '_diplomat_alloc',

--- a/pkgs/record_use/doc/use_cases/jaspr.md
+++ b/pkgs/record_use/doc/use_cases/jaspr.md
@@ -9,6 +9,7 @@ use style utilities and the final CSS is tree-shaken.
 For example, a `Column` component might have styling options passed to its
 constructor:
 
+<!-- no-source-file -->
 ```dart
 class Column extends Component {
   @RecordUse()
@@ -24,6 +25,7 @@ class Column extends Component {
 When this component is used, we want to record the constructor call, including
 the arguments:
 
+<!-- no-source-file -->
 ```dart
 class MyComponent extends Component {
   @override

--- a/pkgs/record_use/doc/use_cases/jnigen.md
+++ b/pkgs/record_use/doc/use_cases/jnigen.md
@@ -9,6 +9,7 @@ reachable Java/Kotlin classes, methods, and fields.
 
 ### 1. Which classes are possibly instantiated.
 
+<!-- no-source-file -->
 ```dart
 class PDDocument extends jni$_.JObject {
   PDDocument.fromReference(
@@ -36,6 +37,7 @@ generated classes will ever have const constructors.
 
 ### 2. Which methods, getters and setters are reachable.
 
+<!-- no-source-file -->
 ```dart
 class PDDocument extends jni$_.JObject {
   void addPage(
@@ -48,6 +50,7 @@ This requires tracking instance calls, or generating a static call inside the
 instance call. JNIgen already generates a static field (with a static getter)
 that could be annotated to record a static call:
 
+<!-- no-source-file -->
 ```dart
 class PDDocument extends jni$_.JObject {
   static final _addPage = jni$_.ProtectedJniExtensions.lookup<
@@ -82,6 +85,7 @@ the original Java/Kotlin unique name.
 Since JNIgen is already a code generator, this can be achieved by generating a
 file that maps Dart identifiers to Java identifiers:
 
+<!-- no-source-file -->
 ```dart
 const dartToJava = {
   DartMethodIdentifer(

--- a/pkgs/record_use/doc/use_cases/messages.md
+++ b/pkgs/record_use/doc/use_cases/messages.md
@@ -3,6 +3,7 @@
 The goal of this package is to provide translation. The goal of using link hooks
 is to be able to shrink the translation files based on use.
 
+<!-- no-source-file -->
 ```dart
 class MessageTable {
   @RecordUse()
@@ -14,6 +15,7 @@ class MessageTable {
 }
 ```
 
+<!-- no-source-file -->
 ```dart
 String translateFoo() => lookup(/*int id of foo*/0, 'baz');
 
@@ -26,6 +28,7 @@ the API for the translations.
 
 If a transformer is used, the pre-transform code looks something like:
 
+<!-- no-source-file -->
 ```dart
 class Intl {
   static String message(String messageText,

--- a/pkgs/record_use/example/api/usage.dart
+++ b/pkgs/record_use/example/api/usage.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// ignore_for_file: experimental_member_use, unreachable_from_main
+
+import 'package:meta/meta.dart' show RecordUse;
+
+// snippet-start#usage
+void main() {
+  PirateTranslator.speak('Hello');
+  print(const PirateShip('Black Pearl', 50));
+}
+
+// snippet-start#static-call
+abstract class PirateTranslator {
+  @RecordUse()
+  static String speak(String english) => 'Ahoy $english';
+}
+// snippet-end#static-call
+
+// snippet-start#const-instance
+@RecordUse()
+class PirateShip {
+  final String name;
+  final int cannons;
+
+  const PirateShip(this.name, this.cannons);
+}
+
+// snippet-end#const-instance
+// snippet-end#usage

--- a/pkgs/record_use/example/api/usage_link.dart
+++ b/pkgs/record_use/example/api/usage_link.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// ignore_for_file: experimental_member_use
+// ignore_for_file: depend_on_referenced_packages
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:hooks/hooks.dart';
+import 'package:record_use/record_use_internal.dart';
+
+const methodId = Definition(
+  'package:pirate_speak/pirate_speak.dart',
+  [
+    Name('PirateTranslator'),
+    Name(''),
+  ],
+);
+
+const classId = Definition(
+  'package:pirate_technology/pirate_technology.dart',
+  [
+    Name(
+      'PirateShip',
+    ),
+  ],
+);
+
+// snippet-start#link
+void main(List<String> arguments) {
+  link(arguments, (input, output) async {
+    final usesUri = input.recordedUsagesFile;
+    if (usesUri == null) return;
+    final usesJson = await File.fromUri(usesUri).readAsString();
+    final uses = RecordedUsages.fromJson(
+      jsonDecode(usesJson) as Map<String, Object?>,
+    );
+
+    // snippet-start#static-call
+    final args = uses.constArgumentsFor(methodId);
+    for (final arg in args) {
+      if (arg.positional[0] case StringConstant(value: final english)) {
+        print('Translating to pirate: $english');
+        // Shrink a translations file based on all the different translation
+        // keys.
+      }
+    }
+    // snippet-end#static-call
+
+    // snippet-start#const-instance
+    final ships = uses.constantsOf(classId);
+    for (final ship in ships) {
+      if (ship.fields['name'] case StringConstant(value: final name)) {
+        print('Pirate ship found: $name');
+        // Include the 3d model for this ship in the application but not
+        // bundle the other ships.
+      }
+    }
+    // snippet-end#const-instance
+  });
+}
+
+// snippet-end#link

--- a/pkgs/record_use/lib/src/record_use.dart
+++ b/pkgs/record_use/lib/src/record_use.dart
@@ -30,29 +30,29 @@ extension type RecordedUsages._(Recordings _recordings) {
   /// Returns an empty iterable if the arguments were not collected.
   ///
   /// Example:
+  /// <!-- file://./../../example/api/usage.dart#static-call -->
   /// ```dart
-  /// import 'package:meta/meta.dart' show RecordUse;
-  /// void main() {
-  ///   print(SomeClass.someStaticMethod(42));
+  /// abstract class PirateTranslator {
+  ///   @RecordUse()
+  ///   static String speak(String english) => 'Ahoy $english';
   /// }
+  /// ```
   ///
-  /// class SomeClass {
-  ///   @RecordUse('id')
-  ///   static someStaticMethod(int i) {
-  ///     return i + 1;
+  /// To retrieve the recorded const arguments:
+  ///
+  /// <!-- file://./../../example/api/usage_link.dart#static-call -->
+  /// ```dart
+  /// final args = uses.constArgumentsFor(methodId);
+  /// for (final arg in args) {
+  ///   if (arg.positional[0] case StringConstant(value: final english)) {
+  ///     print('Translating to pirate: $english');
+  ///     // Shrink a translations file based on all the different translation
+  ///     // keys.
   ///   }
   /// }
   /// ```
-  ///
-  /// Would mean that
-  /// ```
-  /// constArgumentsFor(
-  ///           Definition(
-  ///             'package:my_package/file.dart',
-  ///             [Name('SomeClass'), Name('someStaticMethod')],
-  ///           ),
-  ///         ).first.positional[0] is IntConstant
-  /// ```
+  // TODO(https://github.com/dart-lang/native/issues/2718): Make tearoffs more
+  // front and center.
   Iterable<({Map<String, MaybeConstant> named, List<MaybeConstant> positional})>
   constArgumentsFor(Definition definition) =>
       _recordings.calls[definition]?.whereType<CallWithArguments>().map(
@@ -72,36 +72,32 @@ extension type RecordedUsages._(Recordings _recordings) {
   /// exist, this method returns an empty iterable.
   ///
   /// Example:
+  /// <!-- file://./../../example/api/usage.dart#const-instance -->
   /// ```dart
-  /// void main() {
-  ///   print(SomeClass.someStaticMethod(42));
-  /// }
+  /// @RecordUse()
+  /// class PirateShip {
+  ///   final String name;
+  ///   final int cannons;
   ///
-  /// class SomeClass {
-  ///   @AnnotationClass('freddie')
-  ///   static someStaticMethod(int i) {
-  ///     return i + 1;
+  ///   const PirateShip(this.name, this.cannons);
+  /// }
+  /// ```
+  ///
+  /// To retrieve the constant instances:
+  ///
+  /// <!-- file://./../../example/api/usage_link.dart#const-instance -->
+  /// ```dart
+  /// final ships = uses.constantsOf(classId);
+  /// for (final ship in ships) {
+  ///   if (ship.fields['name'] case StringConstant(value: final name)) {
+  ///     print('Pirate ship found: $name');
+  ///     // Include the 3d model for this ship in the application but not
+  ///     // bundle the other ships.
   ///   }
   /// }
-  ///
-  /// @RecordUse()
-  /// class AnnotationClass {
-  ///   final String s;
-  ///   const AnnotationClass(this.s);
-  /// }
   /// ```
-  ///
-  /// Would mean that
-  /// ```
-  /// constantsOf(
-  ///       Definition(
-  ///           'package:my_package/file.dart',
-  ///           [Name('AnnotationClass')]),
-  ///       ).first.fields['s'] is StringConstant;
-  /// ```
-  ///
-  /// What kinds of fields can be recorded depends on the implementation of
-  /// https://dart-review.googlesource.com/c/sdk/+/369620/13/pkg/vm/lib/transformations/record_use/record_instance.dart
+  // TODO(https://github.com/dart-lang/native/issues/2718): Make non-consts more
+  // front and center.
   Iterable<InstanceConstant> constantsOf(Definition definition) =>
       _recordings.instances[definition]
           ?.whereType<InstanceConstantReference>()
@@ -116,6 +112,8 @@ extension type RecordedUsages._(Recordings _recordings) {
   /// package. If there are no calls to the definition, either because it was
   /// treeshaken, because it was not annotated, or because it does not exist,
   /// this method returns `false`.
+  // TODO(https://github.com/dart-lang/native/issues/2718): Make non-consts more
+  // front and center.
   bool hasNonConstArguments(Definition definition) =>
       (_recordings.calls[definition] ?? []).any(
         (element) => switch (element) {


### PR DESCRIPTION
Fix the doc comments in this package.

* Fixes the docs to be up to date with current usage.
  * Adds a pirate themed API doc.
* Ignores the use cases for now.
  * In the future we should make these full fledged examples in the examples/ dir.
* Makes the snippets tool more powerful with anchors and nested snippets.
