### PR TITLE
[record_use] `Definition` rework JSON encoding

### DIFF
--- a/pkgs/record_use/doc/schema/record_use.schema.json
+++ b/pkgs/record_use/doc/schema/record_use.schema.json
@@ -240,11 +240,12 @@
     "Definition": {
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "scope": {
-          "type": "string"
+        "path": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Name"
+          },
+          "minItems": 1
         },
         "uri": {
           "type": "string",
@@ -252,7 +253,7 @@
         }
       },
       "required": [
-        "name",
+        "path",
         "uri"
       ]
     },
@@ -350,6 +351,56 @@
         "value"
       ]
     },
+    "Name": {
+      "type": "object",
+      "properties": {
+        "disambiguators": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "anyOf": [
+              {
+                "enum": [
+                  "instance",
+                  "static"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "kind": {
+          "type": "string",
+          "anyOf": [
+            {
+              "enum": [
+                "class",
+                "constructor",
+                "enum",
+                "extension",
+                "extension_type",
+                "getter",
+                "method",
+                "mixin",
+                "operator",
+                "setter"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
     "RecordedUses": {
       "type": "object",
       "properties": {
@@ -394,7 +445,7 @@
             "$ref": "#/definitions/Call"
           }
         },
-        "identifier": {
+        "definition": {
           "$ref": "#/definitions/Definition"
         },
         "instances": {
@@ -405,7 +456,7 @@
         }
       },
       "required": [
-        "identifier"
+        "definition"
       ]
     }
   }

--- a/pkgs/record_use/lib/src/recordings.dart
+++ b/pkgs/record_use/lib/src/recordings.dart
@@ -78,7 +78,7 @@ Error: $e
 
     for (final recordingSyntax in syntax.recordings ?? <RecordingSyntax>[]) {
       final definition = DefinitionProtected.fromSyntax(
-        recordingSyntax.identifier,
+        recordingSyntax.definition,
       );
       if (recordingSyntax.calls case final callSyntaxes?) {
         final callReferences = callSyntaxes
@@ -170,7 +170,7 @@ Error: $e
       final instancesForDefinition = instances[definition];
       recordings.add(
         RecordingSyntax(
-          identifier: definition.toSyntax(),
+          definition: definition.toSyntax(),
           calls: callsForDefinition
               ?.map((call) => call.toSyntax(constantsIndex))
               .toList(),

--- a/pkgs/record_use/lib/src/syntax.g.dart
+++ b/pkgs/record_use/lib/src/syntax.g.dart
@@ -108,6 +108,33 @@ class CallSyntax extends JsonObjectSyntax {
   String toString() => 'CallSyntax($json)';
 }
 
+class ClassNameSyntax extends NameSyntax {
+  ClassNameSyntax.fromJson(
+    super.json, {
+    super.path,
+  }) : super._fromJson();
+
+  ClassNameSyntax({
+    super.disambiguators,
+    required super.name,
+    super.path = const [],
+  }) : super(kind: 'class');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+  ];
+
+  @override
+  String toString() => 'ClassNameSyntax($json)';
+}
+
+extension ClassNameSyntaxExtension on NameSyntax {
+  bool get isClassName => kind == 'class';
+
+  ClassNameSyntax get asClassName => ClassNameSyntax.fromJson(json, path: path);
+}
+
 class ConstantSyntax extends JsonObjectSyntax {
   factory ConstantSyntax.fromJson(
     Map<String, Object?> json, {
@@ -211,6 +238,34 @@ extension ConstantInstanceSyntaxExtension on InstanceSyntax {
       ConstantInstanceSyntax.fromJson(json, path: path);
 }
 
+class ConstructorNameSyntax extends NameSyntax {
+  ConstructorNameSyntax.fromJson(
+    super.json, {
+    super.path,
+  }) : super._fromJson();
+
+  ConstructorNameSyntax({
+    super.disambiguators,
+    required super.name,
+    super.path = const [],
+  }) : super(kind: 'constructor');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+  ];
+
+  @override
+  String toString() => 'ConstructorNameSyntax($json)';
+}
+
+extension ConstructorNameSyntaxExtension on NameSyntax {
+  bool get isConstructorName => kind == 'constructor';
+
+  ConstructorNameSyntax get asConstructorName =>
+      ConstructorNameSyntax.fromJson(json, path: path);
+}
+
 class CreationInstanceSyntax extends InstanceSyntax {
   CreationInstanceSyntax.fromJson(
     super.json, {
@@ -288,32 +343,40 @@ class DefinitionSyntax extends JsonObjectSyntax {
   }) : super.fromJson();
 
   DefinitionSyntax({
-    required String name,
-    String? scope,
+    required List<NameSyntax> definitionPath,
     required String uri,
     super.path = const [],
   }) : super() {
-    _name = name;
-    _scope = scope;
+    _definitionPath = definitionPath;
     _uri = uri;
     json.sortOnKey();
   }
 
-  String get name => _reader.get<String>('name');
-
-  set _name(String value) {
-    json.setOrRemove('name', value);
+  List<NameSyntax> get definitionPath {
+    final jsonValue = _reader.list('path');
+    return [
+      for (final (index, element) in jsonValue.indexed)
+        NameSyntax.fromJson(
+          element as Map<String, Object?>,
+          path: [...path, 'path', index],
+        ),
+    ];
   }
 
-  List<String> _validateName() => _reader.validate<String>('name');
-
-  String? get scope => _reader.get<String?>('scope');
-
-  set _scope(String? value) {
-    json.setOrRemove('scope', value);
+  set _definitionPath(List<NameSyntax> value) {
+    json['path'] = [for (final item in value) item.json];
   }
 
-  List<String> _validateScope() => _reader.validate<String?>('scope');
+  List<String> _validateDefinitionPath() {
+    final listErrors = _reader.validateList<Map<String, Object?>>(
+      'path',
+    );
+    if (listErrors.isNotEmpty) {
+      return listErrors;
+    }
+    final elements = definitionPath;
+    return [for (final element in elements) ...element.validate()];
+  }
 
   static final _uriPattern = RegExp(r'^package:');
 
@@ -335,13 +398,123 @@ class DefinitionSyntax extends JsonObjectSyntax {
   @override
   List<String> validate() => [
     ...super.validate(),
-    ..._validateName(),
-    ..._validateScope(),
+    ..._validateDefinitionPath(),
     ..._validateUri(),
   ];
 
   @override
   String toString() => 'DefinitionSyntax($json)';
+}
+
+class EnumNameSyntax extends NameSyntax {
+  EnumNameSyntax.fromJson(
+    super.json, {
+    super.path,
+  }) : super._fromJson();
+
+  EnumNameSyntax({
+    super.disambiguators,
+    required super.name,
+    super.path = const [],
+  }) : super(kind: 'enum');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+  ];
+
+  @override
+  String toString() => 'EnumNameSyntax($json)';
+}
+
+extension EnumNameSyntaxExtension on NameSyntax {
+  bool get isEnumName => kind == 'enum';
+
+  EnumNameSyntax get asEnumName => EnumNameSyntax.fromJson(json, path: path);
+}
+
+class ExtensionNameSyntax extends NameSyntax {
+  ExtensionNameSyntax.fromJson(
+    super.json, {
+    super.path,
+  }) : super._fromJson();
+
+  ExtensionNameSyntax({
+    super.disambiguators,
+    required super.name,
+    super.path = const [],
+  }) : super(kind: 'extension');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+  ];
+
+  @override
+  String toString() => 'ExtensionNameSyntax($json)';
+}
+
+extension ExtensionNameSyntaxExtension on NameSyntax {
+  bool get isExtensionName => kind == 'extension';
+
+  ExtensionNameSyntax get asExtensionName =>
+      ExtensionNameSyntax.fromJson(json, path: path);
+}
+
+class ExtensionTypeNameSyntax extends NameSyntax {
+  ExtensionTypeNameSyntax.fromJson(
+    super.json, {
+    super.path,
+  }) : super._fromJson();
+
+  ExtensionTypeNameSyntax({
+    super.disambiguators,
+    required super.name,
+    super.path = const [],
+  }) : super(kind: 'extension_type');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+  ];
+
+  @override
+  String toString() => 'ExtensionTypeNameSyntax($json)';
+}
+
+extension ExtensionTypeNameSyntaxExtension on NameSyntax {
+  bool get isExtensionTypeName => kind == 'extension_type';
+
+  ExtensionTypeNameSyntax get asExtensionTypeName =>
+      ExtensionTypeNameSyntax.fromJson(json, path: path);
+}
+
+class GetterNameSyntax extends NameSyntax {
+  GetterNameSyntax.fromJson(
+    super.json, {
+    super.path,
+  }) : super._fromJson();
+
+  GetterNameSyntax({
+    super.disambiguators,
+    required super.name,
+    super.path = const [],
+  }) : super(kind: 'getter');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+  ];
+
+  @override
+  String toString() => 'GetterNameSyntax($json)';
+}
+
+extension GetterNameSyntaxExtension on NameSyntax {
+  bool get isGetterName => kind == 'getter';
+
+  GetterNameSyntax get asGetterName =>
+      GetterNameSyntax.fromJson(json, path: path);
 }
 
 class InstanceSyntax extends JsonObjectSyntax {
@@ -683,6 +856,155 @@ class MetadataSyntax extends JsonObjectSyntax {
   String toString() => 'MetadataSyntax($json)';
 }
 
+class MethodNameSyntax extends NameSyntax {
+  MethodNameSyntax.fromJson(
+    super.json, {
+    super.path,
+  }) : super._fromJson();
+
+  MethodNameSyntax({
+    super.disambiguators,
+    required super.name,
+    super.path = const [],
+  }) : super(kind: 'method');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+  ];
+
+  @override
+  String toString() => 'MethodNameSyntax($json)';
+}
+
+extension MethodNameSyntaxExtension on NameSyntax {
+  bool get isMethodName => kind == 'method';
+
+  MethodNameSyntax get asMethodName =>
+      MethodNameSyntax.fromJson(json, path: path);
+}
+
+class MixinNameSyntax extends NameSyntax {
+  MixinNameSyntax.fromJson(
+    super.json, {
+    super.path,
+  }) : super._fromJson();
+
+  MixinNameSyntax({
+    super.disambiguators,
+    required super.name,
+    super.path = const [],
+  }) : super(kind: 'mixin');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+  ];
+
+  @override
+  String toString() => 'MixinNameSyntax($json)';
+}
+
+extension MixinNameSyntaxExtension on NameSyntax {
+  bool get isMixinName => kind == 'mixin';
+
+  MixinNameSyntax get asMixinName => MixinNameSyntax.fromJson(json, path: path);
+}
+
+class NameSyntax extends JsonObjectSyntax {
+  factory NameSyntax.fromJson(
+    Map<String, Object?> json, {
+    List<Object> path = const [],
+  }) {
+    final result = NameSyntax._fromJson(json, path: path);
+    if (result.isClassName) {
+      return result.asClassName;
+    }
+    if (result.isConstructorName) {
+      return result.asConstructorName;
+    }
+    if (result.isEnumName) {
+      return result.asEnumName;
+    }
+    if (result.isExtensionName) {
+      return result.asExtensionName;
+    }
+    if (result.isExtensionTypeName) {
+      return result.asExtensionTypeName;
+    }
+    if (result.isGetterName) {
+      return result.asGetterName;
+    }
+    if (result.isMethodName) {
+      return result.asMethodName;
+    }
+    if (result.isMixinName) {
+      return result.asMixinName;
+    }
+    if (result.isOperatorName) {
+      return result.asOperatorName;
+    }
+    if (result.isSetterName) {
+      return result.asSetterName;
+    }
+    return result;
+  }
+
+  NameSyntax._fromJson(
+    super.json, {
+    super.path = const [],
+  }) : super.fromJson();
+
+  NameSyntax({
+    List<String>? disambiguators,
+    String? kind,
+    required String name,
+    super.path = const [],
+  }) : super() {
+    _disambiguators = disambiguators;
+    _kind = kind;
+    _name = name;
+    json.sortOnKey();
+  }
+
+  List<String>? get disambiguators =>
+      _reader.optionalStringList('disambiguators');
+
+  set _disambiguators(List<String>? value) {
+    json.setOrRemove('disambiguators', value);
+  }
+
+  List<String> _validateDisambiguators() =>
+      _reader.validateOptionalStringList('disambiguators');
+
+  String? get kind => _reader.get<String?>('kind');
+
+  set _kind(String? value) {
+    json.setOrRemove('kind', value);
+  }
+
+  List<String> _validateKind() => _reader.validate<String?>('kind');
+
+  String get name => _reader.get<String>('name');
+
+  set _name(String value) {
+    json.setOrRemove('name', value);
+  }
+
+  List<String> _validateName() => _reader.validate<String>('name');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateDisambiguators(),
+    ..._validateKind(),
+    ..._validateName(),
+  ];
+
+  @override
+  String toString() => 'NameSyntax($json)';
+}
+
 class NullConstantSyntax extends ConstantSyntax {
   NullConstantSyntax.fromJson(
     super.json, {
@@ -705,6 +1027,34 @@ extension NullConstantSyntaxExtension on ConstantSyntax {
 
   NullConstantSyntax get asNullConstant =>
       NullConstantSyntax.fromJson(json, path: path);
+}
+
+class OperatorNameSyntax extends NameSyntax {
+  OperatorNameSyntax.fromJson(
+    super.json, {
+    super.path,
+  }) : super._fromJson();
+
+  OperatorNameSyntax({
+    super.disambiguators,
+    required super.name,
+    super.path = const [],
+  }) : super(kind: 'operator');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+  ];
+
+  @override
+  String toString() => 'OperatorNameSyntax($json)';
+}
+
+extension OperatorNameSyntaxExtension on NameSyntax {
+  bool get isOperatorName => kind == 'operator';
+
+  OperatorNameSyntax get asOperatorName =>
+      OperatorNameSyntax.fromJson(json, path: path);
 }
 
 class RecordedUsesSyntax extends JsonObjectSyntax {
@@ -830,12 +1180,12 @@ class RecordingSyntax extends JsonObjectSyntax {
 
   RecordingSyntax({
     List<CallSyntax>? calls,
-    required DefinitionSyntax identifier,
+    required DefinitionSyntax definition,
     List<InstanceSyntax>? instances,
     super.path = const [],
   }) : super() {
     _calls = calls;
-    _identifier = identifier;
+    _definition = definition;
     _instances = instances;
     json.sortOnKey();
   }
@@ -874,21 +1224,21 @@ class RecordingSyntax extends JsonObjectSyntax {
     return [for (final element in elements) ...element.validate()];
   }
 
-  DefinitionSyntax get identifier {
-    final jsonValue = _reader.map$('identifier');
-    return DefinitionSyntax.fromJson(jsonValue, path: [...path, 'identifier']);
+  DefinitionSyntax get definition {
+    final jsonValue = _reader.map$('definition');
+    return DefinitionSyntax.fromJson(jsonValue, path: [...path, 'definition']);
   }
 
-  set _identifier(DefinitionSyntax value) {
-    json['identifier'] = value.json;
+  set _definition(DefinitionSyntax value) {
+    json['definition'] = value.json;
   }
 
-  List<String> _validateIdentifier() {
-    final mapErrors = _reader.validate<Map<String, Object?>>('identifier');
+  List<String> _validateDefinition() {
+    final mapErrors = _reader.validate<Map<String, Object?>>('definition');
     if (mapErrors.isNotEmpty) {
       return mapErrors;
     }
-    return identifier.validate();
+    return definition.validate();
   }
 
   List<InstanceSyntax>? get instances {
@@ -929,12 +1279,40 @@ class RecordingSyntax extends JsonObjectSyntax {
   List<String> validate() => [
     ...super.validate(),
     ..._validateCalls(),
-    ..._validateIdentifier(),
+    ..._validateDefinition(),
     ..._validateInstances(),
   ];
 
   @override
   String toString() => 'RecordingSyntax($json)';
+}
+
+class SetterNameSyntax extends NameSyntax {
+  SetterNameSyntax.fromJson(
+    super.json, {
+    super.path,
+  }) : super._fromJson();
+
+  SetterNameSyntax({
+    super.disambiguators,
+    required super.name,
+    super.path = const [],
+  }) : super(kind: 'setter');
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+  ];
+
+  @override
+  String toString() => 'SetterNameSyntax($json)';
+}
+
+extension SetterNameSyntaxExtension on NameSyntax {
+  bool get isSetterName => kind == 'setter';
+
+  SetterNameSyntax get asSetterName =>
+      SetterNameSyntax.fromJson(json, path: path);
 }
 
 class StringConstantSyntax extends ConstantSyntax {

--- a/pkgs/record_use/test/json_schema/schema_test.dart
+++ b/pkgs/record_use/test/json_schema/schema_test.dart
@@ -53,8 +53,12 @@ const constNullIndex = 4;
 const constInstanceIndex = 6;
 const constMapIndex = 3;
 const constUnsupportedIndex = 8;
-List<(List<Object>, void Function(ValidationResults result))>
-recordUseFields = [
+typedef SchemaTestField = (
+  List<Object> path,
+  void Function(ValidationResults result) missingExpectations,
+);
+
+List<SchemaTestField> recordUseFields = [
   (['constants'], expectOptionalFieldMissing),
   for (var index = 0; index < 9; index++) ...[
     (['constants', index, 'type'], expectRequiredFieldMissing),
@@ -74,22 +78,28 @@ recordUseFields = [
     // omitted. Also, Null has no value field.
   ],
   (['recordings'], expectOptionalFieldMissing),
-  (['recordings', 0, 'identifier'], expectRequiredFieldMissing),
+  (['recordings', 0, 'definition'], expectRequiredFieldMissing),
+  (['recordings', 0, 'definition', 'uri'], expectRequiredFieldMissing),
+  (['recordings', 0, 'definition', 'path'], expectRequiredFieldMissing),
+  (['recordings', 0, 'definition', 'path', 0], expectOptionalFieldMissing),
   (
-    ['recordings', 0, 'identifier', 'uri'],
+    ['recordings', 0, 'definition', 'path', 0, 'name'],
     expectRequiredFieldMissing,
   ),
-  // TODO(https://github.com/dart-lang/native/issues/1093): Potentially split
-  // out the concept of a class definition (which should never have a scope),
-  // and static method definition, which optionally have a scope. And the scope
-  // is always an enclosing class.
   (
-    ['recordings', 0, 'identifier', 'scope'],
+    ['recordings', 0, 'definition', 'path', 0, 'kind'],
     expectOptionalFieldMissing,
   ),
   (
-    ['recordings', 0, 'identifier', 'name'],
-    expectRequiredFieldMissing,
+    [
+      'recordings',
+      0,
+      'definition',
+      'path',
+      0,
+      'disambiguators',
+    ],
+    expectOptionalFieldMissing,
   ),
 
   // TODO(https://github.com/dart-lang/native/issues/1093): Whether calls or
@@ -116,20 +126,13 @@ recordUseFields = [
   ),
 ];
 
-List<(List<Object>, void Function(ValidationResults result))>
-constructorInvocationFields = [
+List<SchemaTestField> constructorInvocationFields = [
   (
     ['recordings', 0, 'instances', 0, 'loading_unit'],
     expectRequiredFieldMissing,
   ),
-  (
-    ['recordings', 0, 'instances', 0, 'type'],
-    expectRequiredFieldMissing,
-  ),
-  (
-    ['recordings', 0, 'instances', 0, 'positional'],
-    expectOptionalFieldMissing,
-  ),
+  (['recordings', 0, 'instances', 0, 'type'], expectRequiredFieldMissing),
+  (['recordings', 0, 'instances', 0, 'positional'], expectOptionalFieldMissing),
   (
     ['recordings', 0, 'instances', 0, 'named', 'param'],
     expectOptionalFieldMissing,
@@ -175,8 +178,6 @@ AllTestData loadTestsData(Uri directory) {
 Uri packageUri = findPackageRoot('record_use');
 
 /// Test removing a field or modifying it.
-///
-/// Changing a field to a wrong type is always expected to fail.
 ///
 /// Removing a field can be valid, the expectations must be passed in
 /// [missingExpectations].

--- a/pkgs/record_use/test/json_schema/uri_pattern_test.dart
+++ b/pkgs/record_use/test/json_schema/uri_pattern_test.dart
@@ -27,11 +27,11 @@ void main() {
 
     test('JSON schema validation fails for non-package URI', () {
       final json = recordedUses.toJson();
-      // Modify the first recording's identifier URI to be invalid.
+      // Modify the first recording's definition URI to be invalid.
       final recordings = json['recordings'] as List;
       final recording = recordings[0] as Map;
-      final identifier = recording['identifier'] as Map;
-      identifier['uri'] = 'dart:core'; // Should start with package:
+      final definition = recording['definition'] as Map;
+      definition['uri'] = 'dart:core'; // Should start with package:
 
       final result = schema.validate(json);
       expect(result.isValid, isFalse);

--- a/pkgs/record_use/test/maybe_constant_test.dart
+++ b/pkgs/record_use/test/maybe_constant_test.dart
@@ -15,7 +15,12 @@ void main() {
       ],
       'recordings': [
         {
-          'identifier': {'uri': 'package:a/a.dart', 'name': 'foo'},
+          'definition': {
+            'uri': 'package:a/a.dart',
+            'path': [
+              {'name': 'foo'},
+            ],
+          },
           'calls': [
             {
               'type': 'with_arguments',

--- a/pkgs/record_use/test/syntax/uri_pattern_test.dart
+++ b/pkgs/record_use/test/syntax/uri_pattern_test.dart
@@ -11,11 +11,11 @@ void main() {
   group('Definition.uri pattern', () {
     test('Recordings.fromJson fails for non-package URI', () {
       final json = recordedUses.toJson();
-      // Modify the first recording's identifier URI to be invalid.
+      // Modify the first recording's definition URI to be invalid.
       final recordings = json['recordings'] as List;
       final recording = recordings[0] as Map;
-      final identifier = recording['identifier'] as Map;
-      identifier['uri'] = 'file:///foo.dart'; // Should start with package:
+      final definition = recording['definition'] as Map;
+      definition['uri'] = 'file:///foo.dart'; // Should start with package:
 
       expect(
         () => Recordings.fromJson(json),
@@ -31,11 +31,11 @@ void main() {
 
     test('RecordedUsages.fromJson fails for non-package URI', () {
       final json = recordedUses.toJson();
-      // Modify the first recording's identifier URI to be invalid.
+      // Modify the first recording's definition URI to be invalid.
       final recordings = json['recordings'] as List;
       final recording = recordings[0] as Map;
-      final identifier = recording['identifier'] as Map;
-      identifier['uri'] = 'file:///foo.dart'; // Should start with package:
+      final definition = recording['definition'] as Map;
+      definition['uri'] = 'file:///foo.dart'; // Should start with package:
 
       expect(
         () => RecordedUsages.fromJson(json),

--- a/pkgs/record_use/test/syntax/validation_test.dart
+++ b/pkgs/record_use/test/syntax/validation_test.dart
@@ -11,11 +11,11 @@ void main() {
   group('Recordings.fromJson validation', () {
     test('Recordings.fromJson fails for invalid JSON', () {
       final json = recordedUses.toJson();
-      // Modify the first recording's identifier URI to be an invalid type.
+      // Modify the first recording's definition URI to be an invalid type.
       final recordings = json['recordings'] as List;
       final recording = recordings[0] as Map;
-      final identifier = recording['identifier'] as Map;
-      identifier['uri'] = 123; // Should be a string
+      final definition = recording['definition'] as Map;
+      definition['uri'] = 123; // Should be a string
 
       expect(
         () => Recordings.fromJson(json),

--- a/pkgs/record_use/test/test_data.dart
+++ b/pkgs/record_use/test/test_data.dart
@@ -192,10 +192,16 @@ const recordedUsesJson = '''{
   ],
   "recordings": [
     {
-      "identifier": {
+      "definition": {
         "uri": "package:js_runtime/js_helper.dart",
-        "scope": "MyClass",
-        "name": "get:loadDeferredLibrary"
+        "path": [
+          {
+            "name": "MyClass"
+          },
+          {
+            "name": "get:loadDeferredLibrary"
+          }
+        ]
       },
       "calls": [
         {
@@ -227,9 +233,13 @@ const recordedUsesJson = '''{
       ]
     },
     {
-      "identifier": {
+      "definition": {
         "uri": "package:js_runtime/js_helper.dart",
-        "name": "MyAnnotation"
+        "path": [
+          {
+            "name": "MyAnnotation"
+          }
+        ]
       },
       "instances": [
         {
@@ -272,10 +282,16 @@ const recordedUsesJson2 = '''{
   ],
   "recordings": [
     {
-      "identifier": {
+      "definition": {
         "uri": "package:js_runtime/js_helper.dart",
-        "scope": "MyClass",
-        "name": "get:loadDeferredLibrary"
+        "path": [
+          {
+            "name": "MyClass"
+          },
+          {
+            "name": "get:loadDeferredLibrary"
+          }
+        ]
       },
       "calls": [
         {

--- a/pkgs/record_use/test_data/json/basic.json
+++ b/pkgs/record_use/test_data/json/basic.json
@@ -21,9 +21,20 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod2",
-        "scope": "SomeClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "SomeClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "someStaticMethod2"
+          }
+        ],
         "uri": "package:record_use_test/basic.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/complex.json
+++ b/pkgs/record_use/test_data/json/complex.json
@@ -25,9 +25,20 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "generate",
-        "scope": "OtherClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "OtherClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "generate"
+          }
+        ],
         "uri": "package:record_use_test/complex.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/const_argument_instance.json
+++ b/pkgs/record_use/test_data/json/const_argument_instance.json
@@ -27,8 +27,13 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod2",
+      "definition": {
+        "path": [
+          {
+            "kind": "method",
+            "name": "someStaticMethod2"
+          }
+        ],
         "uri": "package:record_use_test/const_argument_instance.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/constructor_invocation.json
+++ b/pkgs/record_use/test_data/json/constructor_invocation.json
@@ -20,8 +20,13 @@
   },
   "recordings": [
     {
-      "identifier": {
-        "name": "MyClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "MyClass"
+          }
+        ],
         "uri": "package:record_use_test/test.dart"
       },
       "instances": [

--- a/pkgs/record_use/test_data/json/enum_const_arg.json
+++ b/pkgs/record_use/test_data/json/enum_const_arg.json
@@ -32,8 +32,13 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "doSomething",
+      "definition": {
+        "path": [
+          {
+            "kind": "method",
+            "name": "doSomething"
+          }
+        ],
         "uri": "package:record_use_test/enum_const_arg.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/extension.json
+++ b/pkgs/record_use/test_data/json/extension.json
@@ -21,8 +21,13 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "_extension#0|callWithArgs",
+      "definition": {
+        "path": [
+          {
+            "kind": "method",
+            "name": "_extension#0|callWithArgs"
+          }
+        ],
         "uri": "package:record_use_test/extension.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/instance_class.json
+++ b/pkgs/record_use/test_data/json/instance_class.json
@@ -18,8 +18,13 @@
   },
   "recordings": [
     {
-      "identifier": {
-        "name": "MyClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "MyClass"
+          }
+        ],
         "uri": "package:record_use_test/instance_class.dart"
       },
       "instances": [

--- a/pkgs/record_use/test_data/json/instance_complex.json
+++ b/pkgs/record_use/test_data/json/instance_complex.json
@@ -74,8 +74,13 @@
   },
   "recordings": [
     {
-      "identifier": {
-        "name": "MyClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "MyClass"
+          }
+        ],
         "uri": "package:record_use_test/instance_complex.dart"
       },
       "instances": [

--- a/pkgs/record_use/test_data/json/instance_duplicates.json
+++ b/pkgs/record_use/test_data/json/instance_duplicates.json
@@ -28,8 +28,13 @@
   },
   "recordings": [
     {
-      "identifier": {
-        "name": "MyClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "MyClass"
+          }
+        ],
         "uri": "package:record_use_test/instance_duplicates.dart"
       },
       "instances": [

--- a/pkgs/record_use/test_data/json/instance_not_annotation.json
+++ b/pkgs/record_use/test_data/json/instance_not_annotation.json
@@ -11,8 +11,13 @@
   },
   "recordings": [
     {
-      "identifier": {
-        "name": "MyClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "MyClass"
+          }
+        ],
         "uri": "package:record_use_test/instance_not_annotation.dart"
       },
       "instances": [

--- a/pkgs/record_use/test_data/json/loading_units_multiple.json
+++ b/pkgs/record_use/test_data/json/loading_units_multiple.json
@@ -28,9 +28,20 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod",
-        "scope": "SomeClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "SomeClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "someStaticMethod"
+          }
+        ],
         "uri": "package:record_use_test/loading_units_multiple_helper_shared.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/loading_units_simple.json
+++ b/pkgs/record_use/test_data/json/loading_units_simple.json
@@ -21,9 +21,20 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod",
-        "scope": "SomeClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "SomeClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "someStaticMethod"
+          }
+        ],
         "uri": "package:record_use_test/loading_units_simple.dart"
       }
     },
@@ -37,9 +48,20 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod",
-        "scope": "SomeClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "SomeClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "someStaticMethod"
+          }
+        ],
         "uri": "package:record_use_test/loading_units_simple_helper.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/map_complex_keys.json
+++ b/pkgs/record_use/test_data/json/map_complex_keys.json
@@ -46,9 +46,20 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod",
-        "scope": "SomeClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "SomeClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "someStaticMethod"
+          }
+        ],
         "uri": "package:record_use_test/map_complex_keys.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/named_and_positional.json
+++ b/pkgs/record_use/test_data/json/named_and_positional.json
@@ -77,9 +77,20 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod",
-        "scope": "SomeClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "SomeClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "someStaticMethod"
+          }
+        ],
         "uri": "package:record_use_test/named_and_positional.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/named_both.json
+++ b/pkgs/record_use/test_data/json/named_both.json
@@ -69,9 +69,20 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod",
-        "scope": "SomeClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "SomeClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "someStaticMethod"
+          }
+        ],
         "uri": "package:record_use_test/named_both.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/named_optional.json
+++ b/pkgs/record_use/test_data/json/named_optional.json
@@ -32,9 +32,20 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod",
-        "scope": "SomeClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "SomeClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "someStaticMethod"
+          }
+        ],
         "uri": "package:record_use_test/named_optional.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/named_required.json
+++ b/pkgs/record_use/test_data/json/named_required.json
@@ -32,9 +32,20 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod",
-        "scope": "SomeClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "SomeClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "someStaticMethod"
+          }
+        ],
         "uri": "package:record_use_test/named_required.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/named_with_function_arg.json
+++ b/pkgs/record_use/test_data/json/named_with_function_arg.json
@@ -24,8 +24,13 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "Ext|foo",
+      "definition": {
+        "path": [
+          {
+            "kind": "method",
+            "name": "Ext|foo"
+          }
+        ],
         "uri": "package:record_use_test/named_with_function_arg.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/nested.json
+++ b/pkgs/record_use/test_data/json/nested.json
@@ -31,8 +31,13 @@
   },
   "recordings": [
     {
-      "identifier": {
-        "name": "MyClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "MyClass"
+          }
+        ],
         "uri": "package:record_use_test/nested.dart"
       },
       "instances": [
@@ -49,8 +54,13 @@
       ]
     },
     {
-      "identifier": {
-        "name": "MyOtherClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "MyOtherClass"
+          }
+        ],
         "uri": "package:record_use_test/nested.dart"
       },
       "instances": [

--- a/pkgs/record_use/test_data/json/nested_instance_constant.json
+++ b/pkgs/record_use/test_data/json/nested_instance_constant.json
@@ -18,8 +18,13 @@
   },
   "recordings": [
     {
-      "identifier": {
-        "name": "Recorded",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "Recorded"
+          }
+        ],
         "uri": "package:record_use_test/nested_instance_constant.dart"
       },
       "instances": [

--- a/pkgs/record_use/test_data/json/partfile_main.json
+++ b/pkgs/record_use/test_data/json/partfile_main.json
@@ -21,9 +21,20 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod",
-        "scope": "SomeClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "SomeClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "someStaticMethod"
+          }
+        ],
         "uri": "package:record_use_test/partfile_main.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/positional_both.json
+++ b/pkgs/record_use/test_data/json/positional_both.json
@@ -42,9 +42,20 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod",
-        "scope": "SomeClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "SomeClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "someStaticMethod"
+          }
+        ],
         "uri": "package:record_use_test/positional_both.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/positional_both_with_type_argument.json
+++ b/pkgs/record_use/test_data/json/positional_both_with_type_argument.json
@@ -42,9 +42,20 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod",
-        "scope": "SomeClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "SomeClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "someStaticMethod"
+          }
+        ],
         "uri": "package:record_use_test/positional_both_with_type_argument.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/positional_optional.json
+++ b/pkgs/record_use/test_data/json/positional_optional.json
@@ -32,9 +32,20 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod",
-        "scope": "SomeClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "SomeClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "someStaticMethod"
+          }
+        ],
         "uri": "package:record_use_test/positional_optional.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/record_enum.json
+++ b/pkgs/record_use/test_data/json/record_enum.json
@@ -29,8 +29,13 @@
   },
   "recordings": [
     {
-      "identifier": {
-        "name": "MyClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "MyClass"
+          }
+        ],
         "uri": "package:record_use_test/record_enum.dart"
       },
       "instances": [

--- a/pkgs/record_use/test_data/json/record_instance_constant_empty.json
+++ b/pkgs/record_use/test_data/json/record_instance_constant_empty.json
@@ -17,8 +17,13 @@
   },
   "recordings": [
     {
-      "identifier": {
-        "name": "MyClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "MyClass"
+          }
+        ],
         "uri": "package:record_use_test/record_instance_constant_empty.dart"
       },
       "instances": [

--- a/pkgs/record_use/test_data/json/recorded_uses.json
+++ b/pkgs/record_use/test_data/json/recorded_uses.json
@@ -74,15 +74,31 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "generate",
-        "scope": "OtherClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "OtherClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "generate"
+          }
+        ],
         "uri": "package:record_use_test/complex.dart"
       }
     },
     {
-      "identifier": {
-        "name": "MyClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "MyClass"
+          }
+        ],
         "uri": "package:record_use_test/instance_class.dart"
       },
       "instances": [

--- a/pkgs/record_use/test_data/json/simple.json
+++ b/pkgs/record_use/test_data/json/simple.json
@@ -21,9 +21,20 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod",
-        "scope": "SomeClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "SomeClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "someStaticMethod"
+          }
+        ],
         "uri": "package:record_use_test/simple.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/tearoff.json
+++ b/pkgs/record_use/test_data/json/tearoff.json
@@ -12,9 +12,20 @@
           "type": "tearoff"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod",
-        "scope": "SomeClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "SomeClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "someStaticMethod"
+          }
+        ],
         "uri": "package:record_use_test/tearoff.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/top_level_method.json
+++ b/pkgs/record_use/test_data/json/top_level_method.json
@@ -21,8 +21,13 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someTopLevelMethod",
+      "definition": {
+        "path": [
+          {
+            "kind": "method",
+            "name": "someTopLevelMethod"
+          }
+        ],
         "uri": "package:record_use_test/top_level_method.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/types_of_arguments.json
+++ b/pkgs/record_use/test_data/json/types_of_arguments.json
@@ -118,9 +118,20 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "someStaticMethod",
-        "scope": "SomeClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "SomeClass"
+          },
+          {
+            "disambiguators": [
+              "static"
+            ],
+            "kind": "method",
+            "name": "someStaticMethod"
+          }
+        ],
         "uri": "package:record_use_test/types_of_arguments.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/unsupported_collections.json
+++ b/pkgs/record_use/test_data/json/unsupported_collections.json
@@ -47,8 +47,13 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "recorded",
+      "definition": {
+        "path": [
+          {
+            "kind": "method",
+            "name": "recorded"
+          }
+        ],
         "uri": "package:record_use_test/unsupported_collections.dart"
       }
     }

--- a/pkgs/record_use/test_data/json/unsupported_instance.json
+++ b/pkgs/record_use/test_data/json/unsupported_instance.json
@@ -27,14 +27,24 @@
           "type": "with_arguments"
         }
       ],
-      "identifier": {
-        "name": "recorded",
+      "definition": {
+        "path": [
+          {
+            "kind": "method",
+            "name": "recorded"
+          }
+        ],
         "uri": "package:record_use_test/unsupported_instance.dart"
       }
     },
     {
-      "identifier": {
-        "name": "MyClass",
+      "definition": {
+        "path": [
+          {
+            "kind": "class",
+            "name": "MyClass"
+          }
+        ],
         "uri": "package:record_use_test/unsupported_instance.dart"
       },
       "instances": [

--- a/pkgs/record_use/tool/generate_syntax.dart
+++ b/pkgs/record_use/tool/generate_syntax.dart
@@ -17,6 +17,9 @@ void main(List<String> args) {
 
   final analyzedSchema = SchemaAnalyzer(
     schema,
+    nameOverrides: {
+      'path': 'definitionPath',
+    },
   ).analyze();
   final textDumpFile = File.fromUri(
     Platform.script.resolve('../lib/src/syntax.g.txt'),


### PR DESCRIPTION
The JSON encoding that goes together with:

* https://github.com/dart-lang/native/pull/3075

This will enable us implementing the kinds and disambiguators in the compilers.

Related bugs:

* https://github.com/dart-lang/native/issues/2888
* https://github.com/dart-lang/native/issues/3062