### PR TITLE
[hooks_runner] Add `CCACHE_` env variables to allowlist

### DIFF
--- a/pkgs/hooks/CHANGELOG.md
+++ b/pkgs/hooks/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2-wip
+
+- Update documentation about `CCACHE_` environment variables.
+
 ## 1.0.1
 
 - Update documentation about environment variables.

--- a/pkgs/hooks/lib/hooks.dart
+++ b/pkgs/hooks/lib/hooks.dart
@@ -101,6 +101,8 @@
 ///     *   `ANDROID_HOME`: Standard location for the Android SDK/NDK.
 ///     *   `ANDROID_NDK`, `ANDROID_NDK_HOME`, `ANDROID_NDK_LATEST_HOME`,
 ///         `ANDROID_NDK_ROOT`: Alternative locations for the NDK.
+/// *   **Ccache:**
+///     *   Any variable starting with `CCACHE_`.
 /// *   **Nix:**
 ///     *   Any variable starting with `NIX_`.
 ///

--- a/pkgs/hooks/lib/src/api/build_and_link.dart
+++ b/pkgs/hooks/lib/src/api/build_and_link.dart
@@ -106,6 +106,8 @@ import '../validation.dart';
 ///     *   `ANDROID_HOME`: Standard location for the Android SDK/NDK.
 ///     *   `ANDROID_NDK`, `ANDROID_NDK_HOME`, `ANDROID_NDK_LATEST_HOME`,
 ///         `ANDROID_NDK_ROOT`: Alternative locations for the NDK.
+/// *   **Ccache:**
+///     *   Any variable starting with `CCACHE_`.
 /// *   **Nix:**
 ///     *   Any variable starting with `NIX_`.
 ///
@@ -272,6 +274,8 @@ Future<void> build(
 ///     *   `ANDROID_HOME`: Standard location for the Android SDK/NDK.
 ///     *   `ANDROID_NDK`, `ANDROID_NDK_HOME`, `ANDROID_NDK_LATEST_HOME`,
 ///         `ANDROID_NDK_ROOT`: Alternative locations for the NDK.
+/// *   **Ccache:**
+///     *   Any variable starting with `CCACHE_`.
 /// *   **Nix:**
 ///     *   Any variable starting with `NIX_`.
 ///

--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A library that contains a Dart API for the JSON-based protocol for
   `hook/build.dart` and `hook/link.dart`.
 
-version: 1.0.1
+version: 1.0.2-wip
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks
 

--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Filter `recorded_uses.json` passed to link hooks based on the
   package name of the definition.
+- Add `CCACHE_` to the environment variables allowlist.
 
 ## 1.0.2
 

--- a/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
@@ -611,6 +611,7 @@ class NativeAssetsBuildRunner {
       ..._httpProxyEnvironmentVariables,
     };
     const variablePrefixesFilter = {
+      'CCACHE_', // Needed for Ccache.
       'NIX_', // Needed for Nix-installed toolchains.
     };
 

--- a/pkgs/hooks_runner/test/build_runner/environment_filter_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/environment_filter_test.dart
@@ -47,4 +47,41 @@ void main() {
       expect(result.exitCode, 0);
     });
   });
+
+  test('includeHookEnvironmentVariable allows Ccache variables', () {
+    expect(
+      NativeAssetsBuildRunner.includeHookEnvironmentVariable('CCACHE_DIR'),
+      isTrue,
+    );
+    expect(
+      NativeAssetsBuildRunner.includeHookEnvironmentVariable('CCACHE_DISABLE'),
+      isTrue,
+    );
+    expect(
+      NativeAssetsBuildRunner.includeHookEnvironmentVariable('NOT_CCACHE'),
+      isFalse,
+    );
+  });
+
+  test('includeHookEnvironmentVariable allows standard variables', () {
+    expect(
+      NativeAssetsBuildRunner.includeHookEnvironmentVariable('PATH'),
+      isTrue,
+    );
+    expect(
+      NativeAssetsBuildRunner.includeHookEnvironmentVariable('HOME'),
+      isTrue,
+    );
+    expect(
+      NativeAssetsBuildRunner.includeHookEnvironmentVariable('ANDROID_HOME'),
+      isTrue,
+    );
+  });
+
+  test('includeHookEnvironmentVariable allows NIX_ variables', () {
+    expect(
+      NativeAssetsBuildRunner.includeHookEnvironmentVariable('NIX_CC'),
+      isTrue,
+    );
+  });
 }


### PR DESCRIPTION
Might or might not fix https://github.com/dart-lang/native/issues/3102. In any case, allowlisting these for build hooks is the right thing to do. We want native toolchains to work properly.