### PR TITLE
[infra] apply dot-shorthands

### DIFF
--- a/pkgs/code_assets/example/mini_audio/lib/src/mini_audio.dart
+++ b/pkgs/code_assets/example/mini_audio/lib/src/mini_audio.dart
@@ -16,7 +16,7 @@ final class MiniAudio {
   MiniAudio() {
     _engine = malloc();
     final result = ma_engine_init(nullptr, _engine);
-    if (result != ma_result.MA_SUCCESS) {
+    if (result != .MA_SUCCESS) {
       throw MiniAudioException(
         'Failed to initialize miniaudio engine: ${result.name}.',
       );
@@ -33,7 +33,7 @@ final class MiniAudio {
   void playSound(String filePath) => using((arena) {
     final filePath_ = filePath.toNativeUtf8(allocator: arena);
     final result = ma_engine_play_sound(_engine, filePath_.cast(), nullptr);
-    if (result != ma_result.MA_SUCCESS) {
+    if (result != .MA_SUCCESS) {
       throw MiniAudioException('Failed to play audio: ${result.name}}.');
     }
   });

--- a/pkgs/code_assets/lib/src/code_assets/architecture.dart
+++ b/pkgs/code_assets/lib/src/code_assets/architecture.dart
@@ -45,29 +45,29 @@ final class Architecture {
     x64,
   ];
 
-  static const _abiToArch = {
-    Abi.androidArm: Architecture.arm,
-    Abi.androidArm64: Architecture.arm64,
-    Abi.androidIA32: Architecture.ia32,
-    Abi.androidX64: Architecture.x64,
-    Abi.androidRiscv64: Architecture.riscv64,
-    Abi.fuchsiaArm64: Architecture.arm64,
-    Abi.fuchsiaRiscv64: Architecture.riscv64,
-    Abi.fuchsiaX64: Architecture.x64,
-    Abi.iosArm: Architecture.arm,
-    Abi.iosArm64: Architecture.arm64,
-    Abi.iosX64: Architecture.x64,
-    Abi.linuxArm: Architecture.arm,
-    Abi.linuxArm64: Architecture.arm64,
-    Abi.linuxIA32: Architecture.ia32,
-    Abi.linuxRiscv32: Architecture.riscv32,
-    Abi.linuxRiscv64: Architecture.riscv64,
-    Abi.linuxX64: Architecture.x64,
-    Abi.macosArm64: Architecture.arm64,
-    Abi.macosX64: Architecture.x64,
-    Abi.windowsArm64: Architecture.arm64,
-    Abi.windowsIA32: Architecture.ia32,
-    Abi.windowsX64: Architecture.x64,
+  static const Map<Abi, Architecture> _abiToArch = {
+    Abi.androidArm: arm,
+    Abi.androidArm64: arm64,
+    Abi.androidIA32: ia32,
+    Abi.androidX64: x64,
+    Abi.androidRiscv64: riscv64,
+    Abi.fuchsiaArm64: arm64,
+    Abi.fuchsiaRiscv64: riscv64,
+    Abi.fuchsiaX64: x64,
+    Abi.iosArm: arm,
+    Abi.iosArm64: arm64,
+    Abi.iosX64: x64,
+    Abi.linuxArm: arm,
+    Abi.linuxArm64: arm64,
+    Abi.linuxIA32: ia32,
+    Abi.linuxRiscv32: riscv32,
+    Abi.linuxRiscv64: riscv64,
+    Abi.linuxX64: x64,
+    Abi.macosArm64: arm64,
+    Abi.macosX64: x64,
+    Abi.windowsArm64: arm64,
+    Abi.windowsIA32: ia32,
+    Abi.windowsX64: x64,
   };
 
   /// The name of this [Architecture].
@@ -82,7 +82,7 @@ final class Architecture {
   /// The name can be obtained from [Architecture.name] or
   /// [Architecture.toString].
   factory Architecture.fromString(String name) =>
-      ArchitectureSyntaxExtension.fromSyntax(ArchitectureSyntax.fromJson(name));
+      ArchitectureSyntaxExtension.fromSyntax(.fromJson(name));
 
   /// The current [Architecture].
   static final Architecture current = _abiToArch[Abi.current()]!;
@@ -90,12 +90,11 @@ final class Architecture {
 
 /// Extension methods for [Architecture] to convert to and from the syntax.
 extension ArchitectureSyntaxExtension on Architecture {
-  static final _toSyntax = {
-    for (final item in Architecture.values)
-      item: ArchitectureSyntax.fromJson(item.name),
+  static final Map<Architecture, ArchitectureSyntax> _toSyntax = {
+    for (final item in Architecture.values) item: .fromJson(item.name),
   };
 
-  static final _fromSyntax = {
+  static final Map<ArchitectureSyntax, Architecture> _fromSyntax = {
     for (var entry in _toSyntax.entries) entry.value: entry.key,
   };
 

--- a/pkgs/code_assets/lib/src/code_assets/code_asset.dart
+++ b/pkgs/code_assets/lib/src/code_assets/code_asset.dart
@@ -103,7 +103,7 @@ final class CodeAsset {
       asset.encoding,
       path: asset.encodingJsonPath ?? [],
     );
-    return CodeAsset._(
+    return ._(
       id: syntaxNode.id,
       linkMode: LinkModeSyntaxExtension.fromSyntax(syntaxNode.linkMode),
       file: syntaxNode.file,
@@ -111,12 +111,11 @@ final class CodeAsset {
   }
 
   /// Creates a copy of this [CodeAsset] with the given fields replaced.
-  CodeAsset copyWith({LinkMode? linkMode, String? id, Uri? file}) =>
-      CodeAsset._(
-        id: id ?? this.id,
-        linkMode: linkMode ?? this.linkMode,
-        file: file ?? this.file,
-      );
+  CodeAsset copyWith({LinkMode? linkMode, String? id, Uri? file}) => ._(
+    id: id ?? this.id,
+    linkMode: linkMode ?? this.linkMode,
+    file: file ?? this.file,
+  );
 
   @override
   bool operator ==(Object other) {

--- a/pkgs/code_assets/lib/src/code_assets/config.dart
+++ b/pkgs/code_assets/lib/src/code_assets/config.dart
@@ -77,7 +77,7 @@ final class CodeConfig {
   /// Configuration provided when [CodeConfig.targetOS] is [OS.macOS].
   IOSCodeConfig get iOS => switch (_syntax.iOS) {
     null => throw StateError('Cannot access iOSConfig if targetOS is not iOS.'),
-    final c => IOSCodeConfig._(c),
+    final c => ._(c),
   };
 
   /// Configuration provided when [CodeConfig.targetOS] is [OS.android].
@@ -85,7 +85,7 @@ final class CodeConfig {
     null => throw StateError(
       'Cannot access androidConfig if targetOS is not android.',
     ),
-    final c => AndroidCodeConfig._(c),
+    final c => ._(c),
   };
 
   /// Configuration provided when [CodeConfig.targetOS] is [OS.macOS].
@@ -93,7 +93,7 @@ final class CodeConfig {
     null => throw StateError(
       'Cannot access macOSConfig if targetOS is not MacOS.',
     ),
-    final c => MacOSCodeConfig._(c),
+    final c => ._(c),
   };
 }
 
@@ -105,7 +105,7 @@ final class IOSCodeConfig {
   IOSCodeConfig._(this._syntax);
 
   /// Whether to target device or simulator.
-  IOSSdk get targetSdk => IOSSdk.fromString(_syntax.targetSdk);
+  IOSSdk get targetSdk => .fromString(_syntax.targetSdk);
 
   /// The lowest iOS version that the compiled code will be compatible with.
   int get targetVersion => _syntax.targetVersion;

--- a/pkgs/code_assets/lib/src/code_assets/link_mode.dart
+++ b/pkgs/code_assets/lib/src/code_assets/link_mode.dart
@@ -25,7 +25,7 @@ abstract final class LinkMode {
   ///
   /// The json is expected to be valid encoding obtained via [LinkMode.toJson].
   factory LinkMode.fromJson(Map<String, Object?> json) =>
-      LinkModeSyntaxExtension.fromSyntax(LinkModeSyntax.fromJson(json));
+      LinkModeSyntaxExtension.fromSyntax(.fromJson(json));
 
   /// The json representation of this [LinkMode].
   ///

--- a/pkgs/code_assets/lib/src/code_assets/link_mode_preference.dart
+++ b/pkgs/code_assets/lib/src/code_assets/link_mode_preference.dart
@@ -18,9 +18,7 @@ final class LinkModePreference {
   ///
   /// The [name] must be one of [LinkModePreference.values].
   factory LinkModePreference.fromString(String name) =>
-      LinkModePreferenceSyntaxExtension.fromSyntax(
-        LinkModePreferenceSyntax.fromJson(name),
-      );
+      LinkModePreferenceSyntaxExtension.fromSyntax(.fromJson(name));
 
   /// Provide native assets as dynamic libraries.
   ///
@@ -57,14 +55,14 @@ final class LinkModePreference {
 /// Extension methods for [LinkModePreference] to convert to and from the
 /// syntax model.
 extension LinkModePreferenceSyntaxExtension on LinkModePreference {
-  static const _toSyntax = {
+  static const Map<LinkModePreference, LinkModePreferenceSyntax> _toSyntax = {
     LinkModePreference.dynamic: LinkModePreferenceSyntax.dynamic,
     LinkModePreference.preferDynamic: LinkModePreferenceSyntax.preferDynamic,
     LinkModePreference.preferStatic: LinkModePreferenceSyntax.preferStatic,
     LinkModePreference.static: LinkModePreferenceSyntax.static,
   };
 
-  static const _fromSyntax = {
+  static const Map<LinkModePreferenceSyntax, LinkModePreference> _fromSyntax = {
     LinkModePreferenceSyntax.dynamic: LinkModePreference.dynamic,
     LinkModePreferenceSyntax.preferDynamic: LinkModePreference.preferDynamic,
     LinkModePreferenceSyntax.preferStatic: LinkModePreference.preferStatic,

--- a/pkgs/code_assets/lib/src/code_assets/os.dart
+++ b/pkgs/code_assets/lib/src/code_assets/os.dart
@@ -40,10 +40,10 @@ final class OS {
   static const List<OS> values = [android, fuchsia, iOS, linux, macOS, windows];
 
   /// Typical cross compilation between OSes.
-  static const osCrossCompilationDefault = {
-    OS.macOS: [OS.macOS, OS.iOS, OS.android],
-    OS.linux: [OS.linux, OS.android],
-    OS.windows: [OS.windows, OS.android],
+  static const Map<OS, List<OS>> osCrossCompilationDefault = {
+    macOS: [macOS, iOS, android],
+    linux: [linux, android],
+    windows: [windows, android],
   };
 
   /// The name of this [OS].
@@ -62,16 +62,16 @@ final class OS {
   /// The current [OS].
   ///
   /// Consisten with the [Platform.version] string.
-  static final OS current = OS.fromString(Platform.operatingSystem);
+  static final OS current = .fromString(Platform.operatingSystem);
 }
 
 /// Extension methods for [OS] to convert to and from the syntax model.
 extension OSSyntaxExtension on OS {
-  static final _toSyntax = {
-    for (final item in OS.values) item: OSSyntax.fromJson(item.name),
+  static final Map<OS, OSSyntax> _toSyntax = {
+    for (final item in OS.values) item: .fromJson(item.name),
   };
 
-  static final _fromSyntax = {
+  static final Map<OSSyntax, OS> _fromSyntax = {
     for (var entry in _toSyntax.entries) entry.value: entry.key,
   };
 

--- a/pkgs/code_assets/lib/src/code_assets/testing.dart
+++ b/pkgs/code_assets/lib/src/code_assets/testing.dart
@@ -45,33 +45,33 @@ Future<void> testCodeBuildHook({
   bool? linkingEnabled,
   Architecture? targetArchitecture,
   OS? targetOS,
-  IOSSdk? targetIOSSdk = IOSSdk.iPhoneOS,
+  IOSSdk? targetIOSSdk = .iPhoneOS,
   int? targetIOSVersion = 17,
   int? targetMacOSVersion = 13,
   int? targetAndroidNdkApi = 30,
   CCompilerConfig? cCompiler,
-  LinkModePreference? linkModePreference = LinkModePreference.dynamic,
+  LinkModePreference? linkModePreference = .dynamic,
   // TODO(https://github.com/dart-lang/native/issues/2241): Cleanup how the
   // following parameters are passed in.
   PackageUserDefines? userDefines,
   Map<String, List<EncodedAsset>>? assets,
 }) async {
-  targetOS ??= OS.current;
+  targetOS ??= .current;
   final extension = CodeAssetExtension(
     linkModePreference: linkModePreference!,
     cCompiler: cCompiler,
-    targetArchitecture: targetArchitecture ?? Architecture.current,
+    targetArchitecture: targetArchitecture ?? .current,
     targetOS: targetOS,
-    iOS: targetOS == OS.iOS
+    iOS: targetOS == .iOS
         ? IOSCodeConfig(
             targetSdk: targetIOSSdk!,
             targetVersion: targetIOSVersion!,
           )
         : null,
-    macOS: targetOS == OS.macOS
+    macOS: targetOS == .macOS
         ? MacOSCodeConfig(targetVersion: targetMacOSVersion!)
         : null,
-    android: targetOS == OS.android
+    android: targetOS == .android
         ? AndroidCodeConfig(targetNdkApi: targetAndroidNdkApi!)
         : null,
   );

--- a/pkgs/code_assets/lib/src/code_assets/validation.dart
+++ b/pkgs/code_assets/lib/src/code_assets/validation.dart
@@ -9,8 +9,6 @@ import 'package:hooks/hooks.dart';
 import 'code_asset.dart';
 import 'config.dart';
 import 'link_mode.dart';
-import 'link_mode_preference.dart';
-import 'os.dart';
 import 'syntax.g.dart';
 
 /// Validates the code asset specific parts of a [BuildInput].
@@ -43,7 +41,7 @@ ValidationErrors _validateConfig(String inputName, HookConfig config) {
       ..._validateFile('$inputName.cCompiler.linker', cCompiler.linker),
       ..._validateFile('$inputName.cCompiler.archiver', cCompiler.archiver),
     ]);
-    if (code.targetOS == OS.windows &&
+    if (code.targetOS == .windows &&
         cCompiler.windows.developerCommandPrompt != null) {
       errors.addAll([
         ..._validateFile(
@@ -210,10 +208,8 @@ void _validateCodeAsset(
   if (validateLinkMode) {
     final preference = codeConfig.linkModePreference;
     final linkMode = codeAsset.linkMode;
-    if ((linkMode is DynamicLoading &&
-            preference == LinkModePreference.static) ||
-        (linkMode is StaticLinking &&
-            preference == LinkModePreference.dynamic)) {
+    if ((linkMode is DynamicLoading && preference == .static) ||
+        (linkMode is StaticLinking && preference == .dynamic)) {
       errors.add(
         'CodeAsset "$id" has a link mode "$linkMode", which '
         'is not allowed by by the input link mode preference '

--- a/pkgs/code_assets/test/code_assets/config_test.dart
+++ b/pkgs/code_assets/test/code_assets/config_test.dart
@@ -48,7 +48,7 @@ void main() async {
   // check the nested key.
   Map<String, Object> inputJson({
     String hookType = 'build',
-    OS targetOS = OS.android,
+    OS targetOS = .android,
   }) {
     final codeConfig = {
       'target_architecture': 'arm64',
@@ -65,9 +65,9 @@ void main() async {
           },
         },
       },
-      if (targetOS == OS.android) 'android': {'target_ndk_api': 30},
-      if (targetOS == OS.macOS) 'macos': {'target_version': 13},
-      if (targetOS == OS.iOS)
+      if (targetOS == .android) 'android': {'target_ndk_api': 30},
+      if (targetOS == .macOS) 'macos': {'target_version': 13},
+      if (targetOS == .iOS)
         'ios': {'target_sdk': 'iphoneos', 'target_version': 13},
     };
     return {
@@ -128,16 +128,16 @@ void main() async {
 
   void expectCorrectCodeConfig(
     CodeConfig codeCondig, {
-    OS targetOS = OS.android,
+    OS targetOS = .android,
   }) {
     expect(codeCondig.targetArchitecture, Architecture.arm64);
-    if (targetOS == OS.android) {
+    if (targetOS == .android) {
       expect(codeCondig.android.targetNdkApi, 30);
     }
-    if (targetOS == OS.macOS) {
+    if (targetOS == .macOS) {
       expect(codeCondig.macOS.targetVersion, 13);
     }
-    if (targetOS == OS.iOS) {
+    if (targetOS == .iOS) {
       expect(codeCondig.iOS.targetVersion, 13);
       expect(codeCondig.iOS.targetSdk, IOSSdk.iPhoneOS);
     }

--- a/pkgs/code_assets/test/code_assets/validation_test.dart
+++ b/pkgs/code_assets/test/code_assets/validation_test.dart
@@ -46,13 +46,13 @@ void main() {
   }
 
   BuildInput makeCodeBuildInput({
-    LinkModePreference linkModePreference = LinkModePreference.dynamic,
+    LinkModePreference linkModePreference = .dynamic,
   }) {
     final builder = makeBuildInputBuilder()
       ..addExtension(
         CodeAssetExtension(
-          targetOS: OS.linux,
-          targetArchitecture: Architecture.arm64,
+          targetOS: .linux,
+          targetArchitecture: .arm64,
           linkModePreference: linkModePreference,
         ),
       );
@@ -71,13 +71,13 @@ void main() {
   }
 
   LinkInput makeCodeLinkInput({
-    LinkModePreference linkModePreference = LinkModePreference.dynamic,
+    LinkModePreference linkModePreference = .dynamic,
   }) {
     final builder = makeLinkInputBuilder()
       ..addExtension(
         CodeAssetExtension(
-          targetOS: OS.linux,
-          targetArchitecture: Architecture.arm64,
+          targetOS: .linux,
+          targetArchitecture: .arm64,
           linkModePreference: linkModePreference,
         ),
       );
@@ -306,13 +306,10 @@ void main() {
         final builder = makeBuildInputBuilder()
           ..addExtension(
             CodeAssetExtension(
-              targetOS: OS.iOS,
-              targetArchitecture: Architecture.arm64,
-              linkModePreference: LinkModePreference.dynamic,
-              iOS: IOSCodeConfig(
-                targetSdk: IOSSdk.iPhoneOS,
-                targetVersion: 123,
-              ),
+              targetOS: .iOS,
+              targetArchitecture: .arm64,
+              linkModePreference: .dynamic,
+              iOS: IOSCodeConfig(targetSdk: .iPhoneOS, targetVersion: 123),
             ),
           );
         traverseJson<Map<String, Object?>>(builder.json, [
@@ -340,9 +337,9 @@ void main() {
       final builder = makeBuildInputBuilder()
         ..addExtension(
           CodeAssetExtension(
-            targetOS: OS.android,
-            targetArchitecture: Architecture.arm64,
-            linkModePreference: LinkModePreference.dynamic,
+            targetOS: .android,
+            targetArchitecture: .arm64,
+            linkModePreference: .dynamic,
             android: AndroidCodeConfig(targetNdkApi: 123),
           ),
         );
@@ -368,9 +365,9 @@ void main() {
       final builder = makeBuildInputBuilder()
         ..addExtension(
           CodeAssetExtension(
-            targetOS: OS.macOS,
-            targetArchitecture: Architecture.arm64,
-            linkModePreference: LinkModePreference.dynamic,
+            targetOS: .macOS,
+            targetArchitecture: .arm64,
+            linkModePreference: .dynamic,
             macOS: MacOSCodeConfig(targetVersion: 123),
           ),
         );
@@ -413,9 +410,9 @@ void main() {
       final builder = makeBuildInputBuilder()
         ..addExtension(
           CodeAssetExtension(
-            targetOS: OS.windows,
-            targetArchitecture: Architecture.x64,
-            linkModePreference: LinkModePreference.dynamic,
+            targetOS: .windows,
+            targetArchitecture: .x64,
+            linkModePreference: .dynamic,
             cCompiler: CCompilerConfig(
               compiler: nonExistent,
               linker: nonExistent,

--- a/pkgs/data_assets/lib/src/data_assets/config.dart
+++ b/pkgs/data_assets/lib/src/data_assets/config.dart
@@ -109,7 +109,7 @@ extension BuildOutputAssetsBuilderData on BuildOutputAssetsBuilder {
   /// Provides access to emitting data assets.
   ///
   /// Should only be used if [HookConfigDataConfig.buildDataAssets] is true.
-  BuildOutputDataAssetsBuilder get data => BuildOutputDataAssetsBuilder._(this);
+  BuildOutputDataAssetsBuilder get data => ._(this);
 }
 
 /// Extension on [BuildOutputBuilder] to add [DataAsset]s.

--- a/pkgs/hooks/lib/src/api/build_and_link.dart
+++ b/pkgs/hooks/lib/src/api/build_and_link.dart
@@ -205,7 +205,7 @@ Future<void> build(
       for (final error in errors) '- $error',
     ].join('\n');
     stderr.writeln(message);
-    output.setFailure(FailureType.build);
+    output.setFailure(.build);
     await _writeOutput(output, outputFile);
     exit(BuildError(message: message).exitCode);
   }
@@ -373,7 +373,7 @@ Future<void> link(
       for (final error in errors) '- $error',
     ].join('\n');
     stderr.writeln(message);
-    output.setFailure(FailureType.build);
+    output.setFailure(.build);
     await _writeOutput(output, outputFile);
     exit(BuildError(message: message).exitCode);
   }

--- a/pkgs/hooks/lib/src/config.dart
+++ b/pkgs/hooks/lib/src/config.dart
@@ -92,8 +92,7 @@ sealed class HookInput {
 
   final HookInputSyntax _syntax;
 
-  HookInput(Map<String, Object?> json)
-    : _syntax = HookInputSyntax.fromJson(json) {
+  HookInput(Map<String, Object?> json) : _syntax = .fromJson(json) {
     // Trigger validation, remove with cleanup.
     outputDirectory;
     outputDirectoryShared;
@@ -166,7 +165,7 @@ final class HookInputUserDefines {
 
 /// The builder for [HookInput].
 sealed class HookInputBuilder {
-  final _syntax = HookInputSyntax.fromJson({})
+  final HookInputSyntax _syntax = .fromJson({})
     ..config = ConfigSyntax(buildAssetTypes: [], extensions: null);
 
   /// The JSON representation of this hook input builder.
@@ -225,7 +224,7 @@ final class BuildInput extends HookInput {
   final BuildInputSyntax _syntaxBuildInput;
 
   ///// Creates a [BuildInput] from the given [json].
-  BuildInput(super.json) : _syntaxBuildInput = BuildInputSyntax.fromJson(json);
+  BuildInput(super.json) : _syntaxBuildInput = .fromJson(json);
 
   @override
   BuildConfig get config => BuildConfig._(this);
@@ -284,7 +283,7 @@ final class BuildInputAssets {
 /// The builder for [BuildInput].
 final class BuildInputBuilder extends HookInputBuilder {
   @override
-  BuildInputSyntax get _syntax => BuildInputSyntax.fromJson(super._syntax.json);
+  BuildInputSyntax get _syntax => .fromJson(super._syntax.json);
 
   /// Sets up the build input with the given [assets].
   void setupBuildInput({Map<String, List<EncodedAsset>>? assets}) {
@@ -361,7 +360,7 @@ final class LinkInput extends HookInput {
   final LinkInputSyntax _syntaxLinkInput;
 
   /// Creates a [LinkInput] from the given [json].
-  LinkInput(super.json) : _syntaxLinkInput = LinkInputSyntax.fromJson(json) {
+  LinkInput(super.json) : _syntaxLinkInput = .fromJson(json) {
     // Run validation.
     _encodedAssets;
   }
@@ -399,7 +398,7 @@ final class LinkInputAssets {
 /// The builder for [LinkInput].
 final class LinkInputBuilder extends HookInputBuilder {
   @override
-  LinkInputSyntax get _syntax => LinkInputSyntax.fromJson(super._syntax.json);
+  LinkInputSyntax get _syntax => .fromJson(super._syntax.json);
 
   /// Sets up the link input.
   void setupLink({
@@ -430,9 +429,7 @@ final class LinkInputBuilder extends HookInputBuilder {
 /// The builder for [BuildConfig].
 final class LinkConfigBuilder extends HookConfigBuilder {
   @override
-  late final BuildConfigSyntax _syntax = BuildConfigSyntax.fromJson(
-    super._syntax.json,
-  );
+  late final BuildConfigSyntax _syntax = .fromJson(super._syntax.json);
 
   LinkConfigBuilder._(super.builder) : super._();
 }
@@ -444,9 +441,7 @@ extension EncodedAssetSyntax on List<EncodedAsset> {
     if (assets == null) {
       return [];
     }
-    return [
-      for (final asset in assets) EncodedAsset.fromJson(asset.json, asset.path),
-    ];
+    return [for (final asset in assets) .fromJson(asset.json, asset.path)];
   }
 }
 
@@ -491,11 +486,11 @@ sealed class HookOutput {
 
 /// The builder for [HookOutput].
 sealed class HookOutputBuilder {
-  final _syntax = HookOutputSyntax(
+  final HookOutputSyntax _syntax = HookOutputSyntax(
     timestamp: DateTime.now().roundDownToSeconds().toString(),
     assets: null,
     dependencies: null,
-    status: OutputStatusSyntax.success,
+    status: .success,
     failureDetails: null,
     assetsForLinking: {},
   );
@@ -529,13 +524,13 @@ sealed class HookOutputBuilder {
 
   /// Sets the failure of this output.
   void setFailure(FailureType value) {
-    _syntax.status = OutputStatusSyntax.failure;
+    _syntax.status = .failure;
     _syntax.failureDetails = FailureSyntax(
       type: switch (value) {
-        FailureType.build => FailureTypeSyntax.build,
-        FailureType.infra => FailureTypeSyntax.infra,
-        FailureType.uncategorized => FailureTypeSyntax.uncategorized,
-        _ => FailureTypeSyntax.uncategorized,
+        .build => .build,
+        .infra => .infra,
+        .uncategorized => .uncategorized,
+        _ => .uncategorized,
       },
     );
   }
@@ -656,14 +651,13 @@ final class BuildOutputAssets {
 /// The builder for [BuildOutput].
 final class BuildOutputBuilder extends HookOutputBuilder {
   /// The metadata builder for this build output.
-  BuildOutputMetadataBuilder get metadata => BuildOutputMetadataBuilder._(this);
+  BuildOutputMetadataBuilder get metadata => ._(this);
 
   /// The assets builder for this build output.
-  BuildOutputAssetsBuilder get assets => BuildOutputAssetsBuilder._(this);
+  BuildOutputAssetsBuilder get assets => ._(this);
 
   @override
-  BuildOutputSyntax get _syntax =>
-      BuildOutputSyntax.fromJson(super._syntax.json);
+  BuildOutputSyntax get _syntax => .fromJson(super._syntax.json);
 
   /// Builds the [BuildOutput].
   BuildOutput build() => BuildOutput(json);
@@ -1096,8 +1090,7 @@ final class LinkOutputAssetsBuilder {
     }
   }
 
-  LinkOutputSyntax get _syntax =>
-      LinkOutputSyntax.fromJson(_builder._syntax.json);
+  LinkOutputSyntax get _syntax => .fromJson(_builder._syntax.json);
 }
 
 /// The configuration in [HookInput.config].
@@ -1217,10 +1210,10 @@ final class HookOutputFailure {
   /// This helps in categorizing the error and determining the appropriate
   /// response or fix.
   FailureType get type => switch (_syntax.failureDetails?.type) {
-    FailureTypeSyntax.build => FailureType.build,
-    FailureTypeSyntax.infra => FailureType.infra,
-    FailureTypeSyntax.uncategorized => FailureType.uncategorized,
-    _ => FailureType.uncategorized,
+    .build => .build,
+    .infra => .infra,
+    .uncategorized => .uncategorized,
+    _ => .uncategorized,
   };
 }
 
@@ -1250,9 +1243,9 @@ sealed class BuildOutputMaybeFailure {
     final status = syntax.status;
     switch (status) {
       case null: // backwards compatibility.
-      case OutputStatusSyntax.success:
+      case .success:
         return BuildOutput(json);
-      case OutputStatusSyntax.failure:
+      case .failure:
         return BuildOutputFailure._(json);
     }
     throw StateError('Unknown status: $status.');
@@ -1269,9 +1262,9 @@ sealed class LinkOutputMaybeFailure {
     final status = syntax.status;
     switch (status) {
       case null: // backwards compatibility.
-      case OutputStatusSyntax.success:
+      case .success:
         return LinkOutput(json);
-      case OutputStatusSyntax.failure:
+      case .failure:
         return LinkOutputFailure._(json);
     }
     throw StateError('Unknown status: $status.');
@@ -1325,7 +1318,7 @@ final class BuildError extends HookError {
 
   /// The failure type for build errors is [FailureType.build].
   @override
-  FailureType get failureType => FailureType.build;
+  FailureType get failureType => .build;
 }
 
 /// An error indicating an infrastructure-related problem during hook execution.
@@ -1347,5 +1340,5 @@ final class InfraError extends HookError {
 
   /// The failure type for infrastructure errors is [FailureType.infra].
   @override
-  FailureType get failureType => FailureType.infra;
+  FailureType get failureType => .infra;
 }

--- a/pkgs/hooks/test/json_schema/helpers.dart
+++ b/pkgs/hooks/test/json_schema/helpers.dart
@@ -247,7 +247,7 @@ FieldsReturn _hookFields({
   required Party party,
 }) => <(List<Object>, void Function(ValidationResults result))>[
   ([r'$schema'], expectOptionalFieldMissing),
-  if (inputOrOutput == InputOrOutput.input) ...[
+  if (inputOrOutput == .input) ...[
     (['user_defines'], expectOptionalFieldMissing),
     (['user_defines', 'workspace_pubspec'], expectOptionalFieldMissing),
     (
@@ -262,21 +262,21 @@ FieldsReturn _hookFields({
     (['package_name'], expectRequiredFieldMissing),
     (['package_root'], expectRequiredFieldMissing),
     (['config', 'build_asset_types'], expectRequiredFieldMissing),
-    if (hook == Hook.build) ...[
+    if (hook == .build) ...[
       (['config', 'linking_enabled'], expectRequiredFieldMissing),
     ],
-    if (hook == Hook.link) ...[
+    if (hook == .link) ...[
       (['assets'], expectOptionalFieldMissing),
       (['assets', 0], expectOptionalFieldMissing),
       (['assets', 0, 'type'], expectRequiredFieldMissing),
     ],
     (['out_file'], expectRequiredFieldMissing),
   ],
-  if (inputOrOutput == InputOrOutput.output) ...[
+  if (inputOrOutput == .output) ...[
     (['timestamp'], expectRequiredFieldMissing),
     (['dependencies'], expectOptionalFieldMissing),
     (['dependencies', 0], expectOptionalFieldMissing),
-    if (hook == Hook.build) ...[
+    if (hook == .build) ...[
       for (final path in [
         ['assets_for_build'],
         ['assets_for_linking', 'package_with_linker'],
@@ -289,8 +289,8 @@ FieldsReturn _hookFields({
     ],
   ],
   for (final path in [
-    if (inputOrOutput == InputOrOutput.output || hook == Hook.link) ['assets'],
-    if (inputOrOutput == InputOrOutput.output && hook == Hook.build) ...[
+    if (inputOrOutput == .output || hook == .link) ['assets'],
+    if (inputOrOutput == .output && hook == .build) ...[
       ['assets_for_build'],
       ['assets_for_linking', 'package_with_linker'],
     ],

--- a/pkgs/hooks/test/json_schema/schema_test.dart
+++ b/pkgs/hooks/test/json_schema/schema_test.dart
@@ -40,14 +40,12 @@ _metadataAssetFields({
   required Party party,
 }) => <(List<Object>, void Function(ValidationResults result))>[
   for (final path in [
-    if (inputOrOutput == InputOrOutput.input && hook == Hook.link) ...[
+    if (inputOrOutput == .input && hook == .link) ...[
       ['assets'],
       ['assets_from_linking'],
     ],
-    if (inputOrOutput == InputOrOutput.output)
-      ['assets_for_linking', 'package_with_linker'],
-    if (inputOrOutput == InputOrOutput.output && hook == Hook.build)
-      ['assets_for_build'],
+    if (inputOrOutput == .output) ['assets_for_linking', 'package_with_linker'],
+    if (inputOrOutput == .output && hook == .build) ['assets_for_build'],
   ]) ...[
     ([...path, 1], expectOptionalFieldMissing),
     ([...path, 1, 'type'], expectRequiredFieldMissing),

--- a/pkgs/hooks_runner/lib/src/build_runner/build_planner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_planner.dart
@@ -76,8 +76,8 @@ class NativeAssetsBuildPlanner {
     'BuildPlanner.packagesWithHook',
     arguments: {'hook': hook.toString()},
     () async => switch (hook) {
-      Hook.build => _packagesWithBuildHook ??= await _runPackagesWithHook(hook),
-      Hook.link => _packagesWithLinkHook ??= await _runPackagesWithHook(hook),
+      .build => _packagesWithBuildHook ??= await _runPackagesWithHook(hook),
+      .link => _packagesWithLinkHook ??= await _runPackagesWithHook(hook),
     },
   );
 
@@ -130,7 +130,7 @@ class NativeAssetsBuildPlanner {
       _timeAsync(
         'BuildPlanner.makeBuildHookPlan',
         () async => _makeHookPlan(
-          hookType: Hook.build,
+          hookType: .build,
           cachedPlan: _buildHookPlan,
           setCachedPlan: (plan) => _buildHookPlan = plan,
           reverseOrder: false,
@@ -153,7 +153,7 @@ class NativeAssetsBuildPlanner {
       _timeAsync(
         'BuildPlanner.makeLinkHookPlan',
         () async => _makeHookPlan(
-          hookType: Hook.link,
+          hookType: .link,
           cachedPlan: _linkHookPlan,
           setCachedPlan: (plan) => _linkHookPlan = plan,
           reverseOrder: true, // Key difference from [makeBuildHookPlan]
@@ -194,7 +194,7 @@ class NativeAssetsBuildPlanner {
           'Cyclic dependency for ${hookType.name} hooks in the '
           'following packages: $stronglyConnectedComponentWithNativeAssets.',
         );
-        return const Failure(HooksRunnerFailure.projectConfig);
+        return const Failure(.projectConfig);
       } else if (stronglyConnectedComponentWithNativeAssets.length == 1) {
         result.add(
           packageMap[stronglyConnectedComponentWithNativeAssets.single]!,

--- a/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
@@ -93,7 +93,7 @@ class NativeAssetsBuildRunner {
   /// flutter_tools (for `flutter run` and `flutter build`).
   Future<List<String>> packagesWithBuildHooks() async {
     final planner = await _planner;
-    final packagesWithHook = await planner.packagesWithHook(Hook.build);
+    final packagesWithHook = await planner.packagesWithHook(.build);
     return packagesWithHook.map((e) => e.name).toList();
   }
 
@@ -136,7 +136,7 @@ class NativeAssetsBuildRunner {
     required List<ProtocolExtension> extensions,
     required bool linkingEnabled,
   }) async => _timeAsync('BuildRunner.build', () async {
-    final planResult = await _makePlan(hook: Hook.build, buildResult: null);
+    final planResult = await _makePlan(hook: .build, buildResult: null);
     if (planResult.isFailure) {
       return planResult.asFailure;
     }
@@ -171,7 +171,7 @@ class NativeAssetsBuildRunner {
       inputBuilder.setupBuildInput(assets: assetsForBuild);
 
       final (buildDirUri, outDirUri, outDirSharedUri) = await _setupDirectories(
-        Hook.build,
+        .build,
         inputBuilder,
         package,
       );
@@ -195,7 +195,7 @@ class NativeAssetsBuildRunner {
       }
 
       final result = await _runHookForPackageCached(
-        Hook.build,
+        .build,
         input,
         (input, output) async => [
           for (final e in extensions)
@@ -252,10 +252,7 @@ class NativeAssetsBuildRunner {
     Uri? resourceIdentifiers,
     required BuildResult buildResult,
   }) async => _timeAsync('BuildRunner.link', () async {
-    final planResult = await _makePlan(
-      hook: Hook.link,
-      buildResult: buildResult,
-    );
+    final planResult = await _makePlan(hook: .link, buildResult: buildResult);
     if (planResult.isFailure) return planResult.asFailure;
     final (buildPlan, packageGraph) = planResult.success;
     if (buildPlan.isEmpty) {
@@ -306,7 +303,7 @@ class NativeAssetsBuildRunner {
       }
 
       final (buildDirUri, outDirUri, outDirSharedUri) = await _setupDirectories(
-        Hook.link,
+        .link,
         inputBuilder,
         package,
       );
@@ -350,7 +347,7 @@ class NativeAssetsBuildRunner {
       }
 
       final result = await _runHookForPackageCached(
-        Hook.link,
+        .link,
         input,
         (input, output) async => [
           for (final e in extensions)
@@ -924,7 +921,7 @@ ${compileResult.stdout}
     if (input is BuildInput) {
       final planner = await _planner;
       final packagesWithLink = (await planner.packagesWithHook(
-        Hook.link,
+        .link,
       )).map((p) => p.name);
       for (final targetPackage
           in (output as BuildOutput).assets.encodedAssetsForLinking.keys) {
@@ -960,14 +957,14 @@ ${compileResult.stdout}
   _makePlan({required Hook hook, BuildResult? buildResult}) async =>
       _timeAsync('_makePlan', () async {
         switch (hook) {
-          case Hook.build:
+          case .build:
             final planner = await _planner;
             final planResult = await planner.makeBuildHookPlan();
             if (planResult.isFailure) {
               return planResult.asFailure;
             }
             return Success((planResult.success, planner.packageGraph));
-          case Hook.link:
+          case .link:
             final planner = await _planner;
             final planResult = await planner.makeLinkHookPlan();
             if (planResult.isFailure) {
@@ -998,10 +995,10 @@ ${e.message}''');
       return const Failure(HooksRunnerFailure.hookRun);
     }
     switch (hook) {
-      case Hook.build:
+      case .build:
         final buildInput = BuildInput(hookInputJson);
         return Success(buildInput);
-      case Hook.link:
+      case .link:
         final linkInput = LinkInput(hookInputJson);
         return Success(linkInput);
     }
@@ -1038,7 +1035,7 @@ ${e.message}''');
       return const Failure(HooksRunnerFailure.hookRun);
     }
     switch (hook) {
-      case Hook.build:
+      case .build:
         final output = BuildOutputMaybeFailure(hookOutputJson);
         switch (output) {
           case BuildOutput _:
@@ -1048,7 +1045,7 @@ ${e.message}''');
           case BuildOutputFailure _:
             return const Failure(HooksRunnerFailure.hookRun);
         }
-      case Hook.link:
+      case .link:
         final output = LinkOutputMaybeFailure(hookOutputJson);
         switch (output) {
           case LinkOutput _:

--- a/pkgs/hooks_runner/lib/src/model/target.dart
+++ b/pkgs/hooks_runner/lib/src/model/target.dart
@@ -111,7 +111,7 @@ final class Target implements Comparable<Target> {
   /// Read from the [Platform.version] string.
   static final Target current = Target.fromDartPlatform(Platform.version);
 
-  Architecture get architecture => Architecture.fromAbi(abi);
+  Architecture get architecture => .fromAbi(abi);
 
   OS get os => {
     Abi.androidArm: OS.android,

--- a/pkgs/hooks_runner/test/build_runner/build_planner_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/build_planner_test.dart
@@ -38,7 +38,7 @@ void main() async {
             fileSystem: const LocalFileSystem(),
           );
       final packagesWithHook = await nativeAssetsBuildPlanner.packagesWithHook(
-        Hook.build,
+        .build,
       );
       expect(packagesWithHook.length, 1);
       final buildPlan = await nativeAssetsBuildPlanner.makeBuildHookPlan();

--- a/pkgs/hooks_runner/test/build_runner/build_process_helper.dart
+++ b/pkgs/hooks_runner/test/build_runner/build_process_helper.dart
@@ -43,13 +43,13 @@ void main(List<String> args) async {
           CodeAssetExtension(
             targetArchitecture: target.architecture,
             targetOS: targetOS,
-            macOS: targetOS == OS.macOS
+            macOS: targetOS == .macOS
                 ? MacOSCodeConfig(targetVersion: defaultMacOSVersion)
                 : null,
-            android: targetOS == OS.android
+            android: targetOS == .android
                 ? AndroidCodeConfig(targetNdkApi: 30)
                 : null,
-            linkModePreference: LinkModePreference.dynamic,
+            linkModePreference: .dynamic,
           ),
           DataAssetsExtension(),
         ],

--- a/pkgs/hooks_runner/test/build_runner/build_runner_caching_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/build_runner_caching_test.dart
@@ -34,7 +34,7 @@ void main() async {
           logger,
           dartExecutable,
           capturedLogs: logMessages,
-          buildAssetTypes: [BuildAssetType.code],
+          buildAssetTypes: [.code],
           userDefines: userDefines,
         )).success;
         expect(
@@ -78,7 +78,7 @@ void main() async {
           logger,
           dartExecutable,
           capturedLogs: logMessages,
-          buildAssetTypes: [BuildAssetType.code],
+          buildAssetTypes: [.code],
           userDefines: userDefines,
         )).success;
         final hookUri = packageUri.resolve('hook/build.dart');
@@ -128,7 +128,7 @@ void main() async {
           logger,
           dartExecutable,
           capturedLogs: logMessages,
-          buildAssetTypes: [BuildAssetType.code],
+          buildAssetTypes: [.code],
           userDefines: userDefines,
         )).success;
         expect(
@@ -156,7 +156,7 @@ void main() async {
           packageUri,
           logger,
           dartExecutable,
-          buildAssetTypes: [BuildAssetType.code],
+          buildAssetTypes: [.code],
         )).success;
         await expectSymbols(
           asset: CodeAsset.fromEncoded(result.encodedAssets.single),
@@ -175,7 +175,7 @@ void main() async {
           packageUri,
           logger,
           dartExecutable,
-          buildAssetTypes: [BuildAssetType.code],
+          buildAssetTypes: [.code],
         )).success;
 
         final cUri = packageUri.resolve('src/').resolve('native_add.c');
@@ -210,7 +210,7 @@ void main() async {
         packageUri,
         logger,
         dartExecutable,
-        buildAssetTypes: [BuildAssetType.code],
+        buildAssetTypes: [.code],
       )).success;
       {
         final compiledHook = logMessages
@@ -238,7 +238,7 @@ void main() async {
           packageUri,
           logger,
           dartExecutable,
-          buildAssetTypes: [BuildAssetType.code],
+          buildAssetTypes: [.code],
         )).success;
 
         final hookUri = packageUri.resolve('hook/build.dart');
@@ -272,7 +272,7 @@ void main() async {
           packageUri,
           logger,
           dartExecutable,
-          buildAssetTypes: [BuildAssetType.code],
+          buildAssetTypes: [.code],
           hookEnvironment: modifiedEnvKey == 'PATH'
               ? null
               : filteredEnvironment(
@@ -307,7 +307,7 @@ void main() async {
           packageUri,
           logger,
           dartExecutable,
-          buildAssetTypes: [BuildAssetType.code],
+          buildAssetTypes: [.code],
         )).success;
         expect(logMessages.join('\n'), contains('hook.dill'));
         expect(

--- a/pkgs/hooks_runner/test/build_runner/build_runner_failure_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/build_runner_failure_test.dart
@@ -27,7 +27,7 @@ void main() async {
           packageUri,
           logger,
           dartExecutable,
-          buildAssetTypes: [BuildAssetType.code],
+          buildAssetTypes: [.code],
         )).success;
         expect(result.encodedAssets.length, 1);
         await expectSymbols(
@@ -51,7 +51,7 @@ void main() async {
           packageUri,
           createCapturingLogger(logMessages, level: Level.SEVERE),
           dartExecutable,
-          buildAssetTypes: [BuildAssetType.code],
+          buildAssetTypes: [.code],
         );
         final fullLog = logMessages.join('\n');
         expect(result.isFailure, isTrue);
@@ -80,7 +80,7 @@ void main() async {
           packageUri,
           logger,
           dartExecutable,
-          buildAssetTypes: [BuildAssetType.code],
+          buildAssetTypes: [.code],
         )).success;
         expect(result.encodedAssets.length, 1);
         await expectSymbols(
@@ -111,7 +111,7 @@ void main() async {
           logger,
           capturedLogs: logMessages,
           dartExecutable,
-          buildAssetTypes: [BuildAssetType.code],
+          buildAssetTypes: [.code],
         );
         Matcher stringContainsBuildHookCompilation(String packageName) =>
             stringContainsInOrder([
@@ -143,7 +143,7 @@ void main() async {
         packageUri,
         logger,
         dartExecutable,
-        buildAssetTypes: [BuildAssetType.code],
+        buildAssetTypes: [.code],
       );
       expect(result.isFailure, isTrue);
       expect(result.failure, HooksRunnerFailure.infra);

--- a/pkgs/hooks_runner/test/build_runner/fail_on_os_sdk_version_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/fail_on_os_sdk_version_test.dart
@@ -25,7 +25,7 @@ final List<(Target, List<(int sdkVersion, bool success)>)> osInput = [
       (minNdkApiVersionForThisPackage - 1, false),
     ],
   ),
-  if (OS.current == OS.macOS) ...[
+  if (OS.current == .macOS) ...[
     (
       Target.macOSArm64,
       [
@@ -67,12 +67,10 @@ void main() async {
                 final logMessages = <String>[];
                 final (buildResult, linkResult) = await buildAndLink(
                   target: target,
-                  targetIOSSdk: (target.os == OS.iOS) ? IOSSdk.iPhoneOS : null,
-                  targetIOSVersion: (target.os == OS.iOS) ? version : null,
-                  targetMacOSVersion: (target.os == OS.macOS) ? version : null,
-                  targetAndroidNdkApi: (target.os == OS.android)
-                      ? version
-                      : null,
+                  targetIOSSdk: (target.os == .iOS) ? .iPhoneOS : null,
+                  targetIOSVersion: (target.os == .iOS) ? version : null,
+                  targetMacOSVersion: (target.os == .macOS) ? version : null,
+                  targetAndroidNdkApi: (target.os == .android) ? version : null,
                   packageUri,
                   createCapturingLogger(logMessages, level: Level.SEVERE),
                   dartExecutable,

--- a/pkgs/hooks_runner/test/build_runner/helpers.dart
+++ b/pkgs/hooks_runner/test/build_runner/helpers.dart
@@ -65,7 +65,7 @@ Future<Result<BuildResult, HooksRunnerFailure>> build(
   Uri packageUri,
   Logger logger,
   Uri dartExecutable, {
-  LinkModePreference linkModePreference = LinkModePreference.dynamic,
+  LinkModePreference linkModePreference = .dynamic,
   CCompilerConfig? cCompiler,
   List<String>? capturedLogs,
   String? runPackageName,
@@ -79,7 +79,7 @@ Future<Result<BuildResult, HooksRunnerFailure>> build(
   Map<String, String>? hookEnvironment,
   UserDefines? userDefines,
 }) async {
-  final targetOS = target?.os ?? OS.current;
+  final targetOS = target?.os ?? .current;
   final runPackageName_ =
       runPackageName ?? packageUri.pathSegments.lastWhere((e) => e.isNotEmpty);
   final packageLayout = await PackageLayout.fromWorkingDirectory(
@@ -101,24 +101,23 @@ Future<Result<BuildResult, HooksRunnerFailure>> build(
           extensions: [
             if (buildAssetTypes.contains(BuildAssetType.code))
               CodeAssetExtension(
-                targetArchitecture:
-                    target?.architecture ?? Architecture.current,
+                targetArchitecture: target?.architecture ?? .current,
                 targetOS: targetOS,
                 linkModePreference: linkModePreference,
                 cCompiler: cCompiler ?? dartCICompilerConfig,
-                iOS: targetOS == OS.iOS
+                iOS: targetOS == .iOS
                     ? IOSCodeConfig(
                         targetSdk: targetIOSSdk!,
                         targetVersion: targetIOSVersion!,
                       )
                     : null,
-                macOS: targetOS == OS.macOS
+                macOS: targetOS == .macOS
                     ? MacOSCodeConfig(
                         targetVersion:
                             targetMacOSVersion ?? defaultMacOSVersion,
                       )
                     : null,
-                android: targetOS == OS.android
+                android: targetOS == .android
                     ? AndroidCodeConfig(targetNdkApi: targetAndroidNdkApi!)
                     : null,
               ),
@@ -145,7 +144,7 @@ Future<Result<LinkResult, HooksRunnerFailure>> link(
   Uri packageUri,
   Logger logger,
   Uri dartExecutable, {
-  LinkModePreference linkModePreference = LinkModePreference.dynamic,
+  LinkModePreference linkModePreference = .dynamic,
   CCompilerConfig? cCompiler,
   List<String>? capturedLogs,
   String? runPackageName,
@@ -158,7 +157,7 @@ Future<Result<LinkResult, HooksRunnerFailure>> link(
   Target? target,
   required List<BuildAssetType> buildAssetTypes,
 }) async {
-  final targetOS = target?.os ?? OS.current;
+  final targetOS = target?.os ?? .current;
   final runPackageName_ =
       runPackageName ?? packageUri.pathSegments.lastWhere((e) => e.isNotEmpty);
   final packageLayout = await PackageLayout.fromWorkingDirectory(
@@ -178,24 +177,23 @@ Future<Result<LinkResult, HooksRunnerFailure>> link(
           extensions: [
             if (buildAssetTypes.contains(BuildAssetType.code))
               CodeAssetExtension(
-                targetArchitecture:
-                    target?.architecture ?? Architecture.current,
-                targetOS: target?.os ?? OS.current,
+                targetArchitecture: target?.architecture ?? .current,
+                targetOS: target?.os ?? .current,
                 linkModePreference: linkModePreference,
                 cCompiler: cCompiler ?? dartCICompilerConfig,
-                iOS: targetOS == OS.iOS
+                iOS: targetOS == .iOS
                     ? IOSCodeConfig(
                         targetSdk: targetIOSSdk!,
                         targetVersion: targetIOSVersion!,
                       )
                     : null,
-                macOS: targetOS == OS.macOS
+                macOS: targetOS == .macOS
                     ? MacOSCodeConfig(
                         targetVersion:
                             targetMacOSVersion ?? defaultMacOSVersion,
                       )
                     : null,
-                android: targetOS == OS.android
+                android: targetOS == .android
                     ? AndroidCodeConfig(targetNdkApi: targetAndroidNdkApi!)
                     : null,
               ),
@@ -218,7 +216,7 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
   Uri packageUri,
   Logger logger,
   Uri dartExecutable, {
-  LinkModePreference linkModePreference = LinkModePreference.dynamic,
+  LinkModePreference linkModePreference = .dynamic,
   CCompilerConfig? cCompiler,
   List<String>? capturedLogs,
   PackageLayout? packageLayout,
@@ -245,27 +243,27 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
     fileSystem: const LocalFileSystem(),
     packageLayout: packageLayout,
   );
-  final targetOS = target?.os ?? OS.current;
+  final targetOS = target?.os ?? .current;
   final buildResult = await buildRunner.build(
     extensions: [
       if (buildAssetTypes.contains(BuildAssetType.code))
         CodeAssetExtension(
-          targetArchitecture: target?.architecture ?? Architecture.current,
-          targetOS: target?.os ?? OS.current,
+          targetArchitecture: target?.architecture ?? .current,
+          targetOS: target?.os ?? .current,
           linkModePreference: linkModePreference,
           cCompiler: cCompiler ?? dartCICompilerConfig,
-          iOS: targetOS == OS.iOS
+          iOS: targetOS == .iOS
               ? IOSCodeConfig(
                   targetSdk: targetIOSSdk!,
                   targetVersion: targetIOSVersion!,
                 )
               : null,
-          macOS: targetOS == OS.macOS
+          macOS: targetOS == .macOS
               ? MacOSCodeConfig(
                   targetVersion: targetMacOSVersion ?? defaultMacOSVersion,
                 )
               : null,
-          android: targetOS == OS.android
+          android: targetOS == .android
               ? AndroidCodeConfig(targetNdkApi: targetAndroidNdkApi!)
               : null,
         ),
@@ -286,22 +284,22 @@ Future<(BuildResult?, LinkResult?)> buildAndLink(
     extensions: [
       if (buildAssetTypes.contains(BuildAssetType.code))
         CodeAssetExtension(
-          targetArchitecture: target?.architecture ?? Architecture.current,
-          targetOS: target?.os ?? OS.current,
+          targetArchitecture: target?.architecture ?? .current,
+          targetOS: target?.os ?? .current,
           linkModePreference: linkModePreference,
           cCompiler: cCompiler ?? dartCICompilerConfig,
-          iOS: targetOS == OS.iOS
+          iOS: targetOS == .iOS
               ? IOSCodeConfig(
                   targetSdk: targetIOSSdk!,
                   targetVersion: targetIOSVersion!,
                 )
               : null,
-          macOS: targetOS == OS.macOS
+          macOS: targetOS == .macOS
               ? MacOSCodeConfig(
                   targetVersion: targetMacOSVersion ?? defaultMacOSVersion,
                 )
               : null,
-          android: targetOS == OS.android
+          android: targetOS == .android
               ? AndroidCodeConfig(targetNdkApi: targetAndroidNdkApi!)
               : null,
         ),

--- a/pkgs/hooks_runner/test/build_runner/link_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/link_test.dart
@@ -36,7 +36,7 @@ void main() async {
         logger,
         dartExecutable,
         buildResult: buildResult,
-        buildAssetTypes: [BuildAssetType.data],
+        buildAssetTypes: [.data],
       )).success;
       expect(linkResult.encodedAssets.length, 2);
 
@@ -91,7 +91,7 @@ void main() async {
         logger,
         dartExecutable,
         buildResult: buildResult,
-        buildAssetTypes: [BuildAssetType.data],
+        buildAssetTypes: [.data],
       )).success;
 
       expect(
@@ -127,7 +127,7 @@ void main() async {
         logger,
         dartExecutable,
         buildResult: buildResult,
-        buildAssetTypes: [BuildAssetType.data],
+        buildAssetTypes: [.data],
       )).success;
 
       expect(
@@ -155,7 +155,7 @@ void main() async {
         dartExecutable,
         capturedLogs: logMessages,
         buildResult: HookResult(),
-        buildAssetTypes: [BuildAssetType.data],
+        buildAssetTypes: [.data],
       );
       final fullLog = logMessages.join('\n');
 
@@ -186,7 +186,7 @@ void main() async {
         logger,
         dartExecutable,
         linkingEnabled: true,
-        buildAssetTypes: [BuildAssetType.code],
+        buildAssetTypes: [.code],
       )).success;
       expect(buildResult.encodedAssets.length, 0);
       expect(buildResult.encodedAssetsForLinking.length, 1);
@@ -198,7 +198,7 @@ void main() async {
         dartExecutable,
         buildResult: buildResult,
         capturedLogs: logMessages,
-        buildAssetTypes: [BuildAssetType.code],
+        buildAssetTypes: [.code],
       )).success;
       expect(linkResult.encodedAssets.length, 1);
       expect(linkResult.encodedAssets.first.isCodeAsset, isTrue);

--- a/pkgs/json_syntax_generator/lib/src/parser/schema_analyzer.dart
+++ b/pkgs/json_syntax_generator/lib/src/parser/schema_analyzer.dart
@@ -97,7 +97,7 @@ class SchemaAnalyzer {
   }
 
   void _analyzeEnumClass(JsonSchemas schemas, {String? name}) {
-    if (schemas.type != SchemaType.string) {
+    if (schemas.type != .string) {
       throw UnimplementedError(schemas.type.toString());
     }
     var typeName = schemas.className;
@@ -307,11 +307,11 @@ class SchemaAnalyzer {
     switch (type) {
       case null:
         dartType = ObjectDartType(isNullable: isNullable);
-      case SchemaType.boolean:
+      case .boolean:
         dartType = BoolDartType(isNullable: isNullable);
-      case SchemaType.integer:
+      case .integer:
         dartType = IntDartType(isNullable: isNullable);
-      case SchemaType.string:
+      case .string:
         if (schemas.generateUri) {
           dartType = UriDartType(isNullable: isNullable);
         } else if (schemas.generateEnum && allowEnum) {
@@ -328,7 +328,7 @@ class SchemaAnalyzer {
           final pattern = schemas.patterns.firstOrNull;
           dartType = StringDartType(isNullable: isNullable, pattern: pattern);
         }
-      case SchemaType.object:
+      case .object:
         final additionalPropertiesSchema =
             schemas.additionalPropertiesSchemas.isNotEmpty
             ? schemas.additionalPropertiesSchemas
@@ -342,11 +342,11 @@ class SchemaAnalyzer {
           final (additionalPropertiesType, additionalNullable) =
               additionalPropertiesSchema.typeAndNullable;
           switch (additionalPropertiesType) {
-            case SchemaType.array:
+            case .array:
               final items = additionalPropertiesSchema.items;
               final (itemType, itemNullable) = items.typeAndNullable;
               switch (itemType) {
-                case SchemaType.object:
+                case .object:
                   _analyzeClass(items);
                   final itemClass = _classes[items.className]!;
                   dartType = MapDartType(
@@ -363,7 +363,7 @@ class SchemaAnalyzer {
                 default:
                   throw UnimplementedError(itemType.toString());
               }
-            case SchemaType.object:
+            case .object:
               final additionalPropertiesBool =
                   additionalPropertiesSchema.additionalPropertiesBool;
               if (additionalPropertiesBool != true) {
@@ -416,7 +416,7 @@ class SchemaAnalyzer {
                 if (types.contains(SchemaType.string) &&
                     types.contains(SchemaType.nullValue)) {
                   final stringPattern = oneOf
-                      .where((e) => e.type == SchemaType.string)
+                      .where((e) => e.type == .string)
                       .single
                       .patterns
                       .firstOrNull;
@@ -432,13 +432,13 @@ class SchemaAnalyzer {
                   throw UnimplementedError();
                 }
               }
-            case SchemaType.string:
+            case .string:
               dartType = MapDartType(
                 keyType: keyDartType,
                 valueType: StringDartType(isNullable: additionalNullable),
                 isNullable: isNullable,
               );
-            case SchemaType.integer:
+            case .integer:
               dartType = MapDartType(
                 keyType: keyDartType,
                 valueType: IntDartType(isNullable: additionalNullable),
@@ -457,11 +457,11 @@ class SchemaAnalyzer {
             isNullable: isNullable,
           );
         }
-      case SchemaType.array:
+      case .array:
         final items = schemas.items;
         final (itemType, itemNullable) = items.typeAndNullable;
         switch (itemType) {
-          case SchemaType.string:
+          case .string:
             if (items.generateUri) {
               dartType = ListDartType(
                 itemType: UriDartType(isNullable: itemNullable),
@@ -473,12 +473,12 @@ class SchemaAnalyzer {
                 isNullable: isNullable,
               );
             }
-          case SchemaType.integer:
+          case .integer:
             dartType = ListDartType(
               itemType: IntDartType(isNullable: itemNullable),
               isNullable: isNullable,
             );
-          case SchemaType.object:
+          case .object:
             final typeName = items.className;
             if (typeName != null) {
               _analyzeClass(items);
@@ -794,7 +794,7 @@ extension type JsonSchemas._(List<JsonSchema> _schemas) {
 }
 
 extension on JsonSchemas {
-  bool get generateEnum => type == SchemaType.string && anyOfs.isNotEmpty;
+  bool get generateEnum => type == .string && anyOfs.isNotEmpty;
 
   /// A class with opaque members and an `unknown` option.
   bool get generateOpenEnum =>
@@ -802,7 +802,7 @@ extension on JsonSchemas {
 
   /// Generate getters/setters as `Map<String, ...>`.
   bool get generateMapOf =>
-      type == SchemaType.object &&
+      type == .object &&
       (additionalPropertiesSchemas.isNotEmpty ||
           additionalPropertiesBool == true ||
           patternPropertiesSchemas.isNotEmpty);
@@ -810,7 +810,7 @@ extension on JsonSchemas {
   bool get generateSubClasses => generateSubClassesKey != null;
 
   String? get generateSubClassesKey {
-    if (type != SchemaType.object) return null;
+    if (type != .object) return null;
     for (final p in propertyKeys) {
       final propertySchemas = property(p);
       if (propertySchemas.anyOfs.isNotEmpty) {
@@ -825,7 +825,7 @@ extension on JsonSchemas {
     return null;
   }
 
-  bool get generateClass => type == SchemaType.object && !generateMapOf;
+  bool get generateClass => type == .object && !generateMapOf;
 
   /// Generate getters/setters as `Uri`.
   bool get generateUri {
@@ -840,8 +840,7 @@ extension on JsonSchemas {
     return false;
   }
 
-  bool get stringWithPattern =>
-      type == SchemaType.string && patterns.isNotEmpty;
+  bool get stringWithPattern => type == .string && patterns.isNotEmpty;
 
   static String? _pathToClassName(String path) {
     if (path.contains('#/definitions/')) {

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -11,10 +11,8 @@ import 'package:meta/meta.dart';
 
 import 'build_mode.dart';
 import 'ctool.dart';
-import 'language.dart';
 import 'linkmode.dart';
 import 'logger.dart';
-import 'optimization_level.dart';
 import 'output_type.dart';
 import 'run_cbuilder.dart';
 
@@ -74,12 +72,12 @@ class CBuilder extends CTool implements Builder {
     this.ndebugDefine = true,
     super.pic = true,
     super.std,
-    super.language = Language.c,
+    super.language = .c,
     super.cppLinkStdLib,
     super.linkModePreference,
-    super.optimizationLevel = OptimizationLevel.o3,
-    this.buildMode = BuildMode.release,
-  }) : super(type: OutputType.library);
+    super.optimizationLevel = .o3,
+    this.buildMode = .release,
+  }) : super(type: .library);
 
   CBuilder.executable({
     required super.name,
@@ -101,12 +99,12 @@ class CBuilder extends CTool implements Builder {
     this.ndebugDefine = true,
     bool? pie = false,
     super.std,
-    super.language = Language.c,
+    super.language = .c,
     super.cppLinkStdLib,
-    super.optimizationLevel = OptimizationLevel.o3,
-    this.buildMode = BuildMode.release,
+    super.optimizationLevel = .o3,
+    this.buildMode = .release,
   }) : super(
-         type: OutputType.executable,
+         type: .executable,
          assetName: null,
          installName: null,
          pic: pie,

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
@@ -10,11 +10,8 @@ import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 
 import 'ctool.dart';
-import 'language.dart';
 import 'linker_options.dart';
 import 'linkmode.dart';
-import 'optimization_level.dart';
-import 'output_type.dart';
 import 'run_cbuilder.dart';
 
 /// Specification for linking an artifact with a C linker.
@@ -37,11 +34,11 @@ class CLinker extends CTool implements Linker {
     super.defines = const {},
     super.pic = true,
     super.std,
-    super.language = Language.c,
+    super.language = .c,
     super.cppLinkStdLib,
     super.linkModePreference,
-    super.optimizationLevel = OptimizationLevel.o3,
-  }) : super(type: OutputType.library);
+    super.optimizationLevel = .o3,
+  }) : super(type: .library);
 
   /// Runs the C Linker with on this C build spec.
   ///

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/compiler_resolver.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/compiler_resolver.dart
@@ -33,8 +33,8 @@ class CompilerResolver {
     required this.logger,
     OS? hostOS, // Only visible for testing.
     Architecture? hostArchitecture, // Only visible for testing.
-  }) : hostOS = hostOS ?? OS.current,
-       hostArchitecture = hostArchitecture ?? Architecture.current,
+  }) : hostOS = hostOS ?? .current,
+       hostArchitecture = hostArchitecture ?? .current,
        context = ToolResolvingContext(logger: logger);
 
   Future<ToolInstance> resolveCompiler() async {
@@ -65,28 +65,28 @@ class CompilerResolver {
     final targetArch = codeConfig.targetArchitecture;
 
     switch ((hostOS, targetOS, targetArch)) {
-      case (_, OS.android, _):
+      case (_, .android, _):
         yield androidNdkClang;
-      case (OS.macOS, OS.macOS || OS.iOS, _):
+      case (.macOS, .macOS || .iOS, _):
         yield appleClang;
         yield clang;
-      case (OS.linux, OS.linux, _) when hostArchitecture == targetArch:
+      case (.linux, .linux, _) when hostArchitecture == targetArch:
         yield clang;
-      case (OS.linux, _, Architecture.arm):
+      case (.linux, _, .arm):
         yield armLinuxGnueabihfGcc;
-      case (OS.linux, _, Architecture.arm64):
+      case (.linux, _, .arm64):
         yield aarch64LinuxGnuGcc;
-      case (OS.linux, _, Architecture.ia32):
+      case (.linux, _, .ia32):
         yield i686LinuxGnuGcc;
-      case (OS.linux, _, Architecture.x64):
+      case (.linux, _, .x64):
         yield x86_64LinuxGnuGcc;
-      case (OS.linux, _, Architecture.riscv64):
+      case (.linux, _, .riscv64):
         yield riscv64LinuxGnuGcc;
-      case (OS.windows, _, Architecture.ia32):
+      case (.windows, _, .ia32):
         yield clIA32;
-      case (OS.windows, _, Architecture.arm64):
+      case (.windows, _, .arm64):
         yield clArm64;
-      case (OS.windows, _, Architecture.x64):
+      case (.windows, _, .x64):
         yield cl;
     }
   }
@@ -143,32 +143,32 @@ class CompilerResolver {
     // TODO(dacoharkes): Support falling back on other tools.
     if (targetArchitecture == hostArchitecture &&
         targetOS == hostOS &&
-        hostOS == OS.linux) {
+        hostOS == .linux) {
       return llvmAr;
     }
-    if (targetOS == OS.macOS || targetOS == OS.iOS) return appleAr;
-    if (targetOS == OS.android) return androidNdkLlvmAr;
-    if (hostOS == OS.linux) {
+    if (targetOS == .macOS || targetOS == .iOS) return appleAr;
+    if (targetOS == .android) return androidNdkLlvmAr;
+    if (hostOS == .linux) {
       switch (targetArchitecture) {
-        case Architecture.arm:
+        case .arm:
           return armLinuxGnueabihfGccAr;
-        case Architecture.arm64:
+        case .arm64:
           return aarch64LinuxGnuGccAr;
-        case Architecture.ia32:
+        case .ia32:
           return i686LinuxGnuGccAr;
-        case Architecture.x64:
+        case .x64:
           return x86_64LinuxGnuGccAr;
-        case Architecture.riscv64:
+        case .riscv64:
           return riscv64LinuxGnuGccAr;
       }
     }
-    if (hostOS == OS.windows) {
+    if (hostOS == .windows) {
       switch (targetArchitecture) {
-        case Architecture.ia32:
+        case .ia32:
           return libIA32;
-        case Architecture.arm64:
+        case .arm64:
           return libArm64;
-        case Architecture.x64:
+        case .x64:
           return lib;
       }
     }
@@ -191,7 +191,7 @@ class CompilerResolver {
   }
 
   Future<Map<String, String>> resolveEnvironment(ToolInstance compiler) async {
-    if (codeConfig.targetOS != OS.windows) {
+    if (codeConfig.targetOS != .windows) {
       return {};
     }
 

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/optimization_level.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/optimization_level.dart
@@ -42,16 +42,16 @@ final class OptimizationLevel {
   String clangFlag() => '-$_level';
 
   String msvcFlag() => switch (this) {
-    o3 => o2.msvcFlag(),
+    .o3 => o2.msvcFlag(),
     _ => '/$_level',
   };
 
   static const List<OptimizationLevel> values = [
-    o0,
-    o1,
-    o2,
-    o3,
-    oS,
-    unspecified,
+    .o0,
+    .o1,
+    .o2,
+    .o3,
+    .oS,
+    .unspecified,
   ];
 }

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -71,7 +71,7 @@ class RunCBuilder {
     this.defines = const {},
     this.pic,
     this.std,
-    this.language = Language.c,
+    this.language = .c,
     this.cppLinkStdLib,
     required this.optimizationLevel,
   }) : outDir = input.outputDirectory,
@@ -98,12 +98,12 @@ class RunCBuilder {
   Future<Uri> archiver() async => (await _resolver.resolveArchiver()).uri;
 
   Future<Uri> iosSdk(IOSSdk iosSdk, ToolResolvingContext context) async {
-    if (iosSdk == IOSSdk.iPhoneOS) {
+    if (iosSdk == .iPhoneOS) {
       return (await iPhoneOSSdk.defaultResolver!.resolve(
         context,
       )).where((i) => i.tool == iPhoneOSSdk).first.uri;
     }
-    assert(iosSdk == IOSSdk.iPhoneSimulator);
+    assert(iosSdk == .iPhoneSimulator);
     return (await iPhoneSimulatorSdk.defaultResolver!.resolve(
       context,
     )).where((i) => i.tool == iPhoneSimulatorSdk).first.uri;
@@ -141,7 +141,7 @@ class RunCBuilder {
     }
 
     final IOSSdk? targetIosSdk;
-    if (codeConfig.targetOS == OS.iOS) {
+    if (codeConfig.targetOS == .iOS) {
       targetIosSdk = codeConfig.iOS.targetSdk;
     } else {
       targetIosSdk = null;
@@ -151,7 +151,7 @@ class RunCBuilder {
     // invoking clang. Mimic that behavior here.
     // See https://github.com/dart-lang/native/issues/171.
     final int? targetAndroidNdkApi;
-    if (codeConfig.targetOS == OS.android) {
+    if (codeConfig.targetOS == .android) {
       final minimumApi = codeConfig.targetArchitecture == Architecture.riscv64
           ? 35
           : 21;
@@ -160,10 +160,10 @@ class RunCBuilder {
       targetAndroidNdkApi = null;
     }
 
-    final targetIOSVersion = codeConfig.targetOS == OS.iOS
+    final targetIOSVersion = codeConfig.targetOS == .iOS
         ? codeConfig.iOS.targetVersion
         : null;
-    final targetMacOSVersion = codeConfig.targetOS == OS.macOS
+    final targetMacOSVersion = codeConfig.targetOS == .macOS
         ? codeConfig.macOS.targetVersion
         : null;
 

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_test.dart
@@ -145,7 +145,7 @@ void main() {
               targetOS: targetOS,
               macOS: macOSConfig,
               targetArchitecture: Architecture.current,
-              linkModePreference: LinkModePreference.dynamic,
+              linkModePreference: .dynamic,
               cCompiler: cCompiler,
             ),
           );
@@ -159,7 +159,7 @@ void main() {
           name: name,
           assetName: name,
           pic: pic,
-          buildMode: BuildMode.release,
+          buildMode: .release,
         );
         await cbuilder.run(
           input: buildInput,
@@ -272,7 +272,7 @@ void main() {
       sources: [definesCUri.toFilePath()],
       forcedIncludes: [forcedIncludeCUri.toFilePath()],
       flags: [flag],
-      buildMode: BuildMode.release,
+      buildMode: .release,
     );
     await cbuilder.run(input: buildInput, output: buildOutput, logger: logger);
 
@@ -333,7 +333,7 @@ void main() {
       assetName: name,
       includes: [includeDirectoryUri.toFilePath()],
       sources: [includesCUri.toFilePath()],
-      buildMode: BuildMode.release,
+      buildMode: .release,
     );
     await cbuilder.run(
       input: buildInput,
@@ -395,7 +395,7 @@ void main() {
       name: name,
       assetName: name,
       std: std,
-      buildMode: BuildMode.release,
+      buildMode: .release,
     );
     await cbuilder.run(input: buildInput, output: buildOutput, logger: logger);
 
@@ -462,8 +462,8 @@ void main() {
     final cbuilder = CBuilder.executable(
       name: name,
       sources: [helloWorldCppUri.toFilePath()],
-      language: Language.cpp,
-      buildMode: BuildMode.release,
+      language: .cpp,
+      buildMode: .release,
     );
     await cbuilder.run(input: buildInput, output: buildOutput, logger: logger);
 
@@ -522,9 +522,9 @@ void main() {
     final cbuilder = CBuilder.executable(
       name: name,
       sources: [helloWorldCppUri.toFilePath()],
-      language: Language.cpp,
+      language: .cpp,
       cppLinkStdLib: 'stdc++',
-      buildMode: BuildMode.release,
+      buildMode: .release,
     );
 
     if (buildInput.config.code.targetOS == OS.windows) {
@@ -609,7 +609,7 @@ void main() {
       assetName: 'debug',
       includes: [dynamicallyLinkedSrcUri.toFilePath()],
       sources: [debugCUri.toFilePath()],
-      buildMode: BuildMode.release,
+      buildMode: .release,
     );
 
     await debugBuilder.run(
@@ -701,7 +701,7 @@ Future<void> testDefines({
             : null,
         targetArchitecture: Architecture.current,
         // Ignored by executables.
-        linkModePreference: LinkModePreference.dynamic,
+        linkModePreference: .dynamic,
         cCompiler: cCompiler,
       ),
     );
@@ -741,7 +741,7 @@ Future<void> testDefines({
     );
   }
 
-  if (ndebugDefine && buildMode != BuildMode.debug) {
+  if (ndebugDefine && buildMode != .debug) {
     expect(result.stdout, contains('Macro NDEBUG is defined: 1'));
   } else {
     expect(result.stdout, contains('Macro NDEBUG is undefined.'));

--- a/pkgs/record_use/lib/src/metadata.dart
+++ b/pkgs/record_use/lib/src/metadata.dart
@@ -28,8 +28,8 @@ class Metadata {
     );
     // TODO(https://github.com/dart-lang/native/issues/2984): Nest extension
     // fields.
-    return Metadata._(
-      MetadataSyntax.fromJson({...syntax.json, ...?extension}),
+    return ._(
+      .fromJson({...syntax.json, ...?extension}),
     );
   }
 
@@ -40,7 +40,7 @@ class Metadata {
   /// VM.
   Map<String, Object?> get json => _syntax.json;
 
-  Version get version => Version.parse(_syntax.version);
+  Version get version => .parse(_syntax.version);
 
   String get comment => _syntax.comment;
 

--- a/tool/ci.dart
+++ b/tool/ci.dart
@@ -521,7 +521,7 @@ class ApiToolTask extends Task {
     required ArgResults argResults,
   }) async {
     if (pubTask.shouldRun(argResults)) {
-      // Pull in https://github.com/bmw-tech/dart_apitool/pull/252.
+      // Pull in https://github.com/bmw-tech/dart_apitool/pull/256.
       await _runProcess('dart', [
         'pub',
         'global',
@@ -530,7 +530,7 @@ class ApiToolTask extends Task {
         'git',
         'https://github.com/bmw-tech/dart_apitool.git',
         '--git-ref',
-        '906fa0f3dca24d81d1c26ee71c884ecbb6234ecf',
+        '6d710709e5d51bab52ecd911c84a3264e5277a69',
       ]);
     }
     await _runMaybeParallel([


### PR DESCRIPTION
We don't have lints yet to apply dot shorthands (https://github.com/dart-lang/sdk/issues/61957). However, we do have Gemini CLI...

I undid all the `.new` usages, as I found those unreadable.

Note: this PR is AI generated, it might have applied dot shorthands inconsistently. I wanted to look at what the resulted code looks like, and I like it.

Blocked by:

* https://github.com/bmw-tech/dart_apitool/issues/255
* https://github.com/dart-lang/ecosystem/pull/397