### PR TITLE
[record_use] Instance constant definitions

### DIFF
--- a/pkgs/record_use/doc/schema/record_use.schema.json
+++ b/pkgs/record_use/doc/schema/record_use.schema.json
@@ -114,11 +114,17 @@
           },
           "then": {
             "properties": {
+              "definition_index": {
+                "type": "integer"
+              },
               "value": {
                 "type": "object",
                 "additionalProperties": true
               }
-            }
+            },
+            "required": [
+              "definition_index"
+            ]
           }
         },
         {

--- a/pkgs/record_use/lib/src/recordings.dart
+++ b/pkgs/record_use/lib/src/recordings.dart
@@ -230,6 +230,7 @@ Error: $e
     final allDefinitions = {
       ...calls.keys,
       ...instances.keys,
+      ...allConstants.whereType<InstanceConstant>().map((c) => c.definition),
     }.toList();
     return DefinitionSerializationContext(
       allDefinitions.asMapToIndices,

--- a/pkgs/record_use/lib/src/serialization_context.dart
+++ b/pkgs/record_use/lib/src/serialization_context.dart
@@ -31,7 +31,7 @@
 ///
 /// 1. **Definitions**: [Definition] objects are deserialized from or
 ///    serialized to the [RecordedUsesSyntax.definitions] pool first.
-/// 2. **Constants**: [Constant] objects are (de)serialized from or serialized
+/// 2. **Constants**: [Constant] objects are deserialized from or serialized
 ///    to the [RecordedUsesSyntax.constants] pool second. They may contain
 ///    references to the definitions pool (e.g. for [InstanceConstant]) and the
 ///    constants pool (for recursive collections).

--- a/pkgs/record_use/lib/src/syntax.g.dart
+++ b/pkgs/record_use/lib/src/syntax.g.dart
@@ -187,7 +187,19 @@ class ConstantSyntax extends JsonObjectSyntax {
   List<String> _validateType() => _reader.validate<String>('type');
 
   @override
-  List<String> validate() => [...super.validate(), ..._validateType()];
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateType(),
+    ..._validateExtraRulesConstant(),
+  ];
+
+  List<String> _validateExtraRulesConstant() {
+    final result = <String>[];
+    if (_reader.tryTraverse(['type']) == 'instance') {
+      result.addAll(_reader.validate<Object>('definition_index'));
+    }
+    return result;
+  }
 
   @override
   String toString() => 'ConstantSyntax($json)';
@@ -584,18 +596,32 @@ class InstanceConstantSyntax extends ConstantSyntax {
     super.path,
   }) : super._fromJson();
 
-  InstanceConstantSyntax({JsonObjectSyntax? value, super.path = const []})
-    : super(type: 'instance') {
+  InstanceConstantSyntax({
+    required int definitionIndex,
+    JsonObjectSyntax? value,
+    super.path = const [],
+  }) : super(type: 'instance') {
+    _definitionIndex = definitionIndex;
     _value = value;
     json.sortOnKey();
   }
 
   /// Setup all fields for [InstanceConstantSyntax] that are not in
   /// [ConstantSyntax].
-  void setup({required JsonObjectSyntax? value}) {
+  void setup({required int definitionIndex, required JsonObjectSyntax? value}) {
+    _definitionIndex = definitionIndex;
     _value = value;
     json.sortOnKey();
   }
+
+  int get definitionIndex => _reader.get<int>('definition_index');
+
+  set _definitionIndex(int value) {
+    json.setOrRemove('definition_index', value);
+  }
+
+  List<String> _validateDefinitionIndex() =>
+      _reader.validate<int>('definition_index');
 
   JsonObjectSyntax? get value {
     final jsonValue = _reader.optionalMap('value');
@@ -616,7 +642,11 @@ class InstanceConstantSyntax extends ConstantSyntax {
   }
 
   @override
-  List<String> validate() => [...super.validate(), ..._validateValue()];
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateDefinitionIndex(),
+    ..._validateValue(),
+  ];
 
   @override
   String toString() => 'InstanceConstantSyntax($json)';

--- a/pkgs/record_use/test/complex_keys_test.dart
+++ b/pkgs/record_use/test/complex_keys_test.dart
@@ -7,8 +7,14 @@ import 'package:record_use/record_use_internal.dart';
 import 'package:test/test.dart';
 
 void main() {
+  const classDefinition = Definition(
+    'package:test/test.dart',
+    [Name('MyClass')],
+  );
+
   test('MapConstant with InstanceConstant keys round-trip', () {
     const instanceKey = InstanceConstant(
+      definition: classDefinition,
       fields: {
         'id': IntConstant(1),
         'tag': StringConstant('key'),
@@ -49,6 +55,7 @@ void main() {
 
   test('MapConstant equality with InstanceConstant keys', () {
     const instanceKey = InstanceConstant(
+      definition: classDefinition,
       fields: {
         'id': IntConstant(1),
         'tag': StringConstant('key'),
@@ -62,6 +69,7 @@ void main() {
     expect(
       mapConstant.entries.first.key,
       const InstanceConstant(
+        definition: classDefinition,
         fields: {
           'id': IntConstant(1),
           'tag': StringConstant('key'),

--- a/pkgs/record_use/test/test_data.dart
+++ b/pkgs/record_use/test/test_data.dart
@@ -63,12 +63,13 @@ final recordedUses = Recordings(
     instanceId: [
       const InstanceConstantReference(
         instanceConstant: InstanceConstant(
+          definition: instanceId,
           fields: {'a': IntConstant(42), 'b': NullConstant()},
         ),
         loadingUnit: '3',
       ),
       const InstanceConstantReference(
-        instanceConstant: InstanceConstant(fields: {}),
+        instanceConstant: InstanceConstant(definition: instanceId, fields: {}),
         loadingUnit: '3',
       ),
     ],
@@ -176,6 +177,7 @@ const recordedUsesJson = '''{
       "type": "null"
     },
     {
+      "definition_index": 1,
       "type": "instance",
       "value": {
         "a": 14,
@@ -183,6 +185,7 @@ const recordedUsesJson = '''{
       }
     },
     {
+      "definition_index": 1,
       "type": "instance"
     }
   ],

--- a/pkgs/record_use/test_data/json/const_argument_instance.json
+++ b/pkgs/record_use/test_data/json/const_argument_instance.json
@@ -6,6 +6,7 @@
       "value": 14
     },
     {
+      "definition_index": 0,
       "type": "instance",
       "value": {
         "i": 0

--- a/pkgs/record_use/test_data/json/enum_const_arg.json
+++ b/pkgs/record_use/test_data/json/enum_const_arg.json
@@ -10,6 +10,7 @@
       "value": "b"
     },
     {
+      "definition_index": 0,
       "type": "instance",
       "value": {
         "index": 0,

--- a/pkgs/record_use/test_data/json/instance_class.json
+++ b/pkgs/record_use/test_data/json/instance_class.json
@@ -6,6 +6,7 @@
       "value": 42
     },
     {
+      "definition_index": 0,
       "type": "instance",
       "value": {
         "i": 0

--- a/pkgs/record_use/test_data/json/instance_complex.json
+++ b/pkgs/record_use/test_data/json/instance_complex.json
@@ -57,6 +57,7 @@
       "type": "null"
     },
     {
+      "definition_index": 0,
       "type": "instance",
       "value": {
         "i": 0,

--- a/pkgs/record_use/test_data/json/instance_duplicates.json
+++ b/pkgs/record_use/test_data/json/instance_duplicates.json
@@ -6,6 +6,7 @@
       "value": 42
     },
     {
+      "definition_index": 0,
       "type": "instance",
       "value": {
         "i": 0
@@ -16,6 +17,7 @@
       "value": 43
     },
     {
+      "definition_index": 0,
       "type": "instance",
       "value": {
         "i": 2

--- a/pkgs/record_use/test_data/json/instance_not_annotation.json
+++ b/pkgs/record_use/test_data/json/instance_not_annotation.json
@@ -2,6 +2,7 @@
   "$schema": "../../doc/schema/record_use.schema.json",
   "constants": [
     {
+      "definition_index": 0,
       "type": "instance"
     }
   ],

--- a/pkgs/record_use/test_data/json/nested.json
+++ b/pkgs/record_use/test_data/json/nested.json
@@ -6,6 +6,7 @@
       "value": 42
     },
     {
+      "definition_index": 0,
       "type": "instance",
       "value": {
         "i": 0
@@ -16,12 +17,14 @@
       "value": "test"
     },
     {
+      "definition_index": 0,
       "type": "instance",
       "value": {
         "i": 2
       }
     },
     {
+      "definition_index": 1,
       "type": "instance"
     }
   ],

--- a/pkgs/record_use/test_data/json/nested_instance_constant.json
+++ b/pkgs/record_use/test_data/json/nested_instance_constant.json
@@ -6,6 +6,7 @@
       "value": "id"
     },
     {
+      "definition_index": 0,
       "type": "instance",
       "value": {
         "id": 0

--- a/pkgs/record_use/test_data/json/record_enum.json
+++ b/pkgs/record_use/test_data/json/record_enum.json
@@ -10,6 +10,7 @@
       "value": "a"
     },
     {
+      "definition_index": 0,
       "type": "instance",
       "value": {
         "index": 0,
@@ -17,6 +18,7 @@
       }
     },
     {
+      "definition_index": 0,
       "type": "instance",
       "value": {
         "a": 2

--- a/pkgs/record_use/test_data/json/record_instance_constant_empty.json
+++ b/pkgs/record_use/test_data/json/record_instance_constant_empty.json
@@ -2,9 +2,11 @@
   "$schema": "../../doc/schema/record_use.schema.json",
   "constants": [
     {
+      "definition_index": 0,
       "type": "instance"
     },
     {
+      "definition_index": 0,
       "type": "instance",
       "value": {
         "a": 0

--- a/pkgs/record_use/test_data/json/recorded_uses.json
+++ b/pkgs/record_use/test_data/json/recorded_uses.json
@@ -30,6 +30,7 @@
       "value": 42
     },
     {
+      "definition_index": 1,
       "type": "instance",
       "value": {
         "i": 5

--- a/pkgs/record_use/test_data/json/unsupported_instance.json
+++ b/pkgs/record_use/test_data/json/unsupported_instance.json
@@ -6,6 +6,7 @@
       "type": "unsupported"
     },
     {
+      "definition_index": 1,
       "type": "instance",
       "value": {
         "field": 0


### PR DESCRIPTION
For const instances, store the class they are an instance of.

So that you don't have to guess what class the instance is from.

Towards:

* https://github.com/dart-lang/native/issues/2867

Implementation follows the design from:

* https://github.com/dart-lang/native/issues/3106