### PR TITLE
[record_use] Adopt `DefinitionKind` in test data

### DIFF
--- a/pkgs/hooks/example/link/package_with_assets/hook/link.dart
+++ b/pkgs/hooks/example/link/package_with_assets/hook/link.dart
@@ -13,12 +13,12 @@ import 'package:record_use/record_use.dart';
 
 const someMethodDefinition = Definition(
   'package:package_with_assets/package_with_assets.dart',
-  [Name('someMethod')],
+  [Name(kind: DefinitionKind.methodKind, 'someMethod')],
 );
 
 const someOtherMethodDefinition = Definition(
   'package:package_with_assets/package_with_assets.dart',
-  [Name('someOtherMethod')],
+  [Name(kind: DefinitionKind.methodKind, 'someOtherMethod')],
 );
 
 final assetMapping = {

--- a/pkgs/hooks_runner/test/build_runner/resources_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/resources_test.dart
@@ -121,8 +121,12 @@ void main() async {
 final _pirateAdventureRecordings = Recordings(
   metadata: Metadata(version: Version(1, 0, 0), comment: 'Filtering test'),
   calls: {
-    const Definition('package:pirate_speak/src/definitions.dart', [
-      Name('pirateSpeak'),
+    Definition('package:pirate_speak/src/definitions.dart', [
+      Name(
+        kind: DefinitionKind.methodKind,
+        'pirateSpeak',
+        disambiguators: {DefinitionDisambiguator.staticDisambiguator},
+      ),
     ]): [
       const CallWithArguments(
         loadingUnit: 'root',
@@ -135,8 +139,12 @@ final _pirateAdventureRecordings = Recordings(
         namedArguments: {},
       ),
     ],
-    const Definition('package:pirate_technology/src/definitions.dart', [
-      Name('useCannon'),
+    Definition('package:pirate_technology/src/definitions.dart', [
+      Name(
+        kind: DefinitionKind.methodKind,
+        'useCannon',
+        disambiguators: {DefinitionDisambiguator.staticDisambiguator},
+      ),
     ]): [
       const CallWithArguments(
         loadingUnit: 'root',

--- a/pkgs/hooks_runner/test_data/pirate_speak/hook/link.dart
+++ b/pkgs/hooks_runner/test_data/pirate_speak/hook/link.dart
@@ -52,9 +52,15 @@ Future<Recordings> _loadRecordings(Uri file) async {
 Set<String> _extractUsedPhrases(Recordings recordings) {
   final usages = RecordedUsages.fromJson(recordings.toJson());
   final usedPhrases = <String>{};
-  const pirateSpeakDef = Definition(
+  final pirateSpeakDef = Definition(
     'package:pirate_speak/src/definitions.dart',
-    [Name('pirateSpeak')],
+    [
+      Name(
+        kind: DefinitionKind.methodKind,
+        'pirateSpeak',
+        disambiguators: {DefinitionDisambiguator.staticDisambiguator},
+      ),
+    ],
   );
 
   for (final call in usages.constArgumentsFor(pirateSpeakDef)) {

--- a/pkgs/record_use/example/api/usage_link.dart
+++ b/pkgs/record_use/example/api/usage_link.dart
@@ -11,11 +11,20 @@ import 'dart:io';
 import 'package:hooks/hooks.dart';
 import 'package:record_use/record_use_internal.dart';
 
-const methodId = Definition(
+final methodId = Definition(
   'package:pirate_speak/pirate_speak.dart',
   [
-    Name('PirateTranslator'),
-    Name(''),
+    const Name(
+      kind: DefinitionKind.classKind,
+      'PirateTranslator',
+    ),
+    Name(
+      kind: DefinitionKind.methodKind,
+      'speak',
+      disambiguators: {
+        DefinitionDisambiguator.staticDisambiguator,
+      },
+    ),
   ],
 );
 
@@ -23,6 +32,7 @@ const classId = Definition(
   'package:pirate_technology/pirate_technology.dart',
   [
     Name(
+      kind: DefinitionKind.classKind,
       'PirateShip',
     ),
   ],

--- a/pkgs/record_use/test_data/drop_data_asset/hook/link.dart
+++ b/pkgs/record_use/test_data/drop_data_asset/hook/link.dart
@@ -31,7 +31,10 @@ void main(List<String> arguments) async {
       final calls = usages.constArgumentsFor(
         Definition(
           'package:${input.packageName}/src/${input.packageName}.dart',
-          [const Name('MyMath'), Name(methodName)],
+          [
+            const Name(kind: DefinitionKind.classKind, 'MyMath'),
+            Name(methodName),
+          ],
         ),
       );
       print('Checking calls to $methodName...');
@@ -53,7 +56,7 @@ void main(List<String> arguments) async {
       final instances = usages.constantsOf(
         Definition(
           'package:${input.packageName}/src/${input.packageName}.dart',
-          [Name(className)],
+          [Name(kind: DefinitionKind.classKind, className)],
         ),
       );
       print('Checking instances of $className...');

--- a/pkgs/record_use/test_data/drop_dylib_recording/hook/link.dart
+++ b/pkgs/record_use/test_data/drop_dylib_recording/hook/link.dart
@@ -35,7 +35,17 @@ void main(List<String> arguments) async {
       final calls = usages.constArgumentsFor(
         Definition(
           'package:drop_dylib_recording/src/drop_dylib_recording.dart',
-          [const Name('MyMath'), Name(methodName)],
+          [
+            const Name(
+              kind: DefinitionKind.classKind,
+              'MyMath',
+            ),
+            Name(
+              kind: DefinitionKind.methodKind,
+              methodName,
+              disambiguators: {DefinitionDisambiguator.staticDisambiguator},
+            ),
+          ],
         ),
       );
       for (final call in calls) {
@@ -58,7 +68,12 @@ void main(List<String> arguments) async {
       final instances = usages.constantsOf(
         Definition(
           'package:drop_dylib_recording/src/drop_dylib_recording.dart',
-          [Name(className)],
+          [
+            Name(
+              kind: DefinitionKind.classKind,
+              className,
+            ),
+          ],
         ),
       );
       for (final instance in instances) {


### PR DESCRIPTION
We need to update the test data for https://dart-review.googlesource.com/c/sdk/+/481100.

(Also, we should consider going to a list instead of a set for disambiguators. I don't think the list will be long, and it would re-allow consts. Though, we'll make a new API akin to https://github.com/dart-lang/native/issues/3062#issuecomment-3885343421 we should make sure that's const-able.)