### PR TITLE
[infra] Skip generated packages from workspace check

### DIFF
--- a/tool/ci.dart
+++ b/tool/ci.dart
@@ -190,6 +190,9 @@ class WorkspaceTask extends Task {
     final rootDir = Directory.fromUri(repositoryRoot.resolve('pkgs'));
     for (final entity in rootDir.listSync(recursive: true)) {
       if (entity is File && entity.path.endsWith('pubspec.yaml')) {
+        if (entity.path.split(Platform.pathSeparator).contains('.dart_tool')) {
+          continue;
+        }
         packages.add(
           Uri.file(
             p.relative(entity.parent.path, from: repositoryRoot.toFilePath()),


### PR DESCRIPTION
Fixes:

```
The following packages exist in the repository, but are not part of the workspace:
 - pkgs/objective_c/example/flutter_app/.dart_tool/widget_preview_scaffold
 - pkgs/jni/example/.dart_tool/widget_preview_scaffold
Please add them to the workspace. If that is not possible, add a commented out entry to the root pubspec and provide a reason why they cannot be part of the workspace as a trailing comment.
```