### PR TITLE
[record_use] Static call receiver

### DIFF
--- a/pkgs/record_use/doc/schema/record_use.schema.json
+++ b/pkgs/record_use/doc/schema/record_use.schema.json
@@ -24,6 +24,12 @@
           "items": {
             "type": "integer"
           }
+        },
+        "receiver": {
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
       "required": [

--- a/pkgs/record_use/lib/src/constant.dart
+++ b/pkgs/record_use/lib/src/constant.dart
@@ -480,4 +480,13 @@ extension MaybeConstantProtected on MaybeConstant {
     ConstantSyntax syntax,
     DeserializationContext context,
   ) => MaybeConstant._fromSyntax(syntax, context);
+
+  @visibleForTesting
+  bool semanticEquals(
+    MaybeConstant other, {
+    bool allowPromotionOfUnsupported = false,
+  }) => this.semanticEquals(
+    other,
+    allowPromotionOfUnsupported: allowPromotionOfUnsupported,
+  );
 }

--- a/pkgs/record_use/lib/src/record_use.dart
+++ b/pkgs/record_use/lib/src/record_use.dart
@@ -53,12 +53,19 @@ extension type RecordedUsages._(Recordings _recordings) {
   /// ```
   // TODO(https://github.com/dart-lang/native/issues/2718): Make tearoffs more
   // front and center.
-  Iterable<({Map<String, MaybeConstant> named, List<MaybeConstant> positional})>
+  Iterable<
+    ({
+      Map<String, MaybeConstant> named,
+      List<MaybeConstant> positional,
+      MaybeConstant? receiver,
+    })
+  >
   constArgumentsFor(Definition definition) =>
       _recordings.calls[definition]?.whereType<CallWithArguments>().map(
         (call) => (
           named: call.namedArguments,
           positional: call.positionalArguments,
+          receiver: call.receiver,
         ),
       ) ??
       [];

--- a/pkgs/record_use/lib/src/recordings.dart
+++ b/pkgs/record_use/lib/src/recordings.dart
@@ -244,11 +244,13 @@ Error: $e
     final values = <MaybeConstant>{
       ...calls.values
           .expand((calls) => calls)
-          .whereType<CallWithArguments>()
           .expand(
             (call) => [
-              ...call.positionalArguments,
-              ...call.namedArguments.values,
+              if (call.receiver != null) call.receiver!,
+              if (call is CallWithArguments) ...[
+                ...call.positionalArguments,
+                ...call.namedArguments.values,
+              ],
             ],
           ),
       ...instances.values

--- a/pkgs/record_use/lib/src/syntax.g.dart
+++ b/pkgs/record_use/lib/src/syntax.g.dart
@@ -72,10 +72,12 @@ class CallSyntax extends JsonObjectSyntax {
 
   CallSyntax({
     required List<int> loadingUnitIndices,
+    int? receiver,
     required String type,
     super.path = const [],
   }) : super() {
     _loadingUnitIndices = loadingUnitIndices;
+    _receiver = receiver;
     _type = type;
     json.sortOnKey();
   }
@@ -89,6 +91,14 @@ class CallSyntax extends JsonObjectSyntax {
   List<String> _validateLoadingUnitIndices() =>
       _reader.validateList<int>('loading_unit_indices');
 
+  int? get receiver => _reader.get<int?>('receiver');
+
+  set _receiver(int? value) {
+    json.setOrRemove('receiver', value);
+  }
+
+  List<String> _validateReceiver() => _reader.validate<int?>('receiver');
+
   String get type => _reader.get<String>('type');
 
   set _type(String value) {
@@ -101,6 +111,7 @@ class CallSyntax extends JsonObjectSyntax {
   List<String> validate() => [
     ...super.validate(),
     ..._validateLoadingUnitIndices(),
+    ..._validateReceiver(),
     ..._validateType(),
   ];
 
@@ -1513,8 +1524,11 @@ class TearoffCallSyntax extends CallSyntax {
     super.path,
   }) : super._fromJson();
 
-  TearoffCallSyntax({required super.loadingUnitIndices, super.path = const []})
-    : super(type: 'tearoff');
+  TearoffCallSyntax({
+    required super.loadingUnitIndices,
+    super.receiver,
+    super.path = const [],
+  }) : super(type: 'tearoff');
 
   @override
   List<String> validate() => [
@@ -1705,6 +1719,7 @@ class WithArgumentsCallSyntax extends CallSyntax {
     required super.loadingUnitIndices,
     Map<String, int>? named,
     List<int>? positional,
+    super.receiver,
     super.path = const [],
   }) : super(type: 'with_arguments') {
     _named = named;

--- a/pkgs/record_use/test/extension_receiver_test.dart
+++ b/pkgs/record_use/test/extension_receiver_test.dart
@@ -1,0 +1,114 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:record_use/record_use_internal.dart';
+import 'package:test/test.dart';
+
+const loadingUnit1 = LoadingUnit('1');
+
+void main() {
+  test('Call with receiver in JSON', () {
+    const json = {
+      'metadata': {'version': '1.0.0', 'comment': 'test'},
+      'constants': [
+        {'type': 'string', 'value': 'receiver'},
+        {'type': 'int', 'value': 42},
+      ],
+      'loading_units': [
+        {'name': '1'},
+      ],
+      'definitions': [
+        {
+          'uri': 'package:a/a.dart',
+          'path': [
+            {'name': 'foo'},
+          ],
+        },
+      ],
+      'uses': {
+        'static_calls': [
+          {
+            'definition_index': 0,
+            'uses': [
+              {
+                'type': 'with_arguments',
+                'loading_unit_indices': [0],
+                'receiver': 0,
+                'positional': [1],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    final recordings = Recordings.fromJson(json);
+    const definition = Definition('package:a/a.dart', [Name('foo')]);
+    final calls = recordings.calls[definition]!;
+    final call = calls[0] as CallWithArguments;
+
+    expect(call.receiver, const StringConstant('receiver'));
+    expect(call.positionalArguments[0], const IntConstant(42));
+  });
+
+  test('Call with receiver serialization round-trip', () {
+    const definition = Definition('package:a/a.dart', [Name('foo')]);
+    final recordings = Recordings(
+      metadata: Metadata(version: version, comment: 'test'),
+      calls: {
+        definition: [
+          const CallWithArguments(
+            receiver: StringConstant('receiver'),
+            positionalArguments: [IntConstant(42)],
+            namedArguments: {},
+            loadingUnits: [loadingUnit1],
+          ),
+        ],
+      },
+      instances: {},
+    );
+
+    final json = recordings.toJson();
+    final roundTripped = Recordings.fromJson(json);
+
+    expect(roundTripped, equals(recordings));
+
+    final usesJson = json['uses'] as Map;
+    final recordingsJson = usesJson['static_calls'] as List;
+    final recording = recordingsJson[0] as Map;
+    final call = (recording['uses'] as List)[0] as Map;
+    expect(call.containsKey('receiver'), isTrue);
+    final constants = json['constants'] as List;
+    final receiverConst = constants[call['receiver'] as int] as Map;
+    expect(receiverConst['value'], 'receiver');
+  });
+
+  test('CallTearoff with receiver serialization round-trip', () {
+    const definition = Definition('package:a/a.dart', [Name('foo')]);
+    final recordings = Recordings(
+      metadata: Metadata(version: version, comment: 'test'),
+      calls: {
+        definition: [
+          const CallTearoff(
+            receiver: StringConstant('receiver'),
+            loadingUnits: [loadingUnit1],
+          ),
+        ],
+      },
+      instances: {},
+    );
+
+    final json = recordings.toJson();
+    final roundTripped = Recordings.fromJson(json);
+
+    expect(roundTripped, equals(recordings));
+
+    final usesJson = json['uses'] as Map;
+    final recordingsJson = usesJson['static_calls'] as List;
+    final recording = recordingsJson[0] as Map;
+    final call = (recording['uses'] as List)[0] as Map;
+    expect(call['type'], 'tearoff');
+    expect(call.containsKey('receiver'), isTrue);
+  });
+}

--- a/pkgs/record_use/test/usage_test.dart
+++ b/pkgs/record_use/test/usage_test.dart
@@ -59,7 +59,7 @@ void main() {
               ),
             )
             .toList();
-    final (named: named0, positional: positional0) = arguments[0];
+    final (named: named0, positional: positional0, receiver: _) = arguments[0];
     expect(named0, {
       'freddy': const StringConstant('mercury'),
       'leroy': const StringConstant('jenkins'),
@@ -69,7 +69,7 @@ void main() {
       BoolConstant(false),
       IntConstant(1),
     ]);
-    final (named: named1, positional: positional1) = arguments[1];
+    final (named: named1, positional: positional1, receiver: _) = arguments[1];
     expect(named1, {
       'freddy': const IntConstant(0),
       'leroy': const StringConstant('jenkins'),


### PR DESCRIPTION
A field for storing receiver (non) constant values for static calls.

Extension methods and extension types have receivers for their instance calls - which are static calls.

Issue:

* https://github.com/dart-lang/native/issues/2948