### PR TITLE
[ffigen] Fix SDK path detection for non-standard Xcode paths

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -23,6 +23,8 @@
   always enabled.
 - Fix(https://github.com/dart-lang/native/issues/2877) 
   such that ObjCObject `isA` now accepts a nullable `ObjCObject?` and returns `false` when called with `null`, aligning its behavior with Dart’s `is`operator. 
+- Use `xcrun` for resolving macOS SDK paths, enabling support for non-standard
+  Xcode installations. ([#3134](https://github.com/dart-lang/native/issues/3134))
 
 ## 20.1.1
 

--- a/pkgs/ffigen/lib/src/config_provider/path_finder.dart
+++ b/pkgs/ffigen/lib/src/config_provider/path_finder.dart
@@ -10,13 +10,14 @@ import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
+import 'utils.dart' show macSdkPath, xcodePath;
+
 /// This will return include path from either LLVM, XCode or CommandLineTools.
 List<String> getCStandardLibraryHeadersForMac(Logger logger) {
   final includePaths = <String>[];
 
   /// Add system headers.
-  const systemHeaders =
-      '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include';
+  final systemHeaders = p.join(macSdkPath, 'usr', 'include');
   if (Directory(systemHeaders).existsSync()) {
     logger.fine('Added $systemHeaders to compiler-opts.');
     includePaths.add('-I$systemHeaders');
@@ -24,9 +25,15 @@ List<String> getCStandardLibraryHeadersForMac(Logger logger) {
 
   /// Find headers from XCode or LLVM installed via brew.
   const brewLlvmPath = '/usr/local/opt/llvm/lib/clang';
-  const xcodeClangPath =
-      '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/';
-  const searchPaths = [brewLlvmPath, xcodeClangPath];
+  final xcodeClangPath = p.join(
+    xcodePath,
+    'Toolchains',
+    'XcodeDefault.xctoolchain',
+    'usr',
+    'lib',
+    'clang',
+  );
+  final searchPaths = [brewLlvmPath, xcodeClangPath];
   for (final searchPath in searchPaths) {
     if (!Directory(searchPath).existsSync()) continue;
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
-->

## Description

Use `xcrun` and `xcode-select` to dynamically resolve macOS SDK paths instead of hardcoded `/Applications/Xcode.app` paths. This enables ffigen to work with non-standard Xcode installations such as those managed by the Xcodes app.

## Related Issues

Fixes #3134

## PR Checklist

- [x] I’ve reviewed the [contributor guide](https://github.com/dart-lang/native/blob/main/CONTRIBUTING.md) and applied the relevant portions to this PR.
- [x] I've run `dart tool/ci.dart --all` locally and resolved all issues identified. This ensures the PR is formatted, has no lint errors, and ran all code generators. This applies to the packages part of the toplevel `pubspec.yaml` workspace.
- [x] All existing and new tests are passing. I added new tests to check the change I am making.
- [x] The PR is actually solving the issue. PRs that don't solve the issue will be closed. Please be respectful of the maintainers' time. If it's not clear what the issue is, feel free to ask questions on the GitHub issue before submitting a PR.
- [x] I have updated `CHANGELOG.md` for the relevant packages. (Not needed for small changes such as doc typos).
- [x] I have [updated the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change) if necessary.
