### PR TITLE
[record_use] Enum value constants

### DIFF
--- a/pkgs/record_use/doc/schema/record_use.schema.json
+++ b/pkgs/record_use/doc/schema/record_use.schema.json
@@ -89,6 +89,7 @@
             {
               "enum": [
                 "bool",
+                "enum",
                 "instance",
                 "int",
                 "list",
@@ -126,6 +127,39 @@
             },
             "required": [
               "value"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "enum"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "definition_index": {
+                "type": "integer"
+              },
+              "index": {
+                "type": "integer"
+              },
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "integer"
+                }
+              }
+            },
+            "required": [
+              "definition_index",
+              "index",
+              "name"
             ]
           }
         },

--- a/pkgs/record_use/lib/record_use_internal.dart
+++ b/pkgs/record_use/lib/record_use_internal.dart
@@ -6,6 +6,7 @@ export 'src/constant.dart'
     show
         BoolConstant,
         Constant,
+        EnumConstant,
         InstanceConstant,
         IntConstant,
         ListConstant,

--- a/pkgs/record_use/lib/src/recordings.dart
+++ b/pkgs/record_use/lib/src/recordings.dart
@@ -296,6 +296,7 @@ Error: $e
       ...calls.keys,
       ...instances.keys,
       ...allConstants.whereType<InstanceConstant>().map((c) => c.definition),
+      ...allConstants.whereType<EnumConstant>().map((c) => c.definition),
     };
     return DefinitionSerializationContext.fromPrevious(
       loadingUnitContext,
@@ -577,6 +578,9 @@ extension FlattenConstantsExtension on Iterable<MaybeConstant> {
         (e) => [e.key, e.value],
       ),
       InstanceConstant() => constant.fields.values,
+      EnumConstant() => [
+        ...constant.fields.values,
+      ],
       RecordConstant() => [
         ...constant.positional,
         ...constant.named.values,

--- a/pkgs/record_use/lib/src/reference.dart
+++ b/pkgs/record_use/lib/src/reference.dart
@@ -341,6 +341,12 @@ final class CallTearoff extends CallReference {
   }
 }
 
+// TODO(https://github.com/dart-lang/native/issues/2908): Support enum
+// constant instances here as well. Enums cannot have constructor calls or
+// constructor tearoffs though. So how to do the type hierarchy here?
+// TODO(https://github.com/dart-lang/native/issues/3057): Extension type const
+// instances?
+//
 sealed class InstanceReference extends Reference {
   const InstanceReference({required super.loadingUnits});
 

--- a/pkgs/record_use/lib/src/syntax.g.dart
+++ b/pkgs/record_use/lib/src/syntax.g.dart
@@ -217,6 +217,9 @@ class ConstantSyntax extends JsonObjectSyntax {
     if (result.isBoolConstant) {
       return result.asBoolConstant;
     }
+    if (result.isEnumConstant) {
+      return result.asEnumConstant;
+    }
     if (result.isInstanceConstant) {
       return result.asInstanceConstant;
     }
@@ -495,6 +498,101 @@ class DefinitionSyntax extends JsonObjectSyntax {
 
   @override
   String toString() => 'DefinitionSyntax($json)';
+}
+
+class EnumConstantSyntax extends ConstantSyntax {
+  EnumConstantSyntax.fromJson(
+    super.json, {
+    super.path,
+  }) : super._fromJson();
+
+  EnumConstantSyntax({
+    required int definitionIndex,
+    required int index,
+    required String name,
+    Map<String, int>? value,
+    super.path = const [],
+  }) : super(type: 'enum') {
+    _definitionIndex = definitionIndex;
+    _index = index;
+    _name = name;
+    _value = value;
+    json.sortOnKey();
+  }
+
+  /// Setup all fields for [EnumConstantSyntax] that are not in
+  /// [ConstantSyntax].
+  void setup({
+    required int definitionIndex,
+    required int index,
+    required String name,
+    required Map<String, int>? value,
+  }) {
+    _definitionIndex = definitionIndex;
+    _index = index;
+    _name = name;
+    _value = value;
+    json.sortOnKey();
+  }
+
+  int get definitionIndex => _reader.get<int>('definition_index');
+
+  set _definitionIndex(int value) {
+    json.setOrRemove('definition_index', value);
+  }
+
+  List<String> _validateDefinitionIndex() =>
+      _reader.validate<int>('definition_index');
+
+  int get index => _reader.get<int>('index');
+
+  set _index(int value) {
+    json.setOrRemove('index', value);
+  }
+
+  List<String> _validateIndex() => _reader.validate<int>('index');
+
+  String get name => _reader.get<String>('name');
+
+  set _name(String value) {
+    json.setOrRemove('name', value);
+  }
+
+  List<String> _validateName() => _reader.validate<String>('name');
+
+  Map<String, int>? get value => _reader.optionalMap<int>(
+    'value',
+  );
+
+  set _value(Map<String, int>? value) {
+    _checkArgumentMapKeys(
+      value,
+    );
+    json.setOrRemove('value', value);
+  }
+
+  List<String> _validateValue() => _reader.validateOptionalMap<int>(
+    'value',
+  );
+
+  @override
+  List<String> validate() => [
+    ...super.validate(),
+    ..._validateDefinitionIndex(),
+    ..._validateIndex(),
+    ..._validateName(),
+    ..._validateValue(),
+  ];
+
+  @override
+  String toString() => 'EnumConstantSyntax($json)';
+}
+
+extension EnumConstantSyntaxExtension on ConstantSyntax {
+  bool get isEnumConstant => type == 'enum';
+
+  EnumConstantSyntax get asEnumConstant =>
+      EnumConstantSyntax.fromJson(json, path: path);
 }
 
 class EnumNameSyntax extends NameSyntax {

--- a/pkgs/record_use/test/json_schema/schema_test.dart
+++ b/pkgs/record_use/test/json_schema/schema_test.dart
@@ -55,6 +55,7 @@ const constInstanceIndex = 7;
 const constMapIndex = 3;
 const constUnsupportedIndex = 9;
 const constRecordIndex = 10;
+const constEnumIndex = 11;
 typedef SchemaTestField = (
   List<Object> path,
   void Function(ValidationResults result) missingExpectations,
@@ -62,16 +63,23 @@ typedef SchemaTestField = (
 
 List<SchemaTestField> recordUseFields = [
   (['constants'], expectOptionalFieldMissing),
-  for (var index = 0; index < 11; index++) ...[
+  for (var index = 0; index < 12; index++) ...[
     (['constants', index, 'type'], expectRequiredFieldMissing),
     if (index != constNullIndex &&
         index != constNonConstantIndex &&
         index != constInstanceIndex &&
         index != constUnsupportedIndex &&
-        index != constRecordIndex)
+        index != constRecordIndex &&
+        index != constEnumIndex)
       (['constants', index, 'value'], expectRequiredFieldMissing),
     if (index == constInstanceIndex)
       (['constants', index, 'value'], expectOptionalFieldMissing),
+    if (index == constEnumIndex) ...[
+      (['constants', index, 'definition_index'], expectRequiredFieldMissing),
+      (['constants', index, 'index'], expectRequiredFieldMissing),
+      (['constants', index, 'name'], expectRequiredFieldMissing),
+      (['constants', index, 'value'], expectOptionalFieldMissing),
+    ],
     if (index == constMapIndex) ...[
       (['constants', index, 'value', 0, 'key'], expectRequiredFieldMissing),
       (['constants', index, 'value', 0, 'value'], expectRequiredFieldMissing),

--- a/pkgs/record_use/test/maybe_constant_test.dart
+++ b/pkgs/record_use/test/maybe_constant_test.dart
@@ -81,6 +81,12 @@ void main() {
                 positional: [IntConstant(1)],
                 named: {'a': IntConstant(2)},
               ),
+              EnumConstant(
+                definition: definition,
+                index: 0,
+                name: 'red',
+                fields: {'hex': IntConstant(0xff0000)},
+              ),
             ],
             namedArguments: {
               'a': IntConstant(42),
@@ -89,6 +95,11 @@ void main() {
               'd': RecordConstant(
                 positional: [IntConstant(3)],
                 named: {'b': IntConstant(4)},
+              ),
+              'e': EnumConstant(
+                definition: definition,
+                index: 1,
+                name: 'green',
               ),
             },
             loadingUnits: [loadingUnit1],

--- a/pkgs/record_use/test_data/json/recorded_uses.json
+++ b/pkgs/record_use/test_data/json/recorded_uses.json
@@ -57,6 +57,15 @@
         6
       ],
       "type": "record"
+    },
+    {
+      "definition_index": 2,
+      "index": 0,
+      "name": "red",
+      "type": "enum",
+      "value": {
+        "hex": 6
+      }
     }
   ],
   "definitions": [
@@ -84,6 +93,15 @@
         }
       ],
       "uri": "package:record_use_test/instance_class.dart"
+    },
+    {
+      "path": [
+        {
+          "kind": "enum",
+          "name": "Color"
+        }
+      ],
+      "uri": "package:record_use_test/color.dart"
     }
   ],
   "loading_units": [
@@ -133,7 +151,8 @@
               7,
               8,
               9,
-              10
+              10,
+              11
             ],
             "type": "with_arguments"
           }


### PR DESCRIPTION
The `package:record_use` part of:

* https://github.com/dart-lang/native/issues/2944

Does not address:

* https://github.com/dart-lang/native/issues/2908
   (For this I need to think a bit more for how to organize the const-instance recording API to deal with the enum kind, and potentially even the extension type kind.)