### PR TITLE
[record_use] Simplify `Metadata`

### DIFF
--- a/pkgs/record_use/lib/record_use_internal.dart
+++ b/pkgs/record_use/lib/record_use_internal.dart
@@ -34,4 +34,3 @@ export 'src/reference.dart'
         InstanceConstantReference,
         InstanceCreationReference,
         InstanceReference;
-export 'src/version.dart' show version;

--- a/pkgs/record_use/lib/src/metadata.dart
+++ b/pkgs/record_use/lib/src/metadata.dart
@@ -6,6 +6,7 @@ import 'package:pub_semver/pub_semver.dart';
 
 import 'helper.dart';
 import 'syntax.g.dart';
+import 'version.dart';
 
 /// Metadata attached to a recorded usages file.
 ///
@@ -18,10 +19,12 @@ class Metadata {
   const Metadata._(this._syntax);
 
   factory Metadata({
-    required Version version,
-    required String comment,
+    Version? version,
+    String comment =
+        'Recorded usages of objects tagged with a `RecordUse` annotation.',
     Map<String, Object?>? extension,
   }) {
+    version ??= versionInternal;
     final syntax = MetadataSyntax(
       comment: comment,
       version: version.toString(),

--- a/pkgs/record_use/lib/src/recordings.dart
+++ b/pkgs/record_use/lib/src/recordings.dart
@@ -36,10 +36,10 @@ class Recordings {
   final Map<Definition, List<InstanceReference>> instances;
 
   Recordings({
-    required this.metadata,
+    Metadata? metadata,
     required this.calls,
     required this.instances,
-  });
+  }) : metadata = metadata ?? Metadata();
 
   /// Decodes a JSON representation into a [Recordings] object.
   ///

--- a/pkgs/record_use/lib/src/version.dart
+++ b/pkgs/record_use/lib/src/version.dart
@@ -7,4 +7,4 @@ import 'package:pub_semver/pub_semver.dart' show Version;
 // TODO: Delete this version number. Instead of relying on versions, we want to
 //   lazy read JSONs so that we don't break on versions that might be
 //   incompatible but we don't access any of the incompatible fields.
-final version = Version(0, 4, 0);
+final versionInternal = Version(0, 4, 0);

--- a/pkgs/record_use/test/extension_receiver_test.dart
+++ b/pkgs/record_use/test/extension_receiver_test.dart
@@ -55,7 +55,6 @@ void main() {
   test('Call with receiver serialization round-trip', () {
     const definition = Definition('package:a/a.dart', [Name('foo')]);
     final recordings = Recordings(
-      metadata: Metadata(version: version, comment: 'test'),
       calls: {
         definition: [
           const CallWithArguments(
@@ -87,7 +86,6 @@ void main() {
   test('CallTearoff with receiver serialization round-trip', () {
     const definition = Definition('package:a/a.dart', [Name('foo')]);
     final recordings = Recordings(
-      metadata: Metadata(version: version, comment: 'test'),
       calls: {
         definition: [
           const CallTearoff(

--- a/pkgs/record_use/test/maybe_constant_test.dart
+++ b/pkgs/record_use/test/maybe_constant_test.dart
@@ -69,7 +69,6 @@ void main() {
   test('MaybeConstant serialization round-trip', () {
     const definition = Definition('package:a/a.dart', [Name('foo')]);
     final recordings = Recordings(
-      metadata: Metadata(version: version, comment: 'test'),
       calls: {
         definition: [
           const CallWithArguments(
@@ -135,7 +134,7 @@ void main() {
     const definition = Definition('package:a/a.dart', [Name('foo')]);
 
     final actualRecordings = Recordings(
-      metadata: Metadata(version: version, comment: 'actual'),
+      metadata: Metadata(comment: 'actual'),
       calls: {
         definition: [
           const CallWithArguments(
@@ -149,7 +148,7 @@ void main() {
     );
 
     final expectedRecordings = Recordings(
-      metadata: Metadata(version: version, comment: 'expected'),
+      metadata: Metadata(comment: 'expected'),
       calls: {
         definition: [
           const CallWithArguments(


### PR DESCRIPTION
The backends don't need to manually populate `version` and `comment`, it's always the same.