### PR TITLE
[record_use] Cache hash codes in Expando instances

### DIFF
--- a/pkgs/record_use/lib/src/constant.dart
+++ b/pkgs/record_use/lib/src/constant.dart
@@ -390,7 +390,7 @@ final class ListConstant extends Constant {
   const ListConstant(this.value);
 
   @override
-  int get hashCode => deepHash(value);
+  int get hashCode => cacheHashCode(() => deepHash(value));
 
   @override
   bool operator ==(Object other) {
@@ -436,8 +436,10 @@ final class MapConstant extends Constant {
   const MapConstant(this.entries);
 
   @override
-  int get hashCode => Object.hashAll(
-    entries.map((e) => Object.hash(e.key, e.value)),
+  int get hashCode => cacheHashCode(
+    () => Object.hashAll(
+      entries.map((e) => Object.hash(e.key, e.value)),
+    ),
   );
 
   @override
@@ -534,7 +536,8 @@ final class InstanceConstant extends Constant {
   }
 
   @override
-  int get hashCode => Object.hash(definition, deepHash(fields));
+  int get hashCode =>
+      cacheHashCode(() => Object.hash(definition, deepHash(fields)));
 
   @override
   String toString() =>
@@ -614,7 +617,9 @@ final class EnumConstant extends Constant {
   }
 
   @override
-  int get hashCode => Object.hash(definition, index, name, deepHash(fields));
+  int get hashCode => cacheHashCode(
+    () => Object.hash(definition, index, name, deepHash(fields)),
+  );
 
   @override
   String toString() =>
@@ -681,7 +686,9 @@ final class RecordConstant extends Constant {
   }
 
   @override
-  int get hashCode => Object.hash(deepHash(positional), deepHash(named));
+  int get hashCode => cacheHashCode(
+    () => Object.hash(deepHash(positional), deepHash(named)),
+  );
 
   @override
   String toString() =>

--- a/pkgs/record_use/lib/src/definition.dart
+++ b/pkgs/record_use/lib/src/definition.dart
@@ -4,6 +4,7 @@
 
 import 'package:meta/meta.dart';
 
+import 'helper.dart';
 import 'syntax.g.dart';
 
 /// A unique identifier for a code element, such as a class, method,
@@ -84,7 +85,8 @@ class Definition {
   }
 
   @override
-  int get hashCode => Object.hash(library, Object.hashAll(path));
+  int get hashCode =>
+      cacheHashCode(() => Object.hash(library, Object.hashAll(path)));
 
   /// Returns a URI representation of this definition.
   ///
@@ -143,10 +145,8 @@ class Name {
   }
 
   @override
-  int get hashCode => Object.hash(
-    name,
-    kind,
-    Object.hashAllUnordered(disambiguators),
+  int get hashCode => cacheHashCode(
+    () => Object.hash(name, kind, Object.hashAllUnordered(disambiguators)),
   );
 
   /// Returns a string representation of this name that can be used as a part of

--- a/pkgs/record_use/lib/src/helper.dart
+++ b/pkgs/record_use/lib/src/helper.dart
@@ -7,3 +7,11 @@ import 'package:collection/collection.dart';
 final deepEquals = const DeepCollectionEquality().equals;
 
 final deepHash = const DeepCollectionEquality().hash;
+
+final _hashCodeCache = Expando<int>();
+
+extension HashCodeCaching on Object {
+  /// Caches the hash code of this object.
+  int cacheHashCode(int Function() compute) =>
+      _hashCodeCache[this] ??= compute();
+}

--- a/pkgs/record_use/lib/src/metadata.dart
+++ b/pkgs/record_use/lib/src/metadata.dart
@@ -65,7 +65,7 @@ class Metadata {
   }
 
   @override
-  int get hashCode => deepHash(json);
+  int get hashCode => cacheHashCode(() => deepHash(json));
 }
 
 /// Package private (protected) methods for [Metadata].

--- a/pkgs/record_use/lib/src/recordings.dart
+++ b/pkgs/record_use/lib/src/recordings.dart
@@ -331,10 +331,12 @@ Error: $e
   }
 
   @override
-  int get hashCode => Object.hash(
-    metadata.hashCode,
-    deepHash(calls),
-    deepHash(instances),
+  int get hashCode => cacheHashCode(
+    () => Object.hash(
+      metadata.hashCode,
+      deepHash(calls),
+      deepHash(instances),
+    ),
   );
 
   /// Compares this set of usages ('actual') with the [expected] set

--- a/pkgs/record_use/lib/src/reference.dart
+++ b/pkgs/record_use/lib/src/reference.dart
@@ -31,7 +31,7 @@ sealed class Reference {
   }
 
   @override
-  int get hashCode => deepHash(loadingUnits);
+  int get hashCode => cacheHashCode(() => deepHash(loadingUnits));
 
   bool _semanticEqualsShared(
     Reference other, {
@@ -206,11 +206,13 @@ final class CallWithArguments extends CallReference {
   }
 
   @override
-  int get hashCode => Object.hash(
-    deepHash(positionalArguments),
-    deepHash(namedArguments),
-    receiver,
-    super.hashCode,
+  int get hashCode => cacheHashCode(
+    () => Object.hash(
+      deepHash(positionalArguments),
+      deepHash(namedArguments),
+      receiver,
+      super.hashCode,
+    ),
   );
 
   @override
@@ -436,7 +438,8 @@ final class InstanceConstantReference extends InstanceReference {
   }
 
   @override
-  int get hashCode => Object.hash(instanceConstant, super.hashCode);
+  int get hashCode =>
+      cacheHashCode(() => Object.hash(instanceConstant, super.hashCode));
 
   @override
   @visibleForTesting
@@ -514,10 +517,12 @@ final class InstanceCreationReference extends InstanceReference {
   }
 
   @override
-  int get hashCode => Object.hash(
-    deepHash(positionalArguments),
-    deepHash(namedArguments),
-    super.hashCode,
+  int get hashCode => cacheHashCode(
+    () => Object.hash(
+      deepHash(positionalArguments),
+      deepHash(namedArguments),
+      super.hashCode,
+    ),
   );
 
   @override


### PR DESCRIPTION
For https://github.com/dart-lang/native/issues/3115, we want to store the depth of constant objects in an `Expando`, to avoid exponential runtime in deep constants.

We already use hashmaps/hashsets on constants, and computing the hashCode is currently already recursing. To make computing the hashcode of a large `Recordings` linear, cache the `hashCode`s in an `Expando`.

See the recommendation of this pattern in:

* https://github.com/dart-lang/language/issues/2225