### PR TITLE
[record_use] Enum constant instances

### DIFF
--- a/pkgs/record_use/lib/src/recordings.dart
+++ b/pkgs/record_use/lib/src/recordings.dart
@@ -259,10 +259,9 @@ Error: $e
           .expand((instances) => instances)
           .expand(
             (instance) => switch (instance) {
-              InstanceConstantReference(:final instanceConstant) => {
-                ...instanceConstant.fields.values,
+              InstanceConstantReference(:final instanceConstant) => [
                 instanceConstant,
-              },
+              ],
               InstanceCreationReference(
                 :final positionalArguments,
                 :final namedArguments,

--- a/pkgs/record_use/lib/src/reference.dart
+++ b/pkgs/record_use/lib/src/reference.dart
@@ -361,7 +361,7 @@ sealed class InstanceReference extends Reference {
       :final loadingUnitIndices,
     ) =>
       InstanceConstantReference(
-        instanceConstant: context.constants[constantIndex] as InstanceConstant,
+        instanceConstant: context.constants[constantIndex] as Constant,
         loadingUnits: loadingUnitIndices
             .map((index) => context.loadingUnits[index])
             .toList(),
@@ -412,7 +412,7 @@ sealed class InstanceReference extends Reference {
 }
 
 final class InstanceConstantReference extends InstanceReference {
-  final InstanceConstant instanceConstant;
+  final Constant instanceConstant;
 
   const InstanceConstantReference({
     required this.instanceConstant,

--- a/pkgs/record_use/test/instance_references_test.dart
+++ b/pkgs/record_use/test/instance_references_test.dart
@@ -31,6 +31,30 @@ void main() {
           loadingUnits: [loadingUnitRoot],
         ),
         const ConstructorTearoffReference(loadingUnits: [loadingUnitOther]),
+        const InstanceConstantReference(
+          instanceConstant: EnumConstant(
+            definition: definition,
+            index: 0,
+            name: 'value1',
+          ),
+          loadingUnits: [loadingUnitRoot],
+        ),
+        const InstanceConstantReference(
+          instanceConstant: EnumConstant(
+            definition: definition,
+            index: 1,
+            name: 'enhancedValue',
+            fields: {
+              'description': StringConstant('A description'),
+              'count': IntConstant(123),
+              'nested': InstanceConstant(
+                definition: definition,
+                fields: {'inner': BoolConstant(true)},
+              ),
+            },
+          ),
+          loadingUnits: [loadingUnitRoot],
+        ),
       ],
     },
   );
@@ -38,7 +62,7 @@ void main() {
   test('Deserialize creation and tearoff instances', () {
     final instances = recordings.instances[definition];
     expect(instances, isNotNull);
-    expect(instances, hasLength(2));
+    expect(instances, hasLength(4));
 
     final creation = instances![0];
     expect(creation, isA<InstanceCreationReference>());
@@ -60,6 +84,30 @@ void main() {
     expect(tearoff, isA<ConstructorTearoffReference>());
     if (tearoff is ConstructorTearoffReference) {
       expect(tearoff.loadingUnits.first.name, loadingUnitOther.name);
+    }
+
+    final enumInstance = instances[2];
+    expect(enumInstance, isA<InstanceConstantReference>());
+    if (enumInstance is InstanceConstantReference) {
+      expect(enumInstance.instanceConstant, isA<EnumConstant>());
+      expect((enumInstance.instanceConstant as EnumConstant).name, 'value1');
+    }
+
+    final enhancedEnumInstance = instances[3];
+    expect(enhancedEnumInstance, isA<InstanceConstantReference>());
+    if (enhancedEnumInstance is InstanceConstantReference) {
+      expect(enhancedEnumInstance.instanceConstant, isA<EnumConstant>());
+      final enumConstant =
+          enhancedEnumInstance.instanceConstant as EnumConstant;
+      expect(enumConstant.name, 'enhancedValue');
+      expect(enumConstant.fields, hasLength(3));
+      expect(
+        (enumConstant.fields['description'] as StringConstant).value,
+        'A description',
+      );
+      expect((enumConstant.fields['count'] as IntConstant).value, 123);
+      final nested = enumConstant.fields['nested'] as InstanceConstant;
+      expect((nested.fields['inner'] as BoolConstant).value, true);
     }
   });
 

--- a/pkgs/record_use/test/semantic_equality_test.dart
+++ b/pkgs/record_use/test/semantic_equality_test.dart
@@ -275,4 +275,61 @@ void main() {
       isFalse,
     );
   });
+
+  test('InstanceConstantReference semantic equality with EnumConstant', () {
+    final recordings1 = Recordings(
+      metadata: metadata,
+      calls: const {},
+      instances: {
+        definition1: [
+          const InstanceConstantReference(
+            instanceConstant: EnumConstant(
+              definition: definition1,
+              index: 0,
+              name: 'a',
+              fields: {'f': IntConstant(1)},
+            ),
+            loadingUnits: [],
+          ),
+        ],
+      },
+    );
+    final recordings2 = Recordings(
+      metadata: metadata,
+      calls: const {},
+      instances: {
+        definition1: [
+          const InstanceConstantReference(
+            instanceConstant: EnumConstant(
+              definition: definition1,
+              index: 0,
+              name: 'a',
+              fields: {'f': IntConstant(1)},
+            ),
+            loadingUnits: [],
+          ),
+        ],
+      },
+    );
+    final recordings3 = Recordings(
+      metadata: metadata,
+      calls: const {},
+      instances: {
+        definition1: [
+          const InstanceConstantReference(
+            instanceConstant: EnumConstant(
+              definition: definition1,
+              index: 1,
+              name: 'b',
+              fields: {'f': IntConstant(1)},
+            ),
+            loadingUnits: [],
+          ),
+        ],
+      },
+    );
+
+    expect(recordings1.semanticEquals(recordings2), isTrue);
+    expect(recordings1.semanticEquals(recordings3), isFalse);
+  });
 }

--- a/pkgs/record_use/test/test_data.dart
+++ b/pkgs/record_use/test/test_data.dart
@@ -16,6 +16,10 @@ const instanceId = Definition(
   'package:js_runtime/js_helper.dart',
   [Name('MyAnnotation')],
 );
+const enumId = Definition(
+  'package:js_runtime/js_helper.dart',
+  [Name('MyEnum')],
+);
 
 const loadingUnitOJs = LoadingUnit('o.js');
 const loadingUnit3 = LoadingUnit('3');
@@ -76,6 +80,17 @@ final recordedUses = Recordings(
       ),
       const InstanceConstantReference(
         instanceConstant: InstanceConstant(definition: instanceId, fields: {}),
+        loadingUnits: [loadingUnit3],
+      ),
+    ],
+    enumId: [
+      const InstanceConstantReference(
+        instanceConstant: EnumConstant(
+          definition: enumId,
+          index: 0,
+          name: 'val1',
+          fields: {'a': IntConstant(42)},
+        ),
         loadingUnits: [loadingUnit3],
       ),
     ],

--- a/pkgs/record_use/test/to_string_test.dart
+++ b/pkgs/record_use/test/to_string_test.dart
@@ -48,5 +48,20 @@ void main() {
         'package:a/a.dart::#_bar',
       );
     });
+
+    test('InstanceConstantReference with EnumConstant', () {
+      const ref = InstanceConstantReference(
+        instanceConstant: EnumConstant(
+          definition: Definition('package:a/a.dart', [Name('MyEnum')]),
+          index: 0,
+          name: 'val1',
+        ),
+        loadingUnits: [loadingUnitFoo],
+      );
+      expect(
+        ref.toString(),
+        'InstanceConstantReference(instanceConstant: EnumConstant(package:a/a.dart#MyEnum, index: 0, name: val1, fields: {}), loadingUnits: dart.foo)',
+      );
+    });
   });
 }

--- a/pkgs/record_use/test_data/json/recorded_uses_v2.json
+++ b/pkgs/record_use/test_data/json/recorded_uses_v2.json
@@ -88,6 +88,15 @@
     {
       "definition_index": 1,
       "type": "instance"
+    },
+    {
+      "definition_index": 2,
+      "index": 0,
+      "name": "val1",
+      "type": "enum",
+      "value": {
+        "a": 14
+      }
     }
   ],
   "definitions": [
@@ -106,6 +115,14 @@
       "path": [
         {
           "name": "MyAnnotation"
+        }
+      ],
+      "uri": "package:js_runtime/js_helper.dart"
+    },
+    {
+      "path": [
+        {
+          "name": "MyEnum"
         }
       ],
       "uri": "package:js_runtime/js_helper.dart"
@@ -137,6 +154,18 @@
           },
           {
             "constant_index": 17,
+            "loading_unit_indices": [
+              1
+            ],
+            "type": "constant"
+          }
+        ]
+      },
+      {
+        "definition_index": 2,
+        "uses": [
+          {
+            "constant_index": 18,
             "loading_unit_indices": [
               1
             ],


### PR DESCRIPTION
The `package:record_use` part of:

* https://github.com/dart-lang/native/issues/2908

As discussed offline, these cannot have constructor calls or constructor tearoffs, but we're not going to specialize the API.