### PR TITLE
[record_use] `Constant`s `_depth` and `_size`

### DIFF
--- a/pkgs/record_use/lib/src/helper.dart
+++ b/pkgs/record_use/lib/src/helper.dart
@@ -9,9 +9,17 @@ final deepEquals = const DeepCollectionEquality().equals;
 final deepHash = const DeepCollectionEquality().hash;
 
 final _hashCodeCache = Expando<int>();
+final _depthCache = Expando<int>();
+final _sizeCache = Expando<int>();
 
 extension HashCodeCaching on Object {
   /// Caches the hash code of this object.
   int cacheHashCode(int Function() compute) =>
       _hashCodeCache[this] ??= compute();
+
+  /// Caches the depth of this object.
+  int cacheDepth(int Function() compute) => _depthCache[this] ??= compute();
+
+  /// Caches the size of this object.
+  int cacheSize(int Function() compute) => _sizeCache[this] ??= compute();
 }


### PR DESCRIPTION
For https://github.com/dart-lang/native/issues/3115, we want to store the depth of constant objects.

Another stable property that we can use for ordering would be size of the reachable graph. (Constants are always a DAG.)

These stable properties can also be used for shortcutting equality checks.

(Using the same `Expando`-based caching on const objects as https://github.com/dart-lang/native/pull/3150.)