### PR TITLE
[record_use] Canonicalize before serialization

### DIFF
--- a/pkgs/record_use/lib/src/canonicalization_context.dart
+++ b/pkgs/record_use/lib/src/canonicalization_context.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'constant.dart';
+import 'definition.dart';
+import 'loading_unit.dart';
+
+/// A context used to canonicalize [Definition]s, [LoadingUnit]s, and
+/// [MaybeConstant]s.
+class CanonicalizationContext {
+  final Set<Definition> _definitions = {};
+  final Set<LoadingUnit> _loadingUnits = {};
+  final Set<MaybeConstant> _constants = {};
+
+  /// Canonicalizes the given [Definition].
+  Definition canonicalizeDefinition(Definition definition) {
+    final existing = _definitions.lookup(definition);
+    if (existing != null) return existing;
+    final canonical = definition.canonicalizeChildren(this);
+    _definitions.add(canonical);
+    return canonical;
+  }
+
+  /// Canonicalizes the given [LoadingUnit].
+  LoadingUnit canonicalizeLoadingUnit(LoadingUnit loadingUnit) {
+    final existing = _loadingUnits.lookup(loadingUnit);
+    if (existing != null) return existing;
+    final canonical = loadingUnit.canonicalizeChildren(this);
+    _loadingUnits.add(canonical);
+    return canonical;
+  }
+
+  /// Canonicalizes the given [MaybeConstant].
+  MaybeConstant canonicalizeConstant(MaybeConstant constant) {
+    final existing = _constants.lookup(constant);
+    if (existing != null) return existing;
+    final canonical = constant.canonicalizeChildren(this);
+    _constants.add(canonical);
+    return canonical;
+  }
+
+  /// All canonicalized [Definition]s.
+  Iterable<Definition> get definitions => _definitions;
+
+  /// All canonicalized [LoadingUnit]s.
+  Iterable<LoadingUnit> get loadingUnits => _loadingUnits;
+
+  /// All canonicalized [MaybeConstant]s.
+  Iterable<MaybeConstant> get constants => _constants;
+}

--- a/pkgs/record_use/lib/src/definition.dart
+++ b/pkgs/record_use/lib/src/definition.dart
@@ -4,6 +4,7 @@
 
 import 'package:meta/meta.dart';
 
+import 'canonicalization_context.dart';
 import 'helper.dart';
 import 'syntax.g.dart';
 
@@ -65,6 +66,9 @@ class Definition {
         )
         .toList(),
   );
+
+  /// Canonicalizes the children of this [Definition].
+  Definition _canonicalizeChildren(CanonicalizationContext context) => this;
 
   /// The parent, if it exists.
   Definition? get parent => path.length > 1
@@ -272,6 +276,9 @@ final class DefinitionDisambiguator {
 /// internal types from leaking from the API.
 extension DefinitionProtected on Definition {
   DefinitionSyntax toSyntax() => _toSyntax();
+
+  Definition canonicalizeChildren(CanonicalizationContext context) =>
+      _canonicalizeChildren(context);
 
   static Definition fromSyntax(DefinitionSyntax syntax) =>
       Definition._fromSyntax(syntax);

--- a/pkgs/record_use/lib/src/loading_unit.dart
+++ b/pkgs/record_use/lib/src/loading_unit.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'canonicalization_context.dart';
 import 'definition.dart';
 
 /// A loading unit in which a usage of a [Definition] was recorded.
@@ -10,6 +11,9 @@ final class LoadingUnit {
   final String name;
 
   const LoadingUnit(this.name);
+
+  /// Canonicalizes the children of this [LoadingUnit].
+  LoadingUnit _canonicalizeChildren(CanonicalizationContext context) => this;
 
   @override
   bool operator ==(Object other) {
@@ -23,4 +27,13 @@ final class LoadingUnit {
 
   @override
   String toString() => 'LoadingUnit($name)';
+}
+
+/// Package private (protected) methods for [LoadingUnit].
+///
+/// This avoids bloating the public API and public API docs and prevents
+/// internal types from leaking from the API.
+extension LoadingUnitProtected on LoadingUnit {
+  LoadingUnit canonicalizeChildren(CanonicalizationContext context) =>
+      _canonicalizeChildren(context);
 }

--- a/pkgs/record_use/lib/src/serialization_context.dart
+++ b/pkgs/record_use/lib/src/serialization_context.dart
@@ -83,35 +83,27 @@ final class DeserializationContext extends DefinitionDeserializationContext {
   ) : super.fromPrevious(previous, previous.definitions);
 }
 
-/// Context providing access to the loading unit index map during serialization.
+/// The serialization state containing indices for all pools.
+///
+/// Canonicalization is responsible for collecting all reachable objects across
+/// the recording and providing the basis for these index maps.
 @immutable
-base class LoadingUnitSerializationContext {
+final class SerializationContext {
+  /// The mapping from semantic [LoadingUnit] objects to their unique integer
+  /// index within the loading unit pool ([RecordedUsesSyntax.loadingUnits]).
   final Map<LoadingUnit, int> loadingUnits;
 
-  const LoadingUnitSerializationContext(this.loadingUnits);
-}
-
-/// Context providing access to the [Definition] index map during serialization.
-@immutable
-base class DefinitionSerializationContext
-    extends LoadingUnitSerializationContext {
+  /// The mapping from semantic [Definition] objects to their unique integer
+  /// index within the definitions pool ([RecordedUsesSyntax.definitions]).
   final Map<Definition, int> definitions;
 
-  DefinitionSerializationContext.fromPrevious(
-    LoadingUnitSerializationContext previous,
-    this.definitions,
-  ) : super(previous.loadingUnits);
-}
-
-/// The final serialization state where all index maps are available.
-@immutable
-final class SerializationContext extends DefinitionSerializationContext {
   /// The mapping from semantic [MaybeConstant] objects to their unique integer
   /// index within the constants pool ([RecordedUsesSyntax.constants]).
   final Map<MaybeConstant, int> constants;
 
-  SerializationContext.fromPrevious(
-    DefinitionSerializationContext previous,
-    this.constants,
-  ) : super.fromPrevious(previous, previous.definitions);
+  const SerializationContext({
+    required this.loadingUnits,
+    required this.definitions,
+    required this.constants,
+  });
 }

--- a/pkgs/record_use/test/canonicalization_test.dart
+++ b/pkgs/record_use/test/canonicalization_test.dart
@@ -1,0 +1,93 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:record_use/record_use_internal.dart';
+import 'package:record_use/src/canonicalization_context.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Canonicalization', () {
+    test('canonicalizeConstant deduplicates identical constants', () {
+      final context = CanonicalizationContext();
+      // We avoid 'const' to ensure we have non-identical objects that are
+      // semantically equal, verifying that the canonicalization logic
+      // correctly deduplicates them.
+      // ignore: prefer_const_constructors
+      final c1 = IntConstant(42);
+      // ignore: prefer_const_constructors
+      final c2 = IntConstant(42);
+
+      expect(identical(c1, c2), isFalse);
+
+      final canonical1 = context.canonicalizeConstant(c1);
+      final canonical2 = context.canonicalizeConstant(c2);
+
+      expect(identical(canonical1, canonical2), isTrue);
+    });
+
+    test('canonicalizeConstant handles nested constants', () {
+      final context = CanonicalizationContext();
+      // ignore: prefer_const_constructors
+      final list1 = ListConstant([
+        // ignore: prefer_const_constructors
+        IntConstant(1),
+        // ignore: prefer_const_constructors
+        IntConstant(2),
+      ]);
+      // ignore: prefer_const_constructors
+      final list2 = ListConstant([
+        // ignore: prefer_const_constructors
+        IntConstant(1),
+        // ignore: prefer_const_constructors
+        IntConstant(2),
+      ]);
+
+      expect(identical(list1, list2), isFalse);
+
+      final canonical1 = context.canonicalizeConstant(list1) as ListConstant;
+      final canonical2 = context.canonicalizeConstant(list2) as ListConstant;
+
+      expect(identical(canonical1, canonical2), isTrue);
+      expect(identical(canonical1.value[0], canonical2.value[0]), isTrue);
+    });
+
+    test('Recordings.toJson canonicalizes constants across calls', () {
+      const definition = Definition('package:a/a.dart', [Name('foo')]);
+      const constant = IntConstant(42);
+
+      final recordings = Recordings(
+        calls: {
+          definition: [
+            const CallWithArguments(
+              positionalArguments: [constant],
+              namedArguments: {},
+              loadingUnits: [],
+            ),
+            const CallWithArguments(
+              positionalArguments: [constant],
+              namedArguments: {},
+              loadingUnits: [],
+            ),
+          ],
+        },
+        instances: {},
+      );
+
+      final json = recordings.toJson();
+      final constants = json['constants'] as List;
+
+      // The constant 42 should only appear once in the constants table.
+      expect(constants, hasLength(1));
+      expect(constants[0], {'type': 'int', 'value': 42});
+
+      // Both calls should reference the same constant index.
+      final uses = json['uses'] as Map;
+      final staticCalls = uses['static_calls'] as List;
+      final recording = staticCalls[0] as Map;
+      final calls = recording['uses'] as List;
+      expect((calls[0] as Map)['positional'], [0]);
+      expect((calls[1] as Map)['positional'], [0]);
+    });
+  });
+}


### PR DESCRIPTION
For https://github.com/dart-lang/native/issues/3115, we want sort things.

Since nodes can have children, sorting and canonicalization needs to happen at the same time.

This PR does not yet start sorting, but it does rewrite the code with a canonicalization pattern.

This significantly cleans up the serialization, as we no longer need to collect the objects for the pools. This happens as a side-effect of the canonicalization in the canonicalization context.