### PR TITLE
[record_use] Deterministic serialization order

### DIFF
--- a/pkgs/record_use/lib/src/definition.dart
+++ b/pkgs/record_use/lib/src/definition.dart
@@ -68,7 +68,11 @@ class Definition {
   );
 
   /// Canonicalizes the children of this [Definition].
-  Definition _canonicalizeChildren(CanonicalizationContext context) => this;
+  Definition _canonicalizeChildren(CanonicalizationContext context) =>
+      Definition(
+        library,
+        [for (final name in path) name._canonicalizeChildren(context)],
+      );
 
   /// The parent, if it exists.
   Definition? get parent => path.length > 1
@@ -136,6 +140,18 @@ class Name {
     this.kind,
     this.disambiguators = const {},
   });
+
+  Name _canonicalizeChildren(CanonicalizationContext context) {
+    if (disambiguators.isEmpty) return this;
+    return Name(
+      name,
+      kind: kind,
+      disambiguators: Set.from(
+        disambiguators.toList()
+          ..sort((a, b) => a.toString().compareTo(b.toString())),
+      ),
+    );
+  }
 
   @override
   bool operator ==(Object other) {

--- a/pkgs/record_use/lib/src/reference.dart
+++ b/pkgs/record_use/lib/src/reference.dart
@@ -178,26 +178,25 @@ final class CallWithArguments extends CallReference {
   });
 
   @override
-  Reference _canonicalizeChildren(CanonicalizationContext context) =>
-      CallWithArguments(
-        loadingUnits: loadingUnits
-            .map((u) => context.canonicalizeLoadingUnit(u))
-            .toList(),
-        receiver: receiver != null
-            ? context.canonicalizeConstant(receiver!)
-            : null,
-        positionalArguments: positionalArguments
-            .map((c) => context.canonicalizeConstant(c))
-            .toList(),
-        namedArguments: Map.fromEntries(
-          namedArguments.entries.map(
-            (e) => MapEntry(
-              e.key,
-              context.canonicalizeConstant(e.value),
-            ),
-          ),
-        ),
-      );
+  Reference _canonicalizeChildren(CanonicalizationContext context) {
+    final sortedNamedArgs = namedArguments.entries.toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+    return CallWithArguments(
+      loadingUnits: [
+        for (final u in loadingUnits) context.canonicalizeLoadingUnit(u),
+      ],
+      receiver: receiver != null
+          ? context.canonicalizeConstant(receiver!)
+          : null,
+      positionalArguments: [
+        for (final c in positionalArguments) context.canonicalizeConstant(c),
+      ],
+      namedArguments: {
+        for (final e in sortedNamedArgs)
+          e.key: context.canonicalizeConstant(e.value),
+      },
+    );
+  }
 
   @override
   WithArgumentsCallSyntax _toSyntax(SerializationContext context) {
@@ -207,15 +206,16 @@ final class CallWithArguments extends CallReference {
     }
 
     return WithArgumentsCallSyntax(
-      loadingUnitIndices: loadingUnits
-          .map((unit) => context.loadingUnits[unit]!)
-          .toList(),
+      loadingUnitIndices: [
+        for (final unit in loadingUnits) context.loadingUnits[unit]!,
+      ],
       named: namedArgs.isNotEmpty ? namedArgs : null,
       positional: positionalArguments.isEmpty
           ? null
-          : positionalArguments
-                .map((argument) => context.constants[argument]!)
-                .toList(),
+          : [
+              for (final argument in positionalArguments)
+                context.constants[argument]!,
+            ],
       receiver: receiver != null ? context.constants[receiver!] : null,
     );
   }
@@ -326,9 +326,9 @@ final class CallTearoff extends CallReference {
   @override
   Reference _canonicalizeChildren(CanonicalizationContext context) =>
       CallTearoff(
-        loadingUnits: loadingUnits
-            .map((u) => context.canonicalizeLoadingUnit(u))
-            .toList(),
+        loadingUnits: [
+          for (final u in loadingUnits) context.canonicalizeLoadingUnit(u),
+        ],
         receiver: receiver != null
             ? context.canonicalizeConstant(receiver!)
             : null,
@@ -337,9 +337,9 @@ final class CallTearoff extends CallReference {
   @override
   TearoffCallSyntax _toSyntax(SerializationContext context) =>
       TearoffCallSyntax(
-        loadingUnitIndices: loadingUnits
-            .map((unit) => context.loadingUnits[unit]!)
-            .toList(),
+        loadingUnitIndices: [
+          for (final unit in loadingUnits) context.loadingUnits[unit]!,
+        ],
         receiver: receiver != null ? context.constants[receiver!] : null,
       );
 
@@ -459,9 +459,9 @@ final class InstanceConstantReference extends InstanceReference {
   @override
   Reference _canonicalizeChildren(CanonicalizationContext context) =>
       InstanceConstantReference(
-        loadingUnits: loadingUnits
-            .map((u) => context.canonicalizeLoadingUnit(u))
-            .toList(),
+        loadingUnits: [
+          for (final u in loadingUnits) context.canonicalizeLoadingUnit(u),
+        ],
         instanceConstant:
             context.canonicalizeConstant(instanceConstant) as Constant,
       );
@@ -470,9 +470,9 @@ final class InstanceConstantReference extends InstanceReference {
   ConstantInstanceSyntax _toSyntax(SerializationContext context) =>
       ConstantInstanceSyntax(
         constantIndex: context.constants[instanceConstant]!,
-        loadingUnitIndices: loadingUnits
-            .map((unit) => context.loadingUnits[unit]!)
-            .toList(),
+        loadingUnitIndices: [
+          for (final unit in loadingUnits) context.loadingUnits[unit]!,
+        ],
       );
 
   @override
@@ -534,23 +534,22 @@ final class InstanceCreationReference extends InstanceReference {
   });
 
   @override
-  Reference _canonicalizeChildren(CanonicalizationContext context) =>
-      InstanceCreationReference(
-        loadingUnits: loadingUnits
-            .map((u) => context.canonicalizeLoadingUnit(u))
-            .toList(),
-        positionalArguments: positionalArguments
-            .map((c) => context.canonicalizeConstant(c))
-            .toList(),
-        namedArguments: Map.fromEntries(
-          namedArguments.entries.map(
-            (e) => MapEntry(
-              e.key,
-              context.canonicalizeConstant(e.value),
-            ),
-          ),
-        ),
-      );
+  Reference _canonicalizeChildren(CanonicalizationContext context) {
+    final sortedNamedArgs = namedArguments.entries.toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+    return InstanceCreationReference(
+      loadingUnits: [
+        for (final u in loadingUnits) context.canonicalizeLoadingUnit(u),
+      ],
+      positionalArguments: [
+        for (final c in positionalArguments) context.canonicalizeConstant(c),
+      ],
+      namedArguments: {
+        for (final e in sortedNamedArgs)
+          e.key: context.canonicalizeConstant(e.value),
+      },
+    );
+  }
 
   @override
   CreationInstanceSyntax _toSyntax(SerializationContext context) {
@@ -560,15 +559,16 @@ final class InstanceCreationReference extends InstanceReference {
     }
 
     return CreationInstanceSyntax(
-      loadingUnitIndices: loadingUnits
-          .map((unit) => context.loadingUnits[unit]!)
-          .toList(),
+      loadingUnitIndices: [
+        for (final unit in loadingUnits) context.loadingUnits[unit]!,
+      ],
       named: namedArgs.isNotEmpty ? namedArgs : null,
       positional: positionalArguments.isEmpty
           ? null
-          : positionalArguments
-                .map((argument) => context.constants[argument]!)
-                .toList(),
+          : [
+              for (final argument in positionalArguments)
+                context.constants[argument]!,
+            ],
     );
   }
 
@@ -664,17 +664,17 @@ final class ConstructorTearoffReference extends InstanceReference {
   @override
   Reference _canonicalizeChildren(CanonicalizationContext context) =>
       ConstructorTearoffReference(
-        loadingUnits: loadingUnits
-            .map((u) => context.canonicalizeLoadingUnit(u))
-            .toList(),
+        loadingUnits: [
+          for (final u in loadingUnits) context.canonicalizeLoadingUnit(u),
+        ],
       );
 
   @override
   TearoffInstanceSyntax _toSyntax(SerializationContext context) =>
       TearoffInstanceSyntax(
-        loadingUnitIndices: loadingUnits
-            .map((unit) => context.loadingUnits[unit]!)
-            .toList(),
+        loadingUnitIndices: [
+          for (final unit in loadingUnits) context.loadingUnits[unit]!,
+        ],
       );
 
   @override

--- a/pkgs/record_use/test/json_schema/schema_test.dart
+++ b/pkgs/record_use/test/json_schema/schema_test.dart
@@ -49,13 +49,13 @@ void main() {
   }
 }
 
-const constNullIndex = 4;
-const constNonConstantIndex = 5;
-const constInstanceIndex = 7;
-const constMapIndex = 3;
-const constUnsupportedIndex = 9;
-const constRecordIndex = 10;
-const constEnumIndex = 11;
+const constNonConstantIndex = 0;
+const constUnsupportedIndex = 1;
+const constNullIndex = 2;
+const constMapIndex = 8;
+const constRecordIndex = 9;
+const constEnumIndex = 10;
+const constInstanceIndex = 11;
 typedef SchemaTestField = (
   List<Object> path,
   void Function(ValidationResults result) missingExpectations,
@@ -94,21 +94,21 @@ List<SchemaTestField> recordUseFields = [
     // omitted. Also, Null and NonConstant have no value field.
   ],
   (['definitions'], expectOptionalFieldMissing),
-  (['definitions', 0, 'uri'], expectRequiredFieldMissing),
-  (['definitions', 0, 'path'], expectRequiredFieldMissing),
-  (['definitions', 0, 'path', 0], expectOptionalFieldMissing),
+  (['definitions', 1, 'uri'], expectRequiredFieldMissing),
+  (['definitions', 1, 'path'], expectRequiredFieldMissing),
+  (['definitions', 1, 'path', 0], expectOptionalFieldMissing),
   (
-    ['definitions', 0, 'path', 0, 'name'],
+    ['definitions', 1, 'path', 0, 'name'],
     expectRequiredFieldMissing,
   ),
   (
-    ['definitions', 0, 'path', 0, 'kind'],
+    ['definitions', 1, 'path', 0, 'kind'],
     expectOptionalFieldMissing,
   ),
   (
     [
       'definitions',
-      0,
+      1,
       'path',
       0,
       'disambiguators',

--- a/pkgs/record_use/test_data/json/constructor_invocation.json
+++ b/pkgs/record_use/test_data/json/constructor_invocation.json
@@ -2,15 +2,15 @@
   "$schema": "../../doc/schema/record_use.schema.json",
   "constants": [
     {
+      "type": "non_constant"
+    },
+    {
       "type": "int",
       "value": 1
     },
     {
       "type": "int",
       "value": 2
-    },
-    {
-      "type": "non_constant"
     },
     {
       "type": "string",
@@ -47,12 +47,12 @@
               0
             ],
             "named": {
-              "other": 2,
+              "other": 0,
               "param": 3
             },
             "positional": [
-              0,
-              1
+              1,
+              2
             ],
             "type": "creation"
           }

--- a/pkgs/record_use/test_data/json/enum_const_arg.json
+++ b/pkgs/record_use/test_data/json/enum_const_arg.json
@@ -13,8 +13,8 @@
       "definition_index": 0,
       "type": "instance",
       "value": {
-        "index": 0,
-        "_name": 1
+        "_name": 1,
+        "index": 0
       }
     }
   ],

--- a/pkgs/record_use/test_data/json/instance_complex.json
+++ b/pkgs/record_use/test_data/json/instance_complex.json
@@ -2,70 +2,70 @@
   "$schema": "../../doc/schema/record_use.schema.json",
   "constants": [
     {
-      "type": "int",
-      "value": 15
-    },
-    {
-      "type": "string",
-      "value": "s"
-    },
-    {
-      "type": "string",
-      "value": "h"
+      "type": "null"
     },
     {
       "type": "bool",
       "value": false
     },
     {
-      "type": "map",
-      "value": [
-        {
-          "key": 2,
-          "value": 3
-        }
-      ]
-    },
-    {
       "type": "bool",
       "value": true
-    },
-    {
-      "type": "string",
-      "value": "l"
     },
     {
       "type": "int",
       "value": 3
     },
     {
+      "type": "int",
+      "value": 15
+    },
+    {
+      "type": "string",
+      "value": "h"
+    },
+    {
+      "type": "string",
+      "value": "l"
+    },
+    {
+      "type": "string",
+      "value": "s"
+    },
+    {
+      "type": "map",
+      "value": [
+        {
+          "key": 5,
+          "value": 1
+        }
+      ]
+    },
+    {
       "type": "map",
       "value": [
         {
           "key": 6,
-          "value": 7
+          "value": 3
         }
       ]
     },
     {
       "type": "list",
       "value": [
-        8
+        9
       ]
-    },
-    {
-      "type": "null"
     },
     {
       "definition_index": 0,
       "type": "instance",
       "value": {
-        "i": 0,
-        "s": 1,
-        "m": 4,
-        "b": 5,
-        "l": 9,
-        "n": 10
+        "b": 2,
+        "i": 4,
+        "l": 10,
+        "m": 8,
+        "n": 0,
+        "s": 7
       }
     }
   ],

--- a/pkgs/record_use/test_data/json/instance_duplicates.json
+++ b/pkgs/record_use/test_data/json/instance_duplicates.json
@@ -6,13 +6,6 @@
       "value": 42
     },
     {
-      "definition_index": 0,
-      "type": "instance",
-      "value": {
-        "i": 0
-      }
-    },
-    {
       "type": "int",
       "value": 43
     },
@@ -20,7 +13,14 @@
       "definition_index": 0,
       "type": "instance",
       "value": {
-        "i": 2
+        "i": 0
+      }
+    },
+    {
+      "definition_index": 0,
+      "type": "instance",
+      "value": {
+        "i": 1
       }
     }
   ],
@@ -50,7 +50,7 @@
         "definition_index": 0,
         "uses": [
           {
-            "constant_index": 1,
+            "constant_index": 2,
             "loading_unit_indices": [
               0
             ],

--- a/pkgs/record_use/test_data/json/map_complex_keys.json
+++ b/pkgs/record_use/test_data/json/map_complex_keys.json
@@ -2,30 +2,30 @@
   "$schema": "../../doc/schema/record_use.schema.json",
   "constants": [
     {
-      "type": "int",
-      "value": 1
-    },
-    {
-      "type": "string",
-      "value": "int-key"
-    },
-    {
       "type": "bool",
       "value": true
+    },
+    {
+      "type": "int",
+      "value": 1
     },
     {
       "type": "string",
       "value": "bool-key"
     },
     {
+      "type": "string",
+      "value": "int-key"
+    },
+    {
       "type": "map",
       "value": [
         {
           "key": 0,
-          "value": 1
+          "value": 2
         },
         {
-          "key": 2,
+          "key": 1,
           "value": 3
         }
       ]

--- a/pkgs/record_use/test_data/json/named_and_positional.json
+++ b/pkgs/record_use/test_data/json/named_and_positional.json
@@ -2,15 +2,7 @@
   "$schema": "../../doc/schema/record_use.schema.json",
   "constants": [
     {
-      "type": "int",
-      "value": 3
-    },
-    {
       "type": "null"
-    },
-    {
-      "type": "int",
-      "value": 5
     },
     {
       "type": "int",
@@ -22,7 +14,15 @@
     },
     {
       "type": "int",
+      "value": 3
+    },
+    {
+      "type": "int",
       "value": 4
+    },
+    {
+      "type": "int",
+      "value": 5
     }
   ],
   "definitions": [
@@ -62,11 +62,24 @@
               0
             ],
             "named": {
-              "l": 1,
-              "k": 0
+              "k": 3,
+              "l": 0
             },
             "positional": [
+              3
+            ],
+            "type": "with_arguments"
+          },
+          {
+            "loading_unit_indices": [
               0
+            ],
+            "named": {
+              "k": 1,
+              "l": 0
+            },
+            "positional": [
+              5
             ],
             "type": "with_arguments"
           },
@@ -76,10 +89,10 @@
             ],
             "named": {
               "k": 3,
-              "l": 1
+              "l": 2
             },
             "positional": [
-              2
+              5
             ],
             "type": "with_arguments"
           },
@@ -88,24 +101,11 @@
               0
             ],
             "named": {
-              "l": 4,
-              "k": 0
+              "k": 4,
+              "l": 2
             },
             "positional": [
-              2
-            ],
-            "type": "with_arguments"
-          },
-          {
-            "loading_unit_indices": [
-              0
-            ],
-            "named": {
-              "l": 4,
-              "k": 5
-            },
-            "positional": [
-              2
+              5
             ],
             "type": "with_arguments"
           }

--- a/pkgs/record_use/test_data/json/named_both.json
+++ b/pkgs/record_use/test_data/json/named_both.json
@@ -2,15 +2,7 @@
   "$schema": "../../doc/schema/record_use.schema.json",
   "constants": [
     {
-      "type": "int",
-      "value": 3
-    },
-    {
       "type": "null"
-    },
-    {
-      "type": "int",
-      "value": 5
     },
     {
       "type": "int",
@@ -22,7 +14,15 @@
     },
     {
       "type": "int",
+      "value": 3
+    },
+    {
+      "type": "int",
       "value": 4
+    },
+    {
+      "type": "int",
+      "value": 5
     }
   ],
   "definitions": [
@@ -62,20 +62,9 @@
               0
             ],
             "named": {
-              "i": 0,
-              "l": 1,
-              "k": 0
-            },
-            "type": "with_arguments"
-          },
-          {
-            "loading_unit_indices": [
-              0
-            ],
-            "named": {
-              "i": 2,
+              "i": 3,
               "k": 3,
-              "l": 1
+              "l": 0
             },
             "type": "with_arguments"
           },
@@ -84,9 +73,9 @@
               0
             ],
             "named": {
-              "i": 2,
-              "l": 4,
-              "k": 0
+              "i": 5,
+              "k": 1,
+              "l": 0
             },
             "type": "with_arguments"
           },
@@ -95,9 +84,20 @@
               0
             ],
             "named": {
-              "i": 2,
-              "l": 4,
-              "k": 5
+              "i": 5,
+              "k": 3,
+              "l": 2
+            },
+            "type": "with_arguments"
+          },
+          {
+            "loading_unit_indices": [
+              0
+            ],
+            "named": {
+              "i": 5,
+              "k": 4,
+              "l": 2
             },
             "type": "with_arguments"
           }

--- a/pkgs/record_use/test_data/json/nested.json
+++ b/pkgs/record_use/test_data/json/nested.json
@@ -6,6 +6,14 @@
       "value": 42
     },
     {
+      "type": "string",
+      "value": "test"
+    },
+    {
+      "definition_index": 1,
+      "type": "instance"
+    },
+    {
       "definition_index": 0,
       "type": "instance",
       "value": {
@@ -13,19 +21,11 @@
       }
     },
     {
-      "type": "string",
-      "value": "test"
-    },
-    {
       "definition_index": 0,
       "type": "instance",
       "value": {
-        "i": 2
+        "i": 1
       }
-    },
-    {
-      "definition_index": 1,
-      "type": "instance"
     }
   ],
   "definitions": [
@@ -63,14 +63,14 @@
         "definition_index": 0,
         "uses": [
           {
-            "constant_index": 1,
+            "constant_index": 3,
             "loading_unit_indices": [
               0
             ],
             "type": "constant"
           },
           {
-            "constant_index": 3,
+            "constant_index": 4,
             "loading_unit_indices": [
               0
             ],
@@ -82,7 +82,7 @@
         "definition_index": 1,
         "uses": [
           {
-            "constant_index": 4,
+            "constant_index": 2,
             "loading_unit_indices": [
               0
             ],

--- a/pkgs/record_use/test_data/json/positional_both.json
+++ b/pkgs/record_use/test_data/json/positional_both.json
@@ -3,19 +3,19 @@
   "constants": [
     {
       "type": "int",
-      "value": 5
-    },
-    {
-      "type": "int",
       "value": 3
     },
     {
       "type": "int",
-      "value": 6
+      "value": 4
     },
     {
       "type": "int",
-      "value": 4
+      "value": 5
+    },
+    {
+      "type": "int",
+      "value": 6
     }
   ],
   "definitions": [
@@ -55,8 +55,8 @@
               0
             ],
             "positional": [
-              0,
-              1
+              2,
+              0
             ],
             "type": "with_arguments"
           },
@@ -65,8 +65,8 @@
               0
             ],
             "positional": [
-              2,
-              3
+              3,
+              1
             ],
             "type": "with_arguments"
           }

--- a/pkgs/record_use/test_data/json/positional_both_with_type_argument.json
+++ b/pkgs/record_use/test_data/json/positional_both_with_type_argument.json
@@ -3,19 +3,19 @@
   "constants": [
     {
       "type": "int",
-      "value": 5
-    },
-    {
-      "type": "int",
       "value": 3
     },
     {
       "type": "int",
-      "value": 6
+      "value": 4
     },
     {
       "type": "int",
-      "value": 4
+      "value": 5
+    },
+    {
+      "type": "int",
+      "value": 6
     }
   ],
   "definitions": [
@@ -55,8 +55,8 @@
               0
             ],
             "positional": [
-              0,
-              1
+              2,
+              0
             ],
             "type": "with_arguments"
           },
@@ -65,8 +65,8 @@
               0
             ],
             "positional": [
-              2,
-              3
+              3,
+              1
             ],
             "type": "with_arguments"
           }

--- a/pkgs/record_use/test_data/json/record_enum.json
+++ b/pkgs/record_use/test_data/json/record_enum.json
@@ -13,8 +13,8 @@
       "definition_index": 0,
       "type": "instance",
       "value": {
-        "index": 0,
-        "_name": 1
+        "_name": 1,
+        "index": 0
       }
     },
     {

--- a/pkgs/record_use/test_data/json/recorded_uses.json
+++ b/pkgs/record_use/test_data/json/recorded_uses.json
@@ -2,6 +2,24 @@
   "$schema": "../../doc/schema/record_use.schema.json",
   "constants": [
     {
+      "type": "non_constant"
+    },
+    {
+      "message": "MethodTearoff",
+      "type": "unsupported"
+    },
+    {
+      "type": "null"
+    },
+    {
+      "type": "bool",
+      "value": false
+    },
+    {
+      "type": "int",
+      "value": 42
+    },
+    {
       "type": "string",
       "value": "42"
     },
@@ -10,65 +28,56 @@
       "value": "h"
     },
     {
-      "type": "bool",
-      "value": false
+      "type": "list",
+      "value": [
+        4
+      ]
     },
     {
       "type": "map",
       "value": [
         {
-          "key": 1,
-          "value": 2
+          "key": 6,
+          "value": 3
         }
       ]
     },
     {
-      "type": "null"
-    },
-    {
-      "type": "non_constant"
-    },
-    {
-      "type": "int",
-      "value": 42
-    },
-    {
-      "definition_index": 1,
-      "type": "instance",
-      "value": {
-        "i": 6
-      }
-    },
-    {
-      "type": "list",
-      "value": [
-        6
-      ]
-    },
-    {
-      "message": "MethodTearoff",
-      "type": "unsupported"
-    },
-    {
       "named": {
-        "a": 0
+        "a": 5
       },
       "positional": [
-        6
+        4
       ],
       "type": "record"
     },
     {
-      "definition_index": 2,
+      "definition_index": 0,
       "index": 0,
       "name": "red",
       "type": "enum",
       "value": {
-        "hex": 6
+        "hex": 4
+      }
+    },
+    {
+      "definition_index": 2,
+      "type": "instance",
+      "value": {
+        "i": 4
       }
     }
   ],
   "definitions": [
+    {
+      "path": [
+        {
+          "kind": "enum",
+          "name": "Color"
+        }
+      ],
+      "uri": "package:record_use_test/color.dart"
+    },
     {
       "path": [
         {
@@ -93,15 +102,6 @@
         }
       ],
       "uri": "package:record_use_test/instance_class.dart"
-    },
-    {
-      "path": [
-        {
-          "kind": "enum",
-          "name": "Color"
-        }
-      ],
-      "uri": "package:record_use_test/color.dart"
     }
   ],
   "loading_units": [
@@ -116,10 +116,10 @@
   "uses": {
     "instances": [
       {
-        "definition_index": 1,
+        "definition_index": 2,
         "uses": [
           {
-            "constant_index": 7,
+            "constant_index": 11,
             "loading_unit_indices": [
               0
             ],
@@ -130,29 +130,29 @@
     ],
     "static_calls": [
       {
-        "definition_index": 0,
+        "definition_index": 1,
         "uses": [
           {
             "loading_unit_indices": [
               0
             ],
             "named": {
-              "a": 0,
-              "b": 2,
-              "c": 6,
-              "d": 5
+              "a": 5,
+              "b": 3,
+              "c": 4,
+              "d": 0
             },
             "positional": [
-              0,
-              3,
-              4,
               5,
-              6,
-              7,
               8,
+              2,
+              0,
+              4,
+              11,
+              7,
+              1,
               9,
-              10,
-              11
+              10
             ],
             "type": "with_arguments"
           }

--- a/pkgs/record_use/test_data/json/recorded_uses_v2.json
+++ b/pkgs/record_use/test_data/json/recorded_uses_v2.json
@@ -2,8 +2,7 @@
   "$schema": "../../doc/schema/record_use.schema.json",
   "constants": [
     {
-      "type": "string",
-      "value": "lib_SHA1"
+      "type": "null"
     },
     {
       "type": "bool",
@@ -11,32 +10,19 @@
     },
     {
       "type": "int",
+      "value": 0
+    },
+    {
+      "type": "int",
       "value": 1
     },
     {
-      "type": "string",
-      "value": "mercury"
-    },
-    {
-      "type": "string",
-      "value": "jenkins"
-    },
-    {
-      "type": "string",
-      "value": "key"
+      "type": "int",
+      "value": 42
     },
     {
       "type": "int",
       "value": 99
-    },
-    {
-      "type": "map",
-      "value": [
-        {
-          "key": 5,
-          "value": 6
-        }
-      ]
     },
     {
       "type": "string",
@@ -51,43 +37,41 @@
       "value": "insert"
     },
     {
+      "type": "string",
+      "value": "jenkins"
+    },
+    {
+      "type": "string",
+      "value": "key"
+    },
+    {
+      "type": "string",
+      "value": "lib_SHA1"
+    },
+    {
+      "type": "string",
+      "value": "mercury"
+    },
+    {
+      "definition_index": 0,
+      "type": "instance"
+    },
+    {
       "type": "list",
       "value": [
-        9,
-        10,
+        7,
+        8,
         1
       ]
     },
     {
-      "type": "list",
+      "type": "map",
       "value": [
-        8,
-        11,
-        9
+        {
+          "key": 10,
+          "value": 5
+        }
       ]
-    },
-    {
-      "type": "int",
-      "value": 0
-    },
-    {
-      "type": "int",
-      "value": 42
-    },
-    {
-      "type": "null"
-    },
-    {
-      "definition_index": 1,
-      "type": "instance",
-      "value": {
-        "a": 14,
-        "b": 15
-      }
-    },
-    {
-      "definition_index": 1,
-      "type": "instance"
     },
     {
       "definition_index": 2,
@@ -95,18 +79,31 @@
       "name": "val1",
       "type": "enum",
       "value": {
-        "a": 14
+        "a": 4
       }
+    },
+    {
+      "definition_index": 0,
+      "type": "instance",
+      "value": {
+        "a": 4,
+        "b": 0
+      }
+    },
+    {
+      "type": "list",
+      "value": [
+        6,
+        14,
+        7
+      ]
     }
   ],
   "definitions": [
     {
       "path": [
         {
-          "name": "MyClass"
-        },
-        {
-          "name": "get:loadDeferredLibrary"
+          "name": "MyAnnotation"
         }
       ],
       "uri": "package:js_runtime/js_helper.dart"
@@ -114,7 +111,10 @@
     {
       "path": [
         {
-          "name": "MyAnnotation"
+          "name": "MyClass"
+        },
+        {
+          "name": "get:loadDeferredLibrary"
         }
       ],
       "uri": "package:js_runtime/js_helper.dart"
@@ -130,10 +130,10 @@
   ],
   "loading_units": [
     {
-      "name": "o.js"
+      "name": "3"
     },
     {
-      "name": "3"
+      "name": "o.js"
     }
   ],
   "metadata": {
@@ -143,19 +143,19 @@
   "uses": {
     "instances": [
       {
-        "definition_index": 1,
+        "definition_index": 0,
         "uses": [
           {
-            "constant_index": 16,
+            "constant_index": 17,
             "loading_unit_indices": [
-              1
+              0
             ],
             "type": "constant"
           },
           {
-            "constant_index": 17,
+            "constant_index": 13,
             "loading_unit_indices": [
-              1
+              0
             ],
             "type": "constant"
           }
@@ -165,9 +165,9 @@
         "definition_index": 2,
         "uses": [
           {
-            "constant_index": 18,
+            "constant_index": 16,
             "loading_unit_indices": [
-              1
+              0
             ],
             "type": "constant"
           }
@@ -176,35 +176,35 @@
     ],
     "static_calls": [
       {
-        "definition_index": 0,
+        "definition_index": 1,
         "uses": [
           {
             "loading_unit_indices": [
-              0
+              1
             ],
             "named": {
-              "freddy": 3,
-              "leroy": 4
+              "freddy": 12,
+              "leroy": 9
             },
             "positional": [
-              0,
+              11,
               1,
-              2
+              3
             ],
             "type": "with_arguments"
           },
           {
             "loading_unit_indices": [
-              0
+              1
             ],
             "named": {
-              "freddy": 13,
-              "leroy": 4
+              "freddy": 2,
+              "leroy": 9
             },
             "positional": [
-              0,
-              7,
-              12
+              11,
+              15,
+              18
             ],
             "type": "with_arguments"
           }

--- a/pkgs/record_use/test_data/json/recorded_uses_v2_2.json
+++ b/pkgs/record_use/test_data/json/recorded_uses_v2_2.json
@@ -10,12 +10,12 @@
       "value": 1
     },
     {
-      "type": "string",
-      "value": "mercury"
-    },
-    {
       "type": "int",
       "value": 42
+    },
+    {
+      "type": "string",
+      "value": "mercury"
     }
   ],
   "definitions": [
@@ -50,8 +50,8 @@
               0
             ],
             "named": {
-              "freddy": 2,
-              "answer": 3
+              "answer": 2,
+              "freddy": 3
             },
             "positional": [
               0,

--- a/pkgs/record_use/test_data/json/types_of_arguments.json
+++ b/pkgs/record_use/test_data/json/types_of_arguments.json
@@ -2,19 +2,18 @@
   "$schema": "../../doc/schema/record_use.schema.json",
   "constants": [
     {
-      "type": "int",
-      "value": 42
+      "type": "non_constant"
     },
     {
       "type": "null"
     },
     {
-      "type": "string",
-      "value": "s"
-    },
-    {
       "type": "bool",
       "value": true
+    },
+    {
+      "type": "int",
+      "value": 42
     },
     {
       "type": "string",
@@ -29,13 +28,6 @@
       "value": "a2"
     },
     {
-      "type": "list",
-      "value": [
-        5,
-        6
-      ]
-    },
-    {
       "type": "string",
       "value": "b"
     },
@@ -48,10 +40,21 @@
       "value": "b2"
     },
     {
+      "type": "string",
+      "value": "s"
+    },
+    {
       "type": "list",
       "value": [
-        9,
-        10
+        5,
+        6
+      ]
+    },
+    {
+      "type": "list",
+      "value": [
+        8,
+        9
       ]
     },
     {
@@ -59,16 +62,13 @@
       "value": [
         {
           "key": 4,
-          "value": 7
+          "value": 11
         },
         {
-          "key": 8,
-          "value": 11
+          "key": 7,
+          "value": 12
         }
       ]
-    },
-    {
-      "type": "non_constant"
     }
   ],
   "definitions": [
@@ -108,7 +108,7 @@
               0
             ],
             "positional": [
-              0
+              3
             ],
             "type": "with_arguments"
           },
@@ -126,6 +126,15 @@
               0
             ],
             "positional": [
+              10
+            ],
+            "type": "with_arguments"
+          },
+          {
+            "loading_unit_indices": [
+              0
+            ],
+            "positional": [
               2
             ],
             "type": "with_arguments"
@@ -135,25 +144,16 @@
               0
             ],
             "positional": [
-              3
-            ],
-            "type": "with_arguments"
-          },
-          {
-            "loading_unit_indices": [
-              0
-            ],
-            "positional": [
-              12
-            ],
-            "type": "with_arguments"
-          },
-          {
-            "loading_unit_indices": [
-              0
-            ],
-            "positional": [
               13
+            ],
+            "type": "with_arguments"
+          },
+          {
+            "loading_unit_indices": [
+              0
+            ],
+            "positional": [
+              0
             ],
             "type": "with_arguments"
           }

--- a/pkgs/record_use/test_data/json/unsupported_collections.json
+++ b/pkgs/record_use/test_data/json/unsupported_collections.json
@@ -6,20 +6,20 @@
       "type": "unsupported"
     },
     {
+      "type": "string",
+      "value": "key"
+    },
+    {
       "type": "list",
       "value": [
         0
       ]
     },
     {
-      "type": "string",
-      "value": "key"
-    },
-    {
       "type": "map",
       "value": [
         {
-          "key": 2,
+          "key": 1,
           "value": 0
         }
       ]
@@ -55,7 +55,7 @@
               0
             ],
             "positional": [
-              1
+              2
             ],
             "type": "with_arguments"
           },

--- a/pkgs/record_use/test_data/json/unsupported_instance.json
+++ b/pkgs/record_use/test_data/json/unsupported_instance.json
@@ -6,7 +6,7 @@
       "type": "unsupported"
     },
     {
-      "definition_index": 1,
+      "definition_index": 0,
       "type": "instance",
       "value": {
         "field": 0
@@ -17,8 +17,8 @@
     {
       "path": [
         {
-          "kind": "method",
-          "name": "recorded"
+          "kind": "class",
+          "name": "MyClass"
         }
       ],
       "uri": "package:record_use_test/unsupported_instance.dart"
@@ -26,8 +26,8 @@
     {
       "path": [
         {
-          "kind": "class",
-          "name": "MyClass"
+          "kind": "method",
+          "name": "recorded"
         }
       ],
       "uri": "package:record_use_test/unsupported_instance.dart"
@@ -45,7 +45,7 @@
   "uses": {
     "instances": [
       {
-        "definition_index": 1,
+        "definition_index": 0,
         "uses": [
           {
             "constant_index": 1,
@@ -59,7 +59,7 @@
     ],
     "static_calls": [
       {
-        "definition_index": 0,
+        "definition_index": 1,
         "uses": [
           {
             "loading_unit_indices": [


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/3115

Sorts children in `_canonicalizeChildren` where necessary and then sorts the pools.

* Definitions are sorted consistently with their `toString`
* Constants are sorted first by depth, then kind, then size, and as a last resort look at the internals. (The internals for the composites subsequently first look degree before recursing.)
* loading units are sorted by their name.

(We can theoretically get a more performant ordering by using a stable hash for strings / ints instead of the ones built in in Dart and use those stable hashes as a tie breaker after depth, kind, size, and degree. But right now I don't want to depend on a third party package for having a stable hash of the node contents. The current hashcodes are unstable across runs/machines as String does not have a stable hash code.)