### PR TITLE
[hooks_runner] Automatically add recorded uses to hook dependencies

### DIFF
--- a/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
@@ -523,7 +523,10 @@ class NativeAssetsBuildRunner {
                   ' in ${buildDirUri.toFilePath()}.'
                   ' Last build on ${output.timestamp}.',
                 );
-                return Success((output, hookHashes.fileSystemEntities));
+                return Success((
+                  output,
+                  [...hookHashes.fileSystemEntities, ?resources],
+                ));
               }
             }
           }
@@ -552,14 +555,17 @@ class NativeAssetsBuildRunner {
         } else {
           final success = result.success;
           final modifiedDuringBuild = await dependenciesHashes.hashDependencies(
-            [...success.dependencies],
+            [...success.dependencies, ?resources],
             lastModifiedCutoffTime,
             hookEnvironment,
           );
           if (modifiedDuringBuild != null) {
             logger.severe('File modified during build. Build must be rerun.');
           }
-          return Success((success, hookHashes.fileSystemEntities));
+          return Success((
+            success,
+            [...hookHashes.fileSystemEntities, ?resources],
+          ));
         }
       },
     ),

--- a/pkgs/record_use/test_data/drop_data_asset/hook/link.dart
+++ b/pkgs/record_use/test_data/drop_data_asset/hook/link.dart
@@ -93,8 +93,6 @@ void main(List<String> arguments) async {
 
     print('Keeping only ${neededCodeAssets.map((e) => e.id).join(', ')}.');
     output.assets.data.addAll(neededCodeAssets);
-
-    output.dependencies.add(recordedUsagesFile);
   });
 }
 

--- a/pkgs/record_use/test_data/drop_dylib_recording/hook/link.dart
+++ b/pkgs/record_use/test_data/drop_dylib_recording/hook/link.dart
@@ -108,8 +108,6 @@ void main(List<String> arguments) async {
 
     print('Keeping only ${neededCodeAssets.map((e) => e.id).join(', ')}.');
     output.assets.code.addAll(neededCodeAssets);
-
-    output.dependencies.add(recordedUsagesFile);
   });
 }
 


### PR DESCRIPTION
Automatically added the `recorded_uses.json` as a dependency to the link hook.

Relying on link hook writers to do it is error prone. Also we aggressively filter the file now, so it shouldn't often trigger a rerun.