### PR TITLE
[swift2objc] Fix nesting bugs

### DIFF
--- a/pkgs/swift2objc/lib/src/ast/_core/interfaces/declaration.dart
+++ b/pkgs/swift2objc/lib/src/ast/_core/interfaces/declaration.dart
@@ -7,6 +7,7 @@ import '../../ast_node.dart';
 import '../../declarations/built_in/built_in_declaration.dart';
 import '../shared/referred_type.dart';
 import 'availability.dart';
+import 'nestable_declaration.dart';
 
 /// A common interface for all Swift entities declarations.
 abstract interface class Declaration implements AstNode, Availability {
@@ -20,7 +21,14 @@ extension AsDeclaredType<T extends Declaration> on T {
   DeclaredType<T> get asDeclaredType => DeclaredType(id: id, declaration: this);
 }
 
-extension DeclarationIsBuiltIn on Declaration {
+extension DeclarationExtensions on Declaration {
   bool get isBuiltIn =>
       this is BuiltInDeclaration || source == builtInInputConfig;
+
+  String get fullName {
+    final parent = this is InnerNestableDeclaration
+        ? (this as InnerNestableDeclaration).nestingParent
+        : null;
+    return parent != null ? '${parent.fullName}.$name' : name;
+  }
 }

--- a/pkgs/swift2objc/lib/src/transformer/_core/utils.dart
+++ b/pkgs/swift2objc/lib/src/transformer/_core/utils.dart
@@ -84,7 +84,7 @@ import 'unique_namer.dart';
     );
 
     return (
-      '${transformedTypeDeclaration.name}($value)',
+      '${transformedTypeDeclaration.fullName}($value)',
       transformedTypeDeclaration.asDeclaredType,
     );
   } else if (type is OptionalType) {

--- a/pkgs/swift2objc/lib/src/transformer/transform.dart
+++ b/pkgs/swift2objc/lib/src/transformer/transform.dart
@@ -31,6 +31,8 @@ class TransformationState {
 
   // Bindings that will be generated as stubs.
   final stubs = <Declaration>{};
+
+  late final UniqueNamer globalNamer;
 }
 
 /// Transforms the given declarations into the desired ObjC wrapped declarations
@@ -61,7 +63,7 @@ List<Declaration> transform(
   state.stubs.addAll(listDecls.stubDecls);
   state.bindings.addAll(listDecls.stubDecls);
 
-  final globalNamer = UniqueNamer(
+  state.globalNamer = UniqueNamer(
     state.bindings.map((declaration) => declaration.name),
   );
 
@@ -72,9 +74,9 @@ List<Declaration> transform(
 
   final transformedDeclarations = [
     ...topLevelDecls.map(
-      (d) => maybeTransformDeclaration(d, globalNamer, state),
+      (d) => maybeTransformDeclaration(d, state.globalNamer, state),
     ),
-    transformGlobals(globals, globalNamer, state),
+    transformGlobals(globals, state.globalNamer, state),
   ].nonNulls.toList();
 
   return [
@@ -112,10 +114,20 @@ Declaration? maybeTransformDeclaration(
   }
 
   if (declaration is InnerNestableDeclaration &&
-      declaration.nestingParent != null) {
+      declaration.nestingParent != null &&
+      !nested) {
     // It's important that nested declarations are only transformed in the
-    // context of their parent, so that their parentNamer is correct.
-    assert(nested);
+    // context of their parent, so that their parentNamer is correct. So find
+    // the top level declaration this is nested in, and transform that first.
+    maybeTransformDeclaration(
+      _topLevelNestingParent(declaration),
+      state.globalNamer,
+      state,
+    );
+
+    // Now that the parents are transformed, this declaration should haven been
+    // transformed, and will be in the cache.
+    return state.map[declaration]!;
   }
 
   return switch (declaration) {
@@ -136,3 +148,8 @@ List<Declaration> _getPrimitiveWrapperClasses(TransformationState state) =>
         .map((entry) => entry.value)
         .nonNulls
         .toList();
+
+Declaration _topLevelNestingParent(Declaration declaration) =>
+    declaration is InnerNestableDeclaration && declaration.nestingParent != null
+    ? _topLevelNestingParent(declaration.nestingParent!)
+    : declaration;

--- a/pkgs/swift2objc/test/integration/nested_types_input.swift
+++ b/pkgs/swift2objc/test/integration/nested_types_input.swift
@@ -12,6 +12,10 @@ public class OuterClass {
     public static func makeOuter() -> OuterClass { return OuterClass(); }
     public static func makeInner() -> InnerStruct { return InnerStruct(); }
   }
+
+  public func makeOther() -> OuterStruct.InnerClass {
+    return OuterStruct.InnerClass();
+  }
 }
 
 public struct OuterStruct {
@@ -27,5 +31,9 @@ public struct OuterStruct {
   public struct InnerStruct {
     public static func makeOuter() -> OuterStruct { return OuterStruct(); }
     public static func makeInner() -> InnerStruct { return InnerStruct(); }
+  }
+
+  public func makeOther() -> OuterClass.InnerClass {
+    return OuterClass.InnerClass();
   }
 }

--- a/pkgs/swift2objc/test/integration/nested_types_output.swift
+++ b/pkgs/swift2objc/test/integration/nested_types_output.swift
@@ -16,12 +16,17 @@ import Foundation
 
   @objc static public func makeInnerClass() -> OuterClassWrapper.InnerClassWrapper {
     let result = OuterClass.makeInnerClass()
-    return InnerClassWrapper(result)
+    return OuterClassWrapper.InnerClassWrapper(result)
   }
 
   @objc static public func makeInnerStruct() -> OuterClassWrapper.InnerStructWrapper {
     let result = OuterClass.makeInnerStruct()
-    return InnerStructWrapper(result)
+    return OuterClassWrapper.InnerStructWrapper(result)
+  }
+
+  @objc public func makeOther() -> OuterStructWrapper.InnerClassWrapper {
+    let result = wrappedInstance.makeOther()
+    return OuterStructWrapper.InnerClassWrapper(result)
   }
 
   @objc public class InnerClassWrapper: NSObject {
@@ -78,12 +83,17 @@ import Foundation
 
   @objc static public func makeInnerStruct() -> OuterStructWrapper.InnerStructWrapper {
     let result = OuterStruct.makeInnerStruct()
-    return InnerStructWrapper(result)
+    return OuterStructWrapper.InnerStructWrapper(result)
   }
 
   @objc static public func makeInnerClass() -> OuterStructWrapper.InnerClassWrapper {
     let result = OuterStruct.makeInnerClass()
-    return InnerClassWrapper(result)
+    return OuterStructWrapper.InnerClassWrapper(result)
+  }
+
+  @objc public func makeOther() -> OuterClassWrapper.InnerClassWrapper {
+    let result = wrappedInstance.makeOther()
+    return OuterClassWrapper.InnerClassWrapper(result)
   }
 
   @objc public class InnerStructWrapper: NSObject {


### PR DESCRIPTION
First, `transformReferredType` calls `transformDeclaration` without the proper nesting. Fixed this by walking up the nesting tree to find the top level decl, and transforming that first.

Fixing this exposed another issue where nested type's constructors are not using the fully qualified names. Fixed this by adding a util for getting the full name.

Fixes https://github.com/dart-lang/native/issues/3172

cc https://github.com/dart-lang/native/pull/3158