### PR TITLE
[jni] Remove hack in findClass and fix call sites

### DIFF
--- a/pkgs/jni/lib/src/jni.dart
+++ b/pkgs/jni/lib/src/jni.dart
@@ -190,10 +190,6 @@ abstract final class Jni {
   /// Uses the correct class loader on Android.
   /// Prefer this over `Jni.env.FindClass`.
   static JClassPtr findClass(String name) {
-    // TODO(https://github.com/dart-lang/native/issues/3174): Remove this hack.
-    if (name.startsWith('L') && name.endsWith(';')) {
-      name = name.substring(1, name.length - 1);
-    }
     return using((arena) => _bindings.JniFindClass(name.toNativeChars(arena)))
         .checkedClassRef;
   }

--- a/pkgs/jni/lib/src/types.dart
+++ b/pkgs/jni/lib/src/types.dart
@@ -51,7 +51,10 @@ abstract class JType<T extends JObject?> extends JTypeBase<T>
   const JType();
 
   JClass get jClass {
-    return JClass.forName(signature);
+    final name = signature.startsWith('L') && signature.endsWith(';')
+        ? signature.substring(1, signature.length - 1)
+        : signature;
+    return JClass.forName(name);
   }
 
   @override


### PR DESCRIPTION

## Description

This PR removes the temporary hack in `Jni.findClass` that was stripping 'L' and ';' from class signatures. To support this, I've updated `JType.jClass` to handle the signature stripping instead, ensuring that only binary class names are passed for lookup.

## Related Issues

Fixes #3174

## PR Checklist
- [x] I’ve reviewed the [contributor guide](https://github.com/dart-lang/native/blob/main/CONTRIBUTING.md) and applied the relevant portions to this PR.
- [ ] I've run `dart tool/ci.dart --all` locally.
- [x] All existing and new tests are passing.
- [x] The PR is actually solving the issue.
- [ ] I have updated [CHANGELOG.md](cci:7://file:///c:/Users/dhara/Documents/Aashish/vscode/native/pkgs/jni/CHANGELOG.md:0:0-0:0) for the relevant packages.
- [ ] I have [updated the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change) if necessary.