### PR TITLE
[native_toolchain_c] Run less tests

### DIFF
--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -14,48 +14,77 @@ import '../helpers.dart';
 const Timeout longTimeout = Timeout(Duration(minutes: 5));
 
 void main() {
-  const targets = [
-    Architecture.arm,
-    Architecture.arm64,
-    Architecture.ia32,
-    Architecture.x64,
-    Architecture.riscv64,
+  // These configurations are a selection of combinations of architectures,
+  // link modes, and optimization levels.
+  // We don't test the full cartesian product to keep the CI time manageable.
+  // When adding a new configuration, consider if it tests a new combination
+  // that is not yet covered by the existing tests.
+  final configurations = [
+    (
+      architecture: Architecture.arm,
+      apiLevel: flutterAndroidNdkVersionLowestSupported,
+      linkMode: DynamicLoadingBundled(),
+      optimizationLevel: OptimizationLevel.o0,
+    ),
+    (
+      architecture: Architecture.arm64,
+      apiLevel: flutterAndroidNdkVersionHighestSupported,
+      linkMode: StaticLinking(),
+      optimizationLevel: OptimizationLevel.o1,
+    ),
+    (
+      architecture: Architecture.ia32,
+      apiLevel: flutterAndroidNdkVersionLowestSupported,
+      linkMode: StaticLinking(),
+      optimizationLevel: OptimizationLevel.o2,
+    ),
+    (
+      architecture: Architecture.x64,
+      apiLevel: flutterAndroidNdkVersionHighestSupported,
+      linkMode: DynamicLoadingBundled(),
+      optimizationLevel: OptimizationLevel.o3,
+    ),
+    (
+      architecture: Architecture.riscv64,
+      apiLevel: flutterAndroidNdkVersionLowestSupported,
+      linkMode: DynamicLoadingBundled(),
+      optimizationLevel: OptimizationLevel.oS,
+    ),
+    (
+      architecture: Architecture.arm64,
+      apiLevel: flutterAndroidNdkVersionLowestSupported,
+      linkMode: StaticLinking(),
+      optimizationLevel: OptimizationLevel.unspecified,
+    ),
+    (
+      architecture: Architecture.arm,
+      apiLevel: flutterAndroidNdkVersionHighestSupported,
+      linkMode: DynamicLoadingBundled(),
+      optimizationLevel: OptimizationLevel.o2,
+    ),
   ];
 
-  const optimizationLevels = OptimizationLevel.values;
-  var selectOptimizationLevel = 0;
-
-  for (final linkMode in [DynamicLoadingBundled(), StaticLinking()]) {
-    for (final target in targets) {
-      for (final apiLevel in [
-        flutterAndroidNdkVersionLowestSupported,
-        flutterAndroidNdkVersionHighestSupported,
-      ]) {
-        // Cycle through all optimization levels.
-        final optimizationLevel = optimizationLevels[selectOptimizationLevel];
-        selectOptimizationLevel =
-            (selectOptimizationLevel + 1) % optimizationLevels.length;
-        test(
-          'CBuilder $linkMode library $target minSdkVersion $apiLevel '
-          '$optimizationLevel',
-          timeout: longTimeout,
-          () async {
-            final tempUri = await tempDirForTest();
-            final libUri = await buildLib(
-              tempUri,
-              target,
-              apiLevel,
-              linkMode,
-              optimizationLevel: optimizationLevel,
-            );
-            await expectMachineArchitecture(libUri, target, OS.android);
-            if (linkMode == DynamicLoadingBundled()) {
-              await expectPageSize(libUri, 16 * 1024);
-            }
-          },
+  for (final (:architecture, :apiLevel, :linkMode, :optimizationLevel)
+      in configurations) {
+    test(
+      'CBuilder $linkMode library $architecture minSdkVersion $apiLevel '
+      '$optimizationLevel',
+      timeout: longTimeout,
+      () async {
+        final tempUri = await tempDirForTest();
+        final libUri = await buildLib(
+          tempUri,
+          architecture,
+          apiLevel,
+          linkMode,
+          optimizationLevel: optimizationLevel,
         );
-      }
-    }
+        await expectMachineArchitecture(libUri, architecture, OS.android);
+        if (linkMode == DynamicLoadingBundled()) {
+          await expectPageSize(libUri, 16 * 1024);
+        }
+      },
+    );
   }
 
   test('CBuilder API levels binary difference', timeout: longTimeout, () async {
@@ -124,13 +153,13 @@ Future<Uri> buildLib(
     ..config.setupBuild(linkingEnabled: false)
     ..addExtension(
       CodeAssetExtension(
-        targetOS: OS.android,
+        targetOS: .android,
         targetArchitecture: targetArchitecture,
         cCompiler: cCompiler,
         android: AndroidCodeConfig(targetNdkApi: androidNdkApi),
         linkModePreference: linkMode == DynamicLoadingBundled()
-            ? LinkModePreference.dynamic
-            : LinkModePreference.static,
+            ? .dynamic
+            : .static,
       ),
     );
 
@@ -142,7 +171,7 @@ Future<Uri> buildLib(
     assetName: name,
     sources: [addCUri.toFilePath()],
     flags: flags,
-    buildMode: BuildMode.release,
+    buildMode: .release,
   );
   await cbuilder.run(input: buildInput, output: buildOutput, logger: logger);
 

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -22,165 +22,192 @@ void main() {
     return;
   }
 
-  const targets = [Architecture.arm64, Architecture.x64];
-
   const name = 'add';
 
-  const optimizationLevels = OptimizationLevel.values;
-  var selectOptimizationLevel = 0;
+  // These configurations are a selection of combinations of architectures,
+  // link modes, and optimization levels.
+  // We don't test the full cartesian product to keep the CI time manageable.
+  // When adding a new configuration, consider if it tests a new combination
+  // that is not yet covered by the existing tests.
+  final configurations = [
+    (
+      language: Language.c,
+      linkMode: DynamicLoadingBundled(),
+      targetIOSSdk: IOSSdk.iPhoneOS,
+      target: Architecture.arm64,
+      hasInstallName: false,
+      optimizationLevel: OptimizationLevel.o0,
+    ),
+    (
+      language: Language.objectiveC,
+      linkMode: StaticLinking(),
+      targetIOSSdk: IOSSdk.iPhoneSimulator,
+      target: Architecture.x64,
+      hasInstallName: false,
+      optimizationLevel: OptimizationLevel.o1,
+    ),
+    (
+      language: Language.c,
+      linkMode: StaticLinking(),
+      targetIOSSdk: IOSSdk.iPhoneSimulator,
+      target: Architecture.arm64,
+      hasInstallName: false,
+      optimizationLevel: OptimizationLevel.o2,
+    ),
+    (
+      language: Language.objectiveC,
+      linkMode: DynamicLoadingBundled(),
+      targetIOSSdk: IOSSdk.iPhoneOS,
+      target: Architecture.arm64,
+      hasInstallName: true,
+      optimizationLevel: OptimizationLevel.o3,
+    ),
+    (
+      language: Language.c,
+      linkMode: DynamicLoadingBundled(),
+      targetIOSSdk: IOSSdk.iPhoneSimulator,
+      target: Architecture.x64,
+      hasInstallName: true,
+      optimizationLevel: OptimizationLevel.oS,
+    ),
+    (
+      language: Language.objectiveC,
+      linkMode: StaticLinking(),
+      targetIOSSdk: IOSSdk.iPhoneOS,
+      target: Architecture.arm64,
+      hasInstallName: false,
+      optimizationLevel: OptimizationLevel.unspecified,
+    ),
+  ];
 
-  for (final language in [Language.c, Language.objectiveC]) {
-    for (final linkMode in [DynamicLoadingBundled(), StaticLinking()]) {
-      for (final targetIOSSdk in IOSSdk.values) {
-        for (final target in targets) {
-          if (target == Architecture.x64 && targetIOSSdk == IOSSdk.iPhoneOS) {
-            continue;
-          }
-          final libName = OS.iOS.libraryFileName(name, linkMode);
-          for (final installName in [
-            null,
-            if (linkMode == DynamicLoadingBundled())
-              Uri.file('@executable_path/Frameworks/$libName'),
-          ]) {
-            // Cycle through all optimization levels.
-            final optimizationLevel =
-                optimizationLevels[selectOptimizationLevel];
-            selectOptimizationLevel =
-                (selectOptimizationLevel + 1) % optimizationLevels.length;
-            test(
-              'CBuilder $linkMode $language library $targetIOSSdk $target'
-                      ' ${installName ?? ''} $optimizationLevel'
-                  .trim(),
-              () async {
-                final tempUri = await tempDirForTest();
-                final tempUri2 = await tempDirForTest();
-                final sourceUri = switch (language) {
-                  Language.c => packageUri.resolve(
-                    'test/cbuilder/testfiles/add/src/add.c',
-                  ),
-                  Language.objectiveC => packageUri.resolve(
-                    'test/cbuilder/testfiles/add_objective_c/src/add.m',
-                  ),
-                  Language() => throw UnimplementedError(),
-                };
+  for (final (
+        :language,
+        :linkMode,
+        :targetIOSSdk,
+        :target,
+        :hasInstallName,
+        :optimizationLevel,
+      )
+      in configurations) {
+    final libName = OS.iOS.libraryFileName(name, linkMode);
+    final installName = hasInstallName
+        ? Uri.file('@executable_path/Frameworks/$libName')
+        : null;
+    test(
+      'CBuilder $linkMode $language library $targetIOSSdk $target'
+              ' ${installName ?? ''} $optimizationLevel'
+          .trim(),
+      () async {
+        final tempUri = await tempDirForTest();
+        final tempUri2 = await tempDirForTest();
+        final sourceUri = switch (language) {
+          .c => packageUri.resolve('test/cbuilder/testfiles/add/src/add.c'),
+          .objectiveC => packageUri.resolve(
+            'test/cbuilder/testfiles/add_objective_c/src/add.m',
+          ),
+          Language() => throw UnimplementedError(),
+        };
 
-                final buildInputBuilder = BuildInputBuilder()
-                  ..setupShared(
-                    packageName: name,
-                    packageRoot: tempUri,
-                    outputFile: tempUri.resolve('output.json'),
-                    outputDirectoryShared: tempUri2,
-                  )
-                  ..config.setupBuild(linkingEnabled: false)
-                  ..addExtension(
-                    CodeAssetExtension(
-                      targetOS: OS.iOS,
-                      targetArchitecture: target,
-                      linkModePreference: linkMode == DynamicLoadingBundled()
-                          ? LinkModePreference.dynamic
-                          : LinkModePreference.static,
-                      iOS: IOSCodeConfig(
-                        targetSdk: targetIOSSdk,
-                        targetVersion: flutteriOSHighestBestEffort,
-                      ),
-                      cCompiler: cCompiler,
-                    ),
-                  );
+        final buildInputBuilder = BuildInputBuilder()
+          ..setupShared(
+            packageName: name,
+            packageRoot: tempUri,
+            outputFile: tempUri.resolve('output.json'),
+            outputDirectoryShared: tempUri2,
+          )
+          ..config.setupBuild(linkingEnabled: false)
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: .iOS,
+              targetArchitecture: target,
+              linkModePreference: linkMode == DynamicLoadingBundled()
+                  ? .dynamic
+                  : .static,
+              iOS: IOSCodeConfig(
+                targetSdk: targetIOSSdk,
+                targetVersion: flutteriOSHighestBestEffort,
+              ),
+              cCompiler: cCompiler,
+            ),
+          );
 
-                final buildInput = buildInputBuilder.build();
-                final buildOutput = BuildOutputBuilder();
+        final buildInput = buildInputBuilder.build();
+        final buildOutput = BuildOutputBuilder();
 
-                final cbuilder = CBuilder.library(
-                  name: name,
-                  assetName: name,
-                  sources: [sourceUri.toFilePath()],
-                  installName: installName,
-                  language: language,
-                  optimizationLevel: optimizationLevel,
-                  buildMode: BuildMode.release,
-                );
-                await cbuilder.run(
-                  input: buildInput,
-                  output: buildOutput,
-                  logger: logger,
-                );
+        final cbuilder = CBuilder.library(
+          name: name,
+          assetName: name,
+          sources: [sourceUri.toFilePath()],
+          installName: installName,
+          language: language,
+          optimizationLevel: optimizationLevel,
+          buildMode: .release,
+        );
+        await cbuilder.run(
+          input: buildInput,
+          output: buildOutput,
+          logger: logger,
+        );
 
-                final libUri = buildInput.outputDirectory.resolve(libName);
-                final objdumpResult = await runProcess(
-                  executable: Uri.file('objdump'),
-                  arguments: ['-t', libUri.path],
-                  logger: logger,
-                );
-                expect(objdumpResult.exitCode, 0);
-                final machine = objdumpResult.stdout
-                    .split('\n')
-                    .firstWhere((e) => e.contains('file format'));
-                expect(machine, contains(objdumpFileFormatIOS[target]));
+        final libUri = buildInput.outputDirectory.resolve(libName);
+        final objdumpResult = await runProcess(
+          executable: Uri.file('objdump'),
+          arguments: ['-t', libUri.path],
+          logger: logger,
+        );
+        expect(objdumpResult.exitCode, 0);
+        final machine = objdumpResult.stdout
+            .split('\n')
+            .firstWhere((e) => e.contains('file format'));
+        expect(machine, contains(objdumpFileFormatIOS[target]));
 
-                final otoolResult = await runProcess(
-                  executable: Uri.file('otool'),
-                  arguments: ['-l', libUri.path],
-                  logger: logger,
-                );
-                expect(otoolResult.exitCode, 0);
-                // As of native_assets_cli 0.10.0, the min target OS version is
-                // always being passed in.
-                expect(
-                  otoolResult.stdout,
-                  isNot(contains('LC_VERSION_MIN_IPHONEOS')),
-                );
-                expect(otoolResult.stdout, contains('LC_BUILD_VERSION'));
-                final platform = otoolResult.stdout
-                    .split('\n')
-                    .firstWhere((e) => e.contains('platform'));
-                if (targetIOSSdk == IOSSdk.iPhoneOS) {
-                  const platformIosDevice = 2;
-                  expect(platform, contains(platformIosDevice.toString()));
-                } else {
-                  const platformIosSimulator = 7;
-                  expect(platform, contains(platformIosSimulator.toString()));
-                }
+        final otoolResult = await runProcess(
+          executable: Uri.file('otool'),
+          arguments: ['-l', libUri.path],
+          logger: logger,
+        );
+        expect(otoolResult.exitCode, 0);
+        // As of native_assets_cli 0.10.0, the min target OS version is
+        // always being passed in.
+        expect(otoolResult.stdout, isNot(contains('LC_VERSION_MIN_IPHONEOS')));
+        expect(otoolResult.stdout, contains('LC_BUILD_VERSION'));
+        final platform = otoolResult.stdout
+            .split('\n')
+            .firstWhere((e) => e.contains('platform'));
+        if (targetIOSSdk == IOSSdk.iPhoneOS) {
+          const platformIosDevice = 2;
+          expect(platform, contains(platformIosDevice.toString()));
+        } else {
+          const platformIosSimulator = 7;
+          expect(platform, contains(platformIosSimulator.toString()));
+        }
 
-                if (linkMode == DynamicLoadingBundled()) {
-                  final libInstallName = await runOtoolInstallName(
-                    libUri,
-                    libName,
-                  );
-                  if (installName == null) {
-                    // If no install path is passed, we have an absolute path.
-                    final tempName = buildInput.outputDirectory.pathSegments
-                        .lastWhere((e) => e != '');
-                    final pathEnding = Uri.directory(
-                      tempName,
-                    ).resolve(libName).toFilePath();
-                    expect(Uri.file(libInstallName).isAbsolute, true);
-                    expect(libInstallName, contains(pathEnding));
-                    final targetInstallName =
-                        '@executable_path/Frameworks/$libName';
-                    await runProcess(
-                      executable: Uri.file('install_name_tool'),
-                      arguments: [
-                        '-id',
-                        targetInstallName,
-                        libUri.toFilePath(),
-                      ],
-                      logger: logger,
-                    );
-                    final libInstallName2 = await runOtoolInstallName(
-                      libUri,
-                      libName,
-                    );
-                    expect(libInstallName2, targetInstallName);
-                  } else {
-                    expect(libInstallName, installName.toFilePath());
-                  }
-                }
-              },
+        if (linkMode == DynamicLoadingBundled()) {
+          final libInstallName = await runOtoolInstallName(libUri, libName);
+          if (installName == null) {
+            // If no install path is passed, we have an absolute path.
+            final tempName = buildInput.outputDirectory.pathSegments.lastWhere(
+              (e) => e != '',
             );
+            final pathEnding = Uri.directory(
+              tempName,
+            ).resolve(libName).toFilePath();
+            expect(Uri.file(libInstallName).isAbsolute, true);
+            expect(libInstallName, contains(pathEnding));
+            final targetInstallName = '@executable_path/Frameworks/$libName';
+            await runProcess(
+              executable: Uri.file('install_name_tool'),
+              arguments: ['-id', targetInstallName, libUri.toFilePath()],
+              logger: logger,
+            );
+            final libInstallName2 = await runOtoolInstallName(libUri, libName);
+            expect(libInstallName2, targetInstallName);
+          } else {
+            expect(libInstallName, installName.toFilePath());
           }
         }
-      }
-    }
+      },
+    );
   }
 
   for (final iosVersion in [
@@ -235,11 +262,11 @@ Future<Uri> buildLib(
     ..config.setupBuild(linkingEnabled: false)
     ..addExtension(
       CodeAssetExtension(
-        targetOS: OS.iOS,
+        targetOS: .iOS,
         targetArchitecture: targetArchitecture,
         linkModePreference: linkMode == DynamicLoadingBundled()
-            ? LinkModePreference.dynamic
-            : LinkModePreference.static,
+            ? .dynamic
+            : .static,
         iOS: IOSCodeConfig(
           targetSdk: IOSSdk.iPhoneOS,
           targetVersion: targetIOSVersion,
@@ -255,7 +282,7 @@ Future<Uri> buildLib(
     name: name,
     assetName: name,
     sources: [addCUri.toFilePath()],
-    buildMode: BuildMode.release,
+    buildMode: .release,
   );
   await cbuilder.run(input: buildInput, output: buildOutput, logger: logger);
 

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -20,72 +20,93 @@ void main() {
     return;
   }
 
-  const targets = [
-    Architecture.arm,
-    Architecture.arm64,
-    Architecture.ia32,
-    Architecture.x64,
-    Architecture.riscv64,
+  // These configurations are a selection of combinations of architectures,
+  // link modes, and optimization levels.
+  // We don't test the full cartesian product to keep the CI time manageable.
+  // When adding a new configuration, consider if it tests a new combination
+  // that is not yet covered by the existing tests.
+  final configurations = [
+    (
+      linkMode: DynamicLoadingBundled(),
+      target: Architecture.arm,
+      optimizationLevel: OptimizationLevel.o0,
+    ),
+    (
+      linkMode: StaticLinking(),
+      target: Architecture.arm64,
+      optimizationLevel: OptimizationLevel.o1,
+    ),
+    (
+      linkMode: DynamicLoadingBundled(),
+      target: Architecture.ia32,
+      optimizationLevel: OptimizationLevel.o2,
+    ),
+    (
+      linkMode: StaticLinking(),
+      target: Architecture.x64,
+      optimizationLevel: OptimizationLevel.o3,
+    ),
+    (
+      linkMode: DynamicLoadingBundled(),
+      target: Architecture.riscv64,
+      optimizationLevel: OptimizationLevel.oS,
+    ),
+    (
+      linkMode: StaticLinking(),
+      target: Architecture.arm,
+      optimizationLevel: OptimizationLevel.unspecified,
+    ),
   ];
 
-  const optimizationLevels = OptimizationLevel.values;
-  var selectOptimizationLevel = 0;
+  for (final (:linkMode, :target, :optimizationLevel) in configurations) {
+    test('CBuilder $linkMode library $target $optimizationLevel', () async {
+      final tempUri = await tempDirForTest();
+      final tempUri2 = await tempDirForTest();
+      final addCUri = packageUri.resolve(
+        'test/cbuilder/testfiles/add/src/add.c',
+      );
+      const name = 'add';
 
-  for (final linkMode in [DynamicLoadingBundled(), StaticLinking()]) {
-    for (final target in targets) {
-      // Cycle through all optimization levels.
-      final optimizationLevel = optimizationLevels[selectOptimizationLevel];
-      selectOptimizationLevel =
-          (selectOptimizationLevel + 1) % optimizationLevels.length;
-      test('CBuilder $linkMode library $target $optimizationLevel', () async {
-        final tempUri = await tempDirForTest();
-        final tempUri2 = await tempDirForTest();
-        final addCUri = packageUri.resolve(
-          'test/cbuilder/testfiles/add/src/add.c',
-        );
-        const name = 'add';
-
-        final buildInputBuilder = BuildInputBuilder()
-          ..setupShared(
-            packageName: name,
-            packageRoot: tempUri,
-            outputFile: tempUri.resolve('output.json'),
-            outputDirectoryShared: tempUri2,
-          )
-          ..config.setupBuild(linkingEnabled: false)
-          ..addExtension(
-            CodeAssetExtension(
-              targetOS: OS.linux,
-              targetArchitecture: target,
-              linkModePreference: linkMode == DynamicLoadingBundled()
-                  ? LinkModePreference.dynamic
-                  : LinkModePreference.static,
-              cCompiler: cCompiler,
-            ),
-          );
-
-        final buildInput = buildInputBuilder.build();
-        final buildOutput = BuildOutputBuilder();
-
-        final cbuilder = CBuilder.library(
-          name: name,
-          assetName: name,
-          sources: [addCUri.toFilePath()],
-          optimizationLevel: optimizationLevel,
-          buildMode: BuildMode.release,
-        );
-        await cbuilder.run(
-          input: buildInput,
-          output: buildOutput,
-          logger: logger,
+      final buildInputBuilder = BuildInputBuilder()
+        ..setupShared(
+          packageName: name,
+          packageRoot: tempUri,
+          outputFile: tempUri.resolve('output.json'),
+          outputDirectoryShared: tempUri2,
+        )
+        ..config.setupBuild(linkingEnabled: false)
+        ..addExtension(
+          CodeAssetExtension(
+            targetOS: .linux,
+            targetArchitecture: target,
+            linkModePreference: linkMode == DynamicLoadingBundled()
+                ? .dynamic
+                : .static,
+            cCompiler: cCompiler,
+          ),
         );
 
-        final libUri = buildInput.outputDirectory.resolve(
-          OS.linux.libraryFileName(name, linkMode),
-        );
-        final machine = await readelfMachine(libUri.path);
-        expect(machine, contains(readElfMachine[target]));
-      });
-    }
+      final buildInput = buildInputBuilder.build();
+      final buildOutput = BuildOutputBuilder();
+
+      final cbuilder = CBuilder.library(
+        name: name,
+        assetName: name,
+        sources: [addCUri.toFilePath()],
+        optimizationLevel: optimizationLevel,
+        buildMode: .release,
+      );
+      await cbuilder.run(
+        input: buildInput,
+        output: buildOutput,
+        logger: logger,
+      );
+
+      final libUri = buildInput.outputDirectory.resolve(
+        OS.linux.libraryFileName(name, linkMode),
+      );
+      final machine = await readelfMachine(libUri.path);
+      expect(machine, contains(readElfMachine[target]));
+    });
   }
 }

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -38,19 +38,6 @@ void main() async {
     stderr.writeln("Install with 'brew install lld' on macOS.");
   }
 
-  final targets = [
-    (OS.macOS, Architecture.arm64),
-    (OS.macOS, Architecture.x64),
-    (OS.linux, Architecture.arm),
-    (OS.linux, Architecture.arm64),
-    (OS.linux, Architecture.ia32),
-    (OS.linux, Architecture.x64),
-
-    // Not supported by Apple Clang right now.
-    // (OS.linux, Architecture.riscv32),
-    // (OS.linux, Architecture.riscv64),
-  ];
-
   // Dont include 'mach-o' or 'Mach-O', different spelling is used.
   const objdumpFileFormat = {
     (OS.macOS, Architecture.arm64): 'arm64',
@@ -64,118 +51,168 @@ void main() async {
     (OS.linux, Architecture.riscv64): 'elf64-riscv64',
   };
 
-  const optimizationLevels = OptimizationLevel.values;
-  var selectOptimizationLevel = 0;
+  // These configurations are a selection of combinations of architectures,
+  // link modes, and optimization levels.
+  // We don't test the full cartesian product to keep the CI time manageable.
+  // When adding a new configuration, consider if it tests a new combination
+  // that is not yet covered by the existing tests.
+  final configurations = [
+    (
+      language: Language.c,
+      linkMode: DynamicLoadingBundled(),
+      os: OS.macOS,
+      arch: Architecture.arm64,
+      optimizationLevel: OptimizationLevel.o0,
+    ),
+    (
+      language: Language.objectiveC,
+      linkMode: StaticLinking(),
+      os: OS.macOS,
+      arch: Architecture.x64,
+      optimizationLevel: OptimizationLevel.o1,
+    ),
+    (
+      language: Language.c,
+      linkMode: StaticLinking(),
+      os: OS.linux,
+      arch: Architecture.arm,
+      optimizationLevel: OptimizationLevel.o2,
+    ),
+    (
+      language: Language.c,
+      linkMode: DynamicLoadingBundled(),
+      os: OS.linux,
+      arch: Architecture.arm64,
+      optimizationLevel: OptimizationLevel.o3,
+    ),
+    (
+      language: Language.c,
+      linkMode: StaticLinking(),
+      os: OS.linux,
+      arch: Architecture.ia32,
+      optimizationLevel: OptimizationLevel.oS,
+    ),
+    (
+      language: Language.c,
+      linkMode: DynamicLoadingBundled(),
+      os: OS.linux,
+      arch: Architecture.x64,
+      optimizationLevel: OptimizationLevel.unspecified,
+    ),
+    (
+      language: Language.objectiveC,
+      linkMode: DynamicLoadingBundled(),
+      os: OS.macOS,
+      arch: Architecture.arm64,
+      optimizationLevel: OptimizationLevel.o2,
+    ),
+    (
+      language: Language.c,
+      linkMode: StaticLinking(),
+      os: OS.macOS,
+      arch: Architecture.x64,
+      optimizationLevel: OptimizationLevel.o3,
+    ),
+  ];
 
-  for (final language in [Language.c, Language.objectiveC]) {
-    for (final linkMode in [DynamicLoadingBundled(), StaticLinking()]) {
-      for (final (os, arch) in targets) {
-        // Don't build Objective-C targets for linux.
-        if (language == .objectiveC && os == .linux) continue;
+  for (final (:language, :linkMode, :os, :arch, :optimizationLevel)
+      in configurations) {
+    test(
+      'CBuilder $linkMode $language library $os $arch $optimizationLevel',
+      () async {
+        final tempUri = await tempDirForTest();
+        final tempUri2 = await tempDirForTest();
+        final sourceUri = switch (language) {
+          .c => packageUri.resolve('test/cbuilder/testfiles/add/src/add.c'),
+          .objectiveC => packageUri.resolve(
+            'test/cbuilder/testfiles/add_objective_c/src/add.m',
+          ),
+          Language() => throw UnimplementedError(),
+        };
+        const name = 'add';
 
-        // Cycle through all optimization levels.
-        final optimizationLevel = optimizationLevels[selectOptimizationLevel];
-        selectOptimizationLevel =
-            (selectOptimizationLevel + 1) % optimizationLevels.length;
+        // When cross-compiling from MacOS, explicitly specify apple clang.
+        //
+        // The default tool-finding does not support macos cross compiling
+        // right now.
+        var chosenCCompiler = cCompiler;
+        if (os == .linux) {
+          // still respect the CI-provided compiler
+          chosenCCompiler ??= await resolveAppleToolchain();
+        }
 
-        test(
-          'CBuilder $linkMode $language library $os $arch $optimizationLevel',
-          () async {
-            final tempUri = await tempDirForTest();
-            final tempUri2 = await tempDirForTest();
-            final sourceUri = switch (language) {
-              .c => packageUri.resolve('test/cbuilder/testfiles/add/src/add.c'),
-              .objectiveC => packageUri.resolve(
-                'test/cbuilder/testfiles/add_objective_c/src/add.m',
-              ),
-              Language() => throw UnimplementedError(),
-            };
-            const name = 'add';
+        final buildInputBuilder = BuildInputBuilder()
+          ..setupShared(
+            packageName: name,
+            packageRoot: tempUri,
+            outputFile: tempUri.resolve('output.json'),
+            outputDirectoryShared: tempUri2,
+          )
+          ..config.setupBuild(linkingEnabled: false)
+          ..addExtension(
+            CodeAssetExtension(
+              targetOS: os,
+              targetArchitecture: arch,
+              linkModePreference: linkMode == DynamicLoadingBundled()
+                  ? .dynamic
+                  : .static,
+              cCompiler: chosenCCompiler,
+              macOS: MacOSCodeConfig(targetVersion: defaultMacOSVersion),
+            ),
+          );
+        final buildInput = buildInputBuilder.build();
+        final buildOutput = BuildOutputBuilder();
 
-            // When cross-compiling from MacOS, explicitly specify apple clang.
-            //
-            // The default tool-finding does not support macos cross compiling
-            // right now.
-            var chosenCCompiler = cCompiler;
-            if (os == .linux) {
-              // still respect the CI-provided compiler
-              chosenCCompiler ??= await resolveAppleToolchain();
-            }
-
-            final buildInputBuilder = BuildInputBuilder()
-              ..setupShared(
-                packageName: name,
-                packageRoot: tempUri,
-                outputFile: tempUri.resolve('output.json'),
-                outputDirectoryShared: tempUri2,
-              )
-              ..config.setupBuild(linkingEnabled: false)
-              ..addExtension(
-                CodeAssetExtension(
-                  targetOS: os,
-                  targetArchitecture: arch,
-                  linkModePreference: linkMode == DynamicLoadingBundled()
-                      ? .dynamic
-                      : .static,
-                  cCompiler: chosenCCompiler,
-                  macOS: MacOSCodeConfig(targetVersion: defaultMacOSVersion),
+        final cbuilder = CBuilder.library(
+          name: name,
+          assetName: name,
+          sources: [sourceUri.toFilePath()],
+          language: language,
+          optimizationLevel: optimizationLevel,
+          buildMode: .release,
+          flags: [
+            if (os == .linux)
+              switch (arch) {
+                .arm => '--target=arm-linux-gnueabihf',
+                .arm64 => '--target=aarch64-linux-gnu',
+                .ia32 => '--target=i686-linux-gnu',
+                .x64 => '--target=x86_64-linux-gnu',
+                .riscv32 => '--target=riscv32-linux-gnu',
+                .riscv64 => '--target=riscv64-linux-gnu',
+                _ => throw UnsupportedError(
+                  'Unexpected linux architecture: $arch',
                 ),
-              );
-            final buildInput = buildInputBuilder.build();
-            final buildOutput = BuildOutputBuilder();
-
-            final cbuilder = CBuilder.library(
-              name: name,
-              assetName: name,
-              sources: [sourceUri.toFilePath()],
-              language: language,
-              optimizationLevel: optimizationLevel,
-              buildMode: .release,
-              flags: [
-                if (os == .linux)
-                  switch (arch) {
-                    .arm => '--target=arm-linux-gnueabihf',
-                    .arm64 => '--target=aarch64-linux-gnu',
-                    .ia32 => '--target=i686-linux-gnu',
-                    .x64 => '--target=x86_64-linux-gnu',
-                    .riscv32 => '--target=riscv32-linux-gnu',
-                    .riscv64 => '--target=riscv64-linux-gnu',
-                    _ => throw UnsupportedError(
-                      'Unexpected linux architecture: $arch',
-                    ),
-                  },
-                // Only homebrew lld can link for linux, and we don't have a
-                // sysroot so we can't use stdlibs / C-runtime files.
-                if (os == .linux) ...[
-                  '--ld-path=$lldPath',
-                  '-nostartfiles',
-                  '-nostdlib',
-                ],
-              ],
-            );
-            await cbuilder.run(
-              input: buildInput,
-              output: buildOutput,
-              logger: logger,
-            );
-
-            final libUri = buildInput.outputDirectory.resolve(
-              os.libraryFileName(name, linkMode),
-            );
-            final result = await runProcess(
-              executable: Uri.file('objdump'),
-              arguments: ['-t', libUri.path],
-              logger: logger,
-            );
-            expect(result.exitCode, 0);
-            final machine = result.stdout
-                .split('\n')
-                .firstWhere((e) => e.contains('file format'));
-            expect(machine, contains(objdumpFileFormat[(os, arch)]));
-          },
+              },
+            // Only homebrew lld can link for linux, and we don't have a
+            // sysroot so we can't use stdlibs / C-runtime files.
+            if (os == .linux) ...[
+              '--ld-path=$lldPath',
+              '-nostartfiles',
+              '-nostdlib',
+            ],
+          ],
         );
-      }
-    }
+        await cbuilder.run(
+          input: buildInput,
+          output: buildOutput,
+          logger: logger,
+        );
+
+        final libUri = buildInput.outputDirectory.resolve(
+          os.libraryFileName(name, linkMode),
+        );
+        final result = await runProcess(
+          executable: Uri.file('objdump'),
+          arguments: ['-t', libUri.path],
+          logger: logger,
+        );
+        expect(result.exitCode, 0);
+        final machine = result.stdout
+            .split('\n')
+            .firstWhere((e) => e.contains('file format'));
+        expect(machine, contains(objdumpFileFormat[(os, arch)]));
+      },
+    );
   }
 
   const flutterMacOSLowestBestEffort = 12;

--- a/pkgs/native_toolchain_c/test/clinker/objects_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/objects_cross_android_test.dart
@@ -12,16 +12,44 @@ const Timeout longTimeout = Timeout(Duration(minutes: 5));
 
 void main() {
   const targetOS = OS.android;
-  final architectures = supportedArchitecturesFor(targetOS);
 
-  for (final apiLevel in [
-    flutterAndroidNdkVersionLowestSupported,
-    flutterAndroidNdkVersionHighestSupported,
-  ]) {
-    group('Android API$apiLevel:', () {
+  // These configurations are a selection of combinations of architectures
+  // and API levels.
+  // We don't test the full cartesian product to keep the CI time manageable.
+  // When adding a new configuration, consider if it tests a new combination
+  // that is not yet covered by the existing tests.
+  final configurations = [
+    (
+      architecture: Architecture.arm,
+      apiLevel: flutterAndroidNdkVersionLowestSupported,
+    ),
+    (
+      architecture: Architecture.arm64,
+      apiLevel: flutterAndroidNdkVersionHighestSupported,
+    ),
+    (
+      architecture: Architecture.ia32,
+      apiLevel: flutterAndroidNdkVersionLowestSupported,
+    ),
+    (
+      architecture: Architecture.x64,
+      apiLevel: flutterAndroidNdkVersionHighestSupported,
+    ),
+    (
+      architecture: Architecture.riscv64,
+      apiLevel: flutterAndroidNdkVersionLowestSupported,
+    ),
+    (
+      architecture: Architecture.arm64,
+      apiLevel: flutterAndroidNdkVersionLowestSupported,
+    ),
+  ];
+
+  for (final (:architecture, :apiLevel) in configurations) {
+    group('Android API$apiLevel ($architecture):', () {
       runObjectsTests(
         targetOS,
-        architectures,
+        [architecture],
         androidTargetNdkApi: apiLevel,
         timeout: longTimeout,
       );

--- a/pkgs/native_toolchain_c/test/clinker/objects_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/objects_cross_ios_test.dart
@@ -21,19 +21,28 @@ void main() {
 
   const targetOS = OS.iOS;
 
-  for (final iOSVersion in [
-    flutteriOSHighestBestEffort,
-    flutteriOSHighestSupported,
-  ]) {
-    for (final iOSTargetSdk in IOSSdk.values) {
-      group('$iOSTargetSdk $iOSVersion:', () {
-        runObjectsTests(
-          targetOS,
-          iOSSupportedArchitecturesFor(iOSTargetSdk),
-          iOSTargetVersion: iOSVersion,
-          iOSTargetSdk: iOSTargetSdk,
-        );
-      });
-    }
+  // These configurations are a selection of combinations of architectures
+  // and iOS versions.
+  // We don't test the full cartesian product to keep the CI time manageable.
+  // When adding a new configuration, consider if it tests a new combination
+  // that is not yet covered by the existing tests.
+  final configurations = [
+    (iOSTargetSdk: IOSSdk.iPhoneOS, iOSVersion: flutteriOSHighestBestEffort),
+    (
+      iOSTargetSdk: IOSSdk.iPhoneSimulator,
+      iOSVersion: flutteriOSHighestSupported,
+    ),
+    (iOSTargetSdk: IOSSdk.iPhoneOS, iOSVersion: flutteriOSHighestSupported),
+  ];
+
+  for (final (:iOSTargetSdk, :iOSVersion) in configurations) {
+    group('$iOSTargetSdk $iOSVersion:', () {
+      runObjectsTests(
+        targetOS,
+        iOSSupportedArchitecturesFor(iOSTargetSdk),
+        iOSTargetVersion: iOSVersion,
+        iOSTargetSdk: iOSTargetSdk,
+      );
+    });
   }
 }

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_cross_android_test.dart
@@ -11,18 +11,41 @@ import 'treeshake_helper.dart';
 void main() {
   const targetOS = OS.android;
 
-  for (final apiLevel in [
-    flutterAndroidNdkVersionLowestSupported,
-    flutterAndroidNdkVersionHighestSupported,
-  ]) {
-    for (final architecture in supportedArchitecturesFor(targetOS)) {
-      group('Android API$apiLevel ($architecture):', () {
-        runTreeshakeTests(
-          targetOS,
-          architecture,
-          androidTargetNdkApi: apiLevel,
-        );
-      });
-    }
+  // These configurations are a selection of combinations of architectures
+  // and API levels.
+  // We don't test the full cartesian product to keep the CI time manageable.
+  // When adding a new configuration, consider if it tests a new combination
+  // that is not yet covered by the existing tests.
+  final configurations = [
+    (
+      architecture: Architecture.arm,
+      apiLevel: flutterAndroidNdkVersionLowestSupported,
+    ),
+    (
+      architecture: Architecture.arm64,
+      apiLevel: flutterAndroidNdkVersionHighestSupported,
+    ),
+    (
+      architecture: Architecture.ia32,
+      apiLevel: flutterAndroidNdkVersionLowestSupported,
+    ),
+    (
+      architecture: Architecture.x64,
+      apiLevel: flutterAndroidNdkVersionHighestSupported,
+    ),
+    (
+      architecture: Architecture.riscv64,
+      apiLevel: flutterAndroidNdkVersionLowestSupported,
+    ),
+    (
+      architecture: Architecture.arm64,
+      apiLevel: flutterAndroidNdkVersionLowestSupported,
+    ),
+  ];
+
+  for (final (:architecture, :apiLevel) in configurations) {
+    group('Android API$apiLevel ($architecture):', () {
+      runTreeshakeTests(targetOS, architecture, androidTargetNdkApi: apiLevel);
+    });
   }
 }

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_cross_ios_test.dart
@@ -21,21 +21,42 @@ void main() {
 
   const targetOS = OS.iOS;
 
-  for (final iOSVersion in [
-    flutteriOSHighestBestEffort,
-    flutteriOSHighestSupported,
-  ]) {
-    for (final iOSTargetSdk in IOSSdk.values) {
-      for (final architecture in iOSSupportedArchitecturesFor(iOSTargetSdk)) {
-        group('$iOSTargetSdk $iOSVersion ($architecture):', () {
-          runTreeshakeTests(
-            targetOS,
-            architecture,
-            iOSTargetVersion: iOSVersion,
-            iOSTargetSdk: iOSTargetSdk,
-          );
-        });
-      }
-    }
+  // These configurations are a selection of combinations of architectures
+  // and iOS versions.
+  // We don't test the full cartesian product to keep the CI time manageable.
+  // When adding a new configuration, consider if it tests a new combination
+  // that is not yet covered by the existing tests.
+  final configurations = [
+    (
+      architecture: Architecture.arm64,
+      iOSTargetSdk: IOSSdk.iPhoneOS,
+      iOSVersion: flutteriOSHighestBestEffort,
+    ),
+    (
+      architecture: Architecture.arm64,
+      iOSTargetSdk: IOSSdk.iPhoneSimulator,
+      iOSVersion: flutteriOSHighestSupported,
+    ),
+    (
+      architecture: Architecture.x64,
+      iOSTargetSdk: IOSSdk.iPhoneSimulator,
+      iOSVersion: flutteriOSHighestBestEffort,
+    ),
+    (
+      architecture: Architecture.arm64,
+      iOSTargetSdk: IOSSdk.iPhoneOS,
+      iOSVersion: flutteriOSHighestSupported,
+    ),
+  ];
+
+  for (final (:architecture, :iOSTargetSdk, :iOSVersion) in configurations) {
+    group('$iOSTargetSdk $iOSVersion ($architecture):', () {
+      runTreeshakeTests(
+        targetOS,
+        architecture,
+        iOSTargetVersion: iOSVersion,
+        iOSTargetSdk: iOSTargetSdk,
+      );
+    });
   }
 }


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/3182

   * `cbuilder_cross_android_test.dart`: 22 → 9 tests
   * `cbuilder_cross_ios_test.dart`: 22 → 10 tests
   * `cbuilder_cross_linux_host_test.dart`: 10 → 6 tests
   * `cbuilder_cross_macos_host_test.dart`: 20 → 12 tests
   * `treeshake_cross_android_test.dart`: 30 → 18 tests
   * `treeshake_cross_ios_test.dart`: 18 → 12 tests
   * `objects_cross_android_test.dart`: 10 → 6 tests
   * `objects_cross_ios_test.dart`: 6 → 4 tests