### PR TITLE
[native_toolchain_c] Use pair-wise testing

### DIFF
--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -30,4 +30,6 @@ dev_dependencies:
   native_test_helpers:
     path: ../native_test_helpers/
   test: ^1.25.15
+  test_case_selector:
+    path: ../test_case_selector/
   test_descriptor: ^2.0.2

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -8,64 +8,60 @@ import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:test/test.dart';
+import 'package:test_case_selector/test_case_selector.dart';
 
 import '../helpers.dart';
 
 const Timeout longTimeout = Timeout(Duration(minutes: 5));
 
+/// This comment is generated. To regenerate, run:
+/// `REGENERATE_TEST_CONFIGS=true dart test`
+///
+/// | #   | Architecture | Link Mode | Optimization Level | Android Api Level |
+/// |-----|--------------|-----------|--------------------|-------------------|
+/// | 1   | arm          | bundled   | unspecified        | 34                |
+/// | 2   | arm          | static    | O2                 | 21                |
+/// | 3   | arm64        | bundled   | O0                 | 34                |
+/// | 4   | arm64        | static    | Os                 | 21                |
+/// | 5   | ia32         | bundled   | O1                 | 21                |
+/// | 6   | ia32         | static    | O2                 | 34                |
+/// | 7   | riscv64      | bundled   | O0                 | 21                |
+/// | 8   | riscv64      | static    | O1                 | 34                |
+/// | 9   | x64          | bundled   | O3                 | 21                |
+/// | 10  | x64          | static    | O3                 | 34                |
+final configurations =
+    TestCaseSelector(
+      dimensions: {
+        Architecture: [
+          Architecture.arm,
+          Architecture.arm64,
+          Architecture.ia32,
+          Architecture.x64,
+          Architecture.riscv64,
+        ],
+        LinkMode: [DynamicLoadingBundled(), StaticLinking()],
+        OptimizationLevel: OptimizationLevel.values,
+        AndroidApiLevel: [
+          AndroidApiLevel.flutterLowestSupported,
+          AndroidApiLevel.flutterHighestSupported,
+        ],
+      },
+      interactionGroups: [
+        {Architecture, LinkMode},
+        {Architecture, AndroidApiLevel},
+      ],
+    ).selectAndValidate(
+      tableUri: packageUri.resolve(
+        'test/cbuilder/cbuilder_cross_android_test.dart',
+      ),
+    );
 void main() {
-  // These configurations are a selection of combinations of architectures,
-  // link modes, and optimization levels.
-  // We don't test the full cartesian product to keep the CI time manageable.
-  // When adding a new configuration, consider if it tests a new combination
-  // that is not yet covered by the existing tests.
-  final configurations = [
-    (
-      architecture: Architecture.arm,
-      apiLevel: flutterAndroidNdkVersionLowestSupported,
-      linkMode: DynamicLoadingBundled(),
-      optimizationLevel: OptimizationLevel.o0,
-    ),
-    (
-      architecture: Architecture.arm64,
-      apiLevel: flutterAndroidNdkVersionHighestSupported,
-      linkMode: StaticLinking(),
-      optimizationLevel: OptimizationLevel.o1,
-    ),
-    (
-      architecture: Architecture.ia32,
-      apiLevel: flutterAndroidNdkVersionLowestSupported,
-      linkMode: StaticLinking(),
-      optimizationLevel: OptimizationLevel.o2,
-    ),
-    (
-      architecture: Architecture.x64,
-      apiLevel: flutterAndroidNdkVersionHighestSupported,
-      linkMode: DynamicLoadingBundled(),
-      optimizationLevel: OptimizationLevel.o3,
-    ),
-    (
-      architecture: Architecture.riscv64,
-      apiLevel: flutterAndroidNdkVersionLowestSupported,
-      linkMode: DynamicLoadingBundled(),
-      optimizationLevel: OptimizationLevel.oS,
-    ),
-    (
-      architecture: Architecture.arm64,
-      apiLevel: flutterAndroidNdkVersionLowestSupported,
-      linkMode: StaticLinking(),
-      optimizationLevel: OptimizationLevel.unspecified,
-    ),
-    (
-      architecture: Architecture.arm,
-      apiLevel: flutterAndroidNdkVersionHighestSupported,
-      linkMode: DynamicLoadingBundled(),
-      optimizationLevel: OptimizationLevel.o2,
-    ),
-  ];
+  for (final config in configurations) {
+    final architecture = config.get<Architecture>();
+    final linkMode = config.get<LinkMode>();
+    final optimizationLevel = config.get<OptimizationLevel>();
+    final apiLevel = config.get<AndroidApiLevel>().value;
 
-  for (final (:architecture, :apiLevel, :linkMode, :optimizationLevel)
-      in configurations) {
     test(
       'CBuilder $linkMode library $architecture minSdkVersion $apiLevel '
       '$optimizationLevel',
@@ -90,8 +86,8 @@ void main() {
   test('CBuilder API levels binary difference', timeout: longTimeout, () async {
     const target = Architecture.arm64;
     final linkMode = DynamicLoadingBundled();
-    const apiLevel1 = flutterAndroidNdkVersionLowestSupported;
-    const apiLevel2 = flutterAndroidNdkVersionHighestSupported;
+    final apiLevel1 = AndroidApiLevel.flutterLowestSupported.value;
+    final apiLevel2 = AndroidApiLevel.flutterHighestSupported.value;
     final tempUri = await tempDirForTest();
     final out1Uri = tempUri.resolve('out1/');
     final out2Uri = tempUri.resolve('out2/');
@@ -137,7 +133,7 @@ void main() {
             targetArchitecture: Architecture.arm64,
             cCompiler: cCompiler,
             android: AndroidCodeConfig(
-              targetNdkApi: flutterAndroidNdkVersionLowestSupported,
+              targetNdkApi: AndroidApiLevel.flutterLowestSupported.value,
             ),
             linkModePreference: .dynamic,
           ),
@@ -176,7 +172,7 @@ void main() {
   test('page size override', timeout: longTimeout, () async {
     const target = Architecture.arm64;
     final linkMode = DynamicLoadingBundled();
-    const apiLevel1 = flutterAndroidNdkVersionLowestSupported;
+    final apiLevel1 = AndroidApiLevel.flutterLowestSupported.value;
     final tempUri = await tempDirForTest();
     final outUri = tempUri.resolve('out1/');
     await Directory.fromUri(outUri).create();

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_ios_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: lines_longer_than_80_chars
+
 @TestOn('mac-os')
 @OnPlatform({'mac-os': Timeout.factor(2)})
 library;
@@ -13,8 +15,58 @@ import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:native_toolchain_c/src/utils/run_process.dart';
 import 'package:test/test.dart';
+import 'package:test_case_selector/test_case_selector.dart';
 
 import '../helpers.dart';
+
+const name = 'add';
+
+/// This comment is generated. To regenerate, run:
+/// `REGENERATE_TEST_CONFIGS=true dart test`
+///
+/// | #   | Architecture | IOSSdk          | IOSVersion | Link Mode | Language    | Optimization Level |
+/// |-----|--------------|-----------------|------------|-----------|-------------|--------------------|
+/// | 1   | arm64        | iphoneos        | 16         | bundled   | c           | Os                 |
+/// | 2   | arm64        | iphoneos        | 16         | static    | c           | unspecified        |
+/// | 3   | arm64        | iphoneos        | 17         | bundled   | c           | O3                 |
+/// | 4   | arm64        | iphonesimulator | 16         | static    | objective c | O0                 |
+/// | 5   | x64          | iphonesimulator | 17         | bundled   | objective c | O1                 |
+/// | 6   | x64          | iphonesimulator | 17         | static    | c           | O2                 |
+final configurations =
+    TestCaseSelector(
+      dimensions: {
+        Architecture: [Architecture.arm64, Architecture.x64],
+        IOSSdk: [IOSSdk.iPhoneOS, IOSSdk.iPhoneSimulator],
+        IOSVersion: [
+          IOSVersion.flutterHighestBestEffort,
+          IOSVersion.flutterHighestSupported,
+        ],
+        LinkMode: [DynamicLoadingBundled(), StaticLinking()],
+        Language: [Language.c, Language.objectiveC],
+        OptimizationLevel: OptimizationLevel.values,
+      },
+      interactionGroups: [
+        {Architecture, IOSSdk},
+        {IOSSdk, IOSVersion},
+        {Architecture, LinkMode},
+        {Architecture, Language},
+        {Language, LinkMode},
+        {IOSSdk, LinkMode},
+        {IOSVersion, LinkMode},
+        {Language, IOSVersion},
+      ],
+      isValid: (config) {
+        if (config.get<IOSSdk>() == IOSSdk.iPhoneOS &&
+            config.get<Architecture>() == Architecture.x64) {
+          return false;
+        }
+        return true;
+      },
+    ).selectAndValidate(
+      tableUri: packageUri.resolve(
+        'test/cbuilder/cbuilder_cross_ios_test.dart',
+      ),
+    );
 
 void main() {
   if (!Platform.isMacOS) {
@@ -22,79 +74,24 @@ void main() {
     return;
   }
 
-  const name = 'add';
+  for (final config in configurations) {
+    final architecture = config.get<Architecture>();
+    final linkMode = config.get<LinkMode>();
+    final language = config.get<Language>();
+    final targetIOSSdk = config.get<IOSSdk>();
+    final iOSVersion = config.get<IOSVersion>();
+    final optimizationLevel = config.get<OptimizationLevel>();
 
-  // These configurations are a selection of combinations of architectures,
-  // link modes, and optimization levels.
-  // We don't test the full cartesian product to keep the CI time manageable.
-  // When adding a new configuration, consider if it tests a new combination
-  // that is not yet covered by the existing tests.
-  final configurations = [
-    (
-      language: Language.c,
-      linkMode: DynamicLoadingBundled(),
-      targetIOSSdk: IOSSdk.iPhoneOS,
-      target: Architecture.arm64,
-      hasInstallName: false,
-      optimizationLevel: OptimizationLevel.o0,
-    ),
-    (
-      language: Language.objectiveC,
-      linkMode: StaticLinking(),
-      targetIOSSdk: IOSSdk.iPhoneSimulator,
-      target: Architecture.x64,
-      hasInstallName: false,
-      optimizationLevel: OptimizationLevel.o1,
-    ),
-    (
-      language: Language.c,
-      linkMode: StaticLinking(),
-      targetIOSSdk: IOSSdk.iPhoneSimulator,
-      target: Architecture.arm64,
-      hasInstallName: false,
-      optimizationLevel: OptimizationLevel.o2,
-    ),
-    (
-      language: Language.objectiveC,
-      linkMode: DynamicLoadingBundled(),
-      targetIOSSdk: IOSSdk.iPhoneOS,
-      target: Architecture.arm64,
-      hasInstallName: true,
-      optimizationLevel: OptimizationLevel.o3,
-    ),
-    (
-      language: Language.c,
-      linkMode: DynamicLoadingBundled(),
-      targetIOSSdk: IOSSdk.iPhoneSimulator,
-      target: Architecture.x64,
-      hasInstallName: true,
-      optimizationLevel: OptimizationLevel.oS,
-    ),
-    (
-      language: Language.objectiveC,
-      linkMode: StaticLinking(),
-      targetIOSSdk: IOSSdk.iPhoneOS,
-      target: Architecture.arm64,
-      hasInstallName: false,
-      optimizationLevel: OptimizationLevel.unspecified,
-    ),
-  ];
+    final hasInstallName =
+        linkMode == DynamicLoadingBundled() &&
+        architecture == Architecture.arm64;
 
-  for (final (
-        :language,
-        :linkMode,
-        :targetIOSSdk,
-        :target,
-        :hasInstallName,
-        :optimizationLevel,
-      )
-      in configurations) {
     final libName = OS.iOS.libraryFileName(name, linkMode);
     final installName = hasInstallName
         ? Uri.file('@executable_path/Frameworks/$libName')
         : null;
     test(
-      'CBuilder $linkMode $language library $targetIOSSdk $target'
+      'CBuilder $targetIOSSdk $architecture $iOSVersion $linkMode $language'
               ' ${installName ?? ''} $optimizationLevel'
           .trim(),
       () async {
@@ -119,13 +116,13 @@ void main() {
           ..addExtension(
             CodeAssetExtension(
               targetOS: .iOS,
-              targetArchitecture: target,
+              targetArchitecture: architecture,
               linkModePreference: linkMode == DynamicLoadingBundled()
                   ? .dynamic
                   : .static,
               iOS: IOSCodeConfig(
                 targetSdk: targetIOSSdk,
-                targetVersion: flutteriOSHighestBestEffort,
+                targetVersion: iOSVersion.value,
               ),
               cCompiler: cCompiler,
             ),
@@ -159,7 +156,7 @@ void main() {
         final machine = objdumpResult.stdout
             .split('\n')
             .firstWhere((e) => e.contains('file format'));
-        expect(machine, contains(objdumpFileFormatIOS[target]));
+        expect(machine, contains(objdumpFileFormatIOS[architecture]));
 
         final otoolResult = await runProcess(
           executable: Uri.file('otool'),
@@ -167,6 +164,7 @@ void main() {
           logger: logger,
         );
         expect(otoolResult.exitCode, 0);
+        expect(otoolResult.stdout, contains('minos $iOSVersion.0'));
         // As of native_assets_cli 0.10.0, the min target OS version is
         // always being passed in.
         expect(otoolResult.stdout, isNot(contains('LC_VERSION_MIN_IPHONEOS')));
@@ -209,85 +207,4 @@ void main() {
       },
     );
   }
-
-  for (final iosVersion in [
-    flutteriOSHighestBestEffort,
-    flutteriOSHighestSupported,
-  ]) {
-    for (final linkMode in [DynamicLoadingBundled(), StaticLinking()]) {
-      test('$linkMode ios min version $iosVersion', () async {
-        const target = Architecture.arm64;
-        final tempUri = await tempDirForTest();
-        final out1Uri = tempUri.resolve('out1/');
-        await Directory.fromUri(out1Uri).create();
-        final out2Uri = tempUri.resolve('out1/');
-        await Directory.fromUri(out2Uri).create();
-        final lib1Uri = await buildLib(
-          out1Uri,
-          out2Uri,
-          target,
-          iosVersion,
-          linkMode,
-        );
-
-        final otoolResult = await runProcess(
-          executable: Uri.file('otool'),
-          arguments: ['-l', lib1Uri.path],
-          logger: logger,
-        );
-        expect(otoolResult.exitCode, 0);
-        expect(otoolResult.stdout, contains('minos $iosVersion.0'));
-      });
-    }
-  }
-}
-
-Future<Uri> buildLib(
-  Uri tempUri,
-  Uri tempUri2,
-  Architecture targetArchitecture,
-  int targetIOSVersion,
-  LinkMode linkMode,
-) async {
-  final addCUri = packageUri.resolve('test/cbuilder/testfiles/add/src/add.c');
-  const name = 'add';
-
-  final buildInputBuilder = BuildInputBuilder()
-    ..setupShared(
-      packageName: name,
-      packageRoot: tempUri,
-      outputFile: tempUri.resolve('output.json'),
-      outputDirectoryShared: tempUri2,
-    )
-    ..config.setupBuild(linkingEnabled: false)
-    ..addExtension(
-      CodeAssetExtension(
-        targetOS: .iOS,
-        targetArchitecture: targetArchitecture,
-        linkModePreference: linkMode == DynamicLoadingBundled()
-            ? .dynamic
-            : .static,
-        iOS: IOSCodeConfig(
-          targetSdk: IOSSdk.iPhoneOS,
-          targetVersion: targetIOSVersion,
-        ),
-        cCompiler: cCompiler,
-      ),
-    );
-
-  final buildInput = buildInputBuilder.build();
-  final buildOutput = BuildOutputBuilder();
-
-  final cbuilder = CBuilder.library(
-    name: name,
-    assetName: name,
-    sources: [addCUri.toFilePath()],
-    buildMode: .release,
-  );
-  await cbuilder.run(input: buildInput, output: buildOutput, logger: logger);
-
-  final libUri = buildInput.outputDirectory.resolve(
-    OS.iOS.libraryFileName(name, linkMode),
-  );
-  return libUri;
 }

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_linux_host_test.dart
@@ -11,8 +11,46 @@ import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:test/test.dart';
+import 'package:test_case_selector/test_case_selector.dart';
 
 import '../helpers.dart';
+
+/// This comment is generated. To regenerate, run:
+/// `REGENERATE_TEST_CONFIGS=true dart test`
+///
+/// | #   | Architecture | Link Mode | Optimization Level |
+/// |-----|--------------|-----------|--------------------|
+/// | 1   | arm          | bundled   | unspecified        |
+/// | 2   | arm          | static    | O0                 |
+/// | 3   | arm64        | bundled   | O2                 |
+/// | 4   | arm64        | static    | unspecified        |
+/// | 5   | ia32         | bundled   | O3                 |
+/// | 6   | ia32         | static    | Os                 |
+/// | 7   | riscv64      | bundled   | O0                 |
+/// | 8   | riscv64      | static    | O2                 |
+/// | 9   | x64          | bundled   | O1                 |
+/// | 10  | x64          | static    | O2                 |
+final configurations =
+    TestCaseSelector(
+      dimensions: {
+        Architecture: [
+          Architecture.arm,
+          Architecture.arm64,
+          Architecture.ia32,
+          Architecture.x64,
+          Architecture.riscv64,
+        ],
+        LinkMode: [DynamicLoadingBundled(), StaticLinking()],
+        OptimizationLevel: OptimizationLevel.values,
+      },
+      interactionGroups: [
+        {Architecture, LinkMode},
+      ],
+    ).selectAndValidate(
+      tableUri: packageUri.resolve(
+        'test/cbuilder/cbuilder_cross_linux_host_test.dart',
+      ),
+    );
 
 void main() {
   if (!Platform.isLinux) {
@@ -20,46 +58,12 @@ void main() {
     return;
   }
 
-  // These configurations are a selection of combinations of architectures,
-  // link modes, and optimization levels.
-  // We don't test the full cartesian product to keep the CI time manageable.
-  // When adding a new configuration, consider if it tests a new combination
-  // that is not yet covered by the existing tests.
-  final configurations = [
-    (
-      linkMode: DynamicLoadingBundled(),
-      target: Architecture.arm,
-      optimizationLevel: OptimizationLevel.o0,
-    ),
-    (
-      linkMode: StaticLinking(),
-      target: Architecture.arm64,
-      optimizationLevel: OptimizationLevel.o1,
-    ),
-    (
-      linkMode: DynamicLoadingBundled(),
-      target: Architecture.ia32,
-      optimizationLevel: OptimizationLevel.o2,
-    ),
-    (
-      linkMode: StaticLinking(),
-      target: Architecture.x64,
-      optimizationLevel: OptimizationLevel.o3,
-    ),
-    (
-      linkMode: DynamicLoadingBundled(),
-      target: Architecture.riscv64,
-      optimizationLevel: OptimizationLevel.oS,
-    ),
-    (
-      linkMode: StaticLinking(),
-      target: Architecture.arm,
-      optimizationLevel: OptimizationLevel.unspecified,
-    ),
-  ];
+  for (final config in configurations) {
+    final linkMode = config.get<LinkMode>();
+    final target = config.get<Architecture>();
+    final optimizationLevel = config.get<OptimizationLevel>();
 
-  for (final (:linkMode, :target, :optimizationLevel) in configurations) {
-    test('CBuilder $linkMode library $target $optimizationLevel', () async {
+    test('CBuilder $target $linkMode $optimizationLevel', () async {
       final tempUri = await tempDirForTest();
       final tempUri2 = await tempDirForTest();
       final addCUri = packageUri.resolve(

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_macos_host_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: lines_longer_than_80_chars
+
 @TestOn('mac-os')
 @OnPlatform({'mac-os': Timeout.factor(2)})
 library;
@@ -17,8 +19,72 @@ import 'package:native_toolchain_c/src/native_toolchain/clang.dart';
 import 'package:native_toolchain_c/src/tool/tool_resolver.dart';
 import 'package:native_toolchain_c/src/utils/run_process.dart';
 import 'package:test/test.dart';
+import 'package:test_case_selector/test_case_selector.dart';
 
 import '../helpers.dart';
+
+// Dont include 'mach-o' or 'Mach-O', different spelling is used.
+const objdumpFileFormat = {
+  (OS.macOS, Architecture.arm64): 'arm64',
+  (OS.macOS, Architecture.x64): '64-bit x86-64',
+  (OS.linux, Architecture.arm): 'elf32-littlearm',
+  (OS.linux, Architecture.arm64): 'elf64-littleaarch64',
+  (OS.linux, Architecture.ia32): 'elf32-i386',
+  (OS.linux, Architecture.x64): 'elf64-x86-64',
+  (OS.linux, Architecture.riscv32): 'elf32-riscv32',
+  (OS.linux, Architecture.riscv64): 'elf64-riscv64',
+};
+
+/// This comment is generated. To regenerate, run:
+/// `REGENERATE_TEST_CONFIGS=true dart test`
+///
+/// | #   | OS    | Architecture | Link Mode | Language    | Optimization Level |
+/// |-----|-------|--------------|-----------|-------------|--------------------|
+/// | 1   | linux | arm          | bundled   | c           | O2                 |
+/// | 2   | linux | arm          | static    | c           | O0                 |
+/// | 3   | linux | arm64        | static    | c           | O2                 |
+/// | 4   | linux | ia32         | bundled   | c           | Os                 |
+/// | 5   | linux | ia32         | static    | c           | O1                 |
+/// | 6   | linux | x64          | static    | c           | unspecified        |
+/// | 7   | macos | arm64        | bundled   | c           | O3                 |
+/// | 8   | macos | x64          | bundled   | objective c | O1                 |
+final configurations =
+    TestCaseSelector(
+      dimensions: {
+        OS: [OS.macOS, OS.linux],
+        Architecture: [
+          Architecture.arm,
+          Architecture.arm64,
+          Architecture.ia32,
+          Architecture.x64,
+          // Risc-V not supported by Apple Clang right now.
+        ],
+        LinkMode: [DynamicLoadingBundled(), StaticLinking()],
+        Language: [Language.c, Language.objectiveC],
+        OptimizationLevel: OptimizationLevel.values,
+      },
+      interactionGroups: [
+        {OS, Architecture},
+        {Architecture, LinkMode},
+        {OS, Language},
+      ],
+      isValid: (config) {
+        final os = config.get<OS>();
+        final arch = config.get<Architecture>();
+        final language = config.get<Language>();
+        if (!objdumpFileFormat.containsKey((os, arch))) {
+          return false;
+        }
+        if (os == OS.linux && language == Language.objectiveC) {
+          return false;
+        }
+        return true;
+      },
+    ).selectAndValidate(
+      tableUri: packageUri.resolve(
+        'test/cbuilder/cbuilder_cross_macos_host_test.dart',
+      ),
+    );
 
 void main() async {
   if (!Platform.isMacOS) {
@@ -38,87 +104,20 @@ void main() async {
     stderr.writeln("Install with 'brew install lld' on macOS.");
   }
 
-  // Dont include 'mach-o' or 'Mach-O', different spelling is used.
-  const objdumpFileFormat = {
-    (OS.macOS, Architecture.arm64): 'arm64',
-    (OS.macOS, Architecture.x64): '64-bit x86-64',
-    (OS.linux, Architecture.arm): 'elf32-littlearm',
-    (OS.linux, Architecture.arm64): 'elf64-littleaarch64',
-    (OS.linux, Architecture.ia32): 'elf32-i386',
-    (OS.linux, Architecture.x64): 'elf64-x86-64',
+  if (!Platform.isMacOS) {
+    // Avoid needing status files on Dart SDK CI.
+    return;
+  }
 
-    (OS.linux, Architecture.riscv32): 'elf32-riscv32',
-    (OS.linux, Architecture.riscv64): 'elf64-riscv64',
-  };
+  for (final config in configurations) {
+    final language = config.get<Language>();
+    final linkMode = config.get<LinkMode>();
+    final os = config.get<OS>();
+    final arch = config.get<Architecture>();
+    final optimizationLevel = config.get<OptimizationLevel>();
 
-  // These configurations are a selection of combinations of architectures,
-  // link modes, and optimization levels.
-  // We don't test the full cartesian product to keep the CI time manageable.
-  // When adding a new configuration, consider if it tests a new combination
-  // that is not yet covered by the existing tests.
-  final configurations = [
-    (
-      language: Language.c,
-      linkMode: DynamicLoadingBundled(),
-      os: OS.macOS,
-      arch: Architecture.arm64,
-      optimizationLevel: OptimizationLevel.o0,
-    ),
-    (
-      language: Language.objectiveC,
-      linkMode: StaticLinking(),
-      os: OS.macOS,
-      arch: Architecture.x64,
-      optimizationLevel: OptimizationLevel.o1,
-    ),
-    (
-      language: Language.c,
-      linkMode: StaticLinking(),
-      os: OS.linux,
-      arch: Architecture.arm,
-      optimizationLevel: OptimizationLevel.o2,
-    ),
-    (
-      language: Language.c,
-      linkMode: DynamicLoadingBundled(),
-      os: OS.linux,
-      arch: Architecture.arm64,
-      optimizationLevel: OptimizationLevel.o3,
-    ),
-    (
-      language: Language.c,
-      linkMode: StaticLinking(),
-      os: OS.linux,
-      arch: Architecture.ia32,
-      optimizationLevel: OptimizationLevel.oS,
-    ),
-    (
-      language: Language.c,
-      linkMode: DynamicLoadingBundled(),
-      os: OS.linux,
-      arch: Architecture.x64,
-      optimizationLevel: OptimizationLevel.unspecified,
-    ),
-    (
-      language: Language.objectiveC,
-      linkMode: DynamicLoadingBundled(),
-      os: OS.macOS,
-      arch: Architecture.arm64,
-      optimizationLevel: OptimizationLevel.o2,
-    ),
-    (
-      language: Language.c,
-      linkMode: StaticLinking(),
-      os: OS.macOS,
-      arch: Architecture.x64,
-      optimizationLevel: OptimizationLevel.o3,
-    ),
-  ];
-
-  for (final (:language, :linkMode, :os, :arch, :optimizationLevel)
-      in configurations) {
     test(
-      'CBuilder $linkMode $language library $os $arch $optimizationLevel',
+      'CBuilder $os $arch $linkMode $language $optimizationLevel',
       () async {
         final tempUri = await tempDirForTest();
         final tempUri2 = await tempDirForTest();
@@ -212,15 +211,13 @@ void main() async {
             .firstWhere((e) => e.contains('file format'));
         expect(machine, contains(objdumpFileFormat[(os, arch)]));
       },
+      skip: os == OS.linux && !lldAvailable ? 'ld.lld not available' : null,
     );
   }
 
-  const flutterMacOSLowestBestEffort = 12;
-  const flutterMacOSLowestSupported = 13;
-
   for (final macosVersion in [
-    flutterMacOSLowestBestEffort,
-    flutterMacOSLowestSupported,
+    MacOSVersion.flutterLowestBestEffort,
+    MacOSVersion.flutterLowestSupported,
   ]) {
     for (final linkMode in [DynamicLoadingBundled(), StaticLinking()]) {
       test('$linkMode macos min version $macosVersion', () async {
@@ -229,12 +226,12 @@ void main() async {
         final out1Uri = tempUri.resolve('out1/');
         await Directory.fromUri(out1Uri).create();
         final out2Uri = tempUri.resolve('out2/');
-        await Directory.fromUri(out1Uri).create();
+        await Directory.fromUri(out2Uri).create();
         final lib1Uri = await buildLib(
           out1Uri,
           out2Uri,
           target,
-          macosVersion,
+          macosVersion.value,
           linkMode,
         );
 

--- a/pkgs/native_toolchain_c/test/clinker/objects_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/objects_cross_android_test.dart
@@ -4,48 +4,51 @@
 
 import 'package:code_assets/code_assets.dart';
 import 'package:test/test.dart';
+import 'package:test_case_selector/test_case_selector.dart';
 
 import '../helpers.dart';
 import 'objects_helper.dart';
 
 const Timeout longTimeout = Timeout(Duration(minutes: 5));
+const targetOS = OS.android;
+
+/// This comment is generated. To regenerate, run:
+/// `REGENERATE_TEST_CONFIGS=true dart test`
+///
+/// | #   | Architecture | Android Api Level |
+/// |-----|--------------|-------------------|
+/// | 1   | arm          | 34                |
+/// | 2   | arm64        | 34                |
+/// | 3   | ia32         | 34                |
+/// | 4   | riscv64      | 21                |
+/// | 5   | x64          | 34                |
+final configurations =
+    TestCaseSelector(
+      dimensions: {
+        Architecture: [
+          Architecture.arm,
+          Architecture.arm64,
+          Architecture.ia32,
+          Architecture.x64,
+          Architecture.riscv64,
+        ],
+        AndroidApiLevel: [
+          AndroidApiLevel.flutterLowestSupported,
+          AndroidApiLevel.flutterHighestSupported,
+        ],
+      },
+      interactionGroups: [],
+    ).selectAndValidate(
+      tableUri: packageUri.resolve(
+        'test/clinker/objects_cross_android_test.dart',
+      ),
+    );
 
 void main() {
-  const targetOS = OS.android;
+  for (final config in configurations) {
+    final architecture = config.get<Architecture>();
+    final apiLevel = config.get<AndroidApiLevel>().value;
 
-  // These configurations are a selection of combinations of architectures
-  // and API levels.
-  // We don't test the full cartesian product to keep the CI time manageable.
-  // When adding a new configuration, consider if it tests a new combination
-  // that is not yet covered by the existing tests.
-  final configurations = [
-    (
-      architecture: Architecture.arm,
-      apiLevel: flutterAndroidNdkVersionLowestSupported,
-    ),
-    (
-      architecture: Architecture.arm64,
-      apiLevel: flutterAndroidNdkVersionHighestSupported,
-    ),
-    (
-      architecture: Architecture.ia32,
-      apiLevel: flutterAndroidNdkVersionLowestSupported,
-    ),
-    (
-      architecture: Architecture.x64,
-      apiLevel: flutterAndroidNdkVersionHighestSupported,
-    ),
-    (
-      architecture: Architecture.riscv64,
-      apiLevel: flutterAndroidNdkVersionLowestSupported,
-    ),
-    (
-      architecture: Architecture.arm64,
-      apiLevel: flutterAndroidNdkVersionLowestSupported,
-    ),
-  ];
-
-  for (final (:architecture, :apiLevel) in configurations) {
     group('Android API$apiLevel ($architecture):', () {
       runObjectsTests(
         targetOS,

--- a/pkgs/native_toolchain_c/test/clinker/objects_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/objects_cross_ios_test.dart
@@ -9,9 +9,33 @@ import 'dart:io';
 
 import 'package:code_assets/code_assets.dart';
 import 'package:test/test.dart';
+import 'package:test_case_selector/test_case_selector.dart';
 
 import '../helpers.dart';
 import 'objects_helper.dart';
+
+const targetOS = OS.iOS;
+
+/// This comment is generated. To regenerate, run:
+/// `REGENERATE_TEST_CONFIGS=true dart test`
+///
+/// | #   | IOSSdk          | IOSVersion |
+/// |-----|-----------------|------------|
+/// | 1   | iphoneos        | 16         |
+/// | 2   | iphonesimulator | 17         |
+final configurations =
+    TestCaseSelector(
+      dimensions: {
+        IOSSdk: [IOSSdk.iPhoneOS, IOSSdk.iPhoneSimulator],
+        IOSVersion: [
+          IOSVersion.flutterHighestBestEffort,
+          IOSVersion.flutterHighestSupported,
+        ],
+      },
+      interactionGroups: [],
+    ).selectAndValidate(
+      tableUri: packageUri.resolve('test/clinker/objects_cross_ios_test.dart'),
+    );
 
 void main() {
   if (!Platform.isMacOS) {
@@ -19,23 +43,10 @@ void main() {
     return;
   }
 
-  const targetOS = OS.iOS;
+  for (final config in configurations) {
+    final iOSTargetSdk = config.get<IOSSdk>();
+    final iOSVersion = config.get<IOSVersion>().value;
 
-  // These configurations are a selection of combinations of architectures
-  // and iOS versions.
-  // We don't test the full cartesian product to keep the CI time manageable.
-  // When adding a new configuration, consider if it tests a new combination
-  // that is not yet covered by the existing tests.
-  final configurations = [
-    (iOSTargetSdk: IOSSdk.iPhoneOS, iOSVersion: flutteriOSHighestBestEffort),
-    (
-      iOSTargetSdk: IOSSdk.iPhoneSimulator,
-      iOSVersion: flutteriOSHighestSupported,
-    ),
-    (iOSTargetSdk: IOSSdk.iPhoneOS, iOSVersion: flutteriOSHighestSupported),
-  ];
-
-  for (final (:iOSTargetSdk, :iOSVersion) in configurations) {
     group('$iOSTargetSdk $iOSVersion:', () {
       runObjectsTests(
         targetOS,

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_cross_android_test.dart
@@ -2,48 +2,54 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: lines_longer_than_80_chars
+
 import 'package:code_assets/code_assets.dart';
 import 'package:test/test.dart';
+import 'package:test_case_selector/test_case_selector.dart';
 
 import '../helpers.dart';
 import 'treeshake_helper.dart';
 
+const targetOS = OS.android;
+
+/// This comment is generated. To regenerate, run:
+/// `REGENERATE_TEST_CONFIGS=true dart test`
+///
+/// | #   | Architecture | Android Api Level |
+/// |-----|--------------|-------------------|
+/// | 1   | arm          | 34                |
+/// | 2   | arm64        | 34                |
+/// | 3   | ia32         | 34                |
+/// | 4   | riscv64      | 21                |
+/// | 5   | x64          | 34                |
+final configurations =
+    TestCaseSelector(
+      dimensions: {
+        Architecture: [
+          Architecture.arm,
+          Architecture.arm64,
+          Architecture.ia32,
+          Architecture.x64,
+          Architecture.riscv64,
+        ],
+        AndroidApiLevel: [
+          AndroidApiLevel.flutterLowestSupported,
+          AndroidApiLevel.flutterHighestSupported,
+        ],
+      },
+      interactionGroups: [],
+    ).selectAndValidate(
+      tableUri: packageUri.resolve(
+        'test/clinker/treeshake_cross_android_test.dart',
+      ),
+    );
+
 void main() {
-  const targetOS = OS.android;
+  for (final config in configurations) {
+    final architecture = config.get<Architecture>();
+    final apiLevel = config.get<AndroidApiLevel>().value;
 
-  // These configurations are a selection of combinations of architectures
-  // and API levels.
-  // We don't test the full cartesian product to keep the CI time manageable.
-  // When adding a new configuration, consider if it tests a new combination
-  // that is not yet covered by the existing tests.
-  final configurations = [
-    (
-      architecture: Architecture.arm,
-      apiLevel: flutterAndroidNdkVersionLowestSupported,
-    ),
-    (
-      architecture: Architecture.arm64,
-      apiLevel: flutterAndroidNdkVersionHighestSupported,
-    ),
-    (
-      architecture: Architecture.ia32,
-      apiLevel: flutterAndroidNdkVersionLowestSupported,
-    ),
-    (
-      architecture: Architecture.x64,
-      apiLevel: flutterAndroidNdkVersionHighestSupported,
-    ),
-    (
-      architecture: Architecture.riscv64,
-      apiLevel: flutterAndroidNdkVersionLowestSupported,
-    ),
-    (
-      architecture: Architecture.arm64,
-      apiLevel: flutterAndroidNdkVersionLowestSupported,
-    ),
-  ];
-
-  for (final (:architecture, :apiLevel) in configurations) {
     group('Android API$apiLevel ($architecture):', () {
       runTreeshakeTests(targetOS, architecture, androidTargetNdkApi: apiLevel);
     });

--- a/pkgs/native_toolchain_c/test/clinker/treeshake_cross_ios_test.dart
+++ b/pkgs/native_toolchain_c/test/clinker/treeshake_cross_ios_test.dart
@@ -9,9 +9,48 @@ import 'dart:io';
 
 import 'package:code_assets/code_assets.dart';
 import 'package:test/test.dart';
+import 'package:test_case_selector/test_case_selector.dart';
 
 import '../helpers.dart';
 import 'treeshake_helper.dart';
+
+const targetOS = OS.iOS;
+
+/// This comment is generated. To regenerate, run:
+/// `REGENERATE_TEST_CONFIGS=true dart test`
+///
+/// | #   | Architecture | IOSSdk          | IOSVersion |
+/// |-----|--------------|-----------------|------------|
+/// | 1   | arm64        | iphoneos        | 16         |
+/// | 2   | arm64        | iphoneos        | 17         |
+/// | 3   | arm64        | iphonesimulator | 16         |
+/// | 4   | x64          | iphonesimulator | 17         |
+final configurations =
+    TestCaseSelector(
+      dimensions: {
+        Architecture: [Architecture.arm64, Architecture.x64],
+        IOSSdk: [IOSSdk.iPhoneOS, IOSSdk.iPhoneSimulator],
+        IOSVersion: [
+          IOSVersion.flutterHighestBestEffort,
+          IOSVersion.flutterHighestSupported,
+        ],
+      },
+      interactionGroups: [
+        {Architecture, IOSSdk},
+        {IOSSdk, IOSVersion},
+      ],
+      isValid: (config) {
+        if (config.get<IOSSdk>() == IOSSdk.iPhoneOS &&
+            config.get<Architecture>() == Architecture.x64) {
+          return false;
+        }
+        return true;
+      },
+    ).selectAndValidate(
+      tableUri: packageUri.resolve(
+        'test/clinker/treeshake_cross_ios_test.dart',
+      ),
+    );
 
 void main() {
   if (!Platform.isMacOS) {
@@ -19,37 +58,11 @@ void main() {
     return;
   }
 
-  const targetOS = OS.iOS;
+  for (final config in configurations) {
+    final architecture = config.get<Architecture>();
+    final iOSTargetSdk = config.get<IOSSdk>();
+    final iOSVersion = config.get<IOSVersion>().value;
 
-  // These configurations are a selection of combinations of architectures
-  // and iOS versions.
-  // We don't test the full cartesian product to keep the CI time manageable.
-  // When adding a new configuration, consider if it tests a new combination
-  // that is not yet covered by the existing tests.
-  final configurations = [
-    (
-      architecture: Architecture.arm64,
-      iOSTargetSdk: IOSSdk.iPhoneOS,
-      iOSVersion: flutteriOSHighestBestEffort,
-    ),
-    (
-      architecture: Architecture.arm64,
-      iOSTargetSdk: IOSSdk.iPhoneSimulator,
-      iOSVersion: flutteriOSHighestSupported,
-    ),
-    (
-      architecture: Architecture.x64,
-      iOSTargetSdk: IOSSdk.iPhoneSimulator,
-      iOSVersion: flutteriOSHighestBestEffort,
-    ),
-    (
-      architecture: Architecture.arm64,
-      iOSTargetSdk: IOSSdk.iPhoneOS,
-      iOSVersion: flutteriOSHighestSupported,
-    ),
-  ];
-
-  for (final (:architecture, :iOSTargetSdk, :iOSVersion) in configurations) {
     group('$iOSTargetSdk $iOSVersion ($architecture):', () {
       runTreeshakeTests(
         targetOS,

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -317,13 +317,43 @@ Future<void> expectPageSize(Uri dylib, int pageSize) async {
   }
 }
 
-int defaultMacOSVersion = 13;
+class AndroidApiLevel {
+  final int value;
+  const AndroidApiLevel(this.value);
 
-/// From https://docs.flutter.dev/reference/supported-platforms.
-const flutterAndroidNdkVersionLowestSupported = 21;
+  @override
+  String toString() => '$value';
 
-/// From https://docs.flutter.dev/reference/supported-platforms.
-const flutterAndroidNdkVersionHighestSupported = 34;
+  /// From https://docs.flutter.dev/reference/supported-platforms.
+  static const flutterLowestSupported = AndroidApiLevel(21);
+
+  /// From https://docs.flutter.dev/reference/supported-platforms.
+  static const flutterHighestSupported = AndroidApiLevel(34);
+}
+
+class IOSVersion {
+  final int value;
+  const IOSVersion(this.value);
+
+  @override
+  String toString() => '$value';
+
+  static const flutterHighestBestEffort = IOSVersion(16);
+  static const flutterHighestSupported = IOSVersion(17);
+}
+
+class MacOSVersion {
+  final int value;
+  const MacOSVersion(this.value);
+
+  @override
+  String toString() => '$value';
+
+  static const flutterLowestBestEffort = MacOSVersion(12);
+  static const flutterLowestSupported = MacOSVersion(13);
+}
+
+int defaultMacOSVersion = MacOSVersion.flutterLowestSupported.value;
 
 /// File-format strings used by the `objdump` tool for Android binaries that
 /// run on a given architecture.
@@ -415,6 +445,3 @@ List<Architecture> iOSSupportedArchitecturesFor(IOSSdk iosSdk) =>
       .iPhoneSimulator => supportedArchitecturesFor(OS.iOS),
       IOSSdk() => throw UnimplementedError(),
     };
-
-const flutteriOSHighestBestEffort = 16;
-const flutteriOSHighestSupported = 17;

--- a/pkgs/test_case_selector/lib/src/markdown_renderer.dart
+++ b/pkgs/test_case_selector/lib/src/markdown_renderer.dart
@@ -1,0 +1,108 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'test_case.dart';
+
+/// Renders a list of [TestCase]s as a Markdown table.
+class MarkdownRenderer {
+  final List<TestCase> testCases;
+  final List<Type> dimensionTypes;
+  final String prefix;
+
+  MarkdownRenderer({
+    required this.testCases,
+    required this.dimensionTypes,
+    this.prefix = '',
+  });
+
+  /// Renders the Markdown table as a string.
+  String render() {
+    if (testCases.isEmpty) return '';
+
+    // 1. Gather all strings for the table.
+    final headerStrings = [
+      '#',
+      ...dimensionTypes.map((t) {
+        // Default: split CamelCase into spaces (e.g., AndroidApiLevel ->
+        // Android Api Level).
+        return t
+            .toString()
+            .split('.')
+            .last
+            .replaceAllMapped(
+              RegExp(r'([a-z])([A-Z])'),
+              (match) => '${match.group(1)} ${match.group(2)}',
+            );
+      }),
+    ];
+
+    final rowStrings =
+        testCases
+            .map(
+              (config) =>
+                  dimensionTypes
+                      .map((t) => config.values[t]!.toString())
+                      .toList(),
+            )
+            .toList();
+
+    // 2. Sort rows alphabetically based on the first column.
+    rowStrings.sort((a, b) {
+      for (var i = 0; i < a.length; i++) {
+        final cmp = a[i].compareTo(b[i]);
+        if (cmp != 0) return cmp;
+      }
+      return 0;
+    });
+
+    // 3. Add numbering.
+    for (var i = 0; i < rowStrings.length; i++) {
+      rowStrings[i].insert(0, (i + 1).toString());
+    }
+
+    // 4. Calculate max width for each column.
+    final numColumns = dimensionTypes.length + 1;
+    final columnWidths = List<int>.filled(numColumns, 0);
+    for (var i = 0; i < numColumns; i++) {
+      columnWidths[i] = headerStrings[i].length;
+      for (final row in rowStrings) {
+        if (row[i].length > columnWidths[i]) {
+          columnWidths[i] = row[i].length;
+        }
+      }
+      // Ensure a minimum width for the separator (---)
+      if (columnWidths[i] < 3) columnWidths[i] = 3;
+    }
+
+    // 5. Format rows with padding.
+    String formatRow(List<String> cells) {
+      final paddedCells = <String>[];
+      for (var i = 0; i < cells.length; i++) {
+        paddedCells.add(cells[i].padRight(columnWidths[i]));
+      }
+      return '$prefix| ${paddedCells.join(' | ')} |';
+    }
+
+    final header = formatRow(headerStrings);
+    final separator = formatRow(
+      List<String>.filled(
+        numColumns,
+        '---',
+      ).map((s) => s.substring(0, 3)).toList(),
+    ).replaceAll(' ', '-'); // Make separator look like | --- | --- |
+    // But don't replace the prefix spaces if any.
+    final actualSeparator = prefix + separator.substring(prefix.length);
+
+    final rows = rowStrings.map(formatRow);
+
+    return [
+      '${prefix}This comment is generated. To regenerate, run:',
+      '$prefix`REGENERATE_TEST_CONFIGS=true dart test`',
+      prefix.trimRight(),
+      header,
+      actualSeparator,
+      ...rows,
+    ].join('\n');
+  }
+}

--- a/pkgs/test_case_selector/lib/src/selector.dart
+++ b/pkgs/test_case_selector/lib/src/selector.dart
@@ -1,0 +1,420 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'test_case.dart';
+
+/// Example:
+/// ```dart
+/// enum VehicleType { bicycle, motorcycle, car, semiTruck }
+/// enum PaintColor { crimsonRed, stealthBlack, arcticWhite }
+/// enum WeightClass { ultraLight, light, medium, heavy }
+///
+/// /// This comment is generated. To regenerate, run:
+/// /// `REGENERATE_TEST_CONFIGS=true dart test`
+/// ///
+/// /// | #   | Vehicle Type | Paint Color  | Weight Class |
+/// /// |-----|--------------|--------------|--------------|
+/// /// | 1   | bicycle      | arcticWhite  | ultraLight   |
+/// /// | 2   | bicycle      | crimsonRed   | ultraLight   |
+/// /// | 3   | bicycle      | stealthBlack | ultraLight   |
+/// /// | 4   | motorcycle   | arcticWhite  | light        |
+/// /// | 5   | motorcycle   | crimsonRed   | medium       |
+/// /// | 6   | semiTruck    | stealthBlack | heavy        |
+/// final configurations = TestCaseSelector(
+///   dimensions: {
+///     VehicleType: VehicleType.values,
+///     PaintColor: PaintColor.values,
+///     WeightClass: WeightClass.values,
+///   },
+///   interactionGroups: [
+///     {VehicleType, PaintColor},
+///     {VehicleType, WeightClass},
+///   ],
+///   isValid: (tc) {
+///     final type = tc.get<VehicleType>();
+///     final weight = tc.get<WeightClass>();
+///     if (type == VehicleType.bicycle) {
+///       return weight == WeightClass.ultraLight;
+///     }
+///     if (type == VehicleType.semiTruck) return weight == WeightClass.heavy;
+///     return true;
+///   },
+/// ).selectAndValidate(
+///   tableUri: packageUri.resolve('test/my_test.dart'),
+/// );
+/// ```
+class TestCaseSelector {
+  /// Maps a Type (representing a dimension like `Architecture`) to a list of
+  /// possible values for that dimension.
+  final Map<Type, List<Object>> dimensions;
+
+  /// A list of sets of Types.
+  ///
+  /// Each set defines a group of dimensions where every combination of values
+  /// between those dimensions must be covered at least once in the selected
+  /// suite.
+  final List<Set<Type>> interactionGroups;
+
+  /// An optional predicate to filter out invalid combinations.
+  ///
+  /// The selector will ensure that every [TestCase] in the resulting
+  /// suite satisfies this predicate.
+  final bool Function(TestCase)? isValid;
+
+  /// The dimension types in the order they were provided in the [dimensions]
+  /// map.
+  final List<Type> _displayDimensionTypes;
+
+  /// The dimension types sorted alphabetically to ensure deterministic
+  /// requirement ordering.
+  final List<Type> _dimensionTypes;
+
+  /// Creates a selector with the provided [dimensions] and [interactionGroups].
+  TestCaseSelector({
+    required this.dimensions,
+    required this.interactionGroups,
+    this.isValid,
+  }) : _displayDimensionTypes = dimensions.keys.toList(),
+       _dimensionTypes =
+           dimensions.keys.toList()
+             ..sort((a, b) => a.toString().compareTo(b.toString()));
+
+  List<Type> get displayDimensionTypes => _displayDimensionTypes;
+
+  /// Selects a list of [TestCase]s based on the provided [dimensions],
+  /// [interactionGroups], and [isValid] predicate.
+  List<TestCase> select() {
+    final requirementsList = <_Requirement>[];
+    final requirementsSet = <_Requirement>{};
+
+    void addRequirement(_Requirement req) {
+      if (requirementsSet.add(req)) {
+        requirementsList.add(req);
+      }
+    }
+
+    // Sort interaction groups to ensure deterministic requirement ordering.
+    final sortedInteractionGroups =
+        interactionGroups.map((group) {
+          final sortedGroup = group.toList();
+          sortedGroup.sort((a, b) => a.toString().compareTo(b.toString()));
+          return sortedGroup;
+        }).toList();
+    sortedInteractionGroups.sort((a, b) => a.join(',').compareTo(b.join(',')));
+
+    final interactionGroupDimIndices =
+        sortedInteractionGroups.map((group) {
+          return group.map(_dimensionTypes.indexOf).toList();
+        }).toList();
+
+    final groupsByDim = <int, List<List<int>>>{};
+    for (final dimIndices in interactionGroupDimIndices) {
+      for (final d in dimIndices) {
+        (groupsByDim[d] ??= []).add(dimIndices);
+      }
+    }
+
+    // 1. Identify all combinations that need to be covered based on interaction
+    // groups.
+    for (final dimIndices in interactionGroupDimIndices) {
+      final valuesLengths =
+          dimIndices
+              .map((d) => dimensions[_dimensionTypes[d]]!.length)
+              .toList();
+
+      void generate(int index, List<int> currentIndices) {
+        if (index == dimIndices.length) {
+          final packed = <int>[];
+          for (var i = 0; i < dimIndices.length; i++) {
+            packed.add(_pack(dimIndices[i], currentIndices[i]));
+          }
+          addRequirement(_Requirement(packed));
+          return;
+        }
+        for (var v = 0; v < valuesLengths[index]; v++) {
+          currentIndices[index] = v;
+          generate(index + 1, currentIndices);
+        }
+      }
+
+      generate(0, List<int>.filled(dimIndices.length, 0));
+    }
+
+    // 2. Ensure all individual values are covered at least once.
+    for (var d = 0; d < _dimensionTypes.length; d++) {
+      final values = dimensions[_dimensionTypes[d]]!;
+      for (var v = 0; v < values.length; v++) {
+        addRequirement(_Requirement([_pack(d, v)]));
+      }
+    }
+
+    final testSuite = <TestCase>[];
+    final random = _StableRandom(42); // Seeded for reproducibility.
+
+    // 3. Greedily build configurations until all requirements are covered.
+    while (requirementsSet.isNotEmpty) {
+      Map<int, int>? bestCandidate;
+      var bestCandidateScore = -1;
+
+      // Try a few different starting candidates and pick the one that results
+      // in the best coverage.
+      for (var attempt = 0; attempt < 50; attempt++) {
+        final candidate = <int, int>{};
+        for (var d = 0; d < _dimensionTypes.length; d++) {
+          final numValues = dimensions[_dimensionTypes[d]]!.length;
+          if (attempt == 0) {
+            // First attempt: try a random value for each dimension.
+            candidate[d] = random.nextInt(numValues);
+          } else {
+            // Other attempts: prioritize dimensions that have uncovered values.
+            final uncoveredForDim = <int>[];
+            for (var v = 0; v < numValues; v++) {
+              if (requirementsSet.contains(_Requirement([_pack(d, v)]))) {
+                uncoveredForDim.add(v);
+              }
+            }
+
+            if (uncoveredForDim.isNotEmpty) {
+              candidate[d] =
+                  uncoveredForDim[random.nextInt(uncoveredForDim.length)];
+            } else {
+              candidate[d] = random.nextInt(numValues);
+            }
+          }
+        }
+
+        // If the starting point is invalid, try to nudge it towards validity.
+        if (isValid != null && !isValid!(TestCase(_toValues(candidate)))) {
+          _nudgeToValid(candidate, _dimensionTypes.length);
+        }
+
+        // If it's still invalid after nudging, skip this attempt.
+        if (isValid != null && !isValid!(TestCase(_toValues(candidate)))) {
+          continue;
+        }
+
+        // Hill-climbing approach to improve the candidate.
+        var improved = true;
+        while (improved) {
+          improved = false;
+          for (var d = 0; d < _dimensionTypes.length; d++) {
+            final numValues = dimensions[_dimensionTypes[d]]!.length;
+            var bestVal = candidate[d]!;
+            var maxScore = _calculateScore(
+              candidate,
+              d,
+              bestVal,
+              requirementsSet,
+              groupsByDim,
+            );
+
+            for (var v = 0; v < numValues; v++) {
+              if (v == candidate[d]) continue;
+
+              // Check if changing this dimension would make the configuration
+              // invalid.
+              final originalVal = candidate[d]!;
+              candidate[d] = v;
+              final valid =
+                  isValid == null || isValid!(TestCase(_toValues(candidate)));
+              if (!valid) {
+                candidate[d] = originalVal;
+                continue;
+              }
+
+              final score = _calculateScore(
+                candidate,
+                d,
+                v,
+                requirementsSet,
+                groupsByDim,
+              );
+              if (score > maxScore) {
+                maxScore = score;
+                bestVal = v;
+                improved = true;
+              } else {
+                candidate[d] = originalVal;
+              }
+            }
+            candidate[d] = bestVal;
+          }
+        }
+
+        final score = _calculateTotalCoverageScore(
+          candidate,
+          requirementsSet,
+          interactionGroupDimIndices,
+        );
+        if (score > bestCandidateScore) {
+          bestCandidateScore = score;
+          bestCandidate = Map.of(candidate);
+        }
+      }
+
+      if (bestCandidate != null && bestCandidateScore > 0) {
+        testSuite.add(TestCase(_toValues(bestCandidate)));
+        _markCovered(
+          requirementsSet,
+          requirementsList,
+          bestCandidate,
+          interactionGroupDimIndices,
+        );
+      } else {
+        // If we can't cover anything new, we might be trying to cover
+        // impossible pairs or values.
+        // Try to identify one and remove it.
+        final first = requirementsList.first;
+        requirementsSet.remove(first);
+        requirementsList.removeAt(0);
+      }
+
+      // Circuit breaker to prevent infinite loops in case of logic errors.
+      if (testSuite.length > 1000) break;
+    }
+
+    return testSuite;
+  }
+
+  /// Attempts to find a valid configuration by changing one dimension at a
+  /// time.
+  void _nudgeToValid(Map<int, int> candidate, int numDimensions) {
+    if (isValid == null) return;
+    for (var d = 0; d < numDimensions; d++) {
+      final numValues = dimensions[_dimensionTypes[d]]!.length;
+      for (var v = 0; v < numValues; v++) {
+        final originalVal = candidate[d]!;
+        candidate[d] = v;
+        if (isValid!(TestCase(_toValues(candidate)))) return;
+        candidate[d] = originalVal;
+      }
+    }
+  }
+
+  Map<Type, Object> _toValues(Map<int, int> candidate) {
+    final values = <Type, Object>{};
+    candidate.forEach((dimIndex, valIndex) {
+      final type = _dimensionTypes[dimIndex];
+      values[type] = dimensions[type]![valIndex];
+    });
+    return values;
+  }
+
+  int _calculateTotalCoverageScore(
+    Map<int, int> candidate,
+    Set<_Requirement> requirements,
+    List<List<int>> interactionGroupDimIndices,
+  ) {
+    var score = 0;
+    candidate.forEach((d, v) {
+      if (requirements.contains(_Requirement([_pack(d, v)]))) {
+        score += 1;
+      }
+    });
+
+    for (final dimIndices in interactionGroupDimIndices) {
+      final packed = <int>[];
+      for (final d in dimIndices) {
+        packed.add(_pack(d, candidate[d]!));
+      }
+      if (requirements.contains(_Requirement(packed))) {
+        score += 100;
+      }
+    }
+    return score;
+  }
+
+  int _calculateScore(
+    Map<int, int> candidate,
+    int dimChanged,
+    int newVal,
+    Set<_Requirement> requirements,
+    Map<int, List<List<int>>> groupsByDim,
+  ) {
+    var score = 0;
+
+    // Reward covering a new individual value.
+    if (requirements.contains(_Requirement([_pack(dimChanged, newVal)]))) {
+      score += 1;
+    }
+
+    // Reward covering new interaction groups.
+    final groups = groupsByDim[dimChanged] ?? [];
+    for (final group in groups) {
+      final packedValues = <int>[];
+      for (final d in group) {
+        packedValues.add(_pack(d, d == dimChanged ? newVal : candidate[d]!));
+      }
+      if (requirements.contains(_Requirement(packedValues))) {
+        score += 100;
+      }
+    }
+    return score;
+  }
+
+  // Packs (dimIndex, valIndex) into 31 bits.
+  static int _pack(int dim, int val) {
+    assert(dim < (1 << 16));
+    assert(val < (1 << 15));
+    return (dim << 15) | val;
+  }
+
+  void _markCovered(
+    Set<_Requirement> requirementsSet,
+    List<_Requirement> requirementsList,
+    Map<int, int> candidate,
+    List<List<int>> interactionGroupDimIndices,
+  ) {
+    void remove(_Requirement req) {
+      if (requirementsSet.remove(req)) {
+        requirementsList.remove(req);
+      }
+    }
+
+    candidate.forEach((d, v) {
+      remove(_Requirement([_pack(d, v)]));
+    });
+
+    for (final dimIndices in interactionGroupDimIndices) {
+      final packedValues = <int>[];
+      for (final d in dimIndices) {
+        packedValues.add(_pack(d, candidate[d]!));
+      }
+      remove(_Requirement(packedValues));
+    }
+  }
+}
+
+class _Requirement {
+  final List<int> packedValues;
+  final int _hashCode;
+
+  _Requirement(this.packedValues) : _hashCode = Object.hashAll(packedValues);
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! _Requirement) return false;
+    final otherPacked = other.packedValues;
+    if (packedValues.length != otherPacked.length) return false;
+    for (var i = 0; i < packedValues.length; i++) {
+      if (packedValues[i] != otherPacked[i]) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => _hashCode;
+}
+
+/// A simple linear congruential generator for stable random numbers.
+class _StableRandom {
+  int _state;
+
+  _StableRandom(this._state);
+
+  int nextInt(int max) {
+    _state = (_state * 1103515245 + 12345) & 0x7FFFFFFF;
+    return (_state >> 16) % max;
+  }
+}

--- a/pkgs/test_case_selector/lib/src/source_updater.dart
+++ b/pkgs/test_case_selector/lib/src/source_updater.dart
@@ -1,0 +1,117 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+/// Updates a Dart source file with a generated Markdown table.
+class SourceUpdater {
+  final Uri tableUri;
+  final String newTable;
+
+  static const _regenerateEnvVar = 'REGENERATE_TEST_CONFIGS';
+
+  SourceUpdater({
+    required this.tableUri,
+    required this.newTable,
+  });
+
+  /// Updates the file if the environment variable is set, or runs a test to
+  /// check if the file is up-to-date.
+  void updateOrValidate({bool? update}) {
+    final file = File.fromUri(tableUri);
+    final shouldUpdate =
+        update ?? Platform.environment[_regenerateEnvVar] == 'true';
+
+    if (shouldUpdate) {
+      final content = file.readAsStringSync().replaceAll('\r\n', '\n');
+      final lines = content.split('\n');
+
+      // Ensure ignore_for_file is present.
+      const ignoreLine = '// ignore_for_file: lines_longer_than_80_chars';
+      if (!content.contains(ignoreLine)) {
+        var insertIndex = 0;
+        for (var i = 0; i < lines.length; i++) {
+          if (lines[i].startsWith('//') || lines[i].trim().isEmpty) {
+            insertIndex = i + 1;
+          } else {
+            break;
+          }
+        }
+        lines.insert(insertIndex, ignoreLine);
+        lines.insert(insertIndex + 1, '');
+      }
+
+      // Find where the TestCaseSelector is instantiated.
+      var startIndex = -1;
+      for (var i = 0; i < lines.length; i++) {
+        if (lines[i].trim().startsWith('final configurations =')) {
+          startIndex = i;
+          break;
+        }
+      }
+
+      if (startIndex != -1) {
+        var firstCommentIndex = startIndex;
+        while (firstCommentIndex > 0 &&
+            lines[firstCommentIndex - 1].trim().startsWith('///')) {
+          firstCommentIndex--;
+        }
+
+        final newLines = [
+          ...lines.sublist(0, firstCommentIndex),
+          newTable,
+          ...lines.sublist(startIndex),
+        ];
+        file.writeAsStringSync(newLines.join('\n'));
+      } else {
+        throw StateError(
+          'Could not find "final configurations =" in '
+          '${tableUri.toFilePath()}.\n'
+          'Ensure the file contains a top-level assignment for configurations.',
+        );
+      }
+    } else {
+      test('Test configuration table up-to-date', () {
+        final content =
+            file.existsSync()
+                ? file.readAsStringSync().replaceAll('\r\n', '\n')
+                : '';
+        final actual = _extractTableFromDart(content);
+        final expected = newTable.replaceAll('\r\n', '\n');
+        expect(
+          actual,
+          expected,
+          reason:
+              'The test configurations table at $tableUri is not '
+              'up-to-date. Please run the tests with $_regenerateEnvVar=true '
+              'to regenerate it.',
+        );
+      });
+    }
+  }
+
+  String _extractTableFromDart(String content) {
+    final lines = content.split('\n');
+    final tableLines = <String>[];
+    var inTable = false;
+    for (final line in lines) {
+      final trimmed = line.trim();
+      if (trimmed.startsWith('///')) {
+        final commentBody = trimmed.substring(3).trimLeft();
+        if (commentBody.startsWith('This comment is generated.') ||
+            commentBody.startsWith('| #')) {
+          inTable = true;
+        }
+        if (inTable) {
+          tableLines.add(line);
+        }
+      } else if (inTable) {
+        break;
+      }
+    }
+    return tableLines.join('\n');
+  }
+}

--- a/pkgs/test_case_selector/lib/src/test_case.dart
+++ b/pkgs/test_case_selector/lib/src/test_case.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+
+/// A single selected test case containing a value for each dimension.
+///
+/// Use [get] to retrieve the value for a specific dimension type in a
+/// type-safe manner.
+class TestCase {
+  final Map<Type, Object> _values;
+
+  /// Internal accessor for rendering.
+  @internal
+  Map<Type, Object> get values => _values;
+
+  TestCase(this._values);
+
+  /// Returns the value for a specific dimension type [T].
+  ///
+  /// This is the primary way to access dimension values when iterating over
+  /// selected test cases.
+  ///
+  /// Example:
+  ///
+  /// ```dart
+  /// for (final tc in configurations) {
+  ///   final arch = tc.get<Architecture>();
+  ///   final os = tc.get<OS>();
+  ///   // ...
+  /// }
+  /// ```
+  ///
+  /// Throws an [ArgumentError] if the type [T] is not present in this test
+  /// case.
+  T get<T>() {
+    final value = _values[T];
+    if (value == null) {
+      throw ArgumentError('Dimension type $T not found in this test case.');
+    }
+    return value as T;
+  }
+
+  @override
+  String toString() => _values.entries
+      .map((e) => '${e.key.toString().split('.').last}: ${e.value}')
+      .join(', ');
+}

--- a/pkgs/test_case_selector/lib/test_case_selector.dart
+++ b/pkgs/test_case_selector/lib/test_case_selector.dart
@@ -1,0 +1,102 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// A utility for selecting a minimized suite of test cases that ensures
+/// specific interactions between different test dimensions are covered.
+///
+/// This implements a greedy algorithm for "interaction pairs" (pairwise
+/// testing) to reduce the total number of tests while maintaining high
+/// confidence.
+///
+/// The selected test cases are automatically documented as a Markdown table
+/// in a doc comment within the source file.
+///
+/// Example:
+///
+/// ```dart
+/// enum VehicleType { bicycle, motorcycle, car, semiTruck }
+/// enum PaintColor { crimsonRed, stealthBlack, arcticWhite }
+/// enum WeightClass { ultraLight, light, medium, heavy }
+///
+/// /// This comment is generated. To regenerate, run:
+/// /// `REGENERATE_TEST_CONFIGS=true dart test`
+/// ///
+/// /// | #   | Vehicle Type | Paint Color  | Weight Class |
+/// /// |-----|--------------|--------------|--------------|
+/// /// | 1   | bicycle      | arcticWhite  | ultraLight   |
+/// /// | 2   | bicycle      | crimsonRed   | ultraLight   |
+/// /// | 3   | bicycle      | stealthBlack | ultraLight   |
+/// /// | 4   | motorcycle   | arcticWhite  | light        |
+/// /// | 5   | motorcycle   | crimsonRed   | medium       |
+/// /// | 6   | semiTruck    | stealthBlack | heavy        |
+/// final configurations = TestCaseSelector(
+///   dimensions: {
+///     VehicleType: VehicleType.values,
+///     PaintColor: PaintColor.values,
+///     WeightClass: WeightClass.values,
+///   },
+///   interactionGroups: [
+///     {VehicleType, PaintColor},
+///     {VehicleType, WeightClass},
+///   ],
+///   isValid: (tc) {
+///     final type = tc.get<VehicleType>();
+///     final weight = tc.get<WeightClass>();
+///     if (type == VehicleType.bicycle) {
+///       return weight == WeightClass.ultraLight;
+///     }
+///     if (type == VehicleType.semiTruck) return weight == WeightClass.heavy;
+///     return true;
+///   },
+/// ).selectAndValidate(
+///   tableUri: packageUri.resolve('test/my_test.dart'),
+/// );
+///
+/// void main() {
+///   for (final config in configurations) {
+///     final type = config.get<VehicleType>();
+///     // ...
+///   }
+/// }
+/// ```
+library;
+
+import 'src/markdown_renderer.dart';
+import 'src/selector.dart';
+import 'src/source_updater.dart';
+import 'src/test_case.dart';
+
+export 'src/selector.dart';
+export 'src/test_case.dart';
+
+extension TestCaseSelectorExtension on TestCaseSelector {
+  /// Selects test cases and ensures the Markdown table in the source file
+  /// is up-to-date.
+  ///
+  /// The [tableUri] must point to the `.dart` file where the `configurations`
+  /// assignment is located.
+  ///
+  /// If the `REGENERATE_TEST_CONFIGS` environment variable is set to `true`,
+  /// the file at [tableUri] will be updated with the new table. Otherwise,
+  /// a test will be run to ensure the table is up-to-date.
+  List<TestCase> selectAndValidate({
+    required Uri tableUri,
+    bool? update,
+  }) {
+    final testCases = select();
+    final renderer = MarkdownRenderer(
+      testCases: testCases,
+      dimensionTypes: displayDimensionTypes,
+      prefix: '/// ',
+    );
+    final table = renderer.render();
+
+    SourceUpdater(
+      tableUri: tableUri,
+      newTable: table,
+    ).updateOrValidate(update: update);
+
+    return testCases;
+  }
+}

--- a/pkgs/test_case_selector/pubspec.yaml
+++ b/pkgs/test_case_selector/pubspec.yaml
@@ -1,0 +1,17 @@
+name: test_case_selector
+description: A utility for selecting a minimized suite of test cases using pairwise/interaction-strength algorithms.
+version: 0.1.0
+publish_to: none
+repository: https://github.com/dart-lang/native/tree/main/pkgs/test_case_selector
+
+resolution: workspace
+
+environment:
+  sdk: ^3.7.0
+
+dependencies:
+  meta: ^1.17.0
+  test: ^1.26.0
+
+dev_dependencies:
+  lints: ^6.0.0

--- a/pkgs/test_case_selector/test/markdown_renderer_test.dart
+++ b/pkgs/test_case_selector/test/markdown_renderer_test.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:test_case_selector/src/markdown_renderer.dart';
+import 'package:test_case_selector/src/test_case.dart';
+
+class VehicleType {
+  final String name;
+  VehicleType(this.name);
+  @override
+  String toString() => name;
+  static final bicycle = VehicleType('bicycle');
+  static final semiTruck = VehicleType('semiTruck');
+}
+
+class PaintColor {
+  final String name;
+  PaintColor(this.name);
+  @override
+  String toString() => name;
+  static final arcticWhite = PaintColor('arcticWhite');
+  static final crimsonRed = PaintColor('crimsonRed');
+}
+
+void main() {
+  group('MarkdownRenderer', () {
+    test('renders a simple table', () {
+      final testCases = [
+        TestCase({
+          VehicleType: VehicleType.bicycle,
+          PaintColor: PaintColor.arcticWhite,
+        }),
+        TestCase({
+          VehicleType: VehicleType.semiTruck,
+          PaintColor: PaintColor.crimsonRed,
+        }),
+      ];
+      final renderer = MarkdownRenderer(
+        testCases: testCases,
+        dimensionTypes: [VehicleType, PaintColor],
+        prefix: '/// ',
+      );
+
+      final output = renderer.render();
+
+      expect(output, contains('| #   | Vehicle Type | Paint Color |'));
+      expect(output, contains('|-----|--------------|-------------|'));
+      expect(output, contains('| 1   | bicycle      | arcticWhite |'));
+      expect(output, contains('| 2   | semiTruck    | crimsonRed  |'));
+      expect(output, startsWith('/// This comment is generated.'));
+    });
+  });
+}

--- a/pkgs/test_case_selector/test/selector_test.dart
+++ b/pkgs/test_case_selector/test/selector_test.dart
@@ -1,0 +1,176 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:test_case_selector/test_case_selector.dart';
+
+enum VehicleType { bicycle, motorcycle, car, semiTruck }
+
+enum PaintColor { crimsonRed, stealthBlack, arcticWhite }
+
+enum WeightClass { ultraLight, light, medium, heavy }
+
+enum TestDimA { a1, a2 }
+
+enum TestDimB { b1, b2 }
+
+enum TestDimC { c1, c2 }
+
+void main() {
+  group('TestCaseSelector (Vehicle Configurator)', () {
+    test('covers all colors and vehicle types', () {
+      final vehicles = VehicleType.values;
+      final colors = PaintColor.values;
+
+      final configurations =
+          TestCaseSelector(
+            dimensions: {
+              VehicleType: vehicles,
+              PaintColor: colors,
+            },
+            interactionGroups: [
+              {VehicleType, PaintColor},
+            ],
+          ).select();
+
+      // Verify all individual values are covered.
+      for (final v in vehicles) {
+        expect(configurations.any((tc) => tc.get<VehicleType>() == v), isTrue);
+      }
+      for (final c in colors) {
+        expect(configurations.any((tc) => tc.get<PaintColor>() == c), isTrue);
+      }
+
+      // Verify all interaction pairs (Cartesian product since it's one group).
+      for (final v in vehicles) {
+        for (final c in colors) {
+          expect(
+            configurations.any(
+              (tc) => tc.get<VehicleType>() == v && tc.get<PaintColor>() == c,
+            ),
+            isTrue,
+          );
+        }
+      }
+
+      expect(configurations.length, 12); // 4 types * 3 colors
+    });
+
+    test('reduces configurations with multiple interaction groups', () {
+      final configurations =
+          TestCaseSelector(
+            dimensions: {
+              VehicleType: VehicleType.values,
+              PaintColor: PaintColor.values,
+              WeightClass: WeightClass.values,
+            },
+            interactionGroups: [
+              {VehicleType, WeightClass},
+              {VehicleType, PaintColor},
+            ],
+          ).select();
+
+      // Verify interaction pairs from both groups are covered.
+      for (final v in VehicleType.values) {
+        for (final w in WeightClass.values) {
+          expect(
+            configurations.any(
+              (c) => c.get<VehicleType>() == v && c.get<WeightClass>() == w,
+            ),
+            isTrue,
+          );
+        }
+        for (final p in PaintColor.values) {
+          expect(
+            configurations.any(
+              (c) => c.get<VehicleType>() == v && c.get<PaintColor>() == p,
+            ),
+            isTrue,
+          );
+        }
+      }
+
+      // Full product: 4 * 3 * 4 = 48.
+      // Pairwise should be much lower (around 16).
+      expect(configurations.length, lessThan(30));
+      expect(configurations.length, greaterThanOrEqualTo(16));
+    });
+
+    test('covers full cross-product for 3-way interaction group', () {
+      final configurations =
+          TestCaseSelector(
+            dimensions: {
+              TestDimA: TestDimA.values,
+              TestDimB: TestDimB.values,
+              TestDimC: TestDimC.values,
+            },
+            interactionGroups: [
+              {TestDimA, TestDimB, TestDimC},
+            ],
+          ).select();
+
+      final seen = <String>{};
+      for (final tc in configurations) {
+        seen.add(
+          '${tc.get<TestDimA>()},${tc.get<TestDimB>()},${tc.get<TestDimC>()}',
+        );
+      }
+
+      for (final a in TestDimA.values) {
+        for (final b in TestDimB.values) {
+          for (final c in TestDimC.values) {
+            expect(
+              seen.contains('$a,$b,$c'),
+              isTrue,
+              reason: 'Combination $a,$b,$c should be covered',
+            );
+          }
+        }
+      }
+
+      expect(configurations.length, 8); // 2 * 2 * 2
+    });
+
+    test('respects vehicle weight constraints (isValid)', () {
+      final configurations =
+          TestCaseSelector(
+            dimensions: {
+              VehicleType: VehicleType.values,
+              WeightClass: WeightClass.values,
+            },
+            interactionGroups: [
+              {VehicleType, WeightClass},
+            ],
+            isValid: (tc) {
+              final type = tc.get<VehicleType>();
+              final weight = tc.get<WeightClass>();
+
+              if (type == VehicleType.bicycle) {
+                return weight == WeightClass.ultraLight;
+              }
+              if (type == VehicleType.semiTruck) {
+                return weight == WeightClass.heavy;
+              }
+              if (type == VehicleType.motorcycle) {
+                return weight != WeightClass.heavy;
+              }
+              return true;
+            },
+          ).select();
+
+      for (final tc in configurations) {
+        final type = tc.get<VehicleType>();
+        final weight = tc.get<WeightClass>();
+
+        if (type == VehicleType.bicycle) {
+          expect(weight, WeightClass.ultraLight);
+        } else if (type == VehicleType.semiTruck) {
+          expect(weight, WeightClass.heavy);
+        } else if (type == VehicleType.motorcycle) {
+          expect(weight, isNot(WeightClass.heavy));
+        }
+      }
+    });
+  });
+}

--- a/pkgs/test_case_selector/test/source_updater_test.dart
+++ b/pkgs/test_case_selector/test/source_updater_test.dart
@@ -1,0 +1,91 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:test_case_selector/src/source_updater.dart';
+
+void main() {
+  group('SourceUpdater', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('source_updater_test');
+    });
+
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test('updates file with table and ignore line', () {
+      final file = File.fromUri(tempDir.uri.resolve('my_test.dart'));
+      file.writeAsStringSync('''
+// Copyright header
+
+final configurations = TestCaseSelector(
+  // ...
+);
+''');
+
+      const newTable = '''
+/// This comment is generated. To regenerate, run:
+/// `REGENERATE_TEST_CONFIGS=true dart test`
+///
+/// | #   | Vehicle Type |
+/// |-----|--------------|
+/// | 1   | bicycle      |
+''';
+
+      final updater = SourceUpdater(
+        tableUri: file.uri,
+        newTable: newTable,
+      );
+
+      updater.updateOrValidate(update: true);
+
+      final content = file.readAsStringSync();
+      expect(
+        content,
+        contains('// ignore_for_file: lines_longer_than_80_chars'),
+      );
+      expect(content, contains('/// | #   | Vehicle Type |'));
+      expect(content, contains('final configurations ='));
+    });
+
+    test('replaces existing doc comments', () {
+      final file = File.fromUri(tempDir.uri.resolve('my_test.dart'));
+      file.writeAsStringSync('''
+// Copyright header
+
+// ignore_for_file: lines_longer_than_80_chars
+
+/// Old table
+/// | # |
+/// |---|
+final configurations = TestCaseSelector(
+  // ...
+);
+''');
+
+      const newTable = '''
+/// New table
+/// | # |
+/// |---|
+''';
+
+      final updater = SourceUpdater(
+        tableUri: file.uri,
+        newTable: newTable,
+      );
+
+      updater.updateOrValidate(update: true);
+
+      final content = file.readAsStringSync();
+      expect(content, isNot(contains('Old table')));
+      expect(content, contains('/// New table'));
+      expect(content, contains('final configurations ='));
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -114,6 +114,7 @@ workspace:
   - pkgs/record_use/test_data/drop_dylib_recording
   - pkgs/record_use/test_data/library_uris
   - pkgs/record_use/test_data/library_uris_helper
+  - pkgs/test_case_selector
   # - pkgs/swift2objc  # TODO
   # - pkgs/swiftgen  # TODO
   # - pkgs/swiftgen/example  # TODO


### PR DESCRIPTION
Gemini CLI vibe-coded test-case selection based on https://en.wikipedia.org/wiki/All-pairs_testing.

The interaction groups define the pairs we want to cover. The greedy algorithm covers all pairs (unless the configurations are invalid).

For the dimensions not mentioned in any interaction groups, the algorithm just does value coverage.

The test cases are written out to a markdown table such as

```
This file is generated. To regenerate, run:
`REGENERATE_TEST_CONFIGS=true dart test`

| #   | Architecture | Link Mode | Optimization Level | Android Api Level |
|-----|--------------|-----------|--------------------|-------------------|
| 1   | arm          | bundled   | unspecified        | 34                |
| 2   | arm          | static    | O2                 | 21                |
| 3   | arm64        | bundled   | O0                 | 34                |
| 4   | arm64        | static    | Os                 | 21                |
| 5   | ia32         | bundled   | O1                 | 21                |
| 6   | ia32         | static    | O2                 | 34                |
| 7   | riscv64      | bundled   | O0                 | 21                |
| 8   | riscv64      | static    | O1                 | 34                |
| 9   | x64          | bundled   | O3                 | 21                |
| 10  | x64          | static    | O3                 | 34                |
```

The test case generator is written in such a way that it is stable across runs and OSes (stable hashing).

Follow up of https://github.com/dart-lang/native/pull/3183.