### PR TITLE
[infra] Release record_use, hooks, hooks_runner, and native_toolchain_c

### DIFF
--- a/pkgs/hooks/CHANGELOG.md
+++ b/pkgs/hooks/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.2-wip
+## 1.0.2
 
 - Update documentation about `CCACHE_` environment variables.
 

--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A library that contains a Dart API for the JSON-based protocol for
   `hook/build.dart` and `hook/link.dart`.
 
-version: 1.0.2-wip
+version: 1.0.2
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks
 

--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0-wip
+## 1.1.0
 
 - Filter `recorded_uses.json` passed to link hooks based on the
   package name of the definition.

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 1.1.0-wip
+version: 1.1.0
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 
@@ -22,7 +22,7 @@ dependencies:
   meta: ^1.16.0
   package_config: ^2.1.0
   pub_semver: ^2.2.0
-  record_use: ^0.5.0-wip
+  record_use: ^0.5.0
   yaml: ^3.1.3
 
 dev_dependencies:

--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.17.5-wip
+## 0.17.5
 
 - Search for NDK in `ANDROID_HOME` and `ANDROID_NDK` environment variables.
 - On iOS and macOS, use the `-encryptable` linker flag. This resolves an

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.17.5-wip
+version: 0.17.5
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:

--- a/pkgs/record_use/CHANGELOG.md
+++ b/pkgs/record_use/CHANGELOG.md
@@ -1,7 +1,11 @@
-## 0.5.0-wip
+## 0.5.0
 
-- Completely overhauled the JSON format.
-- Completely overhauled the Dart API.
+- Complete reimplementation of the package. The Dart API changed completely, the
+  underlying JSON format changed completely, the internal architecture changed
+  completely to be based on a JSON schema, the format can now express many more
+  recordings, the code samples in the doc comments are now tested and up to
+  date, and many more changes. This is by no means a final version, but will
+  enable people to play with the current state of the implementation.
 
 ## 0.4.2
 

--- a/pkgs/record_use/README.md
+++ b/pkgs/record_use/README.md
@@ -1,6 +1,10 @@
 > [!CAUTION]
-> This is an experimental package, and it's API can break at any time. Use at
-> your own discretion.
+> This is an experimental package. Its API and the underlying JSON format
+> **will break** as we are actively iterating. Use at your own discretion.
+>
+> We are continuously changing the implementation, so a released version of the
+> package may only work with one or two [dev releases] of the Dart SDK. This
+> version will work with the first dev release _after_ `3.12.0-203.0.dev`.
 
 This package provides the data classes for the usage recording feature in the
 Dart SDK.
@@ -92,3 +96,5 @@ void main(List<String> arguments) {
 
 ## Contributing
 Contributions are welcome! Please open an issue or submit a pull request.
+
+[dev releases]: https://dart.dev/get-dart/archive#dev-channel

--- a/pkgs/record_use/pubspec.yaml
+++ b/pkgs/record_use/pubspec.yaml
@@ -1,7 +1,7 @@
 name: record_use
 description: >
   The serialization logic and API for the usage recording SDK feature.
-version: 0.5.0-wip
+version: 0.5.0
 repository: https://github.com/dart-lang/native/tree/main/pkgs/record_use
 
 environment:


### PR DESCRIPTION
Let's release a version of `package:record_use`. I'd like for enthusiast to be able to give what we've built the last months a spin.

After https://dart-review.googlesource.com/c/sdk/+/484941, the Dart SDK will emit v0.5.0 format record use files. And we've added so many features recently and will until https://dart-review.googlesource.com/c/sdk/+/485522 without breaking the format. 

Tricky bits:

* We'll need to point experimenters to the specific dev release of the Dart SDK that will work with the published version of the package. (Which in this case will be the one released on next Tuesday.)

Rolling bits:

* We might need to roll `hooks_runner` manually into Flutter due to the new `record_use` dependency. (Which will not be used yet in Flutter. -> And we will postpone using it in Flutter because breaking changes in the format would break flutter due to version skew between the record_use in the Dart SDK and the record_use in flutter_tools.)