### PR TITLE
[infra] Only run formatting on dev

### DIFF
--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -74,7 +74,7 @@ jobs:
       - run: dart pub get
 
       - name: Run pub get, analysis, formatting, generators, tests, and examples.
-        run: dart tool/ci.dart --all --no-apitool
+        run: dart tool/ci.dart --all --no-apitool ${{ matrix.sdk == 'stable' && '--no-format' || '' }}
 
       - name: Upload coverage
         uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e

--- a/pkgs/hooks_runner/lib/src/build_runner/build_planner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_planner.dart
@@ -332,8 +332,7 @@ class PackageGraph {
 /// compilation. This enum holds static information about these hooks.
 enum Hook {
   link('link'),
-  build('build')
-  ;
+  build('build');
 
   final String _scriptName;
 


### PR DESCRIPTION
Apparently in rare cases the formatter can differ between stable and dev releases. I suspect this is only the case for bug fixes. For actual formatting changes they are gated behind language features.

For these rare cases, we can either (1) try to rewrite the code, or (2) only run dev, or (3) only run stable.

I believe most people develop on a dev release on this repo due to changes being coupled with new `dart:ffi` features, or new experiments in `dartdev` and `flutter_tools`. So, let's stick with dev.