### PR TITLE
[record_use] Canonicalize and sort references

### DIFF
--- a/pkgs/record_use/lib/src/constant.dart
+++ b/pkgs/record_use/lib/src/constant.dart
@@ -890,9 +890,7 @@ final class InstanceConstant extends Constant {
 
   @override
   int _compareToSameType(InstanceConstant other) {
-    final definitionCompare = definition.toString().compareTo(
-      other.definition.toString(),
-    );
+    final definitionCompare = definition.compareTo(other.definition);
     if (definitionCompare != 0) return definitionCompare;
     final lengthCompare = fields.length.compareTo(other.fields.length);
     if (lengthCompare != 0) return lengthCompare;
@@ -1056,9 +1054,7 @@ final class EnumConstant extends Constant {
 
   @override
   int _compareToSameType(EnumConstant other) {
-    final definitionCompare = definition.toString().compareTo(
-      other.definition.toString(),
-    );
+    final definitionCompare = definition.compareTo(other.definition);
     if (definitionCompare != 0) return definitionCompare;
     final indexCompare = index.compareTo(other.index);
     if (indexCompare != 0) return indexCompare;

--- a/pkgs/record_use/lib/src/definition.dart
+++ b/pkgs/record_use/lib/src/definition.dart
@@ -96,6 +96,9 @@ class Definition {
   int get hashCode =>
       cacheHashCode(() => Object.hash(library, Object.hashAll(path)));
 
+  // This should align with [toString] ordering.
+  int _compareTo(Definition other) => toString().compareTo(other.toString());
+
   /// Returns a URI representation of this definition.
   ///
   /// The [library] is the base URI and the [path] is the fragment.
@@ -147,8 +150,7 @@ class Name {
       name,
       kind: kind,
       disambiguators: Set.from(
-        disambiguators.toList()
-          ..sort((a, b) => a.toString().compareTo(b.toString())),
+        disambiguators.toList()..sort((a, b) => a.compareTo(b)),
       ),
     );
   }
@@ -182,8 +184,7 @@ class Name {
     }
     buffer.write(name);
     if (disambiguators.isNotEmpty) {
-      final sorted = disambiguators.toList()
-        ..sort((a, b) => a.toString().compareTo(b.toString()));
+      final sorted = disambiguators.toList()..sort((a, b) => a.compareTo(b));
       for (final disambiguator in sorted) {
         buffer.write('@$disambiguator');
       }
@@ -237,8 +238,18 @@ final class DefinitionKind {
   @override
   int get hashCode => _name.hashCode;
 
+  int _compareTo(DefinitionKind other) => _name.compareTo(other._name);
+
   @override
   String toString() => _name;
+}
+
+/// Package private (protected) methods for [DefinitionKind].
+///
+/// This avoids bloating the public API and public API docs and prevents
+/// internal types from leaking from the API.
+extension DefinitionKindProtected on DefinitionKind {
+  int compareTo(DefinitionKind other) => _compareTo(other);
 }
 
 /// Extra metadata to disambiguate between elements that might have the same
@@ -282,8 +293,18 @@ final class DefinitionDisambiguator {
   @override
   int get hashCode => _name.hashCode;
 
+  int _compareTo(DefinitionDisambiguator other) => _name.compareTo(other._name);
+
   @override
   String toString() => _name;
+}
+
+/// Package private (protected) methods for [DefinitionDisambiguator].
+///
+/// This avoids bloating the public API and public API docs and prevents
+/// internal types from leaking from the API.
+extension DefinitionDisambiguatorProtected on DefinitionDisambiguator {
+  int compareTo(DefinitionDisambiguator other) => _compareTo(other);
 }
 
 /// Package private (protected) methods for [Definition].
@@ -295,6 +316,8 @@ extension DefinitionProtected on Definition {
 
   Definition canonicalizeChildren(CanonicalizationContext context) =>
       _canonicalizeChildren(context);
+
+  int compareTo(Definition other) => _compareTo(other);
 
   static Definition fromSyntax(DefinitionSyntax syntax) =>
       Definition._fromSyntax(syntax);

--- a/pkgs/record_use/lib/src/recordings.dart
+++ b/pkgs/record_use/lib/src/recordings.dart
@@ -329,28 +329,30 @@ Error: $e
     );
   }
 
-  Recordings _canonicalizeChildren(CanonicalizationContext context) {
-    final newCalls = <Definition, List<CallReference>>{};
-    for (final entry in calls.entries) {
+  Recordings _canonicalizeChildren(CanonicalizationContext context) =>
+      Recordings(
+        metadata: metadata,
+        calls: _canonicalizeReferences(context, calls),
+        instances: _canonicalizeReferences(context, instances),
+      );
+
+  Map<Definition, List<R>> _canonicalizeReferences<R extends Reference>(
+    CanonicalizationContext context,
+    Map<Definition, List<R>> references,
+  ) {
+    final map = <Definition, Set<R>>{};
+    for (final entry in references.entries) {
       final definition = context.canonicalizeDefinition(entry.key);
-      final references = [
-        for (final r in entry.value) r.canonicalizeChildren(context),
-      ];
-      newCalls.putIfAbsent(definition, () => []).addAll(references);
+      final set = map.putIfAbsent(definition, () => {});
+      for (final reference in entry.value) {
+        set.add(reference.canonicalizeChildren(context) as R);
+      }
     }
-    final newInstances = <Definition, List<InstanceReference>>{};
-    for (final entry in instances.entries) {
-      final definition = context.canonicalizeDefinition(entry.key);
-      final references = [
-        for (final r in entry.value) r.canonicalizeChildren(context),
-      ];
-      newInstances.putIfAbsent(definition, () => []).addAll(references);
-    }
-    return Recordings(
-      metadata: metadata,
-      calls: newCalls,
-      instances: newInstances,
-    );
+    final sortedKeys = map.keys.toList()..sort((a, b) => a.compareTo(b));
+    return <Definition, List<R>>{
+      for (final key in sortedKeys)
+        key: map[key]!.toList()..sort((a, b) => a.compareTo(b)),
+    };
   }
 
   static LoadingUnitDeserializationContext _deserializeLoadingUnits(
@@ -414,7 +416,7 @@ Error: $e
     final sortedLoadingUnits = canonContext.loadingUnits.toList()
       ..sort((a, b) => a.name.compareTo(b.name));
     final sortedDefinitions = canonContext.definitions.toList()
-      ..sort((a, b) => a.toString().compareTo(b.toString()));
+      ..sort((a, b) => a.compareTo(b));
     final sortedConstants = canonContext.constants.toList()
       ..sort((a, b) => a.compareTo(b));
 
@@ -425,28 +427,20 @@ Error: $e
     );
 
     final callRecordings = <CallRecordingSyntax>[];
-    for (final definition in context.definitions.keys) {
-      final callsForDefinition = canon.calls[definition];
-      if (callsForDefinition == null || callsForDefinition.isEmpty) continue;
+    for (final entry in canon.calls.entries) {
       callRecordings.add(
         CallRecordingSyntax(
-          definitionIndex: context.definitions[definition]!,
-          uses: callsForDefinition
-              .map((call) => call.toSyntax(context))
-              .toList(),
+          definitionIndex: context.definitions[entry.key]!,
+          uses: entry.value.map((call) => call.toSyntax(context)).toList(),
         ),
       );
     }
     final instanceRecordings = <InstanceRecordingSyntax>[];
-    for (final definition in context.definitions.keys) {
-      final instancesForDefinition = canon.instances[definition];
-      if (instancesForDefinition == null || instancesForDefinition.isEmpty) {
-        continue;
-      }
+    for (final entry in canon.instances.entries) {
       instanceRecordings.add(
         InstanceRecordingSyntax(
-          definitionIndex: context.definitions[definition]!,
-          uses: instancesForDefinition
+          definitionIndex: context.definitions[entry.key]!,
+          uses: entry.value
               .map((instance) => instance.toSyntax(context))
               .toList(),
         ),
@@ -733,6 +727,11 @@ Error: $e
       instances: newInstancesForDefinition,
     );
   }
+}
+
+extension RecordingsProtected on Recordings {
+  Recordings canonicalizeChildren(CanonicalizationContext context) =>
+      _canonicalizeChildren(context);
 }
 
 extension MapifyIterableExtension<T> on Iterable<T> {

--- a/pkgs/record_use/lib/src/reference.dart
+++ b/pkgs/record_use/lib/src/reference.dart
@@ -42,6 +42,20 @@ sealed class Reference {
   @override
   int get hashCode => cacheHashCode(() => loadingUnit.hashCode);
 
+  int _compareTo(Reference other) {
+    var result = loadingUnit.name.compareTo(other.loadingUnit.name);
+    if (result != 0) return result;
+    result = _orderingTypePriority.compareTo(other._orderingTypePriority);
+    if (result != 0) return result;
+    return _compareToInternal(other);
+  }
+
+  int _compareToInternal(covariant Reference other);
+
+  /// A stable priority for this type.
+  @protected
+  int get _orderingTypePriority;
+
   bool _semanticEqualsShared(
     Reference other, {
     String Function(String)? uriMapping,
@@ -59,6 +73,104 @@ sealed class Reference {
   String toString() => loadingUnit.name;
 }
 
+mixin _HasArguments {
+  List<MaybeConstant> get positionalArguments;
+  Map<String, MaybeConstant> get namedArguments;
+
+  int _compareToArguments(covariant _HasArguments other) {
+    if (positionalArguments.length != other.positionalArguments.length) {
+      return positionalArguments.length.compareTo(
+        other.positionalArguments.length,
+      );
+    }
+    for (var i = 0; i < positionalArguments.length; i++) {
+      final result = positionalArguments[i].compareTo(
+        other.positionalArguments[i],
+      );
+      if (result != 0) return result;
+    }
+    if (namedArguments.length != other.namedArguments.length) {
+      return namedArguments.length.compareTo(other.namedArguments.length);
+    }
+    final thisSorted = namedArguments.keys.toList()..sort();
+    final otherSorted = other.namedArguments.keys.toList()..sort();
+    for (var i = 0; i < thisSorted.length; i++) {
+      var result = thisSorted[i].compareTo(otherSorted[i]);
+      if (result != 0) return result;
+      result = namedArguments[thisSorted[i]]!.compareTo(
+        other.namedArguments[otherSorted[i]]!,
+      );
+      if (result != 0) return result;
+    }
+    return 0;
+  }
+
+  List<MaybeConstant> _canonicalizePositional(
+    CanonicalizationContext context,
+  ) => [for (final c in positionalArguments) context.canonicalizeConstant(c)];
+
+  Map<String, MaybeConstant> _canonicalizeNamed(
+    CanonicalizationContext context,
+  ) {
+    final sortedNamedArgs = namedArguments.entries.toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+    return {
+      for (final e in sortedNamedArgs)
+        e.key: context.canonicalizeConstant(e.value),
+    };
+  }
+
+  List<MaybeConstant> _filterPositional({String? definitionPackageName}) => [
+    for (final c in positionalArguments)
+      c.filter(definitionPackageName: definitionPackageName),
+  ];
+
+  Map<String, MaybeConstant> _filterNamed({String? definitionPackageName}) =>
+      namedArguments.map(
+        (key, value) => MapEntry(
+          key,
+          value.filter(definitionPackageName: definitionPackageName),
+        ),
+      );
+
+  bool _semanticEqualsArguments(
+    _HasArguments other, {
+    required bool allowMoreConstArguments,
+    required bool allowPromotionOfUnsupported,
+  }) {
+    if (positionalArguments.length != other.positionalArguments.length) {
+      return false;
+    }
+    for (final (index, argument) in other.positionalArguments.indexed) {
+      if (argument is NonConstant && allowMoreConstArguments) {
+        continue;
+      }
+      // ignore: invalid_use_of_visible_for_testing_member
+      if (!positionalArguments[index].semanticEquals(
+        argument,
+        allowPromotionOfUnsupported: allowPromotionOfUnsupported,
+      )) {
+        return false;
+      }
+    }
+    for (final entry in other.namedArguments.entries) {
+      final name = entry.key;
+      final argument = entry.value;
+      if (argument is NonConstant && allowMoreConstArguments) {
+        continue;
+      }
+      // ignore: invalid_use_of_visible_for_testing_member
+      if (!namedArguments[name]!.semanticEquals(
+        argument,
+        allowPromotionOfUnsupported: allowPromotionOfUnsupported,
+      )) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
 /// A reference to a call to some [Definition].
 ///
 /// This might be an actual call, in which case we record the arguments, or a
@@ -70,6 +182,21 @@ sealed class CallReference extends Reference {
   final MaybeConstant? receiver;
 
   const CallReference({required super.loadingUnit, this.receiver});
+
+  @override
+  int _compareToInternal(covariant CallReference other) {
+    if (receiver != null && other.receiver != null) {
+      final result = receiver!.compareTo(other.receiver!);
+      if (result != 0) return result;
+    } else if (receiver != null) {
+      return 1;
+    } else if (other.receiver != null) {
+      return -1;
+    }
+    return _compareToCallInternal(other);
+  }
+
+  int _compareToCallInternal(covariant CallReference other);
 
   static CallReference _fromSyntax(
     CallSyntax syntax,
@@ -164,8 +291,10 @@ sealed class CallReference extends Reference {
 ///
 /// Any non-provided arguments with default values will have their default
 /// values filled in.
-final class CallWithArguments extends CallReference {
+final class CallWithArguments extends CallReference with _HasArguments {
+  @override
   final List<MaybeConstant> positionalArguments;
+  @override
   final Map<String, MaybeConstant> namedArguments;
 
   const CallWithArguments({
@@ -176,38 +305,31 @@ final class CallWithArguments extends CallReference {
   });
 
   @override
-  Reference _canonicalizeChildren(CanonicalizationContext context) {
-    final sortedNamedArgs = namedArguments.entries.toList()
-      ..sort((a, b) => a.key.compareTo(b.key));
-    return CallWithArguments(
-      loadingUnit: context.canonicalizeLoadingUnit(loadingUnit),
-      receiver: receiver != null
-          ? context.canonicalizeConstant(receiver!)
-          : null,
-      positionalArguments: [
-        for (final c in positionalArguments) context.canonicalizeConstant(c),
-      ],
-      namedArguments: {
-        for (final e in sortedNamedArgs)
-          e.key: context.canonicalizeConstant(e.value),
-      },
-    );
-  }
+  int get _orderingTypePriority => 0;
+
+  @override
+  int _compareToCallInternal(covariant CallWithArguments other) =>
+      _compareToArguments(other);
+
+  @override
+  Reference _canonicalizeChildren(CanonicalizationContext context) =>
+      CallWithArguments(
+        loadingUnit: context.canonicalizeLoadingUnit(loadingUnit),
+        receiver: receiver != null
+            ? context.canonicalizeConstant(receiver!)
+            : null,
+        positionalArguments: _canonicalizePositional(context),
+        namedArguments: _canonicalizeNamed(context),
+      );
 
   @override
   CallReference _filter({String? definitionPackageName}) => CallWithArguments(
     loadingUnit: loadingUnit,
     receiver: receiver?.filter(definitionPackageName: definitionPackageName),
-    positionalArguments: [
-      for (final c in positionalArguments)
-        c.filter(definitionPackageName: definitionPackageName),
-    ],
-    namedArguments: namedArguments.map(
-      (key, value) => MapEntry(
-        key,
-        value.filter(definitionPackageName: definitionPackageName),
-      ),
+    positionalArguments: _filterPositional(
+      definitionPackageName: definitionPackageName,
     ),
+    namedArguments: _filterNamed(definitionPackageName: definitionPackageName),
   );
 
   @override
@@ -263,34 +385,12 @@ final class CallWithArguments extends CallReference {
   }) {
     switch (other) {
       case CallWithArguments():
-        if (positionalArguments.length != other.positionalArguments.length) {
+        if (!_semanticEqualsArguments(
+          other,
+          allowMoreConstArguments: allowMoreConstArguments,
+          allowPromotionOfUnsupported: allowPromotionOfUnsupported,
+        )) {
           return false;
-        }
-        for (final (index, argument) in other.positionalArguments.indexed) {
-          if (argument is NonConstant && allowMoreConstArguments) {
-            continue;
-          }
-          // ignore: invalid_use_of_visible_for_testing_member
-          if (!positionalArguments[index].semanticEquals(
-            argument,
-            allowPromotionOfUnsupported: allowPromotionOfUnsupported,
-          )) {
-            return false;
-          }
-        }
-        for (final entry in other.namedArguments.entries) {
-          final name = entry.key;
-          final argument = entry.value;
-          if (argument is NonConstant && allowMoreConstArguments) {
-            continue;
-          }
-          // ignore: invalid_use_of_visible_for_testing_member
-          if (!namedArguments[name]!.semanticEquals(
-            argument,
-            allowPromotionOfUnsupported: allowPromotionOfUnsupported,
-          )) {
-            return false;
-          }
         }
         return _semanticEqualsCall(
           other,
@@ -330,6 +430,12 @@ final class CallWithArguments extends CallReference {
 /// record the arguments possibly passed to the method somewhere else.
 final class CallTearoff extends CallReference {
   const CallTearoff({required super.loadingUnit, super.receiver});
+
+  @override
+  int get _orderingTypePriority => 1;
+
+  @override
+  int _compareToCallInternal(covariant CallTearoff other) => 0;
 
   @override
   Reference _canonicalizeChildren(CanonicalizationContext context) =>
@@ -396,6 +502,12 @@ final class CallTearoff extends CallReference {
 //
 sealed class InstanceReference extends Reference {
   const InstanceReference({required super.loadingUnit});
+
+  @override
+  int _compareToInternal(covariant InstanceReference other) =>
+      _compareToInstanceInternal(other);
+
+  int _compareToInstanceInternal(covariant InstanceReference other);
 
   static InstanceReference _fromSyntax(
     InstanceSyntax syntax,
@@ -466,6 +578,13 @@ final class InstanceConstantReference extends InstanceReference {
     required this.instanceConstant,
     required super.loadingUnit,
   });
+
+  @override
+  int get _orderingTypePriority => 2;
+
+  @override
+  int _compareToInstanceInternal(covariant InstanceConstantReference other) =>
+      instanceConstant.compareTo(other.instanceConstant);
 
   @override
   Reference _canonicalizeChildren(CanonicalizationContext context) =>
@@ -543,9 +662,12 @@ final class InstanceConstantReference extends InstanceReference {
 ///
 /// Any non-provided arguments with default values will have their default
 /// values filled in.
-final class InstanceCreationReference extends InstanceReference {
+final class InstanceCreationReference extends InstanceReference
+    with _HasArguments {
   final Definition definition;
+  @override
   final List<MaybeConstant> positionalArguments;
+  @override
   final Map<String, MaybeConstant> namedArguments;
 
   const InstanceCreationReference({
@@ -556,36 +678,34 @@ final class InstanceCreationReference extends InstanceReference {
   });
 
   @override
-  Reference _canonicalizeChildren(CanonicalizationContext context) {
-    final sortedNamedArgs = namedArguments.entries.toList()
-      ..sort((a, b) => a.key.compareTo(b.key));
-    return InstanceCreationReference(
-      definition: context.canonicalizeDefinition(definition),
-      loadingUnit: context.canonicalizeLoadingUnit(loadingUnit),
-      positionalArguments: [
-        for (final c in positionalArguments) context.canonicalizeConstant(c),
-      ],
-      namedArguments: {
-        for (final e in sortedNamedArgs)
-          e.key: context.canonicalizeConstant(e.value),
-      },
-    );
+  int get _orderingTypePriority => 3;
+
+  @override
+  int _compareToInstanceInternal(covariant InstanceCreationReference other) {
+    final result = definition.compareTo(other.definition);
+    if (result != 0) return result;
+    return _compareToArguments(other);
   }
+
+  @override
+  Reference _canonicalizeChildren(CanonicalizationContext context) =>
+      InstanceCreationReference(
+        definition: context.canonicalizeDefinition(definition),
+        loadingUnit: context.canonicalizeLoadingUnit(loadingUnit),
+        positionalArguments: _canonicalizePositional(context),
+        namedArguments: _canonicalizeNamed(context),
+      );
 
   @override
   InstanceReference _filter({String? definitionPackageName}) =>
       InstanceCreationReference(
         definition: definition,
         loadingUnit: loadingUnit,
-        positionalArguments: [
-          for (final c in positionalArguments)
-            c.filter(definitionPackageName: definitionPackageName),
-        ],
-        namedArguments: namedArguments.map(
-          (key, value) => MapEntry(
-            key,
-            value.filter(definitionPackageName: definitionPackageName),
-          ),
+        positionalArguments: _filterPositional(
+          definitionPackageName: definitionPackageName,
+        ),
+        namedArguments: _filterNamed(
+          definitionPackageName: definitionPackageName,
         ),
       );
 
@@ -644,34 +764,12 @@ final class InstanceCreationReference extends InstanceReference {
     if (!definition.semanticEquals(other.definition, uriMapping: uriMapping)) {
       return false;
     }
-    if (positionalArguments.length != other.positionalArguments.length) {
+    if (!_semanticEqualsArguments(
+      other,
+      allowMoreConstArguments: allowMoreConstArguments,
+      allowPromotionOfUnsupported: allowPromotionOfUnsupported,
+    )) {
       return false;
-    }
-    for (final (index, argument) in other.positionalArguments.indexed) {
-      if (argument is NonConstant && allowMoreConstArguments) {
-        continue;
-      }
-      // ignore: invalid_use_of_visible_for_testing_member
-      if (!positionalArguments[index].semanticEquals(
-        argument,
-        allowPromotionOfUnsupported: allowPromotionOfUnsupported,
-      )) {
-        return false;
-      }
-    }
-    for (final entry in other.namedArguments.entries) {
-      final name = entry.key;
-      final argument = entry.value;
-      if (argument is NonConstant && allowMoreConstArguments) {
-        continue;
-      }
-      // ignore: invalid_use_of_visible_for_testing_member
-      if (!namedArguments[name]!.semanticEquals(
-        argument,
-        allowPromotionOfUnsupported: allowPromotionOfUnsupported,
-      )) {
-        return false;
-      }
     }
     return _semanticEqualsShared(
       other,
@@ -707,6 +805,13 @@ final class ConstructorTearoffReference extends InstanceReference {
     required this.definition,
     required super.loadingUnit,
   });
+
+  @override
+  int get _orderingTypePriority => 4;
+
+  @override
+  int _compareToInstanceInternal(covariant ConstructorTearoffReference other) =>
+      definition.compareTo(other.definition);
 
   @override
   Reference _canonicalizeChildren(CanonicalizationContext context) =>
@@ -778,6 +883,8 @@ extension ReferenceProtected on Reference {
 
   Reference filter({String? definitionPackageName}) =>
       _filter(definitionPackageName: definitionPackageName);
+
+  int compareTo(Reference other) => _compareTo(other);
 }
 
 /// Package private (protected) methods for [CallReference].
@@ -792,6 +899,8 @@ extension CallReferenceProtected on CallReference {
 
   CallReference filter({String? definitionPackageName}) =>
       _filter(definitionPackageName: definitionPackageName);
+
+  int compareTo(Reference other) => _compareTo(other);
 
   static CallReference fromSyntax(
     CallSyntax syntax,
@@ -811,6 +920,8 @@ extension InstanceReferenceProtected on InstanceReference {
 
   InstanceReference filter({String? definitionPackageName}) =>
       _filter(definitionPackageName: definitionPackageName);
+
+  int compareTo(Reference other) => _compareTo(other);
 
   static InstanceReference fromSyntax(
     InstanceSyntax syntax,

--- a/pkgs/record_use/test/canonicalization_test.dart
+++ b/pkgs/record_use/test/canonicalization_test.dart
@@ -81,13 +81,78 @@ void main() {
       expect(constants, hasLength(1));
       expect(constants[0], {'type': 'int', 'value': 42});
 
-      // Both calls should reference the same constant index.
+      // Both calls are identical, so they should be deduplicated into one.
       final uses = json['uses'] as Map;
       final staticCalls = uses['static_calls'] as List;
       final recording = staticCalls[0] as Map;
       final calls = recording['uses'] as List;
+      expect(calls, hasLength(1));
       expect((calls[0] as Map)['positional'], [0]);
-      expect((calls[1] as Map)['positional'], [0]);
+    });
+
+    test('Recordings.toJson deduplicates and sorts references', () {
+      const definition = Definition('package:a/a.dart', [Name('foo')]);
+      const unit1 = LoadingUnit('1');
+      const unit2 = LoadingUnit('2');
+
+      final recordings = Recordings(
+        calls: {
+          definition: [
+            const CallWithArguments(
+              positionalArguments: [IntConstant(2)],
+              namedArguments: {},
+              loadingUnit: unit1,
+            ),
+            const CallWithArguments(
+              positionalArguments: [IntConstant(1)],
+              namedArguments: {},
+              loadingUnit: unit1,
+            ),
+            const CallWithArguments(
+              positionalArguments: [IntConstant(1)],
+              namedArguments: {},
+              loadingUnit: unit1,
+            ),
+            const CallWithArguments(
+              positionalArguments: [IntConstant(1)],
+              namedArguments: {},
+              loadingUnit: unit2,
+            ),
+          ],
+        },
+        instances: {},
+      );
+
+      final json = recordings.toJson();
+      final uses = json['uses'] as Map;
+      final staticCalls = uses['static_calls'] as List;
+      final recording = staticCalls[0] as Map;
+      final calls = recording['uses'] as List;
+
+      // Should have 3 unique calls after deduplication, sorted by toString.
+      // CallWithArguments(positional: IntConstant(1), loadingUnit: 1)
+      // CallWithArguments(positional: IntConstant(1), loadingUnit: 2)
+      // CallWithArguments(positional: IntConstant(2), loadingUnit: 1)
+      expect(calls, hasLength(3));
+
+      final backAgain = Recordings.fromJson(json);
+      final backCalls = backAgain.calls[definition]!;
+      expect(backCalls, hasLength(3));
+
+      // Verify sorting (based on toString which includes positional args and
+      // loading units)
+      expect(
+        backCalls[0].toString(),
+        contains('positional: IntConstant(1), loadingUnit: 1'),
+      );
+      expect(
+        backCalls[1].toString(),
+        contains('positional: IntConstant(2), loadingUnit: 1'),
+      );
+      expect(
+        backCalls[2].toString(),
+        contains('positional: IntConstant(1), loadingUnit: 2'),
+      );
     });
   });
 }

--- a/pkgs/record_use/test/instance_references_test.dart
+++ b/pkgs/record_use/test/instance_references_test.dart
@@ -4,6 +4,8 @@
 
 import 'package:pub_semver/pub_semver.dart';
 import 'package:record_use/record_use.dart';
+import 'package:record_use/src/canonicalization_context.dart';
+import 'package:record_use/src/recordings.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -123,8 +125,9 @@ void main() {
   });
 
   test('Round trip serialization', () {
-    final serializedJson = recordings.toJson();
+    final canon = recordings.canonicalizeChildren(CanonicalizationContext());
+    final serializedJson = canon.toJson();
     final roundTrippedRecordings = Recordings.fromJson(serializedJson);
-    expect(roundTrippedRecordings, equals(recordings));
+    expect(roundTrippedRecordings, equals(canon));
   });
 }

--- a/pkgs/record_use/test/test_data.dart
+++ b/pkgs/record_use/test/test_data.dart
@@ -7,6 +7,8 @@ import 'dart:io';
 import 'package:native_test_helpers/native_test_helpers.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:record_use/record_use.dart';
+import 'package:record_use/src/canonicalization_context.dart';
+import 'package:record_use/src/recordings.dart';
 
 const callId = Definition(
   'package:js_runtime/js_helper.dart',
@@ -95,7 +97,7 @@ final recordedUses = Recordings(
       ),
     ],
   },
-);
+).canonicalizeChildren(CanonicalizationContext());
 
 final recordedUses2 = Recordings(
   metadata: Metadata(
@@ -117,7 +119,7 @@ final recordedUses2 = Recordings(
     ],
   },
   instances: {},
-);
+).canonicalizeChildren(CanonicalizationContext());
 
 final _testDataUri = findPackageRoot('record_use').resolve('test_data/json/');
 

--- a/pkgs/record_use/test_data/json/recorded_uses_v2.json
+++ b/pkgs/record_use/test_data/json/recorded_uses_v2.json
@@ -146,12 +146,12 @@
         "definition_index": 0,
         "uses": [
           {
-            "constant_index": 17,
+            "constant_index": 13,
             "loading_unit_index": 0,
             "type": "constant"
           },
           {
-            "constant_index": 13,
+            "constant_index": 17,
             "loading_unit_index": 0,
             "type": "constant"
           }

--- a/pkgs/record_use/test_data/json/types_of_arguments.json
+++ b/pkgs/record_use/test_data/json/types_of_arguments.json
@@ -106,7 +106,7 @@
           {
             "loading_unit_index": 0,
             "positional": [
-              3
+              0
             ],
             "type": "with_arguments"
           },
@@ -120,13 +120,6 @@
           {
             "loading_unit_index": 0,
             "positional": [
-              10
-            ],
-            "type": "with_arguments"
-          },
-          {
-            "loading_unit_index": 0,
-            "positional": [
               2
             ],
             "type": "with_arguments"
@@ -134,14 +127,21 @@
           {
             "loading_unit_index": 0,
             "positional": [
-              13
+              3
             ],
             "type": "with_arguments"
           },
           {
             "loading_unit_index": 0,
             "positional": [
-              0
+              10
+            ],
+            "type": "with_arguments"
+          },
+          {
+            "loading_unit_index": 0,
+            "positional": [
+              13
             ],
             "type": "with_arguments"
           }


### PR DESCRIPTION
Deduplicates identical references from the same loading unit.

Also sorts the references.

Closes:

* https://github.com/dart-lang/native/issues/3092

AI transparency:

* Generated with Gemini CLI. Architecture mine. Implementation AI. Iterated on with follow up prompts. Code has been reviewed by me.