### PR TITLE
[native_toolchain_c] Fix Android c++_static not linking libc++abi

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,9 +1,9 @@
-## 0.17.6-wip
+## 0.17.6
 
-- On Android, let clang handle C++ standard library linking instead of passing
-  `-l` directly. This fixes `cppLinkStdLib: 'c++_static'` not linking
-  `libc++abi`, which caused `dlopen` failures on newer Android versions.
-  ([#3240](https://github.com/dart-lang/native/issues/3240))
+- On Android, use the NDK's `libc++.a` linker script when `cppLinkStdLib` is
+  `'c++_static'`. This ensures both `libc++_static` and `libc++abi` are linked,
+  fixing `dlopen` failures on newer Android versions caused by missing C++ ABI
+  symbols. ([#3240](https://github.com/dart-lang/native/issues/3240))
 
 ## 0.17.5
 

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/ctool.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/ctool.dart
@@ -155,6 +155,10 @@ abstract class CTool {
   /// | Linux   | `stdc++`     |
   /// | macOS   | `c++`        |
   /// | Fuchsia | `c++`        |
+  ///
+  /// On Android, set this to `c++_static` to statically link the
+  /// C++ standard library. This bundles libc++ into the resulting
+  /// binary instead of depending on `libc++_shared.so` at runtime.
   final String? cppLinkStdLib;
 
   /// If the code asset should be a dynamic or static library.

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/run_cbuilder.dart
@@ -294,16 +294,19 @@ class RunCBuilder {
         if (language == .cpp) ...[
           '-x',
           'c++',
-          // On Android, let clang's driver handle C++ standard library linking
-          // rather than passing `-l <lib>` directly. This ensures that both
-          // libc++_static.a and libc++abi.a are linked when statically linking
-          // the C++ standard library. See:
+          // On Android with c++_static, use -Bstatic/-Bdynamic to force
+          // static resolution of -lc++. This picks up the NDK's libc++.a
+          // linker script which expands to INPUT(-lc++_static -lc++abi),
+          // ensuring libc++abi is also linked. Passing -l c++_static directly
+          // would miss libc++abi. See:
           // https://android.googlesource.com/platform/ndk/+show/refs/heads/main/docs/BuildSystemMaintainers.md
-          if (codeConfig.targetOS == .android) ...[
-            if ((cppLinkStdLib ?? defaultCppLinkStdLib[codeConfig.targetOS]!) ==
-                'c++_static')
-              '-static-libstdc++',
-            // For c++_shared (the default), clang links it automatically.
+          if (codeConfig.targetOS == .android &&
+              (cppLinkStdLib ?? defaultCppLinkStdLib[codeConfig.targetOS]!) ==
+                  'c++_static') ...[
+            '-Wl,-Bstatic',
+            '-l',
+            'c++',
+            '-Wl,-Bdynamic',
           ] else ...[
             '-l',
             cppLinkStdLib ?? defaultCppLinkStdLib[codeConfig.targetOS]!,

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.17.6-wip
+version: 0.17.6
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:

--- a/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
+++ b/pkgs/native_toolchain_c/test/cbuilder/cbuilder_cross_android_test.dart
@@ -111,6 +111,68 @@ void main() {
     expect(bytes2, bytes3);
   });
 
+  test(
+    'CBuilder c++_static links libc++abi on Android',
+    timeout: longTimeout,
+    () async {
+      final tempUri = await tempDirForTest();
+      final cxxabiUri = packageUri.resolve(
+        'test/cbuilder/testfiles/cxxabi/src/cxxabi.cc',
+      );
+      const name = 'cxxabi';
+
+      final tempUriShared = tempUri.resolve('shared/');
+      await Directory.fromUri(tempUriShared).create();
+      final buildInputBuilder = BuildInputBuilder()
+        ..setupShared(
+          packageName: name,
+          packageRoot: tempUri,
+          outputFile: tempUri.resolve('output.json'),
+          outputDirectoryShared: tempUriShared,
+        )
+        ..config.setupBuild(linkingEnabled: false)
+        ..addExtension(
+          CodeAssetExtension(
+            targetOS: .android,
+            targetArchitecture: Architecture.arm64,
+            cCompiler: cCompiler,
+            android: AndroidCodeConfig(
+              targetNdkApi: flutterAndroidNdkVersionLowestSupported,
+            ),
+            linkModePreference: .dynamic,
+          ),
+        );
+
+      final buildInput = buildInputBuilder.build();
+      final buildOutput = BuildOutputBuilder();
+
+      final cbuilder = CBuilder.library(
+        name: name,
+        assetName: name,
+        sources: [cxxabiUri.toFilePath()],
+        language: .cpp,
+        cppLinkStdLib: 'c++_static',
+        buildMode: .release,
+      );
+      await cbuilder.run(
+        input: buildInput,
+        output: buildOutput,
+        logger: logger,
+      );
+
+      final asset = BuildOutput(buildOutput.json).assets.code.first;
+
+      // Without linking libc++abi, typeinfo for std::runtime_error
+      // would be an undefined dynamic symbol, causing dlopen to fail
+      // on newer Android versions.
+      await expectSymbolNotUndefined(
+        asset,
+        OS.android,
+        '_ZTISt13runtime_error',
+      );
+    },
+  );
+
   test('page size override', timeout: longTimeout, () async {
     const target = Architecture.arm64;
     final linkMode = DynamicLoadingBundled();

--- a/pkgs/native_toolchain_c/test/cbuilder/testfiles/cxxabi/src/cxxabi.cc
+++ b/pkgs/native_toolchain_c/test/cbuilder/testfiles/cxxabi/src/cxxabi.cc
@@ -1,0 +1,19 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// This file uses C++ standard library types whose typeinfo and vtable symbols
+// are provided by libc++abi on Android. Building a shared library from this
+// file with c++_static requires linking libc++abi in addition to libc++_static.
+
+#include <stdexcept>
+
+#if _WIN32
+#define FFI_EXPORT __declspec(dllexport)
+#else
+#define FFI_EXPORT
+#endif
+
+FFI_EXPORT void throw_runtime_error() {
+  throw std::runtime_error("test");
+}

--- a/pkgs/native_toolchain_c/test/helpers.dart
+++ b/pkgs/native_toolchain_c/test/helpers.dart
@@ -232,6 +232,32 @@ Future<String?> readSymbols(CodeAsset asset, OS targetOS) async {
   }
 }
 
+/// Asserts that [symbol] is not an undefined dynamic symbol in the
+/// library described by [asset].
+///
+/// Uses [readSymbols] to inspect the symbol table and checks that
+/// the symbol does not appear with the `U` (undefined) binding type.
+Future<void> expectSymbolNotUndefined(
+  CodeAsset asset,
+  OS targetOS,
+  String symbol,
+) async {
+  final symbols = await readSymbols(asset, targetOS);
+  if (symbols == null) {
+    // Skip if the tool to extract symbols is not available.
+    return;
+  }
+  final undefinedMatches = symbols
+      .split('\n')
+      .where((line) => line.contains(' U ') && line.contains(symbol))
+      .toList();
+  expect(
+    undefinedMatches,
+    isEmpty,
+    reason: '$symbol should not be an undefined symbol',
+  );
+}
+
 /// Returns null if the dumpbin tool is not available.
 Future<RunProcessResult?> _runDumpbin(
   List<String> arguments,


### PR DESCRIPTION
## Summary

Fixes `cppLinkStdLib: 'c++_static'` on Android not linking `libc++abi`, which caused `dlopen` failures on newer Android versions with stricter linker namespace enforcement.

## Approach

Uses `-Wl,-Bstatic -lc++ -Wl,-Bdynamic` instead of `-l c++_static` directly. This forces the linker to resolve `-lc++` using the NDK's `libc++.a` linker script, which expands to `INPUT(-lc++_static -lc++abi)`.

`-static-libstdc++` turned out to not work because the Android NDK clang driver does not inject the C++ standard library during linking — it leaves that entirely to the build system.

## Changes

- **`run_cbuilder.dart`**: Use `-Wl,-Bstatic -lc++ -Wl,-Bdynamic` when `cppLinkStdLib` is `c++_static` on Android
- **`ctool.dart`**: Document `c++_static` in the `cppLinkStdLib` API docs
- **`cbuilder_cross_android_test.dart`**: Add test that builds a C++ shared library using `std::runtime_error` and verifies `_ZTISt13runtime_error` is not an undefined symbol
- **`helpers.dart`**: Add `expectSymbolNotUndefined` helper reusing `readSymbols`
- **`cxxabi.cc`**: Test source file that exercises libc++abi symbols
- Version bump to 0.17.6

Fixes #3240