### PR TITLE
[record_use] Revamp `Definition`s API

### DIFF
--- a/pkgs/hooks/example/link/package_with_assets/hook/link.dart
+++ b/pkgs/hooks/example/link/package_with_assets/hook/link.dart
@@ -11,14 +11,14 @@ import 'package:data_assets/data_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:record_use/record_use.dart';
 
-const someMethodDefinition = Definition(
-  'package:package_with_assets/package_with_assets.dart',
-  [Name(kind: .methodKind, 'someMethod')],
+const someMethodDefinition = Method(
+  'someMethod',
+  Library('package:package_with_assets/package_with_assets.dart'),
 );
 
-const someOtherMethodDefinition = Definition(
-  'package:package_with_assets/package_with_assets.dart',
-  [Name(kind: .methodKind, 'someOtherMethod')],
+const someOtherMethodDefinition = Method(
+  'someOtherMethod',
+  Library('package:package_with_assets/package_with_assets.dart'),
 );
 
 final assetMapping = {

--- a/pkgs/hooks_runner/test/build_runner/resources_test.dart
+++ b/pkgs/hooks_runner/test/build_runner/resources_test.dart
@@ -165,9 +165,10 @@ void main() async {
       final newRecordings = Recordings(
         calls: {
           ..._pirateAdventureRecordings.calls,
-          const Definition('package:dummy/dummy.dart', [
-            Name('dummy', kind: DefinitionKind.methodKind),
-          ]): [
+          const Method(
+            'dummy',
+            Library('package:dummy/dummy.dart'),
+          ): [
             const CallWithArguments(
               loadingUnit: loadingUnitRoot,
               positionalArguments: [],
@@ -201,13 +202,10 @@ void main() async {
 /// bin/pirate_adventure.dart.
 final _pirateAdventureRecordings = Recordings(
   calls: {
-    Definition('package:pirate_speak/src/definitions.dart', [
-      Name(
-        kind: .methodKind,
-        'pirateSpeak',
-        disambiguators: {.staticDisambiguator},
-      ),
-    ]): [
+    const Method(
+      'pirateSpeak',
+      Library('package:pirate_speak/src/definitions.dart'),
+    ): [
       const CallWithArguments(
         loadingUnit: loadingUnitRoot,
         positionalArguments: [StringConstant('Hello')],
@@ -219,13 +217,10 @@ final _pirateAdventureRecordings = Recordings(
         namedArguments: {},
       ),
     ],
-    Definition('package:pirate_technology/src/definitions.dart', [
-      Name(
-        kind: .methodKind,
-        'useCannon',
-        disambiguators: {.staticDisambiguator},
-      ),
-    ]): [
+    const Method(
+      'useCannon',
+      Library('package:pirate_technology/src/definitions.dart'),
+    ): [
       const CallWithArguments(
         loadingUnit: loadingUnitRoot,
         positionalArguments: [],

--- a/pkgs/hooks_runner/test_data/pirate_speak/hook/link.dart
+++ b/pkgs/hooks_runner/test_data/pirate_speak/hook/link.dart
@@ -51,15 +51,9 @@ Future<Recordings> _loadRecordings(Uri file) async {
 
 Set<String> _extractUsedPhrases(Recordings recordings) {
   final usedPhrases = <String>{};
-  final pirateSpeakDef = Definition(
-    'package:pirate_speak/src/definitions.dart',
-    [
-      Name(
-        kind: DefinitionKind.methodKind,
-        'pirateSpeak',
-        disambiguators: {DefinitionDisambiguator.staticDisambiguator},
-      ),
-    ],
+  const pirateSpeakDef = Method(
+    'pirateSpeak',
+    Library('package:pirate_speak/src/definitions.dart'),
   );
 
   for (final call in recordings.calls[pirateSpeakDef] ?? const []) {

--- a/pkgs/hooks_runner/test_data/pirate_technology/hook/link.dart
+++ b/pkgs/hooks_runner/test_data/pirate_technology/hook/link.dart
@@ -50,11 +50,11 @@ Future<Recordings> _loadRecordings(Uri file) async {
 Set<String> _extractUsedTechnologies(Recordings recordings) {
   final usedTechnologies = <String>{};
   for (final definition in recordings.calls.keys) {
-    if (definition.library ==
+    if (definition.library.uri ==
         'package:pirate_technology/src/definitions.dart') {
       // Map function name to tech key (simple capitalization)
       // e.g. useCannon -> Cannon
-      final name = definition.path.last.name;
+      final name = definition.name;
       if (name.startsWith('use')) {
         usedTechnologies.add(name.substring(3));
       }

--- a/pkgs/record_use/example/api/usage_link.dart
+++ b/pkgs/record_use/example/api/usage_link.dart
@@ -11,31 +11,17 @@ import 'dart:io';
 import 'package:hooks/hooks.dart';
 import 'package:record_use/record_use.dart';
 
-final methodId = Definition(
-  'package:pirate_speak/pirate_speak.dart',
-  [
-    const Name(
-      kind: DefinitionKind.classKind,
-      'PirateTranslator',
-    ),
-    Name(
-      kind: DefinitionKind.methodKind,
-      'speak',
-      disambiguators: {
-        .staticDisambiguator,
-      },
-    ),
-  ],
+const methodId = Method(
+  'speak',
+  Class(
+    'PirateTranslator',
+    Library('package:pirate_speak/pirate_speak.dart'),
+  ),
 );
 
-const classId = Definition(
-  'package:pirate_technology/pirate_technology.dart',
-  [
-    Name(
-      kind: DefinitionKind.classKind,
-      'PirateShip',
-    ),
-  ],
+const classId = Class(
+  'PirateShip',
+  Library('package:pirate_technology/pirate_technology.dart'),
 );
 
 // snippet-start#link

--- a/pkgs/record_use/lib/record_use.dart
+++ b/pkgs/record_use/lib/record_use.dart
@@ -116,7 +116,24 @@ export 'src/constant.dart'
         SymbolConstant,
         UnsupportedConstant;
 export 'src/definition.dart'
-    show Definition, DefinitionDisambiguator, DefinitionKind, Name;
+    show
+        Class,
+        Constructor,
+        Definition,
+        DefinitionWithInstances,
+        DefinitionWithMembers,
+        DefinitionWithStaticCalls,
+        Enum,
+        Extension,
+        ExtensionType,
+        Getter,
+        Library,
+        Member,
+        Method,
+        Mixin,
+        Operator,
+        ScopeWithMembers,
+        Setter;
 export 'src/loading_unit.dart' show LoadingUnit;
 export 'src/recordings.dart' show Recordings;
 export 'src/reference.dart'

--- a/pkgs/record_use/lib/src/constant.dart
+++ b/pkgs/record_use/lib/src/constant.dart
@@ -1057,8 +1057,9 @@ final class InstanceConstant extends Constant {
 
   @override
   Constant _filter({String? definitionPackageName}) {
+    final libraryUri = definition.library.uri;
     if (definitionPackageName != null &&
-        !definition.library.startsWith('package:$definitionPackageName/')) {
+        !libraryUri.startsWith('package:$definitionPackageName/')) {
       return UnsupportedConstant(
         'Instance of $definition from other package is not supported.',
       );
@@ -1219,8 +1220,9 @@ final class EnumConstant extends Constant {
 
   @override
   Constant _filter({String? definitionPackageName}) {
+    final libraryUri = definition.library.uri;
     if (definitionPackageName != null &&
-        !definition.library.startsWith('package:$definitionPackageName/')) {
+        !libraryUri.startsWith('package:$definitionPackageName/')) {
       return UnsupportedConstant(
         'Instance of $definition from other package is not supported.',
       );

--- a/pkgs/record_use/lib/src/definition.dart
+++ b/pkgs/record_use/lib/src/definition.dart
@@ -4,314 +4,434 @@
 
 import 'package:meta/meta.dart';
 
-import 'canonicalization_context.dart';
-import 'helper.dart';
+import 'recordings.dart';
 import 'syntax.g.dart';
 
-/// A unique identifier for a code element, such as a class, method,
-/// or field, within a Dart program.
+/// A unique identifier for a code element, such as a [Class] or [Method] within
+/// a Dart program.
 ///
-/// A [Definition] is used to pinpoint a specific element based on its
-/// location and name.
-// TODO(https://github.com/dart-lang/native/issues/3062): Make this API more
-// kind-centric, after we've added support for kinds and disambiguators in the
-// compilers.
-class Definition {
-  /// The URI of the library where the element is defined.
-  ///
-  /// This must be a `package:` URI, so that it is OS- and user independent.
-  ///
-  /// For elements annotated with `@RecordUse`, this URI will always point to a
-  /// file in the `lib/` directory of a package.
-  final String library;
+/// A [Definition] is used to pinpoint a specific element based on its location
+/// and name.
+abstract class Definition {
+  /// The name of this definition.
+  final String name;
 
-  /// The hierarchical path to the element within the library.
-  final List<Name> path;
+  /// The parent scope that contains this definition.
+  final ScopeWithMembers parent;
 
-  /// Creates a [Definition] object.
-  const Definition(this.library, this.path);
+  const Definition._(this.name, this.parent);
 
-  /// Creates a [Definition] object from its syntax representation.
-  static Definition _fromSyntax(DefinitionSyntax syntax) => Definition(
-    syntax.uri,
-    syntax.definitionPath
-        .map(
-          (nameSyntax) => Name(
-            nameSyntax.name,
-            kind: DefinitionKind._fromName(nameSyntax.kind),
-            disambiguators:
-                nameSyntax.disambiguators
-                    ?.map(DefinitionDisambiguator._fromName)
-                    .toSet() ??
-                {},
-          ),
-        )
-        .toList(),
-  );
+  /// The library where this element is defined.
+  Library get library => parent.library;
 
-  /// Converts this [Definition] object to a syntax representation.
-  DefinitionSyntax _toSyntax() => DefinitionSyntax(
-    uri: library,
-    definitionPath: path
-        .map(
-          (name) => NameSyntax(
-            name: name.name,
-            kind: name.kind.toString(),
-            disambiguators: name.disambiguators.isEmpty
-                ? null
-                : name.disambiguators.map((d) => d.toString()).toList(),
-          ),
-        )
-        .toList(),
-  );
-
-  /// Canonicalizes the children of this [Definition].
-  Definition _canonicalizeChildren(CanonicalizationContext context) =>
-      Definition(
-        library,
-        [for (final name in path) name._canonicalizeChildren(context)],
-      );
-
-  /// The parent, if it exists.
-  Definition? get parent => path.length > 1
-      ? Definition(library, path.sublist(0, path.length - 1))
-      : null;
+  NameSyntax _toNameSyntax();
 
   @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    if (other is! Definition) return false;
-    if (other.library != library) return false;
-    if (other.path.length != path.length) return false;
-    for (var i = 0; i < path.length; i++) {
-      if (other.path[i] != path[i]) return false;
-    }
-    return true;
-  }
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Definition &&
+          other.runtimeType == runtimeType &&
+          other.name == name &&
+          other.parent == parent;
 
   @override
-  int get hashCode =>
-      cacheHashCode(() => Object.hash(library, Object.hashAll(path)));
-
-  // This should align with [toString] ordering.
-  int _compareTo(Definition other) => toString().compareTo(other.toString());
-
-  /// Returns a URI representation of this definition.
-  ///
-  /// The [library] is the base URI and the [path] is the fragment.
-  /// [Name]s in the [path] are separated by `::`.
-  @override
-  String toString() => '$library#${path.join('::')}';
+  int get hashCode => Object.hash(runtimeType, name, parent);
 
   /// Compares this [Definition] with [other] for semantic equality.
   ///
-  /// The [library] can be mapped using [uriMapping] before comparison.
+  /// The library URI can be mapped using [uriMapping] before comparison.
   @visibleForTesting
   bool semanticEquals(
     Definition other, {
     String Function(String)? uriMapping,
   }) {
-    if (other.path.length != path.length) return false;
-    for (var i = 0; i < path.length; i++) {
-      if (other.path[i] != path[i]) return false;
+    if (other.runtimeType != runtimeType) return false;
+    if (other.name != name) return false;
+    if (!parent._semanticEquals(other.parent, uriMapping: uriMapping)) {
+      return false;
     }
-    final mappedLibrary = uriMapping == null ? library : uriMapping(library);
-    return mappedLibrary == other.library;
+    return true;
   }
 }
 
-/// A component of a [Definition] path.
-class Name {
-  /// The name of the element itself.
-  final String name;
+/// A [Library] or [DefinitionWithMembers] which can contain [Member]s.
+abstract class ScopeWithMembers {
+  const ScopeWithMembers._();
 
-  /// The kind of the element.
-  final DefinitionKind kind;
+  /// The library which is this scope or contains this scope.
+  Library get library;
+}
 
-  /// Optional disambiguators (e.g. to distinguish between static and instance
-  /// members in extensions and extension types).
-  final Set<DefinitionDisambiguator> disambiguators;
+/// A [Definition] for which instances or constant values can be recorded in
+/// [Recordings.instances].
+abstract interface class DefinitionWithInstances implements Definition {}
 
-  const Name(
-    this.name, {
-    required this.kind,
-    this.disambiguators = const {},
-  });
+/// A [Definition] that can be recorded as a static call in [Recordings.calls].
+abstract interface class DefinitionWithStaticCalls implements Definition {
+  /// Whether this member is an instance member (declared without the `static`
+  /// keyword) or a static member.
+  ///
+  /// For extension and extension type members, instance members are dispatched
+  /// statically and are therefore recorded as static calls in
+  /// [Recordings.calls].
+  bool get isInstanceMember;
+}
 
-  Name _canonicalizeChildren(CanonicalizationContext context) {
-    if (disambiguators.isEmpty) return this;
-    return Name(
-      name,
-      kind: kind,
-      disambiguators: Set.from(
-        disambiguators.toList()..sort((a, b) => a.compareTo(b)),
-      ),
-    );
-  }
+extension on ScopeWithMembers {
+  String get _prefix => '$this${this is Library ? '#' : '::'}';
+
+  bool _semanticEquals(
+    ScopeWithMembers other, {
+    String Function(String)? uriMapping,
+  }) => switch ((this, other)) {
+    (final Library l1, final Library l2) =>
+      (uriMapping?.call(l1.uri) ?? l1.uri) == l2.uri,
+    (final Definition d1, final Definition d2) => d1.semanticEquals(
+      d2,
+      uriMapping: uriMapping,
+    ),
+    _ => false,
+  };
+}
+
+/// A Dart library.
+///
+/// Contains [Definition]s via [Definition.parent].
+final class Library implements ScopeWithMembers {
+  /// The URI of the library in which [Definition]s are defined.
+  ///
+  /// This must be a `package:` URI, so that it is OS- and user independent.
+  final String uri;
+
+  /// Creates a new [Library] with the given [uri].
+  const Library(this.uri);
 
   @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    if (other is! Name) return false;
-    if (other.name != name) return false;
-    if (other.kind != kind) return false;
-    if (other.disambiguators.length != disambiguators.length) return false;
-    return disambiguators.every(other.disambiguators.contains);
-  }
+  Library get library => this;
 
   @override
-  int get hashCode => cacheHashCode(
-    () => Object.hash(name, kind, Object.hashAllUnordered(disambiguators)),
+  bool operator ==(Object other) =>
+      identical(this, other) || other is Library && other.uri == uri;
+
+  @override
+  int get hashCode => uri.hashCode;
+
+  @override
+  String toString() => uri;
+}
+
+/// A [Definition] that can contain other [Member]s.
+///
+/// For example, a [Class] can contain [Method]s and [Getter]s.
+abstract class DefinitionWithMembers extends Definition
+    implements ScopeWithMembers {
+  const DefinitionWithMembers._(super.name, super.parent) : super._();
+}
+
+/// A Dart class.
+final class Class extends DefinitionWithMembers
+    implements DefinitionWithInstances {
+  /// Creates a new [Class] with the given [name] and [parent].
+  const Class(super.name, super.parent) : super._();
+
+  @override
+  NameSyntax _toNameSyntax() => ClassNameSyntax(name: name);
+
+  @override
+  String toString() => '${parent._prefix}class:$name';
+}
+
+/// A Dart mixin.
+final class Mixin extends DefinitionWithMembers {
+  /// Creates a new [Mixin] with the given [name] and [parent].
+  const Mixin(super.name, super.parent) : super._();
+
+  @override
+  NameSyntax _toNameSyntax() => MixinNameSyntax(name: name);
+
+  @override
+  String toString() => '${parent._prefix}mixin:$name';
+}
+
+/// A Dart enum.
+final class Enum extends DefinitionWithMembers
+    implements DefinitionWithInstances {
+  /// Creates a new [Enum] with the given [name] and [parent].
+  const Enum(super.name, super.parent) : super._();
+
+  @override
+  NameSyntax _toNameSyntax() => EnumNameSyntax(name: name);
+
+  @override
+  String toString() => '${parent._prefix}enum:$name';
+}
+
+/// A Dart extension.
+final class Extension extends DefinitionWithMembers {
+  /// Creates a new [Extension] with the given [name] and [parent].
+  const Extension(super.name, super.parent) : super._();
+
+  @override
+  NameSyntax _toNameSyntax() => ExtensionNameSyntax(name: name);
+
+  @override
+  String toString() => '${parent._prefix}extension:$name';
+}
+
+/// A Dart extension type.
+final class ExtensionType extends DefinitionWithMembers {
+  /// Creates a new [ExtensionType] with the given [name] and [parent].
+  const ExtensionType(super.name, super.parent) : super._();
+
+  @override
+  NameSyntax _toNameSyntax() => ExtensionTypeNameSyntax(name: name);
+
+  @override
+  String toString() => '${parent._prefix}extension_type:$name';
+}
+
+/// A member definition.
+abstract class Member extends Definition {
+  const Member._(super.name, super.parent) : super._();
+
+  /// Whether this member is an instance member (declared without the `static`
+  /// keyword) or a static member.
+  ///
+  /// For extension and extension type members, instance members are dispatched
+  /// statically and are therefore recorded as static calls in
+  /// [Recordings.calls].
+  bool get isInstanceMember;
+
+  @override
+  bool operator ==(Object other) =>
+      super == other &&
+      other is Member &&
+      other.isInstanceMember == isInstanceMember;
+
+  @override
+  int get hashCode => Object.hash(super.hashCode, isInstanceMember);
+
+  @override
+  bool semanticEquals(
+    Definition other, {
+    String Function(String)? uriMapping,
+  }) {
+    if (!super.semanticEquals(other, uriMapping: uriMapping)) return false;
+    if (other is! Member) return false;
+    return other.isInstanceMember == isInstanceMember;
+  }
+}
+
+/// A Dart method.
+final class Method extends Member implements DefinitionWithStaticCalls {
+  @override
+  final bool isInstanceMember;
+
+  /// Creates a new [Method] with the given [name] and [parent].
+  ///
+  /// The [isInstanceMember] flag indicates whether this is an instance member
+  /// (declared without the `static` keyword) or a static member.
+  const Method(
+    super.name,
+    super.parent, {
+    this.isInstanceMember = false,
+  }) : super._();
+
+  @override
+  NameSyntax _toNameSyntax() => MethodNameSyntax(
+    name: name,
+    disambiguators: [isInstanceMember ? 'instance' : 'static'],
   );
 
-  /// Returns a string representation of this name that can be used as a part of
-  /// a URI fragment.
-  ///
-  /// The format is `kind:name@disambiguator1@disambiguator2`.
-  /// Disambiguators are sorted alphabetically.
   @override
   String toString() {
-    final buffer = StringBuffer();
-    buffer.write('$kind:');
-    buffer.write(name);
-    if (disambiguators.isNotEmpty) {
-      final sorted = disambiguators.toList()..sort((a, b) => a.compareTo(b));
-      for (final disambiguator in sorted) {
-        buffer.write('@$disambiguator');
-      }
-    }
-    return buffer.toString();
+    final suffix = isInstanceMember ? 'instance' : 'static';
+    return '${parent._prefix}method:$name@$suffix';
   }
 }
 
-/// The kind of code element represented by a [Name].
-///
-/// This is not an enum because adding new elements to an enum is a breaking
-/// change for switch statements. By using a class with static const instances,
-/// we can add new kinds without breaking existing code.
-final class DefinitionKind {
-  final String _name;
-  const DefinitionKind._(this._name);
+/// A Dart getter.
+final class Getter extends Member implements DefinitionWithStaticCalls {
+  @override
+  final bool isInstanceMember;
 
-  static const classKind = DefinitionKind._('class');
-  static const mixinKind = DefinitionKind._('mixin');
-  static const enumKind = DefinitionKind._('enum');
-  static const extensionKind = DefinitionKind._('extension');
-  static const extensionTypeKind = DefinitionKind._('extension_type');
-  static const methodKind = DefinitionKind._('method');
-  static const getterKind = DefinitionKind._('getter');
-  static const setterKind = DefinitionKind._('setter');
-  static const operatorKind = DefinitionKind._('operator');
-  static const constructorKind = DefinitionKind._('constructor');
+  /// Creates a new [Getter] with the given [name] and [parent].
+  ///
+  /// The [isInstanceMember] flag indicates whether this is an instance member
+  /// (declared without the `static` keyword) or a static member.
+  const Getter(
+    super.name,
+    super.parent, {
+    this.isInstanceMember = false,
+  }) : super._();
 
-  static const _knownValues = [
-    classKind,
-    mixinKind,
-    enumKind,
-    extensionKind,
-    extensionTypeKind,
-    methodKind,
-    getterKind,
-    setterKind,
-    operatorKind,
-    constructorKind,
-  ];
-
-  static DefinitionKind _fromName(String name) => _knownValues.firstWhere(
-    (v) => v._name == name,
-    orElse: () => DefinitionKind._(name),
+  @override
+  NameSyntax _toNameSyntax() => GetterNameSyntax(
+    name: name,
+    disambiguators: [isInstanceMember ? 'instance' : 'static'],
   );
 
   @override
-  bool operator ==(Object other) =>
-      other is DefinitionKind && other._name == _name;
-
-  @override
-  int get hashCode => _name.hashCode;
-
-  int _compareTo(DefinitionKind other) => _name.compareTo(other._name);
-
-  @override
-  String toString() => _name;
+  String toString() {
+    final suffix = isInstanceMember ? 'instance' : 'static';
+    return '${parent._prefix}getter:$name@$suffix';
+  }
 }
 
-/// Package private (protected) methods for [DefinitionKind].
-///
-/// This avoids bloating the public API and public API docs and prevents
-/// internal types from leaking from the API.
-extension DefinitionKindProtected on DefinitionKind {
-  int compareTo(DefinitionKind other) => _compareTo(other);
-}
+/// A Dart setter.
+final class Setter extends Member implements DefinitionWithStaticCalls {
+  @override
+  final bool isInstanceMember;
 
-/// Extra metadata to disambiguate between elements that might have the same
-/// name and kind.
-///
-/// This is not an enum because adding new elements to an enum is a breaking
-/// change for switch statements. By using a class with static const instances,
-/// we can add new kinds without breaking existing code.
-final class DefinitionDisambiguator {
-  final String _name;
-  const DefinitionDisambiguator._(this._name);
-
-  /// Applied to members that are static (e.g. a static method in a class).
+  /// Creates a new [Setter] with the given [name] and [parent].
   ///
-  /// Only applies to [DefinitionKind.methodKind], [DefinitionKind.getterKind],
-  /// [DefinitionKind.setterKind], and [DefinitionKind.operatorKind].
-  static const staticDisambiguator = DefinitionDisambiguator._('static');
-
-  /// Applied to members that are instance members (e.g. an instance method in a
-  /// class or extension).
-  ///
-  /// Only applies to [DefinitionKind.methodKind], [DefinitionKind.getterKind],
-  /// [DefinitionKind.setterKind], and [DefinitionKind.operatorKind].
-  static const instanceDisambiguator = DefinitionDisambiguator._('instance');
-
-  static const _knownValues = [
-    staticDisambiguator,
-    instanceDisambiguator,
-  ];
-
-  static DefinitionDisambiguator _fromName(String name) =>
-      _knownValues.firstWhere(
-        (v) => v._name == name,
-        orElse: () => DefinitionDisambiguator._(name),
-      );
+  /// The [isInstanceMember] flag indicates whether this is an instance member
+  /// (declared without the `static` keyword) or a static member.
+  const Setter(
+    super.name,
+    super.parent, {
+    this.isInstanceMember = false,
+  }) : super._();
 
   @override
-  bool operator ==(Object other) =>
-      other is DefinitionDisambiguator && other._name == _name;
+  NameSyntax _toNameSyntax() => SetterNameSyntax(
+    name: name,
+    disambiguators: [isInstanceMember ? 'instance' : 'static'],
+  );
 
   @override
-  int get hashCode => _name.hashCode;
-
-  int _compareTo(DefinitionDisambiguator other) => _name.compareTo(other._name);
-
-  @override
-  String toString() => _name;
+  String toString() {
+    final suffix = isInstanceMember ? 'instance' : 'static';
+    return '${parent._prefix}setter:$name@$suffix';
+  }
 }
 
-/// Package private (protected) methods for [DefinitionDisambiguator].
-///
-/// This avoids bloating the public API and public API docs and prevents
-/// internal types from leaking from the API.
-extension DefinitionDisambiguatorProtected on DefinitionDisambiguator {
-  int compareTo(DefinitionDisambiguator other) => _compareTo(other);
+/// A Dart operator.
+final class Operator extends Member implements DefinitionWithStaticCalls {
+  @override
+  DefinitionWithMembers get parent => super.parent as DefinitionWithMembers;
+
+  /// Creates a new [Operator] with the given [name] and [parent].
+  const Operator(super.name, DefinitionWithMembers super.parent) : super._();
+
+  @override
+  bool get isInstanceMember => true;
+
+  @override
+  NameSyntax _toNameSyntax() => OperatorNameSyntax(name: name);
+
+  @override
+  String toString() => '${parent._prefix}operator:$name';
+}
+
+/// A Dart constructor.
+final class Constructor extends Member {
+  @override
+  DefinitionWithMembers get parent => super.parent as DefinitionWithMembers;
+
+  /// Creates a new [Constructor] with the given [name] and [parent].
+  const Constructor(super.name, DefinitionWithMembers super.parent) : super._();
+
+  @override
+  bool get isInstanceMember => false;
+
+  @override
+  NameSyntax _toNameSyntax() => ConstructorNameSyntax(name: name);
+
+  @override
+  String toString() => '${parent._prefix}constructor:$name';
 }
 
 /// Package private (protected) methods for [Definition].
-///
-/// This avoids bloating the public API and public API docs and prevents
-/// internal types from leaking from the API.
+@internal
 extension DefinitionProtected on Definition {
-  DefinitionSyntax toSyntax() => _toSyntax();
+  DefinitionSyntax toSyntax() {
+    final path = <NameSyntax>[];
+    Definition? current = this;
+    while (current != null) {
+      path.insert(0, current._toNameSyntax());
+      final parent = current.parent;
+      current = parent is Definition ? parent as Definition : null;
+    }
 
-  Definition canonicalizeChildren(CanonicalizationContext context) =>
-      _canonicalizeChildren(context);
+    return DefinitionSyntax(uri: library.uri, definitionPath: path);
+  }
 
-  int compareTo(Definition other) => _compareTo(other);
+  int compareTo(Definition other) => toString().compareTo(other.toString());
 
-  static Definition fromSyntax(DefinitionSyntax syntax) =>
-      Definition._fromSyntax(syntax);
+  static Definition fromSyntax(DefinitionSyntax syntax) {
+    ScopeWithMembers current = Library(syntax.uri);
+    final path = syntax.definitionPath;
+    for (var i = 0; i < path.length; i++) {
+      final nameSyntax = path[i];
+      final name = nameSyntax.name;
+
+      final next = switch (nameSyntax) {
+        ClassNameSyntax() => Class(name, current),
+        MixinNameSyntax() => Mixin(name, current),
+        EnumNameSyntax() => Enum(name, current),
+        ExtensionNameSyntax() => Extension(name, current),
+        ExtensionTypeNameSyntax() => ExtensionType(name, current),
+        MethodNameSyntax(:final disambiguators) => Method(
+          name,
+          current,
+          isInstanceMember: switch (disambiguators) {
+            ['instance'] => true,
+            ['static'] => false,
+            _ => throw FormatException(
+              'Method requires ["instance"] or ["static"] disambiguator: '
+              '$name',
+            ),
+          },
+        ),
+        GetterNameSyntax(:final disambiguators) => Getter(
+          name,
+          current,
+          isInstanceMember: switch (disambiguators) {
+            ['instance'] => true,
+            ['static'] => false,
+            _ => throw FormatException(
+              'Getter requires ["instance"] or ["static"] disambiguator: '
+              '$name',
+            ),
+          },
+        ),
+        SetterNameSyntax(:final disambiguators) => Setter(
+          name,
+          current,
+          isInstanceMember: switch (disambiguators) {
+            ['instance'] => true,
+            ['static'] => false,
+            _ => throw FormatException(
+              'Setter requires ["instance"] or ["static"] disambiguator: '
+              '$name',
+            ),
+          },
+        ),
+        OperatorNameSyntax() => Operator(
+          name,
+          current as DefinitionWithMembers,
+        ),
+        ConstructorNameSyntax() => Constructor(
+          name,
+          current as DefinitionWithMembers,
+        ),
+        _ => throw FormatException(
+          'Unknown definition kind: ${nameSyntax.kind}',
+        ),
+      };
+      if (i < path.length - 1) {
+        current = next as ScopeWithMembers;
+      } else {
+        return next;
+      }
+    }
+    throw const FormatException('Empty definition path');
+  }
+}
+
+/// Package private (protected) methods for [Library].
+@internal
+extension LibraryProtected on Library {
+  int compareTo(Library other) => uri.compareTo(other.uri);
 }

--- a/pkgs/record_use/lib/src/recordings.dart
+++ b/pkgs/record_use/lib/src/recordings.dart
@@ -28,7 +28,7 @@ import 'syntax.g.dart';
 /// The class uses a normalized JSON format, allowing the reuse of constants
 /// across multiple recordings to optimize storage.
 class Recordings {
-  /// The collected [CallReference]s for each [Definition].
+  /// The collected [CallReference]s for each [DefinitionWithStaticCalls].
   ///
   /// Recorded when `@RecordUse()` is placed on a static member (top-level
   /// functions, static methods, getters, setters, or operators) in any
@@ -124,9 +124,9 @@ class Recordings {
   /// - Non-redirecting Factory Constructors: Not yet supported for static
   ///   calls, because they can be the target of redirecting constructors.
   ///   https://github.com/dart-lang/native/issues/3192
-  final Map<Definition, List<CallReference>> calls;
+  final Map<DefinitionWithStaticCalls, List<CallReference>> calls;
 
-  /// The collected [InstanceReference]s for each [Definition].
+  /// The collected [InstanceReference]s for each [DefinitionWithInstances].
   ///
   /// Recorded when `@RecordUse()` is placed on a `final class` or `enum` to
   /// track the lifecycle of instances.
@@ -238,7 +238,7 @@ class Recordings {
   ///   boundaries due to the ambiguity of to which packages' link hook the
   ///   information should be sent.
   ///   https://github.com/dart-lang/native/issues/3200
-  final Map<Definition, List<InstanceReference>> instances;
+  final Map<DefinitionWithInstances, List<InstanceReference>> instances;
 
   Recordings({
     required this.calls,
@@ -278,13 +278,17 @@ Error: $e
     );
     final context = _deserializeConstants(syntax, definitionContext);
 
-    final callsForDefinition = <Definition, List<CallReference>>{};
-    final instancesForDefinition = <Definition, List<InstanceReference>>{};
+    final callsForDefinition =
+        <DefinitionWithStaticCalls, List<CallReference>>{};
+    final instancesForDefinition =
+        <DefinitionWithInstances, List<InstanceReference>>{};
 
     final uses = syntax.uses;
     if (uses != null) {
       for (final callRecording in uses.staticCalls ?? <CallRecordingSyntax>[]) {
-        final definition = context.definitions[callRecording.definitionIndex];
+        final definition =
+            context.definitions[callRecording.definitionIndex]
+                as DefinitionWithStaticCalls;
         final callSyntaxes = callRecording.uses;
         final callReferences = callSyntaxes
             .map<CallReference>(
@@ -301,7 +305,8 @@ Error: $e
       for (final instanceRecording
           in uses.instances ?? <InstanceRecordingSyntax>[]) {
         final definition =
-            context.definitions[instanceRecording.definitionIndex];
+            context.definitions[instanceRecording.definitionIndex]
+                as DefinitionWithInstances;
         final instanceSyntaxes = instanceRecording.uses;
         final instanceReferences = instanceSyntaxes
             .map<InstanceReference>(
@@ -329,11 +334,12 @@ Error: $e
         instances: _canonicalizeReferences(context, instances),
       );
 
-  Map<Definition, List<R>> _canonicalizeReferences<R extends Reference>(
+  Map<K, List<R>>
+  _canonicalizeReferences<K extends Definition, R extends Reference>(
     CanonicalizationContext context,
-    Map<Definition, List<R>> references,
+    Map<K, List<R>> references,
   ) {
-    final map = <Definition, Set<R>>{};
+    final map = <K, Set<R>>{};
     for (final entry in references.entries) {
       final definition = context.canonicalizeDefinition(entry.key);
       final set = map.putIfAbsent(definition, () => {});
@@ -342,7 +348,7 @@ Error: $e
       }
     }
     final sortedKeys = map.keys.toList()..sort((a, b) => a.compareTo(b));
-    return <Definition, List<R>>{
+    return <K, List<R>>{
       for (final key in sortedKeys)
         key: map[key]!.toList()..sort((a, b) => a.compareTo(b)),
     };
@@ -571,12 +577,12 @@ Error: $e
   }
 
   /// Returns true if [expected] is a semantic subset of [actual].
-  static bool _compareUsageMap<R extends Reference>({
-    required Map<Definition, List<R>> actual,
-    required Map<Definition, List<R>> expected,
+  static bool _compareUsageMap<K extends Definition, R extends Reference>({
+    required Map<K, List<R>> actual,
+    required Map<K, List<R>> expected,
     required bool expectedIsSubset,
     required bool allowDeadCodeElimination,
-    required bool Function(Definition, Definition) definitionMatches,
+    required bool Function(K, K) definitionMatches,
     required bool Function(R, R) referenceMatches,
   }) {
     final actualUsages = actual.entries.toList();
@@ -682,7 +688,7 @@ Error: $e
   Recordings filter({String? definitionPackageName}) {
     bool belongsToPackage(Definition definition) {
       if (definitionPackageName == null) return true;
-      final uri = definition.library;
+      final uri = definition.library.uri;
       return uri.startsWith('package:$definitionPackageName/');
     }
 

--- a/pkgs/record_use/test/canonicalization_test.dart
+++ b/pkgs/record_use/test/canonicalization_test.dart
@@ -53,9 +53,10 @@ void main() {
     });
 
     test('Recordings.toJson canonicalizes constants across calls', () {
-      const definition = Definition('package:a/a.dart', [
-        Name('foo', kind: DefinitionKind.methodKind),
-      ]);
+      const definition = Method(
+        'foo',
+        Library('package:a/a.dart'),
+      );
       const constant = IntConstant(42);
 
       final recordings = Recordings(
@@ -93,9 +94,10 @@ void main() {
     });
 
     test('Recordings.toJson deduplicates and sorts references', () {
-      const definition = Definition('package:a/a.dart', [
-        Name('foo', kind: DefinitionKind.methodKind),
-      ]);
+      const definition = Method(
+        'foo',
+        Library('package:a/a.dart'),
+      );
       const unit1 = LoadingUnit('1');
       const unit2 = LoadingUnit('2');
 

--- a/pkgs/record_use/test/complex_keys_test.dart
+++ b/pkgs/record_use/test/complex_keys_test.dart
@@ -6,9 +6,9 @@ import 'package:record_use/record_use.dart';
 import 'package:test/test.dart';
 
 void main() {
-  const classDefinition = Definition(
-    'package:test/test.dart',
-    [Name('MyClass', kind: .classKind)],
+  const classDefinition = Class(
+    'MyClass',
+    Library('package:test/test.dart'),
   );
 
   test('MapConstant with InstanceConstant keys round-trip', () {
@@ -24,9 +24,9 @@ void main() {
       MapEntry(instanceKey, StringConstant('value')),
     ]);
 
-    const definition = Definition(
-      'package:test/test.dart',
-      [Name('testMethod', kind: .methodKind)],
+    const definition = Method(
+      'testMethod',
+      Library('package:test/test.dart'),
     );
 
     final recordings = Recordings(
@@ -90,9 +90,9 @@ void main() {
       MapEntry(recordKey, IntConstant(5)),
     ]);
 
-    const definition = Definition(
-      'package:test/test.dart',
-      [Name('complexMethod', kind: DefinitionKind.methodKind)],
+    const definition = Method(
+      'complexMethod',
+      Library('package:test/test.dart'),
     );
 
     final recordings = Recordings(

--- a/pkgs/record_use/test/double_constant_test.dart
+++ b/pkgs/record_use/test/double_constant_test.dart
@@ -32,9 +32,7 @@ void main() {
       for (final constant in constants) {
         final recordings = Recordings(
           calls: {
-            const Definition('package:a/a.dart', [
-              Name('foo', kind: DefinitionKind.methodKind),
-            ]): [
+            const Method('foo', Library('package:a/a.dart')): [
               CallWithArguments(
                 positionalArguments: [constant],
                 namedArguments: const {},
@@ -42,7 +40,7 @@ void main() {
               ),
             ],
           },
-          instances: {},
+          instances: const {},
         );
 
         final json = jsonEncode(recordings.toJson());
@@ -67,6 +65,7 @@ void main() {
           );
         }
         expect(roundTrippedConstant, equals(constant));
+        expect(roundTripped, equals(recordings));
       }
     });
 

--- a/pkgs/record_use/test/extension_receiver_test.dart
+++ b/pkgs/record_use/test/extension_receiver_test.dart
@@ -21,7 +21,11 @@ void main() {
         {
           'uri': 'package:a/a.dart',
           'path': [
-            {'name': 'foo', 'kind': 'method'},
+            {
+              'name': 'foo',
+              'kind': 'method',
+              'disambiguators': ['static'],
+            },
           ],
         },
       ],
@@ -43,9 +47,10 @@ void main() {
     };
 
     final recordings = Recordings.fromJson(json);
-    const definition = Definition('package:a/a.dart', [
-      Name('foo', kind: DefinitionKind.methodKind),
-    ]);
+    const definition = Method(
+      'foo',
+      Library('package:a/a.dart'),
+    );
     final calls = recordings.calls[definition]!;
     final call = calls[0] as CallWithArguments;
 
@@ -54,9 +59,10 @@ void main() {
   });
 
   test('Call with receiver serialization round-trip', () {
-    const definition = Definition('package:a/a.dart', [
-      Name('foo', kind: DefinitionKind.methodKind),
-    ]);
+    const definition = Method(
+      'foo',
+      Library('package:a/a.dart'),
+    );
     final recordings = Recordings(
       calls: {
         definition: [
@@ -87,9 +93,10 @@ void main() {
   });
 
   test('CallTearoff with receiver serialization round-trip', () {
-    const definition = Definition('package:a/a.dart', [
-      Name('foo', kind: DefinitionKind.methodKind),
-    ]);
+    const definition = Method(
+      'foo',
+      Library('package:a/a.dart'),
+    );
     final recordings = Recordings(
       calls: {
         definition: [

--- a/pkgs/record_use/test/filter_test.dart
+++ b/pkgs/record_use/test/filter_test.dart
@@ -10,13 +10,13 @@ void main() {
     const myPackage = 'my_package';
     const otherPackage = 'other_package';
 
-    const myDefinition = Definition(
-      'package:$myPackage/my_lib.dart',
-      [Name('myFunc', kind: DefinitionKind.methodKind)],
+    const myDefinition = Method(
+      'myFunc',
+      Library('package:$myPackage/my_lib.dart'),
     );
-    const otherDefinition = Definition(
-      'package:$otherPackage/other_lib.dart',
-      [Name('OtherClass', kind: DefinitionKind.classKind)],
+    const otherDefinition = Class(
+      'OtherClass',
+      Library('package:$otherPackage/other_lib.dart'),
     );
 
     const otherInstance = InstanceConstant(
@@ -52,13 +52,13 @@ void main() {
     const myPackage = 'my_package';
     const otherPackage = 'other_package';
 
-    const myDefinition = Definition(
-      'package:$myPackage/my_lib.dart',
-      [Name('myFunc', kind: DefinitionKind.methodKind)],
+    const myDefinition = Method(
+      'myFunc',
+      Library('package:$myPackage/my_lib.dart'),
     );
-    const otherDefinition = Definition(
-      'package:$otherPackage/other_lib.dart',
-      [Name('OtherClass', kind: DefinitionKind.classKind)],
+    const otherDefinition = Class(
+      'OtherClass',
+      Library('package:$otherPackage/other_lib.dart'),
     );
 
     const otherInstance = InstanceConstant(
@@ -72,7 +72,9 @@ void main() {
           const CallWithArguments(
             positionalArguments: [
               ListConstant([otherInstance]),
-              MapConstant([MapEntry(StringConstant('key'), otherInstance)]),
+              MapConstant([
+                MapEntry(StringConstant('key'), otherInstance),
+              ]),
             ],
             namedArguments: {},
             loadingUnit: LoadingUnit(''),
@@ -98,13 +100,13 @@ void main() {
     const myPackage = 'my_package';
     const otherPackage = 'other_package';
 
-    const myDefinition = Definition(
-      'package:$myPackage/my_lib.dart',
-      [Name('myFunc', kind: DefinitionKind.methodKind)],
+    const myDefinition = Method(
+      'myFunc',
+      Library('package:$myPackage/my_lib.dart'),
     );
-    const otherEnumDefinition = Definition(
-      'package:$otherPackage/other_lib.dart',
-      [Name('OtherEnum', kind: DefinitionKind.enumKind)],
+    const otherEnumDefinition = Enum(
+      'OtherEnum',
+      Library('package:$otherPackage/other_lib.dart'),
     );
 
     const otherEnum = EnumConstant(

--- a/pkgs/record_use/test/instance_references_test.dart
+++ b/pkgs/record_use/test/instance_references_test.dart
@@ -8,17 +8,14 @@ import 'package:record_use/src/recordings.dart';
 import 'package:test/test.dart';
 
 void main() {
-  const definition = Definition(
-    'package:test/test.dart',
-    [Name('MyClass', kind: DefinitionKind.classKind)],
+  const definition = Class(
+    'MyClass',
+    Library('package:test/test.dart'),
   );
 
-  const constructorDefinition = Definition(
-    'package:test/test.dart',
-    [
-      Name('MyClass', kind: DefinitionKind.classKind),
-      Name('', kind: DefinitionKind.constructorKind),
-    ],
+  const constructorDefinition = Constructor(
+    '',
+    definition,
   );
 
   const loadingUnitRoot = LoadingUnit('root');

--- a/pkgs/record_use/test/int_constant_test.dart
+++ b/pkgs/record_use/test/int_constant_test.dart
@@ -34,9 +34,7 @@ void main() {
       for (final constant in constants) {
         final recordings = Recordings(
           calls: {
-            const Definition('package:a/a.dart', [
-              Name('foo', kind: DefinitionKind.methodKind),
-            ]): [
+            const Method('foo', Library('package:a/a.dart')): [
               CallWithArguments(
                 positionalArguments: [constant],
                 namedArguments: const {},
@@ -60,6 +58,7 @@ void main() {
 
         expect(roundTrippedConstant.value, equals(constant.value));
         expect(roundTrippedConstant, equals(constant));
+        expect(roundTripped, equals(recordings));
       }
     });
   });

--- a/pkgs/record_use/test/maybe_constant_test.dart
+++ b/pkgs/record_use/test/maybe_constant_test.dart
@@ -22,7 +22,11 @@ void main() {
         {
           'uri': 'package:a/a.dart',
           'path': [
-            {'name': 'foo', 'kind': 'method'},
+            {
+              'name': 'foo',
+              'kind': 'method',
+              'disambiguators': ['static'],
+            },
           ],
         },
       ],
@@ -44,9 +48,10 @@ void main() {
     };
 
     final recordings = Recordings.fromJson(json);
-    const definition = Definition('package:a/a.dart', [
-      Name('foo', kind: .methodKind),
-    ]);
+    const definition = Method(
+      'foo',
+      Library('package:a/a.dart'),
+    );
     final calls = recordings.calls[definition]!;
     final call = calls[0] as CallWithArguments;
 
@@ -68,9 +73,10 @@ void main() {
   });
 
   test('MaybeConstant serialization round-trip', () {
-    const definition = Definition('package:a/a.dart', [
-      Name('foo', kind: .methodKind),
-    ]);
+    const definition = Method(
+      'foo',
+      Library('package:a/a.dart'),
+    );
     final recordings = Recordings(
       calls: {
         definition: [
@@ -136,9 +142,10 @@ void main() {
   });
 
   test('allowPromotionOfUnsupported semantic equality', () {
-    const definition = Definition('package:a/a.dart', [
-      Name('foo', kind: .methodKind),
-    ]);
+    const definition = Method(
+      'foo',
+      Library('package:a/a.dart'),
+    );
 
     final actualRecordings = Recordings(
       calls: {

--- a/pkgs/record_use/test/semantic_equality_test.dart
+++ b/pkgs/record_use/test/semantic_equality_test.dart
@@ -6,25 +6,29 @@ import 'package:record_use/record_use.dart';
 import 'package:test/test.dart';
 
 void main() {
-  const definition1 = Definition(
-    'package:a/a.dart',
-    [Name('definition1', kind: DefinitionKind.methodKind)],
+  const definition1 = Method(
+    'definition1',
+    Library('package:a/a.dart'),
   );
-  const definition2 = Definition(
-    'package:a/a.dart',
-    [Name('definition2', kind: DefinitionKind.methodKind)],
+  const definition2 = Method(
+    'definition2',
+    Library('package:a/a.dart'),
   );
-  const definition1differentLibrary = Definition(
-    'package:a/b.dart',
-    [Name('definition1', kind: DefinitionKind.methodKind)],
+  const definition1differentLibrary = Method(
+    'definition1',
+    Library('package:a/b.dart'),
   );
-  const definition3 = Definition(
-    'package:a/a.dart',
-    [
-      Name('SomeClass', kind: DefinitionKind.classKind),
-      Name('definition1', kind: DefinitionKind.methodKind),
-    ],
+  const definition3 = Method(
+    'definition1',
+    Class('SomeClass', Library('package:a/a.dart')),
+    isInstanceMember: true,
   );
+
+  const classDefinition1 = Class(
+    'Class1',
+    Library('package:a/a.dart'),
+  );
+
   const callDefintion1Static = CallWithArguments(
     positionalArguments: [],
     namedArguments: {},
@@ -43,9 +47,9 @@ void main() {
   const callDefinition1Tearoff = CallTearoff(
     loadingUnit: LoadingUnit(''),
   );
-  const definition1differentLibrary2 = Definition(
-    'memory:a/a.dart',
-    [Name('definition1', kind: DefinitionKind.methodKind)],
+  const definition1differentLibrary2 = Method(
+    'definition1',
+    Library('memory:a/a.dart'),
   );
   const callDefintion1StaticDifferentUri = CallWithArguments(
     positionalArguments: [],
@@ -265,10 +269,10 @@ void main() {
     final recordings1 = Recordings(
       calls: const {},
       instances: {
-        definition1: [
+        classDefinition1: [
           const InstanceConstantReference(
             instanceConstant: EnumConstant(
-              definition: definition1,
+              definition: classDefinition1,
               index: 0,
               name: 'a',
               fields: {'f': IntConstant(1)},
@@ -281,10 +285,10 @@ void main() {
     final recordings2 = Recordings(
       calls: const {},
       instances: {
-        definition1: [
+        classDefinition1: [
           const InstanceConstantReference(
             instanceConstant: EnumConstant(
-              definition: definition1,
+              definition: classDefinition1,
               index: 0,
               name: 'a',
               fields: {'f': IntConstant(1)},
@@ -297,10 +301,10 @@ void main() {
     final recordings3 = Recordings(
       calls: const {},
       instances: {
-        definition1: [
+        classDefinition1: [
           const InstanceConstantReference(
             instanceConstant: EnumConstant(
-              definition: definition1,
+              definition: classDefinition1,
               index: 1,
               name: 'b',
               fields: {'f': IntConstant(1)},
@@ -328,7 +332,10 @@ void main() {
 
     const unsupported = UnsupportedConstant('MethodTearoff');
     const setWithUnsupported = SetConstant([IntConstant(1), unsupported]);
-    const setWithInt2 = SetConstant([IntConstant(1), IntConstant(2)]);
+    const setWithInt2 = SetConstant([
+      IntConstant(1),
+      IntConstant(2),
+    ]);
 
     // unsupported does not match IntConstant(2) by default
     expect(setWithInt2.semanticEquals(setWithUnsupported), isFalse);

--- a/pkgs/record_use/test/syntax/uri_pattern_test.dart
+++ b/pkgs/record_use/test/syntax/uri_pattern_test.dart
@@ -32,10 +32,7 @@ void main() {
       // The Definition class itself doesn't have the regex check in its
       // constructor, only the generated syntax class has it.
       expect(
-        () => const Definition(
-          'dart:core',
-          [Name('foo', kind: DefinitionKind.methodKind)],
-        ),
+        () => const Method('foo', Library('dart:core')),
         returnsNormally,
       );
     });

--- a/pkgs/record_use/test/test_data.dart
+++ b/pkgs/record_use/test/test_data.dart
@@ -9,20 +9,18 @@ import 'package:record_use/record_use.dart';
 import 'package:record_use/src/canonicalization_context.dart';
 import 'package:record_use/src/recordings.dart';
 
-const callId = Definition(
-  'package:js_runtime/js_helper.dart',
-  [
-    Name('MyClass', kind: DefinitionKind.classKind),
-    Name('loadDeferredLibrary', kind: DefinitionKind.getterKind),
-  ],
+const callId = Getter(
+  'loadDeferredLibrary',
+  Class('MyClass', Library('package:js_runtime/js_helper.dart')),
+  isInstanceMember: false,
 );
-const instanceId = Definition(
-  'package:js_runtime/js_helper.dart',
-  [Name('MyAnnotation', kind: DefinitionKind.classKind)],
+const instanceId = Class(
+  'MyAnnotation',
+  Library('package:js_runtime/js_helper.dart'),
 );
-const enumId = Definition(
-  'package:js_runtime/js_helper.dart',
-  [Name('MyEnum', kind: DefinitionKind.enumKind)],
+const enumId = Enum(
+  'MyEnum',
+  Library('package:js_runtime/js_helper.dart'),
 );
 
 const loadingUnitOJs = LoadingUnit('o.js');

--- a/pkgs/record_use/test/to_string_test.dart
+++ b/pkgs/record_use/test/to_string_test.dart
@@ -52,10 +52,7 @@ void main() {
     test('InstanceConstantReference with EnumConstant', () {
       const ref = InstanceConstantReference(
         instanceConstant: EnumConstant(
-          definition: Definition(
-            'package:a/a.dart',
-            [Name('MyEnum', kind: DefinitionKind.enumKind)],
-          ),
+          definition: Enum('MyEnum', Library('package:a/a.dart')),
           index: 0,
           name: 'val1',
         ),

--- a/pkgs/record_use/test_data/drop_data_asset/hook/link.dart
+++ b/pkgs/record_use/test_data/drop_data_asset/hook/link.dart
@@ -26,15 +26,16 @@ void main(List<String> arguments) async {
 
     final symbols = <String>{};
 
-    // Tree-shake unused assets using calls
     for (final methodName in ['add', 'multiply']) {
       final calls =
-          usages.calls[Definition(
-            'package:${input.packageName}/src/${input.packageName}.dart',
-            [
-              const Name(kind: DefinitionKind.classKind, 'MyMath'),
-              Name(methodName, kind: DefinitionKind.methodKind),
-            ],
+          usages.calls[Method(
+            methodName,
+            Class(
+              'MyMath',
+              Library(
+                'package:${input.packageName}/src/${input.packageName}.dart',
+              ),
+            ),
           )] ??
           const [];
       print('Checking calls to $methodName...');
@@ -63,12 +64,13 @@ void main(List<String> arguments) async {
       'Square': 'square',
     };
 
-    // Tree-shake unused assets using instances
     for (final className in classNameToSymbol.keys) {
       final instances =
-          usages.instances[Definition(
-            'package:${input.packageName}/src/${input.packageName}.dart',
-            [Name(kind: DefinitionKind.classKind, className)],
+          usages.instances[Class(
+            className,
+            Library(
+              'package:${input.packageName}/src/${input.packageName}.dart',
+            ),
           )] ??
           const [];
       print('Checking instances of $className...');

--- a/pkgs/record_use/test_data/drop_dylib_recording/hook/link.dart
+++ b/pkgs/record_use/test_data/drop_dylib_recording/hook/link.dart
@@ -30,22 +30,16 @@ void main(List<String> arguments) async {
     ).create();
 
     final dataLines = <String>[];
-    // Tree-shake unused assets using calls
     for (final methodName in ['add', 'multiply']) {
       final calls =
-          usages.calls[Definition(
-            'package:drop_dylib_recording/src/drop_dylib_recording.dart',
-            [
-              const Name(
-                kind: DefinitionKind.classKind,
-                'MyMath',
+          usages.calls[Method(
+            methodName,
+            const Class(
+              'MyMath',
+              Library(
+                'package:drop_dylib_recording/src/drop_dylib_recording.dart',
               ),
-              Name(
-                kind: DefinitionKind.methodKind,
-                methodName,
-                disambiguators: {DefinitionDisambiguator.staticDisambiguator},
-              ),
-            ],
+            ),
           )] ??
           const [];
       for (final call in calls) {
@@ -75,17 +69,13 @@ void main(List<String> arguments) async {
       'Square': 'multiply',
     };
 
-    // Tree-shake unused assets using instances
     for (final className in classNameToSymbol.keys) {
       final instances =
-          usages.instances[Definition(
-            'package:drop_dylib_recording/src/drop_dylib_recording.dart',
-            [
-              Name(
-                kind: DefinitionKind.classKind,
-                className,
-              ),
-            ],
+          usages.instances[Class(
+            className,
+            const Library(
+              'package:drop_dylib_recording/src/drop_dylib_recording.dart',
+            ),
           )] ??
           const [];
       for (final instance in instances) {

--- a/pkgs/record_use/test_data/json/const_argument_instance.json
+++ b/pkgs/record_use/test_data/json/const_argument_instance.json
@@ -17,6 +17,9 @@
     {
       "path": [
         {
+          "disambiguators": [
+            "static"
+          ],
           "kind": "method",
           "name": "someStaticMethod2"
         }

--- a/pkgs/record_use/test_data/json/enum_const_arg.json
+++ b/pkgs/record_use/test_data/json/enum_const_arg.json
@@ -22,6 +22,9 @@
     {
       "path": [
         {
+          "disambiguators": [
+            "static"
+          ],
           "kind": "method",
           "name": "doSomething"
         }

--- a/pkgs/record_use/test_data/json/extension.json
+++ b/pkgs/record_use/test_data/json/extension.json
@@ -10,6 +10,9 @@
     {
       "path": [
         {
+          "disambiguators": [
+            "static"
+          ],
           "kind": "method",
           "name": "_extension#0|callWithArgs"
         }

--- a/pkgs/record_use/test_data/json/named_with_function_arg.json
+++ b/pkgs/record_use/test_data/json/named_with_function_arg.json
@@ -13,6 +13,9 @@
     {
       "path": [
         {
+          "disambiguators": [
+            "static"
+          ],
           "kind": "method",
           "name": "Ext|foo"
         }

--- a/pkgs/record_use/test_data/json/recorded_uses_v2.json
+++ b/pkgs/record_use/test_data/json/recorded_uses_v2.json
@@ -116,6 +116,9 @@
           "name": "MyClass"
         },
         {
+          "disambiguators": [
+            "static"
+          ],
           "kind": "getter",
           "name": "loadDeferredLibrary"
         }

--- a/pkgs/record_use/test_data/json/recorded_uses_v2_2.json
+++ b/pkgs/record_use/test_data/json/recorded_uses_v2_2.json
@@ -26,6 +26,9 @@
           "name": "MyClass"
         },
         {
+          "disambiguators": [
+            "static"
+          ],
           "kind": "getter",
           "name": "loadDeferredLibrary"
         }

--- a/pkgs/record_use/test_data/json/top_level_method.json
+++ b/pkgs/record_use/test_data/json/top_level_method.json
@@ -10,6 +10,9 @@
     {
       "path": [
         {
+          "disambiguators": [
+            "static"
+          ],
           "kind": "method",
           "name": "someTopLevelMethod"
         }

--- a/pkgs/record_use/test_data/json/unsupported_collections.json
+++ b/pkgs/record_use/test_data/json/unsupported_collections.json
@@ -29,6 +29,9 @@
     {
       "path": [
         {
+          "disambiguators": [
+            "static"
+          ],
           "kind": "method",
           "name": "recorded"
         }

--- a/pkgs/record_use/test_data/json/unsupported_instance.json
+++ b/pkgs/record_use/test_data/json/unsupported_instance.json
@@ -26,6 +26,9 @@
     {
       "path": [
         {
+          "disambiguators": [
+            "static"
+          ],
           "kind": "method",
           "name": "recorded"
         }

--- a/pkgs/record_use/test_data/library_uris/hook/link.dart
+++ b/pkgs/record_use/test_data/library_uris/hook/link.dart
@@ -25,28 +25,28 @@ void main(List<String> arguments) async {
 
       // This package.
       final myMethodDefinition = recordings.calls.keys.firstWhere(
-        (i) => i.path.last.name == 'myMethod',
+        (i) => i.name == 'myMethod',
       );
       expect(
-        myMethodDefinition.library,
+        myMethodDefinition.library.uri,
         'package:library_uris/src/definition.dart',
       );
 
       // The helper package.
       final helperMethodDefinition = recordings.calls.keys.firstWhere(
-        (i) => i.path.last.name == 'methodInHelper',
+        (i) => i.name == 'methodInHelper',
       );
       expect(
-        helperMethodDefinition.library,
+        helperMethodDefinition.library.uri,
         'package:library_uris_helper/src/helper_definition.dart',
       );
 
       // Outside the lib dir, no package: uri.
       final methodInBinDefinition = recordings.calls.keys.firstWhere(
-        (i) => i.path.last.name == 'methodInBin',
+        (i) => i.name == 'methodInBin',
       );
       expect(
-        methodInBinDefinition.library,
+        methodInBinDefinition.library.uri,
         // TODO(https://github.com/dart-lang/native/issues/2891): What should
         // this be? We don't have library uris for bin.
         'package:library_uris/../bin/my_bin.dart',


### PR DESCRIPTION
The revamps the `Definition`s API to have a class per kind:

```dart
// before:
final methodId = Definition(
  'package:pirate_speak/pirate_speak.dart',
  [
    const Name(
      kind: DefinitionKind.classKind,
      'PirateTranslator',
    ),
    Name(
      kind: DefinitionKind.methodKind,
      'speak',
      disambiguators: {
        .staticDisambiguator,
      },
    ),
  ],
);

// after:
const methodId = Method(
  Class(
    Library('package:pirate_speak/pirate_speak.dart'),
    'PirateTranslator',
  ),
  'speak',
);

// before:
const classId = Definition(
  'package:pirate_technology/pirate_technology.dart',
  [
    Name(
      kind: DefinitionKind.classKind,
      'PirateShip',
    ),
  ],
);

// after:
const classId = Class(
  Library('package:pirate_technology/pirate_technology.dart'),
  'PirateShip',
);
```

Bug:

* https://github.com/dart-lang/native/issues/3193

Interesting changes:

* `Method`, `Getter`, and `Setter` now require a `instance` or `static` disambiguator, all the others don't. (Side note: it would be nice if we could express that in the JSON schema and generate it as syntax constraint.)
* `Operator` always is an instance method.
* We don't change the syntax, but keep it a flat list.

Open questions:

* If we have the JSON syntax be more permissible, how do we keep the format future proof? Should we if we see kinds and disambiguators that we don't know ignore them? (Disambiguators ignoring is easy, but ignoring kinds means we need to put a dummy object somewhere, because we rely on in indices while deserializing.)

Possible follow up changes:

* Predefine the list of operator names instead of guessing them, and dealing with
  * https://github.com/dart-lang/native/issues/3144
* Dealing with unnamed extensions in a good way:
  * https://github.com/dart-lang/native/issues/3251
* Ditto for default constructors:
  * https://github.com/dart-lang/native/issues/3252
* Add `static` and `dynamic` in the generated syntax instead of as strings in the semantic layer.
* It would be nice if we could express the disambiguators required per kind in the JSON schema and syntax generator.