### PR TITLE
[record_use] Unnamed extensions and constructors

### DIFF
--- a/pkgs/record_use/lib/src/definition.dart
+++ b/pkgs/record_use/lib/src/definition.dart
@@ -168,8 +168,16 @@ final class Enum extends DefinitionWithMembers
 
 /// A Dart extension.
 final class Extension extends DefinitionWithMembers {
+  static const String _unnamedName = '';
+
   /// Creates a new [Extension] with the given [name] and [parent].
   const Extension(super.name, super.parent) : super._();
+
+  /// Creates a new unnamed [Extension] in the given [library].
+  const Extension.unnamed(Library library) : this(_unnamedName, library);
+
+  /// Whether this is an unnamed extension.
+  bool get isUnnamed => name == _unnamedName;
 
   @override
   NameSyntax _toNameSyntax() => ExtensionNameSyntax(name: name);
@@ -326,11 +334,20 @@ final class Operator extends Member implements DefinitionWithStaticCalls {
 
 /// A Dart constructor.
 final class Constructor extends Member {
+  static const String _unnamedName = '';
+
   @override
   DefinitionWithMembers get parent => super.parent as DefinitionWithMembers;
 
   /// Creates a new [Constructor] with the given [name] and [parent].
   const Constructor(super.name, DefinitionWithMembers super.parent) : super._();
+
+  /// Creates a new unnamed [Constructor] in the given [parent].
+  const Constructor.unnamed(DefinitionWithMembers parent)
+    : this(_unnamedName, parent);
+
+  /// Whether this is an unnamed constructor.
+  bool get isUnnamed => name == _unnamedName;
 
   @override
   bool get isInstanceMember => false;

--- a/pkgs/record_use/test/unnamed_definitions_test.dart
+++ b/pkgs/record_use/test/unnamed_definitions_test.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:record_use/record_use.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Unnamed Extension', () {
+    const library = Library('package:a/a.dart');
+
+    test('Extension.unnamed constructor', () {
+      const extension = Extension.unnamed(library);
+      expect(extension.name, '');
+      expect(extension.isUnnamed, isTrue);
+      expect(extension.parent, library);
+    });
+
+    test('Extension named constructor with empty string', () {
+      const extension = Extension('', library);
+      expect(extension.isUnnamed, isTrue);
+    });
+
+    test('Extension named constructor with name', () {
+      const extension = Extension('MyExtension', library);
+      expect(extension.isUnnamed, isFalse);
+    });
+
+    test('toString for unnamed extension', () {
+      const extension = Extension.unnamed(library);
+      expect(extension.toString(), 'package:a/a.dart#extension:');
+    });
+
+    test('semanticEquals for unnamed extension', () {
+      const ext1 = Extension.unnamed(library);
+      const ext2 = Extension.unnamed(library);
+      const ext3 = Extension('MyExtension', library);
+      const library2 = Library('package:a/b.dart');
+      const ext4 = Extension.unnamed(library2);
+
+      expect(ext1.semanticEquals(ext2), isTrue);
+      expect(ext1.semanticEquals(ext3), isFalse);
+      expect(ext1.semanticEquals(ext4), isFalse);
+    });
+  });
+
+  group('Unnamed Constructor', () {
+    const library = Library('package:a/a.dart');
+    const classDef = Class('MyClass', library);
+
+    test('Constructor.unnamed constructor', () {
+      const constructor = Constructor.unnamed(classDef);
+      expect(constructor.name, '');
+      expect(constructor.isUnnamed, isTrue);
+      expect(constructor.parent, classDef);
+    });
+
+    test('Constructor named constructor with empty string', () {
+      const constructor = Constructor('', classDef);
+      expect(constructor.isUnnamed, isTrue);
+    });
+
+    test('Constructor named constructor with name', () {
+      const constructor = Constructor('named', classDef);
+      expect(constructor.isUnnamed, isFalse);
+    });
+
+    test('toString for unnamed constructor', () {
+      const constructor = Constructor.unnamed(classDef);
+      expect(
+        constructor.toString(),
+        'package:a/a.dart#class:MyClass::constructor:',
+      );
+    });
+
+    test('semanticEquals for unnamed constructor', () {
+      const ctor1 = Constructor.unnamed(classDef);
+      const ctor2 = Constructor.unnamed(classDef);
+      const ctor3 = Constructor('named', classDef);
+      const classDef2 = Class('OtherClass', library);
+      const ctor4 = Constructor.unnamed(classDef2);
+
+      expect(ctor1.semanticEquals(ctor2), isTrue);
+      expect(ctor1.semanticEquals(ctor3), isFalse);
+      expect(ctor1.semanticEquals(ctor4), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
* https://github.com/dart-lang/native/issues/3251
* https://github.com/dart-lang/native/issues/3252

Needs manual roll in Dart SDK to actually use `""` for unnamed instead of `"<unnamed>"`.