### PR TITLE
[native_toolchain_c] `CLinker` make `logger` optional

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.17.7-wip
+
+- Made `CLinker.run` `Logger` argument optional. It now defaults to a logger
+  printing to stdout and stderr.
+
 ## 0.17.6
 
 - On Android, use the NDK's `libc++.a` linker script when `cppLinkStdLib` is

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
@@ -12,6 +12,7 @@ import 'package:meta/meta.dart';
 import 'ctool.dart';
 import 'linker_options.dart';
 import 'linkmode.dart';
+import 'logger.dart';
 import 'output_type.dart';
 import 'run_cbuilder.dart';
 
@@ -44,12 +45,16 @@ class CLinker extends CTool implements Linker {
   /// Runs the C Linker with on this C build spec.
   ///
   /// Completes with an error if the linking fails.
+  ///
+  /// If provided, uses [logger] to output logs. Otherwise, uses a default
+  /// logger that streams [Level.WARNING] to stdout and higher levels to stderr.
   @override
   Future<void> run({
     required LinkInput input,
     required LinkOutputBuilder output,
-    required Logger? logger,
+    Logger? logger,
   }) async {
+    logger ??= createDefaultLogger();
     final outDir = input.outputDirectory;
     final packageRoot = input.packageRoot;
     await Directory.fromUri(outDir).create(recursive: true);

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.17.6
+version: 0.17.7-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -90,6 +90,8 @@ workspace:
   - pkgs/hooks_runner/test_data/wrong_linker
   - pkgs/hooks_runner/test_data/wrong_namespace_asset
   # - pkgs/jni  # TODO
+  # - pkgs/jni_flutter  # TODO
+  # - pkgs/jni_flutter/android_test_runner  # TODO
   # - pkgs/jni/example  # TODO
   # - pkgs/jnigen  # TODO
   # - pkgs/jnigen/android_test_runner  # TODO


### PR DESCRIPTION
Makes the default link hook less verbose.

Examples:

* https://github.com/dart-lang/native/pull/3267