### PR TITLE
[ffigen] Bump language version to 3.10

### DIFF
--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -16,7 +16,7 @@ topics:
   - codegen
 
 environment:
-  sdk: '>=3.8.0 <4.0.0'
+  sdk: '>=3.10.0 <4.0.0'
 
 dependencies:
   args: ^2.6.0


### PR DESCRIPTION
With Dart 3.8 the new version of native_toolchain_c which uses dot shorthands causes hook compilation failures:

```
$ dart test
Running build hooks... ../hooks/lib/src/api/build_and_link.dart:208:23: Error: This requires the experimental 'dot-shorthands' language feature to be enabled.
Try passing the '--enable-experiment=dot-shorthands' command line option.
    output.setFailure(.build);
                      ^
```

I'm not entirely sure why the 3.8 language version is used when there's a 3.10 language version in the (dev)dependencies and the Dart SDK itself is 3.12.