### PR TITLE
[jnigen] Fix #3277

### DIFF
--- a/pkgs/jnigen/lib/src/bindings/dart_generator.dart
+++ b/pkgs/jnigen/lib/src/bindings/dart_generator.dart
@@ -1269,14 +1269,17 @@ ${modifier}final _$idName = $_protectedExtension
       } else {
         final returningType = asyncReturnType
             .accept(_TypeGenerator(resolver, includeNullability: false));
+        final returningTypeNullable =
+            asyncReturnType.accept(_TypeGenerator(resolver));
         final returningTypeErased = asyncReturnType.accept(_TypeGenerator(
             resolver,
             includeNullability: false,
             typeErasure: true));
         final returningTypeClass =
             asyncReturnType.accept(_TypeClassGenerator(resolver));
-        final extraAs =
-            returningType != returningTypeErased ? ' as $returningType' : '';
+        final extraAs = returningType != returningTypeErased
+            ? ' as $returningTypeNullable'
+            : '';
         s.write('''
     return \$o${isNullable ? '?' : ''}.as<$returningTypeErased>(
       $returningTypeClass,

--- a/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
+++ b/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
@@ -13099,7 +13099,7 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<jni$_.JObject?>;
+    ) as jni$_.JList<jni$_.JObject?>?;
   }
 
   static final _id_echoAsyncNullableEnumList =
@@ -13162,7 +13162,7 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<NIAnEnum?>;
+    ) as jni$_.JList<NIAnEnum?>?;
   }
 
   static final _id_echoAsyncNullableClassList =
@@ -13226,7 +13226,7 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<NIAllNullableTypes?>;
+    ) as jni$_.JList<NIAllNullableTypes?>?;
   }
 
   static final _id_echoAsyncNullableNonNullEnumList =
@@ -13290,7 +13290,7 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<NIAnEnum>;
+    ) as jni$_.JList<NIAnEnum>?;
   }
 
   static final _id_echoAsyncNullableNonNullClassList =
@@ -13355,7 +13355,7 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<NIAllNullableTypes>;
+    ) as jni$_.JList<NIAllNullableTypes>?;
   }
 
   static final _id_echoAsyncNullableMap =
@@ -13419,7 +13419,7 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JObject?, jni$_.JObject?>;
+    ) as jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?;
   }
 
   static final _id_echoAsyncNullableStringMap =
@@ -13484,7 +13484,7 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JString?, jni$_.JString?>;
+    ) as jni$_.JMap<jni$_.JString?, jni$_.JString?>?;
   }
 
   static final _id_echoAsyncNullableIntMap =
@@ -13548,7 +13548,7 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JLong?, jni$_.JLong?>;
+    ) as jni$_.JMap<jni$_.JLong?, jni$_.JLong?>?;
   }
 
   static final _id_echoAsyncNullableEnumMap =
@@ -13611,7 +13611,7 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<NIAnEnum?, NIAnEnum?>;
+    ) as jni$_.JMap<NIAnEnum?, NIAnEnum?>?;
   }
 
   static final _id_echoAsyncNullableClassMap =
@@ -13675,7 +13675,7 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>;
+    ) as jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>?;
   }
 
   static final _id_echoAsyncNullableEnum =
@@ -19509,7 +19509,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<jni$_.JObject?>;
+    ) as jni$_.JList<jni$_.JObject?>?;
   }
 
   static final _id_echoAsyncNullableEnumList =
@@ -19572,7 +19572,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<NIAnEnum?>;
+    ) as jni$_.JList<NIAnEnum?>?;
   }
 
   static final _id_echoAsyncNullableClassList =
@@ -19636,7 +19636,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<NIAllNullableTypes?>;
+    ) as jni$_.JList<NIAllNullableTypes?>?;
   }
 
   static final _id_echoAsyncNullableMap =
@@ -19700,7 +19700,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JObject?, jni$_.JObject?>;
+    ) as jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?;
   }
 
   static final _id_echoAsyncNullableStringMap =
@@ -19765,7 +19765,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JString?, jni$_.JString?>;
+    ) as jni$_.JMap<jni$_.JString?, jni$_.JString?>?;
   }
 
   static final _id_echoAsyncNullableIntMap =
@@ -19829,7 +19829,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JLong?, jni$_.JLong?>;
+    ) as jni$_.JMap<jni$_.JLong?, jni$_.JLong?>?;
   }
 
   static final _id_echoAsyncNullableEnumMap =
@@ -19892,7 +19892,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<NIAnEnum?, NIAnEnum?>;
+    ) as jni$_.JMap<NIAnEnum?, NIAnEnum?>?;
   }
 
   static final _id_echoAsyncNullableClassMap =
@@ -19956,7 +19956,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>;
+    ) as jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>?;
   }
 
   static final _id_echoAsyncNullableEnum =
@@ -23939,7 +23939,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<jni$_.JObject?>;
+    ) as jni$_.JList<jni$_.JObject?>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableEnumList =
@@ -24003,7 +24003,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<NIAnEnum?>;
+    ) as jni$_.JList<NIAnEnum?>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableClassList =
@@ -24068,7 +24068,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<NIAllNullableTypes?>;
+    ) as jni$_.JList<NIAllNullableTypes?>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableNonNullEnumList =
@@ -24133,7 +24133,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<NIAnEnum>;
+    ) as jni$_.JList<NIAnEnum>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableNonNullClassList =
@@ -24198,7 +24198,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<NIAllNullableTypes>;
+    ) as jni$_.JList<NIAllNullableTypes>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableMap =
@@ -24263,7 +24263,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JObject?, jni$_.JObject?>;
+    ) as jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableStringMap =
@@ -24328,7 +24328,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JString?, jni$_.JString?>;
+    ) as jni$_.JMap<jni$_.JString?, jni$_.JString?>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableIntMap =
@@ -24393,7 +24393,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JLong?, jni$_.JLong?>;
+    ) as jni$_.JMap<jni$_.JLong?, jni$_.JLong?>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableEnumMap =
@@ -24458,7 +24458,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<NIAnEnum?, NIAnEnum?>;
+    ) as jni$_.JMap<NIAnEnum?, NIAnEnum?>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableClassMap =
@@ -24523,7 +24523,7 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>;
+    ) as jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableEnum =
@@ -29032,7 +29032,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<jni$_.JObject?>;
+    ) as jni$_.JList<jni$_.JObject?>?;
   }
 
   static final _id_echoAsyncNullableEnumList =
@@ -29095,7 +29095,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<NIAnEnum?>;
+    ) as jni$_.JList<NIAnEnum?>?;
   }
 
   static final _id_echoAsyncNullableClassList =
@@ -29159,7 +29159,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<NIAllNullableTypes?>;
+    ) as jni$_.JList<NIAllNullableTypes?>?;
   }
 
   static final _id_echoAsyncNullableMap =
@@ -29223,7 +29223,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JObject?, jni$_.JObject?>;
+    ) as jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?;
   }
 
   static final _id_echoAsyncNullableStringMap =
@@ -29288,7 +29288,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JString?, jni$_.JString?>;
+    ) as jni$_.JMap<jni$_.JString?, jni$_.JString?>?;
   }
 
   static final _id_echoAsyncNullableIntMap =
@@ -29352,7 +29352,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JLong?, jni$_.JLong?>;
+    ) as jni$_.JMap<jni$_.JLong?, jni$_.JLong?>?;
   }
 
   static final _id_echoAsyncNullableEnumMap =
@@ -29415,7 +29415,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<NIAnEnum?, NIAnEnum?>;
+    ) as jni$_.JMap<NIAnEnum?, NIAnEnum?>?;
   }
 
   static final _id_echoAsyncNullableClassMap =
@@ -29479,7 +29479,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>;
+    ) as jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>?;
   }
 
   static final _id_echoAsyncNullableEnum =
@@ -33462,7 +33462,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<jni$_.JObject?>;
+    ) as jni$_.JList<jni$_.JObject?>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableEnumList =
@@ -33526,7 +33526,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<NIAnEnum?>;
+    ) as jni$_.JList<NIAnEnum?>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableClassList =
@@ -33591,7 +33591,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<NIAllNullableTypes?>;
+    ) as jni$_.JList<NIAllNullableTypes?>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableNonNullEnumList =
@@ -33656,7 +33656,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<NIAnEnum>;
+    ) as jni$_.JList<NIAnEnum>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableNonNullClassList =
@@ -33721,7 +33721,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JList>(
       jni$_.JList.type,
       releaseOriginal: true,
-    ) as jni$_.JList<NIAllNullableTypes>;
+    ) as jni$_.JList<NIAllNullableTypes>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableMap =
@@ -33786,7 +33786,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JObject?, jni$_.JObject?>;
+    ) as jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableStringMap =
@@ -33851,7 +33851,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JString?, jni$_.JString?>;
+    ) as jni$_.JMap<jni$_.JString?, jni$_.JString?>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableIntMap =
@@ -33916,7 +33916,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JLong?, jni$_.JLong?>;
+    ) as jni$_.JMap<jni$_.JLong?, jni$_.JLong?>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableEnumMap =
@@ -33981,7 +33981,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<NIAnEnum?, NIAnEnum?>;
+    ) as jni$_.JMap<NIAnEnum?, NIAnEnum?>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableClassMap =
@@ -34046,7 +34046,7 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     return $o?.as<jni$_.JMap>(
       jni$_.JMap.type,
       releaseOriginal: true,
-    ) as jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>;
+    ) as jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>?;
   }
 
   static final _id_callFlutterEchoAsyncNullableEnum =
@@ -36846,6 +36846,65 @@ extension SuspendFun$$Methods on SuspendFun {
     );
   }
 
+  static final _id_nullableList = SuspendFun._class.instanceMethodId(
+    r'nullableList',
+    r'(Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;',
+  );
+
+  static final _nullableList = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JniResult Function(
+                  jni$_.Pointer<jni$_.Void>,
+                  jni$_.JMethodIDPtr,
+                  jni$_.VarArgs<
+                      (
+                        jni$_.Pointer<jni$_.Void>,
+                        jni$_.Pointer<jni$_.Void>
+                      )>)>>('globalEnv_CallObjectMethod')
+      .asFunction<
+          jni$_.JniResult Function(
+              jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr,
+              jni$_.Pointer<jni$_.Void>,
+              jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `public suspend fun nullableList(list: kotlin.collections.List<kotlin.String?>?): kotlin.collections.List<kotlin.String?>?`
+  /// The returned object must be released after use, by calling the [release] method.
+  core$_.Future<jni$_.JList<jni$_.JString?>?> nullableList(
+    jni$_.JList<jni$_.JString?>? list,
+  ) async {
+    final $p = jni$_.ReceivePort();
+    final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$list = list?.reference ?? jni$_.jNullReference;
+    final $r = _nullableList(reference.pointer, _id_nullableList.pointer,
+            _$list.pointer, _$continuation.pointer)
+        .object<jni$_.JObject?>();
+    _$continuation.release();
+    jni$_.JObject? $o;
+    if ($r != null && $r.isInstanceOf(jni$_.coroutineSingletonsClass)) {
+      $r.release();
+      final $a = await $p.first;
+      $o = $a == 0
+          ? null
+          : jni$_.JObject.fromReference(
+              jni$_.JGlobalReference(jni$_.JObjectPtr.fromAddress($a)));
+      if ($o != null && $o.isInstanceOf(jni$_.result$Class)) {
+        $o = jni$_.resultValueField.get($o, const jni$_.$JObject$Type$());
+      } else if ($o != null && $o.isInstanceOf(jni$_.result$FailureClass)) {
+        final $e =
+            jni$_.failureExceptionField.get($o, const jni$_.$JObject$Type$());
+        $o.release();
+        jni$_.Jni.throwException($e.reference.toPointer());
+      }
+    } else {
+      $o = $r;
+    }
+    return $o?.as<jni$_.JList>(
+      jni$_.JList.type,
+      releaseOriginal: true,
+    ) as jni$_.JList<jni$_.JString?>?;
+  }
+
   static final _id_get$result = SuspendFun._class.instanceMethodId(
     r'getResult',
     r'()I',
@@ -37166,6 +37225,19 @@ extension type SuspendInterface._(jni$_.JObject _$this)
                 ($a![1] as jni$_.JObject).reference)
             .resumeWithFuture(_$impls[$p]!.nullableInt(
           ($a![0] as jni$_.JBoolean).toDartBool(releaseOriginal: true),
+        ));
+        return ($r as jni$_.JObject?)
+                ?.as(const jni$_.$JObject$Type$())
+                .reference
+                .toPointer() ??
+            jni$_.nullptr;
+      }
+      if ($d ==
+          r'nullableList(Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
+        final $r = jni$_.KotlinContinuation.fromReference(
+                ($a![1] as jni$_.JObject).reference)
+            .resumeWithFuture(_$impls[$p]!.nullableList(
+          ($a![0] as jni$_.JList<jni$_.JString?>?),
         ));
         return ($r as jni$_.JObject?)
                 ?.as(const jni$_.$JObject$Type$())
@@ -37545,6 +37617,65 @@ extension SuspendInterface$$Methods on SuspendInterface {
     );
   }
 
+  static final _id_nullableList = SuspendInterface._class.instanceMethodId(
+    r'nullableList',
+    r'(Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;',
+  );
+
+  static final _nullableList = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JniResult Function(
+                  jni$_.Pointer<jni$_.Void>,
+                  jni$_.JMethodIDPtr,
+                  jni$_.VarArgs<
+                      (
+                        jni$_.Pointer<jni$_.Void>,
+                        jni$_.Pointer<jni$_.Void>
+                      )>)>>('globalEnv_CallObjectMethod')
+      .asFunction<
+          jni$_.JniResult Function(
+              jni$_.Pointer<jni$_.Void>,
+              jni$_.JMethodIDPtr,
+              jni$_.Pointer<jni$_.Void>,
+              jni$_.Pointer<jni$_.Void>)>();
+
+  /// from: `public suspend fun nullableList(list: kotlin.collections.List<kotlin.String?>?): kotlin.collections.List<kotlin.String?>?`
+  /// The returned object must be released after use, by calling the [release] method.
+  core$_.Future<jni$_.JList<jni$_.JString?>?> nullableList(
+    jni$_.JList<jni$_.JString?>? list,
+  ) async {
+    final $p = jni$_.ReceivePort();
+    final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$list = list?.reference ?? jni$_.jNullReference;
+    final $r = _nullableList(reference.pointer, _id_nullableList.pointer,
+            _$list.pointer, _$continuation.pointer)
+        .object<jni$_.JObject?>();
+    _$continuation.release();
+    jni$_.JObject? $o;
+    if ($r != null && $r.isInstanceOf(jni$_.coroutineSingletonsClass)) {
+      $r.release();
+      final $a = await $p.first;
+      $o = $a == 0
+          ? null
+          : jni$_.JObject.fromReference(
+              jni$_.JGlobalReference(jni$_.JObjectPtr.fromAddress($a)));
+      if ($o != null && $o.isInstanceOf(jni$_.result$Class)) {
+        $o = jni$_.resultValueField.get($o, const jni$_.$JObject$Type$());
+      } else if ($o != null && $o.isInstanceOf(jni$_.result$FailureClass)) {
+        final $e =
+            jni$_.failureExceptionField.get($o, const jni$_.$JObject$Type$());
+        $o.release();
+        jni$_.Jni.throwException($e.reference.toPointer());
+      }
+    } else {
+      $o = $r;
+    }
+    return $o?.as<jni$_.JList>(
+      jni$_.JList.type,
+      releaseOriginal: true,
+    ) as jni$_.JList<jni$_.JString?>?;
+  }
+
   static final _id_noReturn = SuspendInterface._class.instanceMethodId(
     r'noReturn',
     r'(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;',
@@ -37603,6 +37734,9 @@ abstract base mixin class $SuspendInterface {
     required core$_.Future<jni$_.JInteger> Function(jni$_.JInteger integer)
         sayInt$1,
     required core$_.Future<jni$_.JInteger?> Function(core$_.bool z) nullableInt,
+    required core$_.Future<jni$_.JList<jni$_.JString?>?> Function(
+            jni$_.JList<jni$_.JString?>? list)
+        nullableList,
     required core$_.Future<void> Function() noReturn,
   }) = _$SuspendInterface;
 
@@ -37612,6 +37746,8 @@ abstract base mixin class $SuspendInterface {
   core$_.Future<jni$_.JInteger> sayInt();
   core$_.Future<jni$_.JInteger> sayInt$1(jni$_.JInteger integer);
   core$_.Future<jni$_.JInteger?> nullableInt(core$_.bool z);
+  core$_.Future<jni$_.JList<jni$_.JString?>?> nullableList(
+      jni$_.JList<jni$_.JString?>? list);
   core$_.Future<void> noReturn();
 }
 
@@ -37626,6 +37762,9 @@ final class _$SuspendInterface with $SuspendInterface {
     required core$_.Future<jni$_.JInteger> Function(jni$_.JInteger integer)
         sayInt$1,
     required core$_.Future<jni$_.JInteger?> Function(core$_.bool z) nullableInt,
+    required core$_.Future<jni$_.JList<jni$_.JString?>?> Function(
+            jni$_.JList<jni$_.JString?>? list)
+        nullableList,
     required core$_.Future<void> Function() noReturn,
   })  : _sayHello = sayHello,
         _sayHello$1 = sayHello$1,
@@ -37633,6 +37772,7 @@ final class _$SuspendInterface with $SuspendInterface {
         _sayInt = sayInt,
         _sayInt$1 = sayInt$1,
         _nullableInt = nullableInt,
+        _nullableList = nullableList,
         _noReturn = noReturn;
 
   final core$_.Future<jni$_.JString> Function() _sayHello;
@@ -37642,6 +37782,8 @@ final class _$SuspendInterface with $SuspendInterface {
   final core$_.Future<jni$_.JInteger> Function(jni$_.JInteger integer)
       _sayInt$1;
   final core$_.Future<jni$_.JInteger?> Function(core$_.bool z) _nullableInt;
+  final core$_.Future<jni$_.JList<jni$_.JString?>?> Function(
+      jni$_.JList<jni$_.JString?>? list) _nullableList;
   final core$_.Future<void> Function() _noReturn;
 
   core$_.Future<jni$_.JString> sayHello() {
@@ -37666,6 +37808,11 @@ final class _$SuspendInterface with $SuspendInterface {
 
   core$_.Future<jni$_.JInteger?> nullableInt(core$_.bool z) {
     return _nullableInt(z);
+  }
+
+  core$_.Future<jni$_.JList<jni$_.JString?>?> nullableList(
+      jni$_.JList<jni$_.JString?>? list) {
+    return _nullableList(list);
   }
 
   core$_.Future<void> noReturn() {

--- a/pkgs/jnigen/test/kotlin_test/kotlin/src/main/kotlin/com/github/dart_lang/jnigen/SuspendFun.kt
+++ b/pkgs/jnigen/test/kotlin_test/kotlin/src/main/kotlin/com/github/dart_lang/jnigen/SuspendFun.kt
@@ -47,6 +47,11 @@ public class SuspendFun {
         return "Hello!"
     }
 
+    suspend fun nullableList(list: List<String?>?): List<String?>? {
+        delay(100L)
+        return list
+    }
+
     var result: Int = 0
     suspend fun noReturn() {
         delay(100L)
@@ -61,6 +66,7 @@ public interface SuspendInterface {
     suspend fun sayInt(): Integer
     suspend fun sayInt(value: Integer): Integer
     suspend fun nullableInt(returnNull: Boolean): Integer?
+    suspend fun nullableList(list: List<String?>?): List<String?>?
     suspend fun noReturn()
 }
 
@@ -78,6 +84,7 @@ ${itf.nullableHello(false)}
 ${itf.sayInt()}
 ${itf.sayInt(Integer(789))}
 ${itf.nullableInt(false)}
+${itf.nullableList(listOf("abc", "def"))}
 ${itf.noReturn()}
 """.trim();
 }

--- a/pkgs/jnigen/test/kotlin_test/runtime_test_registrant.dart
+++ b/pkgs/jnigen/test/kotlin_test/runtime_test_registrant.dart
@@ -35,6 +35,16 @@ void registerTests(String groupName, TestRunnerCallback test) {
         final asyncNull = await suspendFun.nullableHello(true);
         expect(asyncNull, null);
 
+        expect(await suspendFun.nullableList(null), isNull);
+        final list = await suspendFun.nullableList([
+          'abc'.toJString(),
+          null,
+          'def'.toJString(),
+        ].toJList());
+        expect(
+            list!.asDart().map((s) => s?.toDartString(releaseOriginal: true)),
+            ['abc', null, 'def']);
+
         expect(suspendFun.result, 0);
         final voidFuture = suspendFun.noReturn();
         expect(voidFuture, isA<Future<void>>());
@@ -389,6 +399,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
           sayInt$1: (JInteger value) async => JInteger(10 * value.intValue()),
           nullableInt: (bool returnNull) async =>
               returnNull ? null : JInteger(123),
+          nullableList: (JList<JString?>? list) async => list,
           noReturn: () async => result = 123,
         ));
 
@@ -401,6 +412,12 @@ void registerTests(String groupName, TestRunnerCallback test) {
         expect((await itf.sayInt$1(JInteger(456))).intValue(), 4560);
         expect((await itf.nullableInt(false))?.intValue(), 123);
         expect(await itf.nullableInt(true), null);
+        expect(await itf.nullableList(null), null);
+        expect(
+            (await itf.nullableList(['abc'.toJString()].toJList()))
+                ?.asDart()
+                .map((s) => s?.toDartString(releaseOriginal: true)),
+            ['abc']);
         await itf.noReturn();
         expect(result, 123);
 
@@ -413,6 +430,7 @@ Hello
 123
 7890
 123
+[abc, def]
 kotlin.Unit
 '''
                 .trim());
@@ -425,6 +443,7 @@ Hello
 123
 7890
 123
+[abc, def]
 kotlin.Unit
 '''
                 .trim());
@@ -457,6 +476,7 @@ kotlin.Unit
             await Future<void>.delayed(const Duration(milliseconds: 100));
             return returnNull ? null : JInteger(123);
           },
+          nullableList: (JList<JString?>? list) async => list,
           noReturn: () async {
             await Future<void>.delayed(const Duration(milliseconds: 100));
             result = 123;
@@ -472,6 +492,12 @@ kotlin.Unit
         expect((await itf.sayInt$1(JInteger(456))).intValue(), 4560);
         expect((await itf.nullableInt(false))?.intValue(), 123);
         expect(await itf.nullableInt(true), null);
+        expect(await itf.nullableList(null), null);
+        expect(
+            (await itf.nullableList(['abc'.toJString()].toJList()))
+                ?.asDart()
+                .map((s) => s?.toDartString(releaseOriginal: true)),
+            ['abc']);
         await itf.noReturn();
         expect(result, 123);
 
@@ -484,6 +510,7 @@ Hello
 123
 7890
 123
+[abc, def]
 kotlin.Unit
 '''
                 .trim());
@@ -496,6 +523,7 @@ Hello
 123
 7890
 123
+[abc, def]
 kotlin.Unit
 '''
                 .trim());
@@ -509,6 +537,7 @@ kotlin.Unit
           sayInt: () async => throw Exception(),
           sayInt$1: (JInteger value) async => throw Exception(),
           nullableInt: (bool returnNull) async => throw Exception(),
+          nullableList: (JList<JString?>? list) async => throw Exception(),
           noReturn: () async => throw Exception(),
         ));
 
@@ -550,6 +579,10 @@ kotlin.Unit
             throw Exception();
           },
           nullableInt: (bool returnNull) async {
+            await Future<void>.delayed(const Duration(milliseconds: 100));
+            throw Exception();
+          },
+          nullableList: (JList<JString?>? list) async {
             await Future<void>.delayed(const Duration(milliseconds: 100));
             throw Exception();
           },


### PR DESCRIPTION
The extra as added by #3266 needs to include the nullability of the Dart type.

The existing regression test for #3235 covers this case, but didn't hit the error because it's a runtime error, and the test just checks compilation. It's too hard to construct and invoke those large complicated objects, so I added a test case to the SuspendFun.kt integration test.