### PR TITLE
[native_toolchain_c] Introduce `CLibrary`

### DIFF
--- a/pkgs/code_assets/README.md
+++ b/pkgs/code_assets/README.md
@@ -51,20 +51,24 @@ import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
+final builder = CBuilder.library(
+  name: 'sqlite3',
+  assetName: 'src/third_party/sqlite3.g.dart',
+  sources: ['third_party/sqlite/sqlite3.c'],
+);
+
 void main(List<String> args) async {
   await build(args, (input, output) async {
     if (input.config.buildCodeAssets) {
-      final builder = CBuilder.library(
-        name: 'sqlite3',
-        assetName: 'src/third_party/sqlite3.g.dart',
-        sources: ['third_party/sqlite/sqlite3.c'],
+      await builder.run(
+        input: input,
+        output: output,
         defines: {
           if (input.config.code.targetOS == OS.windows)
             // Ensure symbols are exported in dll.
             'SQLITE_API': '__declspec(dllexport)',
         },
       );
-      await builder.run(input: input, output: output);
     }
   });
 }

--- a/pkgs/code_assets/example/mini_audio/hook/build.dart
+++ b/pkgs/code_assets/example/mini_audio/hook/build.dart
@@ -4,30 +4,19 @@
 
 import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
-import 'package:native_toolchain_c/native_toolchain_c.dart';
+import 'package:mini_audio/src/c_library.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {
     if (input.config.buildCodeAssets) {
-      final builder = CBuilder.library(
-        name: 'miniaudio',
-        assetName: 'src/third_party/miniaudio.g.dart',
-        sources: ['third_party/miniaudio.c'],
+      await cLibrary.build(
+        input: input,
+        output: output,
         defines: {
           if (input.config.code.targetOS == OS.windows)
             // Ensure symbols are exported in dll.
             'MA_API': '__declspec(dllexport)',
         },
-        linkModePreference: input.config.linkingEnabled
-            ? LinkModePreference.static
-            : LinkModePreference.dynamic,
-      );
-      await builder.run(
-        input: input,
-        output: output,
-        routing: input.config.linkingEnabled
-            ? [ToLinkHook(input.packageName)]
-            : [const ToAppBundle()],
       );
     }
   });

--- a/pkgs/code_assets/example/mini_audio/hook/link.dart
+++ b/pkgs/code_assets/example/mini_audio/hook/link.dart
@@ -5,29 +5,24 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
+import 'package:mini_audio/src/c_library.dart';
 import 'package:mini_audio/src/third_party/record_use_mapping.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:record_use/record_use.dart';
 
 void main(List<String> arguments) async {
   await link(arguments, (input, output) async {
-    final asset = input.assets.code.single;
-    final assetId = asset.id;
-    final assetName = assetId.split('/').skip(1).join('/');
-    final linker = CLinker.library(
-      name: 'miniaudio',
-      assetName: assetName,
+    await cLibrary.link(
+      input: input,
+      output: output,
       linkerOptions: LinkerOptions.treeshake(
         symbolsToKeep: input.usages?.calls.keys
             .cast<Method>()
             .map((e) => recordUseMapping[e.name])
             .nonNulls,
       ),
-      sources: [asset.file!.toFilePath()],
     );
-    await linker.run(input: input, output: output);
   });
 }
 

--- a/pkgs/code_assets/example/mini_audio/lib/src/c_library.dart
+++ b/pkgs/code_assets/example/mini_audio/lib/src/c_library.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:native_toolchain_c/native_toolchain_c.dart';
+
+/// The C build specification for the miniaudio library.
+///
+/// It is used by the build and link hooks in the `hook/` directory.
+final cLibrary = CLibrary(
+  name: 'miniaudio',
+  assetName: 'src/third_party/miniaudio.g.dart',
+  sources: ['third_party/miniaudio.c'],
+);

--- a/pkgs/code_assets/example/sqlite/hook/build.dart
+++ b/pkgs/code_assets/example/sqlite/hook/build.dart
@@ -4,30 +4,19 @@
 
 import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
-import 'package:native_toolchain_c/native_toolchain_c.dart';
+import 'package:sqlite/src/c_library.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {
     if (input.config.buildCodeAssets) {
-      final builder = CBuilder.library(
-        name: 'sqlite3',
-        assetName: 'src/third_party/sqlite3.g.dart',
-        sources: ['third_party/sqlite/sqlite3.c'],
+      await cLibrary.build(
+        input: input,
+        output: output,
         defines: {
           if (input.config.code.targetOS == OS.windows)
             // Ensure symbols are exported in dll.
             'SQLITE_API': '__declspec(dllexport)',
         },
-        linkModePreference: input.config.linkingEnabled
-            ? LinkModePreference.static
-            : LinkModePreference.dynamic,
-      );
-      await builder.run(
-        input: input,
-        output: output,
-        routing: input.config.linkingEnabled
-            ? [ToLinkHook(input.packageName)]
-            : [const ToAppBundle()],
       );
     }
   });

--- a/pkgs/code_assets/example/sqlite/hook/link.dart
+++ b/pkgs/code_assets/example/sqlite/hook/link.dart
@@ -5,30 +5,24 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:record_use/record_use.dart';
+import 'package:sqlite/src/c_library.dart';
 import 'package:sqlite/src/third_party/record_use_mapping.dart';
 
 void main(List<String> arguments) async {
   await link(arguments, (input, output) async {
-    final asset = input.assets.code.single;
-    final assetId = asset.id;
-    final assetName = assetId.split('/').skip(1).join('/');
-    final linker = CLinker.library(
-      name: 'sqlite3',
-      assetName: assetName,
+    await cLibrary.link(
+      input: input,
+      output: output,
       linkerOptions: LinkerOptions.treeshake(
         symbolsToKeep: input.usages?.calls.keys
             .cast<Method>()
             .map((e) => recordUseMapping[e.name])
             .nonNulls,
       ),
-      sources: [asset.file!.toFilePath()],
     );
-
-    await linker.run(input: input, output: output);
   });
 }
 

--- a/pkgs/code_assets/example/sqlite/lib/src/c_library.dart
+++ b/pkgs/code_assets/example/sqlite/lib/src/c_library.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:native_toolchain_c/native_toolchain_c.dart';
+
+/// The C build specification for the sqlite library.
+///
+/// It is used by the build and link hooks in the `hook/` directory.
+final cLibrary = CLibrary(
+  name: 'sqlite3',
+  assetName: 'src/third_party/sqlite3.g.dart',
+  sources: ['third_party/sqlite/sqlite3.c'],
+);

--- a/pkgs/code_assets/example/sqlite_no_link/hook/build.dart
+++ b/pkgs/code_assets/example/sqlite_no_link/hook/build.dart
@@ -6,20 +6,24 @@ import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
+final builder = CBuilder.library(
+  name: 'sqlite3',
+  assetName: 'src/third_party/sqlite3.g.dart',
+  sources: ['third_party/sqlite/sqlite3.c'],
+);
+
 void main(List<String> args) async {
   await build(args, (input, output) async {
     if (input.config.buildCodeAssets) {
-      final builder = CBuilder.library(
-        name: 'sqlite3',
-        assetName: 'src/third_party/sqlite3.g.dart',
-        sources: ['third_party/sqlite/sqlite3.c'],
+      await builder.run(
+        input: input,
+        output: output,
         defines: {
           if (input.config.code.targetOS == OS.windows)
             // Ensure symbols are exported in dll.
             'SQLITE_API': '__declspec(dllexport)',
         },
       );
-      await builder.run(input: input, output: output);
     }
   });
 }

--- a/pkgs/code_assets/example/stb_image/hook/build.dart
+++ b/pkgs/code_assets/example/stb_image/hook/build.dart
@@ -4,30 +4,19 @@
 
 import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
-import 'package:native_toolchain_c/native_toolchain_c.dart';
+import 'package:stb_image/src/c_library.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {
     if (input.config.buildCodeAssets) {
-      final builder = CBuilder.library(
-        name: 'stb_image',
-        assetName: 'src/third_party/stb_image.g.dart',
-        sources: ['third_party/stb_image.c'],
+      await cLibrary.build(
+        input: input,
+        output: output,
         defines: {
           if (input.config.code.targetOS == OS.windows)
             // Ensure symbols are exported in dll.
             'STBIDEF': '__declspec(dllexport)',
         },
-        linkModePreference: input.config.linkingEnabled
-            ? LinkModePreference.static
-            : LinkModePreference.dynamic,
-      );
-      await builder.run(
-        input: input,
-        output: output,
-        routing: input.config.linkingEnabled
-            ? [ToLinkHook(input.packageName)]
-            : [const ToAppBundle()],
       );
     }
   });

--- a/pkgs/code_assets/example/stb_image/hook/link.dart
+++ b/pkgs/code_assets/example/stb_image/hook/link.dart
@@ -5,30 +5,24 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:record_use/record_use.dart';
+import 'package:stb_image/src/c_library.dart';
 import 'package:stb_image/src/third_party/record_use_mapping.dart';
 
 void main(List<String> arguments) async {
   await link(arguments, (input, output) async {
-    final asset = input.assets.code.single;
-    final assetId = asset.id;
-    final assetName = assetId.split('/').skip(1).join('/');
-    final linker = CLinker.library(
-      name: 'stb_image',
-      assetName: assetName,
+    await cLibrary.link(
+      input: input,
+      output: output,
       linkerOptions: LinkerOptions.treeshake(
         symbolsToKeep: input.usages?.calls.keys
             .cast<Method>()
             .map((e) => recordUseMapping[e.name])
             .nonNulls,
       ),
-      sources: [asset.file!.toFilePath()],
     );
-
-    await linker.run(input: input, output: output);
   });
 }
 

--- a/pkgs/code_assets/example/stb_image/lib/src/c_library.dart
+++ b/pkgs/code_assets/example/stb_image/lib/src/c_library.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:native_toolchain_c/native_toolchain_c.dart';
+
+/// The C build specification for the stb_image library.
+///
+/// It is used by the build and link hooks in the `hook/` directory.
+final cLibrary = CLibrary(
+  name: 'stb_image',
+  assetName: 'src/third_party/stb_image.g.dart',
+  sources: ['third_party/stb_image.c'],
+);

--- a/pkgs/code_assets/test/example/external_references_test.dart
+++ b/pkgs/code_assets/test/example/external_references_test.dart
@@ -32,8 +32,7 @@ void main() {
     final example = packageRoot.resolve('example/');
     const buildCLibraryFromSource = [
       // The essence of this sample is building with native_toolchain_c.
-      'native_toolchain_c',
-      'CBuilder.library(',
+      '.build(',
     ];
     const filesMustExist = <String, List<String>?>{
       'host_name/hook/build.dart': [

--- a/pkgs/hooks/README.md
+++ b/pkgs/hooks/README.md
@@ -28,20 +28,24 @@ import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
+final builder = CBuilder.library(
+  name: 'sqlite3',
+  assetName: 'src/third_party/sqlite3.g.dart',
+  sources: ['third_party/sqlite/sqlite3.c'],
+);
+
 void main(List<String> args) async {
   await build(args, (input, output) async {
     if (input.config.buildCodeAssets) {
-      final builder = CBuilder.library(
-        name: 'sqlite3',
-        assetName: 'src/third_party/sqlite3.g.dart',
-        sources: ['third_party/sqlite/sqlite3.c'],
+      await builder.run(
+        input: input,
+        output: output,
         defines: {
           if (input.config.code.targetOS == OS.windows)
             // Ensure symbols are exported in dll.
             'SQLITE_API': '__declspec(dllexport)',
         },
       );
-      await builder.run(input: input, output: output);
     }
   });
 }

--- a/pkgs/hooks/lib/hooks.dart
+++ b/pkgs/hooks/lib/hooks.dart
@@ -24,20 +24,24 @@
 /// import 'package:hooks/hooks.dart';
 /// import 'package:native_toolchain_c/native_toolchain_c.dart';
 ///
+/// final builder = CBuilder.library(
+///   name: 'sqlite3',
+///   assetName: 'src/third_party/sqlite3.g.dart',
+///   sources: ['third_party/sqlite/sqlite3.c'],
+/// );
+///
 /// void main(List<String> args) async {
 ///   await build(args, (input, output) async {
 ///     if (input.config.buildCodeAssets) {
-///       final builder = CBuilder.library(
-///         name: 'sqlite3',
-///         assetName: 'src/third_party/sqlite3.g.dart',
-///         sources: ['third_party/sqlite/sqlite3.c'],
+///       await builder.run(
+///         input: input,
+///         output: output,
 ///         defines: {
 ///           if (input.config.code.targetOS == OS.windows)
 ///             // Ensure symbols are exported in dll.
 ///             'SQLITE_API': '__declspec(dllexport)',
 ///         },
 ///       );
-///       await builder.run(input: input, output: output);
 ///     }
 ///   });
 /// }

--- a/pkgs/native_toolchain_c/lib/native_toolchain_c.dart
+++ b/pkgs/native_toolchain_c/lib/native_toolchain_c.dart
@@ -7,6 +7,7 @@ library;
 
 export 'src/cbuilder/build_mode.dart';
 export 'src/cbuilder/cbuilder.dart' show CBuilder;
+export 'src/cbuilder/clibrary.dart' show CLibrary;
 export 'src/cbuilder/clinker.dart' show CLinker;
 export 'src/cbuilder/language.dart' show Language;
 export 'src/cbuilder/linker_options.dart' show LinkerOptions;

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/cbuilder.dart
@@ -10,6 +10,8 @@ import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 
 import 'build_mode.dart';
+import 'clibrary.dart';
+import 'clinker.dart';
 import 'ctool.dart';
 import 'linkmode.dart';
 import 'logger.dart';
@@ -117,12 +119,26 @@ class CBuilder extends CTool implements Builder {
   ///
   /// If provided, uses [logger] to output logs. Otherwise, uses a default
   /// logger that streams [Level.WARNING] to stdout and higher levels to stderr.
+  ///
+  /// [routing] determines how the built assets are distributed. Defaults to
+  /// [ToAppBundle].
+  ///
+  /// [linkModePreference] overrides the [CTool.linkModePreference] of this
+  /// [CBuilder]. See [CTool.linkModePreference] for more documentation.
+  ///
+  /// [defines] are merged with the [CTool.defines] of this [CBuilder]. See
+  /// [CTool.defines] for more documentation.
+  ///
+  /// If you're using [CBuilder] in a build hook and [CLinker] in a link hook,
+  /// see [CLibrary] to combine them.
   @override
   Future<void> run({
     required BuildInput input,
     required BuildOutputBuilder output,
     Logger? logger,
     List<AssetRouting> routing = const [ToAppBundle()],
+    LinkModePreference? linkModePreference,
+    Map<String, String?>? defines,
   }) async {
     logger ??= createDefaultLogger();
     if (!input.config.buildCodeAssets) {
@@ -141,7 +157,9 @@ class CBuilder extends CTool implements Builder {
     final packageRoot = input.packageRoot;
     await Directory.fromUri(outDir).create(recursive: true);
     final linkMode = getLinkMode(
-      linkModePreference ?? input.config.code.linkModePreference,
+      linkModePreference ??
+          this.linkModePreference ??
+          input.config.code.linkModePreference,
     );
     final libUri = outDir.resolve(
       input.config.code.targetOS.libraryFileName(name, linkMode),
@@ -192,7 +210,8 @@ class CBuilder extends CTool implements Builder {
       installName: installName,
       flags: flags,
       defines: {
-        ...defines,
+        ...this.defines,
+        ...?defines,
         if (buildModeDefine) buildMode.name.toUpperCase(): null,
         if (ndebugDefine && buildMode != .debug) 'NDEBUG': null,
       },

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/clibrary.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/clibrary.dart
@@ -1,0 +1,256 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:code_assets/code_assets.dart';
+import 'package:hooks/hooks.dart';
+import 'package:logging/logging.dart';
+
+import 'cbuilder.dart';
+import 'clinker.dart';
+import 'ctool.dart';
+import 'language.dart';
+import 'linker_options.dart';
+import 'optimization_level.dart';
+
+/// Specification for building and linking a library with a C compiler.
+///
+/// The [CLibrary] is used if we want to split building and linking C code
+/// across a build and link hook. It abstracts over the [CBuilder] and
+/// [CLinker] so that the plumbing doesn't have to be manual.
+///
+/// Use [CLibrary] in a shared file (e.g. `lib/src/c_library.dart`) and call
+/// [build] from your build hook (`hook/build.dart`) and [link] from your
+/// link hook (`hook/link.dart`).
+///
+/// If you don't need to support link-time optimization (LTO) or other linking
+/// features that require a link hook, you can use [CBuilder] directly in your
+/// build hook.
+class CLibrary {
+  /// Name of the library or executable to build or link.
+  final String name;
+
+  /// The package name to associate the asset with.
+  final String? packageName;
+
+  /// Asset identifier.
+  final String? assetName;
+
+  /// Sources to build the library or executable.
+  final List<String> sources;
+
+  /// Include directories to pass to the compiler.
+  final List<String> includes;
+
+  /// Files passed to the compiler that will be included before all source
+  /// files.
+  final List<String> forcedIncludes;
+
+  /// Frameworks to link.
+  final List<String> frameworks;
+
+  /// Libraries to link to.
+  final List<String> libraries;
+
+  /// Directories to search for [libraries].
+  final List<String> libraryDirectories;
+
+  /// Flags to pass to the build tool.
+  final List<String> flags;
+
+  /// Definitions of preprocessor macros.
+  final Map<String, String?> defines;
+
+  /// Whether the linker will emit position independent code.
+  final bool? pic;
+
+  /// The language standard to use.
+  final String? std;
+
+  /// The language to compile [sources] as.
+  final Language language;
+
+  /// The C++ standard library to link against.
+  final String? cppLinkStdLib;
+
+  /// What optimization level should be used for compiling.
+  final OptimizationLevel optimizationLevel;
+
+  /// Whether to define a macro for the current build mode.
+  final bool buildModeDefine;
+
+  /// Whether to define the standard `NDEBUG` macro.
+  final bool ndebugDefine;
+
+  CLibrary({
+    required this.name,
+    this.packageName,
+    this.assetName,
+    this.sources = const [],
+    this.includes = const [],
+    this.forcedIncludes = const [],
+    this.frameworks = CTool.defaultFrameworks,
+    this.libraries = const [],
+    this.libraryDirectories = CTool.defaultLibraryDirectories,
+    this.flags = const [],
+    this.defines = const {},
+    this.pic = true,
+    this.std,
+    this.language = Language.c,
+    this.cppLinkStdLib,
+    this.optimizationLevel = OptimizationLevel.o3,
+    this.buildModeDefine = true,
+    this.ndebugDefine = true,
+  });
+
+  late final _builder = CBuilder.library(
+    name: name,
+    packageName: packageName,
+    assetName: assetName,
+    sources: sources,
+    includes: includes,
+    forcedIncludes: forcedIncludes,
+    frameworks: frameworks,
+    libraries: libraries,
+    libraryDirectories: libraryDirectories,
+    flags: flags,
+    defines: defines,
+    pic: pic,
+    std: std,
+    language: language,
+    cppLinkStdLib: cppLinkStdLib,
+    optimizationLevel: optimizationLevel,
+    buildModeDefine: buildModeDefine,
+    ndebugDefine: ndebugDefine,
+  );
+
+  late final _linker = CLinker.library(
+    name: name,
+    packageName: packageName,
+    assetName: assetName,
+    includes: includes,
+    forcedIncludes: forcedIncludes,
+    frameworks: frameworks,
+    libraries: libraries,
+    libraryDirectories: libraryDirectories,
+    flags: flags,
+    defines: defines,
+    pic: pic,
+    std: std,
+    language: language,
+    cppLinkStdLib: cppLinkStdLib,
+    optimizationLevel: optimizationLevel,
+  );
+
+  /// Builds the C code.
+  ///
+  /// This should be called from your build hook (`hook/build.dart`).
+  ///
+  /// It takes the [input] and [output] from the build hook.
+  ///
+  /// By default, the output is routed to a link hook in the same package, and
+  /// the link mode is set to static, so the linker can perform optimizations.
+  ///
+  /// If provided, uses [logger] to output logs. Otherwise, uses a default
+  /// logger that streams [Level.WARNING] to stdout and higher levels to stderr.
+  ///
+  /// [routing] determines how the built assets are distributed. Defaults to
+  /// [ToLinkHook] if linking is enabled, otherwise [ToAppBundle].
+  ///
+  /// [linkModePreference] overrides the default link mode (which is static
+  /// if linking is enabled, otherwise dynamic).
+  ///
+  /// [defines] are merged with the [CLibrary.defines] of this [CLibrary]. See
+  /// [CLibrary.defines] for more documentation.
+  Future<void> build({
+    required BuildInput input,
+    required BuildOutputBuilder output,
+    Logger? logger,
+    List<AssetRouting>? routing,
+    LinkModePreference? linkModePreference,
+    Map<String, String?>? defines,
+  }) async {
+    final builder = defines == null
+        ? _builder
+        : CBuilder.library(
+            name: name,
+            packageName: packageName,
+            assetName: assetName,
+            sources: sources,
+            includes: includes,
+            forcedIncludes: forcedIncludes,
+            frameworks: frameworks,
+            libraries: libraries,
+            libraryDirectories: libraryDirectories,
+            flags: flags,
+            defines: {...this.defines, ...defines},
+            pic: pic,
+            std: std,
+            language: language,
+            cppLinkStdLib: cppLinkStdLib,
+            optimizationLevel: optimizationLevel,
+            buildModeDefine: buildModeDefine,
+            ndebugDefine: ndebugDefine,
+          );
+    await builder.run(
+      input: input,
+      output: output,
+      logger: logger,
+      routing:
+          routing ??
+          (input.config.linkingEnabled
+              ? [ToLinkHook(input.packageName)]
+              : [const ToAppBundle()]),
+      linkModePreference:
+          linkModePreference ??
+          (input.config.linkingEnabled
+              ? LinkModePreference.static
+              : LinkModePreference.dynamic),
+    );
+  }
+
+  /// Links the C code.
+  ///
+  /// This should be called from your link hook (`hook/link.dart`).
+  ///
+  /// It takes the [input] and [output] from the link hook.
+  ///
+  /// By default, it links all the code assets that were produced by the build
+  /// step. If [assetName] is set, only code assets matching that name are
+  /// linked.
+  ///
+  /// If provided, uses [logger] to output logs. Otherwise, uses a default
+  /// logger that streams [Level.WARNING] to stdout and higher levels to stderr.
+  ///
+  /// [linkerOptions] overrides the [CLinker.linkerOptions] of the internal
+  /// linker. See [CLinker.linkerOptions] for more documentation.
+  ///
+  /// [linkModePreference] overrides the default link mode preference from the
+  /// build configuration.
+  ///
+  /// [defines] are merged with the [CLibrary.defines] of this [CLibrary]. See
+  /// [CLibrary.defines] for more documentation.
+  Future<void> link({
+    required LinkInput input,
+    required LinkOutputBuilder output,
+    Logger? logger,
+    LinkerOptions? linkerOptions,
+    LinkModePreference? linkModePreference,
+    Map<String, String?>? defines,
+  }) async {
+    // If we have an assetName, we use that to find the assets.
+    final assets = assetName != null
+        ? input.assets.code.where((a) => a.id.endsWith(assetName!))
+        : input.assets.code;
+
+    await _linker.run(
+      input: input,
+      output: output,
+      logger: logger,
+      linkerOptions: linkerOptions,
+      linkModePreference: linkModePreference,
+      sources: assets.map((a) => a.file!.toFilePath()).toList(),
+      defines: defines,
+    );
+  }
+}

--- a/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
+++ b/pkgs/native_toolchain_c/lib/src/cbuilder/clinker.dart
@@ -9,6 +9,8 @@ import 'package:hooks/hooks.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 
+import 'cbuilder.dart';
+import 'clibrary.dart';
 import 'ctool.dart';
 import 'linker_options.dart';
 import 'linkmode.dart';
@@ -18,13 +20,13 @@ import 'run_cbuilder.dart';
 
 /// Specification for linking an artifact with a C linker.
 class CLinker extends CTool implements Linker {
-  final LinkerOptions linkerOptions;
+  final LinkerOptions? linkerOptions;
 
   CLinker.library({
     required super.name,
     super.packageName,
     super.assetName,
-    required this.linkerOptions,
+    this.linkerOptions,
     super.sources = const [],
     super.includes = const [],
     super.forcedIncludes = const [],
@@ -48,24 +50,45 @@ class CLinker extends CTool implements Linker {
   ///
   /// If provided, uses [logger] to output logs. Otherwise, uses a default
   /// logger that streams [Level.WARNING] to stdout and higher levels to stderr.
+  ///
+  /// [linkerOptions] overrides the [CLinker.linkerOptions] of this [CLinker].
+  /// See [CLinker.linkerOptions] for more documentation.
+  ///
+  /// [linkModePreference] overrides the [CTool.linkModePreference] of this
+  /// [CLinker]. See [CTool.linkModePreference] for more documentation.
+  ///
+  /// [sources] overrides the [CTool.sources] of this [CLinker]. See
+  /// [CTool.sources] for more documentation.
+  ///
+  /// [defines] are merged with the [CTool.defines] of this [CLinker]. See
+  /// [CTool.defines] for more documentation.
+  ///
+  /// If you're using [CBuilder] in a build hook and [CLinker] in a link hook,
+  /// see [CLibrary] to combine them.
   @override
   Future<void> run({
     required LinkInput input,
     required LinkOutputBuilder output,
     Logger? logger,
+    LinkerOptions? linkerOptions,
+    LinkModePreference? linkModePreference,
+    List<String>? sources,
+    Map<String, String?>? defines,
   }) async {
     logger ??= createDefaultLogger();
     final outDir = input.outputDirectory;
     final packageRoot = input.packageRoot;
     await Directory.fromUri(outDir).create(recursive: true);
     final linkMode = getLinkMode(
-      linkModePreference ?? input.config.code.linkModePreference,
+      linkModePreference ??
+          this.linkModePreference ??
+          input.config.code.linkModePreference,
     );
     final libUri = outDir.resolve(
       input.config.code.targetOS.libraryFileName(name, linkMode),
     );
-    final sources = [
-      for (final source in this.sources)
+    final resolvedSources = [
+      for (final source in sources ?? this.sources)
         packageRoot.resolveUri(Uri.file(source)),
     ];
     final includes = [
@@ -79,9 +102,9 @@ class CLinker extends CTool implements Linker {
     final task = RunCBuilder(
       input: input,
       codeConfig: input.config.code,
-      linkerOptions: linkerOptions,
+      linkerOptions: linkerOptions ?? this.linkerOptions,
       logger: logger,
-      sources: sources,
+      sources: resolvedSources,
       includes: includes,
       frameworks: frameworks,
       libraries: libraries,
@@ -91,7 +114,7 @@ class CLinker extends CTool implements Linker {
       // ignore: invalid_use_of_visible_for_testing_member
       installName: installName,
       flags: flags,
-      defines: defines,
+      defines: {...this.defines, ...?defines},
       pic: pic,
       std: std,
       language: language,
@@ -121,7 +144,7 @@ class CLinker extends CTool implements Linker {
 
     output.dependencies.addAll({
       // Note: We use a Set here to deduplicate the dependencies.
-      ...sources,
+      ...resolvedSources,
       ...includeFiles,
     });
   }


### PR DESCRIPTION
Closes: https://github.com/dart-lang/native/issues/3284

Introduces the `CLibrary` class which has a build and link method that are meant to be used together from the build and link hooks.