### PR TITLE
[jni] Improve error message when JNI used too early

### DIFF
--- a/pkgs/jni/CHANGELOG.md
+++ b/pkgs/jni/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1-wip
+
+- Improve error message when JNI is used before Flutter plugin initialization.
+
 ## 1.0.0
 
 - **Breaking Change**: The Flutter specific APIs `Jni.androidApplicationContext`

--- a/pkgs/jni/pubspec.yaml
+++ b/pkgs/jni/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jni
 description: A library to access JNI from Dart and Flutter that acts as a support library for package:jnigen.
-version: 1.0.0
+version: 1.0.1-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/jni
 issue_tracker: https://github.com/dart-lang/native/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Ajni
 

--- a/pkgs/jni/src/dartjni.h
+++ b/pkgs/jni/src/dartjni.h
@@ -19,11 +19,12 @@
 #define LOGF(...) __android_log_print(ANDROID_LOG_FATAL, "DartJNI", __VA_ARGS__)
 #else
 #define __ENVP_CAST (void**)
-#define LOGF(...) do {                    \
-    fprintf(stderr, "DartJNI [FATAL] ");  \
-    fprintf(stderr, __VA_ARGS__);         \
-    fprintf(stderr, "\n");                \
-  } while(0)
+#define LOGF(...)                        \
+  do {                                   \
+    fprintf(stderr, "DartJNI [FATAL] "); \
+    fprintf(stderr, __VA_ARGS__);        \
+    fprintf(stderr, "\n");               \
+  } while (0)
 #endif
 
 /// Locking functions for windows and pthread.
@@ -159,8 +160,9 @@ static inline void detach_thread(void* data) {
 static inline void attach_thread() {
   if (jniEnv == NULL) {
     if (jni->jvm == NULL) {
-      LOGF("JNI is not initialized. Are you trying to invoke a Java API"
-        " too early, before Flutter plugin initialization?");
+      LOGF(
+          "JNI is not initialized. Are you trying to invoke a Java API"
+          " too early, before Flutter plugin initialization?");
     }
     (*jni->jvm)->AttachCurrentThread(jni->jvm, __ENVP_CAST & jniEnv, NULL);
 #if !defined(_WIN32)

--- a/pkgs/jni/src/dartjni.h
+++ b/pkgs/jni/src/dartjni.h
@@ -161,8 +161,9 @@ static inline void attach_thread() {
   if (jniEnv == NULL) {
     if (jni->jvm == NULL) {
       LOGF(
-          "JNI is not initialized. Are you trying to invoke a Java API"
-          " too early, before Flutter plugin initialization?");
+          "JNI is not initialized. Are you trying to invoke a Java API from"
+          " Dart code too early, before 'main()' (such as during Dart plugin"
+          " class registration)?");
     }
     (*jni->jvm)->AttachCurrentThread(jni->jvm, __ENVP_CAST & jniEnv, NULL);
 #if !defined(_WIN32)

--- a/pkgs/jni/src/dartjni.h
+++ b/pkgs/jni/src/dartjni.h
@@ -16,8 +16,14 @@
 #if defined(__ANDROID__)
 #include <android/log.h>
 #define __ENVP_CAST (JNIEnv**)
+#define LOGF(...) __android_log_print(ANDROID_LOG_FATAL, "DartJNI", __VA_ARGS__)
 #else
 #define __ENVP_CAST (void**)
+#define LOGF(...) do {                    \
+    fprintf(stderr, "DartJNI [FATAL] ");  \
+    fprintf(stderr, __VA_ARGS__);         \
+    fprintf(stderr, "\n");                \
+  } while(0)
 #endif
 
 /// Locking functions for windows and pthread.
@@ -152,6 +158,10 @@ static inline void detach_thread(void* data) {
 
 static inline void attach_thread() {
   if (jniEnv == NULL) {
+    if (jni->jvm == NULL) {
+      LOGF("JNI is not initialized. Are you trying to invoke a Java API"
+        " too early, before Flutter plugin initialization?");
+    }
     (*jni->jvm)->AttachCurrentThread(jni->jvm, __ENVP_CAST & jniEnv, NULL);
 #if !defined(_WIN32)
     pthread_setspecific(tlsKey, &jniEnv);

--- a/pkgs/jni/src/dartjni.h
+++ b/pkgs/jni/src/dartjni.h
@@ -19,11 +19,11 @@
 #define LOGF(...) __android_log_print(ANDROID_LOG_FATAL, "DartJNI", __VA_ARGS__)
 #else
 #define __ENVP_CAST (void**)
-#define LOGF(...)                        \
-  do {                                   \
-    fprintf(stderr, "DartJNI [FATAL] "); \
-    fprintf(stderr, __VA_ARGS__);        \
-    fprintf(stderr, "\n");               \
+#define LOGF(...)                                                              \
+  do {                                                                         \
+    fprintf(stderr, "DartJNI [FATAL] ");                                       \
+    fprintf(stderr, __VA_ARGS__);                                              \
+    fprintf(stderr, "\n");                                                     \
   } while (0)
 #endif
 


### PR DESCRIPTION
If JNI is used (eg by a user invoking a JNIgen Java API) before Flutter's plugin initialization, this manifests as `jni->jvm` being `NULL`. Detect this and log a nicer error message before the inevitable crash.

Fixes https://github.com/dart-lang/native/issues/2872