### PR TITLE
[hooks_runner] `BuildResult` serialization

### DIFF
--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- Add `toJson()` and `fromJson()` to `BuildResult` to support serialization.
+
 ## 1.1.1
 
 - Bump `package:record_use` to 0.6.0.

--- a/pkgs/hooks_runner/lib/src/model/build_result.dart
+++ b/pkgs/hooks_runner/lib/src/model/build_result.dart
@@ -4,6 +4,8 @@
 
 import 'package:hooks/hooks.dart';
 
+import 'hook_result.dart';
+
 /// The result of executing build hooks from all packages in the dependency tree
 /// of the entry point application.
 abstract class BuildResult {
@@ -15,4 +17,11 @@ abstract class BuildResult {
 
   /// The native assets produced by the hooks, which should be linked.
   Map<String, List<EncodedAsset>> get encodedAssetsForLinking;
+
+  /// Encodes this [BuildResult] to JSON.
+  Map<String, Object?> toJson();
+
+  /// Decodes a [BuildResult] from JSON.
+  factory BuildResult.fromJson(Map<String, Object?> json) =>
+      HookResult.fromJson(json);
 }

--- a/pkgs/hooks_runner/lib/src/model/hook_result.dart
+++ b/pkgs/hooks_runner/lib/src/model/hook_result.dart
@@ -40,6 +40,41 @@ final class HookResult implements BuildResult, LinkResult {
     dependencies: dependencies ?? [],
   );
 
+  @override
+  Map<String, Object?> toJson() => {
+    'encodedAssets': encodedAssets.map((e) => e.toJson()).toList(),
+    'encodedAssetsForLinking': encodedAssetsForLinking.map(
+      (key, value) => MapEntry(
+        key,
+        value.map((e) => e.toJson()).toList(),
+      ),
+    ),
+    'dependencies': dependencies.map((e) => e.toString()).toList(),
+  };
+
+  factory HookResult.fromJson(Map<String, Object?> json) {
+    final encodedAssets = (json['encodedAssets'] as List?)
+        ?.map((e) => EncodedAsset.fromJson(e as Map<String, Object?>))
+        .toList();
+    final encodedAssetsForLinking = (json['encodedAssetsForLinking'] as Map?)
+        ?.map(
+          (key, value) => MapEntry(
+            key as String,
+            (value as List)
+                .map((e) => EncodedAsset.fromJson(e as Map<String, Object?>))
+                .toList(),
+          ),
+        );
+    final dependencies = (json['dependencies'] as List?)
+        ?.map((e) => Uri.parse(e as String))
+        .toList();
+    return HookResult(
+      encodedAssets: encodedAssets,
+      encodedAssetsForLinking: encodedAssetsForLinking,
+      dependencies: dependencies,
+    );
+  }
+
   HookResult copyAdd(HookOutput hookOutput, List<Uri> hookDependencies) {
     final mergedMaps = mergeMaps(
       encodedAssetsForLinking,

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 1.1.1
+version: 1.2.0
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 

--- a/pkgs/hooks_runner/test/model/hook_result_test.dart
+++ b/pkgs/hooks_runner/test/model/hook_result_test.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:hooks/hooks.dart';
+
+import 'package:hooks_runner/src/model/build_result.dart';
+import 'package:hooks_runner/src/model/hook_result.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('HookResult toJson and fromJson', () {
+    final asset = EncodedAsset('test_type', {'key': 'value'});
+    final result = HookResult(
+      encodedAssets: [asset],
+      encodedAssetsForLinking: {
+        'package_a': [asset],
+      },
+      dependencies: [Uri.parse('file:///test.dart')],
+    );
+
+    final json = result.toJson();
+    final deserialized = HookResult.fromJson(json);
+
+    expect(deserialized.encodedAssets, equals(result.encodedAssets));
+    expect(
+      deserialized.encodedAssetsForLinking,
+      equals(result.encodedAssetsForLinking),
+    );
+    expect(deserialized.dependencies, equals(result.dependencies));
+  });
+
+  test('BuildResult.fromJson', () {
+    final asset = EncodedAsset('test_type', {'key': 'value'});
+    final result = HookResult(
+      encodedAssets: [asset],
+      encodedAssetsForLinking: {
+        'package_a': [asset],
+      },
+      dependencies: [Uri.parse('file:///test.dart')],
+    );
+
+    final json = result.toJson();
+    final deserialized = BuildResult.fromJson(json);
+
+    expect(deserialized.encodedAssets, equals(result.encodedAssets));
+    expect(
+      deserialized.encodedAssetsForLinking,
+      equals(result.encodedAssetsForLinking),
+    );
+    expect(deserialized.dependencies, equals(result.dependencies));
+  });
+}


### PR DESCRIPTION
In Flutter we'd like to serialize the build results to file so we can have it in a separate target.

Context:

* https://github.com/flutter/flutter/pull/184869