### PR TITLE
[ffigen] propagate deprecated attributes into generated dart bindings

### DIFF
--- a/pkgs/ffigen/CHANGELOG.md
+++ b/pkgs/ffigen/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 21.0.0
 
+- Propagate `@Deprecated` annotations from C/ObjC headers into generated Dart
+  bindings. Deprecation messages from `__attribute__((deprecated("msg")))` and
+  `API_DEPRECATED("msg", ...)` are included in the annotation.
 - __Breaking change__: Remove deprecated `useDartHandle` field from
   `FfiGenerator`.
 - __Breaking change__: Remove unused `includeSymbolAddress` field from

--- a/pkgs/ffigen/example/libclang-example/generated_bindings.dart
+++ b/pkgs/ffigen/example/libclang-example/generated_bindings.dart
@@ -3651,6 +3651,7 @@ class LibClang {
   late final _clang_getDiagnosticCategory = _clang_getDiagnosticCategoryPtr
       .asFunction<DartClang_getDiagnosticCategory>();
 
+  @Deprecated('Deprecated')
   /// Retrieve the name of a particular diagnostic category.  This
   /// is now deprecated.  Use clang_getDiagnosticCategoryText()
   /// instead.

--- a/pkgs/ffigen/example/libclang-example/generated_bindings.dart
+++ b/pkgs/ffigen/example/libclang-example/generated_bindings.dart
@@ -3651,7 +3651,6 @@ class LibClang {
   late final _clang_getDiagnosticCategory = _clang_getDiagnosticCategoryPtr
       .asFunction<DartClang_getDiagnosticCategory>();
 
-  @Deprecated('Deprecated')
   /// Retrieve the name of a particular diagnostic category.  This
   /// is now deprecated.  Use clang_getDiagnosticCategoryText()
   /// instead.
@@ -3660,6 +3659,7 @@ class LibClang {
   /// \c clang_getDiagnosticCategory().
   ///
   /// \returns The name of the given diagnostic category.
+  @Deprecated('Deprecated')
   CXString clang_getDiagnosticCategoryName(int Category) {
     return _clang_getDiagnosticCategoryName(Category);
   }

--- a/pkgs/ffigen/lib/src/code_generator/compound.dart
+++ b/pkgs/ffigen/lib/src/code_generator/compound.dart
@@ -152,11 +152,11 @@ abstract class Compound extends BindingType with HasLocalScope {
   BindingString toBindingString(Writer w) {
     final s = StringBuffer();
     final enclosingClassName = name;
+    s.write(makeDartDoc(dartDoc));
     final deprecatedAnnotation = apiAvailability?.deprecatedAnnotation;
     if (deprecatedAnnotation != null) {
       s.write('$deprecatedAnnotation\n');
     }
-    s.write(makeDartDoc(dartDoc));
 
     /// Write @Packed(X) annotation if struct is packed.
     final ffiPrefix = context.libs.prefix(ffiImport);

--- a/pkgs/ffigen/lib/src/code_generator/compound.dart
+++ b/pkgs/ffigen/lib/src/code_generator/compound.dart
@@ -5,6 +5,7 @@
 import '../code_generator.dart';
 import '../config_provider.dart';
 import '../context.dart';
+import '../header_parser/sub_parsers/api_availability.dart';
 import '../visitor/ast.dart';
 
 import 'binding_string.dart';
@@ -37,6 +38,8 @@ abstract class Compound extends BindingType with HasLocalScope {
   /// `struct` or `union`, depending on whether the declaration is a typedef.
   final String nativeType;
 
+  final ApiAvailability? apiAvailability;
+
   Compound({
     super.usr,
     super.originalName,
@@ -47,6 +50,7 @@ abstract class Compound extends BindingType with HasLocalScope {
     super.isInternal,
     required this.context,
     String? nativeType,
+    this.apiAvailability,
   }) : members = members ?? [],
        nativeType = nativeType ?? originalName ?? name;
 
@@ -148,6 +152,10 @@ abstract class Compound extends BindingType with HasLocalScope {
   BindingString toBindingString(Writer w) {
     final s = StringBuffer();
     final enclosingClassName = name;
+    final deprecatedAnnotation = apiAvailability?.deprecatedAnnotation;
+    if (deprecatedAnnotation != null) {
+      s.write('$deprecatedAnnotation\n');
+    }
     s.write(makeDartDoc(dartDoc));
 
     /// Write @Packed(X) annotation if struct is packed.

--- a/pkgs/ffigen/lib/src/code_generator/constant.dart
+++ b/pkgs/ffigen/lib/src/code_generator/constant.dart
@@ -47,11 +47,11 @@ class Constant extends NoLookUpBinding {
     final s = StringBuffer();
     final constantName = name;
 
+    s.write(makeDartDoc(dartDoc));
     final deprecatedAnnotation = apiAvailability?.deprecatedAnnotation;
     if (deprecatedAnnotation != null) {
       s.write('$deprecatedAnnotation\n');
     }
-    s.write(makeDartDoc(dartDoc));
     s.write('\nconst $rawType $constantName = $rawValue;\n\n');
 
     return BindingString(

--- a/pkgs/ffigen/lib/src/code_generator/constant.dart
+++ b/pkgs/ffigen/lib/src/code_generator/constant.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../header_parser/sub_parsers/api_availability.dart';
 import '../visitor/ast.dart';
 import 'binding.dart';
 import 'binding_string.dart';
@@ -29,6 +30,8 @@ class Constant extends NoLookUpBinding {
   /// Put quotes if type is a string.
   final String rawValue;
 
+  final ApiAvailability? apiAvailability;
+
   Constant({
     super.usr,
     super.originalName,
@@ -36,6 +39,7 @@ class Constant extends NoLookUpBinding {
     super.dartDoc,
     required this.rawType,
     required this.rawValue,
+    this.apiAvailability,
   }) : super(symbol: Symbol(name, SymbolKind.field));
 
   @override
@@ -43,6 +47,10 @@ class Constant extends NoLookUpBinding {
     final s = StringBuffer();
     final constantName = name;
 
+    final deprecatedAnnotation = apiAvailability?.deprecatedAnnotation;
+    if (deprecatedAnnotation != null) {
+      s.write('$deprecatedAnnotation\n');
+    }
     s.write(makeDartDoc(dartDoc));
     s.write('\nconst $rawType $constantName = $rawValue;\n\n');
 
@@ -65,6 +73,7 @@ class UnnamedEnumConstant extends Constant {
     super.dartDoc,
     required super.rawType,
     required super.rawValue,
+    super.apiAvailability,
   });
 
   @override
@@ -81,6 +90,7 @@ class MacroConstant extends Constant {
     super.dartDoc,
     required super.rawType,
     required super.rawValue,
+    super.apiAvailability,
   });
 
   @override

--- a/pkgs/ffigen/lib/src/code_generator/enum_class.dart
+++ b/pkgs/ffigen/lib/src/code_generator/enum_class.dart
@@ -6,6 +6,7 @@ import 'package:collection/collection.dart';
 
 import '../config_provider.dart';
 import '../context.dart';
+import '../header_parser/sub_parsers/api_availability.dart';
 import '../visitor/ast.dart';
 import 'binding_string.dart';
 import 'imports.dart';
@@ -54,6 +55,8 @@ class EnumClass extends BindingType with HasLocalScope {
   /// Don't code gen this alias at all, just use the [nativeType] directly.
   bool isAnonymous;
 
+  final ApiAvailability? apiAvailability;
+
   EnumClass({
     super.usr,
     super.originalName,
@@ -64,6 +67,7 @@ class EnumClass extends BindingType with HasLocalScope {
     required this.context,
     this.style = EnumStyle.dartEnum,
     this.isAnonymous = false,
+    this.apiAvailability,
   }) : nativeType = nativeType ?? intType,
        enumConstants = enumConstants ?? [];
 
@@ -159,6 +163,10 @@ class EnumClass extends BindingType with HasLocalScope {
 
   /// Writes the DartDoc string for this enum.
   void _writeDartDoc(StringBuffer s) {
+    final deprecatedAnnotation = apiAvailability?.deprecatedAnnotation;
+    if (deprecatedAnnotation != null) {
+      s.write('$deprecatedAnnotation\n');
+    }
     s.write(makeDartDoc(dartDoc));
   }
 

--- a/pkgs/ffigen/lib/src/code_generator/enum_class.dart
+++ b/pkgs/ffigen/lib/src/code_generator/enum_class.dart
@@ -163,11 +163,11 @@ class EnumClass extends BindingType with HasLocalScope {
 
   /// Writes the DartDoc string for this enum.
   void _writeDartDoc(StringBuffer s) {
+    s.write(makeDartDoc(dartDoc));
     final deprecatedAnnotation = apiAvailability?.deprecatedAnnotation;
     if (deprecatedAnnotation != null) {
       s.write('$deprecatedAnnotation\n');
     }
-    s.write(makeDartDoc(dartDoc));
   }
 
   /// Writes a sealed class when no members exist, because Dart enums cannot be

--- a/pkgs/ffigen/lib/src/code_generator/func.dart
+++ b/pkgs/ffigen/lib/src/code_generator/func.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../code_generator.dart';
+import '../header_parser/sub_parsers/api_availability.dart';
 import '../visitor/ast.dart';
 
 import 'binding_string.dart';
@@ -47,6 +48,7 @@ class Func extends LookUpBinding with HasLocalScope {
   final bool objCReturnsRetained;
   final bool useNameForLookup;
   final bool recordUse;
+  final ApiAvailability? apiAvailability;
 
   @override
   final bool loadFromNativeAsset;
@@ -72,6 +74,7 @@ class Func extends LookUpBinding with HasLocalScope {
     this.recordUse = false,
     super.isInternal,
     this.loadFromNativeAsset = false,
+    this.apiAvailability,
   }) : functionType = FunctionType(
          returnType: returnType,
          parameters: parameters,
@@ -101,6 +104,10 @@ class Func extends LookUpBinding with HasLocalScope {
     final s = StringBuffer();
     final enclosingFuncName = name;
 
+    final deprecatedAnnotation = apiAvailability?.deprecatedAnnotation;
+    if (deprecatedAnnotation != null) {
+      s.write('$deprecatedAnnotation\n');
+    }
     s.write(makeDartDoc(dartDoc));
 
     final context = w.context;

--- a/pkgs/ffigen/lib/src/code_generator/func.dart
+++ b/pkgs/ffigen/lib/src/code_generator/func.dart
@@ -104,11 +104,11 @@ class Func extends LookUpBinding with HasLocalScope {
     final s = StringBuffer();
     final enclosingFuncName = name;
 
+    s.write(makeDartDoc(dartDoc));
     final deprecatedAnnotation = apiAvailability?.deprecatedAnnotation;
     if (deprecatedAnnotation != null) {
       s.write('$deprecatedAnnotation\n');
     }
-    s.write(makeDartDoc(dartDoc));
 
     final context = w.context;
     final cType =

--- a/pkgs/ffigen/lib/src/code_generator/objc_category.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_category.dart
@@ -49,11 +49,11 @@ class ObjCCategory extends NoLookUpBinding with ObjCMethods, HasLocalScope {
   BindingString toBindingString(Writer w) {
     final s = StringBuffer();
     s.write('\n');
+    s.write(makeDartDoc(dartDoc));
     final deprecatedAnnotation = apiAvailability.deprecatedAnnotation;
     if (deprecatedAnnotation != null) {
       s.write('$deprecatedAnnotation\n');
     }
-    s.write(makeDartDoc(dartDoc));
     s.write('''
 extension $name on ${parent.getDartType(context)} {
 ${generateMethodBindings(w, parent)}

--- a/pkgs/ffigen/lib/src/code_generator/objc_category.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_category.dart
@@ -4,6 +4,7 @@
 
 import '../code_generator.dart';
 import '../context.dart';
+import '../header_parser/sub_parsers/api_availability.dart';
 import '../visitor/ast.dart';
 import 'binding_string.dart';
 import 'scope.dart';
@@ -18,6 +19,8 @@ class ObjCCategory extends NoLookUpBinding with ObjCMethods, HasLocalScope {
 
   final protocols = <ObjCProtocol>[];
 
+  final ApiAvailability apiAvailability;
+
   ObjCCategory({
     super.usr,
     required String super.originalName,
@@ -25,6 +28,7 @@ class ObjCCategory extends NoLookUpBinding with ObjCMethods, HasLocalScope {
     required this.parent,
     super.dartDoc,
     required this.context,
+    required this.apiAvailability,
   }) : classObject = parent.classObject,
        super(symbol: Symbol(name ?? originalName, SymbolKind.klass));
 
@@ -45,6 +49,10 @@ class ObjCCategory extends NoLookUpBinding with ObjCMethods, HasLocalScope {
   BindingString toBindingString(Writer w) {
     final s = StringBuffer();
     s.write('\n');
+    final deprecatedAnnotation = apiAvailability.deprecatedAnnotation;
+    if (deprecatedAnnotation != null) {
+      s.write('$deprecatedAnnotation\n');
+    }
     s.write(makeDartDoc(dartDoc));
     s.write('''
 extension $name on ${parent.getDartType(context)} {

--- a/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
@@ -8,6 +8,7 @@ import '../header_parser/sub_parsers/api_availability.dart';
 import '../visitor/ast.dart';
 import 'binding_string.dart';
 import 'scope.dart';
+import 'utils.dart';
 import 'writer.dart';
 
 class ObjCInterface extends BindingType with ObjCMethods, HasLocalScope {
@@ -87,6 +88,7 @@ class ObjCInterface extends BindingType with ObjCMethods, HasLocalScope {
 ///
 ''');
     }
+    s.write(makeDartDoc(dartDoc));
     final deprecatedAnnotation = apiAvailability.deprecatedAnnotation;
     if (deprecatedAnnotation != null) {
       s.write('$deprecatedAnnotation\n');

--- a/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_interface.dart
@@ -8,7 +8,6 @@ import '../header_parser/sub_parsers/api_availability.dart';
 import '../visitor/ast.dart';
 import 'binding_string.dart';
 import 'scope.dart';
-import 'utils.dart';
 import 'writer.dart';
 
 class ObjCInterface extends BindingType with ObjCMethods, HasLocalScope {
@@ -88,7 +87,10 @@ class ObjCInterface extends BindingType with ObjCMethods, HasLocalScope {
 ///
 ''');
     }
-    s.write(makeDartDoc(dartDoc));
+    final deprecatedAnnotation = apiAvailability.deprecatedAnnotation;
+    if (deprecatedAnnotation != null) {
+      s.write('$deprecatedAnnotation\n');
+    }
 
     final ctorBody = [
       apiAvailability.runtimeCheck(

--- a/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
@@ -452,7 +452,11 @@ class ObjCMethod extends AstNode with HasLocalScope {
     final paramStr = _joinParamStr(context, params);
 
     // The method declaration.
-    s.write('\n  ${makeDartDoc(dartDoc)}  ');
+    final deprecatedAnnotation = apiAvailability.deprecatedAnnotation;
+    final deprecatedPrefix = deprecatedAnnotation != null
+        ? '$deprecatedAnnotation\n  '
+        : '';
+    s.write('\n  $deprecatedPrefix${makeDartDoc(dartDoc)}  ');
     late String targetStr;
     if (isClassMethod) {
       targetStr = (target as ObjCInterface).classObject.name;

--- a/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_methods.dart
@@ -453,10 +453,11 @@ class ObjCMethod extends AstNode with HasLocalScope {
 
     // The method declaration.
     final deprecatedAnnotation = apiAvailability.deprecatedAnnotation;
-    final deprecatedPrefix = deprecatedAnnotation != null
-        ? '$deprecatedAnnotation\n  '
-        : '';
-    s.write('\n  $deprecatedPrefix${makeDartDoc(dartDoc)}  ');
+    s.write('\n  ${makeDartDoc(dartDoc)}');
+    if (deprecatedAnnotation != null) {
+      s.write('  $deprecatedAnnotation\n');
+    }
+    s.write('  ');
     late String targetStr;
     if (isClassMethod) {
       targetStr = (target as ObjCInterface).classObject.name;

--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -89,6 +89,7 @@ class ObjCProtocol extends BindingType with ObjCMethods, HasLocalScope {
 ///
 ''');
     }
+    s.write(makeDartDoc(dartDoc));
     final deprecatedAnnotation = apiAvailability.deprecatedAnnotation;
     if (deprecatedAnnotation != null) {
       s.write('$deprecatedAnnotation\n');

--- a/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_protocol.dart
@@ -89,7 +89,10 @@ class ObjCProtocol extends BindingType with ObjCMethods, HasLocalScope {
 ///
 ''');
     }
-    s.write(makeDartDoc(dartDoc ?? originalName));
+    final deprecatedAnnotation = apiAvailability.deprecatedAnnotation;
+    if (deprecatedAnnotation != null) {
+      s.write('$deprecatedAnnotation\n');
+    }
 
     final sp = [
       protocolBase,

--- a/pkgs/ffigen/lib/src/code_generator/struct.dart
+++ b/pkgs/ffigen/lib/src/code_generator/struct.dart
@@ -42,6 +42,7 @@ class Struct extends Compound {
     super.isInternal,
     required super.context,
     super.nativeType,
+    super.apiAvailability,
   });
 
   @override

--- a/pkgs/ffigen/lib/src/code_generator/union.dart
+++ b/pkgs/ffigen/lib/src/code_generator/union.dart
@@ -39,6 +39,7 @@ class Union extends Compound {
     super.members,
     required super.context,
     super.nativeType,
+    super.apiAvailability,
   });
 
   @override

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/api_availability.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/api_availability.dart
@@ -43,8 +43,7 @@ class ApiAvailability {
 
   String? get deprecatedAnnotation {
     if (!isDeprecated) return null;
-    final msg = _effectiveDeprecationMessage;
-    final escaped = msg.replaceAll(r'\', r'\\').replaceAll("'", r"\'");
+    final escaped = escapeDartString(_effectiveDeprecationMessage);
     return "@Deprecated('$escaped')";
   }
 
@@ -52,8 +51,20 @@ class ApiAvailability {
     if (deprecationMessage != null && deprecationMessage!.isNotEmpty) {
       return deprecationMessage!;
     }
-    final platformMsg = ios?.message ?? macos?.message;
-    if (platformMsg != null && platformMsg.isNotEmpty) return platformMsg;
+    final iosMsg = ios?.message;
+    final macosMsg = macos?.message;
+    final iosNonEmpty = iosMsg != null && iosMsg.isNotEmpty;
+    final macosNonEmpty = macosMsg != null && macosMsg.isNotEmpty;
+    if (iosNonEmpty && macosNonEmpty) {
+      if (iosMsg != macosMsg) {
+        return 'iOS: $iosMsg, macOS: $macosMsg';
+      }
+      return iosMsg;
+    }
+    final platformMsg = iosNonEmpty
+        ? iosMsg
+        : (macosNonEmpty ? macosMsg : null);
+    if (platformMsg != null) return platformMsg;
     return 'Deprecated';
   }
 

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/api_availability.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/api_availability.dart
@@ -19,14 +19,14 @@ class ApiAvailability {
   final bool alwaysUnavailable;
   final PlatformAvailability? ios;
   final PlatformAvailability? macos;
-  final String? deprecationMessage;
+  final String deprecationMessage;
 
   late final Availability availability;
 
   ApiAvailability({
     this.alwaysDeprecated = false,
     this.alwaysUnavailable = false,
-    this.deprecationMessage,
+    this.deprecationMessage = '',
     this.ios,
     this.macos,
     required ExternalVersions? externalVersions,
@@ -48,23 +48,19 @@ class ApiAvailability {
   }
 
   String get _effectiveDeprecationMessage {
-    if (deprecationMessage != null && deprecationMessage!.isNotEmpty) {
-      return deprecationMessage!;
-    }
-    final iosMsg = ios?.message;
-    final macosMsg = macos?.message;
-    final iosNonEmpty = iosMsg != null && iosMsg.isNotEmpty;
-    final macosNonEmpty = macosMsg != null && macosMsg.isNotEmpty;
+    if (deprecationMessage.isNotEmpty) return deprecationMessage;
+    final iosMsg = ios?.message ?? '';
+    final macosMsg = macos?.message ?? '';
+    final iosNonEmpty = iosMsg.isNotEmpty;
+    final macosNonEmpty = macosMsg.isNotEmpty;
     if (iosNonEmpty && macosNonEmpty) {
       if (iosMsg != macosMsg) {
         return 'iOS: $iosMsg, macOS: $macosMsg';
       }
       return iosMsg;
     }
-    final platformMsg = iosNonEmpty
-        ? iosMsg
-        : (macosNonEmpty ? macosMsg : null);
-    if (platformMsg != null) return platformMsg;
+    if (iosNonEmpty) return iosMsg;
+    if (macosNonEmpty) return macosMsg;
     return 'Deprecated';
   }
 
@@ -111,7 +107,7 @@ class ApiAvailability {
         deprecated: platform.Deprecated.triple,
         obsoleted: platform.Obsoleted.triple,
         unavailable: platform.Unavailable != 0,
-        message: msg.isEmpty ? null : msg,
+        message: msg,
       );
       switch (platform.Platform.string()) {
         case 'ios':
@@ -133,7 +129,7 @@ class ApiAvailability {
     final api = ApiAvailability(
       alwaysDeprecated: alwaysDeprecated.value != 0,
       alwaysUnavailable: alwaysUnavailable.value != 0 || swiftIsUnavailable,
-      deprecationMessage: deprecatedMsg.isEmpty ? null : deprecatedMsg,
+      deprecationMessage: deprecatedMsg,
       ios: ios,
       macos: macos,
       externalVersions: context.config.objectiveC?.externalVersions,
@@ -239,7 +235,7 @@ class PlatformAvailability {
   Version? deprecated;
   Version? obsoleted;
   bool unavailable;
-  String? message;
+  String message;
 
   PlatformAvailability({
     this.name,
@@ -247,7 +243,7 @@ class PlatformAvailability {
     this.deprecated,
     this.obsoleted,
     this.unavailable = false,
-    this.message,
+    this.message = '',
   });
 
   @visibleForTesting

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/api_availability.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/api_availability.dart
@@ -19,17 +19,42 @@ class ApiAvailability {
   final bool alwaysUnavailable;
   final PlatformAvailability? ios;
   final PlatformAvailability? macos;
+  final String? deprecationMessage;
 
   late final Availability availability;
 
   ApiAvailability({
     this.alwaysDeprecated = false,
     this.alwaysUnavailable = false,
+    this.deprecationMessage,
     this.ios,
     this.macos,
     required ExternalVersions? externalVersions,
   }) {
     availability = _getAvailability(externalVersions);
+  }
+
+  /// Whether this symbol is deprecated via `API_DEPRECATED` on any platform.
+  bool get _isPlatformDeprecated =>
+      (ios?.deprecated != null) || (macos?.deprecated != null);
+
+  /// Whether this symbol is deprecated in any way.
+  bool get isDeprecated => alwaysDeprecated || _isPlatformDeprecated;
+
+  String? get deprecatedAnnotation {
+    if (!isDeprecated) return null;
+    final msg = _effectiveDeprecationMessage;
+    final escaped = msg.replaceAll(r'\', r'\\').replaceAll("'", r"\'");
+    return "@Deprecated('$escaped')";
+  }
+
+  String get _effectiveDeprecationMessage {
+    if (deprecationMessage != null && deprecationMessage!.isNotEmpty) {
+      return deprecationMessage!;
+    }
+    final platformMsg = ios?.message ?? macos?.message;
+    if (platformMsg != null && platformMsg.isNotEmpty) return platformMsg;
+    return 'Deprecated';
   }
 
   static ApiAvailability fromCursor(
@@ -47,6 +72,7 @@ class ApiAvailability {
     );
 
     final alwaysDeprecated = calloc<Int>();
+    final deprecatedMessagePtr = calloc<clang_types.CXString>();
     final alwaysUnavailable = calloc<Int>();
     final platforms = calloc<clang_types.CXPlatformAvailability>(
       platformsLength,
@@ -55,7 +81,7 @@ class ApiAvailability {
     clang.clang_getCursorPlatformAvailability(
       cursor,
       alwaysDeprecated,
-      nullptr,
+      deprecatedMessagePtr,
       alwaysUnavailable,
       nullptr,
       platforms,
@@ -68,11 +94,13 @@ class ApiAvailability {
 
     for (var i = 0; i < platformsLength; ++i) {
       final platform = platforms[i];
+      final msg = platform.Message.string();
       final platformAvailability = PlatformAvailability(
         introduced: platform.Introduced.triple,
         deprecated: platform.Deprecated.triple,
         obsoleted: platform.Obsoleted.triple,
         unavailable: platform.Unavailable != 0,
+        message: msg.isEmpty ? null : msg,
       );
       switch (platform.Platform.string()) {
         case 'ios':
@@ -90,9 +118,11 @@ class ApiAvailability {
       }
     }
 
+    final deprecatedMsg = deprecatedMessagePtr.ref.string();
     final api = ApiAvailability(
       alwaysDeprecated: alwaysDeprecated.value != 0,
       alwaysUnavailable: alwaysUnavailable.value != 0 || swiftIsUnavailable,
+      deprecationMessage: deprecatedMsg.isEmpty ? null : deprecatedMsg,
       ios: ios,
       macos: macos,
       externalVersions: context.config.objectiveC?.externalVersions,
@@ -101,7 +131,9 @@ class ApiAvailability {
     for (var i = 0; i < platformsLength; ++i) {
       clang.clang_disposeCXPlatformAvailability(platforms + i);
     }
+    clang.clang_disposeString(deprecatedMessagePtr.ref);
     calloc.free(alwaysDeprecated);
+    calloc.free(deprecatedMessagePtr);
     calloc.free(alwaysUnavailable);
     calloc.free(platforms);
 
@@ -196,6 +228,7 @@ class PlatformAvailability {
   Version? deprecated;
   Version? obsoleted;
   bool unavailable;
+  String? message;
 
   PlatformAvailability({
     this.name,
@@ -203,6 +236,7 @@ class PlatformAvailability {
     this.deprecated,
     this.obsoleted,
     this.unavailable = false,
+    this.message,
   });
 
   @visibleForTesting

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/compounddecl_parser.dart
@@ -106,6 +106,7 @@ Compound? _parseCompoundDeclaration(
     String? dartDoc,
     required Context context,
     String? nativeType,
+    ApiAvailability? apiAvailability,
   })
   constructor,
 ) {
@@ -149,6 +150,7 @@ Compound? _parseCompoundDeclaration(
       ),
       context: context,
       nativeType: cursor.type().spelling(),
+      apiAvailability: apiAvailability,
     );
   } else {
     cursor = context.cursorIndex.getDefinition(cursor);
@@ -166,6 +168,7 @@ Compound? _parseCompoundDeclaration(
       ),
       context: context,
       nativeType: cursor.type().spelling(),
+      apiAvailability: apiAvailability,
     );
   }
   context.bindingsIndex.addCompoundToSeen(usr, compound);

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/enumdecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/enumdecl_parser.dart
@@ -68,6 +68,7 @@ EnumClass parseEnumDeclaration(clang_types.CXCursor cursor, Context context) {
       name: config.enums.rename(decl),
       nativeType: nativeType,
       context: context,
+      apiAvailability: apiAvailability,
     );
     cursor.visitChildren((clang_types.CXCursor child) {
       try {
@@ -128,5 +129,6 @@ EnumClass parseEnumDeclaration(clang_types.CXCursor cursor, Context context) {
         nativeType: nativeType,
         context: context,
         isAnonymous: true,
+        apiAvailability: apiAvailability,
       );
 }

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/functiondecl_parser.dart
@@ -157,6 +157,7 @@ List<Func> parseFunctionDeclaration(
           recordUse: config.functions.recordUse(decl),
           objCReturnsRetained: objCReturnsRetained,
           loadFromNativeAsset: config.output.style is NativeExternalBindings,
+          apiAvailability: apiAvailability,
         ),
       );
     }

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/objccategorydecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/objccategorydecl_parser.dart
@@ -71,6 +71,7 @@ ObjCCategory? parseObjCCategoryDeclaration(
       availability: apiAvailability.dartDoc,
     ),
     context: context,
+    apiAvailability: apiAvailability,
   );
 
   context.bindingsIndex.addObjCCategoryToSeen(usr, category);

--- a/pkgs/ffigen/lib/src/header_parser/sub_parsers/unnamed_enumdecl_parser.dart
+++ b/pkgs/ffigen/lib/src/header_parser/sub_parsers/unnamed_enumdecl_parser.dart
@@ -74,6 +74,7 @@ Constant? _addUnNamedEnumConstant(
     dartDoc: apiAvailability.dartDoc,
     rawType: 'int',
     rawValue: clang.clang_getEnumConstantDeclValue(cursor).toString(),
+    apiAvailability: apiAvailability,
   );
   bindingsIndex.addUnnamedEnumConstantToSeen(cursor.usr(), constant);
   unnamedEnumConstants.add(constant);

--- a/pkgs/ffigen/lib/src/header_parser/utils.dart
+++ b/pkgs/ffigen/lib/src/header_parser/utils.dart
@@ -629,6 +629,18 @@ String writeDoubleAsString(double d) {
   }
 }
 
+/// Escapes a Dart string so it can be placed inside single-quoted string
+/// literals in generated Dart source code.
+///
+/// Handles characters that need escaping: `$ ' \` and control characters.
+String escapeDartString(String s) {
+  final sb = StringBuffer();
+  for (final char in s.runes) {
+    sb.write(_getWritableChar(char));
+  }
+  return sb.toString();
+}
+
 /// Gets a written representation string of a C string.
 ///
 /// E.g- For a string "Hello\nWorld", The new line character is converted to \n.
@@ -639,16 +651,12 @@ String getWrittenStringRepresentation(
   Pointer<Char> strPtr,
   Context context,
 ) {
-  final sb = StringBuffer();
   try {
     // Consider string to be Utf8 encoded by default.
-    sb.clear();
     // This throws a Format Exception if string isn't Utf8 so that we handle it
     // in the catch block.
     final result = strPtr.cast<Utf8>().toDartString();
-    for (final s in result.runes) {
-      sb.write(_getWritableChar(s));
-    }
+    return escapeDartString(result);
   } catch (e) {
     // Handle string if it isn't Utf8. String is considered to be
     // Extended ASCII in this case.
@@ -656,7 +664,7 @@ String getWrittenStringRepresentation(
       "Couldn't decode string value for '$varName' as Utf8, using "
       'ASCII instead.',
     );
-    sb.clear();
+    final sb = StringBuffer();
     final length = strPtr.cast<Utf8>().length;
     final charList = Uint8List.view(
       strPtr.cast<Uint8>().asTypedList(length).buffer,
@@ -667,9 +675,8 @@ String getWrittenStringRepresentation(
     for (final char in charList) {
       sb.write(_getWritableChar(char, utf8: false));
     }
+    return sb.toString();
   }
-
-  return sb.toString();
 }
 
 /// Creates a writable char from [char] code.

--- a/pkgs/ffigen/test/large_integration_tests/_expected_libclang_bindings.dart
+++ b/pkgs/ffigen/test/large_integration_tests/_expected_libclang_bindings.dart
@@ -3275,9 +3275,9 @@ class LibClang {
   late final _clang_getDiagnosticCategory = _clang_getDiagnosticCategoryPtr
       .asFunction<int Function(CXDiagnostic)>();
 
-  @Deprecated('Deprecated')
   /// Retrieve the name of a particular diagnostic category. This is now
   /// deprecated. Use clang_getDiagnosticCategoryText() instead.
+  @Deprecated('Deprecated')
   CXString clang_getDiagnosticCategoryName(int Category) {
     return _clang_getDiagnosticCategoryName(Category);
   }

--- a/pkgs/ffigen/test/large_integration_tests/_expected_libclang_bindings.dart
+++ b/pkgs/ffigen/test/large_integration_tests/_expected_libclang_bindings.dart
@@ -3275,6 +3275,7 @@ class LibClang {
   late final _clang_getDiagnosticCategory = _clang_getDiagnosticCategoryPtr
       .asFunction<int Function(CXDiagnostic)>();
 
+  @Deprecated('Deprecated')
   /// Retrieve the name of a particular diagnostic category. This is now
   /// deprecated. Use clang_getDiagnosticCategoryText() instead.
   CXString clang_getDiagnosticCategoryName(int Category) {

--- a/pkgs/ffigen/test/native_objc_test/deprecated_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/deprecated_test.dart
@@ -798,6 +798,7 @@ void main() {
         expect(
           trimmed,
           contains('''
+@Deprecated('test')
 /// iOS: introduced 1.0.0, deprecated 2.0.0
 /// macOS: introduced 1.0.0, deprecated 2.0.0
 final class DeprecatedStruct extends ffi.Struct'''),
@@ -806,6 +807,7 @@ final class DeprecatedStruct extends ffi.Struct'''),
         expect(
           trimmed,
           contains('''
+@Deprecated('test')
 /// iOS: introduced 1.0.0, deprecated 2.0.0
 /// macOS: introduced 1.0.0, deprecated 2.0.0
 final class DeprecatedUnion extends ffi.Union'''),
@@ -814,6 +816,7 @@ final class DeprecatedUnion extends ffi.Union'''),
         expect(
           trimmed,
           contains('''
+@Deprecated('test')
 /// iOS: introduced 1.0.0, deprecated 2.0.0
 /// macOS: introduced 1.0.0, deprecated 2.0.0
 enum DeprecatedEnum'''),
@@ -822,6 +825,7 @@ enum DeprecatedEnum'''),
         expect(
           trimmed,
           contains('''
+@Deprecated('test')
 /// iOS: introduced 1.0.0, deprecated 2.0.0
 /// macOS: introduced 1.0.0, deprecated 2.0.0
 
@@ -832,6 +836,7 @@ const int deprecatedUnnamedEnum = 1;
         expect(
           trimmed,
           contains('''
+@Deprecated('test')
 /// iOS: introduced 1.0.0, deprecated 2.0.0
 /// macOS: introduced 1.0.0, deprecated 2.0.0
 int deprecatedFunction()'''),
@@ -840,16 +845,14 @@ int deprecatedFunction()'''),
         expect(
           trimmed,
           contains('''
-/// DeprecatedInterface
-///
-/// iOS: introduced 1.0.0, deprecated 2.0.0
-/// macOS: introduced 1.0.0, deprecated 2.0.0
-'''),
+@Deprecated('test')
+extension type DeprecatedInterface'''),
         );
 
         expect(
           trimmed,
           contains('''
+@Deprecated('test')
 /// depIos2Mac2
 ///
 /// iOS: introduced 1.0.0, deprecated 2.0.0
@@ -860,11 +863,8 @@ int deprecatedFunction()'''),
         expect(
           trimmed,
           contains('''
-/// DeprecatedProtocol
-///
-/// iOS: introduced 1.0.0, deprecated 2.0.0
-/// macOS: introduced 1.0.0, deprecated 2.0.0
-'''),
+@Deprecated('test')
+extension type DeprecatedProtocol'''),
         );
 
         expect(
@@ -1012,6 +1012,131 @@ int deprecatedFunction()'''),
       test('unnamed enums', () {
         expect(bindings, contains('normalUnnamedEnum'));
         expect(bindings, isNot(contains('deprecatedUnnamedEnum')));
+      });
+    });
+    group('@Deprecated annotations', () {
+      late final String bindings;
+      setUpAll(() {
+        bindings = bindingsForVersion();
+      });
+
+      test('normal symbols have no @Deprecated annotation', () {
+        final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+        expect(
+          trimmed,
+          isNot(contains("@Deprecated('Deprecated')\nint normalMethod")),
+        );
+        expect(
+          trimmed,
+          isNot(contains("@Deprecated('Deprecated')\nint normalFunction")),
+        );
+      });
+
+      test('alwaysDeprecated method gets @Deprecated with fallback message', () {
+        final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+        expect(
+          trimmed,
+          contains(
+            "@Deprecated('Deprecated')\n/// alwaysDeprecated\nint alwaysDeprecated",
+          ),
+        );
+      });
+
+      test('alwaysDeprecated protocol method gets @Deprecated', () {
+        final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+        expect(
+          trimmed,
+          contains(
+            "@Deprecated('Deprecated')\n/// protAlwaysDeprecated\nint protAlwaysDeprecated",
+          ),
+        );
+      });
+
+      test('alwaysDeprecated category method gets @Deprecated', () {
+        final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+        expect(
+          trimmed,
+          contains(
+            "@Deprecated('Deprecated')\n/// catAlwaysDeprecated\nint catAlwaysDeprecated",
+          ),
+        );
+      });
+
+      test('API_DEPRECATED interface gets @Deprecated with message', () {
+        final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+        expect(
+          trimmed,
+          contains("@Deprecated('test')\nextension type DeprecatedInterface"),
+        );
+      });
+
+      test('API_DEPRECATED protocol gets @Deprecated with message', () {
+        final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+        expect(
+          trimmed,
+          contains("@Deprecated('test')\nextension type DeprecatedProtocol"),
+        );
+      });
+
+      test('API_DEPRECATED category gets @Deprecated with message', () {
+        final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+        expect(
+          trimmed,
+          contains("@Deprecated('test')\n/// DeprecatedCategory\n"),
+        );
+      });
+
+      test('API_DEPRECATED method gets @Deprecated with message', () {
+        final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+        expect(trimmed, contains("@Deprecated('test')\n/// depIos2Mac2\n"));
+      });
+
+      test('API_DEPRECATED function gets @Deprecated with message', () {
+        final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+        expect(
+          trimmed,
+          contains("@Deprecated('test')\nint deprecatedFunction"),
+        );
+      });
+
+      test('API_DEPRECATED struct gets @Deprecated with message', () {
+        final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+        expect(
+          trimmed,
+          contains("@Deprecated('test')\nfinal class DeprecatedStruct"),
+        );
+      });
+
+      test('API_DEPRECATED union gets @Deprecated with message', () {
+        final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+        expect(
+          trimmed,
+          contains("@Deprecated('test')\nfinal class DeprecatedUnion"),
+        );
+      });
+
+      test('API_DEPRECATED enum gets @Deprecated with message', () {
+        final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+        expect(trimmed, contains("@Deprecated('test')\nenum DeprecatedEnum"));
+      });
+
+      test(
+        'API_DEPRECATED unnamed enum constant gets @Deprecated with message',
+        () {
+          final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+          expect(
+            trimmed,
+            contains("@Deprecated('test')\n\nconst int deprecatedUnnamedEnum"),
+          );
+        },
+      );
+
+      test('API_DEPRECATED property getter gets @Deprecated with message', () {
+        final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+        expect(
+          trimmed,
+          contains("@Deprecated('test')\n/// deprecatedProperty\n"),
+        );
       });
     });
   });

--- a/pkgs/ffigen/test/native_objc_test/deprecated_test.dart
+++ b/pkgs/ffigen/test/native_objc_test/deprecated_test.dart
@@ -798,36 +798,36 @@ void main() {
         expect(
           trimmed,
           contains('''
-@Deprecated('test')
 /// iOS: introduced 1.0.0, deprecated 2.0.0
 /// macOS: introduced 1.0.0, deprecated 2.0.0
+@Deprecated('test')
 final class DeprecatedStruct extends ffi.Struct'''),
         );
 
         expect(
           trimmed,
           contains('''
-@Deprecated('test')
 /// iOS: introduced 1.0.0, deprecated 2.0.0
 /// macOS: introduced 1.0.0, deprecated 2.0.0
+@Deprecated('test')
 final class DeprecatedUnion extends ffi.Union'''),
         );
 
         expect(
           trimmed,
           contains('''
-@Deprecated('test')
 /// iOS: introduced 1.0.0, deprecated 2.0.0
 /// macOS: introduced 1.0.0, deprecated 2.0.0
+@Deprecated('test')
 enum DeprecatedEnum'''),
         );
 
         expect(
           trimmed,
           contains('''
-@Deprecated('test')
 /// iOS: introduced 1.0.0, deprecated 2.0.0
 /// macOS: introduced 1.0.0, deprecated 2.0.0
+@Deprecated('test')
 
 const int deprecatedUnnamedEnum = 1;
 '''),
@@ -836,15 +836,19 @@ const int deprecatedUnnamedEnum = 1;
         expect(
           trimmed,
           contains('''
-@Deprecated('test')
 /// iOS: introduced 1.0.0, deprecated 2.0.0
 /// macOS: introduced 1.0.0, deprecated 2.0.0
+@Deprecated('test')
 int deprecatedFunction()'''),
         );
 
         expect(
           trimmed,
           contains('''
+/// DeprecatedInterface
+///
+/// iOS: introduced 1.0.0, deprecated 2.0.0
+/// macOS: introduced 1.0.0, deprecated 2.0.0
 @Deprecated('test')
 extension type DeprecatedInterface'''),
         );
@@ -852,17 +856,21 @@ extension type DeprecatedInterface'''),
         expect(
           trimmed,
           contains('''
-@Deprecated('test')
 /// depIos2Mac2
 ///
 /// iOS: introduced 1.0.0, deprecated 2.0.0
 /// macOS: introduced 1.0.0, deprecated 2.0.0
+@Deprecated('test')
 '''),
         );
 
         expect(
           trimmed,
           contains('''
+/// DeprecatedProtocol
+///
+/// iOS: introduced 1.0.0, deprecated 2.0.0
+/// macOS: introduced 1.0.0, deprecated 2.0.0
 @Deprecated('test')
 extension type DeprecatedProtocol'''),
         );
@@ -883,6 +891,7 @@ extension type DeprecatedProtocol'''),
 ///
 /// iOS: introduced 1.0.0, deprecated 2.0.0
 /// macOS: introduced 1.0.0, deprecated 2.0.0
+@Deprecated('test')
 '''),
         );
 
@@ -1024,31 +1033,44 @@ extension type DeprecatedProtocol'''),
         final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
         expect(
           trimmed,
-          isNot(contains("@Deprecated('Deprecated')\nint normalMethod")),
+          isNot(
+            contains('''
+@Deprecated('Deprecated')
+int normalMethod'''),
+          ),
         );
         expect(
           trimmed,
-          isNot(contains("@Deprecated('Deprecated')\nint normalFunction")),
-        );
-      });
-
-      test('alwaysDeprecated method gets @Deprecated with fallback message', () {
-        final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
-        expect(
-          trimmed,
-          contains(
-            "@Deprecated('Deprecated')\n/// alwaysDeprecated\nint alwaysDeprecated",
+          isNot(
+            contains('''
+@Deprecated('Deprecated')
+int normalFunction'''),
           ),
         );
       });
+
+      test(
+        'alwaysDeprecated method gets @Deprecated with fallback message',
+        () {
+          final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+          expect(
+            trimmed,
+            contains('''
+/// alwaysDeprecated
+@Deprecated('Deprecated')
+int alwaysDeprecated'''),
+          );
+        },
+      );
 
       test('alwaysDeprecated protocol method gets @Deprecated', () {
         final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
         expect(
           trimmed,
-          contains(
-            "@Deprecated('Deprecated')\n/// protAlwaysDeprecated\nint protAlwaysDeprecated",
-          ),
+          contains('''
+/// protAlwaysDeprecated
+@Deprecated('Deprecated')
+int protAlwaysDeprecated'''),
         );
       });
 
@@ -1056,9 +1078,10 @@ extension type DeprecatedProtocol'''),
         final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
         expect(
           trimmed,
-          contains(
-            "@Deprecated('Deprecated')\n/// catAlwaysDeprecated\nint catAlwaysDeprecated",
-          ),
+          contains('''
+/// catAlwaysDeprecated
+@Deprecated('Deprecated')
+int catAlwaysDeprecated'''),
         );
       });
 
@@ -1066,7 +1089,9 @@ extension type DeprecatedProtocol'''),
         final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
         expect(
           trimmed,
-          contains("@Deprecated('test')\nextension type DeprecatedInterface"),
+          contains('''
+@Deprecated('test')
+extension type DeprecatedInterface'''),
         );
       });
 
@@ -1074,7 +1099,9 @@ extension type DeprecatedProtocol'''),
         final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
         expect(
           trimmed,
-          contains("@Deprecated('test')\nextension type DeprecatedProtocol"),
+          contains('''
+@Deprecated('test')
+extension type DeprecatedProtocol'''),
         );
       });
 
@@ -1082,20 +1109,31 @@ extension type DeprecatedProtocol'''),
         final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
         expect(
           trimmed,
-          contains("@Deprecated('test')\n/// DeprecatedCategory\n"),
+          contains('''
+/// DeprecatedCategory
+@Deprecated('test')
+'''),
         );
       });
 
       test('API_DEPRECATED method gets @Deprecated with message', () {
         final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
-        expect(trimmed, contains("@Deprecated('test')\n/// depIos2Mac2\n"));
+        expect(trimmed, contains('/// depIos2Mac2\n'));
+        expect(
+          trimmed,
+          contains('''
+@Deprecated('test')
+int depIos2Mac2'''),
+        );
       });
 
       test('API_DEPRECATED function gets @Deprecated with message', () {
         final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
         expect(
           trimmed,
-          contains("@Deprecated('test')\nint deprecatedFunction"),
+          contains('''
+@Deprecated('test')
+int deprecatedFunction'''),
         );
       });
 
@@ -1103,7 +1141,9 @@ extension type DeprecatedProtocol'''),
         final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
         expect(
           trimmed,
-          contains("@Deprecated('test')\nfinal class DeprecatedStruct"),
+          contains('''
+@Deprecated('test')
+final class DeprecatedStruct'''),
         );
       });
 
@@ -1111,13 +1151,20 @@ extension type DeprecatedProtocol'''),
         final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
         expect(
           trimmed,
-          contains("@Deprecated('test')\nfinal class DeprecatedUnion"),
+          contains('''
+@Deprecated('test')
+final class DeprecatedUnion'''),
         );
       });
 
       test('API_DEPRECATED enum gets @Deprecated with message', () {
         final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
-        expect(trimmed, contains("@Deprecated('test')\nenum DeprecatedEnum"));
+        expect(
+          trimmed,
+          contains('''
+@Deprecated('test')
+enum DeprecatedEnum'''),
+        );
       });
 
       test(
@@ -1126,7 +1173,10 @@ extension type DeprecatedProtocol'''),
           final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
           expect(
             trimmed,
-            contains("@Deprecated('test')\n\nconst int deprecatedUnnamedEnum"),
+            contains('''
+@Deprecated('test')
+
+const int deprecatedUnnamedEnum'''),
           );
         },
       );
@@ -1135,9 +1185,25 @@ extension type DeprecatedProtocol'''),
         final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
         expect(
           trimmed,
-          contains("@Deprecated('test')\n/// deprecatedProperty\n"),
+          contains('''
+/// deprecatedProperty
+@Deprecated('test')
+'''),
         );
       });
+
+      test(
+        'API_DEPRECATED with different messages per platform combines them',
+        () {
+          final trimmed = bindings.split('\n').map((l) => l.trim()).join('\n');
+          expect(
+            trimmed,
+            contains(
+              "@Deprecated('iOS: Use newIosMethod, macOS: Use newMacMethod')",
+            ),
+          );
+        },
+      );
     });
   });
 }

--- a/pkgs/ffigen/test/native_objc_test/deprecated_test.m
+++ b/pkgs/ffigen/test/native_objc_test/deprecated_test.m
@@ -30,6 +30,8 @@ API_DEPRECATED("test", ios(1.0, 2.0), macos(1.0, 2.0))
 -(int)depMac3 API_DEPRECATED("test", macos(1.0, 3.0));
 -(int)depIos2 API_DEPRECATED("test", ios(1.0, 2.0));
 -(int)depIos2Mac2 API_DEPRECATED("test", ios(1.0, 2.0), macos(1.0, 2.0));
+-(int)depDifferentMessages API_DEPRECATED("Use newIosMethod", ios(1.0, 2.0))
+                           API_DEPRECATED("Use newMacMethod", macos(1.0, 2.0));
 -(int)depIos2Mac3 API_DEPRECATED("test", ios(1.0, 2.0), macos(1.0, 3.0));
 -(int)depIos3 API_DEPRECATED("test", ios(1.0, 3.0));
 -(int)depIos3Mac2 API_DEPRECATED("test", ios(1.0, 3.0), macos(1.0, 2.0));

--- a/pkgs/ffigen/test/unit_tests/objc_inheritance_edge_case_test.dart
+++ b/pkgs/ffigen/test/unit_tests/objc_inheritance_edge_case_test.dart
@@ -70,6 +70,7 @@ void main() {
         usr: name,
         originalName: name,
         parent: parent,
+        apiAvailability: availability,
       );
       parent.categories.add(category);
       for (final m in methods) {

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -22414,6 +22414,9 @@ extension NSURL$Methods on NSURL {
 
   /// iOS: introduced 2.0.0, deprecated 13.0.0
   /// macOS: introduced 10.2.0, deprecated 10.15.0
+  @Deprecated(
+    'The parameterString method is deprecated. Post deprecation for applications linked with or after the macOS 10.15, and for all iOS, watchOS, and tvOS applications, parameterString will always return nil, and the path method will return the complete path including the semicolon separator and params component if the URL string contains them.',
+  )
   NSString? get parameterString {
     objc.checkOsVersionInternal(
       'NSURL.parameterString',


### PR DESCRIPTION
Fixes #3020
Propagates @Deprecated('...') annotations from C/ObjC headers into generated Dart bindings.