### PR TITLE
[hooks_runner] Allowlist `PROCESSOR_ARCHITECTURE` env variable

### DIFF
--- a/pkgs/hooks_runner/CHANGELOG.md
+++ b/pkgs/hooks_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+- Add `PROCESSOR_ARCHITECTURE` to environment variables allowlist.
+
 ## 1.2.0
 
 - Add `toJson()` and `fromJson()` to `BuildResult` to support serialization.

--- a/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
+++ b/pkgs/hooks_runner/lib/src/build_runner/build_runner.dart
@@ -604,6 +604,7 @@ class NativeAssetsBuildRunner {
       'LIBCLANG_PATH', // Needed for Rust's bindgen + clang-sys.
       'PATH', // Needed to invoke native tools.
       'PROGRAMDATA', // Needed for vswhere.exe.
+      'PROCESSOR_ARCHITECTURE', // Needed for CMake Android on Windows.
       'SYSTEMDRIVE', // Needed for CMake.
       'SYSTEMROOT', // Needed for process invocations on Windows.
       'TEMP', // Needed for temp dirs in Dart process.

--- a/pkgs/hooks_runner/pubspec.yaml
+++ b/pkgs/hooks_runner/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_runner
 description: >-
   This package is the backend that invokes build hooks.
 
-version: 1.2.0
+version: 1.2.1
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks_runner
 


### PR DESCRIPTION
The LLVM toolchain has the host architecture in its path, and on Windows the `PROCESSOR_ARCHITECTURE` signals the host architecture to CMake.

So, it makes sense to allowlist this environment variable.

Closes: https://github.com/dart-lang/native/issues/3304