### PR TITLE
[hooks] Add `Recordings` to `LinkInput`

### DIFF
--- a/pkgs/code_assets/example/mini_audio/hook/link.dart
+++ b/pkgs/code_assets/example/mini_audio/hook/link.dart
@@ -2,9 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:hooks/hooks.dart';
 import 'package:mini_audio/src/c_library.dart';
 import 'package:mini_audio/src/third_party/record_use_mapping.dart';
@@ -17,23 +14,11 @@ void main(List<String> arguments) async {
       input: input,
       output: output,
       linkerOptions: LinkerOptions.treeshake(
-        symbolsToKeep: input.usages?.calls.keys
-            .cast<Method>()
-            .map((e) => recordUseMapping[e.name])
-            .nonNulls,
+        // ignore: experimental_member_use
+        symbolsToKeep: input.recordedUses?.calls.keys.cast<Method>().map(
+          (e) => recordUseMapping[e.name]!,
+        ),
       ),
     );
   });
-}
-
-extension on LinkInput {
-  Recordings? get usages {
-    // ignore: experimental_member_use
-    final usagesFile = recordedUsagesFile;
-    if (usagesFile == null) return null;
-    final usagesContent = File.fromUri(usagesFile).readAsStringSync();
-    final usagesJson = jsonDecode(usagesContent) as Map<String, Object?>;
-    final usages = Recordings.fromJson(usagesJson);
-    return usages;
-  }
 }

--- a/pkgs/code_assets/example/sqlite/hook/link.dart
+++ b/pkgs/code_assets/example/sqlite/hook/link.dart
@@ -2,9 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:record_use/record_use.dart';
@@ -17,23 +14,11 @@ void main(List<String> arguments) async {
       input: input,
       output: output,
       linkerOptions: LinkerOptions.treeshake(
-        symbolsToKeep: input.usages?.calls.keys
-            .cast<Method>()
-            .map((e) => recordUseMapping[e.name])
-            .nonNulls,
+        // ignore: experimental_member_use
+        symbolsToKeep: input.recordedUses?.calls.keys.cast<Method>().map(
+          (e) => recordUseMapping[e.name]!,
+        ),
       ),
     );
   });
-}
-
-extension on LinkInput {
-  Recordings? get usages {
-    // ignore: experimental_member_use
-    final usagesFile = recordedUsagesFile;
-    if (usagesFile == null) return null;
-    final usagesContent = File.fromUri(usagesFile).readAsStringSync();
-    final usagesJson = jsonDecode(usagesContent) as Map<String, Object?>;
-    final usages = Recordings.fromJson(usagesJson);
-    return usages;
-  }
 }

--- a/pkgs/code_assets/example/stb_image/hook/link.dart
+++ b/pkgs/code_assets/example/stb_image/hook/link.dart
@@ -2,9 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 import 'package:record_use/record_use.dart';
@@ -17,23 +14,11 @@ void main(List<String> arguments) async {
       input: input,
       output: output,
       linkerOptions: LinkerOptions.treeshake(
-        symbolsToKeep: input.usages?.calls.keys
-            .cast<Method>()
-            .map((e) => recordUseMapping[e.name])
-            .nonNulls,
+        // ignore: experimental_member_use
+        symbolsToKeep: input.recordedUses?.calls.keys.cast<Method>().map(
+          (e) => recordUseMapping[e.name]!,
+        ),
       ),
     );
   });
-}
-
-extension on LinkInput {
-  Recordings? get usages {
-    // ignore: experimental_member_use
-    final usagesFile = recordedUsagesFile;
-    if (usagesFile == null) return null;
-    final usagesContent = File.fromUri(usagesFile).readAsStringSync();
-    final usagesJson = jsonDecode(usagesContent) as Map<String, Object?>;
-    final usages = Recordings.fromJson(usagesJson);
-    return usages;
-  }
 }

--- a/pkgs/hooks/CHANGELOG.md
+++ b/pkgs/hooks/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.3-wip
+
+- Deprecated `recordedUsagesFile` in `LinkInput`.
+- Added `recordedUses` getter to `LinkInput`.
+- Added dependency on `package:record_use`.
+
 ## 1.0.2
 
 - Update documentation about `CCACHE_` environment variables.

--- a/pkgs/hooks/example/link/package_with_assets/hook/link.dart
+++ b/pkgs/hooks/example/link/package_with_assets/hook/link.dart
@@ -4,9 +4,6 @@
 
 // ignore_for_file: experimental_member_use
 
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:data_assets/data_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:record_use/record_use.dart';
@@ -28,11 +25,12 @@ final assetMapping = {
 
 void main(List<String> args) async {
   await link(args, (input, output) async {
-    final usages = input.usages;
+    final usages = input.recordedUses;
 
     final usedAssets = [
-      for (final entry in assetMapping.entries)
-        if (usages.calls.containsKey(entry.key)) entry.value,
+      if (usages != null)
+        for (final entry in assetMapping.entries)
+          if (usages.calls.containsKey(entry.key)) entry.value,
     ];
 
     output.assets.data.addAll(
@@ -41,14 +39,4 @@ void main(List<String> args) async {
       ),
     );
   });
-}
-
-extension on LinkInput {
-  Recordings get usages {
-    final usagesFile = recordedUsagesFile;
-    final usagesContent = File.fromUri(usagesFile!).readAsStringSync();
-    final usagesJson = jsonDecode(usagesContent) as Map<String, Object?>;
-    final usages = Recordings.fromJson(usagesJson);
-    return usages;
-  }
 }

--- a/pkgs/hooks/lib/src/config.dart
+++ b/pkgs/hooks/lib/src/config.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart' show sha256;
 import 'package:meta/meta.dart';
+import 'package:record_use/record_use.dart';
 
 import 'api/build_and_link.dart';
 import 'encoded_asset.dart';
@@ -353,7 +354,23 @@ final class LinkInput extends HookInput {
   /// reserve the right to break this API at any point without respecting
   /// semantic versioning of this package.
   @experimental
+  @Deprecated('Use recordedUses instead')
   Uri? get recordedUsagesFile => _syntaxLinkInput.resourceIdentifiers;
+
+  /// The recorded usages, if any.
+  ///
+  /// Experimental: The record uses feature needs to be enabled as experiment.
+  /// The experiment is only available in the Dart SDK, not in Flutter. We
+  /// reserve the right to break this API at any point without respecting
+  /// semantic versioning of this package.
+  @experimental
+  late final Recordings? recordedUses = () {
+    final file = _syntaxLinkInput.resourceIdentifiers;
+    if (file == null) return null;
+    final content = File.fromUri(file).readAsStringSync();
+    final json = jsonDecode(content) as Map<String, Object?>;
+    return Recordings.fromJson(json);
+  }();
 
   @override
   Uri get outputFile => _syntax.outFile;

--- a/pkgs/hooks/pubspec.yaml
+++ b/pkgs/hooks/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A library that contains a Dart API for the JSON-based protocol for
   `hook/build.dart` and `hook/link.dart`.
 
-version: 1.0.2
+version: 1.0.3-wip
 
 repository: https://github.com/dart-lang/native/tree/main/pkgs/hooks
 
@@ -25,6 +25,7 @@ dependencies:
   logging: ^1.3.0
   meta: ^1.16.0
   pub_semver: ^2.2.0
+  record_use: ^0.6.0
   yaml: ^3.1.3 # Used for reading pubspec.yaml to obtain the package name.
 
 dev_dependencies:

--- a/pkgs/hooks_runner/test_data/pirate_speak/hook/link.dart
+++ b/pkgs/hooks_runner/test_data/pirate_speak/hook/link.dart
@@ -16,13 +16,11 @@ void main(List<String> args) async {
     if (translationAsset == null) return;
 
     // ignore: experimental_member_use
-    final recordedUsagesFile = input.recordedUsagesFile;
-    if (recordedUsagesFile == null) {
+    final recordings = input.recordedUses;
+    if (recordings == null) {
       output.assets.data.add(translationAsset.asDataAsset);
       return;
     }
-
-    final recordings = await _loadRecordings(recordedUsagesFile);
     final usedPhrases = _extractUsedPhrases(recordings);
     final allTranslations = await _loadTranslations(translationAsset);
     final filteredTranslations = _filterTranslations(
@@ -43,11 +41,6 @@ EncodedAsset? _findTranslationAsset(LinkInput input) => input
           a.asDataAsset.id == 'package:pirate_speak/translations',
     )
     .firstOrNull;
-
-Future<Recordings> _loadRecordings(Uri file) async {
-  final content = await File.fromUri(file).readAsString();
-  return Recordings.fromJson(jsonDecode(content) as Map<String, Object?>);
-}
 
 Set<String> _extractUsedPhrases(Recordings recordings) {
   final usedPhrases = <String>{};

--- a/pkgs/hooks_runner/test_data/pirate_technology/hook/link.dart
+++ b/pkgs/hooks_runner/test_data/pirate_technology/hook/link.dart
@@ -18,14 +18,12 @@ void main(List<String> args) async {
     }
 
     // ignore: experimental_member_use
-    final recordedUsagesFile = input.recordedUsagesFile;
+    final recordings = input.recordedUses;
 
-    if (recordedUsagesFile == null) {
+    if (recordings == null) {
       output.assets.data.add(techAsset.asDataAsset);
       return;
     }
-
-    final recordings = await _loadRecordings(recordedUsagesFile);
     final usedTechnologies = _extractUsedTechnologies(recordings);
     final allTech = await _loadTechnologies(techAsset);
     final filteredTech = _filterTechnologies(allTech, usedTechnologies);
@@ -41,11 +39,6 @@ EncodedAsset? _findTechAsset(LinkInput input) => input.assets.encodedAssets
           a.asDataAsset.id == 'package:pirate_technology/technologies',
     )
     .firstOrNull;
-
-Future<Recordings> _loadRecordings(Uri file) async {
-  final content = await File.fromUri(file).readAsString();
-  return Recordings.fromJson(jsonDecode(content) as Map<String, Object?>);
-}
 
 Set<String> _extractUsedTechnologies(Recordings recordings) {
   final usedTechnologies = <String>{};

--- a/pkgs/hooks_runner/test_data/use_all_api/hook/link.dart
+++ b/pkgs/hooks_runner/test_data/use_all_api/hook/link.dart
@@ -19,7 +19,7 @@ void main(List<String> args) async {
     input.assets.code; // link only
     input.assets.data; // link only
     // ignore: experimental_member_use
-    input.recordedUsagesFile; // link only
+    input.recordedUses; // link only
     // c. target config
     // c.2. per asset
     input.config.buildAssetTypes;

--- a/pkgs/record_use/CHANGELOG.md
+++ b/pkgs/record_use/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1-wip
+
+- Nothing yet.
+
 ## 0.6.0
 
 - **Breaking Change**: Changed the JSON format and Dart API in various ways.

--- a/pkgs/record_use/README.md
+++ b/pkgs/record_use/README.md
@@ -54,12 +54,8 @@ This information can then be accessed in a link hook as follows:
 ```dart
 void main(List<String> arguments) {
   link(arguments, (input, output) async {
-    final usesUri = input.recordedUsagesFile;
-    if (usesUri == null) return;
-    final usesJson = await File.fromUri(usesUri).readAsString();
-    final uses = Recordings.fromJson(
-      jsonDecode(usesJson) as Map<String, Object?>,
-    );
+    final uses = input.recordedUses;
+    if (uses == null) return;
 
     final calls = uses.calls[methodId] ?? [];
     for (final call in calls) {

--- a/pkgs/record_use/example/api/usage_link.dart
+++ b/pkgs/record_use/example/api/usage_link.dart
@@ -5,9 +5,6 @@
 // ignore_for_file: experimental_member_use
 // ignore_for_file: depend_on_referenced_packages
 
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:hooks/hooks.dart';
 import 'package:record_use/record_use.dart';
 
@@ -27,12 +24,8 @@ const classId = Class(
 // snippet-start#link
 void main(List<String> arguments) {
   link(arguments, (input, output) async {
-    final usesUri = input.recordedUsagesFile;
-    if (usesUri == null) return;
-    final usesJson = await File.fromUri(usesUri).readAsString();
-    final uses = Recordings.fromJson(
-      jsonDecode(usesJson) as Map<String, Object?>,
-    );
+    final uses = input.recordedUses;
+    if (uses == null) return;
 
     // snippet-start#static-call
     final calls = uses.calls[methodId] ?? [];

--- a/pkgs/record_use/lib/record_use.dart
+++ b/pkgs/record_use/lib/record_use.dart
@@ -56,12 +56,8 @@
 /// ```dart
 /// void main(List<String> arguments) {
 ///   link(arguments, (input, output) async {
-///     final usesUri = input.recordedUsagesFile;
-///     if (usesUri == null) return;
-///     final usesJson = await File.fromUri(usesUri).readAsString();
-///     final uses = Recordings.fromJson(
-///       jsonDecode(usesJson) as Map<String, Object?>,
-///     );
+///     final uses = input.recordedUses;
+///     if (uses == null) return;
 ///
 ///     final calls = uses.calls[methodId] ?? [];
 ///     for (final call in calls) {

--- a/pkgs/record_use/lib/src/syntax.g.dart
+++ b/pkgs/record_use/lib/src/syntax.g.dart
@@ -518,7 +518,7 @@ class DefinitionSyntax extends JsonObjectSyntax {
       throw ArgumentError.value(
         value,
         'value',
-        'Value does not satisify pattern: ${_uriPattern.pattern}.',
+        'Value does not satisfy pattern: ${_uriPattern.pattern}.',
       );
     }
     json.setOrRemove('uri', value);
@@ -1984,7 +1984,7 @@ class SymbolConstantSyntax extends ConstantSyntax {
       throw ArgumentError.value(
         value,
         'value',
-        'Value does not satisify pattern: ${_libraryUriPattern.pattern}.',
+        'Value does not satisfy pattern: ${_libraryUriPattern.pattern}.',
       );
     }
     json.setOrRemove('libraryUri', value);

--- a/pkgs/record_use/pubspec.yaml
+++ b/pkgs/record_use/pubspec.yaml
@@ -1,7 +1,7 @@
 name: record_use
 description: >
   The serialization logic and API for the usage recording SDK feature.
-version: 0.6.0
+version: 0.6.1-wip
 repository: https://github.com/dart-lang/native/tree/main/pkgs/record_use
 
 environment:

--- a/pkgs/record_use/test_data/drop_data_asset/hook/link.dart
+++ b/pkgs/record_use/test_data/drop_data_asset/hook/link.dart
@@ -4,23 +4,19 @@
 
 // ignore_for_file: experimental_member_use
 
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:data_assets/data_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:record_use/record_use.dart';
 
 void main(List<String> arguments) async {
   await link(arguments, (input, output) async {
-    final recordedUsagesFile = input.recordedUsagesFile;
-    if (recordedUsagesFile == null) {
+    final usages = input.recordedUses;
+    if (usages == null) {
       throw ArgumentError(
         'Enable the --enable-experiment=record-use experiment'
         ' to use this app.',
       );
     }
-    final usages = await recordedUsages(recordedUsagesFile);
     final dataAssets = input.assets.data;
     print('Received assets: ${dataAssets.map((a) => a.id).join(', ')}.');
 
@@ -96,13 +92,4 @@ void main(List<String> arguments) async {
     print('Keeping only ${neededCodeAssets.map((e) => e.id).join(', ')}.');
     output.assets.data.addAll(neededCodeAssets);
   });
-}
-
-Future<Recordings> recordedUsages(Uri recordedUsagesFile) async {
-  final file = File.fromUri(recordedUsagesFile);
-  final string = await file.readAsString();
-  final usages = Recordings.fromJson(
-    jsonDecode(string) as Map<String, Object?>,
-  );
-  return usages;
 }

--- a/pkgs/record_use/test_data/drop_dylib_recording/hook/link.dart
+++ b/pkgs/record_use/test_data/drop_dylib_recording/hook/link.dart
@@ -4,7 +4,6 @@
 
 // ignore_for_file: experimental_member_use
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:code_assets/code_assets.dart';
@@ -13,14 +12,13 @@ import 'package:record_use/record_use.dart';
 
 void main(List<String> arguments) async {
   await link(arguments, (input, output) async {
-    final recordedUsagesFile = input.recordedUsagesFile;
-    if (recordedUsagesFile == null) {
+    final usages = input.recordedUses;
+    if (usages == null) {
       throw ArgumentError(
         'Enable the --enable-experiment=record-use experiment'
         ' to use this app.',
       );
     }
-    final usages = await recordedUsages(recordedUsagesFile);
     final codeAssets = input.assets.code;
     print('Received assets: ${codeAssets.map((a) => a.id).join(', ')}.');
 
@@ -99,13 +97,4 @@ void main(List<String> arguments) async {
     print('Keeping only ${neededCodeAssets.map((e) => e.id).join(', ')}.');
     output.assets.code.addAll(neededCodeAssets);
   });
-}
-
-Future<Recordings> recordedUsages(Uri recordedUsagesFile) async {
-  final file = File.fromUri(recordedUsagesFile);
-  final string = await file.readAsString();
-  final usages = Recordings.fromJson(
-    jsonDecode(string) as Map<String, Object?>,
-  );
-  return usages;
 }

--- a/pkgs/record_use/test_data/library_uris/hook/link.dart
+++ b/pkgs/record_use/test_data/library_uris/hook/link.dart
@@ -6,22 +6,17 @@
 // the link hook.
 // This test is run on CI by executing `dart build cli` in this package.
 
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:hooks/hooks.dart';
-import 'package:record_use/record_use.dart';
 
 void main(List<String> arguments) async {
   await link(
     arguments,
     (input, output) async {
       // ignore: experimental_member_use
-      final recordedUsagesFile = input.recordedUsagesFile;
-      if (recordedUsagesFile == null) {
+      final recordings = input.recordedUses;
+      if (recordings == null) {
         throw UnsupportedError('Run with --enable-experiment=record-use.');
       }
-      final recordings = await readUsagesFile(recordedUsagesFile);
 
       // This package.
       final myMethodDefinition = recordings.calls.keys.firstWhere(
@@ -61,13 +56,4 @@ void expect(String actual, String expected) {
       'Expected "$expected" got "$actual"',
     );
   }
-}
-
-Future<Recordings> readUsagesFile(Uri recordedUsagesFile) async {
-  final file = File.fromUri(recordedUsagesFile);
-  final string = await file.readAsString();
-  final usages = Recordings.fromJson(
-    jsonDecode(string) as Map<String, Object?>,
-  );
-  return usages;
 }


### PR DESCRIPTION
Adds a `Recordings` getter to `LinkInput` in `package:hooks`.

This removes boilerplate from link hooks.

It also means we're automatically pulling `package:record_use` always when depending on `package:hooks` once we release `package:hooks` the next time. And that if we want to release a new `package:record_use` we'll also need to rev `package:hooks`.

Reasoning why the getter is defined here:

* `package:record_use` can also be used when building an SDK wrapper when you use `dart compile js`. So you'd use it without hooks in that situation.
* `package:hooks` is a protocol (JSON) that the Dart and Flutter SDK speak. And it's tightly coupled with the SDK. If we ever want to do a breaking change it has to be gradual, first adding the new thing and then leaving a long time for everyone to migrate to the new JSON. The same logic applies to the `record_use` JSON spec. Currently the record_use package is still experimental (pre 1.0), and for that time the getter in the `LinkInput` shall be `@Experimental()`.