### PR TITLE
[ffigen] Golden test infra improvements

### DIFF
--- a/pkgs/ffigen/test/.gitignore
+++ b/pkgs/ffigen/test/.gitignore
@@ -1,1 +1,1 @@
-.temp
+.temp test output

--- a/pkgs/ffigen/test/test_utils.dart
+++ b/pkgs/ffigen/test/test_utils.dart
@@ -23,6 +23,7 @@ export 'package:ffigen/src/config_provider/utils.dart';
 Context testContext([FfiGenerator? generator]) => Context(
   createTestLogger(),
   generator ?? FfiGenerator(output: Output(dartFile: Uri.file('unused'))),
+  tmpDir: absPath(path.join('test', '.temp test output')),
 );
 
 Logger createTestLogger({
@@ -173,7 +174,7 @@ void matchRecordUseMappingWithExpected(
   );
 }
 
-const bool updateExpectations = false;
+final updateExpectations = Platform.environment['UPDATE'] == 'true';
 
 /// Transforms a repo relative path to an absolute path.
 String absPath(String p) => path.join(packagePathForTests, p);
@@ -196,30 +197,46 @@ void _matchFileWithExpected({
 }) {
   final expectedPath = path.joinAll([packagePathForTests, ...pathToExpected]);
   final tmpDirPath = context.tmpDir;
-  final file = File(path.join(tmpDirPath, pathForActual));
+  final actualPath = path.join(tmpDirPath, pathForActual);
+  final actualFile = File(actualPath);
 
-  fileWriter(library: library, file: file);
-  try {
-    final actual = _normalizeGeneratedCode(
-      file.readAsStringSync(),
-      codeNormalizer,
-    );
-    final expected = _normalizeGeneratedCode(
-      File(expectedPath).readAsStringSync(),
-      codeNormalizer,
-    );
-    expect(actual.split('\n'), expected.split('\n'));
-    _expectNoAnalysisErrors(expectedPath);
-    if (file.existsSync()) {
-      file.delete();
-    }
-  } catch (e) {
-    print('Failed test: Debug generated file: ${file.absolute.path}');
+  fileWriter(library: library, file: actualFile);
+  final actual = _normalizeGeneratedCode(
+    actualFile.readAsStringSync(),
+    codeNormalizer,
+  );
+  final expected = _normalizeGeneratedCode(
+    File(expectedPath).readAsStringSync(),
+    codeNormalizer,
+  );
+
+  if (expected != actual) {
     if (updateExpectations) {
       print('Updating expectations. Check the diffs!');
-      file.copySync(expectedPath);
+      actualFile.copySync(expectedPath);
+    } else {
+      final result = Process.runSync('git', [
+        'diff',
+        '--no-index',
+        '--color=always',
+        expectedPath,
+        actualPath,
+      ]);
+      fail('''
+Expected output does not match actual output.
+  ${path.relative(expectedPath)}
+      vs
+  ${path.relative(actualPath)}
+If the diffs are expected, rerun with UPDATE=true
+
+${result.stdout}
+''');
     }
-    rethrow;
+  }
+
+  _expectNoAnalysisErrors(expectedPath);
+  if (actualFile.existsSync()) {
+    actualFile.delete();
   }
 }
 

--- a/pkgs/ffigen/test/test_utils.dart
+++ b/pkgs/ffigen/test/test_utils.dart
@@ -223,13 +223,14 @@ void _matchFileWithExpected({
         actualPath,
       ]);
       fail('''
-Expected output does not match actual output.
+${result.stdout}
+
+Expected output does not match actual output:
   ${path.relative(expectedPath)}
       vs
   ${path.relative(actualPath)}
-If the diffs are expected, rerun with UPDATE=true
 
-${result.stdout}
+If the diffs are expected, rerun with UPDATE=true
 ''');
     }
   }


### PR DESCRIPTION
Various small improvements to the test infra that runs FFIgen codegen and verifies it matches a checked-in expected output file.

- Put the generated file in a gitignored temp dir within the repo, rather than in a system temp dir. System temp dirs are a pain to deal with on mac, since the mac file picker doesn't have a way of pasting the path to the temp file that the test reports. It also causes problems for AIs, which can't view files outside their sandbox.
- As part of https://github.com/dart-lang/native/issues/3026, I've made sure that temp dir contains spaces
- If an environment variable is set (`UPDATE=true`), then if the bindings don't match, replace the expected file with the actual. Previously there was a global variable you could set to true in Dart.
- If there's a mismatch, print a `git diff`, rather than relying on `package:test`'s default mismatch messages.

Example output:
<img width="896" height="585" alt="Screenshot 2026-04-16 at 3 36 11 pm" src="https://github.com/user-attachments/assets/6bc04685-6bdc-423d-be04-b3da7fe2b5a3" />

Part of https://github.com/dart-lang/native/issues/862