### PR TITLE
[ffigen] Fix record use mapping

### DIFF
--- a/pkgs/code_assets/example/mini_audio/lib/src/third_party/record_use_mapping.dart
+++ b/pkgs/code_assets/example/mini_audio/lib/src/third_party/record_use_mapping.dart
@@ -29,7 +29,7 @@
 
 /// Mapping from Dart function name to native symbol name.
 const recordUseMapping = {
-  'ma_engine_init': 'ma_engine_init',
-  'ma_engine_play_sound': 'ma_engine_play_sound',
+  '_ma_engine_init': 'ma_engine_init',
+  '_ma_engine_play_sound': 'ma_engine_play_sound',
   'ma_engine_uninit': 'ma_engine_uninit',
 };

--- a/pkgs/ffigen/lib/src/code_generator/func.dart
+++ b/pkgs/ffigen/lib/src/code_generator/func.dart
@@ -53,6 +53,12 @@ class Func extends LookUpBinding with HasLocalScope {
   @override
   final bool loadFromNativeAsset;
 
+  /// The symbol for the internal function or method name, used for record use
+  /// mapping and avoiding collisions.
+  final Symbol funcVarSymbol;
+
+  bool get needsWrapper => !functionType.sameDartAndFfiDartType && !isInternal;
+
   /// Contains typealias for function type if [exposeFunctionTypedefs] is true.
   Typealias? _exposedFunctionTypealias;
 
@@ -80,6 +86,7 @@ class Func extends LookUpBinding with HasLocalScope {
          parameters: parameters,
          varArgParameters: varArgParameters,
        ),
+       funcVarSymbol = Symbol('_$name', SymbolKind.method),
        super(symbol: Symbol(name, SymbolKind.method)) {
     for (var i = 0; i < functionType.parameters.length; i++) {
       if (functionType.parameters[i].symbol.oldName.isEmpty) {
@@ -119,7 +126,7 @@ class Func extends LookUpBinding with HasLocalScope {
         functionType.getFfiDartType(context, writeArgumentNames: false);
     final needsWrapper = !functionType.sameDartAndFfiDartType && !isInternal;
 
-    final funcVarName = context.rootScope.addPrivate('_$name');
+    final funcVarName = funcVarSymbol.name;
     final ffiReturnType = functionType.returnType.getFfiDartType(context);
     final ffiArgDeclString = functionType.dartTypeParameters
         .map((p) => '${p.type.getFfiDartType(context)} ${p.name},\n')
@@ -235,6 +242,7 @@ late final $funcVarName = $funcPointerName.asFunction<$dartType>($isLeafString);
   @override
   void visitChildren(Visitor visitor) {
     super.visitChildren(visitor);
+    visitor.visit(funcVarSymbol);
     visitor.visit(functionType);
     visitor.visit(_exposedFunctionTypealias);
     visitor.visit(ffiImport);
@@ -249,8 +257,12 @@ late final $funcVarName = $funcPointerName.asFunction<$dartType>($isLeafString);
   @override
   void visit(Visitation visitation) => visitation.visitFunc(this);
 
-  (String, String)? get recordUseMapping =>
-      recordUse ? (name, useNameForLookup ? name : originalName) : null;
+  (String, String)? get recordUseMapping => recordUse
+      ? (
+          needsWrapper ? funcVarSymbol.name : name,
+          useNameForLookup ? name : originalName,
+        )
+      : null;
 }
 
 /// Extension on [Iterable<Func>] to generate record use mapping.

--- a/pkgs/ffigen/lib/src/code_generator/writer.dart
+++ b/pkgs/ffigen/lib/src/code_generator/writer.dart
@@ -43,10 +43,6 @@ class Writer {
 
   final bool silenceEnumWarning;
 
-  /// Holds the mapping from Dart function name to native symbol name for
-  /// functions annotated with `@RecordUse()`.
-  Map<String, String> _recordUseMappings = {};
-
   Writer({
     required this.lookUpBindings,
     required this.ffiNativeBindings,
@@ -65,11 +61,6 @@ class Writer {
   String generate() {
     final s = StringBuffer();
 
-    _recordUseMappings = {
-      ...lookUpBindings.whereType<Func>(),
-      ...ffiNativeBindings.whereType<Func>(),
-    }.toRecordUseMap();
-
     // We write the source first to determine which imports are actually
     // referenced. Headers and [s] are then combined into the final result.
     final result = StringBuffer();
@@ -86,7 +77,9 @@ class Writer {
       ),
     );
 
-    final anyFuncHasRecordUse = _recordUseMappings.isNotEmpty;
+    final anyFuncHasRecordUse =
+        lookUpBindings.whereType<Func>().any((f) => f.recordUse) ||
+        ffiNativeBindings.whereType<Func>().any((f) => f.recordUse);
 
     // Write lint ignore if not specified by user already.
     final ignores = <String>[
@@ -209,6 +202,7 @@ class Writer {
     }
 
     _canGenerateSymbolOutput = true;
+
     return result.toString();
   }
 
@@ -287,7 +281,12 @@ class Writer {
   }
 
   String? generateRecordUseMapping() {
-    if (_recordUseMappings.isEmpty) {
+    final recordUseMappings = {
+      ...lookUpBindings.whereType<Func>(),
+      ...ffiNativeBindings.whereType<Func>(),
+    }.toRecordUseMap();
+
+    if (recordUseMappings.isEmpty) {
       return null;
     }
 
@@ -309,7 +308,7 @@ class Writer {
     s.writeln();
     s.writeln('/// Mapping from Dart function name to native symbol name.');
     s.writeln('const recordUseMapping = {');
-    for (final entry in _recordUseMappings.entries) {
+    for (final entry in recordUseMappings.entries) {
       s.writeln("  '${entry.key}': '${entry.value}',");
     }
     s.writeln('};');

--- a/pkgs/ffigen/lib/src/visitor/find_symbols.dart
+++ b/pkgs/ffigen/lib/src/visitor/find_symbols.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../code_generator/binding.dart';
+import '../code_generator/func.dart';
 import '../code_generator/func_type.dart';
 import '../code_generator/objc_built_in_functions.dart';
 import '../code_generator/objc_category.dart';
@@ -40,6 +41,12 @@ class FindSymbolsVisitation extends Visitation {
 
   @override
   void visitSymbol(Symbol node) => currentScope.add(node);
+
+  @override
+  void visitFunc(Func node) {
+    context.rootScope.add(node.funcVarSymbol);
+    visitBinding(node);
+  }
 
   @override
   void visitBinding(Binding node) {

--- a/pkgs/ffigen/test/code_generator_tests/expected_bindings/_expected_internal_conflict_resolution_bindings.dart
+++ b/pkgs/ffigen/test/code_generator_tests/expected_bindings/_expected_internal_conflict_resolution_bindings.dart
@@ -25,13 +25,13 @@ class init_dylib$1 {
   ) : _lookup = lookup;
 
   void Test() {
-    return _Test$1();
+    return _Test();
   }
 
   late final _TestPtr = _lookup<ffi.NativeFunction<ffi.Void Function()>>(
     'Test',
   );
-  late final _Test$1 = _TestPtr.asFunction<void Function()>();
+  late final _Test = _TestPtr.asFunction<void Function()>();
 
   void _c_test() {
     return __c_test();
@@ -72,7 +72,7 @@ class init_dylib$1 {
 
 final class ArrayHelperPrefixCollisionTest extends ffi.Opaque {}
 
-final class _Test extends ffi.Struct {
+final class _Test$1 extends ffi.Struct {
   @ffi.Array.multi([2])
   external ffi.Array<ffi.Int8> array;
 }

--- a/pkgs/ffigen/test/collision_tests/expected_bindings/_expected_decl_decl_collision_bindings.dart
+++ b/pkgs/ffigen/test/collision_tests/expected_bindings/_expected_decl_decl_collision_bindings.dart
@@ -29,13 +29,12 @@ class Bindings {
   late final _ffi$1 = _ffi$1Ptr.asFunction<void Function()>();
 
   void testCrossDecl$1() {
-    return _testCrossDecl$1();
+    return _testCrossDecl();
   }
 
   late final _testCrossDecl$1Ptr =
       _lookup<ffi$2.NativeFunction<ffi$2.Void Function()>>('testCrossDecl');
-  late final _testCrossDecl$1 = _testCrossDecl$1Ptr
-      .asFunction<void Function()>();
+  late final _testCrossDecl = _testCrossDecl$1Ptr.asFunction<void Function()>();
 
   void testFunc() {
     return _testFunc();

--- a/pkgs/ffigen/test/unit_tests/record_use_test.dart
+++ b/pkgs/ffigen/test/unit_tests/record_use_test.dart
@@ -39,6 +39,37 @@ void main() {
       expect(mapping, contains('const recordUseMapping = {'));
     });
 
+    test(
+      'generate @RecordUse mapping with underscores for wrapper methods',
+      () {
+        final func = Func(
+          name: 'init',
+          originalName: 'init_native',
+          returnType:
+              ObjCObjectPointer(), // This makes sameDartAndFfiDartType false
+          parameters: [
+            Parameter(name: 'a', type: intType, objCConsumed: false),
+          ],
+          recordUse: true,
+          loadFromNativeAsset: true,
+        );
+
+        final library = Library(bindings: [func], context: testContext())
+          ..forceFillNamesForTesting();
+
+        final output = library.generate();
+        expect(output, contains('@meta.RecordUse()'));
+        expect(
+          output,
+          contains('external ffi.Pointer<objc.ObjCObjectImpl> _init('),
+        );
+
+        final mapping = library.writer.generateRecordUseMapping();
+        expect(mapping, contains("'_init': 'init_native'"));
+        expect(mapping, contains('const recordUseMapping = {'));
+      },
+    );
+
     test('no @RecordUse annotation and mapping when recordUse is false', () {
       final func = Func(
         name: 'sum',


### PR DESCRIPTION
Generate the mapping after FFIgen has run, so that we can properly rely on the renamers.

Fixes the code assets sample. (Note this sample isn't tested with `dart` on the CI because record use is still experimental and that would break on changes.)