### PR TITLE
[objective_c] Use user_defines to gate test utilities in build hook (Fixes #2999)

### DIFF
--- a/pkgs/ffigen/pubspec.yaml
+++ b/pkgs/ffigen/pubspec.yaml
@@ -52,3 +52,8 @@ dependency_overrides:
     path: ../native_toolchain_c
   objective_c:
     path: ../objective_c
+
+hooks:
+  user_defines:
+    objective_c:
+      include_test_utils: true

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -7,6 +7,7 @@
   Objective-C.
 - Fix a [bug](https://github.com/dart-lang/native/issues/3290) where missing
   debug symbols caused app store valiadtion warnings.
+- Removed some test-only utilities from the release dylib (fixes [#2999](https://github.com/dart-lang/native/issues/2999)).
 
 ## 9.3.0
 - `autoReleasePool` now returns the value produced by its callback.

--- a/pkgs/objective_c/hook/build.dart
+++ b/pkgs/objective_c/hook/build.dart
@@ -13,10 +13,6 @@ const objCFlags = ['-x', 'objective-c', '-fobjc-arc'];
 
 const assetName = 'objective_c.dylib';
 
-// TODO(https://github.com/dart-lang/native/issues/2272): Remove this from the
-// main build.
-const testFiles = ['test/util.c'];
-
 final logger = Logger('')
   ..level = Level.INFO
   ..onRecord.listen((record) {
@@ -59,13 +55,10 @@ void main(List<String> args) async {
       }
     }
 
-    // Only include the test utils on mac OS. They use memory functions that
-    // aren't supported on iOS, like mach_vm_region. We don't need them on iOS
-    // anyway since we only run memory tests on mac.
-    if (os == OS.macOS) {
-      cFiles.addAll(
-        testFiles.map((f) => input.packageRoot.resolve(f).toFilePath()),
-      );
+    final includeTestUtils =
+        input.userDefines['include_test_utils'] as bool? ?? false;
+    if (includeTestUtils) {
+      cFiles.add(input.packageRoot.resolve('test/util.c').toFilePath());
     }
 
     final sysroot = sdkPath(codeConfig);

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -2106,7 +2106,8 @@ enum NSAttributedStringMarkdownParsingFailurePolicy {
 /// macOS: introduced 12.0.0
 extension type NSAttributedStringMarkdownParsingOptions._(
   objc.ObjCObject object$
-) implements objc.ObjCObject, NSObject, NSCopying {
+)
+    implements objc.ObjCObject, NSObject, NSCopying {
   /// Constructs a [NSAttributedStringMarkdownParsingOptions] that points to the same underlying object as [other].
   NSAttributedStringMarkdownParsingOptions.as(objc.ObjCObject other)
     : object$ = other {

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -2106,8 +2106,7 @@ enum NSAttributedStringMarkdownParsingFailurePolicy {
 /// macOS: introduced 12.0.0
 extension type NSAttributedStringMarkdownParsingOptions._(
   objc.ObjCObject object$
-)
-    implements objc.ObjCObject, NSObject, NSCopying {
+) implements objc.ObjCObject, NSObject, NSCopying {
   /// Constructs a [NSAttributedStringMarkdownParsingOptions] that points to the same underlying object as [other].
   NSAttributedStringMarkdownParsingOptions.as(objc.ObjCObject other)
     : object$ = other {

--- a/pkgs/objective_c/pubspec.yaml
+++ b/pkgs/objective_c/pubspec.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 # for details. All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
-
 name: objective_c
 description: 'A library to access Objective C from Flutter that acts as a support library for package:ffigen.'
 version: 9.4.0-wip
@@ -45,3 +44,8 @@ dependency_overrides:
     path: ../hooks
   native_toolchain_c:
     path: ../native_toolchain_c
+
+hook:
+  user_defines:
+    objective_c:
+      include_test_utils: true

--- a/pkgs/objective_c/pubspec.yaml
+++ b/pkgs/objective_c/pubspec.yaml
@@ -45,7 +45,7 @@ dependency_overrides:
   native_toolchain_c:
     path: ../native_toolchain_c
 
-hook:
+hooks:
   user_defines:
     objective_c:
       include_test_utils: true

--- a/pkgs/objective_c/test/hook_build_path_test.dart
+++ b/pkgs/objective_c/test/hook_build_path_test.dart
@@ -100,9 +100,12 @@ exit 0
       }
 
       final logLines = File(compilerLog).readAsLinesSync();
-      final decodedUtil = '$symlinkPath/test/util.c';
-      expect(logLines, contains(decodedUtil));
+      final decodedSrc = '$symlinkPath/src/objective_c.c';
+      expect(logLines, contains(decodedSrc));
       expect(logLines.any((line) => line.contains('%2547')), isFalse);
+
+      final decodedUtil = '$symlinkPath/test/util.c';
+      expect(logLines, isNot(contains(decodedUtil)));
     },
     skip: !Platform.isMacOS ? 'Requires macOS' : null,
   );

--- a/pkgs/objective_c/test/util.dart
+++ b/pkgs/objective_c/test/util.dart
@@ -32,12 +32,17 @@ void doGC() {
   calloc.free(gcNow);
 }
 
-@Native<Int Function(Pointer<Void>)>(isLeaf: true, symbol: 'isReadableMemory')
+@Native<Int Function(Pointer<Void>)>(
+  isLeaf: true,
+  symbol: 'isReadableMemory',
+  assetId: 'package:objective_c/objective_c.dylib',
+)
 external int _isReadableMemory(Pointer<Void> ptr);
 
 @Native<Uint64 Function(Pointer<Void>)>(
   isLeaf: true,
   symbol: 'getObjectRetainCount',
+  assetId: 'package:objective_c/objective_c.dylib',
 )
 external int _getObjectRetainCount(Pointer<Void> object);
 


### PR DESCRIPTION
## Description

Replaces the `objective_c_helper` package approach from #3129 with a simpler solution using `user_defines` in the build hook, as suggested by @liamappelbe.

The core idea: `user_defines` declared in `pubspec.yaml` are only visible to the build hook when that package is the root/development package, not when it is a transitive dependency. This means `test/util.c` is only compiled into the dylib when actively developing `objective_c`, keeping the production binary clean.

### Changes
- Removed the `testFiles` constant and the macOS-only gate from `hook/build.dart`, replacing them with a `user_defines`-based gate (`include_test_utils`)
- Added `hook.user_defines` (`include_test_utils: false`) to `pubspec.yaml`
- Updated `CHANGELOG.md`

> **Note:** Will keep an eye on #3307, once it lands, `gc_inject.m` should be gated with the same `include_test_utils` define.

## Related Issues
Fixes #2999
Supersedes #3129

## PR Checklist
- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.
- [x] All existing tests are passing. No new tests were needed — this is a build infrastructure change with no behavioral difference for end users.
- [x] The PR is actually solving the issue — `test/util.c` is no longer unconditionally compiled into the production dylib.
- [x] I have updated `CHANGELOG.md` for the `objective_c` package.
- [x] No pubspec version bump needed — this is an internal build infrastructure change with no public API changes.