### PR TITLE
[native_toolchain_c] Fix Windows env quoting in runProcess (#3321)

### DIFF
--- a/pkgs/native_toolchain_c/CHANGELOG.md
+++ b/pkgs/native_toolchain_c/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.18.1
+
+- Fix Windows environment variable handling in `runProcess`: no longer launch
+  the subprocess through a shell (which mangled values containing spaces or
+  quotes), and properly quote environment values when echoing the command to
+  the log. ([#3321](https://github.com/dart-lang/native/issues/3321))
+
 ## 0.18.0
 
 - Made `CLinker.run` `Logger` argument optional. It now defaults to a logger

--- a/pkgs/native_toolchain_c/lib/src/utils/run_process.dart
+++ b/pkgs/native_toolchain_c/lib/src/utils/run_process.dart
@@ -27,7 +27,9 @@ Future<RunProcessResult> runProcess({
       workingDirectory != null && workingDirectory != Directory.current.uri;
   final commandString = [
     if (printWorkingDir) '(cd ${workingDirectory.toFilePath()};',
-    ...?environment?.entries.map((entry) => '${entry.key}=${entry.value}'),
+    ...?environment?.entries.map(
+      (entry) => '${entry.key}=${_quoteForCommandLog(entry.value)}',
+    ),
     executable.toFilePath(),
     ...arguments.map((a) => a.contains(' ') ? "'$a'" : a),
     if (printWorkingDir) ')',
@@ -41,7 +43,7 @@ Future<RunProcessResult> runProcess({
     arguments,
     workingDirectory: workingDirectory?.toFilePath(),
     environment: environment,
-    runInShell: Platform.isWindows && workingDirectory != null,
+    runInShell: false,
   );
 
   final stdoutSub = process.stdout.listen((List<int> data) {
@@ -91,6 +93,13 @@ Future<RunProcessResult> runProcess({
     );
   }
   return result;
+}
+
+String _quoteForCommandLog(String value) {
+  if (value.isEmpty || value.contains(RegExp(r'[\s"]'))) {
+    return '"${value.replaceAll('"', '\\"')}"';
+  }
+  return value;
 }
 
 /// Drop in replacement of [ProcessResult].

--- a/pkgs/native_toolchain_c/pubspec.yaml
+++ b/pkgs/native_toolchain_c/pubspec.yaml
@@ -1,7 +1,7 @@
 name: native_toolchain_c
 description: >-
   A library to invoke the native C compiler installed on the host machine.
-version: 0.18.0
+version: 0.18.1
 repository: https://github.com/dart-lang/native/tree/main/pkgs/native_toolchain_c
 
 topics:

--- a/pkgs/native_toolchain_c/test/utils/run_process_test.dart
+++ b/pkgs/native_toolchain_c/test/utils/run_process_test.dart
@@ -33,6 +33,19 @@ void main() {
     expect(messages.join('\n'), contains('FOO=BAR'));
   });
 
+  test('log quotes env values with spaces', () async {
+    final messages = <String>[];
+    await runProcess(
+      executable: whichUri,
+      environment: {'FOO': 'C:/Program Files/Visual Studio'},
+      logger: createCapturingLogger(messages),
+    );
+    expect(
+      messages.join('\n'),
+      contains('FOO="C:/Program Files/Visual Studio"'),
+    );
+  });
+
   test('stderr', () async {
     final messages = <String>[];
     const filePath = 'a/dart/file/which/does/not/exist.dart';


### PR DESCRIPTION
On Windows, `runProcess` launched the subprocess with `runInShell: true` whenever a `workingDirectory` was supplied. The shell re-parsed every entry in the supplied `environment` map, so values containing spaces or quotes (common for `PATH`, `INCLUDE`, `LIB` entries from MSVC environment batch files) were corrupted before reaching the child process.

This PR:

- Drops `runInShell` unconditionally — the child now receives `environment` verbatim from `dart:io`'s `Process.start`.
- Adds `_quoteForCommandLog`, which quotes env values containing whites

## Related Issues

Fixes #3321

## PR Checklist

- [X] I’ve reviewed the [contributor guide](https://github.com/dart-lang/native/blob/main/CONTRIBUTING.md) and applied the relevant portions to this PR.
- [X] I've run `dart tool/ci.dart --all` locally and resolved all issues identified. This ensures the PR is formatted, has no lint errors, and ran all code generators. This applies to the packages part of the toplevel `pubspec.yaml` workspace.
- [X] All existing and new tests are passing. I added new tests to check the change I am making.
- [X] The PR is actually solving the issue. PRs that don't solve the issue will be closed. Please be respectful of the maintainers' time. If it's not clear what the issue is, feel free to ask questions on the GitHub issue before submitting a PR.
- [ ] I have updated `CHANGELOG.md` for the relevant packages. (Not needed for small changes such as doc typos).
- [X] I have [updated the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change) if necessary.
