### PR TITLE
[objective_c] Implement NSNumber methods for bool

### DIFF
--- a/pkgs/ffigen/lib/src/code_generator/objc_built_in_types.dart
+++ b/pkgs/ffigen/lib/src/code_generator/objc_built_in_types.dart
@@ -139,5 +139,6 @@ const objCBuiltInCategories = {
   'NSExtendedSet',
   'NSNumberCreation',
   'NSNumberIsFloat',
+  'NSNumberIsBool',
   'NSStringExtensionMethods',
 };

--- a/pkgs/objective_c/CHANGELOG.md
+++ b/pkgs/objective_c/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Fix a [bug](https://github.com/dart-lang/native/issues/3290) where missing
   debug symbols caused app store valiadtion warnings.
 - Removed some test-only utilities from the release dylib (fixes [#2999](https://github.com/dart-lang/native/issues/2999)).
+- Added `bool.toNSNumber()` extension method, `NSNumber.isBool` check and
+  converter support for bool.
 
 ## 9.3.0
 - `autoReleasePool` now returns the value produced by its callback.
@@ -18,7 +20,7 @@
 ## 9.2.5
 - Fix a [bug](https://github.com/dart-lang/native/issues/3011) by adding
   minimum OS version flags to the build script.
- 
+
 ## 9.2.4
 
 - Fix a [bug](https://github.com/dart-lang/native/issues/2990) build hook path

--- a/pkgs/objective_c/ffigen_objc.yaml
+++ b/pkgs/objective_c/ffigen_objc.yaml
@@ -121,6 +121,7 @@ objc-categories:
     - NSExtendedSet
     - NSNumberCreation
     - NSNumberIsFloat
+    - NSNumberIsBool
     - NSStringExtensionMethods
 structs:
   include:

--- a/pkgs/objective_c/lib/src/converter.dart
+++ b/pkgs/objective_c/lib/src/converter.dart
@@ -27,6 +27,7 @@ ObjCObject toObjCObject(
 }) => switch (dartObject) {
   null => NSNull.null$(),
   ObjCObject() => dartObject,
+  bool() => dartObject.toNSNumber(),
   num() => dartObject.toNSNumber(),
   String() => dartObject.toNSString(),
   DateTime() => dartObject.toNSDate(),
@@ -81,7 +82,11 @@ Object toDartObject(
   // object could have a Dart runtime type of eg NSObject, even if the
   // underlying ObjC object that the Dart object is wrapping is a NSNumber.
   if (NSNumber.isA(objCObject)) {
-    return NSNumber.as(objCObject).numValue;
+    final nsNumber = NSNumber.as(objCObject);
+    if (nsNumber.isBool) {
+      return nsNumber.boolValue;
+    }
+    return nsNumber.numValue;
   }
   if (NSString.isA(objCObject)) {
     return NSString.as(objCObject).toDartString();

--- a/pkgs/objective_c/lib/src/ns_number.dart
+++ b/pkgs/objective_c/lib/src/ns_number.dart
@@ -22,6 +22,10 @@ extension NumToNSNumber on num {
   }
 }
 
+extension BoolToNSNumber on bool {
+  NSNumber toNSNumber() => NSNumberCreation.numberWithBool(this);
+}
+
 extension NSNumberToNum on NSNumber {
   num get numValue => isFloat ? doubleValue : longLongValue;
 }

--- a/pkgs/objective_c/lib/src/objective_c_bindings_exported.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_exported.dart
@@ -133,6 +133,7 @@ export 'objective_c_bindings_generated.dart'
         NSNumber,
         NSNumber$Methods,
         NSNumberCreation,
+        NSNumberIsBool,
         NSNumberIsFloat,
         NSObject,
         NSObject$Methods,

--- a/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
+++ b/pkgs/objective_c/lib/src/objective_c_bindings_generated.dart
@@ -14060,6 +14060,14 @@ extension NSNumberCreation on NSNumber {
   }
 }
 
+/// NSNumberIsBool
+extension NSNumberIsBool on NSNumber {
+  /// isBool
+  bool get isBool {
+    return _objc_msgSend_91o635(object$.ref.pointer, _sel_isBool);
+  }
+}
+
 /// NSNumberIsFloat
 extension NSNumberIsFloat on NSNumber {
   /// isFloat
@@ -40867,6 +40875,7 @@ late final _sel_invocationWithMethodSignature_ = objc.registerName(
 late final _sel_invoke = objc.registerName("invoke");
 late final _sel_invokeUsingIMP_ = objc.registerName("invokeUsingIMP:");
 late final _sel_invokeWithTarget_ = objc.registerName("invokeWithTarget:");
+late final _sel_isBool = objc.registerName("isBool");
 late final _sel_isCancellable = objc.registerName("isCancellable");
 late final _sel_isCancelled = objc.registerName("isCancelled");
 late final _sel_isEqualToArray_ = objc.registerName("isEqualToArray:");

--- a/pkgs/objective_c/src/ns_number.h
+++ b/pkgs/objective_c/src/ns_number.h
@@ -8,7 +8,11 @@
 #import <Foundation/Foundation.h>
 
 @interface NSNumber (NSNumberIsFloat)
-@property (readonly) bool isFloat;
+@property(readonly) bool isFloat;
 @end
 
-#endif  // OBJECTIVE_C_SRC_NS_NUMBER_H_
+@interface NSNumber (NSNumberIsBool)
+@property(readonly) bool isBool;
+@end
+
+#endif // OBJECTIVE_C_SRC_NS_NUMBER_H_

--- a/pkgs/objective_c/src/ns_number.m
+++ b/pkgs/objective_c/src/ns_number.m
@@ -5,8 +5,13 @@
 #import "ns_number.h"
 
 @implementation NSNumber (NSNumberIsFloat)
--(bool)isFloat {
-  const char *t = [self objCType];
-  return strcmp(t, @encode(float)) == 0 || strcmp(t, @encode(double)) == 0;
+- (bool)isFloat {
+  return CFNumberIsFloatType((__bridge CFNumberRef)self);
+}
+@end
+
+@implementation NSNumber (NSNumberIsBool)
+- (bool)isBool {
+  return CFGetTypeID((__bridge CFTypeRef)self) == CFBooleanGetTypeID();
 }
 @end

--- a/pkgs/objective_c/test/converter_test.dart
+++ b/pkgs/objective_c/test/converter_test.dart
@@ -19,6 +19,15 @@ void main() {
       expect(toObjCObject(null), NSNull.null$());
       expect(toNullableDartObject(NSNull.null$()), null);
 
+      expect(toObjCObject(false), isA<NSNumber>());
+      expect((toObjCObject(false) as NSNumber).boolValue, isFalse);
+
+      expect(toObjCObject(true), isA<NSNumber>());
+      expect((toObjCObject(true) as NSNumber).boolValue, isTrue);
+
+      expect(toDartObject(toObjCObject(false)), isFalse);
+      expect(toDartObject(toObjCObject(true)), isTrue);
+
       expect(toObjCObject(123), isA<NSNumber>());
       expect((toObjCObject(123) as NSNumber).longLongValue, 123);
       expect(toDartObject(toObjCObject(123)), isA<int>());

--- a/pkgs/objective_c/test/nsnumber_test.dart
+++ b/pkgs/objective_c/test/nsnumber_test.dart
@@ -19,6 +19,8 @@ void main() {
       expect(n.doubleValue, 1.23);
       expect(n.numValue, isA<double>());
       expect(n.numValue, 1.23);
+      expect(n.isFloat, isTrue);
+      expect(n.isBool, isFalse);
     });
 
     test('from int', () {
@@ -29,6 +31,8 @@ void main() {
       expect(n.doubleValue, 0x7ffffffffffffff0);
       expect(n.numValue, isA<int>());
       expect(n.numValue, 0x7fffffffffffffff);
+      expect(n.isFloat, isFalse);
+      expect(n.isBool, isFalse);
     });
 
     test('from num', () {
@@ -50,5 +54,13 @@ void main() {
       expect(m.numValue, isA<int>());
       expect(m.numValue, 0x7fffffffffffffff);
     });
+  });
+
+  test('from bool', () {
+    final t = true.toNSNumber();
+    final f = false.toNSNumber();
+
+    expect(t.boolValue, isTrue);
+    expect(f.boolValue, isFalse);
   });
 }


### PR DESCRIPTION
Adds `bool.toNSNumber()` extension method, `NSNumber.isBool` check and add converter support for bool.

## Related Issues

*List which issues are fixed by this PR. Use the syntax `Fixes #1234`.*

## PR Checklist

- [x] I’ve reviewed the [contributor guide](https://github.com/dart-lang/native/blob/main/CONTRIBUTING.md) and applied the relevant portions to this PR.
- [x] I've run `dart tool/ci.dart --all` locally and resolved all issues identified. This ensures the PR is formatted, has no lint errors, and ran all code generators. This applies to the packages part of the toplevel `pubspec.yaml` workspace.
- [x] All existing and new tests are passing. I added new tests to check the change I am making.
- [x] The PR is actually solving the issue. PRs that don't solve the issue will be closed. Please be respectful of the maintainers' time. If it's not clear what the issue is, feel free to ask questions on the GitHub issue before submitting a PR.
- [x] I have updated `CHANGELOG.md` for the relevant packages. (Not needed for small changes such as doc typos).
- [x] I have [updated the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change) if necessary.
