### PR TITLE
[jnigen] Fix occasional `dart format` failures

### DIFF
--- a/pkgs/jnigen/CHANGELOG.md
+++ b/pkgs/jnigen/CHANGELOG.md
@@ -5,6 +5,8 @@
   These are now generated as static `create` methods.
 - It's no longer necessary to run `flutter build apk` before running JNIgen in
   a Flutter project.
+- Fix directory-dependent `dart format` failures by explicitly searching for the
+  correct Dart executable to run.
 
 ## 0.16.0
 

--- a/pkgs/jnigen/lib/src/bindings/dart_generator.dart
+++ b/pkgs/jnigen/lib/src/bindings/dart_generator.dart
@@ -10,6 +10,7 @@ import 'package:meta/meta.dart';
 import '../config/config.dart';
 import '../elements/elements.dart';
 import '../logging/logging.dart';
+import '../util/dart_executable.dart';
 import '../util/string_util.dart';
 import 'resolver.dart';
 import 'visitor.dart';
@@ -190,7 +191,7 @@ const _\$jniVersionCheck =
   /// Run dart format command on [path].
   Future<void> _runDartFormat(String path) async {
     log.info('Running dart format...');
-    final formatRes = await Process.run('dart', ['format', path]);
+    final formatRes = await Process.run(dartExecutable, ['format', path]);
     // if negative exit code, likely due to an interrupt.
     if (formatRes.exitCode > 0) {
       log.fatal(

--- a/pkgs/jnigen/lib/src/util/dart_executable.dart
+++ b/pkgs/jnigen/lib/src/util/dart_executable.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+/// The path to the Dart executable.
+///
+/// This is usually just Platform.resolvedExecutable. But when running flutter
+/// tests, the resolvedExecutable will be flutter_tester, and Dart will be in a
+/// directory a few levels up from it.
+final String dartExecutable = _findDart();
+
+String _findDart() {
+  var path = Platform.resolvedExecutable;
+  if (p.basenameWithoutExtension(path) == 'dart') return path;
+  final dartExe = 'dart${p.extension(path)}';
+  while (path.isNotEmpty) {
+    path = p.dirname(path);
+    final dartPath = p.normalize(p.join(path, dartExe));
+    if (File(dartPath).existsSync()) return dartPath;
+    final parent = p.dirname(path);
+    if (parent == path) break;
+  }
+  throw Exception(
+    "Couldn't find Dart executable near ${Platform.resolvedExecutable}",
+  );
+}

--- a/pkgs/jnigen/test/test_util/bindings_test_setup.dart
+++ b/pkgs/jnigen/test/test_util/bindings_test_setup.dart
@@ -12,6 +12,7 @@
 import 'dart:io';
 
 import 'package:jni/jni.dart';
+import 'package:jnigen/src/util/dart_executable.dart';
 import 'package:path/path.dart' hide equals;
 
 import 'test_util.dart';
@@ -27,14 +28,14 @@ final kotlinTestKotlin = join(kotlinTest, 'kotlin');
 late Directory tempClassDir;
 
 Future<void> bindingsTestSetup() async {
-  await runCommand('dart', [
+  await runCommand(dartExecutable, [
     'run',
     'jni:setup',
   ]);
   tempClassDir =
       Directory.current.createTempSync('jnigen_runtime_test_classpath_');
   await compileJavaFiles(Directory(simplePackageTestJava), tempClassDir);
-  await runCommand('dart', [
+  await runCommand(dartExecutable, [
     'run',
     'jnigen:download_maven_jars',
     '--config',

--- a/pkgs/jnigen/test/test_util/test_util.dart
+++ b/pkgs/jnigen/test/test_util/test_util.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:jnigen/jnigen.dart';
 import 'package:jnigen/src/logging/logging.dart';
+import 'package:jnigen/src/util/dart_executable.dart';
 import 'package:jnigen/src/util/find_package.dart';
 import 'package:logging/logging.dart' show Level;
 import 'package:path/path.dart' hide equals;
@@ -88,7 +89,7 @@ void comparePaths(String path1, String path2) {
     final originalDiff = diffProc.stdout;
     log.warning(
         'Paths $path1 and $path2 differ, Running dart format on $path1.');
-    Process.runSync('dart', ['format', path1]);
+    Process.runSync(dartExecutable, ['format', path1]);
     final fallbackDiffProc =
         Process.runSync('git', [...diffCommand, path1, path2]);
     if (fallbackDiffProc.exitCode != 0) {
@@ -136,7 +137,8 @@ Future<void> generateAndAnalyzeBindings(Config config,
   final tempDir = Directory.current.createTempSync('jnigen_test_temp');
   try {
     await _generateTempBindings(config, tempDir);
-    final analyzeResult = Process.runSync('dart', ['analyze', tempDir.path]);
+    final analyzeResult =
+        Process.runSync(dartExecutable, ['analyze', tempDir.path]);
     if (analyzeResult.exitCode != 0) {
       stderr.write(analyzeResult.stdout);
       fail('Analyzer exited with non-zero status (${analyzeResult.exitCode})');

--- a/pkgs/jnigen/tool/regenerate_all_bindings.dart
+++ b/pkgs/jnigen/tool/regenerate_all_bindings.dart
@@ -8,6 +8,8 @@
 
 import 'dart:io';
 
+import 'package:jnigen/src/util/dart_executable.dart';
+
 import 'command_runner.dart';
 
 const scripts = [
@@ -28,13 +30,14 @@ void main() async {
   final current = Directory.current.uri;
   for (var script in scripts) {
     runners.add(Runner('Run generate script: $script', current)
-      ..chainCommand('dart', ['run', script]));
+      ..chainCommand(dartExecutable, ['run', script]));
   }
 
   for (var yamlDir in yamlBasedExamples) {
     runners.add(
         Runner('Regenerate bindings in $yamlDir', current.resolve(yamlDir))
-          ..chainCommand('dart', ['run', 'jnigen', '--config', 'jnigen.yaml']));
+          ..chainCommand(
+              dartExecutable, ['run', 'jnigen', '--config', 'jnigen.yaml']));
   }
 
   await Future.wait(runners.map((runner) => runner.run()).toList());


### PR DESCRIPTION
Replaced all `Process.run('dart', ...` calls (and similar) with `Process.run(dartExecutable, ...`, copying the `dartExecutable` util from `pkgs/ffigen/lib/src/code_generator/utils.dart`.

Fixes #3142