### PR TITLE
[jni_flutter] Fix jni_flutter Android Gradle space-assignment deprecations

### DIFF
--- a/pkgs/jni_flutter/android/build.gradle
+++ b/pkgs/jni_flutter/android/build.gradle
@@ -1,7 +1,7 @@
 // The Android Gradle Plugin builds the native code with the Android NDK.
 
-group 'com.github.dart_lang.jni_flutter'
-version '1.0'
+group = 'com.github.dart_lang.jni_flutter'
+version = '1.0'
 
 buildscript {
     repositories {
@@ -21,13 +21,13 @@ apply plugin: 'com.android.library'
 
 android {
     if (project.android.hasProperty("namespace")) {
-        namespace 'com.github.dart_lang.jni_flutter'
+        namespace = 'com.github.dart_lang.jni_flutter'
     }
 
-    compileSdk 35
+    compileSdk = 35
 
     defaultConfig {
-        minSdk 21
+        minSdk = 21
         consumerProguardFiles 'consumer-rules.pro'
     }
 


### PR DESCRIPTION
This PR updates `pkgs/jni_flutter/android/build.gradle` to use explicit Groovy property assignment syntax.

Changed only `pkgs/jni_flutter/android/build.gradle`:

- `group '...'` -> `group = '...'`
- `version '...'` -> `version = '...'`
- `namespace '...'` -> `namespace = '...'`
- `compileSdk 35` -> `compileSdk = 35`
- `minSdk 21` -> `minSdk = 21`

No Dart, Java, Kotlin, native runtime, public API, or dependency behavior is intended to change.

This follows Gradle's upgrade guide for Groovy space-assignment deprecations, which are scheduled for removal in Gradle 10.

Related issue: #3347

Reference: https://docs.gradle.org/current/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
