### PR TITLE
[jnigen] Clean up `.reference.pointer` pattern

### DIFF
--- a/pkgs/jni/lib/src/core_bindings.dart
+++ b/pkgs/jni/lib/src/core_bindings.dart
@@ -98,7 +98,8 @@ extension type JBoolean._(jni$_.JObject _$this) implements jni$_.JObject {
   factory JBoolean(
     core$_.bool z,
   ) {
-    return _new$(_class.reference.pointer, _id_new$.pointer, z ? 1 : 0)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer, z ? 1 : 0)
         .object<JBoolean>();
   }
 
@@ -123,8 +124,9 @@ extension type JBoolean._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.bool z,
     core$_.bool z1,
   ) {
-    return _compare(_class.reference.pointer, _id_compare.pointer, z ? 1 : 0,
-            z1 ? 1 : 0)
+    final _$$classRef = _class.reference;
+    return _compare(
+            _$$classRef.pointer, _id_compare.pointer, z ? 1 : 0, z1 ? 1 : 0)
         .integer;
   }
 
@@ -148,9 +150,10 @@ extension type JBoolean._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool getBoolean(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _getBoolean(
-            _class.reference.pointer, _id_getBoolean.pointer, _$string.pointer)
+            _$$classRef.pointer, _id_getBoolean.pointer, _$string.pointer)
         .boolean;
   }
 
@@ -172,8 +175,8 @@ extension type JBoolean._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int hashCode$2(
     core$_.bool z,
   ) {
-    return _hashCode$2(
-            _class.reference.pointer, _id_hashCode$2.pointer, z ? 1 : 0)
+    final _$$classRef = _class.reference;
+    return _hashCode$2(_$$classRef.pointer, _id_hashCode$2.pointer, z ? 1 : 0)
         .integer;
   }
 
@@ -198,8 +201,9 @@ extension type JBoolean._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.bool z,
     core$_.bool z1,
   ) {
-    return _logicalAnd(_class.reference.pointer, _id_logicalAnd.pointer,
-            z ? 1 : 0, z1 ? 1 : 0)
+    final _$$classRef = _class.reference;
+    return _logicalAnd(
+            _$$classRef.pointer, _id_logicalAnd.pointer, z ? 1 : 0, z1 ? 1 : 0)
         .boolean;
   }
 
@@ -224,8 +228,9 @@ extension type JBoolean._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.bool z,
     core$_.bool z1,
   ) {
-    return _logicalOr(_class.reference.pointer, _id_logicalOr.pointer,
-            z ? 1 : 0, z1 ? 1 : 0)
+    final _$$classRef = _class.reference;
+    return _logicalOr(
+            _$$classRef.pointer, _id_logicalOr.pointer, z ? 1 : 0, z1 ? 1 : 0)
         .boolean;
   }
 
@@ -250,8 +255,9 @@ extension type JBoolean._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.bool z,
     core$_.bool z1,
   ) {
-    return _logicalXor(_class.reference.pointer, _id_logicalXor.pointer,
-            z ? 1 : 0, z1 ? 1 : 0)
+    final _$$classRef = _class.reference;
+    return _logicalXor(
+            _$$classRef.pointer, _id_logicalXor.pointer, z ? 1 : 0, z1 ? 1 : 0)
         .boolean;
   }
 
@@ -275,9 +281,10 @@ extension type JBoolean._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool parseBoolean(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _parseBoolean(_class.reference.pointer, _id_parseBoolean.pointer,
-            _$string.pointer)
+    return _parseBoolean(
+            _$$classRef.pointer, _id_parseBoolean.pointer, _$string.pointer)
         .boolean;
   }
 
@@ -300,8 +307,8 @@ extension type JBoolean._(jni$_.JObject _$this) implements jni$_.JObject {
   static JString? toString$2(
     core$_.bool z,
   ) {
-    return _toString$2(
-            _class.reference.pointer, _id_toString$2.pointer, z ? 1 : 0)
+    final _$$classRef = _class.reference;
+    return _toString$2(_$$classRef.pointer, _id_toString$2.pointer, z ? 1 : 0)
         .object<JString?>();
   }
 
@@ -324,7 +331,8 @@ extension type JBoolean._(jni$_.JObject _$this) implements jni$_.JObject {
   static JBoolean? valueOf(
     core$_.bool z,
   ) {
-    return _valueOf(_class.reference.pointer, _id_valueOf.pointer, z ? 1 : 0)
+    final _$$classRef = _class.reference;
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, z ? 1 : 0)
         .object<JBoolean?>();
   }
 
@@ -349,9 +357,10 @@ extension type JBoolean._(jni$_.JObject _$this) implements jni$_.JObject {
   static JBoolean? valueOf$1(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _valueOf$1(
-            _class.reference.pointer, _id_valueOf$1.pointer, _$string.pointer)
+            _$$classRef.pointer, _id_valueOf$1.pointer, _$string.pointer)
         .object<JBoolean?>();
   }
 }
@@ -376,7 +385,8 @@ extension JBoolean$$Methods on JBoolean {
 
   /// from: `public boolean booleanValue()`
   core$_.bool booleanValue() {
-    return _booleanValue(reference.pointer, _id_booleanValue.pointer).boolean;
+    final _$$selfRef = reference;
+    return _booleanValue(_$$selfRef.pointer, _id_booleanValue.pointer).boolean;
   }
 
   static final _id_compareTo = JBoolean._class.instanceMethodId(
@@ -399,9 +409,10 @@ extension JBoolean$$Methods on JBoolean {
   core$_.int compareTo(
     JBoolean? boolean,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     return _compareTo(
-            reference.pointer, _id_compareTo.pointer, _$boolean.pointer)
+            _$$selfRef.pointer, _id_compareTo.pointer, _$boolean.pointer)
         .integer;
   }
 
@@ -425,8 +436,9 @@ extension JBoolean$$Methods on JBoolean {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -449,7 +461,8 @@ extension JBoolean$$Methods on JBoolean {
 
   /// from: `public int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_toString$1 = JBoolean._class.instanceMethodId(
@@ -472,7 +485,8 @@ extension JBoolean$$Methods on JBoolean {
   /// from: `public java.lang.String toString()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<JString?>();
   }
 
@@ -549,7 +563,8 @@ extension type JByte._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   factory JByte(
     core$_.int b,
   ) {
-    return _new$(_class.reference.pointer, _id_new$.pointer, b).object<JByte>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer, b).object<JByte>();
   }
 
   static final _id_compare = _class.staticMethodId(
@@ -573,8 +588,8 @@ extension type JByte._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int b,
     core$_.int b1,
   ) {
-    return _compare(_class.reference.pointer, _id_compare.pointer, b, b1)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _compare(_$$classRef.pointer, _id_compare.pointer, b, b1).integer;
   }
 
   static final _id_compareUnsigned = _class.staticMethodId(
@@ -598,8 +613,9 @@ extension type JByte._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int b,
     core$_.int b1,
   ) {
+    final _$$classRef = _class.reference;
     return _compareUnsigned(
-            _class.reference.pointer, _id_compareUnsigned.pointer, b, b1)
+            _$$classRef.pointer, _id_compareUnsigned.pointer, b, b1)
         .integer;
   }
 
@@ -624,9 +640,9 @@ extension type JByte._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static JByte? decode(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _decode(
-            _class.reference.pointer, _id_decode.pointer, _$string.pointer)
+    return _decode(_$$classRef.pointer, _id_decode.pointer, _$string.pointer)
         .object<JByte?>();
   }
 
@@ -648,8 +664,8 @@ extension type JByte._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static core$_.int hashCode$2(
     core$_.int b,
   ) {
-    return _hashCode$2(_class.reference.pointer, _id_hashCode$2.pointer, b)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _hashCode$2(_$$classRef.pointer, _id_hashCode$2.pointer, b).integer;
   }
 
   static final _id_parseByte = _class.staticMethodId(
@@ -672,9 +688,10 @@ extension type JByte._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static core$_.int parseByte(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _parseByte(
-            _class.reference.pointer, _id_parseByte.pointer, _$string.pointer)
+            _$$classRef.pointer, _id_parseByte.pointer, _$string.pointer)
         .byte;
   }
 
@@ -700,9 +717,10 @@ extension type JByte._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     JString? string,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _parseByte$1(_class.reference.pointer, _id_parseByte$1.pointer,
-            _$string.pointer, i)
+    return _parseByte$1(
+            _$$classRef.pointer, _id_parseByte$1.pointer, _$string.pointer, i)
         .byte;
   }
 
@@ -725,7 +743,8 @@ extension type JByte._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static JString? toString$2(
     core$_.int b,
   ) {
-    return _toString$2(_class.reference.pointer, _id_toString$2.pointer, b)
+    final _$$classRef = _class.reference;
+    return _toString$2(_$$classRef.pointer, _id_toString$2.pointer, b)
         .object<JString?>();
   }
 
@@ -747,8 +766,8 @@ extension type JByte._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static core$_.int toUnsignedInt(
     core$_.int b,
   ) {
-    return _toUnsignedInt(
-            _class.reference.pointer, _id_toUnsignedInt.pointer, b)
+    final _$$classRef = _class.reference;
+    return _toUnsignedInt(_$$classRef.pointer, _id_toUnsignedInt.pointer, b)
         .integer;
   }
 
@@ -770,8 +789,8 @@ extension type JByte._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static core$_.int toUnsignedLong(
     core$_.int b,
   ) {
-    return _toUnsignedLong(
-            _class.reference.pointer, _id_toUnsignedLong.pointer, b)
+    final _$$classRef = _class.reference;
+    return _toUnsignedLong(_$$classRef.pointer, _id_toUnsignedLong.pointer, b)
         .long;
   }
 
@@ -794,7 +813,8 @@ extension type JByte._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static JByte? valueOf(
     core$_.int b,
   ) {
-    return _valueOf(_class.reference.pointer, _id_valueOf.pointer, b)
+    final _$$classRef = _class.reference;
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, b)
         .object<JByte?>();
   }
 
@@ -819,9 +839,10 @@ extension type JByte._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static JByte? valueOf$1(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _valueOf$1(
-            _class.reference.pointer, _id_valueOf$1.pointer, _$string.pointer)
+            _$$classRef.pointer, _id_valueOf$1.pointer, _$string.pointer)
         .object<JByte?>();
   }
 
@@ -848,9 +869,10 @@ extension type JByte._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     JString? string,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _valueOf$2(_class.reference.pointer, _id_valueOf$2.pointer,
-            _$string.pointer, i)
+    return _valueOf$2(
+            _$$classRef.pointer, _id_valueOf$2.pointer, _$string.pointer, i)
         .object<JByte?>();
   }
 }
@@ -875,7 +897,8 @@ extension JByte$$Methods on JByte {
 
   /// from: `public byte byteValue()`
   core$_.int byteValue() {
-    return _byteValue(reference.pointer, _id_byteValue.pointer).byte;
+    final _$$selfRef = reference;
+    return _byteValue(_$$selfRef.pointer, _id_byteValue.pointer).byte;
   }
 
   static final _id_compareTo = JByte._class.instanceMethodId(
@@ -898,8 +921,9 @@ extension JByte$$Methods on JByte {
   core$_.int compareTo(
     JByte? byte,
   ) {
+    final _$$selfRef = reference;
     final _$byte = byte?.reference ?? jni$_.jNullReference;
-    return _compareTo(reference.pointer, _id_compareTo.pointer, _$byte.pointer)
+    return _compareTo(_$$selfRef.pointer, _id_compareTo.pointer, _$byte.pointer)
         .integer;
   }
 
@@ -922,7 +946,9 @@ extension JByte$$Methods on JByte {
 
   /// from: `public double doubleValue()`
   core$_.double doubleValue() {
-    return _doubleValue(reference.pointer, _id_doubleValue.pointer).doubleFloat;
+    final _$$selfRef = reference;
+    return _doubleValue(_$$selfRef.pointer, _id_doubleValue.pointer)
+        .doubleFloat;
   }
 
   static final _id_equals = JByte._class.instanceMethodId(
@@ -945,8 +971,9 @@ extension JByte$$Methods on JByte {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -969,7 +996,8 @@ extension JByte$$Methods on JByte {
 
   /// from: `public float floatValue()`
   core$_.double floatValue() {
-    return _floatValue(reference.pointer, _id_floatValue.pointer).float;
+    final _$$selfRef = reference;
+    return _floatValue(_$$selfRef.pointer, _id_floatValue.pointer).float;
   }
 
   static final _id_hashCode$1 = JByte._class.instanceMethodId(
@@ -991,7 +1019,8 @@ extension JByte$$Methods on JByte {
 
   /// from: `public int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_intValue = JByte._class.instanceMethodId(
@@ -1013,7 +1042,8 @@ extension JByte$$Methods on JByte {
 
   /// from: `public int intValue()`
   core$_.int intValue() {
-    return _intValue(reference.pointer, _id_intValue.pointer).integer;
+    final _$$selfRef = reference;
+    return _intValue(_$$selfRef.pointer, _id_intValue.pointer).integer;
   }
 
   static final _id_longValue = JByte._class.instanceMethodId(
@@ -1035,7 +1065,8 @@ extension JByte$$Methods on JByte {
 
   /// from: `public long longValue()`
   core$_.int longValue() {
-    return _longValue(reference.pointer, _id_longValue.pointer).long;
+    final _$$selfRef = reference;
+    return _longValue(_$$selfRef.pointer, _id_longValue.pointer).long;
   }
 
   static final _id_shortValue = JByte._class.instanceMethodId(
@@ -1057,7 +1088,8 @@ extension JByte$$Methods on JByte {
 
   /// from: `public short shortValue()`
   core$_.int shortValue() {
-    return _shortValue(reference.pointer, _id_shortValue.pointer).short;
+    final _$$selfRef = reference;
+    return _shortValue(_$$selfRef.pointer, _id_shortValue.pointer).short;
   }
 
   static final _id_toString$1 = JByte._class.instanceMethodId(
@@ -1080,7 +1112,8 @@ extension JByte$$Methods on JByte {
   /// from: `public java.lang.String toString()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<JString?>();
   }
 
@@ -1141,8 +1174,9 @@ extension JCharacter$JSubset$$Methods on JCharacter$JSubset {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -1165,7 +1199,8 @@ extension JCharacter$JSubset$$Methods on JCharacter$JSubset {
 
   /// from: `public final int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_toString$1 = JCharacter$JSubset._class.instanceMethodId(
@@ -1188,7 +1223,8 @@ extension JCharacter$JSubset$$Methods on JCharacter$JSubset {
   /// from: `public final java.lang.String toString()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<JString?>();
   }
 }
@@ -4851,9 +4887,9 @@ extension type JCharacter$JUnicodeBlock._(jni$_.JObject _$this)
   static JCharacter$JUnicodeBlock? forName(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _forName(
-            _class.reference.pointer, _id_forName.pointer, _$string.pointer)
+    return _forName(_$$classRef.pointer, _id_forName.pointer, _$string.pointer)
         .object<JCharacter$JUnicodeBlock?>();
   }
 
@@ -4876,7 +4912,8 @@ extension type JCharacter$JUnicodeBlock._(jni$_.JObject _$this)
   static JCharacter$JUnicodeBlock? of(
     core$_.int c,
   ) {
-    return _of(_class.reference.pointer, _id_of.pointer, c)
+    final _$$classRef = _class.reference;
+    return _of(_$$classRef.pointer, _id_of.pointer, c)
         .object<JCharacter$JUnicodeBlock?>();
   }
 
@@ -4899,7 +4936,8 @@ extension type JCharacter$JUnicodeBlock._(jni$_.JObject _$this)
   static JCharacter$JUnicodeBlock? of$1(
     core$_.int i,
   ) {
-    return _of$1(_class.reference.pointer, _id_of$1.pointer, i)
+    final _$$classRef = _class.reference;
+    return _of$1(_$$classRef.pointer, _id_of$1.pointer, i)
         .object<JCharacter$JUnicodeBlock?>();
   }
 }
@@ -6747,7 +6785,8 @@ extension type JCharacter$JUnicodeScript._(jni$_.JObject _$this)
   /// from: `static public java.lang.Character$UnicodeScript[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<JCharacter$JUnicodeScript?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<JCharacter$JUnicodeScript?>?>();
   }
 
@@ -6772,9 +6811,10 @@ extension type JCharacter$JUnicodeScript._(jni$_.JObject _$this)
   static JCharacter$JUnicodeScript? valueOf(
     JString? synthetic,
   ) {
+    final _$$classRef = _class.reference;
     final _$synthetic = synthetic?.reference ?? jni$_.jNullReference;
     return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$synthetic.pointer)
+            _$$classRef.pointer, _id_valueOf.pointer, _$synthetic.pointer)
         .object<JCharacter$JUnicodeScript?>();
   }
 
@@ -6799,9 +6839,9 @@ extension type JCharacter$JUnicodeScript._(jni$_.JObject _$this)
   static JCharacter$JUnicodeScript? forName(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _forName(
-            _class.reference.pointer, _id_forName.pointer, _$string.pointer)
+    return _forName(_$$classRef.pointer, _id_forName.pointer, _$string.pointer)
         .object<JCharacter$JUnicodeScript?>();
   }
 
@@ -6824,7 +6864,8 @@ extension type JCharacter$JUnicodeScript._(jni$_.JObject _$this)
   static JCharacter$JUnicodeScript? of(
     core$_.int i,
   ) {
-    return _of(_class.reference.pointer, _id_of.pointer, i)
+    final _$$classRef = _class.reference;
+    return _of(_$$classRef.pointer, _id_of.pointer, i)
         .object<JCharacter$JUnicodeScript?>();
   }
 }
@@ -7080,8 +7121,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   factory JCharacter(
     core$_.int c,
   ) {
-    return _new$(_class.reference.pointer, _id_new$.pointer, c)
-        .object<JCharacter>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer, c).object<JCharacter>();
   }
 
   static final _id_charCount = _class.staticMethodId(
@@ -7102,8 +7143,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int charCount(
     core$_.int i,
   ) {
-    return _charCount(_class.reference.pointer, _id_charCount.pointer, i)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _charCount(_$$classRef.pointer, _id_charCount.pointer, i).integer;
   }
 
   static final _id_codePointAt = _class.staticMethodId(
@@ -7128,9 +7169,10 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JCharArray? cs,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$cs = cs?.reference ?? jni$_.jNullReference;
     return _codePointAt(
-            _class.reference.pointer, _id_codePointAt.pointer, _$cs.pointer, i)
+            _$$classRef.pointer, _id_codePointAt.pointer, _$cs.pointer, i)
         .integer;
   }
 
@@ -7164,9 +7206,10 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     core$_.int i1,
   ) {
+    final _$$classRef = _class.reference;
     final _$cs = cs?.reference ?? jni$_.jNullReference;
-    return _codePointAt$1(_class.reference.pointer, _id_codePointAt$1.pointer,
-            _$cs.pointer, i, i1)
+    return _codePointAt$1(
+            _$$classRef.pointer, _id_codePointAt$1.pointer, _$cs.pointer, i, i1)
         .integer;
   }
 
@@ -7192,8 +7235,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JObject? charSequence,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
-    return _codePointAt$2(_class.reference.pointer, _id_codePointAt$2.pointer,
+    return _codePointAt$2(_$$classRef.pointer, _id_codePointAt$2.pointer,
             _$charSequence.pointer, i)
         .integer;
   }
@@ -7220,9 +7264,10 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JCharArray? cs,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$cs = cs?.reference ?? jni$_.jNullReference;
-    return _codePointBefore(_class.reference.pointer,
-            _id_codePointBefore.pointer, _$cs.pointer, i)
+    return _codePointBefore(
+            _$$classRef.pointer, _id_codePointBefore.pointer, _$cs.pointer, i)
         .integer;
   }
 
@@ -7256,8 +7301,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     core$_.int i1,
   ) {
+    final _$$classRef = _class.reference;
     final _$cs = cs?.reference ?? jni$_.jNullReference;
-    return _codePointBefore$1(_class.reference.pointer,
+    return _codePointBefore$1(_$$classRef.pointer,
             _id_codePointBefore$1.pointer, _$cs.pointer, i, i1)
         .integer;
   }
@@ -7284,8 +7330,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JObject? charSequence,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
-    return _codePointBefore$2(_class.reference.pointer,
+    return _codePointBefore$2(_$$classRef.pointer,
             _id_codePointBefore$2.pointer, _$charSequence.pointer, i)
         .integer;
   }
@@ -7320,8 +7367,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     core$_.int i1,
   ) {
+    final _$$classRef = _class.reference;
     final _$cs = cs?.reference ?? jni$_.jNullReference;
-    return _codePointCount(_class.reference.pointer, _id_codePointCount.pointer,
+    return _codePointCount(_$$classRef.pointer, _id_codePointCount.pointer,
             _$cs.pointer, i, i1)
         .integer;
   }
@@ -7356,9 +7404,10 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     core$_.int i1,
   ) {
+    final _$$classRef = _class.reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
-    return _codePointCount$1(_class.reference.pointer,
-            _id_codePointCount$1.pointer, _$charSequence.pointer, i, i1)
+    return _codePointCount$1(_$$classRef.pointer, _id_codePointCount$1.pointer,
+            _$charSequence.pointer, i, i1)
         .integer;
   }
 
@@ -7382,9 +7431,10 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int codePointOf(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _codePointOf(
-            _class.reference.pointer, _id_codePointOf.pointer, _$string.pointer)
+            _$$classRef.pointer, _id_codePointOf.pointer, _$string.pointer)
         .integer;
   }
 
@@ -7409,8 +7459,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int c,
     core$_.int c1,
   ) {
-    return _compare(_class.reference.pointer, _id_compare.pointer, c, c1)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _compare(_$$classRef.pointer, _id_compare.pointer, c, c1).integer;
   }
 
   static final _id_digit = _class.staticMethodId(
@@ -7434,7 +7484,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int c,
     core$_.int i,
   ) {
-    return _digit(_class.reference.pointer, _id_digit.pointer, c, i).integer;
+    final _$$classRef = _class.reference;
+    return _digit(_$$classRef.pointer, _id_digit.pointer, c, i).integer;
   }
 
   static final _id_digit$1 = _class.staticMethodId(
@@ -7458,8 +7509,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     core$_.int i1,
   ) {
-    return _digit$1(_class.reference.pointer, _id_digit$1.pointer, i, i1)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _digit$1(_$$classRef.pointer, _id_digit$1.pointer, i, i1).integer;
   }
 
   static final _id_forDigit = _class.staticMethodId(
@@ -7483,8 +7534,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     core$_.int i1,
   ) {
-    return _forDigit(_class.reference.pointer, _id_forDigit.pointer, i, i1)
-        .char;
+    final _$$classRef = _class.reference;
+    return _forDigit(_$$classRef.pointer, _id_forDigit.pointer, i, i1).char;
   }
 
   static final _id_getDirectionality = _class.staticMethodId(
@@ -7505,8 +7556,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int getDirectionality(
     core$_.int c,
   ) {
+    final _$$classRef = _class.reference;
     return _getDirectionality(
-            _class.reference.pointer, _id_getDirectionality.pointer, c)
+            _$$classRef.pointer, _id_getDirectionality.pointer, c)
         .byte;
   }
 
@@ -7528,8 +7580,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int getDirectionality$1(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _getDirectionality$1(
-            _class.reference.pointer, _id_getDirectionality$1.pointer, i)
+            _$$classRef.pointer, _id_getDirectionality$1.pointer, i)
         .byte;
   }
 
@@ -7552,7 +7605,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static JString? getName(
     core$_.int i,
   ) {
-    return _getName(_class.reference.pointer, _id_getName.pointer, i)
+    final _$$classRef = _class.reference;
+    return _getName(_$$classRef.pointer, _id_getName.pointer, i)
         .object<JString?>();
   }
 
@@ -7574,8 +7628,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int getNumericValue(
     core$_.int c,
   ) {
-    return _getNumericValue(
-            _class.reference.pointer, _id_getNumericValue.pointer, c)
+    final _$$classRef = _class.reference;
+    return _getNumericValue(_$$classRef.pointer, _id_getNumericValue.pointer, c)
         .integer;
   }
 
@@ -7597,8 +7651,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int getNumericValue$1(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _getNumericValue$1(
-            _class.reference.pointer, _id_getNumericValue$1.pointer, i)
+            _$$classRef.pointer, _id_getNumericValue$1.pointer, i)
         .integer;
   }
 
@@ -7620,7 +7675,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int getType(
     core$_.int c,
   ) {
-    return _getType(_class.reference.pointer, _id_getType.pointer, c).integer;
+    final _$$classRef = _class.reference;
+    return _getType(_$$classRef.pointer, _id_getType.pointer, c).integer;
   }
 
   static final _id_getType$1 = _class.staticMethodId(
@@ -7641,8 +7697,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int getType$1(
     core$_.int i,
   ) {
-    return _getType$1(_class.reference.pointer, _id_getType$1.pointer, i)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _getType$1(_$$classRef.pointer, _id_getType$1.pointer, i).integer;
   }
 
   static final _id_hashCode$2 = _class.staticMethodId(
@@ -7663,8 +7719,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int hashCode$2(
     core$_.int c,
   ) {
-    return _hashCode$2(_class.reference.pointer, _id_hashCode$2.pointer, c)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _hashCode$2(_$$classRef.pointer, _id_hashCode$2.pointer, c).integer;
   }
 
   static final _id_highSurrogate = _class.staticMethodId(
@@ -7685,8 +7741,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int highSurrogate(
     core$_.int i,
   ) {
-    return _highSurrogate(
-            _class.reference.pointer, _id_highSurrogate.pointer, i)
+    final _$$classRef = _class.reference;
+    return _highSurrogate(_$$classRef.pointer, _id_highSurrogate.pointer, i)
         .char;
   }
 
@@ -7708,7 +7764,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isAlphabetic(
     core$_.int i,
   ) {
-    return _isAlphabetic(_class.reference.pointer, _id_isAlphabetic.pointer, i)
+    final _$$classRef = _class.reference;
+    return _isAlphabetic(_$$classRef.pointer, _id_isAlphabetic.pointer, i)
         .boolean;
   }
 
@@ -7730,8 +7787,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isBmpCodePoint(
     core$_.int i,
   ) {
-    return _isBmpCodePoint(
-            _class.reference.pointer, _id_isBmpCodePoint.pointer, i)
+    final _$$classRef = _class.reference;
+    return _isBmpCodePoint(_$$classRef.pointer, _id_isBmpCodePoint.pointer, i)
         .boolean;
   }
 
@@ -7753,8 +7810,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isDefined(
     core$_.int c,
   ) {
-    return _isDefined(_class.reference.pointer, _id_isDefined.pointer, c)
-        .boolean;
+    final _$$classRef = _class.reference;
+    return _isDefined(_$$classRef.pointer, _id_isDefined.pointer, c).boolean;
   }
 
   static final _id_isDefined$1 = _class.staticMethodId(
@@ -7775,7 +7832,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isDefined$1(
     core$_.int i,
   ) {
-    return _isDefined$1(_class.reference.pointer, _id_isDefined$1.pointer, i)
+    final _$$classRef = _class.reference;
+    return _isDefined$1(_$$classRef.pointer, _id_isDefined$1.pointer, i)
         .boolean;
   }
 
@@ -7797,7 +7855,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isDigit(
     core$_.int c,
   ) {
-    return _isDigit(_class.reference.pointer, _id_isDigit.pointer, c).boolean;
+    final _$$classRef = _class.reference;
+    return _isDigit(_$$classRef.pointer, _id_isDigit.pointer, c).boolean;
   }
 
   static final _id_isDigit$1 = _class.staticMethodId(
@@ -7818,8 +7877,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isDigit$1(
     core$_.int i,
   ) {
-    return _isDigit$1(_class.reference.pointer, _id_isDigit$1.pointer, i)
-        .boolean;
+    final _$$classRef = _class.reference;
+    return _isDigit$1(_$$classRef.pointer, _id_isDigit$1.pointer, i).boolean;
   }
 
   static final _id_isEmoji = _class.staticMethodId(
@@ -7840,7 +7899,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isEmoji(
     core$_.int i,
   ) {
-    return _isEmoji(_class.reference.pointer, _id_isEmoji.pointer, i).boolean;
+    final _$$classRef = _class.reference;
+    return _isEmoji(_$$classRef.pointer, _id_isEmoji.pointer, i).boolean;
   }
 
   static final _id_isEmojiComponent = _class.staticMethodId(
@@ -7861,8 +7921,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isEmojiComponent(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _isEmojiComponent(
-            _class.reference.pointer, _id_isEmojiComponent.pointer, i)
+            _$$classRef.pointer, _id_isEmojiComponent.pointer, i)
         .boolean;
   }
 
@@ -7884,8 +7945,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isEmojiModifier(
     core$_.int i,
   ) {
-    return _isEmojiModifier(
-            _class.reference.pointer, _id_isEmojiModifier.pointer, i)
+    final _$$classRef = _class.reference;
+    return _isEmojiModifier(_$$classRef.pointer, _id_isEmojiModifier.pointer, i)
         .boolean;
   }
 
@@ -7907,8 +7968,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isEmojiModifierBase(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _isEmojiModifierBase(
-            _class.reference.pointer, _id_isEmojiModifierBase.pointer, i)
+            _$$classRef.pointer, _id_isEmojiModifierBase.pointer, i)
         .boolean;
   }
 
@@ -7930,8 +7992,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isEmojiPresentation(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _isEmojiPresentation(
-            _class.reference.pointer, _id_isEmojiPresentation.pointer, i)
+            _$$classRef.pointer, _id_isEmojiPresentation.pointer, i)
         .boolean;
   }
 
@@ -7953,8 +8016,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isExtendedPictographic(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _isExtendedPictographic(
-            _class.reference.pointer, _id_isExtendedPictographic.pointer, i)
+            _$$classRef.pointer, _id_isExtendedPictographic.pointer, i)
         .boolean;
   }
 
@@ -7976,8 +8040,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isHighSurrogate(
     core$_.int c,
   ) {
-    return _isHighSurrogate(
-            _class.reference.pointer, _id_isHighSurrogate.pointer, c)
+    final _$$classRef = _class.reference;
+    return _isHighSurrogate(_$$classRef.pointer, _id_isHighSurrogate.pointer, c)
         .boolean;
   }
 
@@ -7999,7 +8063,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isISOControl(
     core$_.int c,
   ) {
-    return _isISOControl(_class.reference.pointer, _id_isISOControl.pointer, c)
+    final _$$classRef = _class.reference;
+    return _isISOControl(_$$classRef.pointer, _id_isISOControl.pointer, c)
         .boolean;
   }
 
@@ -8021,8 +8086,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isISOControl$1(
     core$_.int i,
   ) {
-    return _isISOControl$1(
-            _class.reference.pointer, _id_isISOControl$1.pointer, i)
+    final _$$classRef = _class.reference;
+    return _isISOControl$1(_$$classRef.pointer, _id_isISOControl$1.pointer, i)
         .boolean;
   }
 
@@ -8044,8 +8109,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isIdentifierIgnorable(
     core$_.int c,
   ) {
+    final _$$classRef = _class.reference;
     return _isIdentifierIgnorable(
-            _class.reference.pointer, _id_isIdentifierIgnorable.pointer, c)
+            _$$classRef.pointer, _id_isIdentifierIgnorable.pointer, c)
         .boolean;
   }
 
@@ -8067,8 +8133,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isIdentifierIgnorable$1(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _isIdentifierIgnorable$1(
-            _class.reference.pointer, _id_isIdentifierIgnorable$1.pointer, i)
+            _$$classRef.pointer, _id_isIdentifierIgnorable$1.pointer, i)
         .boolean;
   }
 
@@ -8090,8 +8157,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isIdeographic(
     core$_.int i,
   ) {
-    return _isIdeographic(
-            _class.reference.pointer, _id_isIdeographic.pointer, i)
+    final _$$classRef = _class.reference;
+    return _isIdeographic(_$$classRef.pointer, _id_isIdeographic.pointer, i)
         .boolean;
   }
 
@@ -8113,8 +8180,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isJavaIdentifierPart(
     core$_.int c,
   ) {
+    final _$$classRef = _class.reference;
     return _isJavaIdentifierPart(
-            _class.reference.pointer, _id_isJavaIdentifierPart.pointer, c)
+            _$$classRef.pointer, _id_isJavaIdentifierPart.pointer, c)
         .boolean;
   }
 
@@ -8136,8 +8204,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isJavaIdentifierPart$1(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _isJavaIdentifierPart$1(
-            _class.reference.pointer, _id_isJavaIdentifierPart$1.pointer, i)
+            _$$classRef.pointer, _id_isJavaIdentifierPart$1.pointer, i)
         .boolean;
   }
 
@@ -8159,8 +8228,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isJavaIdentifierStart(
     core$_.int c,
   ) {
+    final _$$classRef = _class.reference;
     return _isJavaIdentifierStart(
-            _class.reference.pointer, _id_isJavaIdentifierStart.pointer, c)
+            _$$classRef.pointer, _id_isJavaIdentifierStart.pointer, c)
         .boolean;
   }
 
@@ -8182,8 +8252,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isJavaIdentifierStart$1(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _isJavaIdentifierStart$1(
-            _class.reference.pointer, _id_isJavaIdentifierStart$1.pointer, i)
+            _$$classRef.pointer, _id_isJavaIdentifierStart$1.pointer, i)
         .boolean;
   }
 
@@ -8205,7 +8276,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isJavaLetter(
     core$_.int c,
   ) {
-    return _isJavaLetter(_class.reference.pointer, _id_isJavaLetter.pointer, c)
+    final _$$classRef = _class.reference;
+    return _isJavaLetter(_$$classRef.pointer, _id_isJavaLetter.pointer, c)
         .boolean;
   }
 
@@ -8227,8 +8299,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isJavaLetterOrDigit(
     core$_.int c,
   ) {
+    final _$$classRef = _class.reference;
     return _isJavaLetterOrDigit(
-            _class.reference.pointer, _id_isJavaLetterOrDigit.pointer, c)
+            _$$classRef.pointer, _id_isJavaLetterOrDigit.pointer, c)
         .boolean;
   }
 
@@ -8250,7 +8323,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isLetter(
     core$_.int c,
   ) {
-    return _isLetter(_class.reference.pointer, _id_isLetter.pointer, c).boolean;
+    final _$$classRef = _class.reference;
+    return _isLetter(_$$classRef.pointer, _id_isLetter.pointer, c).boolean;
   }
 
   static final _id_isLetter$1 = _class.staticMethodId(
@@ -8271,8 +8345,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isLetter$1(
     core$_.int i,
   ) {
-    return _isLetter$1(_class.reference.pointer, _id_isLetter$1.pointer, i)
-        .boolean;
+    final _$$classRef = _class.reference;
+    return _isLetter$1(_$$classRef.pointer, _id_isLetter$1.pointer, i).boolean;
   }
 
   static final _id_isLetterOrDigit = _class.staticMethodId(
@@ -8293,8 +8367,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isLetterOrDigit(
     core$_.int c,
   ) {
-    return _isLetterOrDigit(
-            _class.reference.pointer, _id_isLetterOrDigit.pointer, c)
+    final _$$classRef = _class.reference;
+    return _isLetterOrDigit(_$$classRef.pointer, _id_isLetterOrDigit.pointer, c)
         .boolean;
   }
 
@@ -8316,8 +8390,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isLetterOrDigit$1(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _isLetterOrDigit$1(
-            _class.reference.pointer, _id_isLetterOrDigit$1.pointer, i)
+            _$$classRef.pointer, _id_isLetterOrDigit$1.pointer, i)
         .boolean;
   }
 
@@ -8339,8 +8414,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isLowSurrogate(
     core$_.int c,
   ) {
-    return _isLowSurrogate(
-            _class.reference.pointer, _id_isLowSurrogate.pointer, c)
+    final _$$classRef = _class.reference;
+    return _isLowSurrogate(_$$classRef.pointer, _id_isLowSurrogate.pointer, c)
         .boolean;
   }
 
@@ -8362,7 +8437,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isLowerCase(
     core$_.int c,
   ) {
-    return _isLowerCase(_class.reference.pointer, _id_isLowerCase.pointer, c)
+    final _$$classRef = _class.reference;
+    return _isLowerCase(_$$classRef.pointer, _id_isLowerCase.pointer, c)
         .boolean;
   }
 
@@ -8384,8 +8460,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isLowerCase$1(
     core$_.int i,
   ) {
-    return _isLowerCase$1(
-            _class.reference.pointer, _id_isLowerCase$1.pointer, i)
+    final _$$classRef = _class.reference;
+    return _isLowerCase$1(_$$classRef.pointer, _id_isLowerCase$1.pointer, i)
         .boolean;
   }
 
@@ -8407,8 +8483,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isMirrored(
     core$_.int c,
   ) {
-    return _isMirrored(_class.reference.pointer, _id_isMirrored.pointer, c)
-        .boolean;
+    final _$$classRef = _class.reference;
+    return _isMirrored(_$$classRef.pointer, _id_isMirrored.pointer, c).boolean;
   }
 
   static final _id_isMirrored$1 = _class.staticMethodId(
@@ -8429,7 +8505,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isMirrored$1(
     core$_.int i,
   ) {
-    return _isMirrored$1(_class.reference.pointer, _id_isMirrored$1.pointer, i)
+    final _$$classRef = _class.reference;
+    return _isMirrored$1(_$$classRef.pointer, _id_isMirrored$1.pointer, i)
         .boolean;
   }
 
@@ -8451,7 +8528,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isSpace(
     core$_.int c,
   ) {
-    return _isSpace(_class.reference.pointer, _id_isSpace.pointer, c).boolean;
+    final _$$classRef = _class.reference;
+    return _isSpace(_$$classRef.pointer, _id_isSpace.pointer, c).boolean;
   }
 
   static final _id_isSpaceChar = _class.staticMethodId(
@@ -8472,7 +8550,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isSpaceChar(
     core$_.int c,
   ) {
-    return _isSpaceChar(_class.reference.pointer, _id_isSpaceChar.pointer, c)
+    final _$$classRef = _class.reference;
+    return _isSpaceChar(_$$classRef.pointer, _id_isSpaceChar.pointer, c)
         .boolean;
   }
 
@@ -8494,8 +8573,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isSpaceChar$1(
     core$_.int i,
   ) {
-    return _isSpaceChar$1(
-            _class.reference.pointer, _id_isSpaceChar$1.pointer, i)
+    final _$$classRef = _class.reference;
+    return _isSpaceChar$1(_$$classRef.pointer, _id_isSpaceChar$1.pointer, i)
         .boolean;
   }
 
@@ -8517,8 +8596,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isSupplementaryCodePoint(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _isSupplementaryCodePoint(
-            _class.reference.pointer, _id_isSupplementaryCodePoint.pointer, i)
+            _$$classRef.pointer, _id_isSupplementaryCodePoint.pointer, i)
         .boolean;
   }
 
@@ -8540,7 +8620,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isSurrogate(
     core$_.int c,
   ) {
-    return _isSurrogate(_class.reference.pointer, _id_isSurrogate.pointer, c)
+    final _$$classRef = _class.reference;
+    return _isSurrogate(_$$classRef.pointer, _id_isSurrogate.pointer, c)
         .boolean;
   }
 
@@ -8565,8 +8646,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int c,
     core$_.int c1,
   ) {
+    final _$$classRef = _class.reference;
     return _isSurrogatePair(
-            _class.reference.pointer, _id_isSurrogatePair.pointer, c, c1)
+            _$$classRef.pointer, _id_isSurrogatePair.pointer, c, c1)
         .boolean;
   }
 
@@ -8588,7 +8670,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isTitleCase(
     core$_.int c,
   ) {
-    return _isTitleCase(_class.reference.pointer, _id_isTitleCase.pointer, c)
+    final _$$classRef = _class.reference;
+    return _isTitleCase(_$$classRef.pointer, _id_isTitleCase.pointer, c)
         .boolean;
   }
 
@@ -8610,8 +8693,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isTitleCase$1(
     core$_.int i,
   ) {
-    return _isTitleCase$1(
-            _class.reference.pointer, _id_isTitleCase$1.pointer, i)
+    final _$$classRef = _class.reference;
+    return _isTitleCase$1(_$$classRef.pointer, _id_isTitleCase$1.pointer, i)
         .boolean;
   }
 
@@ -8633,8 +8716,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isUnicodeIdentifierPart(
     core$_.int c,
   ) {
+    final _$$classRef = _class.reference;
     return _isUnicodeIdentifierPart(
-            _class.reference.pointer, _id_isUnicodeIdentifierPart.pointer, c)
+            _$$classRef.pointer, _id_isUnicodeIdentifierPart.pointer, c)
         .boolean;
   }
 
@@ -8656,8 +8740,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isUnicodeIdentifierPart$1(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _isUnicodeIdentifierPart$1(
-            _class.reference.pointer, _id_isUnicodeIdentifierPart$1.pointer, i)
+            _$$classRef.pointer, _id_isUnicodeIdentifierPart$1.pointer, i)
         .boolean;
   }
 
@@ -8679,8 +8764,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isUnicodeIdentifierStart(
     core$_.int c,
   ) {
+    final _$$classRef = _class.reference;
     return _isUnicodeIdentifierStart(
-            _class.reference.pointer, _id_isUnicodeIdentifierStart.pointer, c)
+            _$$classRef.pointer, _id_isUnicodeIdentifierStart.pointer, c)
         .boolean;
   }
 
@@ -8703,8 +8789,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isUnicodeIdentifierStart$1(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _isUnicodeIdentifierStart$1(
-            _class.reference.pointer, _id_isUnicodeIdentifierStart$1.pointer, i)
+            _$$classRef.pointer, _id_isUnicodeIdentifierStart$1.pointer, i)
         .boolean;
   }
 
@@ -8726,7 +8813,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isUpperCase(
     core$_.int c,
   ) {
-    return _isUpperCase(_class.reference.pointer, _id_isUpperCase.pointer, c)
+    final _$$classRef = _class.reference;
+    return _isUpperCase(_$$classRef.pointer, _id_isUpperCase.pointer, c)
         .boolean;
   }
 
@@ -8748,8 +8836,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isUpperCase$1(
     core$_.int i,
   ) {
-    return _isUpperCase$1(
-            _class.reference.pointer, _id_isUpperCase$1.pointer, i)
+    final _$$classRef = _class.reference;
+    return _isUpperCase$1(_$$classRef.pointer, _id_isUpperCase$1.pointer, i)
         .boolean;
   }
 
@@ -8771,8 +8859,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isValidCodePoint(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _isValidCodePoint(
-            _class.reference.pointer, _id_isValidCodePoint.pointer, i)
+            _$$classRef.pointer, _id_isValidCodePoint.pointer, i)
         .boolean;
   }
 
@@ -8794,7 +8883,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isWhitespace(
     core$_.int c,
   ) {
-    return _isWhitespace(_class.reference.pointer, _id_isWhitespace.pointer, c)
+    final _$$classRef = _class.reference;
+    return _isWhitespace(_$$classRef.pointer, _id_isWhitespace.pointer, c)
         .boolean;
   }
 
@@ -8816,8 +8906,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.bool isWhitespace$1(
     core$_.int i,
   ) {
-    return _isWhitespace$1(
-            _class.reference.pointer, _id_isWhitespace$1.pointer, i)
+    final _$$classRef = _class.reference;
+    return _isWhitespace$1(_$$classRef.pointer, _id_isWhitespace$1.pointer, i)
         .boolean;
   }
 
@@ -8839,8 +8929,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int lowSurrogate(
     core$_.int i,
   ) {
-    return _lowSurrogate(_class.reference.pointer, _id_lowSurrogate.pointer, i)
-        .char;
+    final _$$classRef = _class.reference;
+    return _lowSurrogate(_$$classRef.pointer, _id_lowSurrogate.pointer, i).char;
   }
 
   static final _id_offsetByCodePoints = _class.staticMethodId(
@@ -8879,8 +8969,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i2,
     core$_.int i3,
   ) {
+    final _$$classRef = _class.reference;
     final _$cs = cs?.reference ?? jni$_.jNullReference;
-    return _offsetByCodePoints(_class.reference.pointer,
+    return _offsetByCodePoints(_$$classRef.pointer,
             _id_offsetByCodePoints.pointer, _$cs.pointer, i, i1, i2, i3)
         .integer;
   }
@@ -8915,8 +9006,9 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     core$_.int i1,
   ) {
+    final _$$classRef = _class.reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
-    return _offsetByCodePoints$1(_class.reference.pointer,
+    return _offsetByCodePoints$1(_$$classRef.pointer,
             _id_offsetByCodePoints$1.pointer, _$charSequence.pointer, i, i1)
         .integer;
   }
@@ -8939,8 +9031,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int reverseBytes(
     core$_.int c,
   ) {
-    return _reverseBytes(_class.reference.pointer, _id_reverseBytes.pointer, c)
-        .char;
+    final _$$classRef = _class.reference;
+    return _reverseBytes(_$$classRef.pointer, _id_reverseBytes.pointer, c).char;
   }
 
   static final _id_toChars = _class.staticMethodId(
@@ -8962,7 +9054,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static jni$_.JCharArray? toChars(
     core$_.int i,
   ) {
-    return _toChars(_class.reference.pointer, _id_toChars.pointer, i)
+    final _$$classRef = _class.reference;
+    return _toChars(_$$classRef.pointer, _id_toChars.pointer, i)
         .object<jni$_.JCharArray?>();
   }
 
@@ -8996,9 +9089,10 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JCharArray? cs,
     core$_.int i1,
   ) {
+    final _$$classRef = _class.reference;
     final _$cs = cs?.reference ?? jni$_.jNullReference;
-    return _toChars$1(_class.reference.pointer, _id_toChars$1.pointer, i,
-            _$cs.pointer, i1)
+    return _toChars$1(
+            _$$classRef.pointer, _id_toChars$1.pointer, i, _$cs.pointer, i1)
         .integer;
   }
 
@@ -9023,8 +9117,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int c,
     core$_.int c1,
   ) {
-    return _toCodePoint(
-            _class.reference.pointer, _id_toCodePoint.pointer, c, c1)
+    final _$$classRef = _class.reference;
+    return _toCodePoint(_$$classRef.pointer, _id_toCodePoint.pointer, c, c1)
         .integer;
   }
 
@@ -9046,8 +9140,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int toLowerCase(
     core$_.int c,
   ) {
-    return _toLowerCase(_class.reference.pointer, _id_toLowerCase.pointer, c)
-        .char;
+    final _$$classRef = _class.reference;
+    return _toLowerCase(_$$classRef.pointer, _id_toLowerCase.pointer, c).char;
   }
 
   static final _id_toLowerCase$1 = _class.staticMethodId(
@@ -9068,8 +9162,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int toLowerCase$1(
     core$_.int i,
   ) {
-    return _toLowerCase$1(
-            _class.reference.pointer, _id_toLowerCase$1.pointer, i)
+    final _$$classRef = _class.reference;
+    return _toLowerCase$1(_$$classRef.pointer, _id_toLowerCase$1.pointer, i)
         .integer;
   }
 
@@ -9092,7 +9186,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static JString? toString$2(
     core$_.int c,
   ) {
-    return _toString$2(_class.reference.pointer, _id_toString$2.pointer, c)
+    final _$$classRef = _class.reference;
+    return _toString$2(_$$classRef.pointer, _id_toString$2.pointer, c)
         .object<JString?>();
   }
 
@@ -9115,7 +9210,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static JString? toString$3(
     core$_.int i,
   ) {
-    return _toString$3(_class.reference.pointer, _id_toString$3.pointer, i)
+    final _$$classRef = _class.reference;
+    return _toString$3(_$$classRef.pointer, _id_toString$3.pointer, i)
         .object<JString?>();
   }
 
@@ -9137,8 +9233,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int toTitleCase(
     core$_.int c,
   ) {
-    return _toTitleCase(_class.reference.pointer, _id_toTitleCase.pointer, c)
-        .char;
+    final _$$classRef = _class.reference;
+    return _toTitleCase(_$$classRef.pointer, _id_toTitleCase.pointer, c).char;
   }
 
   static final _id_toTitleCase$1 = _class.staticMethodId(
@@ -9159,8 +9255,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int toTitleCase$1(
     core$_.int i,
   ) {
-    return _toTitleCase$1(
-            _class.reference.pointer, _id_toTitleCase$1.pointer, i)
+    final _$$classRef = _class.reference;
+    return _toTitleCase$1(_$$classRef.pointer, _id_toTitleCase$1.pointer, i)
         .integer;
   }
 
@@ -9182,8 +9278,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int toUpperCase(
     core$_.int c,
   ) {
-    return _toUpperCase(_class.reference.pointer, _id_toUpperCase.pointer, c)
-        .char;
+    final _$$classRef = _class.reference;
+    return _toUpperCase(_$$classRef.pointer, _id_toUpperCase.pointer, c).char;
   }
 
   static final _id_toUpperCase$1 = _class.staticMethodId(
@@ -9204,8 +9300,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int toUpperCase$1(
     core$_.int i,
   ) {
-    return _toUpperCase$1(
-            _class.reference.pointer, _id_toUpperCase$1.pointer, i)
+    final _$$classRef = _class.reference;
+    return _toUpperCase$1(_$$classRef.pointer, _id_toUpperCase$1.pointer, i)
         .integer;
   }
 
@@ -9228,7 +9324,8 @@ extension type JCharacter._(jni$_.JObject _$this) implements jni$_.JObject {
   static JCharacter? valueOf(
     core$_.int c,
   ) {
-    return _valueOf(_class.reference.pointer, _id_valueOf.pointer, c)
+    final _$$classRef = _class.reference;
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, c)
         .object<JCharacter?>();
   }
 }
@@ -9253,7 +9350,8 @@ extension JCharacter$$Methods on JCharacter {
 
   /// from: `public char charValue()`
   core$_.int charValue() {
-    return _charValue(reference.pointer, _id_charValue.pointer).char;
+    final _$$selfRef = reference;
+    return _charValue(_$$selfRef.pointer, _id_charValue.pointer).char;
   }
 
   static final _id_compareTo = JCharacter._class.instanceMethodId(
@@ -9276,9 +9374,10 @@ extension JCharacter$$Methods on JCharacter {
   core$_.int compareTo(
     JCharacter? character,
   ) {
+    final _$$selfRef = reference;
     final _$character = character?.reference ?? jni$_.jNullReference;
     return _compareTo(
-            reference.pointer, _id_compareTo.pointer, _$character.pointer)
+            _$$selfRef.pointer, _id_compareTo.pointer, _$character.pointer)
         .integer;
   }
 
@@ -9302,8 +9401,9 @@ extension JCharacter$$Methods on JCharacter {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -9326,7 +9426,8 @@ extension JCharacter$$Methods on JCharacter {
 
   /// from: `public int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_toString$1 = JCharacter._class.instanceMethodId(
@@ -9349,7 +9450,8 @@ extension JCharacter$$Methods on JCharacter {
   /// from: `public java.lang.String toString()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<JString?>();
   }
 
@@ -9467,8 +9569,8 @@ extension type JDouble._(jni$_.JObject _$this)
   factory JDouble(
     core$_.double d,
   ) {
-    return _new$(_class.reference.pointer, _id_new$.pointer, d)
-        .object<JDouble>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer, d).object<JDouble>();
   }
 
   static final _id_compare = _class.staticMethodId(
@@ -9492,8 +9594,8 @@ extension type JDouble._(jni$_.JObject _$this)
     core$_.double d,
     core$_.double d1,
   ) {
-    return _compare(_class.reference.pointer, _id_compare.pointer, d, d1)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _compare(_$$classRef.pointer, _id_compare.pointer, d, d1).integer;
   }
 
   static final _id_doubleToLongBits = _class.staticMethodId(
@@ -9514,8 +9616,9 @@ extension type JDouble._(jni$_.JObject _$this)
   static core$_.int doubleToLongBits(
     core$_.double d,
   ) {
+    final _$$classRef = _class.reference;
     return _doubleToLongBits(
-            _class.reference.pointer, _id_doubleToLongBits.pointer, d)
+            _$$classRef.pointer, _id_doubleToLongBits.pointer, d)
         .long;
   }
 
@@ -9537,8 +9640,9 @@ extension type JDouble._(jni$_.JObject _$this)
   static core$_.int doubleToRawLongBits(
     core$_.double d,
   ) {
+    final _$$classRef = _class.reference;
     return _doubleToRawLongBits(
-            _class.reference.pointer, _id_doubleToRawLongBits.pointer, d)
+            _$$classRef.pointer, _id_doubleToRawLongBits.pointer, d)
         .long;
   }
 
@@ -9560,8 +9664,8 @@ extension type JDouble._(jni$_.JObject _$this)
   static core$_.int hashCode$2(
     core$_.double d,
   ) {
-    return _hashCode$2(_class.reference.pointer, _id_hashCode$2.pointer, d)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _hashCode$2(_$$classRef.pointer, _id_hashCode$2.pointer, d).integer;
   }
 
   static final _id_isFinite = _class.staticMethodId(
@@ -9582,7 +9686,8 @@ extension type JDouble._(jni$_.JObject _$this)
   static core$_.bool isFinite(
     core$_.double d,
   ) {
-    return _isFinite(_class.reference.pointer, _id_isFinite.pointer, d).boolean;
+    final _$$classRef = _class.reference;
+    return _isFinite(_$$classRef.pointer, _id_isFinite.pointer, d).boolean;
   }
 
   static final _id_isInfinite$1 = _class.staticMethodId(
@@ -9603,7 +9708,8 @@ extension type JDouble._(jni$_.JObject _$this)
   static core$_.bool isInfinite$1(
     core$_.double d,
   ) {
-    return _isInfinite$1(_class.reference.pointer, _id_isInfinite$1.pointer, d)
+    final _$$classRef = _class.reference;
+    return _isInfinite$1(_$$classRef.pointer, _id_isInfinite$1.pointer, d)
         .boolean;
   }
 
@@ -9625,7 +9731,8 @@ extension type JDouble._(jni$_.JObject _$this)
   static core$_.bool isNaN$1(
     core$_.double d,
   ) {
-    return _isNaN$1(_class.reference.pointer, _id_isNaN$1.pointer, d).boolean;
+    final _$$classRef = _class.reference;
+    return _isNaN$1(_$$classRef.pointer, _id_isNaN$1.pointer, d).boolean;
   }
 
   static final _id_longBitsToDouble = _class.staticMethodId(
@@ -9646,8 +9753,9 @@ extension type JDouble._(jni$_.JObject _$this)
   static core$_.double longBitsToDouble(
     core$_.int j,
   ) {
+    final _$$classRef = _class.reference;
     return _longBitsToDouble(
-            _class.reference.pointer, _id_longBitsToDouble.pointer, j)
+            _$$classRef.pointer, _id_longBitsToDouble.pointer, j)
         .doubleFloat;
   }
 
@@ -9672,7 +9780,8 @@ extension type JDouble._(jni$_.JObject _$this)
     core$_.double d,
     core$_.double d1,
   ) {
-    return _max(_class.reference.pointer, _id_max.pointer, d, d1).doubleFloat;
+    final _$$classRef = _class.reference;
+    return _max(_$$classRef.pointer, _id_max.pointer, d, d1).doubleFloat;
   }
 
   static final _id_min = _class.staticMethodId(
@@ -9696,7 +9805,8 @@ extension type JDouble._(jni$_.JObject _$this)
     core$_.double d,
     core$_.double d1,
   ) {
-    return _min(_class.reference.pointer, _id_min.pointer, d, d1).doubleFloat;
+    final _$$classRef = _class.reference;
+    return _min(_$$classRef.pointer, _id_min.pointer, d, d1).doubleFloat;
   }
 
   static final _id_parseDouble = _class.staticMethodId(
@@ -9719,9 +9829,10 @@ extension type JDouble._(jni$_.JObject _$this)
   static core$_.double parseDouble(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _parseDouble(
-            _class.reference.pointer, _id_parseDouble.pointer, _$string.pointer)
+            _$$classRef.pointer, _id_parseDouble.pointer, _$string.pointer)
         .doubleFloat;
   }
 
@@ -9746,7 +9857,8 @@ extension type JDouble._(jni$_.JObject _$this)
     core$_.double d,
     core$_.double d1,
   ) {
-    return _sum(_class.reference.pointer, _id_sum.pointer, d, d1).doubleFloat;
+    final _$$classRef = _class.reference;
+    return _sum(_$$classRef.pointer, _id_sum.pointer, d, d1).doubleFloat;
   }
 
   static final _id_toHexString = _class.staticMethodId(
@@ -9768,7 +9880,8 @@ extension type JDouble._(jni$_.JObject _$this)
   static JString? toHexString(
     core$_.double d,
   ) {
-    return _toHexString(_class.reference.pointer, _id_toHexString.pointer, d)
+    final _$$classRef = _class.reference;
+    return _toHexString(_$$classRef.pointer, _id_toHexString.pointer, d)
         .object<JString?>();
   }
 
@@ -9791,7 +9904,8 @@ extension type JDouble._(jni$_.JObject _$this)
   static JString? toString$2(
     core$_.double d,
   ) {
-    return _toString$2(_class.reference.pointer, _id_toString$2.pointer, d)
+    final _$$classRef = _class.reference;
+    return _toString$2(_$$classRef.pointer, _id_toString$2.pointer, d)
         .object<JString?>();
   }
 
@@ -9814,7 +9928,8 @@ extension type JDouble._(jni$_.JObject _$this)
   static JDouble? valueOf(
     core$_.double d,
   ) {
-    return _valueOf(_class.reference.pointer, _id_valueOf.pointer, d)
+    final _$$classRef = _class.reference;
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, d)
         .object<JDouble?>();
   }
 
@@ -9839,9 +9954,10 @@ extension type JDouble._(jni$_.JObject _$this)
   static JDouble? valueOf$1(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _valueOf$1(
-            _class.reference.pointer, _id_valueOf$1.pointer, _$string.pointer)
+            _$$classRef.pointer, _id_valueOf$1.pointer, _$string.pointer)
         .object<JDouble?>();
   }
 }
@@ -9866,7 +9982,8 @@ extension JDouble$$Methods on JDouble {
 
   /// from: `public byte byteValue()`
   core$_.int byteValue() {
-    return _byteValue(reference.pointer, _id_byteValue.pointer).byte;
+    final _$$selfRef = reference;
+    return _byteValue(_$$selfRef.pointer, _id_byteValue.pointer).byte;
   }
 
   static final _id_compareTo = JDouble._class.instanceMethodId(
@@ -9889,9 +10006,10 @@ extension JDouble$$Methods on JDouble {
   core$_.int compareTo(
     JDouble? double,
   ) {
+    final _$$selfRef = reference;
     final _$double = double?.reference ?? jni$_.jNullReference;
     return _compareTo(
-            reference.pointer, _id_compareTo.pointer, _$double.pointer)
+            _$$selfRef.pointer, _id_compareTo.pointer, _$double.pointer)
         .integer;
   }
 
@@ -9914,7 +10032,9 @@ extension JDouble$$Methods on JDouble {
 
   /// from: `public double doubleValue()`
   core$_.double doubleValue() {
-    return _doubleValue(reference.pointer, _id_doubleValue.pointer).doubleFloat;
+    final _$$selfRef = reference;
+    return _doubleValue(_$$selfRef.pointer, _id_doubleValue.pointer)
+        .doubleFloat;
   }
 
   static final _id_equals = JDouble._class.instanceMethodId(
@@ -9937,8 +10057,9 @@ extension JDouble$$Methods on JDouble {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -9961,7 +10082,8 @@ extension JDouble$$Methods on JDouble {
 
   /// from: `public float floatValue()`
   core$_.double floatValue() {
-    return _floatValue(reference.pointer, _id_floatValue.pointer).float;
+    final _$$selfRef = reference;
+    return _floatValue(_$$selfRef.pointer, _id_floatValue.pointer).float;
   }
 
   static final _id_hashCode$1 = JDouble._class.instanceMethodId(
@@ -9983,7 +10105,8 @@ extension JDouble$$Methods on JDouble {
 
   /// from: `public int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_intValue = JDouble._class.instanceMethodId(
@@ -10005,7 +10128,8 @@ extension JDouble$$Methods on JDouble {
 
   /// from: `public int intValue()`
   core$_.int intValue() {
-    return _intValue(reference.pointer, _id_intValue.pointer).integer;
+    final _$$selfRef = reference;
+    return _intValue(_$$selfRef.pointer, _id_intValue.pointer).integer;
   }
 
   static final _id_get$isInfinite = JDouble._class.instanceMethodId(
@@ -10027,7 +10151,8 @@ extension JDouble$$Methods on JDouble {
 
   /// from: `public boolean isInfinite()`
   core$_.bool get isInfinite {
-    return _get$isInfinite(reference.pointer, _id_get$isInfinite.pointer)
+    final _$$selfRef = reference;
+    return _get$isInfinite(_$$selfRef.pointer, _id_get$isInfinite.pointer)
         .boolean;
   }
 
@@ -10050,7 +10175,8 @@ extension JDouble$$Methods on JDouble {
 
   /// from: `public boolean isNaN()`
   core$_.bool get isNaN {
-    return _get$isNaN(reference.pointer, _id_get$isNaN.pointer).boolean;
+    final _$$selfRef = reference;
+    return _get$isNaN(_$$selfRef.pointer, _id_get$isNaN.pointer).boolean;
   }
 
   static final _id_longValue = JDouble._class.instanceMethodId(
@@ -10072,7 +10198,8 @@ extension JDouble$$Methods on JDouble {
 
   /// from: `public long longValue()`
   core$_.int longValue() {
-    return _longValue(reference.pointer, _id_longValue.pointer).long;
+    final _$$selfRef = reference;
+    return _longValue(_$$selfRef.pointer, _id_longValue.pointer).long;
   }
 
   static final _id_shortValue = JDouble._class.instanceMethodId(
@@ -10094,7 +10221,8 @@ extension JDouble$$Methods on JDouble {
 
   /// from: `public short shortValue()`
   core$_.int shortValue() {
-    return _shortValue(reference.pointer, _id_shortValue.pointer).short;
+    final _$$selfRef = reference;
+    return _shortValue(_$$selfRef.pointer, _id_shortValue.pointer).short;
   }
 
   static final _id_toString$1 = JDouble._class.instanceMethodId(
@@ -10117,7 +10245,8 @@ extension JDouble$$Methods on JDouble {
   /// from: `public java.lang.String toString()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<JString?>();
   }
 
@@ -10235,8 +10364,8 @@ extension type JFloat._(jni$_.JObject _$this)
   factory JFloat(
     core$_.double f,
   ) {
-    return _new$(_class.reference.pointer, _id_new$.pointer, f)
-        .object<JFloat>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer, f).object<JFloat>();
   }
 
   static final _id_compare = _class.staticMethodId(
@@ -10260,8 +10389,8 @@ extension type JFloat._(jni$_.JObject _$this)
     core$_.double f,
     core$_.double f1,
   ) {
-    return _compare(_class.reference.pointer, _id_compare.pointer, f, f1)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _compare(_$$classRef.pointer, _id_compare.pointer, f, f1).integer;
   }
 
   static final _id_float16ToFloat = _class.staticMethodId(
@@ -10282,8 +10411,8 @@ extension type JFloat._(jni$_.JObject _$this)
   static core$_.double float16ToFloat(
     core$_.int s,
   ) {
-    return _float16ToFloat(
-            _class.reference.pointer, _id_float16ToFloat.pointer, s)
+    final _$$classRef = _class.reference;
+    return _float16ToFloat(_$$classRef.pointer, _id_float16ToFloat.pointer, s)
         .float;
   }
 
@@ -10305,8 +10434,8 @@ extension type JFloat._(jni$_.JObject _$this)
   static core$_.int floatToFloat16(
     core$_.double f,
   ) {
-    return _floatToFloat16(
-            _class.reference.pointer, _id_floatToFloat16.pointer, f)
+    final _$$classRef = _class.reference;
+    return _floatToFloat16(_$$classRef.pointer, _id_floatToFloat16.pointer, f)
         .short;
   }
 
@@ -10328,8 +10457,8 @@ extension type JFloat._(jni$_.JObject _$this)
   static core$_.int floatToIntBits(
     core$_.double f,
   ) {
-    return _floatToIntBits(
-            _class.reference.pointer, _id_floatToIntBits.pointer, f)
+    final _$$classRef = _class.reference;
+    return _floatToIntBits(_$$classRef.pointer, _id_floatToIntBits.pointer, f)
         .integer;
   }
 
@@ -10351,8 +10480,9 @@ extension type JFloat._(jni$_.JObject _$this)
   static core$_.int floatToRawIntBits(
     core$_.double f,
   ) {
+    final _$$classRef = _class.reference;
     return _floatToRawIntBits(
-            _class.reference.pointer, _id_floatToRawIntBits.pointer, f)
+            _$$classRef.pointer, _id_floatToRawIntBits.pointer, f)
         .integer;
   }
 
@@ -10374,8 +10504,8 @@ extension type JFloat._(jni$_.JObject _$this)
   static core$_.int hashCode$2(
     core$_.double f,
   ) {
-    return _hashCode$2(_class.reference.pointer, _id_hashCode$2.pointer, f)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _hashCode$2(_$$classRef.pointer, _id_hashCode$2.pointer, f).integer;
   }
 
   static final _id_intBitsToFloat = _class.staticMethodId(
@@ -10396,8 +10526,8 @@ extension type JFloat._(jni$_.JObject _$this)
   static core$_.double intBitsToFloat(
     core$_.int i,
   ) {
-    return _intBitsToFloat(
-            _class.reference.pointer, _id_intBitsToFloat.pointer, i)
+    final _$$classRef = _class.reference;
+    return _intBitsToFloat(_$$classRef.pointer, _id_intBitsToFloat.pointer, i)
         .float;
   }
 
@@ -10419,7 +10549,8 @@ extension type JFloat._(jni$_.JObject _$this)
   static core$_.bool isFinite(
     core$_.double f,
   ) {
-    return _isFinite(_class.reference.pointer, _id_isFinite.pointer, f).boolean;
+    final _$$classRef = _class.reference;
+    return _isFinite(_$$classRef.pointer, _id_isFinite.pointer, f).boolean;
   }
 
   static final _id_isInfinite$1 = _class.staticMethodId(
@@ -10440,7 +10571,8 @@ extension type JFloat._(jni$_.JObject _$this)
   static core$_.bool isInfinite$1(
     core$_.double f,
   ) {
-    return _isInfinite$1(_class.reference.pointer, _id_isInfinite$1.pointer, f)
+    final _$$classRef = _class.reference;
+    return _isInfinite$1(_$$classRef.pointer, _id_isInfinite$1.pointer, f)
         .boolean;
   }
 
@@ -10462,7 +10594,8 @@ extension type JFloat._(jni$_.JObject _$this)
   static core$_.bool isNaN$1(
     core$_.double f,
   ) {
-    return _isNaN$1(_class.reference.pointer, _id_isNaN$1.pointer, f).boolean;
+    final _$$classRef = _class.reference;
+    return _isNaN$1(_$$classRef.pointer, _id_isNaN$1.pointer, f).boolean;
   }
 
   static final _id_max = _class.staticMethodId(
@@ -10486,7 +10619,8 @@ extension type JFloat._(jni$_.JObject _$this)
     core$_.double f,
     core$_.double f1,
   ) {
-    return _max(_class.reference.pointer, _id_max.pointer, f, f1).float;
+    final _$$classRef = _class.reference;
+    return _max(_$$classRef.pointer, _id_max.pointer, f, f1).float;
   }
 
   static final _id_min = _class.staticMethodId(
@@ -10510,7 +10644,8 @@ extension type JFloat._(jni$_.JObject _$this)
     core$_.double f,
     core$_.double f1,
   ) {
-    return _min(_class.reference.pointer, _id_min.pointer, f, f1).float;
+    final _$$classRef = _class.reference;
+    return _min(_$$classRef.pointer, _id_min.pointer, f, f1).float;
   }
 
   static final _id_parseFloat = _class.staticMethodId(
@@ -10533,9 +10668,10 @@ extension type JFloat._(jni$_.JObject _$this)
   static core$_.double parseFloat(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _parseFloat(
-            _class.reference.pointer, _id_parseFloat.pointer, _$string.pointer)
+            _$$classRef.pointer, _id_parseFloat.pointer, _$string.pointer)
         .float;
   }
 
@@ -10560,7 +10696,8 @@ extension type JFloat._(jni$_.JObject _$this)
     core$_.double f,
     core$_.double f1,
   ) {
-    return _sum(_class.reference.pointer, _id_sum.pointer, f, f1).float;
+    final _$$classRef = _class.reference;
+    return _sum(_$$classRef.pointer, _id_sum.pointer, f, f1).float;
   }
 
   static final _id_toHexString = _class.staticMethodId(
@@ -10582,7 +10719,8 @@ extension type JFloat._(jni$_.JObject _$this)
   static JString? toHexString(
     core$_.double f,
   ) {
-    return _toHexString(_class.reference.pointer, _id_toHexString.pointer, f)
+    final _$$classRef = _class.reference;
+    return _toHexString(_$$classRef.pointer, _id_toHexString.pointer, f)
         .object<JString?>();
   }
 
@@ -10605,7 +10743,8 @@ extension type JFloat._(jni$_.JObject _$this)
   static JString? toString$2(
     core$_.double f,
   ) {
-    return _toString$2(_class.reference.pointer, _id_toString$2.pointer, f)
+    final _$$classRef = _class.reference;
+    return _toString$2(_$$classRef.pointer, _id_toString$2.pointer, f)
         .object<JString?>();
   }
 
@@ -10628,7 +10767,8 @@ extension type JFloat._(jni$_.JObject _$this)
   static JFloat? valueOf(
     core$_.double f,
   ) {
-    return _valueOf(_class.reference.pointer, _id_valueOf.pointer, f)
+    final _$$classRef = _class.reference;
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, f)
         .object<JFloat?>();
   }
 
@@ -10653,9 +10793,10 @@ extension type JFloat._(jni$_.JObject _$this)
   static JFloat? valueOf$1(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _valueOf$1(
-            _class.reference.pointer, _id_valueOf$1.pointer, _$string.pointer)
+            _$$classRef.pointer, _id_valueOf$1.pointer, _$string.pointer)
         .object<JFloat?>();
   }
 }
@@ -10680,7 +10821,8 @@ extension JFloat$$Methods on JFloat {
 
   /// from: `public byte byteValue()`
   core$_.int byteValue() {
-    return _byteValue(reference.pointer, _id_byteValue.pointer).byte;
+    final _$$selfRef = reference;
+    return _byteValue(_$$selfRef.pointer, _id_byteValue.pointer).byte;
   }
 
   static final _id_compareTo = JFloat._class.instanceMethodId(
@@ -10703,8 +10845,10 @@ extension JFloat$$Methods on JFloat {
   core$_.int compareTo(
     JFloat? float,
   ) {
+    final _$$selfRef = reference;
     final _$float = float?.reference ?? jni$_.jNullReference;
-    return _compareTo(reference.pointer, _id_compareTo.pointer, _$float.pointer)
+    return _compareTo(
+            _$$selfRef.pointer, _id_compareTo.pointer, _$float.pointer)
         .integer;
   }
 
@@ -10727,7 +10871,9 @@ extension JFloat$$Methods on JFloat {
 
   /// from: `public double doubleValue()`
   core$_.double doubleValue() {
-    return _doubleValue(reference.pointer, _id_doubleValue.pointer).doubleFloat;
+    final _$$selfRef = reference;
+    return _doubleValue(_$$selfRef.pointer, _id_doubleValue.pointer)
+        .doubleFloat;
   }
 
   static final _id_equals = JFloat._class.instanceMethodId(
@@ -10750,8 +10896,9 @@ extension JFloat$$Methods on JFloat {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -10774,7 +10921,8 @@ extension JFloat$$Methods on JFloat {
 
   /// from: `public float floatValue()`
   core$_.double floatValue() {
-    return _floatValue(reference.pointer, _id_floatValue.pointer).float;
+    final _$$selfRef = reference;
+    return _floatValue(_$$selfRef.pointer, _id_floatValue.pointer).float;
   }
 
   static final _id_hashCode$1 = JFloat._class.instanceMethodId(
@@ -10796,7 +10944,8 @@ extension JFloat$$Methods on JFloat {
 
   /// from: `public int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_intValue = JFloat._class.instanceMethodId(
@@ -10818,7 +10967,8 @@ extension JFloat$$Methods on JFloat {
 
   /// from: `public int intValue()`
   core$_.int intValue() {
-    return _intValue(reference.pointer, _id_intValue.pointer).integer;
+    final _$$selfRef = reference;
+    return _intValue(_$$selfRef.pointer, _id_intValue.pointer).integer;
   }
 
   static final _id_get$isInfinite = JFloat._class.instanceMethodId(
@@ -10840,7 +10990,8 @@ extension JFloat$$Methods on JFloat {
 
   /// from: `public boolean isInfinite()`
   core$_.bool get isInfinite {
-    return _get$isInfinite(reference.pointer, _id_get$isInfinite.pointer)
+    final _$$selfRef = reference;
+    return _get$isInfinite(_$$selfRef.pointer, _id_get$isInfinite.pointer)
         .boolean;
   }
 
@@ -10863,7 +11014,8 @@ extension JFloat$$Methods on JFloat {
 
   /// from: `public boolean isNaN()`
   core$_.bool get isNaN {
-    return _get$isNaN(reference.pointer, _id_get$isNaN.pointer).boolean;
+    final _$$selfRef = reference;
+    return _get$isNaN(_$$selfRef.pointer, _id_get$isNaN.pointer).boolean;
   }
 
   static final _id_longValue = JFloat._class.instanceMethodId(
@@ -10885,7 +11037,8 @@ extension JFloat$$Methods on JFloat {
 
   /// from: `public long longValue()`
   core$_.int longValue() {
-    return _longValue(reference.pointer, _id_longValue.pointer).long;
+    final _$$selfRef = reference;
+    return _longValue(_$$selfRef.pointer, _id_longValue.pointer).long;
   }
 
   static final _id_shortValue = JFloat._class.instanceMethodId(
@@ -10907,7 +11060,8 @@ extension JFloat$$Methods on JFloat {
 
   /// from: `public short shortValue()`
   core$_.int shortValue() {
-    return _shortValue(reference.pointer, _id_shortValue.pointer).short;
+    final _$$selfRef = reference;
+    return _shortValue(_$$selfRef.pointer, _id_shortValue.pointer).short;
   }
 
   static final _id_toString$1 = JFloat._class.instanceMethodId(
@@ -10930,7 +11084,8 @@ extension JFloat$$Methods on JFloat {
   /// from: `public java.lang.String toString()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<JString?>();
   }
 
@@ -11008,8 +11163,8 @@ extension type JInteger._(jni$_.JObject _$this)
   factory JInteger(
     core$_.int i,
   ) {
-    return _new$(_class.reference.pointer, _id_new$.pointer, i)
-        .object<JInteger>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer, i).object<JInteger>();
   }
 
   static final _id_bitCount = _class.staticMethodId(
@@ -11030,7 +11185,8 @@ extension type JInteger._(jni$_.JObject _$this)
   static core$_.int bitCount(
     core$_.int i,
   ) {
-    return _bitCount(_class.reference.pointer, _id_bitCount.pointer, i).integer;
+    final _$$classRef = _class.reference;
+    return _bitCount(_$$classRef.pointer, _id_bitCount.pointer, i).integer;
   }
 
   static final _id_compare = _class.staticMethodId(
@@ -11054,8 +11210,8 @@ extension type JInteger._(jni$_.JObject _$this)
     core$_.int i,
     core$_.int i1,
   ) {
-    return _compare(_class.reference.pointer, _id_compare.pointer, i, i1)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _compare(_$$classRef.pointer, _id_compare.pointer, i, i1).integer;
   }
 
   static final _id_compareUnsigned = _class.staticMethodId(
@@ -11079,8 +11235,9 @@ extension type JInteger._(jni$_.JObject _$this)
     core$_.int i,
     core$_.int i1,
   ) {
+    final _$$classRef = _class.reference;
     return _compareUnsigned(
-            _class.reference.pointer, _id_compareUnsigned.pointer, i, i1)
+            _$$classRef.pointer, _id_compareUnsigned.pointer, i, i1)
         .integer;
   }
 
@@ -11105,8 +11262,8 @@ extension type JInteger._(jni$_.JObject _$this)
     core$_.int i,
     core$_.int i1,
   ) {
-    return _compress(_class.reference.pointer, _id_compress.pointer, i, i1)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _compress(_$$classRef.pointer, _id_compress.pointer, i, i1).integer;
   }
 
   static final _id_decode = _class.staticMethodId(
@@ -11130,9 +11287,9 @@ extension type JInteger._(jni$_.JObject _$this)
   static JInteger? decode(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _decode(
-            _class.reference.pointer, _id_decode.pointer, _$string.pointer)
+    return _decode(_$$classRef.pointer, _id_decode.pointer, _$string.pointer)
         .object<JInteger?>();
   }
 
@@ -11157,8 +11314,9 @@ extension type JInteger._(jni$_.JObject _$this)
     core$_.int i,
     core$_.int i1,
   ) {
+    final _$$classRef = _class.reference;
     return _divideUnsigned(
-            _class.reference.pointer, _id_divideUnsigned.pointer, i, i1)
+            _$$classRef.pointer, _id_divideUnsigned.pointer, i, i1)
         .integer;
   }
 
@@ -11183,7 +11341,8 @@ extension type JInteger._(jni$_.JObject _$this)
     core$_.int i,
     core$_.int i1,
   ) {
-    return _expand(_class.reference.pointer, _id_expand.pointer, i, i1).integer;
+    final _$$classRef = _class.reference;
+    return _expand(_$$classRef.pointer, _id_expand.pointer, i, i1).integer;
   }
 
   static final _id_getInteger = _class.staticMethodId(
@@ -11207,9 +11366,10 @@ extension type JInteger._(jni$_.JObject _$this)
   static JInteger? getInteger(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _getInteger(
-            _class.reference.pointer, _id_getInteger.pointer, _$string.pointer)
+            _$$classRef.pointer, _id_getInteger.pointer, _$string.pointer)
         .object<JInteger?>();
   }
 
@@ -11236,9 +11396,10 @@ extension type JInteger._(jni$_.JObject _$this)
     JString? string,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _getInteger$1(_class.reference.pointer, _id_getInteger$1.pointer,
-            _$string.pointer, i)
+    return _getInteger$1(
+            _$$classRef.pointer, _id_getInteger$1.pointer, _$string.pointer, i)
         .object<JInteger?>();
   }
 
@@ -11270,9 +11431,10 @@ extension type JInteger._(jni$_.JObject _$this)
     JString? string,
     JInteger? integer,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$integer = integer?.reference ?? jni$_.jNullReference;
-    return _getInteger$2(_class.reference.pointer, _id_getInteger$2.pointer,
+    return _getInteger$2(_$$classRef.pointer, _id_getInteger$2.pointer,
             _$string.pointer, _$integer.pointer)
         .object<JInteger?>();
   }
@@ -11295,8 +11457,8 @@ extension type JInteger._(jni$_.JObject _$this)
   static core$_.int hashCode$2(
     core$_.int i,
   ) {
-    return _hashCode$2(_class.reference.pointer, _id_hashCode$2.pointer, i)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _hashCode$2(_$$classRef.pointer, _id_hashCode$2.pointer, i).integer;
   }
 
   static final _id_highestOneBit = _class.staticMethodId(
@@ -11317,8 +11479,8 @@ extension type JInteger._(jni$_.JObject _$this)
   static core$_.int highestOneBit(
     core$_.int i,
   ) {
-    return _highestOneBit(
-            _class.reference.pointer, _id_highestOneBit.pointer, i)
+    final _$$classRef = _class.reference;
+    return _highestOneBit(_$$classRef.pointer, _id_highestOneBit.pointer, i)
         .integer;
   }
 
@@ -11340,7 +11502,8 @@ extension type JInteger._(jni$_.JObject _$this)
   static core$_.int lowestOneBit(
     core$_.int i,
   ) {
-    return _lowestOneBit(_class.reference.pointer, _id_lowestOneBit.pointer, i)
+    final _$$classRef = _class.reference;
+    return _lowestOneBit(_$$classRef.pointer, _id_lowestOneBit.pointer, i)
         .integer;
   }
 
@@ -11365,7 +11528,8 @@ extension type JInteger._(jni$_.JObject _$this)
     core$_.int i,
     core$_.int i1,
   ) {
-    return _max(_class.reference.pointer, _id_max.pointer, i, i1).integer;
+    final _$$classRef = _class.reference;
+    return _max(_$$classRef.pointer, _id_max.pointer, i, i1).integer;
   }
 
   static final _id_min = _class.staticMethodId(
@@ -11389,7 +11553,8 @@ extension type JInteger._(jni$_.JObject _$this)
     core$_.int i,
     core$_.int i1,
   ) {
-    return _min(_class.reference.pointer, _id_min.pointer, i, i1).integer;
+    final _$$classRef = _class.reference;
+    return _min(_$$classRef.pointer, _id_min.pointer, i, i1).integer;
   }
 
   static final _id_numberOfLeadingZeros = _class.staticMethodId(
@@ -11410,8 +11575,9 @@ extension type JInteger._(jni$_.JObject _$this)
   static core$_.int numberOfLeadingZeros(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _numberOfLeadingZeros(
-            _class.reference.pointer, _id_numberOfLeadingZeros.pointer, i)
+            _$$classRef.pointer, _id_numberOfLeadingZeros.pointer, i)
         .integer;
   }
 
@@ -11433,8 +11599,9 @@ extension type JInteger._(jni$_.JObject _$this)
   static core$_.int numberOfTrailingZeros(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _numberOfTrailingZeros(
-            _class.reference.pointer, _id_numberOfTrailingZeros.pointer, i)
+            _$$classRef.pointer, _id_numberOfTrailingZeros.pointer, i)
         .integer;
   }
 
@@ -11471,8 +11638,9 @@ extension type JInteger._(jni$_.JObject _$this)
     core$_.int i1,
     core$_.int i2,
   ) {
+    final _$$classRef = _class.reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
-    return _parseInt(_class.reference.pointer, _id_parseInt.pointer,
+    return _parseInt(_$$classRef.pointer, _id_parseInt.pointer,
             _$charSequence.pointer, i, i1, i2)
         .integer;
   }
@@ -11497,9 +11665,10 @@ extension type JInteger._(jni$_.JObject _$this)
   static core$_.int parseInt$1(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _parseInt$1(
-            _class.reference.pointer, _id_parseInt$1.pointer, _$string.pointer)
+            _$$classRef.pointer, _id_parseInt$1.pointer, _$string.pointer)
         .integer;
   }
 
@@ -11525,9 +11694,10 @@ extension type JInteger._(jni$_.JObject _$this)
     JString? string,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _parseInt$2(_class.reference.pointer, _id_parseInt$2.pointer,
-            _$string.pointer, i)
+    return _parseInt$2(
+            _$$classRef.pointer, _id_parseInt$2.pointer, _$string.pointer, i)
         .integer;
   }
 
@@ -11564,9 +11734,10 @@ extension type JInteger._(jni$_.JObject _$this)
     core$_.int i1,
     core$_.int i2,
   ) {
+    final _$$classRef = _class.reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
-    return _parseUnsignedInt(_class.reference.pointer,
-            _id_parseUnsignedInt.pointer, _$charSequence.pointer, i, i1, i2)
+    return _parseUnsignedInt(_$$classRef.pointer, _id_parseUnsignedInt.pointer,
+            _$charSequence.pointer, i, i1, i2)
         .integer;
   }
 
@@ -11590,8 +11761,9 @@ extension type JInteger._(jni$_.JObject _$this)
   static core$_.int parseUnsignedInt$1(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _parseUnsignedInt$1(_class.reference.pointer,
+    return _parseUnsignedInt$1(_$$classRef.pointer,
             _id_parseUnsignedInt$1.pointer, _$string.pointer)
         .integer;
   }
@@ -11618,8 +11790,9 @@ extension type JInteger._(jni$_.JObject _$this)
     JString? string,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _parseUnsignedInt$2(_class.reference.pointer,
+    return _parseUnsignedInt$2(_$$classRef.pointer,
             _id_parseUnsignedInt$2.pointer, _$string.pointer, i)
         .integer;
   }
@@ -11645,8 +11818,9 @@ extension type JInteger._(jni$_.JObject _$this)
     core$_.int i,
     core$_.int i1,
   ) {
+    final _$$classRef = _class.reference;
     return _remainderUnsigned(
-            _class.reference.pointer, _id_remainderUnsigned.pointer, i, i1)
+            _$$classRef.pointer, _id_remainderUnsigned.pointer, i, i1)
         .integer;
   }
 
@@ -11668,7 +11842,8 @@ extension type JInteger._(jni$_.JObject _$this)
   static core$_.int reverse(
     core$_.int i,
   ) {
-    return _reverse(_class.reference.pointer, _id_reverse.pointer, i).integer;
+    final _$$classRef = _class.reference;
+    return _reverse(_$$classRef.pointer, _id_reverse.pointer, i).integer;
   }
 
   static final _id_reverseBytes = _class.staticMethodId(
@@ -11689,7 +11864,8 @@ extension type JInteger._(jni$_.JObject _$this)
   static core$_.int reverseBytes(
     core$_.int i,
   ) {
-    return _reverseBytes(_class.reference.pointer, _id_reverseBytes.pointer, i)
+    final _$$classRef = _class.reference;
+    return _reverseBytes(_$$classRef.pointer, _id_reverseBytes.pointer, i)
         .integer;
   }
 
@@ -11714,7 +11890,8 @@ extension type JInteger._(jni$_.JObject _$this)
     core$_.int i,
     core$_.int i1,
   ) {
-    return _rotateLeft(_class.reference.pointer, _id_rotateLeft.pointer, i, i1)
+    final _$$classRef = _class.reference;
+    return _rotateLeft(_$$classRef.pointer, _id_rotateLeft.pointer, i, i1)
         .integer;
   }
 
@@ -11739,8 +11916,8 @@ extension type JInteger._(jni$_.JObject _$this)
     core$_.int i,
     core$_.int i1,
   ) {
-    return _rotateRight(
-            _class.reference.pointer, _id_rotateRight.pointer, i, i1)
+    final _$$classRef = _class.reference;
+    return _rotateRight(_$$classRef.pointer, _id_rotateRight.pointer, i, i1)
         .integer;
   }
 
@@ -11762,7 +11939,8 @@ extension type JInteger._(jni$_.JObject _$this)
   static core$_.int signum(
     core$_.int i,
   ) {
-    return _signum(_class.reference.pointer, _id_signum.pointer, i).integer;
+    final _$$classRef = _class.reference;
+    return _signum(_$$classRef.pointer, _id_signum.pointer, i).integer;
   }
 
   static final _id_sum = _class.staticMethodId(
@@ -11786,7 +11964,8 @@ extension type JInteger._(jni$_.JObject _$this)
     core$_.int i,
     core$_.int i1,
   ) {
-    return _sum(_class.reference.pointer, _id_sum.pointer, i, i1).integer;
+    final _$$classRef = _class.reference;
+    return _sum(_$$classRef.pointer, _id_sum.pointer, i, i1).integer;
   }
 
   static final _id_toBinaryString = _class.staticMethodId(
@@ -11808,8 +11987,8 @@ extension type JInteger._(jni$_.JObject _$this)
   static JString? toBinaryString(
     core$_.int i,
   ) {
-    return _toBinaryString(
-            _class.reference.pointer, _id_toBinaryString.pointer, i)
+    final _$$classRef = _class.reference;
+    return _toBinaryString(_$$classRef.pointer, _id_toBinaryString.pointer, i)
         .object<JString?>();
   }
 
@@ -11832,7 +12011,8 @@ extension type JInteger._(jni$_.JObject _$this)
   static JString? toHexString(
     core$_.int i,
   ) {
-    return _toHexString(_class.reference.pointer, _id_toHexString.pointer, i)
+    final _$$classRef = _class.reference;
+    return _toHexString(_$$classRef.pointer, _id_toHexString.pointer, i)
         .object<JString?>();
   }
 
@@ -11855,8 +12035,8 @@ extension type JInteger._(jni$_.JObject _$this)
   static JString? toOctalString(
     core$_.int i,
   ) {
-    return _toOctalString(
-            _class.reference.pointer, _id_toOctalString.pointer, i)
+    final _$$classRef = _class.reference;
+    return _toOctalString(_$$classRef.pointer, _id_toOctalString.pointer, i)
         .object<JString?>();
   }
 
@@ -11879,7 +12059,8 @@ extension type JInteger._(jni$_.JObject _$this)
   static JString? toString$2(
     core$_.int i,
   ) {
-    return _toString$2(_class.reference.pointer, _id_toString$2.pointer, i)
+    final _$$classRef = _class.reference;
+    return _toString$2(_$$classRef.pointer, _id_toString$2.pointer, i)
         .object<JString?>();
   }
 
@@ -11905,7 +12086,8 @@ extension type JInteger._(jni$_.JObject _$this)
     core$_.int i,
     core$_.int i1,
   ) {
-    return _toString$3(_class.reference.pointer, _id_toString$3.pointer, i, i1)
+    final _$$classRef = _class.reference;
+    return _toString$3(_$$classRef.pointer, _id_toString$3.pointer, i, i1)
         .object<JString?>();
   }
 
@@ -11927,8 +12109,8 @@ extension type JInteger._(jni$_.JObject _$this)
   static core$_.int toUnsignedLong(
     core$_.int i,
   ) {
-    return _toUnsignedLong(
-            _class.reference.pointer, _id_toUnsignedLong.pointer, i)
+    final _$$classRef = _class.reference;
+    return _toUnsignedLong(_$$classRef.pointer, _id_toUnsignedLong.pointer, i)
         .long;
   }
 
@@ -11951,8 +12133,9 @@ extension type JInteger._(jni$_.JObject _$this)
   static JString? toUnsignedString(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _toUnsignedString(
-            _class.reference.pointer, _id_toUnsignedString.pointer, i)
+            _$$classRef.pointer, _id_toUnsignedString.pointer, i)
         .object<JString?>();
   }
 
@@ -11978,8 +12161,9 @@ extension type JInteger._(jni$_.JObject _$this)
     core$_.int i,
     core$_.int i1,
   ) {
+    final _$$classRef = _class.reference;
     return _toUnsignedString$1(
-            _class.reference.pointer, _id_toUnsignedString$1.pointer, i, i1)
+            _$$classRef.pointer, _id_toUnsignedString$1.pointer, i, i1)
         .object<JString?>();
   }
 
@@ -12002,7 +12186,8 @@ extension type JInteger._(jni$_.JObject _$this)
   static JInteger? valueOf(
     core$_.int i,
   ) {
-    return _valueOf(_class.reference.pointer, _id_valueOf.pointer, i)
+    final _$$classRef = _class.reference;
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, i)
         .object<JInteger?>();
   }
 
@@ -12027,9 +12212,10 @@ extension type JInteger._(jni$_.JObject _$this)
   static JInteger? valueOf$1(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _valueOf$1(
-            _class.reference.pointer, _id_valueOf$1.pointer, _$string.pointer)
+            _$$classRef.pointer, _id_valueOf$1.pointer, _$string.pointer)
         .object<JInteger?>();
   }
 
@@ -12056,9 +12242,10 @@ extension type JInteger._(jni$_.JObject _$this)
     JString? string,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _valueOf$2(_class.reference.pointer, _id_valueOf$2.pointer,
-            _$string.pointer, i)
+    return _valueOf$2(
+            _$$classRef.pointer, _id_valueOf$2.pointer, _$string.pointer, i)
         .object<JInteger?>();
   }
 }
@@ -12083,7 +12270,8 @@ extension JInteger$$Methods on JInteger {
 
   /// from: `public byte byteValue()`
   core$_.int byteValue() {
-    return _byteValue(reference.pointer, _id_byteValue.pointer).byte;
+    final _$$selfRef = reference;
+    return _byteValue(_$$selfRef.pointer, _id_byteValue.pointer).byte;
   }
 
   static final _id_compareTo = JInteger._class.instanceMethodId(
@@ -12106,9 +12294,10 @@ extension JInteger$$Methods on JInteger {
   core$_.int compareTo(
     JInteger? integer,
   ) {
+    final _$$selfRef = reference;
     final _$integer = integer?.reference ?? jni$_.jNullReference;
     return _compareTo(
-            reference.pointer, _id_compareTo.pointer, _$integer.pointer)
+            _$$selfRef.pointer, _id_compareTo.pointer, _$integer.pointer)
         .integer;
   }
 
@@ -12131,7 +12320,9 @@ extension JInteger$$Methods on JInteger {
 
   /// from: `public double doubleValue()`
   core$_.double doubleValue() {
-    return _doubleValue(reference.pointer, _id_doubleValue.pointer).doubleFloat;
+    final _$$selfRef = reference;
+    return _doubleValue(_$$selfRef.pointer, _id_doubleValue.pointer)
+        .doubleFloat;
   }
 
   static final _id_equals = JInteger._class.instanceMethodId(
@@ -12154,8 +12345,9 @@ extension JInteger$$Methods on JInteger {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -12178,7 +12370,8 @@ extension JInteger$$Methods on JInteger {
 
   /// from: `public float floatValue()`
   core$_.double floatValue() {
-    return _floatValue(reference.pointer, _id_floatValue.pointer).float;
+    final _$$selfRef = reference;
+    return _floatValue(_$$selfRef.pointer, _id_floatValue.pointer).float;
   }
 
   static final _id_hashCode$1 = JInteger._class.instanceMethodId(
@@ -12200,7 +12393,8 @@ extension JInteger$$Methods on JInteger {
 
   /// from: `public int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_intValue = JInteger._class.instanceMethodId(
@@ -12222,7 +12416,8 @@ extension JInteger$$Methods on JInteger {
 
   /// from: `public int intValue()`
   core$_.int intValue() {
-    return _intValue(reference.pointer, _id_intValue.pointer).integer;
+    final _$$selfRef = reference;
+    return _intValue(_$$selfRef.pointer, _id_intValue.pointer).integer;
   }
 
   static final _id_longValue = JInteger._class.instanceMethodId(
@@ -12244,7 +12439,8 @@ extension JInteger$$Methods on JInteger {
 
   /// from: `public long longValue()`
   core$_.int longValue() {
-    return _longValue(reference.pointer, _id_longValue.pointer).long;
+    final _$$selfRef = reference;
+    return _longValue(_$$selfRef.pointer, _id_longValue.pointer).long;
   }
 
   static final _id_shortValue = JInteger._class.instanceMethodId(
@@ -12266,7 +12462,8 @@ extension JInteger$$Methods on JInteger {
 
   /// from: `public short shortValue()`
   core$_.int shortValue() {
-    return _shortValue(reference.pointer, _id_shortValue.pointer).short;
+    final _$$selfRef = reference;
+    return _shortValue(_$$selfRef.pointer, _id_shortValue.pointer).short;
   }
 
   static final _id_toString$1 = JInteger._class.instanceMethodId(
@@ -12289,7 +12486,8 @@ extension JInteger$$Methods on JInteger {
   /// from: `public java.lang.String toString()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<JString?>();
   }
 
@@ -12366,7 +12564,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   factory JLong(
     core$_.int j,
   ) {
-    return _new$(_class.reference.pointer, _id_new$.pointer, j).object<JLong>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer, j).object<JLong>();
   }
 
   static final _id_bitCount = _class.staticMethodId(
@@ -12387,7 +12586,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static core$_.int bitCount(
     core$_.int j,
   ) {
-    return _bitCount(_class.reference.pointer, _id_bitCount.pointer, j).integer;
+    final _$$classRef = _class.reference;
+    return _bitCount(_$$classRef.pointer, _id_bitCount.pointer, j).integer;
   }
 
   static final _id_compare = _class.staticMethodId(
@@ -12411,8 +12611,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int j,
     core$_.int j1,
   ) {
-    return _compare(_class.reference.pointer, _id_compare.pointer, j, j1)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _compare(_$$classRef.pointer, _id_compare.pointer, j, j1).integer;
   }
 
   static final _id_compareUnsigned = _class.staticMethodId(
@@ -12436,8 +12636,9 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int j,
     core$_.int j1,
   ) {
+    final _$$classRef = _class.reference;
     return _compareUnsigned(
-            _class.reference.pointer, _id_compareUnsigned.pointer, j, j1)
+            _$$classRef.pointer, _id_compareUnsigned.pointer, j, j1)
         .integer;
   }
 
@@ -12462,8 +12663,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int j,
     core$_.int j1,
   ) {
-    return _compress(_class.reference.pointer, _id_compress.pointer, j, j1)
-        .long;
+    final _$$classRef = _class.reference;
+    return _compress(_$$classRef.pointer, _id_compress.pointer, j, j1).long;
   }
 
   static final _id_decode = _class.staticMethodId(
@@ -12487,9 +12688,9 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static JLong? decode(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _decode(
-            _class.reference.pointer, _id_decode.pointer, _$string.pointer)
+    return _decode(_$$classRef.pointer, _id_decode.pointer, _$string.pointer)
         .object<JLong?>();
   }
 
@@ -12514,8 +12715,9 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int j,
     core$_.int j1,
   ) {
+    final _$$classRef = _class.reference;
     return _divideUnsigned(
-            _class.reference.pointer, _id_divideUnsigned.pointer, j, j1)
+            _$$classRef.pointer, _id_divideUnsigned.pointer, j, j1)
         .long;
   }
 
@@ -12540,7 +12742,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int j,
     core$_.int j1,
   ) {
-    return _expand(_class.reference.pointer, _id_expand.pointer, j, j1).long;
+    final _$$classRef = _class.reference;
+    return _expand(_$$classRef.pointer, _id_expand.pointer, j, j1).long;
   }
 
   static final _id_getLong = _class.staticMethodId(
@@ -12564,9 +12767,9 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static JLong? getLong(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _getLong(
-            _class.reference.pointer, _id_getLong.pointer, _$string.pointer)
+    return _getLong(_$$classRef.pointer, _id_getLong.pointer, _$string.pointer)
         .object<JLong?>();
   }
 
@@ -12598,9 +12801,10 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     JString? string,
     JLong? long,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
-    return _getLong$1(_class.reference.pointer, _id_getLong$1.pointer,
+    return _getLong$1(_$$classRef.pointer, _id_getLong$1.pointer,
             _$string.pointer, _$long.pointer)
         .object<JLong?>();
   }
@@ -12628,9 +12832,10 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     JString? string,
     core$_.int j,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _getLong$2(_class.reference.pointer, _id_getLong$2.pointer,
-            _$string.pointer, j)
+    return _getLong$2(
+            _$$classRef.pointer, _id_getLong$2.pointer, _$string.pointer, j)
         .object<JLong?>();
   }
 
@@ -12652,8 +12857,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static core$_.int hashCode$2(
     core$_.int j,
   ) {
-    return _hashCode$2(_class.reference.pointer, _id_hashCode$2.pointer, j)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _hashCode$2(_$$classRef.pointer, _id_hashCode$2.pointer, j).integer;
   }
 
   static final _id_highestOneBit = _class.staticMethodId(
@@ -12674,8 +12879,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static core$_.int highestOneBit(
     core$_.int j,
   ) {
-    return _highestOneBit(
-            _class.reference.pointer, _id_highestOneBit.pointer, j)
+    final _$$classRef = _class.reference;
+    return _highestOneBit(_$$classRef.pointer, _id_highestOneBit.pointer, j)
         .long;
   }
 
@@ -12697,8 +12902,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static core$_.int lowestOneBit(
     core$_.int j,
   ) {
-    return _lowestOneBit(_class.reference.pointer, _id_lowestOneBit.pointer, j)
-        .long;
+    final _$$classRef = _class.reference;
+    return _lowestOneBit(_$$classRef.pointer, _id_lowestOneBit.pointer, j).long;
   }
 
   static final _id_max = _class.staticMethodId(
@@ -12722,7 +12927,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int j,
     core$_.int j1,
   ) {
-    return _max(_class.reference.pointer, _id_max.pointer, j, j1).long;
+    final _$$classRef = _class.reference;
+    return _max(_$$classRef.pointer, _id_max.pointer, j, j1).long;
   }
 
   static final _id_min = _class.staticMethodId(
@@ -12746,7 +12952,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int j,
     core$_.int j1,
   ) {
-    return _min(_class.reference.pointer, _id_min.pointer, j, j1).long;
+    final _$$classRef = _class.reference;
+    return _min(_$$classRef.pointer, _id_min.pointer, j, j1).long;
   }
 
   static final _id_numberOfLeadingZeros = _class.staticMethodId(
@@ -12767,8 +12974,9 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static core$_.int numberOfLeadingZeros(
     core$_.int j,
   ) {
+    final _$$classRef = _class.reference;
     return _numberOfLeadingZeros(
-            _class.reference.pointer, _id_numberOfLeadingZeros.pointer, j)
+            _$$classRef.pointer, _id_numberOfLeadingZeros.pointer, j)
         .integer;
   }
 
@@ -12790,8 +12998,9 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static core$_.int numberOfTrailingZeros(
     core$_.int j,
   ) {
+    final _$$classRef = _class.reference;
     return _numberOfTrailingZeros(
-            _class.reference.pointer, _id_numberOfTrailingZeros.pointer, j)
+            _$$classRef.pointer, _id_numberOfTrailingZeros.pointer, j)
         .integer;
   }
 
@@ -12828,8 +13037,9 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int i1,
     core$_.int i2,
   ) {
+    final _$$classRef = _class.reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
-    return _parseLong(_class.reference.pointer, _id_parseLong.pointer,
+    return _parseLong(_$$classRef.pointer, _id_parseLong.pointer,
             _$charSequence.pointer, i, i1, i2)
         .long;
   }
@@ -12854,9 +13064,10 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static core$_.int parseLong$1(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _parseLong$1(
-            _class.reference.pointer, _id_parseLong$1.pointer, _$string.pointer)
+            _$$classRef.pointer, _id_parseLong$1.pointer, _$string.pointer)
         .long;
   }
 
@@ -12882,9 +13093,10 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     JString? string,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _parseLong$2(_class.reference.pointer, _id_parseLong$2.pointer,
-            _$string.pointer, i)
+    return _parseLong$2(
+            _$$classRef.pointer, _id_parseLong$2.pointer, _$string.pointer, i)
         .long;
   }
 
@@ -12921,8 +13133,9 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int i1,
     core$_.int i2,
   ) {
+    final _$$classRef = _class.reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
-    return _parseUnsignedLong(_class.reference.pointer,
+    return _parseUnsignedLong(_$$classRef.pointer,
             _id_parseUnsignedLong.pointer, _$charSequence.pointer, i, i1, i2)
         .long;
   }
@@ -12947,8 +13160,9 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static core$_.int parseUnsignedLong$1(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _parseUnsignedLong$1(_class.reference.pointer,
+    return _parseUnsignedLong$1(_$$classRef.pointer,
             _id_parseUnsignedLong$1.pointer, _$string.pointer)
         .long;
   }
@@ -12975,8 +13189,9 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     JString? string,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _parseUnsignedLong$2(_class.reference.pointer,
+    return _parseUnsignedLong$2(_$$classRef.pointer,
             _id_parseUnsignedLong$2.pointer, _$string.pointer, i)
         .long;
   }
@@ -13002,8 +13217,9 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int j,
     core$_.int j1,
   ) {
+    final _$$classRef = _class.reference;
     return _remainderUnsigned(
-            _class.reference.pointer, _id_remainderUnsigned.pointer, j, j1)
+            _$$classRef.pointer, _id_remainderUnsigned.pointer, j, j1)
         .long;
   }
 
@@ -13025,7 +13241,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static core$_.int reverse(
     core$_.int j,
   ) {
-    return _reverse(_class.reference.pointer, _id_reverse.pointer, j).long;
+    final _$$classRef = _class.reference;
+    return _reverse(_$$classRef.pointer, _id_reverse.pointer, j).long;
   }
 
   static final _id_reverseBytes = _class.staticMethodId(
@@ -13046,8 +13263,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static core$_.int reverseBytes(
     core$_.int j,
   ) {
-    return _reverseBytes(_class.reference.pointer, _id_reverseBytes.pointer, j)
-        .long;
+    final _$$classRef = _class.reference;
+    return _reverseBytes(_$$classRef.pointer, _id_reverseBytes.pointer, j).long;
   }
 
   static final _id_rotateLeft = _class.staticMethodId(
@@ -13071,8 +13288,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int j,
     core$_.int i,
   ) {
-    return _rotateLeft(_class.reference.pointer, _id_rotateLeft.pointer, j, i)
-        .long;
+    final _$$classRef = _class.reference;
+    return _rotateLeft(_$$classRef.pointer, _id_rotateLeft.pointer, j, i).long;
   }
 
   static final _id_rotateRight = _class.staticMethodId(
@@ -13096,7 +13313,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int j,
     core$_.int i,
   ) {
-    return _rotateRight(_class.reference.pointer, _id_rotateRight.pointer, j, i)
+    final _$$classRef = _class.reference;
+    return _rotateRight(_$$classRef.pointer, _id_rotateRight.pointer, j, i)
         .long;
   }
 
@@ -13118,7 +13336,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static core$_.int signum(
     core$_.int j,
   ) {
-    return _signum(_class.reference.pointer, _id_signum.pointer, j).integer;
+    final _$$classRef = _class.reference;
+    return _signum(_$$classRef.pointer, _id_signum.pointer, j).integer;
   }
 
   static final _id_sum = _class.staticMethodId(
@@ -13142,7 +13361,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int j,
     core$_.int j1,
   ) {
-    return _sum(_class.reference.pointer, _id_sum.pointer, j, j1).long;
+    final _$$classRef = _class.reference;
+    return _sum(_$$classRef.pointer, _id_sum.pointer, j, j1).long;
   }
 
   static final _id_toBinaryString = _class.staticMethodId(
@@ -13164,8 +13384,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static JString? toBinaryString(
     core$_.int j,
   ) {
-    return _toBinaryString(
-            _class.reference.pointer, _id_toBinaryString.pointer, j)
+    final _$$classRef = _class.reference;
+    return _toBinaryString(_$$classRef.pointer, _id_toBinaryString.pointer, j)
         .object<JString?>();
   }
 
@@ -13188,7 +13408,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static JString? toHexString(
     core$_.int j,
   ) {
-    return _toHexString(_class.reference.pointer, _id_toHexString.pointer, j)
+    final _$$classRef = _class.reference;
+    return _toHexString(_$$classRef.pointer, _id_toHexString.pointer, j)
         .object<JString?>();
   }
 
@@ -13211,8 +13432,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static JString? toOctalString(
     core$_.int j,
   ) {
-    return _toOctalString(
-            _class.reference.pointer, _id_toOctalString.pointer, j)
+    final _$$classRef = _class.reference;
+    return _toOctalString(_$$classRef.pointer, _id_toOctalString.pointer, j)
         .object<JString?>();
   }
 
@@ -13235,7 +13456,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static JString? toString$2(
     core$_.int j,
   ) {
-    return _toString$2(_class.reference.pointer, _id_toString$2.pointer, j)
+    final _$$classRef = _class.reference;
+    return _toString$2(_$$classRef.pointer, _id_toString$2.pointer, j)
         .object<JString?>();
   }
 
@@ -13261,7 +13483,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int j,
     core$_.int i,
   ) {
-    return _toString$3(_class.reference.pointer, _id_toString$3.pointer, j, i)
+    final _$$classRef = _class.reference;
+    return _toString$3(_$$classRef.pointer, _id_toString$3.pointer, j, i)
         .object<JString?>();
   }
 
@@ -13284,8 +13507,9 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static JString? toUnsignedString(
     core$_.int j,
   ) {
+    final _$$classRef = _class.reference;
     return _toUnsignedString(
-            _class.reference.pointer, _id_toUnsignedString.pointer, j)
+            _$$classRef.pointer, _id_toUnsignedString.pointer, j)
         .object<JString?>();
   }
 
@@ -13311,8 +13535,9 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     core$_.int j,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _toUnsignedString$1(
-            _class.reference.pointer, _id_toUnsignedString$1.pointer, j, i)
+            _$$classRef.pointer, _id_toUnsignedString$1.pointer, j, i)
         .object<JString?>();
   }
 
@@ -13337,9 +13562,9 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static JLong? valueOf(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$string.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$string.pointer)
         .object<JLong?>();
   }
 
@@ -13366,9 +13591,10 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
     JString? string,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _valueOf$1(_class.reference.pointer, _id_valueOf$1.pointer,
-            _$string.pointer, i)
+    return _valueOf$1(
+            _$$classRef.pointer, _id_valueOf$1.pointer, _$string.pointer, i)
         .object<JLong?>();
   }
 
@@ -13391,7 +13617,8 @@ extension type JLong._(jni$_.JObject _$this) implements JNumber, jni$_.JObject {
   static JLong? valueOf$2(
     core$_.int j,
   ) {
-    return _valueOf$2(_class.reference.pointer, _id_valueOf$2.pointer, j)
+    final _$$classRef = _class.reference;
+    return _valueOf$2(_$$classRef.pointer, _id_valueOf$2.pointer, j)
         .object<JLong?>();
   }
 }
@@ -13416,7 +13643,8 @@ extension JLong$$Methods on JLong {
 
   /// from: `public byte byteValue()`
   core$_.int byteValue() {
-    return _byteValue(reference.pointer, _id_byteValue.pointer).byte;
+    final _$$selfRef = reference;
+    return _byteValue(_$$selfRef.pointer, _id_byteValue.pointer).byte;
   }
 
   static final _id_compareTo = JLong._class.instanceMethodId(
@@ -13439,8 +13667,9 @@ extension JLong$$Methods on JLong {
   core$_.int compareTo(
     JLong? long,
   ) {
+    final _$$selfRef = reference;
     final _$long = long?.reference ?? jni$_.jNullReference;
-    return _compareTo(reference.pointer, _id_compareTo.pointer, _$long.pointer)
+    return _compareTo(_$$selfRef.pointer, _id_compareTo.pointer, _$long.pointer)
         .integer;
   }
 
@@ -13463,7 +13692,9 @@ extension JLong$$Methods on JLong {
 
   /// from: `public double doubleValue()`
   core$_.double doubleValue() {
-    return _doubleValue(reference.pointer, _id_doubleValue.pointer).doubleFloat;
+    final _$$selfRef = reference;
+    return _doubleValue(_$$selfRef.pointer, _id_doubleValue.pointer)
+        .doubleFloat;
   }
 
   static final _id_equals = JLong._class.instanceMethodId(
@@ -13486,8 +13717,9 @@ extension JLong$$Methods on JLong {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -13510,7 +13742,8 @@ extension JLong$$Methods on JLong {
 
   /// from: `public float floatValue()`
   core$_.double floatValue() {
-    return _floatValue(reference.pointer, _id_floatValue.pointer).float;
+    final _$$selfRef = reference;
+    return _floatValue(_$$selfRef.pointer, _id_floatValue.pointer).float;
   }
 
   static final _id_hashCode$1 = JLong._class.instanceMethodId(
@@ -13532,7 +13765,8 @@ extension JLong$$Methods on JLong {
 
   /// from: `public int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_intValue = JLong._class.instanceMethodId(
@@ -13554,7 +13788,8 @@ extension JLong$$Methods on JLong {
 
   /// from: `public int intValue()`
   core$_.int intValue() {
-    return _intValue(reference.pointer, _id_intValue.pointer).integer;
+    final _$$selfRef = reference;
+    return _intValue(_$$selfRef.pointer, _id_intValue.pointer).integer;
   }
 
   static final _id_longValue = JLong._class.instanceMethodId(
@@ -13576,7 +13811,8 @@ extension JLong$$Methods on JLong {
 
   /// from: `public long longValue()`
   core$_.int longValue() {
-    return _longValue(reference.pointer, _id_longValue.pointer).long;
+    final _$$selfRef = reference;
+    return _longValue(_$$selfRef.pointer, _id_longValue.pointer).long;
   }
 
   static final _id_shortValue = JLong._class.instanceMethodId(
@@ -13598,7 +13834,8 @@ extension JLong$$Methods on JLong {
 
   /// from: `public short shortValue()`
   core$_.int shortValue() {
-    return _shortValue(reference.pointer, _id_shortValue.pointer).short;
+    final _$$selfRef = reference;
+    return _shortValue(_$$selfRef.pointer, _id_shortValue.pointer).short;
   }
 
   static final _id_toString$1 = JLong._class.instanceMethodId(
@@ -13621,7 +13858,8 @@ extension JLong$$Methods on JLong {
   /// from: `public java.lang.String toString()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<JString?>();
   }
 
@@ -13679,7 +13917,8 @@ extension JNumber$$Methods on JNumber {
 
   /// from: `public byte byteValue()`
   core$_.int byteValue() {
-    return _byteValue(reference.pointer, _id_byteValue.pointer).byte;
+    final _$$selfRef = reference;
+    return _byteValue(_$$selfRef.pointer, _id_byteValue.pointer).byte;
   }
 
   static final _id_doubleValue = JNumber._class.instanceMethodId(
@@ -13701,7 +13940,9 @@ extension JNumber$$Methods on JNumber {
 
   /// from: `public abstract double doubleValue()`
   core$_.double doubleValue() {
-    return _doubleValue(reference.pointer, _id_doubleValue.pointer).doubleFloat;
+    final _$$selfRef = reference;
+    return _doubleValue(_$$selfRef.pointer, _id_doubleValue.pointer)
+        .doubleFloat;
   }
 
   static final _id_floatValue = JNumber._class.instanceMethodId(
@@ -13723,7 +13964,8 @@ extension JNumber$$Methods on JNumber {
 
   /// from: `public abstract float floatValue()`
   core$_.double floatValue() {
-    return _floatValue(reference.pointer, _id_floatValue.pointer).float;
+    final _$$selfRef = reference;
+    return _floatValue(_$$selfRef.pointer, _id_floatValue.pointer).float;
   }
 
   static final _id_intValue = JNumber._class.instanceMethodId(
@@ -13745,7 +13987,8 @@ extension JNumber$$Methods on JNumber {
 
   /// from: `public abstract int intValue()`
   core$_.int intValue() {
-    return _intValue(reference.pointer, _id_intValue.pointer).integer;
+    final _$$selfRef = reference;
+    return _intValue(_$$selfRef.pointer, _id_intValue.pointer).integer;
   }
 
   static final _id_longValue = JNumber._class.instanceMethodId(
@@ -13767,7 +14010,8 @@ extension JNumber$$Methods on JNumber {
 
   /// from: `public abstract long longValue()`
   core$_.int longValue() {
-    return _longValue(reference.pointer, _id_longValue.pointer).long;
+    final _$$selfRef = reference;
+    return _longValue(_$$selfRef.pointer, _id_longValue.pointer).long;
   }
 
   static final _id_shortValue = JNumber._class.instanceMethodId(
@@ -13789,7 +14033,8 @@ extension JNumber$$Methods on JNumber {
 
   /// from: `public short shortValue()`
   core$_.int shortValue() {
-    return _shortValue(reference.pointer, _id_shortValue.pointer).short;
+    final _$$selfRef = reference;
+    return _shortValue(_$$selfRef.pointer, _id_shortValue.pointer).short;
   }
 }
 
@@ -13850,8 +14095,8 @@ extension type JShort._(jni$_.JObject _$this)
   factory JShort(
     core$_.int s,
   ) {
-    return _new$(_class.reference.pointer, _id_new$.pointer, s)
-        .object<JShort>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer, s).object<JShort>();
   }
 
   static final _id_compare = _class.staticMethodId(
@@ -13875,8 +14120,8 @@ extension type JShort._(jni$_.JObject _$this)
     core$_.int s,
     core$_.int s1,
   ) {
-    return _compare(_class.reference.pointer, _id_compare.pointer, s, s1)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _compare(_$$classRef.pointer, _id_compare.pointer, s, s1).integer;
   }
 
   static final _id_compareUnsigned = _class.staticMethodId(
@@ -13900,8 +14145,9 @@ extension type JShort._(jni$_.JObject _$this)
     core$_.int s,
     core$_.int s1,
   ) {
+    final _$$classRef = _class.reference;
     return _compareUnsigned(
-            _class.reference.pointer, _id_compareUnsigned.pointer, s, s1)
+            _$$classRef.pointer, _id_compareUnsigned.pointer, s, s1)
         .integer;
   }
 
@@ -13926,9 +14172,9 @@ extension type JShort._(jni$_.JObject _$this)
   static JShort? decode(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _decode(
-            _class.reference.pointer, _id_decode.pointer, _$string.pointer)
+    return _decode(_$$classRef.pointer, _id_decode.pointer, _$string.pointer)
         .object<JShort?>();
   }
 
@@ -13950,8 +14196,8 @@ extension type JShort._(jni$_.JObject _$this)
   static core$_.int hashCode$2(
     core$_.int s,
   ) {
-    return _hashCode$2(_class.reference.pointer, _id_hashCode$2.pointer, s)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _hashCode$2(_$$classRef.pointer, _id_hashCode$2.pointer, s).integer;
   }
 
   static final _id_parseShort = _class.staticMethodId(
@@ -13974,9 +14220,10 @@ extension type JShort._(jni$_.JObject _$this)
   static core$_.int parseShort(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _parseShort(
-            _class.reference.pointer, _id_parseShort.pointer, _$string.pointer)
+            _$$classRef.pointer, _id_parseShort.pointer, _$string.pointer)
         .short;
   }
 
@@ -14002,9 +14249,10 @@ extension type JShort._(jni$_.JObject _$this)
     JString? string,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _parseShort$1(_class.reference.pointer, _id_parseShort$1.pointer,
-            _$string.pointer, i)
+    return _parseShort$1(
+            _$$classRef.pointer, _id_parseShort$1.pointer, _$string.pointer, i)
         .short;
   }
 
@@ -14026,7 +14274,8 @@ extension type JShort._(jni$_.JObject _$this)
   static core$_.int reverseBytes(
     core$_.int s,
   ) {
-    return _reverseBytes(_class.reference.pointer, _id_reverseBytes.pointer, s)
+    final _$$classRef = _class.reference;
+    return _reverseBytes(_$$classRef.pointer, _id_reverseBytes.pointer, s)
         .short;
   }
 
@@ -14049,7 +14298,8 @@ extension type JShort._(jni$_.JObject _$this)
   static JString? toString$2(
     core$_.int s,
   ) {
-    return _toString$2(_class.reference.pointer, _id_toString$2.pointer, s)
+    final _$$classRef = _class.reference;
+    return _toString$2(_$$classRef.pointer, _id_toString$2.pointer, s)
         .object<JString?>();
   }
 
@@ -14071,8 +14321,8 @@ extension type JShort._(jni$_.JObject _$this)
   static core$_.int toUnsignedInt(
     core$_.int s,
   ) {
-    return _toUnsignedInt(
-            _class.reference.pointer, _id_toUnsignedInt.pointer, s)
+    final _$$classRef = _class.reference;
+    return _toUnsignedInt(_$$classRef.pointer, _id_toUnsignedInt.pointer, s)
         .integer;
   }
 
@@ -14094,8 +14344,8 @@ extension type JShort._(jni$_.JObject _$this)
   static core$_.int toUnsignedLong(
     core$_.int s,
   ) {
-    return _toUnsignedLong(
-            _class.reference.pointer, _id_toUnsignedLong.pointer, s)
+    final _$$classRef = _class.reference;
+    return _toUnsignedLong(_$$classRef.pointer, _id_toUnsignedLong.pointer, s)
         .long;
   }
 
@@ -14120,9 +14370,9 @@ extension type JShort._(jni$_.JObject _$this)
   static JShort? valueOf(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$string.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$string.pointer)
         .object<JShort?>();
   }
 
@@ -14149,9 +14399,10 @@ extension type JShort._(jni$_.JObject _$this)
     JString? string,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _valueOf$1(_class.reference.pointer, _id_valueOf$1.pointer,
-            _$string.pointer, i)
+    return _valueOf$1(
+            _$$classRef.pointer, _id_valueOf$1.pointer, _$string.pointer, i)
         .object<JShort?>();
   }
 
@@ -14174,7 +14425,8 @@ extension type JShort._(jni$_.JObject _$this)
   static JShort? valueOf$2(
     core$_.int s,
   ) {
-    return _valueOf$2(_class.reference.pointer, _id_valueOf$2.pointer, s)
+    final _$$classRef = _class.reference;
+    return _valueOf$2(_$$classRef.pointer, _id_valueOf$2.pointer, s)
         .object<JShort?>();
   }
 }
@@ -14199,7 +14451,8 @@ extension JShort$$Methods on JShort {
 
   /// from: `public byte byteValue()`
   core$_.int byteValue() {
-    return _byteValue(reference.pointer, _id_byteValue.pointer).byte;
+    final _$$selfRef = reference;
+    return _byteValue(_$$selfRef.pointer, _id_byteValue.pointer).byte;
   }
 
   static final _id_compareTo = JShort._class.instanceMethodId(
@@ -14222,8 +14475,10 @@ extension JShort$$Methods on JShort {
   core$_.int compareTo(
     JShort? short,
   ) {
+    final _$$selfRef = reference;
     final _$short = short?.reference ?? jni$_.jNullReference;
-    return _compareTo(reference.pointer, _id_compareTo.pointer, _$short.pointer)
+    return _compareTo(
+            _$$selfRef.pointer, _id_compareTo.pointer, _$short.pointer)
         .integer;
   }
 
@@ -14246,7 +14501,9 @@ extension JShort$$Methods on JShort {
 
   /// from: `public double doubleValue()`
   core$_.double doubleValue() {
-    return _doubleValue(reference.pointer, _id_doubleValue.pointer).doubleFloat;
+    final _$$selfRef = reference;
+    return _doubleValue(_$$selfRef.pointer, _id_doubleValue.pointer)
+        .doubleFloat;
   }
 
   static final _id_equals = JShort._class.instanceMethodId(
@@ -14269,8 +14526,9 @@ extension JShort$$Methods on JShort {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -14293,7 +14551,8 @@ extension JShort$$Methods on JShort {
 
   /// from: `public float floatValue()`
   core$_.double floatValue() {
-    return _floatValue(reference.pointer, _id_floatValue.pointer).float;
+    final _$$selfRef = reference;
+    return _floatValue(_$$selfRef.pointer, _id_floatValue.pointer).float;
   }
 
   static final _id_hashCode$1 = JShort._class.instanceMethodId(
@@ -14315,7 +14574,8 @@ extension JShort$$Methods on JShort {
 
   /// from: `public int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_intValue = JShort._class.instanceMethodId(
@@ -14337,7 +14597,8 @@ extension JShort$$Methods on JShort {
 
   /// from: `public int intValue()`
   core$_.int intValue() {
-    return _intValue(reference.pointer, _id_intValue.pointer).integer;
+    final _$$selfRef = reference;
+    return _intValue(_$$selfRef.pointer, _id_intValue.pointer).integer;
   }
 
   static final _id_longValue = JShort._class.instanceMethodId(
@@ -14359,7 +14620,8 @@ extension JShort$$Methods on JShort {
 
   /// from: `public long longValue()`
   core$_.int longValue() {
-    return _longValue(reference.pointer, _id_longValue.pointer).long;
+    final _$$selfRef = reference;
+    return _longValue(_$$selfRef.pointer, _id_longValue.pointer).long;
   }
 
   static final _id_shortValue = JShort._class.instanceMethodId(
@@ -14381,7 +14643,8 @@ extension JShort$$Methods on JShort {
 
   /// from: `public short shortValue()`
   core$_.int shortValue() {
-    return _shortValue(reference.pointer, _id_shortValue.pointer).short;
+    final _$$selfRef = reference;
+    return _shortValue(_$$selfRef.pointer, _id_shortValue.pointer).short;
   }
 
   static final _id_toString$1 = JShort._class.instanceMethodId(
@@ -14404,7 +14667,8 @@ extension JShort$$Methods on JShort {
   /// from: `public java.lang.String toString()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<JString?>();
   }
 
@@ -14470,7 +14734,8 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory JString() {
-    return _new$(_class.reference.pointer, _id_new$.pointer).object<JString>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<JString>();
   }
 
   static final _id_new$1 = _class.constructorId(
@@ -14493,8 +14758,9 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
   factory JString.new$1(
     jni$_.JByteArray? bs,
   ) {
+    final _$$classRef = _class.reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
-    return _new$1(_class.reference.pointer, _id_new$1.pointer, _$bs.pointer)
+    return _new$1(_$$classRef.pointer, _id_new$1.pointer, _$bs.pointer)
         .object<JString>();
   }
 
@@ -14520,8 +14786,9 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JByteArray? bs,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
-    return _new$2(_class.reference.pointer, _id_new$2.pointer, _$bs.pointer, i)
+    return _new$2(_$$classRef.pointer, _id_new$2.pointer, _$bs.pointer, i)
         .object<JString>();
   }
 
@@ -14555,9 +14822,9 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     core$_.int i1,
   ) {
+    final _$$classRef = _class.reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
-    return _new$3(
-            _class.reference.pointer, _id_new$3.pointer, _$bs.pointer, i, i1)
+    return _new$3(_$$classRef.pointer, _id_new$3.pointer, _$bs.pointer, i, i1)
         .object<JString>();
   }
 
@@ -14594,9 +14861,10 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i1,
     core$_.int i2,
   ) {
+    final _$$classRef = _class.reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
-    return _new$4(_class.reference.pointer, _id_new$4.pointer, _$bs.pointer, i,
-            i1, i2)
+    return _new$4(
+            _$$classRef.pointer, _id_new$4.pointer, _$bs.pointer, i, i1, i2)
         .object<JString>();
   }
 
@@ -14633,10 +14901,11 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i1,
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _new$5(_class.reference.pointer, _id_new$5.pointer, _$bs.pointer, i,
-            i1, _$string.pointer)
+    return _new$5(_$$classRef.pointer, _id_new$5.pointer, _$bs.pointer, i, i1,
+            _$string.pointer)
         .object<JString>();
   }
 
@@ -14673,10 +14942,11 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i1,
     jni$_.JObject? charset,
   ) {
+    final _$$classRef = _class.reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
     final _$charset = charset?.reference ?? jni$_.jNullReference;
-    return _new$6(_class.reference.pointer, _id_new$6.pointer, _$bs.pointer, i,
-            i1, _$charset.pointer)
+    return _new$6(_$$classRef.pointer, _id_new$6.pointer, _$bs.pointer, i, i1,
+            _$charset.pointer)
         .object<JString>();
   }
 
@@ -14707,9 +14977,10 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JByteArray? bs,
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _new$7(_class.reference.pointer, _id_new$7.pointer, _$bs.pointer,
+    return _new$7(_$$classRef.pointer, _id_new$7.pointer, _$bs.pointer,
             _$string.pointer)
         .object<JString>();
   }
@@ -14741,9 +15012,10 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JByteArray? bs,
     jni$_.JObject? charset,
   ) {
+    final _$$classRef = _class.reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
     final _$charset = charset?.reference ?? jni$_.jNullReference;
-    return _new$8(_class.reference.pointer, _id_new$8.pointer, _$bs.pointer,
+    return _new$8(_$$classRef.pointer, _id_new$8.pointer, _$bs.pointer,
             _$charset.pointer)
         .object<JString>();
   }
@@ -14768,8 +15040,9 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
   factory JString.new$9(
     jni$_.JCharArray? cs,
   ) {
+    final _$$classRef = _class.reference;
     final _$cs = cs?.reference ?? jni$_.jNullReference;
-    return _new$9(_class.reference.pointer, _id_new$9.pointer, _$cs.pointer)
+    return _new$9(_$$classRef.pointer, _id_new$9.pointer, _$cs.pointer)
         .object<JString>();
   }
 
@@ -14803,9 +15076,9 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     core$_.int i1,
   ) {
+    final _$$classRef = _class.reference;
     final _$cs = cs?.reference ?? jni$_.jNullReference;
-    return _new$10(
-            _class.reference.pointer, _id_new$10.pointer, _$cs.pointer, i, i1)
+    return _new$10(_$$classRef.pointer, _id_new$10.pointer, _$cs.pointer, i, i1)
         .object<JString>();
   }
 
@@ -14839,9 +15112,10 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     core$_.int i1,
   ) {
+    final _$$classRef = _class.reference;
     final _$is$ = is$?.reference ?? jni$_.jNullReference;
     return _new$11(
-            _class.reference.pointer, _id_new$11.pointer, _$is$.pointer, i, i1)
+            _$$classRef.pointer, _id_new$11.pointer, _$is$.pointer, i, i1)
         .object<JString>();
   }
 
@@ -14865,9 +15139,9 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
   factory JString.new$12(
     JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _new$12(
-            _class.reference.pointer, _id_new$12.pointer, _$string.pointer)
+    return _new$12(_$$classRef.pointer, _id_new$12.pointer, _$string.pointer)
         .object<JString>();
   }
 
@@ -14891,9 +15165,10 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
   factory JString.new$13(
     jni$_.JObject? stringBuffer,
   ) {
+    final _$$classRef = _class.reference;
     final _$stringBuffer = stringBuffer?.reference ?? jni$_.jNullReference;
-    return _new$13(_class.reference.pointer, _id_new$13.pointer,
-            _$stringBuffer.pointer)
+    return _new$13(
+            _$$classRef.pointer, _id_new$13.pointer, _$stringBuffer.pointer)
         .object<JString>();
   }
 
@@ -14917,9 +15192,10 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
   factory JString.new$14(
     jni$_.JObject? stringBuilder,
   ) {
+    final _$$classRef = _class.reference;
     final _$stringBuilder = stringBuilder?.reference ?? jni$_.jNullReference;
-    return _new$14(_class.reference.pointer, _id_new$14.pointer,
-            _$stringBuilder.pointer)
+    return _new$14(
+            _$$classRef.pointer, _id_new$14.pointer, _$stringBuilder.pointer)
         .object<JString>();
   }
 
@@ -14944,9 +15220,10 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
   static JString? copyValueOf(
     jni$_.JCharArray? cs,
   ) {
+    final _$$classRef = _class.reference;
     final _$cs = cs?.reference ?? jni$_.jNullReference;
     return _copyValueOf(
-            _class.reference.pointer, _id_copyValueOf.pointer, _$cs.pointer)
+            _$$classRef.pointer, _id_copyValueOf.pointer, _$cs.pointer)
         .object<JString?>();
   }
 
@@ -14981,9 +15258,10 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     core$_.int i1,
   ) {
+    final _$$classRef = _class.reference;
     final _$cs = cs?.reference ?? jni$_.jNullReference;
-    return _copyValueOf$1(_class.reference.pointer, _id_copyValueOf$1.pointer,
-            _$cs.pointer, i, i1)
+    return _copyValueOf$1(
+            _$$classRef.pointer, _id_copyValueOf$1.pointer, _$cs.pointer, i, i1)
         .object<JString?>();
   }
 
@@ -15015,10 +15293,11 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
     JString? string,
     jni$_.JArray<jni$_.JObject?>? objects,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$objects = objects?.reference ?? jni$_.jNullReference;
-    return _format(_class.reference.pointer, _id_format.pointer,
-            _$string.pointer, _$objects.pointer)
+    return _format(_$$classRef.pointer, _id_format.pointer, _$string.pointer,
+            _$objects.pointer)
         .object<JString?>();
   }
 
@@ -15053,10 +15332,11 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
     JString? string,
     jni$_.JArray<jni$_.JObject?>? objects,
   ) {
+    final _$$classRef = _class.reference;
     final _$locale = locale?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$objects = objects?.reference ?? jni$_.jNullReference;
-    return _format$1(_class.reference.pointer, _id_format$1.pointer,
+    return _format$1(_$$classRef.pointer, _id_format$1.pointer,
             _$locale.pointer, _$string.pointer, _$objects.pointer)
         .object<JString?>();
   }
@@ -15089,10 +15369,11 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JObject? charSequence,
     jni$_.JArray<jni$_.JObject?>? charSequences,
   ) {
+    final _$$classRef = _class.reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
     final _$charSequences = charSequences?.reference ?? jni$_.jNullReference;
-    return _join(_class.reference.pointer, _id_join.pointer,
-            _$charSequence.pointer, _$charSequences.pointer)
+    return _join(_$$classRef.pointer, _id_join.pointer, _$charSequence.pointer,
+            _$charSequences.pointer)
         .object<JString?>();
   }
 
@@ -15124,9 +15405,10 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JObject? charSequence,
     jni$_.JObject? iterable,
   ) {
+    final _$$classRef = _class.reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
     final _$iterable = iterable?.reference ?? jni$_.jNullReference;
-    return _join$1(_class.reference.pointer, _id_join$1.pointer,
+    return _join$1(_$$classRef.pointer, _id_join$1.pointer,
             _$charSequence.pointer, _$iterable.pointer)
         .object<JString?>();
   }
@@ -15150,7 +15432,8 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
   static JString? valueOf(
     core$_.bool z,
   ) {
-    return _valueOf(_class.reference.pointer, _id_valueOf.pointer, z ? 1 : 0)
+    final _$$classRef = _class.reference;
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, z ? 1 : 0)
         .object<JString?>();
   }
 
@@ -15173,7 +15456,8 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
   static JString? valueOf$1(
     core$_.int c,
   ) {
-    return _valueOf$1(_class.reference.pointer, _id_valueOf$1.pointer, c)
+    final _$$classRef = _class.reference;
+    return _valueOf$1(_$$classRef.pointer, _id_valueOf$1.pointer, c)
         .object<JString?>();
   }
 
@@ -15198,9 +15482,9 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
   static JString? valueOf$2(
     jni$_.JCharArray? cs,
   ) {
+    final _$$classRef = _class.reference;
     final _$cs = cs?.reference ?? jni$_.jNullReference;
-    return _valueOf$2(
-            _class.reference.pointer, _id_valueOf$2.pointer, _$cs.pointer)
+    return _valueOf$2(_$$classRef.pointer, _id_valueOf$2.pointer, _$cs.pointer)
         .object<JString?>();
   }
 
@@ -15235,9 +15519,10 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     core$_.int i1,
   ) {
+    final _$$classRef = _class.reference;
     final _$cs = cs?.reference ?? jni$_.jNullReference;
-    return _valueOf$3(_class.reference.pointer, _id_valueOf$3.pointer,
-            _$cs.pointer, i, i1)
+    return _valueOf$3(
+            _$$classRef.pointer, _id_valueOf$3.pointer, _$cs.pointer, i, i1)
         .object<JString?>();
   }
 
@@ -15260,7 +15545,8 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
   static JString? valueOf$4(
     core$_.double d,
   ) {
-    return _valueOf$4(_class.reference.pointer, _id_valueOf$4.pointer, d)
+    final _$$classRef = _class.reference;
+    return _valueOf$4(_$$classRef.pointer, _id_valueOf$4.pointer, d)
         .object<JString?>();
   }
 
@@ -15283,7 +15569,8 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
   static JString? valueOf$5(
     core$_.double f,
   ) {
-    return _valueOf$5(_class.reference.pointer, _id_valueOf$5.pointer, f)
+    final _$$classRef = _class.reference;
+    return _valueOf$5(_$$classRef.pointer, _id_valueOf$5.pointer, f)
         .object<JString?>();
   }
 
@@ -15306,7 +15593,8 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
   static JString? valueOf$6(
     core$_.int i,
   ) {
-    return _valueOf$6(_class.reference.pointer, _id_valueOf$6.pointer, i)
+    final _$$classRef = _class.reference;
+    return _valueOf$6(_$$classRef.pointer, _id_valueOf$6.pointer, i)
         .object<JString?>();
   }
 
@@ -15331,9 +15619,10 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
   static JString? valueOf$7(
     jni$_.JObject? object,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _valueOf$7(
-            _class.reference.pointer, _id_valueOf$7.pointer, _$object.pointer)
+            _$$classRef.pointer, _id_valueOf$7.pointer, _$object.pointer)
         .object<JString?>();
   }
 
@@ -15356,7 +15645,8 @@ extension type JString._(jni$_.JObject _$this) implements jni$_.JObject {
   static JString? valueOf$8(
     core$_.int j,
   ) {
-    return _valueOf$8(_class.reference.pointer, _id_valueOf$8.pointer, j)
+    final _$$classRef = _class.reference;
+    return _valueOf$8(_$$classRef.pointer, _id_valueOf$8.pointer, j)
         .object<JString?>();
   }
 }
@@ -15381,7 +15671,8 @@ extension JString$$Methods on JString {
   core$_.int charAt(
     core$_.int i,
   ) {
-    return _charAt(reference.pointer, _id_charAt.pointer, i).char;
+    final _$$selfRef = reference;
+    return _charAt(_$$selfRef.pointer, _id_charAt.pointer, i).char;
   }
 
   static final _id_chars = JString._class.instanceMethodId(
@@ -15404,7 +15695,8 @@ extension JString$$Methods on JString {
   /// from: `public java.util.stream.IntStream chars()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? chars() {
-    return _chars(reference.pointer, _id_chars.pointer)
+    final _$$selfRef = reference;
+    return _chars(_$$selfRef.pointer, _id_chars.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -15427,7 +15719,8 @@ extension JString$$Methods on JString {
   core$_.int codePointAt(
     core$_.int i,
   ) {
-    return _codePointAt(reference.pointer, _id_codePointAt.pointer, i).integer;
+    final _$$selfRef = reference;
+    return _codePointAt(_$$selfRef.pointer, _id_codePointAt.pointer, i).integer;
   }
 
   static final _id_codePointBefore = JString._class.instanceMethodId(
@@ -15449,7 +15742,8 @@ extension JString$$Methods on JString {
   core$_.int codePointBefore(
     core$_.int i,
   ) {
-    return _codePointBefore(reference.pointer, _id_codePointBefore.pointer, i)
+    final _$$selfRef = reference;
+    return _codePointBefore(_$$selfRef.pointer, _id_codePointBefore.pointer, i)
         .integer;
   }
 
@@ -15474,7 +15768,9 @@ extension JString$$Methods on JString {
     core$_.int i,
     core$_.int i1,
   ) {
-    return _codePointCount(reference.pointer, _id_codePointCount.pointer, i, i1)
+    final _$$selfRef = reference;
+    return _codePointCount(
+            _$$selfRef.pointer, _id_codePointCount.pointer, i, i1)
         .integer;
   }
 
@@ -15498,7 +15794,8 @@ extension JString$$Methods on JString {
   /// from: `public java.util.stream.IntStream codePoints()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? codePoints() {
-    return _codePoints(reference.pointer, _id_codePoints.pointer)
+    final _$$selfRef = reference;
+    return _codePoints(_$$selfRef.pointer, _id_codePoints.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -15522,9 +15819,10 @@ extension JString$$Methods on JString {
   core$_.int compareTo(
     JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _compareTo(
-            reference.pointer, _id_compareTo.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_compareTo.pointer, _$string.pointer)
         .integer;
   }
 
@@ -15548,8 +15846,9 @@ extension JString$$Methods on JString {
   core$_.int compareToIgnoreCase(
     JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _compareToIgnoreCase(reference.pointer,
+    return _compareToIgnoreCase(_$$selfRef.pointer,
             _id_compareToIgnoreCase.pointer, _$string.pointer)
         .integer;
   }
@@ -15575,8 +15874,9 @@ extension JString$$Methods on JString {
   JString? concat(
     JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _concat(reference.pointer, _id_concat.pointer, _$string.pointer)
+    return _concat(_$$selfRef.pointer, _id_concat.pointer, _$string.pointer)
         .object<JString?>();
   }
 
@@ -15600,9 +15900,10 @@ extension JString$$Methods on JString {
   core$_.bool contains(
     jni$_.JObject? charSequence,
   ) {
+    final _$$selfRef = reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
     return _contains(
-            reference.pointer, _id_contains.pointer, _$charSequence.pointer)
+            _$$selfRef.pointer, _id_contains.pointer, _$charSequence.pointer)
         .boolean;
   }
 
@@ -15626,8 +15927,9 @@ extension JString$$Methods on JString {
   core$_.bool contentEquals(
     jni$_.JObject? charSequence,
   ) {
+    final _$$selfRef = reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
-    return _contentEquals(reference.pointer, _id_contentEquals.pointer,
+    return _contentEquals(_$$selfRef.pointer, _id_contentEquals.pointer,
             _$charSequence.pointer)
         .boolean;
   }
@@ -15652,8 +15954,9 @@ extension JString$$Methods on JString {
   core$_.bool contentEquals$1(
     jni$_.JObject? stringBuffer,
   ) {
+    final _$$selfRef = reference;
     final _$stringBuffer = stringBuffer?.reference ?? jni$_.jNullReference;
-    return _contentEquals$1(reference.pointer, _id_contentEquals$1.pointer,
+    return _contentEquals$1(_$$selfRef.pointer, _id_contentEquals$1.pointer,
             _$stringBuffer.pointer)
         .boolean;
   }
@@ -15678,8 +15981,9 @@ extension JString$$Methods on JString {
   core$_.bool endsWith(
     JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _endsWith(reference.pointer, _id_endsWith.pointer, _$string.pointer)
+    return _endsWith(_$$selfRef.pointer, _id_endsWith.pointer, _$string.pointer)
         .boolean;
   }
 
@@ -15703,8 +16007,9 @@ extension JString$$Methods on JString {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -15728,9 +16033,10 @@ extension JString$$Methods on JString {
   core$_.bool equalsIgnoreCase(
     JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _equalsIgnoreCase(
-            reference.pointer, _id_equalsIgnoreCase.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_equalsIgnoreCase.pointer, _$string.pointer)
         .boolean;
   }
 
@@ -15755,9 +16061,10 @@ extension JString$$Methods on JString {
   JString? formatted(
     jni$_.JArray<jni$_.JObject?>? objects,
   ) {
+    final _$$selfRef = reference;
     final _$objects = objects?.reference ?? jni$_.jNullReference;
     return _formatted(
-            reference.pointer, _id_formatted.pointer, _$objects.pointer)
+            _$$selfRef.pointer, _id_formatted.pointer, _$objects.pointer)
         .object<JString?>();
   }
 
@@ -15781,7 +16088,8 @@ extension JString$$Methods on JString {
   /// from: `public byte[] getBytes()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JByteArray? get bytes {
-    return _get$bytes(reference.pointer, _id_get$bytes.pointer)
+    final _$$selfRef = reference;
+    return _get$bytes(_$$selfRef.pointer, _id_get$bytes.pointer)
         .object<jni$_.JByteArray?>();
   }
 
@@ -15818,8 +16126,9 @@ extension JString$$Methods on JString {
     jni$_.JByteArray? bs,
     core$_.int i2,
   ) {
+    final _$$selfRef = reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
-    _getBytes(reference.pointer, _id_getBytes.pointer, i, i1, _$bs.pointer, i2)
+    _getBytes(_$$selfRef.pointer, _id_getBytes.pointer, i, i1, _$bs.pointer, i2)
         .check();
   }
 
@@ -15844,9 +16153,10 @@ extension JString$$Methods on JString {
   jni$_.JByteArray? getBytes$1(
     JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _getBytes$1(
-            reference.pointer, _id_getBytes$1.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_getBytes$1.pointer, _$string.pointer)
         .object<jni$_.JByteArray?>();
   }
 
@@ -15871,9 +16181,10 @@ extension JString$$Methods on JString {
   jni$_.JByteArray? getBytes$2(
     jni$_.JObject? charset,
   ) {
+    final _$$selfRef = reference;
     final _$charset = charset?.reference ?? jni$_.jNullReference;
     return _getBytes$2(
-            reference.pointer, _id_getBytes$2.pointer, _$charset.pointer)
+            _$$selfRef.pointer, _id_getBytes$2.pointer, _$charset.pointer)
         .object<jni$_.JByteArray?>();
   }
 
@@ -15910,8 +16221,9 @@ extension JString$$Methods on JString {
     jni$_.JCharArray? cs,
     core$_.int i2,
   ) {
+    final _$$selfRef = reference;
     final _$cs = cs?.reference ?? jni$_.jNullReference;
-    _getChars(reference.pointer, _id_getChars.pointer, i, i1, _$cs.pointer, i2)
+    _getChars(_$$selfRef.pointer, _id_getChars.pointer, i, i1, _$cs.pointer, i2)
         .check();
   }
 
@@ -15934,7 +16246,8 @@ extension JString$$Methods on JString {
 
   /// from: `public int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_indent = JString._class.instanceMethodId(
@@ -15957,7 +16270,9 @@ extension JString$$Methods on JString {
   JString? indent(
     core$_.int i,
   ) {
-    return _indent(reference.pointer, _id_indent.pointer, i).object<JString?>();
+    final _$$selfRef = reference;
+    return _indent(_$$selfRef.pointer, _id_indent.pointer, i)
+        .object<JString?>();
   }
 
   static final _id_indexOf = JString._class.instanceMethodId(
@@ -15979,7 +16294,8 @@ extension JString$$Methods on JString {
   core$_.int indexOf(
     core$_.int i,
   ) {
-    return _indexOf(reference.pointer, _id_indexOf.pointer, i).integer;
+    final _$$selfRef = reference;
+    return _indexOf(_$$selfRef.pointer, _id_indexOf.pointer, i).integer;
   }
 
   static final _id_indexOf$1 = JString._class.instanceMethodId(
@@ -16003,7 +16319,8 @@ extension JString$$Methods on JString {
     core$_.int i,
     core$_.int i1,
   ) {
-    return _indexOf$1(reference.pointer, _id_indexOf$1.pointer, i, i1).integer;
+    final _$$selfRef = reference;
+    return _indexOf$1(_$$selfRef.pointer, _id_indexOf$1.pointer, i, i1).integer;
   }
 
   static final _id_indexOf$2 = JString._class.instanceMethodId(
@@ -16026,9 +16343,10 @@ extension JString$$Methods on JString {
   core$_.int indexOf$2(
     JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _indexOf$2(
-            reference.pointer, _id_indexOf$2.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_indexOf$2.pointer, _$string.pointer)
         .integer;
   }
 
@@ -16054,9 +16372,10 @@ extension JString$$Methods on JString {
     JString? string,
     core$_.int i,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _indexOf$3(
-            reference.pointer, _id_indexOf$3.pointer, _$string.pointer, i)
+            _$$selfRef.pointer, _id_indexOf$3.pointer, _$string.pointer, i)
         .integer;
   }
 
@@ -16080,7 +16399,8 @@ extension JString$$Methods on JString {
   /// from: `public native java.lang.String intern()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? intern() {
-    return _intern(reference.pointer, _id_intern.pointer).object<JString?>();
+    final _$$selfRef = reference;
+    return _intern(_$$selfRef.pointer, _id_intern.pointer).object<JString?>();
   }
 
   static final _id_get$isBlank = JString._class.instanceMethodId(
@@ -16102,7 +16422,8 @@ extension JString$$Methods on JString {
 
   /// from: `public boolean isBlank()`
   core$_.bool get isBlank {
-    return _get$isBlank(reference.pointer, _id_get$isBlank.pointer).boolean;
+    final _$$selfRef = reference;
+    return _get$isBlank(_$$selfRef.pointer, _id_get$isBlank.pointer).boolean;
   }
 
   static final _id_get$isEmpty = JString._class.instanceMethodId(
@@ -16124,7 +16445,8 @@ extension JString$$Methods on JString {
 
   /// from: `public boolean isEmpty()`
   core$_.bool get isEmpty {
-    return _get$isEmpty(reference.pointer, _id_get$isEmpty.pointer).boolean;
+    final _$$selfRef = reference;
+    return _get$isEmpty(_$$selfRef.pointer, _id_get$isEmpty.pointer).boolean;
   }
 
   static final _id_lastIndexOf = JString._class.instanceMethodId(
@@ -16146,7 +16468,8 @@ extension JString$$Methods on JString {
   core$_.int lastIndexOf(
     core$_.int i,
   ) {
-    return _lastIndexOf(reference.pointer, _id_lastIndexOf.pointer, i).integer;
+    final _$$selfRef = reference;
+    return _lastIndexOf(_$$selfRef.pointer, _id_lastIndexOf.pointer, i).integer;
   }
 
   static final _id_lastIndexOf$1 = JString._class.instanceMethodId(
@@ -16170,7 +16493,8 @@ extension JString$$Methods on JString {
     core$_.int i,
     core$_.int i1,
   ) {
-    return _lastIndexOf$1(reference.pointer, _id_lastIndexOf$1.pointer, i, i1)
+    final _$$selfRef = reference;
+    return _lastIndexOf$1(_$$selfRef.pointer, _id_lastIndexOf$1.pointer, i, i1)
         .integer;
   }
 
@@ -16194,9 +16518,10 @@ extension JString$$Methods on JString {
   core$_.int lastIndexOf$2(
     JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _lastIndexOf$2(
-            reference.pointer, _id_lastIndexOf$2.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_lastIndexOf$2.pointer, _$string.pointer)
         .integer;
   }
 
@@ -16222,9 +16547,10 @@ extension JString$$Methods on JString {
     JString? string,
     core$_.int i,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _lastIndexOf$3(
-            reference.pointer, _id_lastIndexOf$3.pointer, _$string.pointer, i)
+            _$$selfRef.pointer, _id_lastIndexOf$3.pointer, _$string.pointer, i)
         .integer;
   }
 
@@ -16247,7 +16573,8 @@ extension JString$$Methods on JString {
 
   /// from: `public int length()`
   core$_.int length() {
-    return _length(reference.pointer, _id_length.pointer).integer;
+    final _$$selfRef = reference;
+    return _length(_$$selfRef.pointer, _id_length.pointer).integer;
   }
 
   static final _id_lines = JString._class.instanceMethodId(
@@ -16270,7 +16597,8 @@ extension JString$$Methods on JString {
   /// from: `public java.util.stream.Stream<java.lang.String> lines()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? lines() {
-    return _lines(reference.pointer, _id_lines.pointer)
+    final _$$selfRef = reference;
+    return _lines(_$$selfRef.pointer, _id_lines.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -16294,8 +16622,9 @@ extension JString$$Methods on JString {
   core$_.bool matches(
     JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _matches(reference.pointer, _id_matches.pointer, _$string.pointer)
+    return _matches(_$$selfRef.pointer, _id_matches.pointer, _$string.pointer)
         .boolean;
   }
 
@@ -16320,8 +16649,9 @@ extension JString$$Methods on JString {
     core$_.int i,
     core$_.int i1,
   ) {
+    final _$$selfRef = reference;
     return _offsetByCodePoints(
-            reference.pointer, _id_offsetByCodePoints.pointer, i, i1)
+            _$$selfRef.pointer, _id_offsetByCodePoints.pointer, i, i1)
         .integer;
   }
 
@@ -16361,8 +16691,9 @@ extension JString$$Methods on JString {
     core$_.int i1,
     core$_.int i2,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _regionMatches(reference.pointer, _id_regionMatches.pointer,
+    return _regionMatches(_$$selfRef.pointer, _id_regionMatches.pointer,
             z ? 1 : 0, i, _$string.pointer, i1, i2)
         .boolean;
   }
@@ -16400,8 +16731,9 @@ extension JString$$Methods on JString {
     core$_.int i1,
     core$_.int i2,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _regionMatches$1(reference.pointer, _id_regionMatches$1.pointer, i,
+    return _regionMatches$1(_$$selfRef.pointer, _id_regionMatches$1.pointer, i,
             _$string.pointer, i1, i2)
         .boolean;
   }
@@ -16426,7 +16758,9 @@ extension JString$$Methods on JString {
   JString? repeat(
     core$_.int i,
   ) {
-    return _repeat(reference.pointer, _id_repeat.pointer, i).object<JString?>();
+    final _$$selfRef = reference;
+    return _repeat(_$$selfRef.pointer, _id_repeat.pointer, i)
+        .object<JString?>();
   }
 
   static final _id_replace = JString._class.instanceMethodId(
@@ -16451,7 +16785,8 @@ extension JString$$Methods on JString {
     core$_.int c,
     core$_.int c1,
   ) {
-    return _replace(reference.pointer, _id_replace.pointer, c, c1)
+    final _$$selfRef = reference;
+    return _replace(_$$selfRef.pointer, _id_replace.pointer, c, c1)
         .object<JString?>();
   }
 
@@ -16483,9 +16818,10 @@ extension JString$$Methods on JString {
     jni$_.JObject? charSequence,
     jni$_.JObject? charSequence1,
   ) {
+    final _$$selfRef = reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
     final _$charSequence1 = charSequence1?.reference ?? jni$_.jNullReference;
-    return _replace$1(reference.pointer, _id_replace$1.pointer,
+    return _replace$1(_$$selfRef.pointer, _id_replace$1.pointer,
             _$charSequence.pointer, _$charSequence1.pointer)
         .object<JString?>();
   }
@@ -16518,9 +16854,10 @@ extension JString$$Methods on JString {
     JString? string,
     JString? string1,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$string1 = string1?.reference ?? jni$_.jNullReference;
-    return _replaceAll(reference.pointer, _id_replaceAll.pointer,
+    return _replaceAll(_$$selfRef.pointer, _id_replaceAll.pointer,
             _$string.pointer, _$string1.pointer)
         .object<JString?>();
   }
@@ -16553,9 +16890,10 @@ extension JString$$Methods on JString {
     JString? string,
     JString? string1,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$string1 = string1?.reference ?? jni$_.jNullReference;
-    return _replaceFirst(reference.pointer, _id_replaceFirst.pointer,
+    return _replaceFirst(_$$selfRef.pointer, _id_replaceFirst.pointer,
             _$string.pointer, _$string1.pointer)
         .object<JString?>();
   }
@@ -16581,8 +16919,9 @@ extension JString$$Methods on JString {
   jni$_.JArray<JString?>? split(
     JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _split(reference.pointer, _id_split.pointer, _$string.pointer)
+    return _split(_$$selfRef.pointer, _id_split.pointer, _$string.pointer)
         .object<jni$_.JArray<JString?>?>();
   }
 
@@ -16609,8 +16948,10 @@ extension JString$$Methods on JString {
     JString? string,
     core$_.int i,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _split$1(reference.pointer, _id_split$1.pointer, _$string.pointer, i)
+    return _split$1(
+            _$$selfRef.pointer, _id_split$1.pointer, _$string.pointer, i)
         .object<jni$_.JArray<JString?>?>();
   }
 
@@ -16634,9 +16975,10 @@ extension JString$$Methods on JString {
   core$_.bool startsWith(
     JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _startsWith(
-            reference.pointer, _id_startsWith.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_startsWith.pointer, _$string.pointer)
         .boolean;
   }
 
@@ -16662,9 +17004,10 @@ extension JString$$Methods on JString {
     JString? string,
     core$_.int i,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _startsWith$1(
-            reference.pointer, _id_startsWith$1.pointer, _$string.pointer, i)
+            _$$selfRef.pointer, _id_startsWith$1.pointer, _$string.pointer, i)
         .boolean;
   }
 
@@ -16688,7 +17031,8 @@ extension JString$$Methods on JString {
   /// from: `public java.lang.String strip()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? strip() {
-    return _strip(reference.pointer, _id_strip.pointer).object<JString?>();
+    final _$$selfRef = reference;
+    return _strip(_$$selfRef.pointer, _id_strip.pointer).object<JString?>();
   }
 
   static final _id_stripIndent = JString._class.instanceMethodId(
@@ -16711,7 +17055,8 @@ extension JString$$Methods on JString {
   /// from: `public java.lang.String stripIndent()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? stripIndent() {
-    return _stripIndent(reference.pointer, _id_stripIndent.pointer)
+    final _$$selfRef = reference;
+    return _stripIndent(_$$selfRef.pointer, _id_stripIndent.pointer)
         .object<JString?>();
   }
 
@@ -16735,7 +17080,8 @@ extension JString$$Methods on JString {
   /// from: `public java.lang.String stripLeading()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? stripLeading() {
-    return _stripLeading(reference.pointer, _id_stripLeading.pointer)
+    final _$$selfRef = reference;
+    return _stripLeading(_$$selfRef.pointer, _id_stripLeading.pointer)
         .object<JString?>();
   }
 
@@ -16759,7 +17105,8 @@ extension JString$$Methods on JString {
   /// from: `public java.lang.String stripTrailing()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? stripTrailing() {
-    return _stripTrailing(reference.pointer, _id_stripTrailing.pointer)
+    final _$$selfRef = reference;
+    return _stripTrailing(_$$selfRef.pointer, _id_stripTrailing.pointer)
         .object<JString?>();
   }
 
@@ -16785,7 +17132,8 @@ extension JString$$Methods on JString {
     core$_.int i,
     core$_.int i1,
   ) {
-    return _subSequence(reference.pointer, _id_subSequence.pointer, i, i1)
+    final _$$selfRef = reference;
+    return _subSequence(_$$selfRef.pointer, _id_subSequence.pointer, i, i1)
         .object<jni$_.JObject?>();
   }
 
@@ -16809,7 +17157,8 @@ extension JString$$Methods on JString {
   JString? substring(
     core$_.int i,
   ) {
-    return _substring(reference.pointer, _id_substring.pointer, i)
+    final _$$selfRef = reference;
+    return _substring(_$$selfRef.pointer, _id_substring.pointer, i)
         .object<JString?>();
   }
 
@@ -16835,7 +17184,8 @@ extension JString$$Methods on JString {
     core$_.int i,
     core$_.int i1,
   ) {
-    return _substring$1(reference.pointer, _id_substring$1.pointer, i, i1)
+    final _$$selfRef = reference;
+    return _substring$1(_$$selfRef.pointer, _id_substring$1.pointer, i, i1)
         .object<JString?>();
   }
 
@@ -16859,7 +17209,8 @@ extension JString$$Methods on JString {
   /// from: `public native char[] toCharArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JCharArray? toCharArray() {
-    return _toCharArray(reference.pointer, _id_toCharArray.pointer)
+    final _$$selfRef = reference;
+    return _toCharArray(_$$selfRef.pointer, _id_toCharArray.pointer)
         .object<jni$_.JCharArray?>();
   }
 
@@ -16883,7 +17234,8 @@ extension JString$$Methods on JString {
   /// from: `public java.lang.String toLowerCase()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? toLowerCase() {
-    return _toLowerCase(reference.pointer, _id_toLowerCase.pointer)
+    final _$$selfRef = reference;
+    return _toLowerCase(_$$selfRef.pointer, _id_toLowerCase.pointer)
         .object<JString?>();
   }
 
@@ -16908,9 +17260,10 @@ extension JString$$Methods on JString {
   JString? toLowerCase$1(
     jni$_.JObject? locale,
   ) {
+    final _$$selfRef = reference;
     final _$locale = locale?.reference ?? jni$_.jNullReference;
     return _toLowerCase$1(
-            reference.pointer, _id_toLowerCase$1.pointer, _$locale.pointer)
+            _$$selfRef.pointer, _id_toLowerCase$1.pointer, _$locale.pointer)
         .object<JString?>();
   }
 
@@ -16934,7 +17287,8 @@ extension JString$$Methods on JString {
   /// from: `public java.lang.String toString()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<JString?>();
   }
 
@@ -16958,7 +17312,8 @@ extension JString$$Methods on JString {
   /// from: `public java.lang.String toUpperCase()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? toUpperCase() {
-    return _toUpperCase(reference.pointer, _id_toUpperCase.pointer)
+    final _$$selfRef = reference;
+    return _toUpperCase(_$$selfRef.pointer, _id_toUpperCase.pointer)
         .object<JString?>();
   }
 
@@ -16983,9 +17338,10 @@ extension JString$$Methods on JString {
   JString? toUpperCase$1(
     jni$_.JObject? locale,
   ) {
+    final _$$selfRef = reference;
     final _$locale = locale?.reference ?? jni$_.jNullReference;
     return _toUpperCase$1(
-            reference.pointer, _id_toUpperCase$1.pointer, _$locale.pointer)
+            _$$selfRef.pointer, _id_toUpperCase$1.pointer, _$locale.pointer)
         .object<JString?>();
   }
 
@@ -17010,9 +17366,10 @@ extension JString$$Methods on JString {
   $R? transform<$R extends jni$_.JObject?>(
     jni$_.JObject? function,
   ) {
+    final _$$selfRef = reference;
     final _$function = function?.reference ?? jni$_.jNullReference;
     return _transform(
-            reference.pointer, _id_transform.pointer, _$function.pointer)
+            _$$selfRef.pointer, _id_transform.pointer, _$function.pointer)
         .object<$R?>();
   }
 
@@ -17036,7 +17393,8 @@ extension JString$$Methods on JString {
   /// from: `public java.lang.String translateEscapes()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? translateEscapes() {
-    return _translateEscapes(reference.pointer, _id_translateEscapes.pointer)
+    final _$$selfRef = reference;
+    return _translateEscapes(_$$selfRef.pointer, _id_translateEscapes.pointer)
         .object<JString?>();
   }
 
@@ -17060,7 +17418,8 @@ extension JString$$Methods on JString {
   /// from: `public java.lang.String trim()`
   /// The returned object must be released after use, by calling the [release] method.
   JString? trim() {
-    return _trim(reference.pointer, _id_trim.pointer).object<JString?>();
+    final _$$selfRef = reference;
+    return _trim(_$$selfRef.pointer, _id_trim.pointer).object<JString?>();
   }
 
   core$_.bool operator <(JString? string) {
@@ -17115,7 +17474,8 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory JArrayList() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<JArrayList<$E>>();
   }
 
@@ -17138,7 +17498,8 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   factory JArrayList.new$1(
     core$_.int i,
   ) {
-    return _new$1(_class.reference.pointer, _id_new$1.pointer, i)
+    final _$$classRef = _class.reference;
+    return _new$1(_$$classRef.pointer, _id_new$1.pointer, i)
         .object<JArrayList<$E>>();
   }
 
@@ -17162,9 +17523,9 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   factory JArrayList.new$2(
     JCollection<$E?>? collection,
   ) {
+    final _$$classRef = _class.reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
-    return _new$2(
-            _class.reference.pointer, _id_new$2.pointer, _$collection.pointer)
+    return _new$2(_$$classRef.pointer, _id_new$2.pointer, _$collection.pointer)
         .object<JArrayList<$E>>();
   }
 
@@ -17189,9 +17550,10 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   static JList<$E?>? copyOf<$E extends jni$_.JObject?>(
     JCollection<$E?>? collection,
   ) {
+    final _$$classRef = _class.reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _copyOf(
-            _class.reference.pointer, _id_copyOf.pointer, _$collection.pointer)
+            _$$classRef.pointer, _id_copyOf.pointer, _$collection.pointer)
         .object<JList<$E?>?>();
   }
 
@@ -17215,7 +17577,8 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `static public java.util.List<E> of()`
   /// The returned object must be released after use, by calling the [release] method.
   static JList<$E?>? of<$E extends jni$_.JObject?>() {
-    return _of(_class.reference.pointer, _id_of.pointer).object<JList<$E?>?>();
+    final _$$classRef = _class.reference;
+    return _of(_$$classRef.pointer, _id_of.pointer).object<JList<$E?>?>();
   }
 
   static final _id_of$1 = _class.staticMethodId(
@@ -17239,8 +17602,9 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   static JList<$E?>? of$1<$E extends jni$_.JObject?>(
     $E? object,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _of$1(_class.reference.pointer, _id_of$1.pointer, _$object.pointer)
+    return _of$1(_$$classRef.pointer, _id_of$1.pointer, _$object.pointer)
         .object<JList<$E?>?>();
   }
 
@@ -17272,9 +17636,10 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object,
     $E? object1,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _of$2(_class.reference.pointer, _id_of$2.pointer, _$object.pointer,
+    return _of$2(_$$classRef.pointer, _id_of$2.pointer, _$object.pointer,
             _$object1.pointer)
         .object<JList<$E?>?>();
   }
@@ -17310,10 +17675,11 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object1,
     $E? object2,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
-    return _of$3(_class.reference.pointer, _id_of$3.pointer, _$object.pointer,
+    return _of$3(_$$classRef.pointer, _id_of$3.pointer, _$object.pointer,
             _$object1.pointer, _$object2.pointer)
         .object<JList<$E?>?>();
   }
@@ -17352,11 +17718,12 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object2,
     $E? object3,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
     final _$object3 = object3?.reference ?? jni$_.jNullReference;
-    return _of$4(_class.reference.pointer, _id_of$4.pointer, _$object.pointer,
+    return _of$4(_$$classRef.pointer, _id_of$4.pointer, _$object.pointer,
             _$object1.pointer, _$object2.pointer, _$object3.pointer)
         .object<JList<$E?>?>();
   }
@@ -17398,13 +17765,14 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object3,
     $E? object4,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
     final _$object3 = object3?.reference ?? jni$_.jNullReference;
     final _$object4 = object4?.reference ?? jni$_.jNullReference;
     return _of$5(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$5.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -17454,6 +17822,7 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object4,
     $E? object5,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -17461,7 +17830,7 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object4 = object4?.reference ?? jni$_.jNullReference;
     final _$object5 = object5?.reference ?? jni$_.jNullReference;
     return _of$6(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$6.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -17515,6 +17884,7 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object5,
     $E? object6,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -17523,7 +17893,7 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object5 = object5?.reference ?? jni$_.jNullReference;
     final _$object6 = object6?.reference ?? jni$_.jNullReference;
     return _of$7(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$7.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -17581,6 +17951,7 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object6,
     $E? object7,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -17590,7 +17961,7 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object6 = object6?.reference ?? jni$_.jNullReference;
     final _$object7 = object7?.reference ?? jni$_.jNullReference;
     return _of$8(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$8.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -17652,6 +18023,7 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object7,
     $E? object8,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -17662,7 +18034,7 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object7 = object7?.reference ?? jni$_.jNullReference;
     final _$object8 = object8?.reference ?? jni$_.jNullReference;
     return _of$9(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$9.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -17728,6 +18100,7 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object8,
     $E? object9,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -17739,7 +18112,7 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object8 = object8?.reference ?? jni$_.jNullReference;
     final _$object9 = object9?.reference ?? jni$_.jNullReference;
     return _of$10(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$10.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -17775,9 +18148,9 @@ extension type JArrayList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   static JList<$E?>? of$11<$E extends jni$_.JObject?>(
     jni$_.JArray<$E?>? objects,
   ) {
+    final _$$classRef = _class.reference;
     final _$objects = objects?.reference ?? jni$_.jNullReference;
-    return _of$11(
-            _class.reference.pointer, _id_of$11.pointer, _$objects.pointer)
+    return _of$11(_$$classRef.pointer, _id_of$11.pointer, _$objects.pointer)
         .object<JList<$E?>?>();
   }
 }
@@ -17803,8 +18176,9 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   core$_.bool add(
     $E? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _add(reference.pointer, _id_add.pointer, _$object.pointer).boolean;
+    return _add(_$$selfRef.pointer, _id_add.pointer, _$object.pointer).boolean;
   }
 
   static final _id_add$1 = JArrayList._class.instanceMethodId(
@@ -17829,8 +18203,9 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
     core$_.int i,
     $E? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    _add$1(reference.pointer, _id_add$1.pointer, i, _$object.pointer).check();
+    _add$1(_$$selfRef.pointer, _id_add$1.pointer, i, _$object.pointer).check();
   }
 
   static final _id_addAll = JArrayList._class.instanceMethodId(
@@ -17855,9 +18230,10 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
     core$_.int i,
     JCollection<$E?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _addAll(
-            reference.pointer, _id_addAll.pointer, i, _$collection.pointer)
+            _$$selfRef.pointer, _id_addAll.pointer, i, _$collection.pointer)
         .boolean;
   }
 
@@ -17881,9 +18257,10 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   core$_.bool addAll$1(
     JCollection<$E?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _addAll$1(
-            reference.pointer, _id_addAll$1.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_addAll$1.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -17907,8 +18284,9 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   void addFirst(
     $E? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    _addFirst(reference.pointer, _id_addFirst.pointer, _$object.pointer)
+    _addFirst(_$$selfRef.pointer, _id_addFirst.pointer, _$object.pointer)
         .check();
   }
 
@@ -17932,8 +18310,9 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   void addLast(
     $E? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    _addLast(reference.pointer, _id_addLast.pointer, _$object.pointer).check();
+    _addLast(_$$selfRef.pointer, _id_addLast.pointer, _$object.pointer).check();
   }
 
   static final _id_clear = JArrayList._class.instanceMethodId(
@@ -17955,7 +18334,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
 
   /// from: `public void clear()`
   void clear() {
-    _clear(reference.pointer, _id_clear.pointer).check();
+    final _$$selfRef = reference;
+    _clear(_$$selfRef.pointer, _id_clear.pointer).check();
   }
 
   static final _id_clone = JArrayList._class.instanceMethodId(
@@ -17978,7 +18358,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   /// from: `public java.lang.Object clone()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? clone() {
-    return _clone(reference.pointer, _id_clone.pointer)
+    final _$$selfRef = reference;
+    return _clone(_$$selfRef.pointer, _id_clone.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -18002,8 +18383,9 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   core$_.bool contains(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _contains(reference.pointer, _id_contains.pointer, _$object.pointer)
+    return _contains(_$$selfRef.pointer, _id_contains.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -18026,7 +18408,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   void ensureCapacity(
     core$_.int i,
   ) {
-    _ensureCapacity(reference.pointer, _id_ensureCapacity.pointer, i).check();
+    final _$$selfRef = reference;
+    _ensureCapacity(_$$selfRef.pointer, _id_ensureCapacity.pointer, i).check();
   }
 
   static final _id_equals = JArrayList._class.instanceMethodId(
@@ -18049,8 +18432,9 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -18074,8 +18458,9 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   void forEach(
     jni$_.JObject? consumer,
   ) {
+    final _$$selfRef = reference;
     final _$consumer = consumer?.reference ?? jni$_.jNullReference;
-    _forEach(reference.pointer, _id_forEach.pointer, _$consumer.pointer)
+    _forEach(_$$selfRef.pointer, _id_forEach.pointer, _$consumer.pointer)
         .check();
   }
 
@@ -18099,7 +18484,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   $E? get(
     core$_.int i,
   ) {
-    return _get(reference.pointer, _id_get.pointer, i).object<$E?>();
+    final _$$selfRef = reference;
+    return _get(_$$selfRef.pointer, _id_get.pointer, i).object<$E?>();
   }
 
   static final _id_get$first = JArrayList._class.instanceMethodId(
@@ -18122,7 +18508,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   /// from: `public E getFirst()`
   /// The returned object must be released after use, by calling the [release] method.
   $E? get first {
-    return _get$first(reference.pointer, _id_get$first.pointer).object<$E?>();
+    final _$$selfRef = reference;
+    return _get$first(_$$selfRef.pointer, _id_get$first.pointer).object<$E?>();
   }
 
   static final _id_get$last = JArrayList._class.instanceMethodId(
@@ -18145,7 +18532,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   /// from: `public E getLast()`
   /// The returned object must be released after use, by calling the [release] method.
   $E? get last {
-    return _get$last(reference.pointer, _id_get$last.pointer).object<$E?>();
+    final _$$selfRef = reference;
+    return _get$last(_$$selfRef.pointer, _id_get$last.pointer).object<$E?>();
   }
 
   static final _id_hashCode$1 = JArrayList._class.instanceMethodId(
@@ -18167,7 +18555,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
 
   /// from: `public int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_indexOf = JArrayList._class.instanceMethodId(
@@ -18190,8 +18579,9 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   core$_.int indexOf(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _indexOf(reference.pointer, _id_indexOf.pointer, _$object.pointer)
+    return _indexOf(_$$selfRef.pointer, _id_indexOf.pointer, _$object.pointer)
         .integer;
   }
 
@@ -18214,7 +18604,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
 
   /// from: `public boolean isEmpty()`
   core$_.bool get isEmpty {
-    return _get$isEmpty(reference.pointer, _id_get$isEmpty.pointer).boolean;
+    final _$$selfRef = reference;
+    return _get$isEmpty(_$$selfRef.pointer, _id_get$isEmpty.pointer).boolean;
   }
 
   static final _id_iterator = JArrayList._class.instanceMethodId(
@@ -18237,7 +18628,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   /// from: `public java.util.Iterator<E> iterator()`
   /// The returned object must be released after use, by calling the [release] method.
   JIterator<$E?>? iterator() {
-    return _iterator(reference.pointer, _id_iterator.pointer)
+    final _$$selfRef = reference;
+    return _iterator(_$$selfRef.pointer, _id_iterator.pointer)
         .object<JIterator<$E?>?>();
   }
 
@@ -18261,9 +18653,10 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   core$_.int lastIndexOf(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _lastIndexOf(
-            reference.pointer, _id_lastIndexOf.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_lastIndexOf.pointer, _$object.pointer)
         .integer;
   }
 
@@ -18287,7 +18680,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   /// from: `public java.util.ListIterator<E> listIterator()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? listIterator() {
-    return _listIterator(reference.pointer, _id_listIterator.pointer)
+    final _$$selfRef = reference;
+    return _listIterator(_$$selfRef.pointer, _id_listIterator.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -18311,7 +18705,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   jni$_.JObject? listIterator$1(
     core$_.int i,
   ) {
-    return _listIterator$1(reference.pointer, _id_listIterator$1.pointer, i)
+    final _$$selfRef = reference;
+    return _listIterator$1(_$$selfRef.pointer, _id_listIterator$1.pointer, i)
         .object<jni$_.JObject?>();
   }
 
@@ -18335,7 +18730,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   $E? remove(
     core$_.int i,
   ) {
-    return _remove(reference.pointer, _id_remove.pointer, i).object<$E?>();
+    final _$$selfRef = reference;
+    return _remove(_$$selfRef.pointer, _id_remove.pointer, i).object<$E?>();
   }
 
   static final _id_remove$1 = JArrayList._class.instanceMethodId(
@@ -18358,8 +18754,9 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   core$_.bool remove$1(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _remove$1(reference.pointer, _id_remove$1.pointer, _$object.pointer)
+    return _remove$1(_$$selfRef.pointer, _id_remove$1.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -18383,9 +18780,10 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   core$_.bool removeAll(
     JCollection<jni$_.JObject?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _removeAll(
-            reference.pointer, _id_removeAll.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_removeAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -18409,7 +18807,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   /// from: `public E removeFirst()`
   /// The returned object must be released after use, by calling the [release] method.
   $E? removeFirst() {
-    return _removeFirst(reference.pointer, _id_removeFirst.pointer)
+    final _$$selfRef = reference;
+    return _removeFirst(_$$selfRef.pointer, _id_removeFirst.pointer)
         .object<$E?>();
   }
 
@@ -18433,9 +18832,10 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   core$_.bool removeIf(
     jni$_.JObject? predicate,
   ) {
+    final _$$selfRef = reference;
     final _$predicate = predicate?.reference ?? jni$_.jNullReference;
     return _removeIf(
-            reference.pointer, _id_removeIf.pointer, _$predicate.pointer)
+            _$$selfRef.pointer, _id_removeIf.pointer, _$predicate.pointer)
         .boolean;
   }
 
@@ -18459,7 +18859,9 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   /// from: `public E removeLast()`
   /// The returned object must be released after use, by calling the [release] method.
   $E? removeLast() {
-    return _removeLast(reference.pointer, _id_removeLast.pointer).object<$E?>();
+    final _$$selfRef = reference;
+    return _removeLast(_$$selfRef.pointer, _id_removeLast.pointer)
+        .object<$E?>();
   }
 
   static final _id_replaceAll = JArrayList._class.instanceMethodId(
@@ -18482,9 +18884,10 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   void replaceAll(
     jni$_.JObject? unaryOperator,
   ) {
+    final _$$selfRef = reference;
     final _$unaryOperator = unaryOperator?.reference ?? jni$_.jNullReference;
     _replaceAll(
-            reference.pointer, _id_replaceAll.pointer, _$unaryOperator.pointer)
+            _$$selfRef.pointer, _id_replaceAll.pointer, _$unaryOperator.pointer)
         .check();
   }
 
@@ -18508,9 +18911,10 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   core$_.bool retainAll(
     JCollection<jni$_.JObject?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _retainAll(
-            reference.pointer, _id_retainAll.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_retainAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -18537,8 +18941,9 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
     core$_.int i,
     $E? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _set(reference.pointer, _id_set.pointer, i, _$object.pointer)
+    return _set(_$$selfRef.pointer, _id_set.pointer, i, _$object.pointer)
         .object<$E?>();
   }
 
@@ -18561,7 +18966,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
 
   /// from: `public int size()`
   core$_.int size() {
-    return _size(reference.pointer, _id_size.pointer).integer;
+    final _$$selfRef = reference;
+    return _size(_$$selfRef.pointer, _id_size.pointer).integer;
   }
 
   static final _id_sort = JArrayList._class.instanceMethodId(
@@ -18584,8 +18990,9 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   void sort(
     jni$_.JObject? comparator,
   ) {
+    final _$$selfRef = reference;
     final _$comparator = comparator?.reference ?? jni$_.jNullReference;
-    _sort(reference.pointer, _id_sort.pointer, _$comparator.pointer).check();
+    _sort(_$$selfRef.pointer, _id_sort.pointer, _$comparator.pointer).check();
   }
 
   static final _id_spliterator = JArrayList._class.instanceMethodId(
@@ -18608,7 +19015,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   /// from: `public java.util.Spliterator<E> spliterator()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? spliterator() {
-    return _spliterator(reference.pointer, _id_spliterator.pointer)
+    final _$$selfRef = reference;
+    return _spliterator(_$$selfRef.pointer, _id_spliterator.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -18634,7 +19042,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
     core$_.int i,
     core$_.int i1,
   ) {
-    return _subList(reference.pointer, _id_subList.pointer, i, i1)
+    final _$$selfRef = reference;
+    return _subList(_$$selfRef.pointer, _id_subList.pointer, i, i1)
         .object<JList<$E?>?>();
   }
 
@@ -18658,7 +19067,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   /// from: `public java.lang.Object[] toArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JArray<jni$_.JObject?>? toArray() {
-    return _toArray(reference.pointer, _id_toArray.pointer)
+    final _$$selfRef = reference;
+    return _toArray(_$$selfRef.pointer, _id_toArray.pointer)
         .object<jni$_.JArray<jni$_.JObject?>?>();
   }
 
@@ -18683,9 +19093,10 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   jni$_.JArray<$T?>? toArray$1<$T extends jni$_.JObject?>(
     jni$_.JArray<$T?>? objects,
   ) {
+    final _$$selfRef = reference;
     final _$objects = objects?.reference ?? jni$_.jNullReference;
     return _toArray$1(
-            reference.pointer, _id_toArray$1.pointer, _$objects.pointer)
+            _$$selfRef.pointer, _id_toArray$1.pointer, _$objects.pointer)
         .object<jni$_.JArray<$T?>?>();
   }
 
@@ -18708,7 +19119,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
 
   /// from: `public void trimToSize()`
   void trimToSize() {
-    _trimToSize(reference.pointer, _id_trimToSize.pointer).check();
+    final _$$selfRef = reference;
+    _trimToSize(_$$selfRef.pointer, _id_trimToSize.pointer).check();
   }
 
   static final _id_containsAll = JArrayList._class.instanceMethodId(
@@ -18731,9 +19143,10 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   core$_.bool containsAll(
     JCollection<jni$_.JObject?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _containsAll(
-            reference.pointer, _id_containsAll.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_containsAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -18757,7 +19170,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   /// from: `public java.util.List<E> reversed()`
   /// The returned object must be released after use, by calling the [release] method.
   JList<$E?>? reversed() {
-    return _reversed(reference.pointer, _id_reversed.pointer)
+    final _$$selfRef = reference;
+    return _reversed(_$$selfRef.pointer, _id_reversed.pointer)
         .object<JList<$E?>?>();
   }
 
@@ -18781,7 +19195,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   /// from: `public java.util.stream.Stream<E> parallelStream()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? parallelStream() {
-    return _parallelStream(reference.pointer, _id_parallelStream.pointer)
+    final _$$selfRef = reference;
+    return _parallelStream(_$$selfRef.pointer, _id_parallelStream.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -18805,7 +19220,8 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   /// from: `public java.util.stream.Stream<E> stream()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? stream() {
-    return _stream(reference.pointer, _id_stream.pointer)
+    final _$$selfRef = reference;
+    return _stream(_$$selfRef.pointer, _id_stream.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -18830,9 +19246,10 @@ extension JArrayList$$Methods<$E extends jni$_.JObject?> on JArrayList<$E> {
   jni$_.JArray<$T?>? toArray$2<$T extends jni$_.JObject?>(
     jni$_.JObject? intFunction,
   ) {
+    final _$$selfRef = reference;
     final _$intFunction = intFunction?.reference ?? jni$_.jNullReference;
     return _toArray$2(
-            reference.pointer, _id_toArray$2.pointer, _$intFunction.pointer)
+            _$$selfRef.pointer, _id_toArray$2.pointer, _$intFunction.pointer)
         .object<jni$_.JArray<$T?>?>();
   }
 }
@@ -19078,8 +19495,9 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
   core$_.bool add(
     $E? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _add(reference.pointer, _id_add.pointer, _$object.pointer).boolean;
+    return _add(_$$selfRef.pointer, _id_add.pointer, _$object.pointer).boolean;
   }
 
   static final _id_addAll = JCollection._class.instanceMethodId(
@@ -19102,8 +19520,9 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
   core$_.bool addAll(
     JCollection<$E?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
-    return _addAll(reference.pointer, _id_addAll.pointer, _$collection.pointer)
+    return _addAll(_$$selfRef.pointer, _id_addAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -19126,7 +19545,8 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
 
   /// from: `public abstract void clear()`
   void clear() {
-    _clear(reference.pointer, _id_clear.pointer).check();
+    final _$$selfRef = reference;
+    _clear(_$$selfRef.pointer, _id_clear.pointer).check();
   }
 
   static final _id_contains = JCollection._class.instanceMethodId(
@@ -19149,8 +19569,9 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
   core$_.bool contains(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _contains(reference.pointer, _id_contains.pointer, _$object.pointer)
+    return _contains(_$$selfRef.pointer, _id_contains.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -19174,9 +19595,10 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
   core$_.bool containsAll(
     JCollection<jni$_.JObject?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _containsAll(
-            reference.pointer, _id_containsAll.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_containsAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -19200,8 +19622,9 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -19224,7 +19647,8 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
 
   /// from: `public abstract int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_isEmpty = JCollection._class.instanceMethodId(
@@ -19246,7 +19670,8 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
 
   /// from: `public abstract boolean isEmpty()`
   core$_.bool isEmpty() {
-    return _isEmpty(reference.pointer, _id_isEmpty.pointer).boolean;
+    final _$$selfRef = reference;
+    return _isEmpty(_$$selfRef.pointer, _id_isEmpty.pointer).boolean;
   }
 
   static final _id_iterator = JCollection._class.instanceMethodId(
@@ -19269,7 +19694,8 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
   /// from: `public abstract java.util.Iterator<E> iterator()`
   /// The returned object must be released after use, by calling the [release] method.
   JIterator<$E?>? iterator() {
-    return _iterator(reference.pointer, _id_iterator.pointer)
+    final _$$selfRef = reference;
+    return _iterator(_$$selfRef.pointer, _id_iterator.pointer)
         .object<JIterator<$E?>?>();
   }
 
@@ -19293,7 +19719,8 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
   /// from: `public java.util.stream.Stream<E> parallelStream()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? parallelStream() {
-    return _parallelStream(reference.pointer, _id_parallelStream.pointer)
+    final _$$selfRef = reference;
+    return _parallelStream(_$$selfRef.pointer, _id_parallelStream.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -19317,8 +19744,9 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
   core$_.bool remove(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _remove(reference.pointer, _id_remove.pointer, _$object.pointer)
+    return _remove(_$$selfRef.pointer, _id_remove.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -19342,9 +19770,10 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
   core$_.bool removeAll(
     JCollection<jni$_.JObject?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _removeAll(
-            reference.pointer, _id_removeAll.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_removeAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -19368,9 +19797,10 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
   core$_.bool removeIf(
     jni$_.JObject? predicate,
   ) {
+    final _$$selfRef = reference;
     final _$predicate = predicate?.reference ?? jni$_.jNullReference;
     return _removeIf(
-            reference.pointer, _id_removeIf.pointer, _$predicate.pointer)
+            _$$selfRef.pointer, _id_removeIf.pointer, _$predicate.pointer)
         .boolean;
   }
 
@@ -19394,9 +19824,10 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
   core$_.bool retainAll(
     JCollection<jni$_.JObject?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _retainAll(
-            reference.pointer, _id_retainAll.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_retainAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -19419,7 +19850,8 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
 
   /// from: `public abstract int size()`
   core$_.int size() {
-    return _size(reference.pointer, _id_size.pointer).integer;
+    final _$$selfRef = reference;
+    return _size(_$$selfRef.pointer, _id_size.pointer).integer;
   }
 
   static final _id_spliterator = JCollection._class.instanceMethodId(
@@ -19442,7 +19874,8 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
   /// from: `public java.util.Spliterator<E> spliterator()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? spliterator() {
-    return _spliterator(reference.pointer, _id_spliterator.pointer)
+    final _$$selfRef = reference;
+    return _spliterator(_$$selfRef.pointer, _id_spliterator.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -19466,7 +19899,8 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
   /// from: `public java.util.stream.Stream<E> stream()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? stream() {
-    return _stream(reference.pointer, _id_stream.pointer)
+    final _$$selfRef = reference;
+    return _stream(_$$selfRef.pointer, _id_stream.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -19490,7 +19924,8 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
   /// from: `public abstract java.lang.Object[] toArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JArray<jni$_.JObject?>? toArray() {
-    return _toArray(reference.pointer, _id_toArray.pointer)
+    final _$$selfRef = reference;
+    return _toArray(_$$selfRef.pointer, _id_toArray.pointer)
         .object<jni$_.JArray<jni$_.JObject?>?>();
   }
 
@@ -19515,9 +19950,10 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
   jni$_.JArray<$T?>? toArray$1<$T extends jni$_.JObject?>(
     jni$_.JObject? intFunction,
   ) {
+    final _$$selfRef = reference;
     final _$intFunction = intFunction?.reference ?? jni$_.jNullReference;
     return _toArray$1(
-            reference.pointer, _id_toArray$1.pointer, _$intFunction.pointer)
+            _$$selfRef.pointer, _id_toArray$1.pointer, _$intFunction.pointer)
         .object<jni$_.JArray<$T?>?>();
   }
 
@@ -19542,9 +19978,10 @@ extension JCollection$$Methods<$E extends jni$_.JObject?> on JCollection<$E> {
   jni$_.JArray<$T?>? toArray$2<$T extends jni$_.JObject?>(
     jni$_.JArray<$T?>? objects,
   ) {
+    final _$$selfRef = reference;
     final _$objects = objects?.reference ?? jni$_.jNullReference;
     return _toArray$2(
-            reference.pointer, _id_toArray$2.pointer, _$objects.pointer)
+            _$$selfRef.pointer, _id_toArray$2.pointer, _$objects.pointer)
         .object<jni$_.JArray<$T?>?>();
   }
 }
@@ -19800,7 +20237,8 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory JHashMap() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<JHashMap<$K, $V>>();
   }
 
@@ -19823,7 +20261,8 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
   factory JHashMap.new$1(
     core$_.int i,
   ) {
-    return _new$1(_class.reference.pointer, _id_new$1.pointer, i)
+    final _$$classRef = _class.reference;
+    return _new$1(_$$classRef.pointer, _id_new$1.pointer, i)
         .object<JHashMap<$K, $V>>();
   }
 
@@ -19848,7 +20287,8 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     core$_.int i,
     core$_.double f,
   ) {
-    return _new$2(_class.reference.pointer, _id_new$2.pointer, i, f)
+    final _$$classRef = _class.reference;
+    return _new$2(_$$classRef.pointer, _id_new$2.pointer, i, f)
         .object<JHashMap<$K, $V>>();
   }
 
@@ -19872,8 +20312,9 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
   factory JHashMap.new$3(
     JMap<$K?, $V?>? map,
   ) {
+    final _$$classRef = _class.reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _new$3(_class.reference.pointer, _id_new$3.pointer, _$map.pointer)
+    return _new$3(_$$classRef.pointer, _id_new$3.pointer, _$map.pointer)
         .object<JHashMap<$K, $V>>();
   }
 
@@ -19897,7 +20338,8 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
       newHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
     core$_.int i,
   ) {
-    return _newHashMap(_class.reference.pointer, _id_newHashMap.pointer, i)
+    final _$$classRef = _class.reference;
+    return _newHashMap(_$$classRef.pointer, _id_newHashMap.pointer, i)
         .object<JHashMap<$K?, $V?>?>();
   }
 
@@ -19923,8 +20365,9 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
       copyOf<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
     JMap<$K?, $V?>? map,
   ) {
+    final _$$classRef = _class.reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _copyOf(_class.reference.pointer, _id_copyOf.pointer, _$map.pointer)
+    return _copyOf(_$$classRef.pointer, _id_copyOf.pointer, _$map.pointer)
         .object<JMap<$K?, $V?>?>();
   }
 
@@ -19957,9 +20400,10 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object,
     $V? object1,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _entry(_class.reference.pointer, _id_entry.pointer, _$object.pointer,
+    return _entry(_$$classRef.pointer, _id_entry.pointer, _$object.pointer,
             _$object1.pointer)
         .object<JMap$JEntry<$K?, $V?>?>();
   }
@@ -19985,8 +20429,8 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
   /// The returned object must be released after use, by calling the [release] method.
   static JMap<$K?, $V?>?
       of<$K extends jni$_.JObject?, $V extends jni$_.JObject?>() {
-    return _of(_class.reference.pointer, _id_of.pointer)
-        .object<JMap<$K?, $V?>?>();
+    final _$$classRef = _class.reference;
+    return _of(_$$classRef.pointer, _id_of.pointer).object<JMap<$K?, $V?>?>();
   }
 
   static final _id_of$1 = _class.staticMethodId(
@@ -20018,9 +20462,10 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object,
     $V? object1,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _of$1(_class.reference.pointer, _id_of$1.pointer, _$object.pointer,
+    return _of$1(_$$classRef.pointer, _id_of$1.pointer, _$object.pointer,
             _$object1.pointer)
         .object<JMap<$K?, $V?>?>();
   }
@@ -20060,11 +20505,12 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object2,
     $V? object3,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
     final _$object3 = object3?.reference ?? jni$_.jNullReference;
-    return _of$2(_class.reference.pointer, _id_of$2.pointer, _$object.pointer,
+    return _of$2(_$$classRef.pointer, _id_of$2.pointer, _$object.pointer,
             _$object1.pointer, _$object2.pointer, _$object3.pointer)
         .object<JMap<$K?, $V?>?>();
   }
@@ -20110,6 +20556,7 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object4,
     $V? object5,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -20117,7 +20564,7 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     final _$object4 = object4?.reference ?? jni$_.jNullReference;
     final _$object5 = object5?.reference ?? jni$_.jNullReference;
     return _of$3(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$3.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -20175,6 +20622,7 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object6,
     $V? object7,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -20184,7 +20632,7 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     final _$object6 = object6?.reference ?? jni$_.jNullReference;
     final _$object7 = object7?.reference ?? jni$_.jNullReference;
     return _of$4(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$4.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -20250,6 +20698,7 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object8,
     $V? object9,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -20261,7 +20710,7 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     final _$object8 = object8?.reference ?? jni$_.jNullReference;
     final _$object9 = object9?.reference ?? jni$_.jNullReference;
     return _of$5(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$5.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -20335,6 +20784,7 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object10,
     $V? object11,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -20348,7 +20798,7 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     final _$object10 = object10?.reference ?? jni$_.jNullReference;
     final _$object11 = object11?.reference ?? jni$_.jNullReference;
     return _of$6(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$6.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -20430,6 +20880,7 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object12,
     $V? object13,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -20445,7 +20896,7 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     final _$object12 = object12?.reference ?? jni$_.jNullReference;
     final _$object13 = object13?.reference ?? jni$_.jNullReference;
     return _of$7(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$7.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -20535,6 +20986,7 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object14,
     $V? object15,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -20552,7 +21004,7 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     final _$object14 = object14?.reference ?? jni$_.jNullReference;
     final _$object15 = object15?.reference ?? jni$_.jNullReference;
     return _of$8(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$8.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -20650,6 +21102,7 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object16,
     $V? object17,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -20669,7 +21122,7 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     final _$object16 = object16?.reference ?? jni$_.jNullReference;
     final _$object17 = object17?.reference ?? jni$_.jNullReference;
     return _of$9(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$9.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -20775,6 +21228,7 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object18,
     $V? object19,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -20796,7 +21250,7 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     final _$object18 = object18?.reference ?? jni$_.jNullReference;
     final _$object19 = object19?.reference ?? jni$_.jNullReference;
     return _of$10(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$10.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -20843,9 +21297,10 @@ extension type JHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
       ofEntries<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
     jni$_.JArray<JMap$JEntry<$K?, $V?>?>? entrys,
   ) {
+    final _$$classRef = _class.reference;
     final _$entrys = entrys?.reference ?? jni$_.jNullReference;
     return _ofEntries(
-            _class.reference.pointer, _id_ofEntries.pointer, _$entrys.pointer)
+            _$$classRef.pointer, _id_ofEntries.pointer, _$entrys.pointer)
         .object<JMap<$K?, $V?>?>();
   }
 }
@@ -20871,7 +21326,8 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
 
   /// from: `public void clear()`
   void clear() {
-    _clear(reference.pointer, _id_clear.pointer).check();
+    final _$$selfRef = reference;
+    _clear(_$$selfRef.pointer, _id_clear.pointer).check();
   }
 
   static final _id_clone = JHashMap._class.instanceMethodId(
@@ -20894,7 +21350,8 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
   /// from: `public java.lang.Object clone()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? clone() {
-    return _clone(reference.pointer, _id_clone.pointer)
+    final _$$selfRef = reference;
+    return _clone(_$$selfRef.pointer, _id_clone.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -20926,9 +21383,10 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
     $K? object,
     jni$_.JObject? biFunction,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$biFunction = biFunction?.reference ?? jni$_.jNullReference;
-    return _compute(reference.pointer, _id_compute.pointer, _$object.pointer,
+    return _compute(_$$selfRef.pointer, _id_compute.pointer, _$object.pointer,
             _$biFunction.pointer)
         .object<$V?>();
   }
@@ -20961,9 +21419,10 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
     $K? object,
     jni$_.JObject? function,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$function = function?.reference ?? jni$_.jNullReference;
-    return _computeIfAbsent(reference.pointer, _id_computeIfAbsent.pointer,
+    return _computeIfAbsent(_$$selfRef.pointer, _id_computeIfAbsent.pointer,
             _$object.pointer, _$function.pointer)
         .object<$V?>();
   }
@@ -20996,9 +21455,10 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
     $K? object,
     jni$_.JObject? biFunction,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$biFunction = biFunction?.reference ?? jni$_.jNullReference;
-    return _computeIfPresent(reference.pointer, _id_computeIfPresent.pointer,
+    return _computeIfPresent(_$$selfRef.pointer, _id_computeIfPresent.pointer,
             _$object.pointer, _$biFunction.pointer)
         .object<$V?>();
   }
@@ -21023,9 +21483,10 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
   core$_.bool containsKey(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _containsKey(
-            reference.pointer, _id_containsKey.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_containsKey.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -21049,9 +21510,10 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
   core$_.bool containsValue(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _containsValue(
-            reference.pointer, _id_containsValue.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_containsValue.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -21075,7 +21537,8 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
   /// from: `public java.util.Set<java.util.Map$Entry<K, V>> entrySet()`
   /// The returned object must be released after use, by calling the [release] method.
   JSet<JMap$JEntry<$K?, $V?>?>? entrySet() {
-    return _entrySet(reference.pointer, _id_entrySet.pointer)
+    final _$$selfRef = reference;
+    return _entrySet(_$$selfRef.pointer, _id_entrySet.pointer)
         .object<JSet<JMap$JEntry<$K?, $V?>?>?>();
   }
 
@@ -21099,8 +21562,9 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
   void forEach(
     jni$_.JObject? biConsumer,
   ) {
+    final _$$selfRef = reference;
     final _$biConsumer = biConsumer?.reference ?? jni$_.jNullReference;
-    _forEach(reference.pointer, _id_forEach.pointer, _$biConsumer.pointer)
+    _forEach(_$$selfRef.pointer, _id_forEach.pointer, _$biConsumer.pointer)
         .check();
   }
 
@@ -21125,8 +21589,9 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
   $V? get(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _get(reference.pointer, _id_get.pointer, _$object.pointer)
+    return _get(_$$selfRef.pointer, _id_get.pointer, _$object.pointer)
         .object<$V?>();
   }
 
@@ -21158,9 +21623,10 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
     jni$_.JObject? object,
     $V? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _getOrDefault(reference.pointer, _id_getOrDefault.pointer,
+    return _getOrDefault(_$$selfRef.pointer, _id_getOrDefault.pointer,
             _$object.pointer, _$object1.pointer)
         .object<$V?>();
   }
@@ -21184,7 +21650,8 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
 
   /// from: `public boolean isEmpty()`
   core$_.bool get isEmpty {
-    return _get$isEmpty(reference.pointer, _id_get$isEmpty.pointer).boolean;
+    final _$$selfRef = reference;
+    return _get$isEmpty(_$$selfRef.pointer, _id_get$isEmpty.pointer).boolean;
   }
 
   static final _id_keySet = JHashMap._class.instanceMethodId(
@@ -21207,7 +21674,8 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
   /// from: `public java.util.Set<K> keySet()`
   /// The returned object must be released after use, by calling the [release] method.
   JSet<$K?>? keySet() {
-    return _keySet(reference.pointer, _id_keySet.pointer).object<JSet<$K?>?>();
+    final _$$selfRef = reference;
+    return _keySet(_$$selfRef.pointer, _id_keySet.pointer).object<JSet<$K?>?>();
   }
 
   static final _id_merge = JHashMap._class.instanceMethodId(
@@ -21241,10 +21709,11 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
     $V? object1,
     jni$_.JObject? biFunction,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$biFunction = biFunction?.reference ?? jni$_.jNullReference;
-    return _merge(reference.pointer, _id_merge.pointer, _$object.pointer,
+    return _merge(_$$selfRef.pointer, _id_merge.pointer, _$object.pointer,
             _$object1.pointer, _$biFunction.pointer)
         .object<$V?>();
   }
@@ -21277,9 +21746,10 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
     $K? object,
     $V? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _put(reference.pointer, _id_put.pointer, _$object.pointer,
+    return _put(_$$selfRef.pointer, _id_put.pointer, _$object.pointer,
             _$object1.pointer)
         .object<$V?>();
   }
@@ -21304,8 +21774,9 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
   void putAll(
     JMap<$K?, $V?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    _putAll(reference.pointer, _id_putAll.pointer, _$map.pointer).check();
+    _putAll(_$$selfRef.pointer, _id_putAll.pointer, _$map.pointer).check();
   }
 
   static final _id_putIfAbsent = JHashMap._class.instanceMethodId(
@@ -21336,9 +21807,10 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
     $K? object,
     $V? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _putIfAbsent(reference.pointer, _id_putIfAbsent.pointer,
+    return _putIfAbsent(_$$selfRef.pointer, _id_putIfAbsent.pointer,
             _$object.pointer, _$object1.pointer)
         .object<$V?>();
   }
@@ -21364,8 +21836,9 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
   $V? remove(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _remove(reference.pointer, _id_remove.pointer, _$object.pointer)
+    return _remove(_$$selfRef.pointer, _id_remove.pointer, _$object.pointer)
         .object<$V?>();
   }
 
@@ -21396,9 +21869,10 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
     jni$_.JObject? object,
     jni$_.JObject? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _remove$1(reference.pointer, _id_remove$1.pointer, _$object.pointer,
+    return _remove$1(_$$selfRef.pointer, _id_remove$1.pointer, _$object.pointer,
             _$object1.pointer)
         .boolean;
   }
@@ -21431,9 +21905,10 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
     $K? object,
     $V? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _replace(reference.pointer, _id_replace.pointer, _$object.pointer,
+    return _replace(_$$selfRef.pointer, _id_replace.pointer, _$object.pointer,
             _$object1.pointer)
         .object<$V?>();
   }
@@ -21468,10 +21943,11 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
     $V? object1,
     $V? object2,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
-    return _replace$1(reference.pointer, _id_replace$1.pointer,
+    return _replace$1(_$$selfRef.pointer, _id_replace$1.pointer,
             _$object.pointer, _$object1.pointer, _$object2.pointer)
         .boolean;
   }
@@ -21496,8 +21972,10 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
   void replaceAll(
     jni$_.JObject? biFunction,
   ) {
+    final _$$selfRef = reference;
     final _$biFunction = biFunction?.reference ?? jni$_.jNullReference;
-    _replaceAll(reference.pointer, _id_replaceAll.pointer, _$biFunction.pointer)
+    _replaceAll(
+            _$$selfRef.pointer, _id_replaceAll.pointer, _$biFunction.pointer)
         .check();
   }
 
@@ -21520,7 +21998,8 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
 
   /// from: `public int size()`
   core$_.int size() {
-    return _size(reference.pointer, _id_size.pointer).integer;
+    final _$$selfRef = reference;
+    return _size(_$$selfRef.pointer, _id_size.pointer).integer;
   }
 
   static final _id_values = JHashMap._class.instanceMethodId(
@@ -21543,7 +22022,8 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
   /// from: `public java.util.Collection<V> values()`
   /// The returned object must be released after use, by calling the [release] method.
   JCollection<$V?>? values() {
-    return _values(reference.pointer, _id_values.pointer)
+    final _$$selfRef = reference;
+    return _values(_$$selfRef.pointer, _id_values.pointer)
         .object<JCollection<$V?>?>();
   }
 
@@ -21567,8 +22047,9 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -21591,7 +22072,8 @@ extension JHashMap$$Methods<$K extends jni$_.JObject?,
 
   /// from: `public abstract int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 }
 
@@ -21630,8 +22112,8 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory JHashSet() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<JHashSet<$E>>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<JHashSet<$E>>();
   }
 
   static final _id_new$1 = _class.constructorId(
@@ -21653,7 +22135,8 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   factory JHashSet.new$1(
     core$_.int i,
   ) {
-    return _new$1(_class.reference.pointer, _id_new$1.pointer, i)
+    final _$$classRef = _class.reference;
+    return _new$1(_$$classRef.pointer, _id_new$1.pointer, i)
         .object<JHashSet<$E>>();
   }
 
@@ -21678,7 +22161,8 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     core$_.int i,
     core$_.double f,
   ) {
-    return _new$2(_class.reference.pointer, _id_new$2.pointer, i, f)
+    final _$$classRef = _class.reference;
+    return _new$2(_$$classRef.pointer, _id_new$2.pointer, i, f)
         .object<JHashSet<$E>>();
   }
 
@@ -21702,9 +22186,9 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   factory JHashSet.new$3(
     JCollection<$E?>? collection,
   ) {
+    final _$$classRef = _class.reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
-    return _new$3(
-            _class.reference.pointer, _id_new$3.pointer, _$collection.pointer)
+    return _new$3(_$$classRef.pointer, _id_new$3.pointer, _$collection.pointer)
         .object<JHashSet<$E>>();
   }
 
@@ -21727,7 +22211,8 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   static JHashSet<$T?>? newHashSet<$T extends jni$_.JObject?>(
     core$_.int i,
   ) {
-    return _newHashSet(_class.reference.pointer, _id_newHashSet.pointer, i)
+    final _$$classRef = _class.reference;
+    return _newHashSet(_$$classRef.pointer, _id_newHashSet.pointer, i)
         .object<JHashSet<$T?>?>();
   }
 
@@ -21752,9 +22237,10 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   static JSet<$E?>? copyOf<$E extends jni$_.JObject?>(
     JCollection<$E?>? collection,
   ) {
+    final _$$classRef = _class.reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _copyOf(
-            _class.reference.pointer, _id_copyOf.pointer, _$collection.pointer)
+            _$$classRef.pointer, _id_copyOf.pointer, _$collection.pointer)
         .object<JSet<$E?>?>();
   }
 
@@ -21778,7 +22264,8 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `static public java.util.Set<E> of()`
   /// The returned object must be released after use, by calling the [release] method.
   static JSet<$E?>? of<$E extends jni$_.JObject?>() {
-    return _of(_class.reference.pointer, _id_of.pointer).object<JSet<$E?>?>();
+    final _$$classRef = _class.reference;
+    return _of(_$$classRef.pointer, _id_of.pointer).object<JSet<$E?>?>();
   }
 
   static final _id_of$1 = _class.staticMethodId(
@@ -21802,8 +22289,9 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   static JSet<$E?>? of$1<$E extends jni$_.JObject?>(
     $E? object,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _of$1(_class.reference.pointer, _id_of$1.pointer, _$object.pointer)
+    return _of$1(_$$classRef.pointer, _id_of$1.pointer, _$object.pointer)
         .object<JSet<$E?>?>();
   }
 
@@ -21835,9 +22323,10 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object,
     $E? object1,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _of$2(_class.reference.pointer, _id_of$2.pointer, _$object.pointer,
+    return _of$2(_$$classRef.pointer, _id_of$2.pointer, _$object.pointer,
             _$object1.pointer)
         .object<JSet<$E?>?>();
   }
@@ -21873,10 +22362,11 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object1,
     $E? object2,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
-    return _of$3(_class.reference.pointer, _id_of$3.pointer, _$object.pointer,
+    return _of$3(_$$classRef.pointer, _id_of$3.pointer, _$object.pointer,
             _$object1.pointer, _$object2.pointer)
         .object<JSet<$E?>?>();
   }
@@ -21915,11 +22405,12 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object2,
     $E? object3,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
     final _$object3 = object3?.reference ?? jni$_.jNullReference;
-    return _of$4(_class.reference.pointer, _id_of$4.pointer, _$object.pointer,
+    return _of$4(_$$classRef.pointer, _id_of$4.pointer, _$object.pointer,
             _$object1.pointer, _$object2.pointer, _$object3.pointer)
         .object<JSet<$E?>?>();
   }
@@ -21961,13 +22452,14 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object3,
     $E? object4,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
     final _$object3 = object3?.reference ?? jni$_.jNullReference;
     final _$object4 = object4?.reference ?? jni$_.jNullReference;
     return _of$5(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$5.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -22017,6 +22509,7 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object4,
     $E? object5,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -22024,7 +22517,7 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object4 = object4?.reference ?? jni$_.jNullReference;
     final _$object5 = object5?.reference ?? jni$_.jNullReference;
     return _of$6(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$6.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -22078,6 +22571,7 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object5,
     $E? object6,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -22086,7 +22580,7 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object5 = object5?.reference ?? jni$_.jNullReference;
     final _$object6 = object6?.reference ?? jni$_.jNullReference;
     return _of$7(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$7.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -22144,6 +22638,7 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object6,
     $E? object7,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -22153,7 +22648,7 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object6 = object6?.reference ?? jni$_.jNullReference;
     final _$object7 = object7?.reference ?? jni$_.jNullReference;
     return _of$8(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$8.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -22215,6 +22710,7 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object7,
     $E? object8,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -22225,7 +22721,7 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object7 = object7?.reference ?? jni$_.jNullReference;
     final _$object8 = object8?.reference ?? jni$_.jNullReference;
     return _of$9(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$9.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -22291,6 +22787,7 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object8,
     $E? object9,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -22302,7 +22799,7 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object8 = object8?.reference ?? jni$_.jNullReference;
     final _$object9 = object9?.reference ?? jni$_.jNullReference;
     return _of$10(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$10.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -22338,9 +22835,9 @@ extension type JHashSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   static JSet<$E?>? of$11<$E extends jni$_.JObject?>(
     jni$_.JArray<$E?>? objects,
   ) {
+    final _$$classRef = _class.reference;
     final _$objects = objects?.reference ?? jni$_.jNullReference;
-    return _of$11(
-            _class.reference.pointer, _id_of$11.pointer, _$objects.pointer)
+    return _of$11(_$$classRef.pointer, _id_of$11.pointer, _$objects.pointer)
         .object<JSet<$E?>?>();
   }
 }
@@ -22366,8 +22863,9 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   core$_.bool add(
     $E? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _add(reference.pointer, _id_add.pointer, _$object.pointer).boolean;
+    return _add(_$$selfRef.pointer, _id_add.pointer, _$object.pointer).boolean;
   }
 
   static final _id_clear = JHashSet._class.instanceMethodId(
@@ -22389,7 +22887,8 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
 
   /// from: `public void clear()`
   void clear() {
-    _clear(reference.pointer, _id_clear.pointer).check();
+    final _$$selfRef = reference;
+    _clear(_$$selfRef.pointer, _id_clear.pointer).check();
   }
 
   static final _id_clone = JHashSet._class.instanceMethodId(
@@ -22412,7 +22911,8 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   /// from: `public java.lang.Object clone()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? clone() {
-    return _clone(reference.pointer, _id_clone.pointer)
+    final _$$selfRef = reference;
+    return _clone(_$$selfRef.pointer, _id_clone.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -22436,8 +22936,9 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   core$_.bool contains(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _contains(reference.pointer, _id_contains.pointer, _$object.pointer)
+    return _contains(_$$selfRef.pointer, _id_contains.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -22460,7 +22961,8 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
 
   /// from: `public boolean isEmpty()`
   core$_.bool get isEmpty {
-    return _get$isEmpty(reference.pointer, _id_get$isEmpty.pointer).boolean;
+    final _$$selfRef = reference;
+    return _get$isEmpty(_$$selfRef.pointer, _id_get$isEmpty.pointer).boolean;
   }
 
   static final _id_iterator = JHashSet._class.instanceMethodId(
@@ -22483,7 +22985,8 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   /// from: `public java.util.Iterator<E> iterator()`
   /// The returned object must be released after use, by calling the [release] method.
   JIterator<$E?>? iterator() {
-    return _iterator(reference.pointer, _id_iterator.pointer)
+    final _$$selfRef = reference;
+    return _iterator(_$$selfRef.pointer, _id_iterator.pointer)
         .object<JIterator<$E?>?>();
   }
 
@@ -22507,8 +23010,9 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   core$_.bool remove(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _remove(reference.pointer, _id_remove.pointer, _$object.pointer)
+    return _remove(_$$selfRef.pointer, _id_remove.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -22531,7 +23035,8 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
 
   /// from: `public int size()`
   core$_.int size() {
-    return _size(reference.pointer, _id_size.pointer).integer;
+    final _$$selfRef = reference;
+    return _size(_$$selfRef.pointer, _id_size.pointer).integer;
   }
 
   static final _id_spliterator = JHashSet._class.instanceMethodId(
@@ -22554,7 +23059,8 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   /// from: `public java.util.Spliterator<E> spliterator()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? spliterator() {
-    return _spliterator(reference.pointer, _id_spliterator.pointer)
+    final _$$selfRef = reference;
+    return _spliterator(_$$selfRef.pointer, _id_spliterator.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -22578,7 +23084,8 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   /// from: `public java.lang.Object[] toArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JArray<jni$_.JObject?>? toArray() {
-    return _toArray(reference.pointer, _id_toArray.pointer)
+    final _$$selfRef = reference;
+    return _toArray(_$$selfRef.pointer, _id_toArray.pointer)
         .object<jni$_.JArray<jni$_.JObject?>?>();
   }
 
@@ -22603,9 +23110,10 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   jni$_.JArray<$T?>? toArray$1<$T extends jni$_.JObject?>(
     jni$_.JArray<$T?>? objects,
   ) {
+    final _$$selfRef = reference;
     final _$objects = objects?.reference ?? jni$_.jNullReference;
     return _toArray$1(
-            reference.pointer, _id_toArray$1.pointer, _$objects.pointer)
+            _$$selfRef.pointer, _id_toArray$1.pointer, _$objects.pointer)
         .object<jni$_.JArray<$T?>?>();
   }
 
@@ -22629,8 +23137,9 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   core$_.bool addAll(
     JCollection<$E?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
-    return _addAll(reference.pointer, _id_addAll.pointer, _$collection.pointer)
+    return _addAll(_$$selfRef.pointer, _id_addAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -22654,9 +23163,10 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   core$_.bool containsAll(
     JCollection<jni$_.JObject?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _containsAll(
-            reference.pointer, _id_containsAll.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_containsAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -22680,8 +23190,9 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -22704,7 +23215,8 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
 
   /// from: `public abstract int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_removeAll = JHashSet._class.instanceMethodId(
@@ -22727,9 +23239,10 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   core$_.bool removeAll(
     JCollection<jni$_.JObject?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _removeAll(
-            reference.pointer, _id_removeAll.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_removeAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -22753,9 +23266,10 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   core$_.bool retainAll(
     JCollection<jni$_.JObject?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _retainAll(
-            reference.pointer, _id_retainAll.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_retainAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -22779,7 +23293,8 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   /// from: `public java.util.stream.Stream<E> parallelStream()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? parallelStream() {
-    return _parallelStream(reference.pointer, _id_parallelStream.pointer)
+    final _$$selfRef = reference;
+    return _parallelStream(_$$selfRef.pointer, _id_parallelStream.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -22803,9 +23318,10 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   core$_.bool removeIf(
     jni$_.JObject? predicate,
   ) {
+    final _$$selfRef = reference;
     final _$predicate = predicate?.reference ?? jni$_.jNullReference;
     return _removeIf(
-            reference.pointer, _id_removeIf.pointer, _$predicate.pointer)
+            _$$selfRef.pointer, _id_removeIf.pointer, _$predicate.pointer)
         .boolean;
   }
 
@@ -22829,7 +23345,8 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   /// from: `public java.util.stream.Stream<E> stream()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? stream() {
-    return _stream(reference.pointer, _id_stream.pointer)
+    final _$$selfRef = reference;
+    return _stream(_$$selfRef.pointer, _id_stream.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -22854,9 +23371,10 @@ extension JHashSet$$Methods<$E extends jni$_.JObject?> on JHashSet<$E> {
   jni$_.JArray<$T?>? toArray$2<$T extends jni$_.JObject?>(
     jni$_.JObject? intFunction,
   ) {
+    final _$$selfRef = reference;
     final _$intFunction = intFunction?.reference ?? jni$_.jNullReference;
     return _toArray$2(
-            reference.pointer, _id_toArray$2.pointer, _$intFunction.pointer)
+            _$$selfRef.pointer, _id_toArray$2.pointer, _$intFunction.pointer)
         .object<jni$_.JArray<$T?>?>();
   }
 }
@@ -22995,9 +23513,10 @@ extension JIterator$$Methods<$E extends jni$_.JObject?> on JIterator<$E> {
   void forEachRemaining(
     jni$_.JObject? consumer,
   ) {
+    final _$$selfRef = reference;
     final _$consumer = consumer?.reference ?? jni$_.jNullReference;
-    _forEachRemaining(
-            reference.pointer, _id_forEachRemaining.pointer, _$consumer.pointer)
+    _forEachRemaining(_$$selfRef.pointer, _id_forEachRemaining.pointer,
+            _$consumer.pointer)
         .check();
   }
 
@@ -23020,7 +23539,8 @@ extension JIterator$$Methods<$E extends jni$_.JObject?> on JIterator<$E> {
 
   /// from: `public abstract boolean hasNext()`
   core$_.bool hasNext() {
-    return _hasNext(reference.pointer, _id_hasNext.pointer).boolean;
+    final _$$selfRef = reference;
+    return _hasNext(_$$selfRef.pointer, _id_hasNext.pointer).boolean;
   }
 
   static final _id_next = JIterator._class.instanceMethodId(
@@ -23043,7 +23563,8 @@ extension JIterator$$Methods<$E extends jni$_.JObject?> on JIterator<$E> {
   /// from: `public abstract E next()`
   /// The returned object must be released after use, by calling the [release] method.
   $E? next() {
-    return _next(reference.pointer, _id_next.pointer).object<$E?>();
+    final _$$selfRef = reference;
+    return _next(_$$selfRef.pointer, _id_next.pointer).object<$E?>();
   }
 
   static final _id_remove = JIterator._class.instanceMethodId(
@@ -23065,7 +23586,8 @@ extension JIterator$$Methods<$E extends jni$_.JObject?> on JIterator<$E> {
 
   /// from: `public void remove()`
   void remove() {
-    _remove(reference.pointer, _id_remove.pointer).check();
+    final _$$selfRef = reference;
+    _remove(_$$selfRef.pointer, _id_remove.pointer).check();
   }
 }
 
@@ -23161,9 +23683,10 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   static JList<$E?>? copyOf<$E extends jni$_.JObject?>(
     JCollection<$E?>? collection,
   ) {
+    final _$$classRef = _class.reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _copyOf(
-            _class.reference.pointer, _id_copyOf.pointer, _$collection.pointer)
+            _$$classRef.pointer, _id_copyOf.pointer, _$collection.pointer)
         .object<JList<$E?>?>();
   }
 
@@ -23187,7 +23710,8 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `static public java.util.List<E> of()`
   /// The returned object must be released after use, by calling the [release] method.
   static JList<$E?>? of<$E extends jni$_.JObject?>() {
-    return _of(_class.reference.pointer, _id_of.pointer).object<JList<$E?>?>();
+    final _$$classRef = _class.reference;
+    return _of(_$$classRef.pointer, _id_of.pointer).object<JList<$E?>?>();
   }
 
   static final _id_of$1 = _class.staticMethodId(
@@ -23211,8 +23735,9 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   static JList<$E?>? of$1<$E extends jni$_.JObject?>(
     $E? object,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _of$1(_class.reference.pointer, _id_of$1.pointer, _$object.pointer)
+    return _of$1(_$$classRef.pointer, _id_of$1.pointer, _$object.pointer)
         .object<JList<$E?>?>();
   }
 
@@ -23244,9 +23769,10 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object,
     $E? object1,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _of$2(_class.reference.pointer, _id_of$2.pointer, _$object.pointer,
+    return _of$2(_$$classRef.pointer, _id_of$2.pointer, _$object.pointer,
             _$object1.pointer)
         .object<JList<$E?>?>();
   }
@@ -23282,10 +23808,11 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object1,
     $E? object2,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
-    return _of$3(_class.reference.pointer, _id_of$3.pointer, _$object.pointer,
+    return _of$3(_$$classRef.pointer, _id_of$3.pointer, _$object.pointer,
             _$object1.pointer, _$object2.pointer)
         .object<JList<$E?>?>();
   }
@@ -23324,11 +23851,12 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object2,
     $E? object3,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
     final _$object3 = object3?.reference ?? jni$_.jNullReference;
-    return _of$4(_class.reference.pointer, _id_of$4.pointer, _$object.pointer,
+    return _of$4(_$$classRef.pointer, _id_of$4.pointer, _$object.pointer,
             _$object1.pointer, _$object2.pointer, _$object3.pointer)
         .object<JList<$E?>?>();
   }
@@ -23370,13 +23898,14 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object3,
     $E? object4,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
     final _$object3 = object3?.reference ?? jni$_.jNullReference;
     final _$object4 = object4?.reference ?? jni$_.jNullReference;
     return _of$5(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$5.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -23426,6 +23955,7 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object4,
     $E? object5,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -23433,7 +23963,7 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object4 = object4?.reference ?? jni$_.jNullReference;
     final _$object5 = object5?.reference ?? jni$_.jNullReference;
     return _of$6(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$6.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -23487,6 +24017,7 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object5,
     $E? object6,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -23495,7 +24026,7 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object5 = object5?.reference ?? jni$_.jNullReference;
     final _$object6 = object6?.reference ?? jni$_.jNullReference;
     return _of$7(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$7.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -23553,6 +24084,7 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object6,
     $E? object7,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -23562,7 +24094,7 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object6 = object6?.reference ?? jni$_.jNullReference;
     final _$object7 = object7?.reference ?? jni$_.jNullReference;
     return _of$8(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$8.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -23624,6 +24156,7 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object7,
     $E? object8,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -23634,7 +24167,7 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object7 = object7?.reference ?? jni$_.jNullReference;
     final _$object8 = object8?.reference ?? jni$_.jNullReference;
     return _of$9(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$9.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -23700,6 +24233,7 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object8,
     $E? object9,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -23711,7 +24245,7 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object8 = object8?.reference ?? jni$_.jNullReference;
     final _$object9 = object9?.reference ?? jni$_.jNullReference;
     return _of$10(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$10.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -23747,9 +24281,9 @@ extension type JList<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   static JList<$E?>? of$11<$E extends jni$_.JObject?>(
     jni$_.JArray<$E?>? objects,
   ) {
+    final _$$classRef = _class.reference;
     final _$objects = objects?.reference ?? jni$_.jNullReference;
-    return _of$11(
-            _class.reference.pointer, _id_of$11.pointer, _$objects.pointer)
+    return _of$11(_$$classRef.pointer, _id_of$11.pointer, _$objects.pointer)
         .object<JList<$E?>?>();
   }
 
@@ -24314,8 +24848,9 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   core$_.bool add(
     $E? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _add(reference.pointer, _id_add.pointer, _$object.pointer).boolean;
+    return _add(_$$selfRef.pointer, _id_add.pointer, _$object.pointer).boolean;
   }
 
   static final _id_add$1 = JList._class.instanceMethodId(
@@ -24340,8 +24875,9 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
     core$_.int i,
     $E? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    _add$1(reference.pointer, _id_add$1.pointer, i, _$object.pointer).check();
+    _add$1(_$$selfRef.pointer, _id_add$1.pointer, i, _$object.pointer).check();
   }
 
   static final _id_addAll = JList._class.instanceMethodId(
@@ -24366,9 +24902,10 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
     core$_.int i,
     JCollection<$E?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _addAll(
-            reference.pointer, _id_addAll.pointer, i, _$collection.pointer)
+            _$$selfRef.pointer, _id_addAll.pointer, i, _$collection.pointer)
         .boolean;
   }
 
@@ -24392,9 +24929,10 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   core$_.bool addAll$1(
     JCollection<$E?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _addAll$1(
-            reference.pointer, _id_addAll$1.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_addAll$1.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -24418,8 +24956,9 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   void addFirst(
     $E? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    _addFirst(reference.pointer, _id_addFirst.pointer, _$object.pointer)
+    _addFirst(_$$selfRef.pointer, _id_addFirst.pointer, _$object.pointer)
         .check();
   }
 
@@ -24443,8 +24982,9 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   void addLast(
     $E? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    _addLast(reference.pointer, _id_addLast.pointer, _$object.pointer).check();
+    _addLast(_$$selfRef.pointer, _id_addLast.pointer, _$object.pointer).check();
   }
 
   static final _id_clear = JList._class.instanceMethodId(
@@ -24466,7 +25006,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
 
   /// from: `public abstract void clear()`
   void clear() {
-    _clear(reference.pointer, _id_clear.pointer).check();
+    final _$$selfRef = reference;
+    _clear(_$$selfRef.pointer, _id_clear.pointer).check();
   }
 
   static final _id_contains = JList._class.instanceMethodId(
@@ -24489,8 +25030,9 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   core$_.bool contains(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _contains(reference.pointer, _id_contains.pointer, _$object.pointer)
+    return _contains(_$$selfRef.pointer, _id_contains.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -24514,9 +25056,10 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   core$_.bool containsAll(
     JCollection<jni$_.JObject?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _containsAll(
-            reference.pointer, _id_containsAll.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_containsAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -24540,8 +25083,9 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -24565,7 +25109,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   $E? get(
     core$_.int i,
   ) {
-    return _get(reference.pointer, _id_get.pointer, i).object<$E?>();
+    final _$$selfRef = reference;
+    return _get(_$$selfRef.pointer, _id_get.pointer, i).object<$E?>();
   }
 
   static final _id_getFirst = JList._class.instanceMethodId(
@@ -24588,7 +25133,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   /// from: `public E getFirst()`
   /// The returned object must be released after use, by calling the [release] method.
   $E? getFirst() {
-    return _getFirst(reference.pointer, _id_getFirst.pointer).object<$E?>();
+    final _$$selfRef = reference;
+    return _getFirst(_$$selfRef.pointer, _id_getFirst.pointer).object<$E?>();
   }
 
   static final _id_getLast = JList._class.instanceMethodId(
@@ -24611,7 +25157,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   /// from: `public E getLast()`
   /// The returned object must be released after use, by calling the [release] method.
   $E? getLast() {
-    return _getLast(reference.pointer, _id_getLast.pointer).object<$E?>();
+    final _$$selfRef = reference;
+    return _getLast(_$$selfRef.pointer, _id_getLast.pointer).object<$E?>();
   }
 
   static final _id_hashCode$1 = JList._class.instanceMethodId(
@@ -24633,7 +25180,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
 
   /// from: `public abstract int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_indexOf = JList._class.instanceMethodId(
@@ -24656,8 +25204,9 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   core$_.int indexOf(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _indexOf(reference.pointer, _id_indexOf.pointer, _$object.pointer)
+    return _indexOf(_$$selfRef.pointer, _id_indexOf.pointer, _$object.pointer)
         .integer;
   }
 
@@ -24680,7 +25229,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
 
   /// from: `public abstract boolean isEmpty()`
   core$_.bool isEmpty() {
-    return _isEmpty(reference.pointer, _id_isEmpty.pointer).boolean;
+    final _$$selfRef = reference;
+    return _isEmpty(_$$selfRef.pointer, _id_isEmpty.pointer).boolean;
   }
 
   static final _id_iterator = JList._class.instanceMethodId(
@@ -24703,7 +25253,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   /// from: `public abstract java.util.Iterator<E> iterator()`
   /// The returned object must be released after use, by calling the [release] method.
   JIterator<$E?>? iterator() {
-    return _iterator(reference.pointer, _id_iterator.pointer)
+    final _$$selfRef = reference;
+    return _iterator(_$$selfRef.pointer, _id_iterator.pointer)
         .object<JIterator<$E?>?>();
   }
 
@@ -24727,9 +25278,10 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   core$_.int lastIndexOf(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _lastIndexOf(
-            reference.pointer, _id_lastIndexOf.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_lastIndexOf.pointer, _$object.pointer)
         .integer;
   }
 
@@ -24753,7 +25305,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   /// from: `public abstract java.util.ListIterator<E> listIterator()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? listIterator() {
-    return _listIterator(reference.pointer, _id_listIterator.pointer)
+    final _$$selfRef = reference;
+    return _listIterator(_$$selfRef.pointer, _id_listIterator.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -24777,7 +25330,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   jni$_.JObject? listIterator$1(
     core$_.int i,
   ) {
-    return _listIterator$1(reference.pointer, _id_listIterator$1.pointer, i)
+    final _$$selfRef = reference;
+    return _listIterator$1(_$$selfRef.pointer, _id_listIterator$1.pointer, i)
         .object<jni$_.JObject?>();
   }
 
@@ -24801,7 +25355,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   $E? remove(
     core$_.int i,
   ) {
-    return _remove(reference.pointer, _id_remove.pointer, i).object<$E?>();
+    final _$$selfRef = reference;
+    return _remove(_$$selfRef.pointer, _id_remove.pointer, i).object<$E?>();
   }
 
   static final _id_remove$1 = JList._class.instanceMethodId(
@@ -24824,8 +25379,9 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   core$_.bool remove$1(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _remove$1(reference.pointer, _id_remove$1.pointer, _$object.pointer)
+    return _remove$1(_$$selfRef.pointer, _id_remove$1.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -24849,9 +25405,10 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   core$_.bool removeAll(
     JCollection<jni$_.JObject?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _removeAll(
-            reference.pointer, _id_removeAll.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_removeAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -24875,7 +25432,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   /// from: `public E removeFirst()`
   /// The returned object must be released after use, by calling the [release] method.
   $E? removeFirst() {
-    return _removeFirst(reference.pointer, _id_removeFirst.pointer)
+    final _$$selfRef = reference;
+    return _removeFirst(_$$selfRef.pointer, _id_removeFirst.pointer)
         .object<$E?>();
   }
 
@@ -24899,7 +25457,9 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   /// from: `public E removeLast()`
   /// The returned object must be released after use, by calling the [release] method.
   $E? removeLast() {
-    return _removeLast(reference.pointer, _id_removeLast.pointer).object<$E?>();
+    final _$$selfRef = reference;
+    return _removeLast(_$$selfRef.pointer, _id_removeLast.pointer)
+        .object<$E?>();
   }
 
   static final _id_replaceAll = JList._class.instanceMethodId(
@@ -24922,9 +25482,10 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   void replaceAll(
     jni$_.JObject? unaryOperator,
   ) {
+    final _$$selfRef = reference;
     final _$unaryOperator = unaryOperator?.reference ?? jni$_.jNullReference;
     _replaceAll(
-            reference.pointer, _id_replaceAll.pointer, _$unaryOperator.pointer)
+            _$$selfRef.pointer, _id_replaceAll.pointer, _$unaryOperator.pointer)
         .check();
   }
 
@@ -24948,9 +25509,10 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   core$_.bool retainAll(
     JCollection<jni$_.JObject?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _retainAll(
-            reference.pointer, _id_retainAll.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_retainAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -24974,7 +25536,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   /// from: `public java.util.List<E> reversed()`
   /// The returned object must be released after use, by calling the [release] method.
   JList<$E?>? reversed() {
-    return _reversed(reference.pointer, _id_reversed.pointer)
+    final _$$selfRef = reference;
+    return _reversed(_$$selfRef.pointer, _id_reversed.pointer)
         .object<JList<$E?>?>();
   }
 
@@ -25001,8 +25564,9 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
     core$_.int i,
     $E? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _set(reference.pointer, _id_set.pointer, i, _$object.pointer)
+    return _set(_$$selfRef.pointer, _id_set.pointer, i, _$object.pointer)
         .object<$E?>();
   }
 
@@ -25025,7 +25589,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
 
   /// from: `public abstract int size()`
   core$_.int size() {
-    return _size(reference.pointer, _id_size.pointer).integer;
+    final _$$selfRef = reference;
+    return _size(_$$selfRef.pointer, _id_size.pointer).integer;
   }
 
   static final _id_sort = JList._class.instanceMethodId(
@@ -25048,8 +25613,9 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   void sort(
     jni$_.JObject? comparator,
   ) {
+    final _$$selfRef = reference;
     final _$comparator = comparator?.reference ?? jni$_.jNullReference;
-    _sort(reference.pointer, _id_sort.pointer, _$comparator.pointer).check();
+    _sort(_$$selfRef.pointer, _id_sort.pointer, _$comparator.pointer).check();
   }
 
   static final _id_spliterator = JList._class.instanceMethodId(
@@ -25072,7 +25638,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   /// from: `public java.util.Spliterator<E> spliterator()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? spliterator() {
-    return _spliterator(reference.pointer, _id_spliterator.pointer)
+    final _$$selfRef = reference;
+    return _spliterator(_$$selfRef.pointer, _id_spliterator.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -25098,7 +25665,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
     core$_.int i,
     core$_.int i1,
   ) {
-    return _subList(reference.pointer, _id_subList.pointer, i, i1)
+    final _$$selfRef = reference;
+    return _subList(_$$selfRef.pointer, _id_subList.pointer, i, i1)
         .object<JList<$E?>?>();
   }
 
@@ -25122,7 +25690,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   /// from: `public abstract java.lang.Object[] toArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JArray<jni$_.JObject?>? toArray() {
-    return _toArray(reference.pointer, _id_toArray.pointer)
+    final _$$selfRef = reference;
+    return _toArray(_$$selfRef.pointer, _id_toArray.pointer)
         .object<jni$_.JArray<jni$_.JObject?>?>();
   }
 
@@ -25147,9 +25716,10 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   jni$_.JArray<$T?>? toArray$1<$T extends jni$_.JObject?>(
     jni$_.JArray<$T?>? objects,
   ) {
+    final _$$selfRef = reference;
     final _$objects = objects?.reference ?? jni$_.jNullReference;
     return _toArray$1(
-            reference.pointer, _id_toArray$1.pointer, _$objects.pointer)
+            _$$selfRef.pointer, _id_toArray$1.pointer, _$objects.pointer)
         .object<jni$_.JArray<$T?>?>();
   }
 
@@ -25173,7 +25743,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   /// from: `public java.util.stream.Stream<E> parallelStream()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? parallelStream() {
-    return _parallelStream(reference.pointer, _id_parallelStream.pointer)
+    final _$$selfRef = reference;
+    return _parallelStream(_$$selfRef.pointer, _id_parallelStream.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -25197,9 +25768,10 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   core$_.bool removeIf(
     jni$_.JObject? predicate,
   ) {
+    final _$$selfRef = reference;
     final _$predicate = predicate?.reference ?? jni$_.jNullReference;
     return _removeIf(
-            reference.pointer, _id_removeIf.pointer, _$predicate.pointer)
+            _$$selfRef.pointer, _id_removeIf.pointer, _$predicate.pointer)
         .boolean;
   }
 
@@ -25223,7 +25795,8 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   /// from: `public java.util.stream.Stream<E> stream()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? stream() {
-    return _stream(reference.pointer, _id_stream.pointer)
+    final _$$selfRef = reference;
+    return _stream(_$$selfRef.pointer, _id_stream.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -25248,9 +25821,10 @@ extension JList$$Methods<$E extends jni$_.JObject?> on JList<$E> {
   jni$_.JArray<$T?>? toArray$2<$T extends jni$_.JObject?>(
     jni$_.JObject? intFunction,
   ) {
+    final _$$selfRef = reference;
     final _$intFunction = intFunction?.reference ?? jni$_.jNullReference;
     return _toArray$2(
-            reference.pointer, _id_toArray$2.pointer, _$intFunction.pointer)
+            _$$selfRef.pointer, _id_toArray$2.pointer, _$intFunction.pointer)
         .object<jni$_.JArray<$T?>?>();
   }
 }
@@ -26095,7 +26669,8 @@ extension type JMap$JEntry<$K extends jni$_.JObject?,
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JObject?
       comparingByKey<$K extends jni$_.JObject?, $V extends jni$_.JObject?>() {
-    return _comparingByKey(_class.reference.pointer, _id_comparingByKey.pointer)
+    final _$$classRef = _class.reference;
+    return _comparingByKey(_$$classRef.pointer, _id_comparingByKey.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -26121,9 +26696,10 @@ extension type JMap$JEntry<$K extends jni$_.JObject?,
       comparingByKey$1<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
     jni$_.JObject? comparator,
   ) {
+    final _$$classRef = _class.reference;
     final _$comparator = comparator?.reference ?? jni$_.jNullReference;
-    return _comparingByKey$1(_class.reference.pointer,
-            _id_comparingByKey$1.pointer, _$comparator.pointer)
+    return _comparingByKey$1(_$$classRef.pointer, _id_comparingByKey$1.pointer,
+            _$comparator.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -26148,8 +26724,8 @@ extension type JMap$JEntry<$K extends jni$_.JObject?,
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JObject?
       comparingByValue<$K extends jni$_.JObject?, $V extends jni$_.JObject?>() {
-    return _comparingByValue(
-            _class.reference.pointer, _id_comparingByValue.pointer)
+    final _$$classRef = _class.reference;
+    return _comparingByValue(_$$classRef.pointer, _id_comparingByValue.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -26175,8 +26751,9 @@ extension type JMap$JEntry<$K extends jni$_.JObject?,
       comparingByValue$1<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
     jni$_.JObject? comparator,
   ) {
+    final _$$classRef = _class.reference;
     final _$comparator = comparator?.reference ?? jni$_.jNullReference;
-    return _comparingByValue$1(_class.reference.pointer,
+    return _comparingByValue$1(_$$classRef.pointer,
             _id_comparingByValue$1.pointer, _$comparator.pointer)
         .object<jni$_.JObject?>();
   }
@@ -26203,9 +26780,9 @@ extension type JMap$JEntry<$K extends jni$_.JObject?,
       copyOf<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
     JMap$JEntry<$K?, $V?>? entry,
   ) {
+    final _$$classRef = _class.reference;
     final _$entry = entry?.reference ?? jni$_.jNullReference;
-    return _copyOf(
-            _class.reference.pointer, _id_copyOf.pointer, _$entry.pointer)
+    return _copyOf(_$$classRef.pointer, _id_copyOf.pointer, _$entry.pointer)
         .object<JMap$JEntry<$K?, $V?>?>();
   }
 
@@ -26385,8 +26962,9 @@ extension JMap$JEntry$$Methods<$K extends jni$_.JObject?,
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -26410,7 +26988,8 @@ extension JMap$JEntry$$Methods<$K extends jni$_.JObject?,
   /// from: `public abstract K getKey()`
   /// The returned object must be released after use, by calling the [release] method.
   $K? getKey() {
-    return _getKey(reference.pointer, _id_getKey.pointer).object<$K?>();
+    final _$$selfRef = reference;
+    return _getKey(_$$selfRef.pointer, _id_getKey.pointer).object<$K?>();
   }
 
   static final _id_getValue = JMap$JEntry._class.instanceMethodId(
@@ -26433,7 +27012,8 @@ extension JMap$JEntry$$Methods<$K extends jni$_.JObject?,
   /// from: `public abstract V getValue()`
   /// The returned object must be released after use, by calling the [release] method.
   $V? getValue() {
-    return _getValue(reference.pointer, _id_getValue.pointer).object<$V?>();
+    final _$$selfRef = reference;
+    return _getValue(_$$selfRef.pointer, _id_getValue.pointer).object<$V?>();
   }
 
   static final _id_hashCode$1 = JMap$JEntry._class.instanceMethodId(
@@ -26455,7 +27035,8 @@ extension JMap$JEntry$$Methods<$K extends jni$_.JObject?,
 
   /// from: `public abstract int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_setValue = JMap$JEntry._class.instanceMethodId(
@@ -26479,8 +27060,9 @@ extension JMap$JEntry$$Methods<$K extends jni$_.JObject?,
   $V? setValue(
     $V? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _setValue(reference.pointer, _id_setValue.pointer, _$object.pointer)
+    return _setValue(_$$selfRef.pointer, _id_setValue.pointer, _$object.pointer)
         .object<$V?>();
   }
 }
@@ -26637,8 +27219,9 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
       copyOf<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
     JMap<$K?, $V?>? map,
   ) {
+    final _$$classRef = _class.reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _copyOf(_class.reference.pointer, _id_copyOf.pointer, _$map.pointer)
+    return _copyOf(_$$classRef.pointer, _id_copyOf.pointer, _$map.pointer)
         .object<JMap<$K?, $V?>?>();
   }
 
@@ -26671,9 +27254,10 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object,
     $V? object1,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _entry(_class.reference.pointer, _id_entry.pointer, _$object.pointer,
+    return _entry(_$$classRef.pointer, _id_entry.pointer, _$object.pointer,
             _$object1.pointer)
         .object<JMap$JEntry<$K?, $V?>?>();
   }
@@ -26699,8 +27283,8 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
   /// The returned object must be released after use, by calling the [release] method.
   static JMap<$K?, $V?>?
       of<$K extends jni$_.JObject?, $V extends jni$_.JObject?>() {
-    return _of(_class.reference.pointer, _id_of.pointer)
-        .object<JMap<$K?, $V?>?>();
+    final _$$classRef = _class.reference;
+    return _of(_$$classRef.pointer, _id_of.pointer).object<JMap<$K?, $V?>?>();
   }
 
   static final _id_of$1 = _class.staticMethodId(
@@ -26732,9 +27316,10 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object,
     $V? object1,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _of$1(_class.reference.pointer, _id_of$1.pointer, _$object.pointer,
+    return _of$1(_$$classRef.pointer, _id_of$1.pointer, _$object.pointer,
             _$object1.pointer)
         .object<JMap<$K?, $V?>?>();
   }
@@ -26774,11 +27359,12 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object2,
     $V? object3,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
     final _$object3 = object3?.reference ?? jni$_.jNullReference;
-    return _of$2(_class.reference.pointer, _id_of$2.pointer, _$object.pointer,
+    return _of$2(_$$classRef.pointer, _id_of$2.pointer, _$object.pointer,
             _$object1.pointer, _$object2.pointer, _$object3.pointer)
         .object<JMap<$K?, $V?>?>();
   }
@@ -26824,6 +27410,7 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object4,
     $V? object5,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -26831,7 +27418,7 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     final _$object4 = object4?.reference ?? jni$_.jNullReference;
     final _$object5 = object5?.reference ?? jni$_.jNullReference;
     return _of$3(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$3.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -26889,6 +27476,7 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object6,
     $V? object7,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -26898,7 +27486,7 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     final _$object6 = object6?.reference ?? jni$_.jNullReference;
     final _$object7 = object7?.reference ?? jni$_.jNullReference;
     return _of$4(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$4.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -26964,6 +27552,7 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object8,
     $V? object9,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -26975,7 +27564,7 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     final _$object8 = object8?.reference ?? jni$_.jNullReference;
     final _$object9 = object9?.reference ?? jni$_.jNullReference;
     return _of$5(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$5.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -27049,6 +27638,7 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object10,
     $V? object11,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -27062,7 +27652,7 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     final _$object10 = object10?.reference ?? jni$_.jNullReference;
     final _$object11 = object11?.reference ?? jni$_.jNullReference;
     return _of$6(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$6.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -27144,6 +27734,7 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object12,
     $V? object13,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -27159,7 +27750,7 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     final _$object12 = object12?.reference ?? jni$_.jNullReference;
     final _$object13 = object13?.reference ?? jni$_.jNullReference;
     return _of$7(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$7.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -27249,6 +27840,7 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object14,
     $V? object15,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -27266,7 +27858,7 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     final _$object14 = object14?.reference ?? jni$_.jNullReference;
     final _$object15 = object15?.reference ?? jni$_.jNullReference;
     return _of$8(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$8.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -27364,6 +27956,7 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object16,
     $V? object17,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -27383,7 +27976,7 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     final _$object16 = object16?.reference ?? jni$_.jNullReference;
     final _$object17 = object17?.reference ?? jni$_.jNullReference;
     return _of$9(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$9.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -27489,6 +28082,7 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     $K? object18,
     $V? object19,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -27510,7 +28104,7 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     final _$object18 = object18?.reference ?? jni$_.jNullReference;
     final _$object19 = object19?.reference ?? jni$_.jNullReference;
     return _of$10(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$10.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -27557,9 +28151,10 @@ extension type JMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
       ofEntries<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
     jni$_.JArray<JMap$JEntry<$K?, $V?>?>? entrys,
   ) {
+    final _$$classRef = _class.reference;
     final _$entrys = entrys?.reference ?? jni$_.jNullReference;
     return _ofEntries(
-            _class.reference.pointer, _id_ofEntries.pointer, _$entrys.pointer)
+            _$$classRef.pointer, _id_ofEntries.pointer, _$entrys.pointer)
         .object<JMap<$K?, $V?>?>();
   }
 
@@ -28118,7 +28713,8 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
 
   /// from: `public abstract void clear()`
   void clear() {
-    _clear(reference.pointer, _id_clear.pointer).check();
+    final _$$selfRef = reference;
+    _clear(_$$selfRef.pointer, _id_clear.pointer).check();
   }
 
   static final _id_compute = JMap._class.instanceMethodId(
@@ -28149,9 +28745,10 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $K? object,
     jni$_.JObject? biFunction,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$biFunction = biFunction?.reference ?? jni$_.jNullReference;
-    return _compute(reference.pointer, _id_compute.pointer, _$object.pointer,
+    return _compute(_$$selfRef.pointer, _id_compute.pointer, _$object.pointer,
             _$biFunction.pointer)
         .object<$V?>();
   }
@@ -28184,9 +28781,10 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $K? object,
     jni$_.JObject? function,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$function = function?.reference ?? jni$_.jNullReference;
-    return _computeIfAbsent(reference.pointer, _id_computeIfAbsent.pointer,
+    return _computeIfAbsent(_$$selfRef.pointer, _id_computeIfAbsent.pointer,
             _$object.pointer, _$function.pointer)
         .object<$V?>();
   }
@@ -28219,9 +28817,10 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $K? object,
     jni$_.JObject? biFunction,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$biFunction = biFunction?.reference ?? jni$_.jNullReference;
-    return _computeIfPresent(reference.pointer, _id_computeIfPresent.pointer,
+    return _computeIfPresent(_$$selfRef.pointer, _id_computeIfPresent.pointer,
             _$object.pointer, _$biFunction.pointer)
         .object<$V?>();
   }
@@ -28246,9 +28845,10 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   core$_.bool containsKey(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _containsKey(
-            reference.pointer, _id_containsKey.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_containsKey.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -28272,9 +28872,10 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   core$_.bool containsValue(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _containsValue(
-            reference.pointer, _id_containsValue.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_containsValue.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -28298,7 +28899,8 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   /// from: `public abstract java.util.Set<java.util.Map$Entry<K, V>> entrySet()`
   /// The returned object must be released after use, by calling the [release] method.
   JSet<JMap$JEntry<$K?, $V?>?>? entrySet() {
-    return _entrySet(reference.pointer, _id_entrySet.pointer)
+    final _$$selfRef = reference;
+    return _entrySet(_$$selfRef.pointer, _id_entrySet.pointer)
         .object<JSet<JMap$JEntry<$K?, $V?>?>?>();
   }
 
@@ -28322,8 +28924,9 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -28347,8 +28950,9 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   void forEach(
     jni$_.JObject? biConsumer,
   ) {
+    final _$$selfRef = reference;
     final _$biConsumer = biConsumer?.reference ?? jni$_.jNullReference;
-    _forEach(reference.pointer, _id_forEach.pointer, _$biConsumer.pointer)
+    _forEach(_$$selfRef.pointer, _id_forEach.pointer, _$biConsumer.pointer)
         .check();
   }
 
@@ -28373,8 +28977,9 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   $V? get(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _get(reference.pointer, _id_get.pointer, _$object.pointer)
+    return _get(_$$selfRef.pointer, _id_get.pointer, _$object.pointer)
         .object<$V?>();
   }
 
@@ -28406,9 +29011,10 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     jni$_.JObject? object,
     $V? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _getOrDefault(reference.pointer, _id_getOrDefault.pointer,
+    return _getOrDefault(_$$selfRef.pointer, _id_getOrDefault.pointer,
             _$object.pointer, _$object1.pointer)
         .object<$V?>();
   }
@@ -28432,7 +29038,8 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
 
   /// from: `public abstract int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_isEmpty = JMap._class.instanceMethodId(
@@ -28454,7 +29061,8 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
 
   /// from: `public abstract boolean isEmpty()`
   core$_.bool isEmpty() {
-    return _isEmpty(reference.pointer, _id_isEmpty.pointer).boolean;
+    final _$$selfRef = reference;
+    return _isEmpty(_$$selfRef.pointer, _id_isEmpty.pointer).boolean;
   }
 
   static final _id_keySet = JMap._class.instanceMethodId(
@@ -28477,7 +29085,8 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   /// from: `public abstract java.util.Set<K> keySet()`
   /// The returned object must be released after use, by calling the [release] method.
   JSet<$K?>? keySet() {
-    return _keySet(reference.pointer, _id_keySet.pointer).object<JSet<$K?>?>();
+    final _$$selfRef = reference;
+    return _keySet(_$$selfRef.pointer, _id_keySet.pointer).object<JSet<$K?>?>();
   }
 
   static final _id_merge = JMap._class.instanceMethodId(
@@ -28511,10 +29120,11 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $V? object1,
     jni$_.JObject? biFunction,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$biFunction = biFunction?.reference ?? jni$_.jNullReference;
-    return _merge(reference.pointer, _id_merge.pointer, _$object.pointer,
+    return _merge(_$$selfRef.pointer, _id_merge.pointer, _$object.pointer,
             _$object1.pointer, _$biFunction.pointer)
         .object<$V?>();
   }
@@ -28547,9 +29157,10 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $K? object,
     $V? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _put(reference.pointer, _id_put.pointer, _$object.pointer,
+    return _put(_$$selfRef.pointer, _id_put.pointer, _$object.pointer,
             _$object1.pointer)
         .object<$V?>();
   }
@@ -28574,8 +29185,9 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   void putAll(
     JMap<$K?, $V?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    _putAll(reference.pointer, _id_putAll.pointer, _$map.pointer).check();
+    _putAll(_$$selfRef.pointer, _id_putAll.pointer, _$map.pointer).check();
   }
 
   static final _id_putIfAbsent = JMap._class.instanceMethodId(
@@ -28606,9 +29218,10 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $K? object,
     $V? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _putIfAbsent(reference.pointer, _id_putIfAbsent.pointer,
+    return _putIfAbsent(_$$selfRef.pointer, _id_putIfAbsent.pointer,
             _$object.pointer, _$object1.pointer)
         .object<$V?>();
   }
@@ -28634,8 +29247,9 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   $V? remove(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _remove(reference.pointer, _id_remove.pointer, _$object.pointer)
+    return _remove(_$$selfRef.pointer, _id_remove.pointer, _$object.pointer)
         .object<$V?>();
   }
 
@@ -28666,9 +29280,10 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     jni$_.JObject? object,
     jni$_.JObject? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _remove$1(reference.pointer, _id_remove$1.pointer, _$object.pointer,
+    return _remove$1(_$$selfRef.pointer, _id_remove$1.pointer, _$object.pointer,
             _$object1.pointer)
         .boolean;
   }
@@ -28701,9 +29316,10 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $K? object,
     $V? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _replace(reference.pointer, _id_replace.pointer, _$object.pointer,
+    return _replace(_$$selfRef.pointer, _id_replace.pointer, _$object.pointer,
             _$object1.pointer)
         .object<$V?>();
   }
@@ -28738,10 +29354,11 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $V? object1,
     $V? object2,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
-    return _replace$1(reference.pointer, _id_replace$1.pointer,
+    return _replace$1(_$$selfRef.pointer, _id_replace$1.pointer,
             _$object.pointer, _$object1.pointer, _$object2.pointer)
         .boolean;
   }
@@ -28766,8 +29383,10 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   void replaceAll(
     jni$_.JObject? biFunction,
   ) {
+    final _$$selfRef = reference;
     final _$biFunction = biFunction?.reference ?? jni$_.jNullReference;
-    _replaceAll(reference.pointer, _id_replaceAll.pointer, _$biFunction.pointer)
+    _replaceAll(
+            _$$selfRef.pointer, _id_replaceAll.pointer, _$biFunction.pointer)
         .check();
   }
 
@@ -28790,7 +29409,8 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
 
   /// from: `public abstract int size()`
   core$_.int size() {
-    return _size(reference.pointer, _id_size.pointer).integer;
+    final _$$selfRef = reference;
+    return _size(_$$selfRef.pointer, _id_size.pointer).integer;
   }
 
   static final _id_values = JMap._class.instanceMethodId(
@@ -28813,7 +29433,8 @@ extension JMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   /// from: `public abstract java.util.Collection<V> values()`
   /// The returned object must be released after use, by calling the [release] method.
   JCollection<$V?>? values() {
-    return _values(reference.pointer, _id_values.pointer)
+    final _$$selfRef = reference;
+    return _values(_$$selfRef.pointer, _id_values.pointer)
         .object<JCollection<$V?>?>();
   }
 }
@@ -29913,9 +30534,10 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   static JSet<$E?>? copyOf<$E extends jni$_.JObject?>(
     JCollection<$E?>? collection,
   ) {
+    final _$$classRef = _class.reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _copyOf(
-            _class.reference.pointer, _id_copyOf.pointer, _$collection.pointer)
+            _$$classRef.pointer, _id_copyOf.pointer, _$collection.pointer)
         .object<JSet<$E?>?>();
   }
 
@@ -29939,7 +30561,8 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `static public java.util.Set<E> of()`
   /// The returned object must be released after use, by calling the [release] method.
   static JSet<$E?>? of<$E extends jni$_.JObject?>() {
-    return _of(_class.reference.pointer, _id_of.pointer).object<JSet<$E?>?>();
+    final _$$classRef = _class.reference;
+    return _of(_$$classRef.pointer, _id_of.pointer).object<JSet<$E?>?>();
   }
 
   static final _id_of$1 = _class.staticMethodId(
@@ -29963,8 +30586,9 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   static JSet<$E?>? of$1<$E extends jni$_.JObject?>(
     $E? object,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _of$1(_class.reference.pointer, _id_of$1.pointer, _$object.pointer)
+    return _of$1(_$$classRef.pointer, _id_of$1.pointer, _$object.pointer)
         .object<JSet<$E?>?>();
   }
 
@@ -29996,9 +30620,10 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object,
     $E? object1,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _of$2(_class.reference.pointer, _id_of$2.pointer, _$object.pointer,
+    return _of$2(_$$classRef.pointer, _id_of$2.pointer, _$object.pointer,
             _$object1.pointer)
         .object<JSet<$E?>?>();
   }
@@ -30034,10 +30659,11 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object1,
     $E? object2,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
-    return _of$3(_class.reference.pointer, _id_of$3.pointer, _$object.pointer,
+    return _of$3(_$$classRef.pointer, _id_of$3.pointer, _$object.pointer,
             _$object1.pointer, _$object2.pointer)
         .object<JSet<$E?>?>();
   }
@@ -30076,11 +30702,12 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object2,
     $E? object3,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
     final _$object3 = object3?.reference ?? jni$_.jNullReference;
-    return _of$4(_class.reference.pointer, _id_of$4.pointer, _$object.pointer,
+    return _of$4(_$$classRef.pointer, _id_of$4.pointer, _$object.pointer,
             _$object1.pointer, _$object2.pointer, _$object3.pointer)
         .object<JSet<$E?>?>();
   }
@@ -30122,13 +30749,14 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object3,
     $E? object4,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
     final _$object3 = object3?.reference ?? jni$_.jNullReference;
     final _$object4 = object4?.reference ?? jni$_.jNullReference;
     return _of$5(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$5.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -30178,6 +30806,7 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object4,
     $E? object5,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -30185,7 +30814,7 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object4 = object4?.reference ?? jni$_.jNullReference;
     final _$object5 = object5?.reference ?? jni$_.jNullReference;
     return _of$6(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$6.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -30239,6 +30868,7 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object5,
     $E? object6,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -30247,7 +30877,7 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object5 = object5?.reference ?? jni$_.jNullReference;
     final _$object6 = object6?.reference ?? jni$_.jNullReference;
     return _of$7(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$7.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -30305,6 +30935,7 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object6,
     $E? object7,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -30314,7 +30945,7 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object6 = object6?.reference ?? jni$_.jNullReference;
     final _$object7 = object7?.reference ?? jni$_.jNullReference;
     return _of$8(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$8.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -30376,6 +31007,7 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object7,
     $E? object8,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -30386,7 +31018,7 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object7 = object7?.reference ?? jni$_.jNullReference;
     final _$object8 = object8?.reference ?? jni$_.jNullReference;
     return _of$9(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$9.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -30452,6 +31084,7 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     $E? object8,
     $E? object9,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
@@ -30463,7 +31096,7 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
     final _$object8 = object8?.reference ?? jni$_.jNullReference;
     final _$object9 = object9?.reference ?? jni$_.jNullReference;
     return _of$10(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_of$10.pointer,
             _$object.pointer,
             _$object1.pointer,
@@ -30499,9 +31132,9 @@ extension type JSet<$E extends jni$_.JObject?>._(jni$_.JObject _$this)
   static JSet<$E?>? of$11<$E extends jni$_.JObject?>(
     jni$_.JArray<$E?>? objects,
   ) {
+    final _$$classRef = _class.reference;
     final _$objects = objects?.reference ?? jni$_.jNullReference;
-    return _of$11(
-            _class.reference.pointer, _id_of$11.pointer, _$objects.pointer)
+    return _of$11(_$$classRef.pointer, _id_of$11.pointer, _$objects.pointer)
         .object<JSet<$E?>?>();
   }
 
@@ -30910,8 +31543,9 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
   core$_.bool add(
     $E? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _add(reference.pointer, _id_add.pointer, _$object.pointer).boolean;
+    return _add(_$$selfRef.pointer, _id_add.pointer, _$object.pointer).boolean;
   }
 
   static final _id_addAll = JSet._class.instanceMethodId(
@@ -30934,8 +31568,9 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
   core$_.bool addAll(
     JCollection<$E?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
-    return _addAll(reference.pointer, _id_addAll.pointer, _$collection.pointer)
+    return _addAll(_$$selfRef.pointer, _id_addAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -30958,7 +31593,8 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
 
   /// from: `public abstract void clear()`
   void clear() {
-    _clear(reference.pointer, _id_clear.pointer).check();
+    final _$$selfRef = reference;
+    _clear(_$$selfRef.pointer, _id_clear.pointer).check();
   }
 
   static final _id_contains = JSet._class.instanceMethodId(
@@ -30981,8 +31617,9 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
   core$_.bool contains(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _contains(reference.pointer, _id_contains.pointer, _$object.pointer)
+    return _contains(_$$selfRef.pointer, _id_contains.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -31006,9 +31643,10 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
   core$_.bool containsAll(
     JCollection<jni$_.JObject?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _containsAll(
-            reference.pointer, _id_containsAll.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_containsAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -31032,8 +31670,9 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -31056,7 +31695,8 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
 
   /// from: `public abstract int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_isEmpty = JSet._class.instanceMethodId(
@@ -31078,7 +31718,8 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
 
   /// from: `public abstract boolean isEmpty()`
   core$_.bool isEmpty() {
-    return _isEmpty(reference.pointer, _id_isEmpty.pointer).boolean;
+    final _$$selfRef = reference;
+    return _isEmpty(_$$selfRef.pointer, _id_isEmpty.pointer).boolean;
   }
 
   static final _id_iterator = JSet._class.instanceMethodId(
@@ -31101,7 +31742,8 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
   /// from: `public abstract java.util.Iterator<E> iterator()`
   /// The returned object must be released after use, by calling the [release] method.
   JIterator<$E?>? iterator() {
-    return _iterator(reference.pointer, _id_iterator.pointer)
+    final _$$selfRef = reference;
+    return _iterator(_$$selfRef.pointer, _id_iterator.pointer)
         .object<JIterator<$E?>?>();
   }
 
@@ -31125,8 +31767,9 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
   core$_.bool remove(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _remove(reference.pointer, _id_remove.pointer, _$object.pointer)
+    return _remove(_$$selfRef.pointer, _id_remove.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -31150,9 +31793,10 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
   core$_.bool removeAll(
     JCollection<jni$_.JObject?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _removeAll(
-            reference.pointer, _id_removeAll.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_removeAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -31176,9 +31820,10 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
   core$_.bool retainAll(
     JCollection<jni$_.JObject?>? collection,
   ) {
+    final _$$selfRef = reference;
     final _$collection = collection?.reference ?? jni$_.jNullReference;
     return _retainAll(
-            reference.pointer, _id_retainAll.pointer, _$collection.pointer)
+            _$$selfRef.pointer, _id_retainAll.pointer, _$collection.pointer)
         .boolean;
   }
 
@@ -31201,7 +31846,8 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
 
   /// from: `public abstract int size()`
   core$_.int size() {
-    return _size(reference.pointer, _id_size.pointer).integer;
+    final _$$selfRef = reference;
+    return _size(_$$selfRef.pointer, _id_size.pointer).integer;
   }
 
   static final _id_spliterator = JSet._class.instanceMethodId(
@@ -31224,7 +31870,8 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
   /// from: `public java.util.Spliterator<E> spliterator()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? spliterator() {
-    return _spliterator(reference.pointer, _id_spliterator.pointer)
+    final _$$selfRef = reference;
+    return _spliterator(_$$selfRef.pointer, _id_spliterator.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -31248,7 +31895,8 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
   /// from: `public abstract java.lang.Object[] toArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JArray<jni$_.JObject?>? toArray() {
-    return _toArray(reference.pointer, _id_toArray.pointer)
+    final _$$selfRef = reference;
+    return _toArray(_$$selfRef.pointer, _id_toArray.pointer)
         .object<jni$_.JArray<jni$_.JObject?>?>();
   }
 
@@ -31273,9 +31921,10 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
   jni$_.JArray<$T?>? toArray$1<$T extends jni$_.JObject?>(
     jni$_.JArray<$T?>? objects,
   ) {
+    final _$$selfRef = reference;
     final _$objects = objects?.reference ?? jni$_.jNullReference;
     return _toArray$1(
-            reference.pointer, _id_toArray$1.pointer, _$objects.pointer)
+            _$$selfRef.pointer, _id_toArray$1.pointer, _$objects.pointer)
         .object<jni$_.JArray<$T?>?>();
   }
 
@@ -31299,7 +31948,8 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
   /// from: `public java.util.stream.Stream<E> parallelStream()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? parallelStream() {
-    return _parallelStream(reference.pointer, _id_parallelStream.pointer)
+    final _$$selfRef = reference;
+    return _parallelStream(_$$selfRef.pointer, _id_parallelStream.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -31323,9 +31973,10 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
   core$_.bool removeIf(
     jni$_.JObject? predicate,
   ) {
+    final _$$selfRef = reference;
     final _$predicate = predicate?.reference ?? jni$_.jNullReference;
     return _removeIf(
-            reference.pointer, _id_removeIf.pointer, _$predicate.pointer)
+            _$$selfRef.pointer, _id_removeIf.pointer, _$predicate.pointer)
         .boolean;
   }
 
@@ -31349,7 +32000,8 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
   /// from: `public java.util.stream.Stream<E> stream()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? stream() {
-    return _stream(reference.pointer, _id_stream.pointer)
+    final _$$selfRef = reference;
+    return _stream(_$$selfRef.pointer, _id_stream.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -31374,9 +32026,10 @@ extension JSet$$Methods<$E extends jni$_.JObject?> on JSet<$E> {
   jni$_.JArray<$T?>? toArray$2<$T extends jni$_.JObject?>(
     jni$_.JObject? intFunction,
   ) {
+    final _$$selfRef = reference;
     final _$intFunction = intFunction?.reference ?? jni$_.jNullReference;
     return _toArray$2(
-            reference.pointer, _id_toArray$2.pointer, _$intFunction.pointer)
+            _$$selfRef.pointer, _id_toArray$2.pointer, _$intFunction.pointer)
         .object<jni$_.JArray<$T?>?>();
   }
 }

--- a/pkgs/jni_flutter/lib/src/generated_plugin.dart
+++ b/pkgs/jni_flutter/lib/src/generated_plugin.dart
@@ -70,7 +70,8 @@ extension type JniFlutterPlugin._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory JniFlutterPlugin() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<JniFlutterPlugin>();
   }
 
@@ -94,8 +95,9 @@ extension type JniFlutterPlugin._(jni$_.JObject _$this)
   /// from: `static public android.content.Context getApplicationContext()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JObject get applicationContext {
+    final _$$classRef = _class.reference;
     return _get$applicationContext(
-            _class.reference.pointer, _id_get$applicationContext.pointer)
+            _$$classRef.pointer, _id_get$applicationContext.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -118,7 +120,8 @@ extension type JniFlutterPlugin._(jni$_.JObject _$this)
   static jni$_.JObject? getActivity(
     core$_.int j,
   ) {
-    return _getActivity(_class.reference.pointer, _id_getActivity.pointer, j)
+    final _$$classRef = _class.reference;
+    return _getActivity(_$$classRef.pointer, _id_getActivity.pointer, j)
         .object<jni$_.JObject?>();
   }
 }
@@ -145,8 +148,9 @@ extension JniFlutterPlugin$$Methods on JniFlutterPlugin {
   void onAttachedToEngine(
     jni$_.JObject flutterPluginBinding,
   ) {
+    final _$$selfRef = reference;
     final _$flutterPluginBinding = flutterPluginBinding.reference;
-    _onAttachedToEngine(reference.pointer, _id_onAttachedToEngine.pointer,
+    _onAttachedToEngine(_$$selfRef.pointer, _id_onAttachedToEngine.pointer,
             _$flutterPluginBinding.pointer)
         .check();
   }
@@ -172,8 +176,9 @@ extension JniFlutterPlugin$$Methods on JniFlutterPlugin {
   void onDetachedFromEngine(
     jni$_.JObject flutterPluginBinding,
   ) {
+    final _$$selfRef = reference;
     final _$flutterPluginBinding = flutterPluginBinding.reference;
-    _onDetachedFromEngine(reference.pointer, _id_onDetachedFromEngine.pointer,
+    _onDetachedFromEngine(_$$selfRef.pointer, _id_onDetachedFromEngine.pointer,
             _$flutterPluginBinding.pointer)
         .check();
   }
@@ -199,8 +204,9 @@ extension JniFlutterPlugin$$Methods on JniFlutterPlugin {
   void onAttachedToActivity(
     jni$_.JObject activityPluginBinding,
   ) {
+    final _$$selfRef = reference;
     final _$activityPluginBinding = activityPluginBinding.reference;
-    _onAttachedToActivity(reference.pointer, _id_onAttachedToActivity.pointer,
+    _onAttachedToActivity(_$$selfRef.pointer, _id_onAttachedToActivity.pointer,
             _$activityPluginBinding.pointer)
         .check();
   }
@@ -226,7 +232,8 @@ extension JniFlutterPlugin$$Methods on JniFlutterPlugin {
 
   /// from: `public void onDetachedFromActivityForConfigChanges()`
   void onDetachedFromActivityForConfigChanges() {
-    _onDetachedFromActivityForConfigChanges(reference.pointer,
+    final _$$selfRef = reference;
+    _onDetachedFromActivityForConfigChanges(_$$selfRef.pointer,
             _id_onDetachedFromActivityForConfigChanges.pointer)
         .check();
   }
@@ -253,9 +260,10 @@ extension JniFlutterPlugin$$Methods on JniFlutterPlugin {
   void onReattachedToActivityForConfigChanges(
     jni$_.JObject activityPluginBinding,
   ) {
+    final _$$selfRef = reference;
     final _$activityPluginBinding = activityPluginBinding.reference;
     _onReattachedToActivityForConfigChanges(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_onReattachedToActivityForConfigChanges.pointer,
             _$activityPluginBinding.pointer)
         .check();
@@ -281,8 +289,9 @@ extension JniFlutterPlugin$$Methods on JniFlutterPlugin {
 
   /// from: `public void onDetachedFromActivity()`
   void onDetachedFromActivity() {
+    final _$$selfRef = reference;
     _onDetachedFromActivity(
-            reference.pointer, _id_onDetachedFromActivity.pointer)
+            _$$selfRef.pointer, _id_onDetachedFromActivity.pointer)
         .check();
   }
 }

--- a/pkgs/jnigen/example/in_app_java/lib/android_utils.g.dart
+++ b/pkgs/jnigen/example/in_app_java/lib/android_utils.g.dart
@@ -174,8 +174,9 @@ extension EmojiCompat$Config$$Methods on EmojiCompat$Config {
   EmojiCompat$Config registerInitCallback(
     EmojiCompat$InitCallback initCallback,
   ) {
+    final _$$selfRef = reference;
     final _$initCallback = initCallback.reference;
-    return _registerInitCallback(reference.pointer,
+    return _registerInitCallback(_$$selfRef.pointer,
             _id_registerInitCallback.pointer, _$initCallback.pointer)
         .object<EmojiCompat$Config>();
   }
@@ -202,8 +203,9 @@ extension EmojiCompat$Config$$Methods on EmojiCompat$Config {
   EmojiCompat$Config unregisterInitCallback(
     EmojiCompat$InitCallback initCallback,
   ) {
+    final _$$selfRef = reference;
     final _$initCallback = initCallback.reference;
-    return _unregisterInitCallback(reference.pointer,
+    return _unregisterInitCallback(_$$selfRef.pointer,
             _id_unregisterInitCallback.pointer, _$initCallback.pointer)
         .object<EmojiCompat$Config>();
   }
@@ -228,8 +230,9 @@ extension EmojiCompat$Config$$Methods on EmojiCompat$Config {
   EmojiCompat$Config setReplaceAll(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _setReplaceAll(
-            reference.pointer, _id_setReplaceAll.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_setReplaceAll.pointer, z ? 1 : 0)
         .object<EmojiCompat$Config>();
   }
 
@@ -254,8 +257,9 @@ extension EmojiCompat$Config$$Methods on EmojiCompat$Config {
   EmojiCompat$Config setUseEmojiAsDefaultStyle(
     core$_.bool z,
   ) {
-    return _setUseEmojiAsDefaultStyle(
-            reference.pointer, _id_setUseEmojiAsDefaultStyle.pointer, z ? 1 : 0)
+    final _$$selfRef = reference;
+    return _setUseEmojiAsDefaultStyle(_$$selfRef.pointer,
+            _id_setUseEmojiAsDefaultStyle.pointer, z ? 1 : 0)
         .object<EmojiCompat$Config>();
   }
 
@@ -286,8 +290,9 @@ extension EmojiCompat$Config$$Methods on EmojiCompat$Config {
     core$_.bool z,
     jni$_.JList<jni$_.JInteger?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _setUseEmojiAsDefaultStyle$1(reference.pointer,
+    return _setUseEmojiAsDefaultStyle$1(_$$selfRef.pointer,
             _id_setUseEmojiAsDefaultStyle$1.pointer, z ? 1 : 0, _$list.pointer)
         .object<EmojiCompat$Config>();
   }
@@ -313,7 +318,8 @@ extension EmojiCompat$Config$$Methods on EmojiCompat$Config {
   EmojiCompat$Config setEmojiSpanIndicatorEnabled(
     core$_.bool z,
   ) {
-    return _setEmojiSpanIndicatorEnabled(reference.pointer,
+    final _$$selfRef = reference;
+    return _setEmojiSpanIndicatorEnabled(_$$selfRef.pointer,
             _id_setEmojiSpanIndicatorEnabled.pointer, z ? 1 : 0)
         .object<EmojiCompat$Config>();
   }
@@ -339,8 +345,9 @@ extension EmojiCompat$Config$$Methods on EmojiCompat$Config {
   EmojiCompat$Config setEmojiSpanIndicatorColor(
     core$_.int i,
   ) {
+    final _$$selfRef = reference;
     return _setEmojiSpanIndicatorColor(
-            reference.pointer, _id_setEmojiSpanIndicatorColor.pointer, i)
+            _$$selfRef.pointer, _id_setEmojiSpanIndicatorColor.pointer, i)
         .object<EmojiCompat$Config>();
   }
 
@@ -365,8 +372,9 @@ extension EmojiCompat$Config$$Methods on EmojiCompat$Config {
   EmojiCompat$Config setMetadataLoadStrategy(
     core$_.int i,
   ) {
+    final _$$selfRef = reference;
     return _setMetadataLoadStrategy(
-            reference.pointer, _id_setMetadataLoadStrategy.pointer, i)
+            _$$selfRef.pointer, _id_setMetadataLoadStrategy.pointer, i)
         .object<EmojiCompat$Config>();
   }
 
@@ -391,8 +399,9 @@ extension EmojiCompat$Config$$Methods on EmojiCompat$Config {
   EmojiCompat$Config setSpanFactory(
     EmojiCompat$SpanFactory spanFactory,
   ) {
+    final _$$selfRef = reference;
     final _$spanFactory = spanFactory.reference;
-    return _setSpanFactory(reference.pointer, _id_setSpanFactory.pointer,
+    return _setSpanFactory(_$$selfRef.pointer, _id_setSpanFactory.pointer,
             _$spanFactory.pointer)
         .object<EmojiCompat$Config>();
   }
@@ -418,8 +427,9 @@ extension EmojiCompat$Config$$Methods on EmojiCompat$Config {
   EmojiCompat$Config setGlyphChecker(
     EmojiCompat$GlyphChecker glyphChecker,
   ) {
+    final _$$selfRef = reference;
     final _$glyphChecker = glyphChecker.reference;
-    return _setGlyphChecker(reference.pointer, _id_setGlyphChecker.pointer,
+    return _setGlyphChecker(_$$selfRef.pointer, _id_setGlyphChecker.pointer,
             _$glyphChecker.pointer)
         .object<EmojiCompat$Config>();
   }
@@ -462,7 +472,8 @@ extension type EmojiCompat$DefaultSpanFactory._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory EmojiCompat$DefaultSpanFactory() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<EmojiCompat$DefaultSpanFactory>();
   }
 }
@@ -491,8 +502,9 @@ extension EmojiCompat$DefaultSpanFactory$$Methods
   jni$_.JObject createSpan(
     jni$_.JObject typefaceEmojiRasterizer,
   ) {
+    final _$$selfRef = reference;
     final _$typefaceEmojiRasterizer = typefaceEmojiRasterizer.reference;
-    return _createSpan(reference.pointer, _id_createSpan.pointer,
+    return _createSpan(_$$selfRef.pointer, _id_createSpan.pointer,
             _$typefaceEmojiRasterizer.pointer)
         .object<jni$_.JObject>();
   }
@@ -632,8 +644,9 @@ extension EmojiCompat$GlyphChecker$$Methods on EmojiCompat$GlyphChecker {
     core$_.int i1,
     core$_.int i2,
   ) {
+    final _$$selfRef = reference;
     final _$charSequence = charSequence.reference;
-    return _hasGlyph(reference.pointer, _id_hasGlyph.pointer,
+    return _hasGlyph(_$$selfRef.pointer, _id_hasGlyph.pointer,
             _$charSequence.pointer, i, i1, i2)
         .boolean;
   }
@@ -708,7 +721,8 @@ extension EmojiCompat$InitCallback$$Methods on EmojiCompat$InitCallback {
 
   /// from: `public void onInitialized()`
   void onInitialized() {
-    _onInitialized(reference.pointer, _id_onInitialized.pointer).check();
+    final _$$selfRef = reference;
+    _onInitialized(_$$selfRef.pointer, _id_onInitialized.pointer).check();
   }
 
   static final _id_onFailed = EmojiCompat$InitCallback._class.instanceMethodId(
@@ -731,8 +745,9 @@ extension EmojiCompat$InitCallback$$Methods on EmojiCompat$InitCallback {
   void onFailed(
     jni$_.JObject? throwable,
   ) {
+    final _$$selfRef = reference;
     final _$throwable = throwable?.reference ?? jni$_.jNullReference;
-    _onFailed(reference.pointer, _id_onFailed.pointer, _$throwable.pointer)
+    _onFailed(_$$selfRef.pointer, _id_onFailed.pointer, _$throwable.pointer)
         .check();
   }
 }
@@ -959,8 +974,9 @@ extension EmojiCompat$MetadataRepoLoader$$Methods
   void load(
     EmojiCompat$MetadataRepoLoaderCallback metadataRepoLoaderCallback,
   ) {
+    final _$$selfRef = reference;
     final _$metadataRepoLoaderCallback = metadataRepoLoaderCallback.reference;
-    _load(reference.pointer, _id_load.pointer,
+    _load(_$$selfRef.pointer, _id_load.pointer,
             _$metadataRepoLoaderCallback.pointer)
         .check();
   }
@@ -1041,8 +1057,9 @@ extension EmojiCompat$MetadataRepoLoaderCallback$$Methods
   void onLoaded(
     jni$_.JObject metadataRepo,
   ) {
+    final _$$selfRef = reference;
     final _$metadataRepo = metadataRepo.reference;
-    _onLoaded(reference.pointer, _id_onLoaded.pointer, _$metadataRepo.pointer)
+    _onLoaded(_$$selfRef.pointer, _id_onLoaded.pointer, _$metadataRepo.pointer)
         .check();
   }
 
@@ -1067,8 +1084,9 @@ extension EmojiCompat$MetadataRepoLoaderCallback$$Methods
   void onFailed(
     jni$_.JObject? throwable,
   ) {
+    final _$$selfRef = reference;
     final _$throwable = throwable?.reference ?? jni$_.jNullReference;
-    _onFailed(reference.pointer, _id_onFailed.pointer, _$throwable.pointer)
+    _onFailed(_$$selfRef.pointer, _id_onFailed.pointer, _$throwable.pointer)
         .check();
   }
 }
@@ -1296,8 +1314,9 @@ extension EmojiCompat$SpanFactory$$Methods on EmojiCompat$SpanFactory {
   jni$_.JObject createSpan(
     jni$_.JObject typefaceEmojiRasterizer,
   ) {
+    final _$$selfRef = reference;
     final _$typefaceEmojiRasterizer = typefaceEmojiRasterizer.reference;
-    return _createSpan(reference.pointer, _id_createSpan.pointer,
+    return _createSpan(_$$selfRef.pointer, _id_createSpan.pointer,
             _$typefaceEmojiRasterizer.pointer)
         .object<jni$_.JObject>();
   }
@@ -1421,8 +1440,9 @@ extension type EmojiCompat._(jni$_.JObject _$this) implements jni$_.JObject {
   static EmojiCompat? init(
     jni$_.JObject context,
   ) {
+    final _$$classRef = _class.reference;
     final _$context = context.reference;
-    return _init(_class.reference.pointer, _id_init.pointer, _$context.pointer)
+    return _init(_$$classRef.pointer, _id_init.pointer, _$context.pointer)
         .object<EmojiCompat?>();
   }
 
@@ -1455,11 +1475,12 @@ extension type EmojiCompat._(jni$_.JObject _$this) implements jni$_.JObject {
     DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory?
         defaultEmojiCompatConfigFactory,
   ) {
+    final _$$classRef = _class.reference;
     final _$context = context.reference;
     final _$defaultEmojiCompatConfigFactory =
         defaultEmojiCompatConfigFactory?.reference ?? jni$_.jNullReference;
-    return _init$1(_class.reference.pointer, _id_init$1.pointer,
-            _$context.pointer, _$defaultEmojiCompatConfigFactory.pointer)
+    return _init$1(_$$classRef.pointer, _id_init$1.pointer, _$context.pointer,
+            _$defaultEmojiCompatConfigFactory.pointer)
         .object<EmojiCompat?>();
   }
 
@@ -1484,9 +1505,9 @@ extension type EmojiCompat._(jni$_.JObject _$this) implements jni$_.JObject {
   static EmojiCompat init$2(
     EmojiCompat$Config config,
   ) {
+    final _$$classRef = _class.reference;
     final _$config = config.reference;
-    return _init$2(
-            _class.reference.pointer, _id_init$2.pointer, _$config.pointer)
+    return _init$2(_$$classRef.pointer, _id_init$2.pointer, _$config.pointer)
         .object<EmojiCompat>();
   }
 
@@ -1509,8 +1530,8 @@ extension type EmojiCompat._(jni$_.JObject _$this) implements jni$_.JObject {
 
   /// from: `static public boolean isConfigured()`
   static core$_.bool get isConfigured {
-    return _get$isConfigured(
-            _class.reference.pointer, _id_get$isConfigured.pointer)
+    final _$$classRef = _class.reference;
+    return _get$isConfigured(_$$classRef.pointer, _id_get$isConfigured.pointer)
         .boolean;
   }
 
@@ -1535,8 +1556,9 @@ extension type EmojiCompat._(jni$_.JObject _$this) implements jni$_.JObject {
   static EmojiCompat reset(
     EmojiCompat$Config config,
   ) {
+    final _$$classRef = _class.reference;
     final _$config = config.reference;
-    return _reset(_class.reference.pointer, _id_reset.pointer, _$config.pointer)
+    return _reset(_$$classRef.pointer, _id_reset.pointer, _$config.pointer)
         .object<EmojiCompat>();
   }
 
@@ -1561,9 +1583,10 @@ extension type EmojiCompat._(jni$_.JObject _$this) implements jni$_.JObject {
   static EmojiCompat? reset$1(
     EmojiCompat? emojiCompat,
   ) {
+    final _$$classRef = _class.reference;
     final _$emojiCompat = emojiCompat?.reference ?? jni$_.jNullReference;
-    return _reset$1(_class.reference.pointer, _id_reset$1.pointer,
-            _$emojiCompat.pointer)
+    return _reset$1(
+            _$$classRef.pointer, _id_reset$1.pointer, _$emojiCompat.pointer)
         .object<EmojiCompat?>();
   }
 
@@ -1586,7 +1609,8 @@ extension type EmojiCompat._(jni$_.JObject _$this) implements jni$_.JObject {
   static void skipDefaultConfigurationLookup(
     core$_.bool z,
   ) {
-    _skipDefaultConfigurationLookup(_class.reference.pointer,
+    final _$$classRef = _class.reference;
+    _skipDefaultConfigurationLookup(_$$classRef.pointer,
             _id_skipDefaultConfigurationLookup.pointer, z ? 1 : 0)
         .check();
   }
@@ -1611,8 +1635,8 @@ extension type EmojiCompat._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public androidx.emoji2.text.EmojiCompat get()`
   /// The returned object must be released after use, by calling the [release] method.
   static EmojiCompat get() {
-    return _get(_class.reference.pointer, _id_get.pointer)
-        .object<EmojiCompat>();
+    final _$$classRef = _class.reference;
+    return _get(_$$classRef.pointer, _id_get.pointer).object<EmojiCompat>();
   }
 
   static final _id_handleOnKeyDown = _class.staticMethodId(
@@ -1645,14 +1669,11 @@ extension type EmojiCompat._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     jni$_.JObject keyEvent,
   ) {
+    final _$$classRef = _class.reference;
     final _$editable = editable.reference;
     final _$keyEvent = keyEvent.reference;
-    return _handleOnKeyDown(
-            _class.reference.pointer,
-            _id_handleOnKeyDown.pointer,
-            _$editable.pointer,
-            i,
-            _$keyEvent.pointer)
+    return _handleOnKeyDown(_$$classRef.pointer, _id_handleOnKeyDown.pointer,
+            _$editable.pointer, i, _$keyEvent.pointer)
         .boolean;
   }
 
@@ -1693,10 +1714,11 @@ extension type EmojiCompat._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i1,
     core$_.bool z,
   ) {
+    final _$$classRef = _class.reference;
     final _$inputConnection = inputConnection.reference;
     final _$editable = editable.reference;
     return _handleDeleteSurroundingText(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_handleDeleteSurroundingText.pointer,
             _$inputConnection.pointer,
             _$editable.pointer,
@@ -1727,7 +1749,8 @@ extension EmojiCompat$$Methods on EmojiCompat {
 
   /// from: `public void load()`
   void load() {
-    _load(reference.pointer, _id_load.pointer).check();
+    final _$$selfRef = reference;
+    _load(_$$selfRef.pointer, _id_load.pointer).check();
   }
 
   static final _id_registerInitCallback = EmojiCompat._class.instanceMethodId(
@@ -1750,8 +1773,9 @@ extension EmojiCompat$$Methods on EmojiCompat {
   void registerInitCallback(
     EmojiCompat$InitCallback initCallback,
   ) {
+    final _$$selfRef = reference;
     final _$initCallback = initCallback.reference;
-    _registerInitCallback(reference.pointer, _id_registerInitCallback.pointer,
+    _registerInitCallback(_$$selfRef.pointer, _id_registerInitCallback.pointer,
             _$initCallback.pointer)
         .check();
   }
@@ -1776,8 +1800,9 @@ extension EmojiCompat$$Methods on EmojiCompat {
   void unregisterInitCallback(
     EmojiCompat$InitCallback initCallback,
   ) {
+    final _$$selfRef = reference;
     final _$initCallback = initCallback.reference;
-    _unregisterInitCallback(reference.pointer,
+    _unregisterInitCallback(_$$selfRef.pointer,
             _id_unregisterInitCallback.pointer, _$initCallback.pointer)
         .check();
   }
@@ -1801,7 +1826,9 @@ extension EmojiCompat$$Methods on EmojiCompat {
 
   /// from: `public int getLoadState()`
   core$_.int get loadState {
-    return _get$loadState(reference.pointer, _id_get$loadState.pointer).integer;
+    final _$$selfRef = reference;
+    return _get$loadState(_$$selfRef.pointer, _id_get$loadState.pointer)
+        .integer;
   }
 
   static final _id_get$isEmojiSpanIndicatorEnabled =
@@ -1825,8 +1852,9 @@ extension EmojiCompat$$Methods on EmojiCompat {
 
   /// from: `public boolean isEmojiSpanIndicatorEnabled()`
   core$_.bool get isEmojiSpanIndicatorEnabled {
+    final _$$selfRef = reference;
     return _get$isEmojiSpanIndicatorEnabled(
-            reference.pointer, _id_get$isEmojiSpanIndicatorEnabled.pointer)
+            _$$selfRef.pointer, _id_get$isEmojiSpanIndicatorEnabled.pointer)
         .boolean;
   }
 
@@ -1851,8 +1879,9 @@ extension EmojiCompat$$Methods on EmojiCompat {
 
   /// from: `public int getEmojiSpanIndicatorColor()`
   core$_.int get emojiSpanIndicatorColor {
+    final _$$selfRef = reference;
     return _get$emojiSpanIndicatorColor(
-            reference.pointer, _id_get$emojiSpanIndicatorColor.pointer)
+            _$$selfRef.pointer, _id_get$emojiSpanIndicatorColor.pointer)
         .integer;
   }
 
@@ -1878,8 +1907,9 @@ extension EmojiCompat$$Methods on EmojiCompat {
     jni$_.JObject charSequence,
     core$_.int i,
   ) {
+    final _$$selfRef = reference;
     final _$charSequence = charSequence.reference;
-    return _getEmojiStart(reference.pointer, _id_getEmojiStart.pointer,
+    return _getEmojiStart(_$$selfRef.pointer, _id_getEmojiStart.pointer,
             _$charSequence.pointer, i)
         .integer;
   }
@@ -1906,8 +1936,9 @@ extension EmojiCompat$$Methods on EmojiCompat {
     jni$_.JObject charSequence,
     core$_.int i,
   ) {
+    final _$$selfRef = reference;
     final _$charSequence = charSequence.reference;
-    return _getEmojiEnd(reference.pointer, _id_getEmojiEnd.pointer,
+    return _getEmojiEnd(_$$selfRef.pointer, _id_getEmojiEnd.pointer,
             _$charSequence.pointer, i)
         .integer;
   }
@@ -1932,8 +1963,9 @@ extension EmojiCompat$$Methods on EmojiCompat {
   core$_.bool hasEmojiGlyph(
     jni$_.JObject charSequence,
   ) {
+    final _$$selfRef = reference;
     final _$charSequence = charSequence.reference;
-    return _hasEmojiGlyph(reference.pointer, _id_hasEmojiGlyph.pointer,
+    return _hasEmojiGlyph(_$$selfRef.pointer, _id_hasEmojiGlyph.pointer,
             _$charSequence.pointer)
         .boolean;
   }
@@ -1960,8 +1992,9 @@ extension EmojiCompat$$Methods on EmojiCompat {
     jni$_.JObject charSequence,
     core$_.int i,
   ) {
+    final _$$selfRef = reference;
     final _$charSequence = charSequence.reference;
-    return _hasEmojiGlyph$1(reference.pointer, _id_hasEmojiGlyph$1.pointer,
+    return _hasEmojiGlyph$1(_$$selfRef.pointer, _id_hasEmojiGlyph$1.pointer,
             _$charSequence.pointer, i)
         .boolean;
   }
@@ -1988,8 +2021,9 @@ extension EmojiCompat$$Methods on EmojiCompat {
     jni$_.JObject charSequence,
     core$_.int i,
   ) {
+    final _$$selfRef = reference;
     final _$charSequence = charSequence.reference;
-    return _getEmojiMatch(reference.pointer, _id_getEmojiMatch.pointer,
+    return _getEmojiMatch(_$$selfRef.pointer, _id_getEmojiMatch.pointer,
             _$charSequence.pointer, i)
         .integer;
   }
@@ -2015,9 +2049,10 @@ extension EmojiCompat$$Methods on EmojiCompat {
   jni$_.JObject? process(
     jni$_.JObject? charSequence,
   ) {
+    final _$$selfRef = reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
     return _process(
-            reference.pointer, _id_process.pointer, _$charSequence.pointer)
+            _$$selfRef.pointer, _id_process.pointer, _$charSequence.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2052,8 +2087,9 @@ extension EmojiCompat$$Methods on EmojiCompat {
     core$_.int i,
     core$_.int i1,
   ) {
+    final _$$selfRef = reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
-    return _process$1(reference.pointer, _id_process$1.pointer,
+    return _process$1(_$$selfRef.pointer, _id_process$1.pointer,
             _$charSequence.pointer, i, i1)
         .object<jni$_.JObject?>();
   }
@@ -2092,8 +2128,9 @@ extension EmojiCompat$$Methods on EmojiCompat {
     core$_.int i1,
     core$_.int i2,
   ) {
+    final _$$selfRef = reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
-    return _process$2(reference.pointer, _id_process$2.pointer,
+    return _process$2(_$$selfRef.pointer, _id_process$2.pointer,
             _$charSequence.pointer, i, i1, i2)
         .object<jni$_.JObject?>();
   }
@@ -2135,8 +2172,9 @@ extension EmojiCompat$$Methods on EmojiCompat {
     core$_.int i2,
     core$_.int i3,
   ) {
+    final _$$selfRef = reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
-    return _process$3(reference.pointer, _id_process$3.pointer,
+    return _process$3(_$$selfRef.pointer, _id_process$3.pointer,
             _$charSequence.pointer, i, i1, i2, i3)
         .object<jni$_.JObject?>();
   }
@@ -2161,8 +2199,9 @@ extension EmojiCompat$$Methods on EmojiCompat {
   /// from: `public java.lang.String getAssetSignature()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString get assetSignature {
+    final _$$selfRef = reference;
     return _get$assetSignature(
-            reference.pointer, _id_get$assetSignature.pointer)
+            _$$selfRef.pointer, _id_get$assetSignature.pointer)
         .object<jni$_.JString>();
   }
 
@@ -2186,8 +2225,9 @@ extension EmojiCompat$$Methods on EmojiCompat {
   void updateEditorInfo(
     jni$_.JObject editorInfo,
   ) {
+    final _$$selfRef = reference;
     final _$editorInfo = editorInfo.reference;
-    _updateEditorInfo(reference.pointer, _id_updateEditorInfo.pointer,
+    _updateEditorInfo(_$$selfRef.pointer, _id_updateEditorInfo.pointer,
             _$editorInfo.pointer)
         .check();
   }
@@ -2233,9 +2273,10 @@ extension type DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory._(
     DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper?
         defaultEmojiCompatConfigHelper,
   ) {
+    final _$$classRef = _class.reference;
     final _$defaultEmojiCompatConfigHelper =
         defaultEmojiCompatConfigHelper?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer,
+    return _new$(_$$classRef.pointer, _id_new$.pointer,
             _$defaultEmojiCompatConfigHelper.pointer)
         .object<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory>();
   }
@@ -2266,8 +2307,9 @@ extension DefaultEmojiCompatConfig$DefaultEmojiCompatConfigFactory$$Methods
   EmojiCompat$Config? create(
     jni$_.JObject context,
   ) {
+    final _$$selfRef = reference;
     final _$context = context.reference;
-    return _create(reference.pointer, _id_create.pointer, _$context.pointer)
+    return _create(_$$selfRef.pointer, _id_create.pointer, _$context.pointer)
         .object<EmojiCompat$Config?>();
   }
 }
@@ -2313,7 +2355,8 @@ extension type DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper._(
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper>();
   }
 }
@@ -2350,10 +2393,11 @@ extension DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$$Methods
     jni$_.JObject packageManager,
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$packageManager = packageManager.reference;
     final _$string = string.reference;
     return _getSigningSignatures(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_getSigningSignatures.pointer,
             _$packageManager.pointer,
             _$string.pointer)
@@ -2394,10 +2438,11 @@ extension DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$$Methods
     jni$_.JObject intent,
     core$_.int i,
   ) {
+    final _$$selfRef = reference;
     final _$packageManager = packageManager.reference;
     final _$intent = intent.reference;
     return _queryIntentContentProviders(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_queryIntentContentProviders.pointer,
             _$packageManager.pointer,
             _$intent.pointer,
@@ -2428,8 +2473,9 @@ extension DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper$$Methods
   jni$_.JObject? getProviderInfo(
     jni$_.JObject resolveInfo,
   ) {
+    final _$$selfRef = reference;
     final _$resolveInfo = resolveInfo.reference;
-    return _getProviderInfo(reference.pointer, _id_getProviderInfo.pointer,
+    return _getProviderInfo(_$$selfRef.pointer, _id_getProviderInfo.pointer,
             _$resolveInfo.pointer)
         .object<jni$_.JObject?>();
   }
@@ -2478,7 +2524,8 @@ extension type DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19._(
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19() {
-    return _new$(_class.reference.pointer, _id_new$.pointer).object<
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<
         DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19>();
   }
 }
@@ -2519,10 +2566,11 @@ extension DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$$Methods
     jni$_.JObject intent,
     core$_.int i,
   ) {
+    final _$$selfRef = reference;
     final _$packageManager = packageManager.reference;
     final _$intent = intent.reference;
     return _queryIntentContentProviders(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_queryIntentContentProviders.pointer,
             _$packageManager.pointer,
             _$intent.pointer,
@@ -2553,8 +2601,9 @@ extension DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API19$$Methods
   jni$_.JObject? getProviderInfo(
     jni$_.JObject resolveInfo,
   ) {
+    final _$$selfRef = reference;
     final _$resolveInfo = resolveInfo.reference;
-    return _getProviderInfo(reference.pointer, _id_getProviderInfo.pointer,
+    return _getProviderInfo(_$$selfRef.pointer, _id_getProviderInfo.pointer,
             _$resolveInfo.pointer)
         .object<jni$_.JObject?>();
   }
@@ -2603,7 +2652,8 @@ extension type DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28._(
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28() {
-    return _new$(_class.reference.pointer, _id_new$.pointer).object<
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<
         DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28>();
   }
 }
@@ -2640,10 +2690,11 @@ extension DefaultEmojiCompatConfig$DefaultEmojiCompatConfigHelper_API28$$Methods
     jni$_.JObject packageManager,
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$packageManager = packageManager.reference;
     final _$string = string.reference;
     return _getSigningSignatures$1(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_getSigningSignatures$1.pointer,
             _$packageManager.pointer,
             _$string.pointer)
@@ -2693,9 +2744,9 @@ extension type DefaultEmojiCompatConfig._(jni$_.JObject _$this)
   static jni$_.JObject? create(
     jni$_.JObject context,
   ) {
+    final _$$classRef = _class.reference;
     final _$context = context.reference;
-    return _create(
-            _class.reference.pointer, _id_create.pointer, _$context.pointer)
+    return _create(_$$classRef.pointer, _id_create.pointer, _$context.pointer)
         .object<jni$_.JObject?>();
   }
 }
@@ -2750,8 +2801,9 @@ extension Build$Partition$$Methods on Build$Partition {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -2775,8 +2827,9 @@ extension Build$Partition$$Methods on Build$Partition {
 
   /// from: `public long getBuildTimeMillis()`
   core$_.int get buildTimeMillis {
+    final _$$selfRef = reference;
     return _get$buildTimeMillis(
-            reference.pointer, _id_get$buildTimeMillis.pointer)
+            _$$selfRef.pointer, _id_get$buildTimeMillis.pointer)
         .long;
   }
 
@@ -2800,7 +2853,8 @@ extension Build$Partition$$Methods on Build$Partition {
   /// from: `public java.lang.String getFingerprint()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? get fingerprint {
-    return _get$fingerprint(reference.pointer, _id_get$fingerprint.pointer)
+    final _$$selfRef = reference;
+    return _get$fingerprint(_$$selfRef.pointer, _id_get$fingerprint.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -2824,7 +2878,8 @@ extension Build$Partition$$Methods on Build$Partition {
   /// from: `public java.lang.String getName()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? get name {
-    return _get$name(reference.pointer, _id_get$name.pointer)
+    final _$$selfRef = reference;
+    return _get$name(_$$selfRef.pointer, _id_get$name.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -2847,7 +2902,8 @@ extension Build$Partition$$Methods on Build$Partition {
 
   /// from: `public int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 }
 
@@ -3005,8 +3061,8 @@ extension type Build$VERSION._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory Build$VERSION() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<Build$VERSION>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<Build$VERSION>();
   }
 }
 
@@ -3157,7 +3213,8 @@ extension type Build$VERSION_CODES._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory Build$VERSION_CODES() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<Build$VERSION_CODES>();
   }
 }
@@ -3613,7 +3670,8 @@ extension type Build._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory Build() {
-    return _new$(_class.reference.pointer, _id_new$.pointer).object<Build>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<Build>();
   }
 
   static final _id_get$fingerprintedPartitions = _class.staticMethodId(
@@ -3637,8 +3695,9 @@ extension type Build._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public java.util.List<android.os.Build$Partition> getFingerprintedPartitions()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JList<Build$Partition?>? get fingerprintedPartitions {
+    final _$$classRef = _class.reference;
     return _get$fingerprintedPartitions(
-            _class.reference.pointer, _id_get$fingerprintedPartitions.pointer)
+            _$$classRef.pointer, _id_get$fingerprintedPartitions.pointer)
         .object<jni$_.JList<Build$Partition?>?>();
   }
 
@@ -3660,8 +3719,9 @@ extension type Build._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int getMajorSdkVersion(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _getMajorSdkVersion(
-            _class.reference.pointer, _id_getMajorSdkVersion.pointer, i)
+            _$$classRef.pointer, _id_getMajorSdkVersion.pointer, i)
         .integer;
   }
 
@@ -3683,8 +3743,9 @@ extension type Build._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int getMinorSdkVersion(
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     return _getMinorSdkVersion(
-            _class.reference.pointer, _id_getMinorSdkVersion.pointer, i)
+            _$$classRef.pointer, _id_getMinorSdkVersion.pointer, i)
         .integer;
   }
 
@@ -3708,8 +3769,8 @@ extension type Build._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public java.lang.String getRadioVersion()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get radioVersion {
-    return _get$radioVersion(
-            _class.reference.pointer, _id_get$radioVersion.pointer)
+    final _$$classRef = _class.reference;
+    return _get$radioVersion(_$$classRef.pointer, _id_get$radioVersion.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -3733,7 +3794,8 @@ extension type Build._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public java.lang.String getSerial()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get serial {
-    return _get$serial(_class.reference.pointer, _id_get$serial.pointer)
+    final _$$classRef = _class.reference;
+    return _get$serial(_$$classRef.pointer, _id_get$serial.pointer)
         .object<jni$_.JString?>();
   }
 }
@@ -3773,7 +3835,8 @@ extension type HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory HashMap() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<HashMap<$K, $V>>();
   }
 
@@ -3796,7 +3859,8 @@ extension type HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
   factory HashMap.new$1(
     core$_.int i,
   ) {
-    return _new$1(_class.reference.pointer, _id_new$1.pointer, i)
+    final _$$classRef = _class.reference;
+    return _new$1(_$$classRef.pointer, _id_new$1.pointer, i)
         .object<HashMap<$K, $V>>();
   }
 
@@ -3821,7 +3885,8 @@ extension type HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
     core$_.int i,
     core$_.double f,
   ) {
-    return _new$2(_class.reference.pointer, _id_new$2.pointer, i, f)
+    final _$$classRef = _class.reference;
+    return _new$2(_$$classRef.pointer, _id_new$2.pointer, i, f)
         .object<HashMap<$K, $V>>();
   }
 
@@ -3845,8 +3910,9 @@ extension type HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
   factory HashMap.new$3(
     jni$_.JMap<$K?, $V?>? map,
   ) {
+    final _$$classRef = _class.reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _new$3(_class.reference.pointer, _id_new$3.pointer, _$map.pointer)
+    return _new$3(_$$classRef.pointer, _id_new$3.pointer, _$map.pointer)
         .object<HashMap<$K, $V>>();
   }
 
@@ -3870,7 +3936,8 @@ extension type HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
       newHashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>(
     core$_.int i,
   ) {
-    return _newHashMap(_class.reference.pointer, _id_newHashMap.pointer, i)
+    final _$$classRef = _class.reference;
+    return _newHashMap(_$$classRef.pointer, _id_newHashMap.pointer, i)
         .object<HashMap<$K?, $V?>?>();
   }
 }
@@ -3896,7 +3963,8 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
 
   /// from: `public void clear()`
   void clear() {
-    _clear(reference.pointer, _id_clear.pointer).check();
+    final _$$selfRef = reference;
+    _clear(_$$selfRef.pointer, _id_clear.pointer).check();
   }
 
   static final _id_clone = HashMap._class.instanceMethodId(
@@ -3919,7 +3987,8 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   /// from: `public java.lang.Object clone()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? clone() {
-    return _clone(reference.pointer, _id_clone.pointer)
+    final _$$selfRef = reference;
+    return _clone(_$$selfRef.pointer, _id_clone.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -3951,9 +4020,10 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $K? object,
     jni$_.JObject? biFunction,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$biFunction = biFunction?.reference ?? jni$_.jNullReference;
-    return _compute(reference.pointer, _id_compute.pointer, _$object.pointer,
+    return _compute(_$$selfRef.pointer, _id_compute.pointer, _$object.pointer,
             _$biFunction.pointer)
         .object<$V?>();
   }
@@ -3986,9 +4056,10 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $K? object,
     jni$_.JObject? function,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$function = function?.reference ?? jni$_.jNullReference;
-    return _computeIfAbsent(reference.pointer, _id_computeIfAbsent.pointer,
+    return _computeIfAbsent(_$$selfRef.pointer, _id_computeIfAbsent.pointer,
             _$object.pointer, _$function.pointer)
         .object<$V?>();
   }
@@ -4021,9 +4092,10 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $K? object,
     jni$_.JObject? biFunction,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$biFunction = biFunction?.reference ?? jni$_.jNullReference;
-    return _computeIfPresent(reference.pointer, _id_computeIfPresent.pointer,
+    return _computeIfPresent(_$$selfRef.pointer, _id_computeIfPresent.pointer,
             _$object.pointer, _$biFunction.pointer)
         .object<$V?>();
   }
@@ -4048,9 +4120,10 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   core$_.bool containsKey(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _containsKey(
-            reference.pointer, _id_containsKey.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_containsKey.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -4074,9 +4147,10 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   core$_.bool containsValue(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _containsValue(
-            reference.pointer, _id_containsValue.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_containsValue.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -4100,7 +4174,8 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   /// from: `public java.util.Set<java.util.Map$Entry<K, V>> entrySet()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JSet<jni$_.JObject?>? entrySet() {
-    return _entrySet(reference.pointer, _id_entrySet.pointer)
+    final _$$selfRef = reference;
+    return _entrySet(_$$selfRef.pointer, _id_entrySet.pointer)
         .object<jni$_.JSet<jni$_.JObject?>?>();
   }
 
@@ -4124,8 +4199,9 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   void forEach(
     jni$_.JObject? biConsumer,
   ) {
+    final _$$selfRef = reference;
     final _$biConsumer = biConsumer?.reference ?? jni$_.jNullReference;
-    _forEach(reference.pointer, _id_forEach.pointer, _$biConsumer.pointer)
+    _forEach(_$$selfRef.pointer, _id_forEach.pointer, _$biConsumer.pointer)
         .check();
   }
 
@@ -4150,8 +4226,9 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   $V? get(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _get(reference.pointer, _id_get.pointer, _$object.pointer)
+    return _get(_$$selfRef.pointer, _id_get.pointer, _$object.pointer)
         .object<$V?>();
   }
 
@@ -4183,9 +4260,10 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     jni$_.JObject? object,
     $V? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _getOrDefault(reference.pointer, _id_getOrDefault.pointer,
+    return _getOrDefault(_$$selfRef.pointer, _id_getOrDefault.pointer,
             _$object.pointer, _$object1.pointer)
         .object<$V?>();
   }
@@ -4209,7 +4287,8 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
 
   /// from: `public boolean isEmpty()`
   core$_.bool get isEmpty {
-    return _get$isEmpty(reference.pointer, _id_get$isEmpty.pointer).boolean;
+    final _$$selfRef = reference;
+    return _get$isEmpty(_$$selfRef.pointer, _id_get$isEmpty.pointer).boolean;
   }
 
   static final _id_keySet = HashMap._class.instanceMethodId(
@@ -4232,7 +4311,8 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   /// from: `public java.util.Set<K> keySet()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JSet<$K?>? keySet() {
-    return _keySet(reference.pointer, _id_keySet.pointer)
+    final _$$selfRef = reference;
+    return _keySet(_$$selfRef.pointer, _id_keySet.pointer)
         .object<jni$_.JSet<$K?>?>();
   }
 
@@ -4267,10 +4347,11 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $V? object1,
     jni$_.JObject? biFunction,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$biFunction = biFunction?.reference ?? jni$_.jNullReference;
-    return _merge(reference.pointer, _id_merge.pointer, _$object.pointer,
+    return _merge(_$$selfRef.pointer, _id_merge.pointer, _$object.pointer,
             _$object1.pointer, _$biFunction.pointer)
         .object<$V?>();
   }
@@ -4303,9 +4384,10 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $K? object,
     $V? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _put(reference.pointer, _id_put.pointer, _$object.pointer,
+    return _put(_$$selfRef.pointer, _id_put.pointer, _$object.pointer,
             _$object1.pointer)
         .object<$V?>();
   }
@@ -4330,8 +4412,9 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   void putAll(
     jni$_.JMap<$K?, $V?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    _putAll(reference.pointer, _id_putAll.pointer, _$map.pointer).check();
+    _putAll(_$$selfRef.pointer, _id_putAll.pointer, _$map.pointer).check();
   }
 
   static final _id_putIfAbsent = HashMap._class.instanceMethodId(
@@ -4362,9 +4445,10 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $K? object,
     $V? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _putIfAbsent(reference.pointer, _id_putIfAbsent.pointer,
+    return _putIfAbsent(_$$selfRef.pointer, _id_putIfAbsent.pointer,
             _$object.pointer, _$object1.pointer)
         .object<$V?>();
   }
@@ -4390,8 +4474,9 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   $V? remove(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _remove(reference.pointer, _id_remove.pointer, _$object.pointer)
+    return _remove(_$$selfRef.pointer, _id_remove.pointer, _$object.pointer)
         .object<$V?>();
   }
 
@@ -4422,9 +4507,10 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     jni$_.JObject? object,
     jni$_.JObject? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _remove$1(reference.pointer, _id_remove$1.pointer, _$object.pointer,
+    return _remove$1(_$$selfRef.pointer, _id_remove$1.pointer, _$object.pointer,
             _$object1.pointer)
         .boolean;
   }
@@ -4457,9 +4543,10 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $K? object,
     $V? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _replace(reference.pointer, _id_replace.pointer, _$object.pointer,
+    return _replace(_$$selfRef.pointer, _id_replace.pointer, _$object.pointer,
             _$object1.pointer)
         .object<$V?>();
   }
@@ -4494,10 +4581,11 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $V? object1,
     $V? object2,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
-    return _replace$1(reference.pointer, _id_replace$1.pointer,
+    return _replace$1(_$$selfRef.pointer, _id_replace$1.pointer,
             _$object.pointer, _$object1.pointer, _$object2.pointer)
         .boolean;
   }
@@ -4522,8 +4610,10 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   void replaceAll(
     jni$_.JObject? biFunction,
   ) {
+    final _$$selfRef = reference;
     final _$biFunction = biFunction?.reference ?? jni$_.jNullReference;
-    _replaceAll(reference.pointer, _id_replaceAll.pointer, _$biFunction.pointer)
+    _replaceAll(
+            _$$selfRef.pointer, _id_replaceAll.pointer, _$biFunction.pointer)
         .check();
   }
 
@@ -4546,7 +4636,8 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
 
   /// from: `public int size()`
   core$_.int size() {
-    return _size(reference.pointer, _id_size.pointer).integer;
+    final _$$selfRef = reference;
+    return _size(_$$selfRef.pointer, _id_size.pointer).integer;
   }
 
   static final _id_values = HashMap._class.instanceMethodId(
@@ -4569,7 +4660,8 @@ extension HashMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   /// from: `public java.util.Collection<V> values()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? values() {
-    return _values(reference.pointer, _id_values.pointer)
+    final _$$selfRef = reference;
+    return _values(_$$selfRef.pointer, _id_values.pointer)
         .object<jni$_.JObject?>();
   }
 }
@@ -4620,9 +4712,10 @@ extension type AndroidUtils._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JObject? text,
     core$_.int duration,
   ) {
+    final _$$classRef = _class.reference;
     final _$mainActivity = mainActivity?.reference ?? jni$_.jNullReference;
     final _$text = text?.reference ?? jni$_.jNullReference;
-    _showToast(_class.reference.pointer, _id_showToast.pointer,
+    _showToast(_$$classRef.pointer, _id_showToast.pointer,
             _$mainActivity.pointer, _$text.pointer, duration)
         .check();
   }

--- a/pkgs/jnigen/example/kotlin_plugin/lib/kotlin_bindings.dart
+++ b/pkgs/jnigen/example/kotlin_plugin/lib/kotlin_bindings.dart
@@ -63,7 +63,8 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory Example() {
-    return _new$(_class.reference.pointer, _id_new$.pointer).object<Example>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<Example>();
   }
 }
 
@@ -89,8 +90,8 @@ extension Example$$Methods on Example {
   core$_.Future<jni$_.JString> thinkBeforeAnswering() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _thinkBeforeAnswering(reference.pointer,
+    final _$$selfRef = reference;
+    final $r = _thinkBeforeAnswering(_$$selfRef.pointer,
             _id_thinkBeforeAnswering.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();

--- a/pkgs/jnigen/example/maven_libs/lib/maven_libs_bindings.dart
+++ b/pkgs/jnigen/example/maven_libs/lib/maven_libs_bindings.dart
@@ -63,7 +63,8 @@ extension type Gson._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory Gson() {
-    return _new$(_class.reference.pointer, _id_new$.pointer).object<Gson>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<Gson>();
   }
 }
 
@@ -88,7 +89,8 @@ extension Gson$$Methods on Gson {
   /// from: `public com.google.gson.GsonBuilder newBuilder()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? newBuilder() {
-    return _newBuilder(reference.pointer, _id_newBuilder.pointer)
+    final _$$selfRef = reference;
+    return _newBuilder(_$$selfRef.pointer, _id_newBuilder.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -112,7 +114,8 @@ extension Gson$$Methods on Gson {
   /// from: `public com.google.gson.internal.Excluder excluder()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? excluder() {
-    return _excluder(reference.pointer, _id_excluder.pointer)
+    final _$$selfRef = reference;
+    return _excluder(_$$selfRef.pointer, _id_excluder.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -136,8 +139,9 @@ extension Gson$$Methods on Gson {
   /// from: `public com.google.gson.FieldNamingStrategy fieldNamingStrategy()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? fieldNamingStrategy() {
+    final _$$selfRef = reference;
     return _fieldNamingStrategy(
-            reference.pointer, _id_fieldNamingStrategy.pointer)
+            _$$selfRef.pointer, _id_fieldNamingStrategy.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -160,7 +164,8 @@ extension Gson$$Methods on Gson {
 
   /// from: `public boolean serializeNulls()`
   core$_.bool serializeNulls() {
-    return _serializeNulls(reference.pointer, _id_serializeNulls.pointer)
+    final _$$selfRef = reference;
+    return _serializeNulls(_$$selfRef.pointer, _id_serializeNulls.pointer)
         .boolean;
   }
 
@@ -183,7 +188,8 @@ extension Gson$$Methods on Gson {
 
   /// from: `public boolean htmlSafe()`
   core$_.bool htmlSafe() {
-    return _htmlSafe(reference.pointer, _id_htmlSafe.pointer).boolean;
+    final _$$selfRef = reference;
+    return _htmlSafe(_$$selfRef.pointer, _id_htmlSafe.pointer).boolean;
   }
 
   static final _id_getAdapter = Gson._class.instanceMethodId(
@@ -207,9 +213,10 @@ extension Gson$$Methods on Gson {
   jni$_.JObject? getAdapter<$T extends jni$_.JObject?>(
     jni$_.JObject? typeToken,
   ) {
+    final _$$selfRef = reference;
     final _$typeToken = typeToken?.reference ?? jni$_.jNullReference;
     return _getAdapter(
-            reference.pointer, _id_getAdapter.pointer, _$typeToken.pointer)
+            _$$selfRef.pointer, _id_getAdapter.pointer, _$typeToken.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -241,11 +248,12 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? typeAdapterFactory,
     jni$_.JObject? typeToken,
   ) {
+    final _$$selfRef = reference;
     final _$typeAdapterFactory =
         typeAdapterFactory?.reference ?? jni$_.jNullReference;
     final _$typeToken = typeToken?.reference ?? jni$_.jNullReference;
     return _getDelegateAdapter(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_getDelegateAdapter.pointer,
             _$typeAdapterFactory.pointer,
             _$typeToken.pointer)
@@ -273,9 +281,10 @@ extension Gson$$Methods on Gson {
   jni$_.JObject? getAdapter$1<$T extends jni$_.JObject?>(
     jni$_.JObject? class$,
   ) {
+    final _$$selfRef = reference;
     final _$class$ = class$?.reference ?? jni$_.jNullReference;
     return _getAdapter$1(
-            reference.pointer, _id_getAdapter$1.pointer, _$class$.pointer)
+            _$$selfRef.pointer, _id_getAdapter$1.pointer, _$class$.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -300,9 +309,10 @@ extension Gson$$Methods on Gson {
   jni$_.JObject? toJsonTree(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _toJsonTree(
-            reference.pointer, _id_toJsonTree.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_toJsonTree.pointer, _$object.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -334,9 +344,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? object,
     jni$_.JObject? type,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$type = type?.reference ?? jni$_.jNullReference;
-    return _toJsonTree$1(reference.pointer, _id_toJsonTree$1.pointer,
+    return _toJsonTree$1(_$$selfRef.pointer, _id_toJsonTree$1.pointer,
             _$object.pointer, _$type.pointer)
         .object<jni$_.JObject?>();
   }
@@ -362,8 +373,9 @@ extension Gson$$Methods on Gson {
   jni$_.JString? toJson(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _toJson(reference.pointer, _id_toJson.pointer, _$object.pointer)
+    return _toJson(_$$selfRef.pointer, _id_toJson.pointer, _$object.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -395,9 +407,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? object,
     jni$_.JObject? type,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$type = type?.reference ?? jni$_.jNullReference;
-    return _toJson$1(reference.pointer, _id_toJson$1.pointer, _$object.pointer,
+    return _toJson$1(_$$selfRef.pointer, _id_toJson$1.pointer, _$object.pointer,
             _$type.pointer)
         .object<jni$_.JString?>();
   }
@@ -429,9 +442,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? object,
     jni$_.JObject? appendable,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$appendable = appendable?.reference ?? jni$_.jNullReference;
-    _toJson$2(reference.pointer, _id_toJson$2.pointer, _$object.pointer,
+    _toJson$2(_$$selfRef.pointer, _id_toJson$2.pointer, _$object.pointer,
             _$appendable.pointer)
         .check();
   }
@@ -466,10 +480,11 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? type,
     jni$_.JObject? appendable,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$type = type?.reference ?? jni$_.jNullReference;
     final _$appendable = appendable?.reference ?? jni$_.jNullReference;
-    _toJson$3(reference.pointer, _id_toJson$3.pointer, _$object.pointer,
+    _toJson$3(_$$selfRef.pointer, _id_toJson$3.pointer, _$object.pointer,
             _$type.pointer, _$appendable.pointer)
         .check();
   }
@@ -504,10 +519,11 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? type,
     jni$_.JObject? jsonWriter,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$type = type?.reference ?? jni$_.jNullReference;
     final _$jsonWriter = jsonWriter?.reference ?? jni$_.jNullReference;
-    _toJson$4(reference.pointer, _id_toJson$4.pointer, _$object.pointer,
+    _toJson$4(_$$selfRef.pointer, _id_toJson$4.pointer, _$object.pointer,
             _$type.pointer, _$jsonWriter.pointer)
         .check();
   }
@@ -533,9 +549,10 @@ extension Gson$$Methods on Gson {
   jni$_.JString? toJson$5(
     jni$_.JObject? jsonElement,
   ) {
+    final _$$selfRef = reference;
     final _$jsonElement = jsonElement?.reference ?? jni$_.jNullReference;
     return _toJson$5(
-            reference.pointer, _id_toJson$5.pointer, _$jsonElement.pointer)
+            _$$selfRef.pointer, _id_toJson$5.pointer, _$jsonElement.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -566,9 +583,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? jsonElement,
     jni$_.JObject? appendable,
   ) {
+    final _$$selfRef = reference;
     final _$jsonElement = jsonElement?.reference ?? jni$_.jNullReference;
     final _$appendable = appendable?.reference ?? jni$_.jNullReference;
-    _toJson$6(reference.pointer, _id_toJson$6.pointer, _$jsonElement.pointer,
+    _toJson$6(_$$selfRef.pointer, _id_toJson$6.pointer, _$jsonElement.pointer,
             _$appendable.pointer)
         .check();
   }
@@ -594,9 +612,10 @@ extension Gson$$Methods on Gson {
   jni$_.JObject? newJsonWriter(
     jni$_.JObject? writer,
   ) {
+    final _$$selfRef = reference;
     final _$writer = writer?.reference ?? jni$_.jNullReference;
     return _newJsonWriter(
-            reference.pointer, _id_newJsonWriter.pointer, _$writer.pointer)
+            _$$selfRef.pointer, _id_newJsonWriter.pointer, _$writer.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -621,9 +640,10 @@ extension Gson$$Methods on Gson {
   jni$_.JObject? newJsonReader(
     jni$_.JObject? reader,
   ) {
+    final _$$selfRef = reference;
     final _$reader = reader?.reference ?? jni$_.jNullReference;
     return _newJsonReader(
-            reference.pointer, _id_newJsonReader.pointer, _$reader.pointer)
+            _$$selfRef.pointer, _id_newJsonReader.pointer, _$reader.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -654,9 +674,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? jsonElement,
     jni$_.JObject? jsonWriter,
   ) {
+    final _$$selfRef = reference;
     final _$jsonElement = jsonElement?.reference ?? jni$_.jNullReference;
     final _$jsonWriter = jsonWriter?.reference ?? jni$_.jNullReference;
-    _toJson$7(reference.pointer, _id_toJson$7.pointer, _$jsonElement.pointer,
+    _toJson$7(_$$selfRef.pointer, _id_toJson$7.pointer, _$jsonElement.pointer,
             _$jsonWriter.pointer)
         .check();
   }
@@ -689,9 +710,10 @@ extension Gson$$Methods on Gson {
     jni$_.JString? string,
     jni$_.JObject? class$,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$class$ = class$?.reference ?? jni$_.jNullReference;
-    return _fromJson(reference.pointer, _id_fromJson.pointer, _$string.pointer,
+    return _fromJson(_$$selfRef.pointer, _id_fromJson.pointer, _$string.pointer,
             _$class$.pointer)
         .object<$T?>();
   }
@@ -724,9 +746,10 @@ extension Gson$$Methods on Gson {
     jni$_.JString? string,
     jni$_.JObject? type,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$type = type?.reference ?? jni$_.jNullReference;
-    return _fromJson$1(reference.pointer, _id_fromJson$1.pointer,
+    return _fromJson$1(_$$selfRef.pointer, _id_fromJson$1.pointer,
             _$string.pointer, _$type.pointer)
         .object<$T?>();
   }
@@ -759,9 +782,10 @@ extension Gson$$Methods on Gson {
     jni$_.JString? string,
     jni$_.JObject? typeToken,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$typeToken = typeToken?.reference ?? jni$_.jNullReference;
-    return _fromJson$2(reference.pointer, _id_fromJson$2.pointer,
+    return _fromJson$2(_$$selfRef.pointer, _id_fromJson$2.pointer,
             _$string.pointer, _$typeToken.pointer)
         .object<$T?>();
   }
@@ -794,9 +818,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? reader,
     jni$_.JObject? class$,
   ) {
+    final _$$selfRef = reference;
     final _$reader = reader?.reference ?? jni$_.jNullReference;
     final _$class$ = class$?.reference ?? jni$_.jNullReference;
-    return _fromJson$3(reference.pointer, _id_fromJson$3.pointer,
+    return _fromJson$3(_$$selfRef.pointer, _id_fromJson$3.pointer,
             _$reader.pointer, _$class$.pointer)
         .object<$T?>();
   }
@@ -829,9 +854,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? reader,
     jni$_.JObject? type,
   ) {
+    final _$$selfRef = reference;
     final _$reader = reader?.reference ?? jni$_.jNullReference;
     final _$type = type?.reference ?? jni$_.jNullReference;
-    return _fromJson$4(reference.pointer, _id_fromJson$4.pointer,
+    return _fromJson$4(_$$selfRef.pointer, _id_fromJson$4.pointer,
             _$reader.pointer, _$type.pointer)
         .object<$T?>();
   }
@@ -864,9 +890,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? reader,
     jni$_.JObject? typeToken,
   ) {
+    final _$$selfRef = reference;
     final _$reader = reader?.reference ?? jni$_.jNullReference;
     final _$typeToken = typeToken?.reference ?? jni$_.jNullReference;
-    return _fromJson$5(reference.pointer, _id_fromJson$5.pointer,
+    return _fromJson$5(_$$selfRef.pointer, _id_fromJson$5.pointer,
             _$reader.pointer, _$typeToken.pointer)
         .object<$T?>();
   }
@@ -899,9 +926,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? jsonReader,
     jni$_.JObject? type,
   ) {
+    final _$$selfRef = reference;
     final _$jsonReader = jsonReader?.reference ?? jni$_.jNullReference;
     final _$type = type?.reference ?? jni$_.jNullReference;
-    return _fromJson$6(reference.pointer, _id_fromJson$6.pointer,
+    return _fromJson$6(_$$selfRef.pointer, _id_fromJson$6.pointer,
             _$jsonReader.pointer, _$type.pointer)
         .object<$T?>();
   }
@@ -934,9 +962,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? jsonReader,
     jni$_.JObject? typeToken,
   ) {
+    final _$$selfRef = reference;
     final _$jsonReader = jsonReader?.reference ?? jni$_.jNullReference;
     final _$typeToken = typeToken?.reference ?? jni$_.jNullReference;
-    return _fromJson$7(reference.pointer, _id_fromJson$7.pointer,
+    return _fromJson$7(_$$selfRef.pointer, _id_fromJson$7.pointer,
             _$jsonReader.pointer, _$typeToken.pointer)
         .object<$T?>();
   }
@@ -969,9 +998,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? jsonElement,
     jni$_.JObject? class$,
   ) {
+    final _$$selfRef = reference;
     final _$jsonElement = jsonElement?.reference ?? jni$_.jNullReference;
     final _$class$ = class$?.reference ?? jni$_.jNullReference;
-    return _fromJson$8(reference.pointer, _id_fromJson$8.pointer,
+    return _fromJson$8(_$$selfRef.pointer, _id_fromJson$8.pointer,
             _$jsonElement.pointer, _$class$.pointer)
         .object<$T?>();
   }
@@ -1004,9 +1034,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? jsonElement,
     jni$_.JObject? type,
   ) {
+    final _$$selfRef = reference;
     final _$jsonElement = jsonElement?.reference ?? jni$_.jNullReference;
     final _$type = type?.reference ?? jni$_.jNullReference;
-    return _fromJson$9(reference.pointer, _id_fromJson$9.pointer,
+    return _fromJson$9(_$$selfRef.pointer, _id_fromJson$9.pointer,
             _$jsonElement.pointer, _$type.pointer)
         .object<$T?>();
   }
@@ -1039,9 +1070,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? jsonElement,
     jni$_.JObject? typeToken,
   ) {
+    final _$$selfRef = reference;
     final _$jsonElement = jsonElement?.reference ?? jni$_.jNullReference;
     final _$typeToken = typeToken?.reference ?? jni$_.jNullReference;
-    return _fromJson$10(reference.pointer, _id_fromJson$10.pointer,
+    return _fromJson$10(_$$selfRef.pointer, _id_fromJson$10.pointer,
             _$jsonElement.pointer, _$typeToken.pointer)
         .object<$T?>();
   }
@@ -1066,7 +1098,8 @@ extension Gson$$Methods on Gson {
   /// from: `public java.lang.String toString()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<jni$_.JString?>();
   }
 }
@@ -1107,7 +1140,8 @@ extension type OkHttpClient$Builder._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory OkHttpClient$Builder() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1131,9 +1165,10 @@ extension type OkHttpClient$Builder._(jni$_.JObject _$this)
   factory OkHttpClient$Builder.new$1(
     OkHttpClient okHttpClient,
   ) {
+    final _$$classRef = _class.reference;
     final _$okHttpClient = okHttpClient.reference;
     return _new$1(
-            _class.reference.pointer, _id_new$1.pointer, _$okHttpClient.pointer)
+            _$$classRef.pointer, _id_new$1.pointer, _$okHttpClient.pointer)
         .object<OkHttpClient$Builder>();
   }
 }
@@ -1160,9 +1195,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder dispatcher(
     jni$_.JObject dispatcher,
   ) {
+    final _$$selfRef = reference;
     final _$dispatcher = dispatcher.reference;
     return _dispatcher(
-            reference.pointer, _id_dispatcher.pointer, _$dispatcher.pointer)
+            _$$selfRef.pointer, _id_dispatcher.pointer, _$dispatcher.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1188,8 +1224,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder connectionPool(
     jni$_.JObject connectionPool,
   ) {
+    final _$$selfRef = reference;
     final _$connectionPool = connectionPool.reference;
-    return _connectionPool(reference.pointer, _id_connectionPool.pointer,
+    return _connectionPool(_$$selfRef.pointer, _id_connectionPool.pointer,
             _$connectionPool.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1214,7 +1251,8 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   /// from: `public fun interceptors(): kotlin.collections.MutableList<okhttp3.Interceptor>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject> interceptors() {
-    return _interceptors(reference.pointer, _id_interceptors.pointer)
+    final _$$selfRef = reference;
+    return _interceptors(_$$selfRef.pointer, _id_interceptors.pointer)
         .object<jni$_.JList<jni$_.JObject>>();
   }
 
@@ -1240,8 +1278,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder addInterceptor(
     jni$_.JObject interceptor,
   ) {
+    final _$$selfRef = reference;
     final _$interceptor = interceptor.reference;
-    return _addInterceptor(reference.pointer, _id_addInterceptor.pointer,
+    return _addInterceptor(_$$selfRef.pointer, _id_addInterceptor.pointer,
             _$interceptor.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1267,8 +1306,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   /// from: `public fun networkInterceptors(): kotlin.collections.MutableList<okhttp3.Interceptor>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject> networkInterceptors() {
+    final _$$selfRef = reference;
     return _networkInterceptors(
-            reference.pointer, _id_networkInterceptors.pointer)
+            _$$selfRef.pointer, _id_networkInterceptors.pointer)
         .object<jni$_.JList<jni$_.JObject>>();
   }
 
@@ -1294,8 +1334,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder addNetworkInterceptor(
     jni$_.JObject interceptor,
   ) {
+    final _$$selfRef = reference;
     final _$interceptor = interceptor.reference;
-    return _addNetworkInterceptor(reference.pointer,
+    return _addNetworkInterceptor(_$$selfRef.pointer,
             _id_addNetworkInterceptor.pointer, _$interceptor.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1321,8 +1362,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder eventListener(
     jni$_.JObject eventListener,
   ) {
+    final _$$selfRef = reference;
     final _$eventListener = eventListener.reference;
-    return _eventListener(reference.pointer, _id_eventListener.pointer,
+    return _eventListener(_$$selfRef.pointer, _id_eventListener.pointer,
             _$eventListener.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1349,8 +1391,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder eventListenerFactory(
     jni$_.JObject factory,
   ) {
+    final _$$selfRef = reference;
     final _$factory = factory.reference;
-    return _eventListenerFactory(reference.pointer,
+    return _eventListenerFactory(_$$selfRef.pointer,
             _id_eventListenerFactory.pointer, _$factory.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1376,8 +1419,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder retryOnConnectionFailure(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _retryOnConnectionFailure(
-            reference.pointer, _id_retryOnConnectionFailure.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_retryOnConnectionFailure.pointer, z ? 1 : 0)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1402,8 +1446,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder authenticator(
     jni$_.JObject authenticator,
   ) {
+    final _$$selfRef = reference;
     final _$authenticator = authenticator.reference;
-    return _authenticator(reference.pointer, _id_authenticator.pointer,
+    return _authenticator(_$$selfRef.pointer, _id_authenticator.pointer,
             _$authenticator.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1429,8 +1474,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder followRedirects(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _followRedirects(
-            reference.pointer, _id_followRedirects.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_followRedirects.pointer, z ? 1 : 0)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1455,8 +1501,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder followSslRedirects(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _followSslRedirects(
-            reference.pointer, _id_followSslRedirects.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_followSslRedirects.pointer, z ? 1 : 0)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1481,9 +1528,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder cookieJar(
     jni$_.JObject cookieJar,
   ) {
+    final _$$selfRef = reference;
     final _$cookieJar = cookieJar.reference;
     return _cookieJar(
-            reference.pointer, _id_cookieJar.pointer, _$cookieJar.pointer)
+            _$$selfRef.pointer, _id_cookieJar.pointer, _$cookieJar.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1508,8 +1556,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder cache(
     jni$_.JObject? cache,
   ) {
+    final _$$selfRef = reference;
     final _$cache = cache?.reference ?? jni$_.jNullReference;
-    return _cache(reference.pointer, _id_cache.pointer, _$cache.pointer)
+    return _cache(_$$selfRef.pointer, _id_cache.pointer, _$cache.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1534,8 +1583,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder dns(
     jni$_.JObject dns,
   ) {
+    final _$$selfRef = reference;
     final _$dns = dns.reference;
-    return _dns(reference.pointer, _id_dns.pointer, _$dns.pointer)
+    return _dns(_$$selfRef.pointer, _id_dns.pointer, _$dns.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1560,8 +1610,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder proxy(
     jni$_.JObject? proxy,
   ) {
+    final _$$selfRef = reference;
     final _$proxy = proxy?.reference ?? jni$_.jNullReference;
-    return _proxy(reference.pointer, _id_proxy.pointer, _$proxy.pointer)
+    return _proxy(_$$selfRef.pointer, _id_proxy.pointer, _$proxy.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1586,8 +1637,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder proxySelector(
     jni$_.JObject proxySelector,
   ) {
+    final _$$selfRef = reference;
     final _$proxySelector = proxySelector.reference;
-    return _proxySelector(reference.pointer, _id_proxySelector.pointer,
+    return _proxySelector(_$$selfRef.pointer, _id_proxySelector.pointer,
             _$proxySelector.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1614,8 +1666,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder proxyAuthenticator(
     jni$_.JObject authenticator,
   ) {
+    final _$$selfRef = reference;
     final _$authenticator = authenticator.reference;
-    return _proxyAuthenticator(reference.pointer,
+    return _proxyAuthenticator(_$$selfRef.pointer,
             _id_proxyAuthenticator.pointer, _$authenticator.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1641,8 +1694,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder socketFactory(
     jni$_.JObject socketFactory,
   ) {
+    final _$$selfRef = reference;
     final _$socketFactory = socketFactory.reference;
-    return _socketFactory(reference.pointer, _id_socketFactory.pointer,
+    return _socketFactory(_$$selfRef.pointer, _id_socketFactory.pointer,
             _$socketFactory.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1669,8 +1723,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder sslSocketFactory(
     jni$_.JObject sSLSocketFactory,
   ) {
+    final _$$selfRef = reference;
     final _$sSLSocketFactory = sSLSocketFactory.reference;
-    return _sslSocketFactory(reference.pointer, _id_sslSocketFactory.pointer,
+    return _sslSocketFactory(_$$selfRef.pointer, _id_sslSocketFactory.pointer,
             _$sSLSocketFactory.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1704,10 +1759,11 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
     jni$_.JObject sSLSocketFactory,
     jni$_.JObject x509TrustManager,
   ) {
+    final _$$selfRef = reference;
     final _$sSLSocketFactory = sSLSocketFactory.reference;
     final _$x509TrustManager = x509TrustManager.reference;
     return _sslSocketFactory$1(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_sslSocketFactory$1.pointer,
             _$sSLSocketFactory.pointer,
             _$x509TrustManager.pointer)
@@ -1736,9 +1792,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder connectionSpecs(
     jni$_.JList<jni$_.JObject> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _connectionSpecs(
-            reference.pointer, _id_connectionSpecs.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_connectionSpecs.pointer, _$list.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1763,8 +1820,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder protocols(
     jni$_.JList<jni$_.JObject> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _protocols(reference.pointer, _id_protocols.pointer, _$list.pointer)
+    return _protocols(_$$selfRef.pointer, _id_protocols.pointer, _$list.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1790,8 +1848,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder hostnameVerifier(
     jni$_.JObject hostnameVerifier,
   ) {
+    final _$$selfRef = reference;
     final _$hostnameVerifier = hostnameVerifier.reference;
-    return _hostnameVerifier(reference.pointer, _id_hostnameVerifier.pointer,
+    return _hostnameVerifier(_$$selfRef.pointer, _id_hostnameVerifier.pointer,
             _$hostnameVerifier.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1818,8 +1877,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder certificatePinner(
     jni$_.JObject certificatePinner,
   ) {
+    final _$$selfRef = reference;
     final _$certificatePinner = certificatePinner.reference;
-    return _certificatePinner(reference.pointer, _id_certificatePinner.pointer,
+    return _certificatePinner(_$$selfRef.pointer, _id_certificatePinner.pointer,
             _$certificatePinner.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1847,9 +1907,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
     core$_.int j,
     jni$_.JObject timeUnit,
   ) {
+    final _$$selfRef = reference;
     final _$timeUnit = timeUnit.reference;
     return _callTimeout(
-            reference.pointer, _id_callTimeout.pointer, j, _$timeUnit.pointer)
+            _$$selfRef.pointer, _id_callTimeout.pointer, j, _$timeUnit.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1874,9 +1935,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder callTimeout$1(
     jni$_.JObject duration,
   ) {
+    final _$$selfRef = reference;
     final _$duration = duration.reference;
     return _callTimeout$1(
-            reference.pointer, _id_callTimeout$1.pointer, _$duration.pointer)
+            _$$selfRef.pointer, _id_callTimeout$1.pointer, _$duration.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1904,8 +1966,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
     core$_.int j,
     jni$_.JObject timeUnit,
   ) {
+    final _$$selfRef = reference;
     final _$timeUnit = timeUnit.reference;
-    return _connectTimeout(reference.pointer, _id_connectTimeout.pointer, j,
+    return _connectTimeout(_$$selfRef.pointer, _id_connectTimeout.pointer, j,
             _$timeUnit.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1932,9 +1995,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder connectTimeout$1(
     jni$_.JObject duration,
   ) {
+    final _$$selfRef = reference;
     final _$duration = duration.reference;
-    return _connectTimeout$1(
-            reference.pointer, _id_connectTimeout$1.pointer, _$duration.pointer)
+    return _connectTimeout$1(_$$selfRef.pointer, _id_connectTimeout$1.pointer,
+            _$duration.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1961,9 +2025,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
     core$_.int j,
     jni$_.JObject timeUnit,
   ) {
+    final _$$selfRef = reference;
     final _$timeUnit = timeUnit.reference;
     return _readTimeout(
-            reference.pointer, _id_readTimeout.pointer, j, _$timeUnit.pointer)
+            _$$selfRef.pointer, _id_readTimeout.pointer, j, _$timeUnit.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1988,9 +2053,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder readTimeout$1(
     jni$_.JObject duration,
   ) {
+    final _$$selfRef = reference;
     final _$duration = duration.reference;
     return _readTimeout$1(
-            reference.pointer, _id_readTimeout$1.pointer, _$duration.pointer)
+            _$$selfRef.pointer, _id_readTimeout$1.pointer, _$duration.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -2017,9 +2083,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
     core$_.int j,
     jni$_.JObject timeUnit,
   ) {
+    final _$$selfRef = reference;
     final _$timeUnit = timeUnit.reference;
     return _writeTimeout(
-            reference.pointer, _id_writeTimeout.pointer, j, _$timeUnit.pointer)
+            _$$selfRef.pointer, _id_writeTimeout.pointer, j, _$timeUnit.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -2045,9 +2112,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder writeTimeout$1(
     jni$_.JObject duration,
   ) {
+    final _$$selfRef = reference;
     final _$duration = duration.reference;
     return _writeTimeout$1(
-            reference.pointer, _id_writeTimeout$1.pointer, _$duration.pointer)
+            _$$selfRef.pointer, _id_writeTimeout$1.pointer, _$duration.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -2074,9 +2142,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
     core$_.int j,
     jni$_.JObject timeUnit,
   ) {
+    final _$$selfRef = reference;
     final _$timeUnit = timeUnit.reference;
     return _pingInterval(
-            reference.pointer, _id_pingInterval.pointer, j, _$timeUnit.pointer)
+            _$$selfRef.pointer, _id_pingInterval.pointer, j, _$timeUnit.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -2102,9 +2171,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder pingInterval$1(
     jni$_.JObject duration,
   ) {
+    final _$$selfRef = reference;
     final _$duration = duration.reference;
     return _pingInterval$1(
-            reference.pointer, _id_pingInterval$1.pointer, _$duration.pointer)
+            _$$selfRef.pointer, _id_pingInterval$1.pointer, _$duration.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -2129,8 +2199,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder minWebSocketMessageToCompress(
     core$_.int j,
   ) {
+    final _$$selfRef = reference;
     return _minWebSocketMessageToCompress(
-            reference.pointer, _id_minWebSocketMessageToCompress.pointer, j)
+            _$$selfRef.pointer, _id_minWebSocketMessageToCompress.pointer, j)
         .object<OkHttpClient$Builder>();
   }
 
@@ -2154,7 +2225,8 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   /// from: `public fun build(): okhttp3.OkHttpClient`
   /// The returned object must be released after use, by calling the [release] method.
   OkHttpClient build() {
-    return _build(reference.pointer, _id_build.pointer).object<OkHttpClient>();
+    final _$$selfRef = reference;
+    return _build(_$$selfRef.pointer, _id_build.pointer).object<OkHttpClient>();
   }
 }
 
@@ -2196,9 +2268,10 @@ extension type OkHttpClient$Companion._(jni$_.JObject _$this)
   factory OkHttpClient$Companion(
     jni$_.JObject? defaultConstructorMarker,
   ) {
+    final _$$classRef = _class.reference;
     final _$defaultConstructorMarker =
         defaultConstructorMarker?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer,
+    return _new$(_$$classRef.pointer, _id_new$.pointer,
             _$defaultConstructorMarker.pointer)
         .object<OkHttpClient$Companion>();
   }
@@ -2251,8 +2324,9 @@ extension type OkHttpClient._(jni$_.JObject _$this) implements jni$_.JObject {
   factory OkHttpClient(
     OkHttpClient$Builder builder,
   ) {
+    final _$$classRef = _class.reference;
     final _$builder = builder.reference;
-    return _new$(_class.reference.pointer, _id_new$.pointer, _$builder.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$builder.pointer)
         .object<OkHttpClient>();
   }
 
@@ -2275,7 +2349,8 @@ extension type OkHttpClient._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory OkHttpClient.new$1() {
-    return _new$1(_class.reference.pointer, _id_new$1.pointer)
+    final _$$classRef = _class.reference;
+    return _new$1(_$$classRef.pointer, _id_new$1.pointer)
         .object<OkHttpClient>();
   }
 }
@@ -2301,7 +2376,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.Dispatcher dispatcher()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject dispatcher() {
-    return _dispatcher(reference.pointer, _id_dispatcher.pointer)
+    final _$$selfRef = reference;
+    return _dispatcher(_$$selfRef.pointer, _id_dispatcher.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2325,7 +2401,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.ConnectionPool connectionPool()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject connectionPool() {
-    return _connectionPool(reference.pointer, _id_connectionPool.pointer)
+    final _$$selfRef = reference;
+    return _connectionPool(_$$selfRef.pointer, _id_connectionPool.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2349,7 +2426,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final java.util.List<okhttp3.Interceptor> interceptors()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject> interceptors() {
-    return _interceptors(reference.pointer, _id_interceptors.pointer)
+    final _$$selfRef = reference;
+    return _interceptors(_$$selfRef.pointer, _id_interceptors.pointer)
         .object<jni$_.JList<jni$_.JObject>>();
   }
 
@@ -2373,8 +2451,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final java.util.List<okhttp3.Interceptor> networkInterceptors()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject> networkInterceptors() {
+    final _$$selfRef = reference;
     return _networkInterceptors(
-            reference.pointer, _id_networkInterceptors.pointer)
+            _$$selfRef.pointer, _id_networkInterceptors.pointer)
         .object<jni$_.JList<jni$_.JObject>>();
   }
 
@@ -2398,8 +2477,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.EventListener$Factory eventListenerFactory()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject eventListenerFactory() {
+    final _$$selfRef = reference;
     return _eventListenerFactory(
-            reference.pointer, _id_eventListenerFactory.pointer)
+            _$$selfRef.pointer, _id_eventListenerFactory.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2423,8 +2503,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final boolean retryOnConnectionFailure()`
   core$_.bool retryOnConnectionFailure() {
+    final _$$selfRef = reference;
     return _retryOnConnectionFailure(
-            reference.pointer, _id_retryOnConnectionFailure.pointer)
+            _$$selfRef.pointer, _id_retryOnConnectionFailure.pointer)
         .boolean;
   }
 
@@ -2448,7 +2529,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.Authenticator authenticator()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject authenticator() {
-    return _authenticator(reference.pointer, _id_authenticator.pointer)
+    final _$$selfRef = reference;
+    return _authenticator(_$$selfRef.pointer, _id_authenticator.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2471,7 +2553,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final boolean followRedirects()`
   core$_.bool followRedirects() {
-    return _followRedirects(reference.pointer, _id_followRedirects.pointer)
+    final _$$selfRef = reference;
+    return _followRedirects(_$$selfRef.pointer, _id_followRedirects.pointer)
         .boolean;
   }
 
@@ -2494,8 +2577,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final boolean followSslRedirects()`
   core$_.bool followSslRedirects() {
+    final _$$selfRef = reference;
     return _followSslRedirects(
-            reference.pointer, _id_followSslRedirects.pointer)
+            _$$selfRef.pointer, _id_followSslRedirects.pointer)
         .boolean;
   }
 
@@ -2519,7 +2603,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.CookieJar cookieJar()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject cookieJar() {
-    return _cookieJar(reference.pointer, _id_cookieJar.pointer)
+    final _$$selfRef = reference;
+    return _cookieJar(_$$selfRef.pointer, _id_cookieJar.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2543,7 +2628,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.Cache cache()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? cache() {
-    return _cache(reference.pointer, _id_cache.pointer)
+    final _$$selfRef = reference;
+    return _cache(_$$selfRef.pointer, _id_cache.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2567,7 +2653,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.Dns dns()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject dns() {
-    return _dns(reference.pointer, _id_dns.pointer).object<jni$_.JObject>();
+    final _$$selfRef = reference;
+    return _dns(_$$selfRef.pointer, _id_dns.pointer).object<jni$_.JObject>();
   }
 
   static final _id_proxy = OkHttpClient._class.instanceMethodId(
@@ -2590,7 +2677,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final java.net.Proxy proxy()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? proxy() {
-    return _proxy(reference.pointer, _id_proxy.pointer)
+    final _$$selfRef = reference;
+    return _proxy(_$$selfRef.pointer, _id_proxy.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2614,7 +2702,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final java.net.ProxySelector proxySelector()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject proxySelector() {
-    return _proxySelector(reference.pointer, _id_proxySelector.pointer)
+    final _$$selfRef = reference;
+    return _proxySelector(_$$selfRef.pointer, _id_proxySelector.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2638,8 +2727,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.Authenticator proxyAuthenticator()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject proxyAuthenticator() {
+    final _$$selfRef = reference;
     return _proxyAuthenticator(
-            reference.pointer, _id_proxyAuthenticator.pointer)
+            _$$selfRef.pointer, _id_proxyAuthenticator.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2663,7 +2753,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final javax.net.SocketFactory socketFactory()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject socketFactory() {
-    return _socketFactory(reference.pointer, _id_socketFactory.pointer)
+    final _$$selfRef = reference;
+    return _socketFactory(_$$selfRef.pointer, _id_socketFactory.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2687,7 +2778,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final javax.net.ssl.SSLSocketFactory sslSocketFactory()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject sslSocketFactory() {
-    return _sslSocketFactory(reference.pointer, _id_sslSocketFactory.pointer)
+    final _$$selfRef = reference;
+    return _sslSocketFactory(_$$selfRef.pointer, _id_sslSocketFactory.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2711,7 +2803,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final javax.net.ssl.X509TrustManager x509TrustManager()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? x509TrustManager() {
-    return _x509TrustManager(reference.pointer, _id_x509TrustManager.pointer)
+    final _$$selfRef = reference;
+    return _x509TrustManager(_$$selfRef.pointer, _id_x509TrustManager.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2735,7 +2828,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final java.util.List<okhttp3.ConnectionSpec> connectionSpecs()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject> connectionSpecs() {
-    return _connectionSpecs(reference.pointer, _id_connectionSpecs.pointer)
+    final _$$selfRef = reference;
+    return _connectionSpecs(_$$selfRef.pointer, _id_connectionSpecs.pointer)
         .object<jni$_.JList<jni$_.JObject>>();
   }
 
@@ -2759,7 +2853,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final java.util.List<okhttp3.Protocol> protocols()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject> protocols() {
-    return _protocols(reference.pointer, _id_protocols.pointer)
+    final _$$selfRef = reference;
+    return _protocols(_$$selfRef.pointer, _id_protocols.pointer)
         .object<jni$_.JList<jni$_.JObject>>();
   }
 
@@ -2783,7 +2878,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final javax.net.ssl.HostnameVerifier hostnameVerifier()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject hostnameVerifier() {
-    return _hostnameVerifier(reference.pointer, _id_hostnameVerifier.pointer)
+    final _$$selfRef = reference;
+    return _hostnameVerifier(_$$selfRef.pointer, _id_hostnameVerifier.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2807,7 +2903,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.CertificatePinner certificatePinner()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject certificatePinner() {
-    return _certificatePinner(reference.pointer, _id_certificatePinner.pointer)
+    final _$$selfRef = reference;
+    return _certificatePinner(_$$selfRef.pointer, _id_certificatePinner.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2832,8 +2929,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.internal.tls.CertificateChainCleaner certificateChainCleaner()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? certificateChainCleaner() {
+    final _$$selfRef = reference;
     return _certificateChainCleaner(
-            reference.pointer, _id_certificateChainCleaner.pointer)
+            _$$selfRef.pointer, _id_certificateChainCleaner.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2856,7 +2954,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final int callTimeoutMillis()`
   core$_.int callTimeoutMillis() {
-    return _callTimeoutMillis(reference.pointer, _id_callTimeoutMillis.pointer)
+    final _$$selfRef = reference;
+    return _callTimeoutMillis(_$$selfRef.pointer, _id_callTimeoutMillis.pointer)
         .integer;
   }
 
@@ -2879,8 +2978,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final int connectTimeoutMillis()`
   core$_.int connectTimeoutMillis() {
+    final _$$selfRef = reference;
     return _connectTimeoutMillis(
-            reference.pointer, _id_connectTimeoutMillis.pointer)
+            _$$selfRef.pointer, _id_connectTimeoutMillis.pointer)
         .integer;
   }
 
@@ -2903,7 +3003,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final int readTimeoutMillis()`
   core$_.int readTimeoutMillis() {
-    return _readTimeoutMillis(reference.pointer, _id_readTimeoutMillis.pointer)
+    final _$$selfRef = reference;
+    return _readTimeoutMillis(_$$selfRef.pointer, _id_readTimeoutMillis.pointer)
         .integer;
   }
 
@@ -2926,8 +3027,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final int writeTimeoutMillis()`
   core$_.int writeTimeoutMillis() {
+    final _$$selfRef = reference;
     return _writeTimeoutMillis(
-            reference.pointer, _id_writeTimeoutMillis.pointer)
+            _$$selfRef.pointer, _id_writeTimeoutMillis.pointer)
         .integer;
   }
 
@@ -2950,8 +3052,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final int pingIntervalMillis()`
   core$_.int pingIntervalMillis() {
+    final _$$selfRef = reference;
     return _pingIntervalMillis(
-            reference.pointer, _id_pingIntervalMillis.pointer)
+            _$$selfRef.pointer, _id_pingIntervalMillis.pointer)
         .integer;
   }
 
@@ -2976,8 +3079,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final long minWebSocketMessageToCompress()`
   core$_.int minWebSocketMessageToCompress() {
+    final _$$selfRef = reference;
     return _minWebSocketMessageToCompress(
-            reference.pointer, _id_minWebSocketMessageToCompress.pointer)
+            _$$selfRef.pointer, _id_minWebSocketMessageToCompress.pointer)
         .long;
   }
 
@@ -3001,7 +3105,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.internal.connection.RouteDatabase getRouteDatabase()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject get routeDatabase {
-    return _get$routeDatabase(reference.pointer, _id_get$routeDatabase.pointer)
+    final _$$selfRef = reference;
+    return _get$routeDatabase(_$$selfRef.pointer, _id_get$routeDatabase.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -3026,8 +3131,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
   jni$_.JObject newCall(
     jni$_.JObject request,
   ) {
+    final _$$selfRef = reference;
     final _$request = request.reference;
-    return _newCall(reference.pointer, _id_newCall.pointer, _$request.pointer)
+    return _newCall(_$$selfRef.pointer, _id_newCall.pointer, _$request.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -3059,9 +3165,10 @@ extension OkHttpClient$$Methods on OkHttpClient {
     jni$_.JObject request,
     jni$_.JObject webSocketListener,
   ) {
+    final _$$selfRef = reference;
     final _$request = request.reference;
     final _$webSocketListener = webSocketListener.reference;
-    return _newWebSocket(reference.pointer, _id_newWebSocket.pointer,
+    return _newWebSocket(_$$selfRef.pointer, _id_newWebSocket.pointer,
             _$request.pointer, _$webSocketListener.pointer)
         .object<jni$_.JObject>();
   }
@@ -3086,7 +3193,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public fun newBuilder(): okhttp3.OkHttpClient.Builder`
   /// The returned object must be released after use, by calling the [release] method.
   OkHttpClient$Builder newBuilder() {
-    return _newBuilder(reference.pointer, _id_newBuilder.pointer)
+    final _$$selfRef = reference;
+    return _newBuilder(_$$selfRef.pointer, _id_newBuilder.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -3110,7 +3218,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public java.lang.Object clone()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject clone() {
-    return _clone(reference.pointer, _id_clone.pointer).object<jni$_.JObject>();
+    final _$$selfRef = reference;
+    return _clone(_$$selfRef.pointer, _id_clone.pointer)
+        .object<jni$_.JObject>();
   }
 }
 

--- a/pkgs/jnigen/example/maven_libs_groovy/lib/maven_libs_bindings.dart
+++ b/pkgs/jnigen/example/maven_libs_groovy/lib/maven_libs_bindings.dart
@@ -63,7 +63,8 @@ extension type Gson._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory Gson() {
-    return _new$(_class.reference.pointer, _id_new$.pointer).object<Gson>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<Gson>();
   }
 }
 
@@ -88,7 +89,8 @@ extension Gson$$Methods on Gson {
   /// from: `public com.google.gson.GsonBuilder newBuilder()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? newBuilder() {
-    return _newBuilder(reference.pointer, _id_newBuilder.pointer)
+    final _$$selfRef = reference;
+    return _newBuilder(_$$selfRef.pointer, _id_newBuilder.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -112,7 +114,8 @@ extension Gson$$Methods on Gson {
   /// from: `public com.google.gson.internal.Excluder excluder()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? excluder() {
-    return _excluder(reference.pointer, _id_excluder.pointer)
+    final _$$selfRef = reference;
+    return _excluder(_$$selfRef.pointer, _id_excluder.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -136,8 +139,9 @@ extension Gson$$Methods on Gson {
   /// from: `public com.google.gson.FieldNamingStrategy fieldNamingStrategy()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? fieldNamingStrategy() {
+    final _$$selfRef = reference;
     return _fieldNamingStrategy(
-            reference.pointer, _id_fieldNamingStrategy.pointer)
+            _$$selfRef.pointer, _id_fieldNamingStrategy.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -160,7 +164,8 @@ extension Gson$$Methods on Gson {
 
   /// from: `public boolean serializeNulls()`
   core$_.bool serializeNulls() {
-    return _serializeNulls(reference.pointer, _id_serializeNulls.pointer)
+    final _$$selfRef = reference;
+    return _serializeNulls(_$$selfRef.pointer, _id_serializeNulls.pointer)
         .boolean;
   }
 
@@ -183,7 +188,8 @@ extension Gson$$Methods on Gson {
 
   /// from: `public boolean htmlSafe()`
   core$_.bool htmlSafe() {
-    return _htmlSafe(reference.pointer, _id_htmlSafe.pointer).boolean;
+    final _$$selfRef = reference;
+    return _htmlSafe(_$$selfRef.pointer, _id_htmlSafe.pointer).boolean;
   }
 
   static final _id_getAdapter = Gson._class.instanceMethodId(
@@ -207,9 +213,10 @@ extension Gson$$Methods on Gson {
   jni$_.JObject? getAdapter<$T extends jni$_.JObject?>(
     jni$_.JObject? typeToken,
   ) {
+    final _$$selfRef = reference;
     final _$typeToken = typeToken?.reference ?? jni$_.jNullReference;
     return _getAdapter(
-            reference.pointer, _id_getAdapter.pointer, _$typeToken.pointer)
+            _$$selfRef.pointer, _id_getAdapter.pointer, _$typeToken.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -241,11 +248,12 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? typeAdapterFactory,
     jni$_.JObject? typeToken,
   ) {
+    final _$$selfRef = reference;
     final _$typeAdapterFactory =
         typeAdapterFactory?.reference ?? jni$_.jNullReference;
     final _$typeToken = typeToken?.reference ?? jni$_.jNullReference;
     return _getDelegateAdapter(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_getDelegateAdapter.pointer,
             _$typeAdapterFactory.pointer,
             _$typeToken.pointer)
@@ -273,9 +281,10 @@ extension Gson$$Methods on Gson {
   jni$_.JObject? getAdapter$1<$T extends jni$_.JObject?>(
     jni$_.JObject? class$,
   ) {
+    final _$$selfRef = reference;
     final _$class$ = class$?.reference ?? jni$_.jNullReference;
     return _getAdapter$1(
-            reference.pointer, _id_getAdapter$1.pointer, _$class$.pointer)
+            _$$selfRef.pointer, _id_getAdapter$1.pointer, _$class$.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -300,9 +309,10 @@ extension Gson$$Methods on Gson {
   jni$_.JObject? toJsonTree(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _toJsonTree(
-            reference.pointer, _id_toJsonTree.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_toJsonTree.pointer, _$object.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -334,9 +344,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? object,
     jni$_.JObject? type,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$type = type?.reference ?? jni$_.jNullReference;
-    return _toJsonTree$1(reference.pointer, _id_toJsonTree$1.pointer,
+    return _toJsonTree$1(_$$selfRef.pointer, _id_toJsonTree$1.pointer,
             _$object.pointer, _$type.pointer)
         .object<jni$_.JObject?>();
   }
@@ -362,8 +373,9 @@ extension Gson$$Methods on Gson {
   jni$_.JString? toJson(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _toJson(reference.pointer, _id_toJson.pointer, _$object.pointer)
+    return _toJson(_$$selfRef.pointer, _id_toJson.pointer, _$object.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -395,9 +407,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? object,
     jni$_.JObject? type,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$type = type?.reference ?? jni$_.jNullReference;
-    return _toJson$1(reference.pointer, _id_toJson$1.pointer, _$object.pointer,
+    return _toJson$1(_$$selfRef.pointer, _id_toJson$1.pointer, _$object.pointer,
             _$type.pointer)
         .object<jni$_.JString?>();
   }
@@ -429,9 +442,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? object,
     jni$_.JObject? appendable,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$appendable = appendable?.reference ?? jni$_.jNullReference;
-    _toJson$2(reference.pointer, _id_toJson$2.pointer, _$object.pointer,
+    _toJson$2(_$$selfRef.pointer, _id_toJson$2.pointer, _$object.pointer,
             _$appendable.pointer)
         .check();
   }
@@ -466,10 +480,11 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? type,
     jni$_.JObject? appendable,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$type = type?.reference ?? jni$_.jNullReference;
     final _$appendable = appendable?.reference ?? jni$_.jNullReference;
-    _toJson$3(reference.pointer, _id_toJson$3.pointer, _$object.pointer,
+    _toJson$3(_$$selfRef.pointer, _id_toJson$3.pointer, _$object.pointer,
             _$type.pointer, _$appendable.pointer)
         .check();
   }
@@ -504,10 +519,11 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? type,
     jni$_.JObject? jsonWriter,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$type = type?.reference ?? jni$_.jNullReference;
     final _$jsonWriter = jsonWriter?.reference ?? jni$_.jNullReference;
-    _toJson$4(reference.pointer, _id_toJson$4.pointer, _$object.pointer,
+    _toJson$4(_$$selfRef.pointer, _id_toJson$4.pointer, _$object.pointer,
             _$type.pointer, _$jsonWriter.pointer)
         .check();
   }
@@ -533,9 +549,10 @@ extension Gson$$Methods on Gson {
   jni$_.JString? toJson$5(
     jni$_.JObject? jsonElement,
   ) {
+    final _$$selfRef = reference;
     final _$jsonElement = jsonElement?.reference ?? jni$_.jNullReference;
     return _toJson$5(
-            reference.pointer, _id_toJson$5.pointer, _$jsonElement.pointer)
+            _$$selfRef.pointer, _id_toJson$5.pointer, _$jsonElement.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -566,9 +583,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? jsonElement,
     jni$_.JObject? appendable,
   ) {
+    final _$$selfRef = reference;
     final _$jsonElement = jsonElement?.reference ?? jni$_.jNullReference;
     final _$appendable = appendable?.reference ?? jni$_.jNullReference;
-    _toJson$6(reference.pointer, _id_toJson$6.pointer, _$jsonElement.pointer,
+    _toJson$6(_$$selfRef.pointer, _id_toJson$6.pointer, _$jsonElement.pointer,
             _$appendable.pointer)
         .check();
   }
@@ -594,9 +612,10 @@ extension Gson$$Methods on Gson {
   jni$_.JObject? newJsonWriter(
     jni$_.JObject? writer,
   ) {
+    final _$$selfRef = reference;
     final _$writer = writer?.reference ?? jni$_.jNullReference;
     return _newJsonWriter(
-            reference.pointer, _id_newJsonWriter.pointer, _$writer.pointer)
+            _$$selfRef.pointer, _id_newJsonWriter.pointer, _$writer.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -621,9 +640,10 @@ extension Gson$$Methods on Gson {
   jni$_.JObject? newJsonReader(
     jni$_.JObject? reader,
   ) {
+    final _$$selfRef = reference;
     final _$reader = reader?.reference ?? jni$_.jNullReference;
     return _newJsonReader(
-            reference.pointer, _id_newJsonReader.pointer, _$reader.pointer)
+            _$$selfRef.pointer, _id_newJsonReader.pointer, _$reader.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -654,9 +674,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? jsonElement,
     jni$_.JObject? jsonWriter,
   ) {
+    final _$$selfRef = reference;
     final _$jsonElement = jsonElement?.reference ?? jni$_.jNullReference;
     final _$jsonWriter = jsonWriter?.reference ?? jni$_.jNullReference;
-    _toJson$7(reference.pointer, _id_toJson$7.pointer, _$jsonElement.pointer,
+    _toJson$7(_$$selfRef.pointer, _id_toJson$7.pointer, _$jsonElement.pointer,
             _$jsonWriter.pointer)
         .check();
   }
@@ -689,9 +710,10 @@ extension Gson$$Methods on Gson {
     jni$_.JString? string,
     jni$_.JObject? class$,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$class$ = class$?.reference ?? jni$_.jNullReference;
-    return _fromJson(reference.pointer, _id_fromJson.pointer, _$string.pointer,
+    return _fromJson(_$$selfRef.pointer, _id_fromJson.pointer, _$string.pointer,
             _$class$.pointer)
         .object<$T?>();
   }
@@ -724,9 +746,10 @@ extension Gson$$Methods on Gson {
     jni$_.JString? string,
     jni$_.JObject? type,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$type = type?.reference ?? jni$_.jNullReference;
-    return _fromJson$1(reference.pointer, _id_fromJson$1.pointer,
+    return _fromJson$1(_$$selfRef.pointer, _id_fromJson$1.pointer,
             _$string.pointer, _$type.pointer)
         .object<$T?>();
   }
@@ -759,9 +782,10 @@ extension Gson$$Methods on Gson {
     jni$_.JString? string,
     jni$_.JObject? typeToken,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$typeToken = typeToken?.reference ?? jni$_.jNullReference;
-    return _fromJson$2(reference.pointer, _id_fromJson$2.pointer,
+    return _fromJson$2(_$$selfRef.pointer, _id_fromJson$2.pointer,
             _$string.pointer, _$typeToken.pointer)
         .object<$T?>();
   }
@@ -794,9 +818,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? reader,
     jni$_.JObject? class$,
   ) {
+    final _$$selfRef = reference;
     final _$reader = reader?.reference ?? jni$_.jNullReference;
     final _$class$ = class$?.reference ?? jni$_.jNullReference;
-    return _fromJson$3(reference.pointer, _id_fromJson$3.pointer,
+    return _fromJson$3(_$$selfRef.pointer, _id_fromJson$3.pointer,
             _$reader.pointer, _$class$.pointer)
         .object<$T?>();
   }
@@ -829,9 +854,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? reader,
     jni$_.JObject? type,
   ) {
+    final _$$selfRef = reference;
     final _$reader = reader?.reference ?? jni$_.jNullReference;
     final _$type = type?.reference ?? jni$_.jNullReference;
-    return _fromJson$4(reference.pointer, _id_fromJson$4.pointer,
+    return _fromJson$4(_$$selfRef.pointer, _id_fromJson$4.pointer,
             _$reader.pointer, _$type.pointer)
         .object<$T?>();
   }
@@ -864,9 +890,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? reader,
     jni$_.JObject? typeToken,
   ) {
+    final _$$selfRef = reference;
     final _$reader = reader?.reference ?? jni$_.jNullReference;
     final _$typeToken = typeToken?.reference ?? jni$_.jNullReference;
-    return _fromJson$5(reference.pointer, _id_fromJson$5.pointer,
+    return _fromJson$5(_$$selfRef.pointer, _id_fromJson$5.pointer,
             _$reader.pointer, _$typeToken.pointer)
         .object<$T?>();
   }
@@ -899,9 +926,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? jsonReader,
     jni$_.JObject? type,
   ) {
+    final _$$selfRef = reference;
     final _$jsonReader = jsonReader?.reference ?? jni$_.jNullReference;
     final _$type = type?.reference ?? jni$_.jNullReference;
-    return _fromJson$6(reference.pointer, _id_fromJson$6.pointer,
+    return _fromJson$6(_$$selfRef.pointer, _id_fromJson$6.pointer,
             _$jsonReader.pointer, _$type.pointer)
         .object<$T?>();
   }
@@ -934,9 +962,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? jsonReader,
     jni$_.JObject? typeToken,
   ) {
+    final _$$selfRef = reference;
     final _$jsonReader = jsonReader?.reference ?? jni$_.jNullReference;
     final _$typeToken = typeToken?.reference ?? jni$_.jNullReference;
-    return _fromJson$7(reference.pointer, _id_fromJson$7.pointer,
+    return _fromJson$7(_$$selfRef.pointer, _id_fromJson$7.pointer,
             _$jsonReader.pointer, _$typeToken.pointer)
         .object<$T?>();
   }
@@ -969,9 +998,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? jsonElement,
     jni$_.JObject? class$,
   ) {
+    final _$$selfRef = reference;
     final _$jsonElement = jsonElement?.reference ?? jni$_.jNullReference;
     final _$class$ = class$?.reference ?? jni$_.jNullReference;
-    return _fromJson$8(reference.pointer, _id_fromJson$8.pointer,
+    return _fromJson$8(_$$selfRef.pointer, _id_fromJson$8.pointer,
             _$jsonElement.pointer, _$class$.pointer)
         .object<$T?>();
   }
@@ -1004,9 +1034,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? jsonElement,
     jni$_.JObject? type,
   ) {
+    final _$$selfRef = reference;
     final _$jsonElement = jsonElement?.reference ?? jni$_.jNullReference;
     final _$type = type?.reference ?? jni$_.jNullReference;
-    return _fromJson$9(reference.pointer, _id_fromJson$9.pointer,
+    return _fromJson$9(_$$selfRef.pointer, _id_fromJson$9.pointer,
             _$jsonElement.pointer, _$type.pointer)
         .object<$T?>();
   }
@@ -1039,9 +1070,10 @@ extension Gson$$Methods on Gson {
     jni$_.JObject? jsonElement,
     jni$_.JObject? typeToken,
   ) {
+    final _$$selfRef = reference;
     final _$jsonElement = jsonElement?.reference ?? jni$_.jNullReference;
     final _$typeToken = typeToken?.reference ?? jni$_.jNullReference;
-    return _fromJson$10(reference.pointer, _id_fromJson$10.pointer,
+    return _fromJson$10(_$$selfRef.pointer, _id_fromJson$10.pointer,
             _$jsonElement.pointer, _$typeToken.pointer)
         .object<$T?>();
   }
@@ -1066,7 +1098,8 @@ extension Gson$$Methods on Gson {
   /// from: `public java.lang.String toString()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<jni$_.JString?>();
   }
 }
@@ -1107,7 +1140,8 @@ extension type OkHttpClient$Builder._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory OkHttpClient$Builder() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1131,9 +1165,10 @@ extension type OkHttpClient$Builder._(jni$_.JObject _$this)
   factory OkHttpClient$Builder.new$1(
     OkHttpClient okHttpClient,
   ) {
+    final _$$classRef = _class.reference;
     final _$okHttpClient = okHttpClient.reference;
     return _new$1(
-            _class.reference.pointer, _id_new$1.pointer, _$okHttpClient.pointer)
+            _$$classRef.pointer, _id_new$1.pointer, _$okHttpClient.pointer)
         .object<OkHttpClient$Builder>();
   }
 }
@@ -1160,9 +1195,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder dispatcher(
     jni$_.JObject dispatcher,
   ) {
+    final _$$selfRef = reference;
     final _$dispatcher = dispatcher.reference;
     return _dispatcher(
-            reference.pointer, _id_dispatcher.pointer, _$dispatcher.pointer)
+            _$$selfRef.pointer, _id_dispatcher.pointer, _$dispatcher.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1188,8 +1224,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder connectionPool(
     jni$_.JObject connectionPool,
   ) {
+    final _$$selfRef = reference;
     final _$connectionPool = connectionPool.reference;
-    return _connectionPool(reference.pointer, _id_connectionPool.pointer,
+    return _connectionPool(_$$selfRef.pointer, _id_connectionPool.pointer,
             _$connectionPool.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1214,7 +1251,8 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   /// from: `public fun interceptors(): kotlin.collections.MutableList<okhttp3.Interceptor>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject> interceptors() {
-    return _interceptors(reference.pointer, _id_interceptors.pointer)
+    final _$$selfRef = reference;
+    return _interceptors(_$$selfRef.pointer, _id_interceptors.pointer)
         .object<jni$_.JList<jni$_.JObject>>();
   }
 
@@ -1240,8 +1278,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder addInterceptor(
     jni$_.JObject interceptor,
   ) {
+    final _$$selfRef = reference;
     final _$interceptor = interceptor.reference;
-    return _addInterceptor(reference.pointer, _id_addInterceptor.pointer,
+    return _addInterceptor(_$$selfRef.pointer, _id_addInterceptor.pointer,
             _$interceptor.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1267,8 +1306,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   /// from: `public fun networkInterceptors(): kotlin.collections.MutableList<okhttp3.Interceptor>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject> networkInterceptors() {
+    final _$$selfRef = reference;
     return _networkInterceptors(
-            reference.pointer, _id_networkInterceptors.pointer)
+            _$$selfRef.pointer, _id_networkInterceptors.pointer)
         .object<jni$_.JList<jni$_.JObject>>();
   }
 
@@ -1294,8 +1334,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder addNetworkInterceptor(
     jni$_.JObject interceptor,
   ) {
+    final _$$selfRef = reference;
     final _$interceptor = interceptor.reference;
-    return _addNetworkInterceptor(reference.pointer,
+    return _addNetworkInterceptor(_$$selfRef.pointer,
             _id_addNetworkInterceptor.pointer, _$interceptor.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1321,8 +1362,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder eventListener(
     jni$_.JObject eventListener,
   ) {
+    final _$$selfRef = reference;
     final _$eventListener = eventListener.reference;
-    return _eventListener(reference.pointer, _id_eventListener.pointer,
+    return _eventListener(_$$selfRef.pointer, _id_eventListener.pointer,
             _$eventListener.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1349,8 +1391,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder eventListenerFactory(
     jni$_.JObject factory,
   ) {
+    final _$$selfRef = reference;
     final _$factory = factory.reference;
-    return _eventListenerFactory(reference.pointer,
+    return _eventListenerFactory(_$$selfRef.pointer,
             _id_eventListenerFactory.pointer, _$factory.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1376,8 +1419,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder retryOnConnectionFailure(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _retryOnConnectionFailure(
-            reference.pointer, _id_retryOnConnectionFailure.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_retryOnConnectionFailure.pointer, z ? 1 : 0)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1402,8 +1446,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder authenticator(
     jni$_.JObject authenticator,
   ) {
+    final _$$selfRef = reference;
     final _$authenticator = authenticator.reference;
-    return _authenticator(reference.pointer, _id_authenticator.pointer,
+    return _authenticator(_$$selfRef.pointer, _id_authenticator.pointer,
             _$authenticator.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1429,8 +1474,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder followRedirects(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _followRedirects(
-            reference.pointer, _id_followRedirects.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_followRedirects.pointer, z ? 1 : 0)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1455,8 +1501,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder followSslRedirects(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _followSslRedirects(
-            reference.pointer, _id_followSslRedirects.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_followSslRedirects.pointer, z ? 1 : 0)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1481,9 +1528,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder cookieJar(
     jni$_.JObject cookieJar,
   ) {
+    final _$$selfRef = reference;
     final _$cookieJar = cookieJar.reference;
     return _cookieJar(
-            reference.pointer, _id_cookieJar.pointer, _$cookieJar.pointer)
+            _$$selfRef.pointer, _id_cookieJar.pointer, _$cookieJar.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1508,8 +1556,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder cache(
     jni$_.JObject? cache,
   ) {
+    final _$$selfRef = reference;
     final _$cache = cache?.reference ?? jni$_.jNullReference;
-    return _cache(reference.pointer, _id_cache.pointer, _$cache.pointer)
+    return _cache(_$$selfRef.pointer, _id_cache.pointer, _$cache.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1534,8 +1583,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder dns(
     jni$_.JObject dns,
   ) {
+    final _$$selfRef = reference;
     final _$dns = dns.reference;
-    return _dns(reference.pointer, _id_dns.pointer, _$dns.pointer)
+    return _dns(_$$selfRef.pointer, _id_dns.pointer, _$dns.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1560,8 +1610,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder proxy(
     jni$_.JObject? proxy,
   ) {
+    final _$$selfRef = reference;
     final _$proxy = proxy?.reference ?? jni$_.jNullReference;
-    return _proxy(reference.pointer, _id_proxy.pointer, _$proxy.pointer)
+    return _proxy(_$$selfRef.pointer, _id_proxy.pointer, _$proxy.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1586,8 +1637,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder proxySelector(
     jni$_.JObject proxySelector,
   ) {
+    final _$$selfRef = reference;
     final _$proxySelector = proxySelector.reference;
-    return _proxySelector(reference.pointer, _id_proxySelector.pointer,
+    return _proxySelector(_$$selfRef.pointer, _id_proxySelector.pointer,
             _$proxySelector.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1614,8 +1666,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder proxyAuthenticator(
     jni$_.JObject authenticator,
   ) {
+    final _$$selfRef = reference;
     final _$authenticator = authenticator.reference;
-    return _proxyAuthenticator(reference.pointer,
+    return _proxyAuthenticator(_$$selfRef.pointer,
             _id_proxyAuthenticator.pointer, _$authenticator.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1641,8 +1694,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder socketFactory(
     jni$_.JObject socketFactory,
   ) {
+    final _$$selfRef = reference;
     final _$socketFactory = socketFactory.reference;
-    return _socketFactory(reference.pointer, _id_socketFactory.pointer,
+    return _socketFactory(_$$selfRef.pointer, _id_socketFactory.pointer,
             _$socketFactory.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1669,8 +1723,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder sslSocketFactory(
     jni$_.JObject sSLSocketFactory,
   ) {
+    final _$$selfRef = reference;
     final _$sSLSocketFactory = sSLSocketFactory.reference;
-    return _sslSocketFactory(reference.pointer, _id_sslSocketFactory.pointer,
+    return _sslSocketFactory(_$$selfRef.pointer, _id_sslSocketFactory.pointer,
             _$sSLSocketFactory.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1704,10 +1759,11 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
     jni$_.JObject sSLSocketFactory,
     jni$_.JObject x509TrustManager,
   ) {
+    final _$$selfRef = reference;
     final _$sSLSocketFactory = sSLSocketFactory.reference;
     final _$x509TrustManager = x509TrustManager.reference;
     return _sslSocketFactory$1(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_sslSocketFactory$1.pointer,
             _$sSLSocketFactory.pointer,
             _$x509TrustManager.pointer)
@@ -1736,9 +1792,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder connectionSpecs(
     jni$_.JList<jni$_.JObject> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _connectionSpecs(
-            reference.pointer, _id_connectionSpecs.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_connectionSpecs.pointer, _$list.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1763,8 +1820,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder protocols(
     jni$_.JList<jni$_.JObject> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _protocols(reference.pointer, _id_protocols.pointer, _$list.pointer)
+    return _protocols(_$$selfRef.pointer, _id_protocols.pointer, _$list.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1790,8 +1848,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder hostnameVerifier(
     jni$_.JObject hostnameVerifier,
   ) {
+    final _$$selfRef = reference;
     final _$hostnameVerifier = hostnameVerifier.reference;
-    return _hostnameVerifier(reference.pointer, _id_hostnameVerifier.pointer,
+    return _hostnameVerifier(_$$selfRef.pointer, _id_hostnameVerifier.pointer,
             _$hostnameVerifier.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1818,8 +1877,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder certificatePinner(
     jni$_.JObject certificatePinner,
   ) {
+    final _$$selfRef = reference;
     final _$certificatePinner = certificatePinner.reference;
-    return _certificatePinner(reference.pointer, _id_certificatePinner.pointer,
+    return _certificatePinner(_$$selfRef.pointer, _id_certificatePinner.pointer,
             _$certificatePinner.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1847,9 +1907,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
     core$_.int j,
     jni$_.JObject timeUnit,
   ) {
+    final _$$selfRef = reference;
     final _$timeUnit = timeUnit.reference;
     return _callTimeout(
-            reference.pointer, _id_callTimeout.pointer, j, _$timeUnit.pointer)
+            _$$selfRef.pointer, _id_callTimeout.pointer, j, _$timeUnit.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1874,9 +1935,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder callTimeout$1(
     jni$_.JObject duration,
   ) {
+    final _$$selfRef = reference;
     final _$duration = duration.reference;
     return _callTimeout$1(
-            reference.pointer, _id_callTimeout$1.pointer, _$duration.pointer)
+            _$$selfRef.pointer, _id_callTimeout$1.pointer, _$duration.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1904,8 +1966,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
     core$_.int j,
     jni$_.JObject timeUnit,
   ) {
+    final _$$selfRef = reference;
     final _$timeUnit = timeUnit.reference;
-    return _connectTimeout(reference.pointer, _id_connectTimeout.pointer, j,
+    return _connectTimeout(_$$selfRef.pointer, _id_connectTimeout.pointer, j,
             _$timeUnit.pointer)
         .object<OkHttpClient$Builder>();
   }
@@ -1932,9 +1995,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder connectTimeout$1(
     jni$_.JObject duration,
   ) {
+    final _$$selfRef = reference;
     final _$duration = duration.reference;
-    return _connectTimeout$1(
-            reference.pointer, _id_connectTimeout$1.pointer, _$duration.pointer)
+    return _connectTimeout$1(_$$selfRef.pointer, _id_connectTimeout$1.pointer,
+            _$duration.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1961,9 +2025,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
     core$_.int j,
     jni$_.JObject timeUnit,
   ) {
+    final _$$selfRef = reference;
     final _$timeUnit = timeUnit.reference;
     return _readTimeout(
-            reference.pointer, _id_readTimeout.pointer, j, _$timeUnit.pointer)
+            _$$selfRef.pointer, _id_readTimeout.pointer, j, _$timeUnit.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -1988,9 +2053,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder readTimeout$1(
     jni$_.JObject duration,
   ) {
+    final _$$selfRef = reference;
     final _$duration = duration.reference;
     return _readTimeout$1(
-            reference.pointer, _id_readTimeout$1.pointer, _$duration.pointer)
+            _$$selfRef.pointer, _id_readTimeout$1.pointer, _$duration.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -2017,9 +2083,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
     core$_.int j,
     jni$_.JObject timeUnit,
   ) {
+    final _$$selfRef = reference;
     final _$timeUnit = timeUnit.reference;
     return _writeTimeout(
-            reference.pointer, _id_writeTimeout.pointer, j, _$timeUnit.pointer)
+            _$$selfRef.pointer, _id_writeTimeout.pointer, j, _$timeUnit.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -2045,9 +2112,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder writeTimeout$1(
     jni$_.JObject duration,
   ) {
+    final _$$selfRef = reference;
     final _$duration = duration.reference;
     return _writeTimeout$1(
-            reference.pointer, _id_writeTimeout$1.pointer, _$duration.pointer)
+            _$$selfRef.pointer, _id_writeTimeout$1.pointer, _$duration.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -2074,9 +2142,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
     core$_.int j,
     jni$_.JObject timeUnit,
   ) {
+    final _$$selfRef = reference;
     final _$timeUnit = timeUnit.reference;
     return _pingInterval(
-            reference.pointer, _id_pingInterval.pointer, j, _$timeUnit.pointer)
+            _$$selfRef.pointer, _id_pingInterval.pointer, j, _$timeUnit.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -2102,9 +2171,10 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder pingInterval$1(
     jni$_.JObject duration,
   ) {
+    final _$$selfRef = reference;
     final _$duration = duration.reference;
     return _pingInterval$1(
-            reference.pointer, _id_pingInterval$1.pointer, _$duration.pointer)
+            _$$selfRef.pointer, _id_pingInterval$1.pointer, _$duration.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -2129,8 +2199,9 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   OkHttpClient$Builder minWebSocketMessageToCompress(
     core$_.int j,
   ) {
+    final _$$selfRef = reference;
     return _minWebSocketMessageToCompress(
-            reference.pointer, _id_minWebSocketMessageToCompress.pointer, j)
+            _$$selfRef.pointer, _id_minWebSocketMessageToCompress.pointer, j)
         .object<OkHttpClient$Builder>();
   }
 
@@ -2154,7 +2225,8 @@ extension OkHttpClient$Builder$$Methods on OkHttpClient$Builder {
   /// from: `public fun build(): okhttp3.OkHttpClient`
   /// The returned object must be released after use, by calling the [release] method.
   OkHttpClient build() {
-    return _build(reference.pointer, _id_build.pointer).object<OkHttpClient>();
+    final _$$selfRef = reference;
+    return _build(_$$selfRef.pointer, _id_build.pointer).object<OkHttpClient>();
   }
 }
 
@@ -2196,9 +2268,10 @@ extension type OkHttpClient$Companion._(jni$_.JObject _$this)
   factory OkHttpClient$Companion(
     jni$_.JObject? defaultConstructorMarker,
   ) {
+    final _$$classRef = _class.reference;
     final _$defaultConstructorMarker =
         defaultConstructorMarker?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer,
+    return _new$(_$$classRef.pointer, _id_new$.pointer,
             _$defaultConstructorMarker.pointer)
         .object<OkHttpClient$Companion>();
   }
@@ -2251,8 +2324,9 @@ extension type OkHttpClient._(jni$_.JObject _$this) implements jni$_.JObject {
   factory OkHttpClient(
     OkHttpClient$Builder builder,
   ) {
+    final _$$classRef = _class.reference;
     final _$builder = builder.reference;
-    return _new$(_class.reference.pointer, _id_new$.pointer, _$builder.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$builder.pointer)
         .object<OkHttpClient>();
   }
 
@@ -2275,7 +2349,8 @@ extension type OkHttpClient._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory OkHttpClient.new$1() {
-    return _new$1(_class.reference.pointer, _id_new$1.pointer)
+    final _$$classRef = _class.reference;
+    return _new$1(_$$classRef.pointer, _id_new$1.pointer)
         .object<OkHttpClient>();
   }
 }
@@ -2301,7 +2376,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.Dispatcher dispatcher()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject dispatcher() {
-    return _dispatcher(reference.pointer, _id_dispatcher.pointer)
+    final _$$selfRef = reference;
+    return _dispatcher(_$$selfRef.pointer, _id_dispatcher.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2325,7 +2401,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.ConnectionPool connectionPool()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject connectionPool() {
-    return _connectionPool(reference.pointer, _id_connectionPool.pointer)
+    final _$$selfRef = reference;
+    return _connectionPool(_$$selfRef.pointer, _id_connectionPool.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2349,7 +2426,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final java.util.List<okhttp3.Interceptor> interceptors()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject> interceptors() {
-    return _interceptors(reference.pointer, _id_interceptors.pointer)
+    final _$$selfRef = reference;
+    return _interceptors(_$$selfRef.pointer, _id_interceptors.pointer)
         .object<jni$_.JList<jni$_.JObject>>();
   }
 
@@ -2373,8 +2451,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final java.util.List<okhttp3.Interceptor> networkInterceptors()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject> networkInterceptors() {
+    final _$$selfRef = reference;
     return _networkInterceptors(
-            reference.pointer, _id_networkInterceptors.pointer)
+            _$$selfRef.pointer, _id_networkInterceptors.pointer)
         .object<jni$_.JList<jni$_.JObject>>();
   }
 
@@ -2398,8 +2477,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.EventListener$Factory eventListenerFactory()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject eventListenerFactory() {
+    final _$$selfRef = reference;
     return _eventListenerFactory(
-            reference.pointer, _id_eventListenerFactory.pointer)
+            _$$selfRef.pointer, _id_eventListenerFactory.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2423,8 +2503,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final boolean retryOnConnectionFailure()`
   core$_.bool retryOnConnectionFailure() {
+    final _$$selfRef = reference;
     return _retryOnConnectionFailure(
-            reference.pointer, _id_retryOnConnectionFailure.pointer)
+            _$$selfRef.pointer, _id_retryOnConnectionFailure.pointer)
         .boolean;
   }
 
@@ -2448,7 +2529,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.Authenticator authenticator()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject authenticator() {
-    return _authenticator(reference.pointer, _id_authenticator.pointer)
+    final _$$selfRef = reference;
+    return _authenticator(_$$selfRef.pointer, _id_authenticator.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2471,7 +2553,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final boolean followRedirects()`
   core$_.bool followRedirects() {
-    return _followRedirects(reference.pointer, _id_followRedirects.pointer)
+    final _$$selfRef = reference;
+    return _followRedirects(_$$selfRef.pointer, _id_followRedirects.pointer)
         .boolean;
   }
 
@@ -2494,8 +2577,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final boolean followSslRedirects()`
   core$_.bool followSslRedirects() {
+    final _$$selfRef = reference;
     return _followSslRedirects(
-            reference.pointer, _id_followSslRedirects.pointer)
+            _$$selfRef.pointer, _id_followSslRedirects.pointer)
         .boolean;
   }
 
@@ -2519,7 +2603,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.CookieJar cookieJar()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject cookieJar() {
-    return _cookieJar(reference.pointer, _id_cookieJar.pointer)
+    final _$$selfRef = reference;
+    return _cookieJar(_$$selfRef.pointer, _id_cookieJar.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2543,7 +2628,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.Cache cache()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? cache() {
-    return _cache(reference.pointer, _id_cache.pointer)
+    final _$$selfRef = reference;
+    return _cache(_$$selfRef.pointer, _id_cache.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2567,7 +2653,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.Dns dns()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject dns() {
-    return _dns(reference.pointer, _id_dns.pointer).object<jni$_.JObject>();
+    final _$$selfRef = reference;
+    return _dns(_$$selfRef.pointer, _id_dns.pointer).object<jni$_.JObject>();
   }
 
   static final _id_proxy = OkHttpClient._class.instanceMethodId(
@@ -2590,7 +2677,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final java.net.Proxy proxy()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? proxy() {
-    return _proxy(reference.pointer, _id_proxy.pointer)
+    final _$$selfRef = reference;
+    return _proxy(_$$selfRef.pointer, _id_proxy.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2614,7 +2702,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final java.net.ProxySelector proxySelector()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject proxySelector() {
-    return _proxySelector(reference.pointer, _id_proxySelector.pointer)
+    final _$$selfRef = reference;
+    return _proxySelector(_$$selfRef.pointer, _id_proxySelector.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2638,8 +2727,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.Authenticator proxyAuthenticator()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject proxyAuthenticator() {
+    final _$$selfRef = reference;
     return _proxyAuthenticator(
-            reference.pointer, _id_proxyAuthenticator.pointer)
+            _$$selfRef.pointer, _id_proxyAuthenticator.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2663,7 +2753,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final javax.net.SocketFactory socketFactory()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject socketFactory() {
-    return _socketFactory(reference.pointer, _id_socketFactory.pointer)
+    final _$$selfRef = reference;
+    return _socketFactory(_$$selfRef.pointer, _id_socketFactory.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2687,7 +2778,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final javax.net.ssl.SSLSocketFactory sslSocketFactory()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject sslSocketFactory() {
-    return _sslSocketFactory(reference.pointer, _id_sslSocketFactory.pointer)
+    final _$$selfRef = reference;
+    return _sslSocketFactory(_$$selfRef.pointer, _id_sslSocketFactory.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2711,7 +2803,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final javax.net.ssl.X509TrustManager x509TrustManager()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? x509TrustManager() {
-    return _x509TrustManager(reference.pointer, _id_x509TrustManager.pointer)
+    final _$$selfRef = reference;
+    return _x509TrustManager(_$$selfRef.pointer, _id_x509TrustManager.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2735,7 +2828,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final java.util.List<okhttp3.ConnectionSpec> connectionSpecs()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject> connectionSpecs() {
-    return _connectionSpecs(reference.pointer, _id_connectionSpecs.pointer)
+    final _$$selfRef = reference;
+    return _connectionSpecs(_$$selfRef.pointer, _id_connectionSpecs.pointer)
         .object<jni$_.JList<jni$_.JObject>>();
   }
 
@@ -2759,7 +2853,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final java.util.List<okhttp3.Protocol> protocols()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject> protocols() {
-    return _protocols(reference.pointer, _id_protocols.pointer)
+    final _$$selfRef = reference;
+    return _protocols(_$$selfRef.pointer, _id_protocols.pointer)
         .object<jni$_.JList<jni$_.JObject>>();
   }
 
@@ -2783,7 +2878,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final javax.net.ssl.HostnameVerifier hostnameVerifier()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject hostnameVerifier() {
-    return _hostnameVerifier(reference.pointer, _id_hostnameVerifier.pointer)
+    final _$$selfRef = reference;
+    return _hostnameVerifier(_$$selfRef.pointer, _id_hostnameVerifier.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2807,7 +2903,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.CertificatePinner certificatePinner()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject certificatePinner() {
-    return _certificatePinner(reference.pointer, _id_certificatePinner.pointer)
+    final _$$selfRef = reference;
+    return _certificatePinner(_$$selfRef.pointer, _id_certificatePinner.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -2832,8 +2929,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.internal.tls.CertificateChainCleaner certificateChainCleaner()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? certificateChainCleaner() {
+    final _$$selfRef = reference;
     return _certificateChainCleaner(
-            reference.pointer, _id_certificateChainCleaner.pointer)
+            _$$selfRef.pointer, _id_certificateChainCleaner.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2856,7 +2954,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final int callTimeoutMillis()`
   core$_.int callTimeoutMillis() {
-    return _callTimeoutMillis(reference.pointer, _id_callTimeoutMillis.pointer)
+    final _$$selfRef = reference;
+    return _callTimeoutMillis(_$$selfRef.pointer, _id_callTimeoutMillis.pointer)
         .integer;
   }
 
@@ -2879,8 +2978,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final int connectTimeoutMillis()`
   core$_.int connectTimeoutMillis() {
+    final _$$selfRef = reference;
     return _connectTimeoutMillis(
-            reference.pointer, _id_connectTimeoutMillis.pointer)
+            _$$selfRef.pointer, _id_connectTimeoutMillis.pointer)
         .integer;
   }
 
@@ -2903,7 +3003,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final int readTimeoutMillis()`
   core$_.int readTimeoutMillis() {
-    return _readTimeoutMillis(reference.pointer, _id_readTimeoutMillis.pointer)
+    final _$$selfRef = reference;
+    return _readTimeoutMillis(_$$selfRef.pointer, _id_readTimeoutMillis.pointer)
         .integer;
   }
 
@@ -2926,8 +3027,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final int writeTimeoutMillis()`
   core$_.int writeTimeoutMillis() {
+    final _$$selfRef = reference;
     return _writeTimeoutMillis(
-            reference.pointer, _id_writeTimeoutMillis.pointer)
+            _$$selfRef.pointer, _id_writeTimeoutMillis.pointer)
         .integer;
   }
 
@@ -2950,8 +3052,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final int pingIntervalMillis()`
   core$_.int pingIntervalMillis() {
+    final _$$selfRef = reference;
     return _pingIntervalMillis(
-            reference.pointer, _id_pingIntervalMillis.pointer)
+            _$$selfRef.pointer, _id_pingIntervalMillis.pointer)
         .integer;
   }
 
@@ -2976,8 +3079,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
 
   /// from: `public final long minWebSocketMessageToCompress()`
   core$_.int minWebSocketMessageToCompress() {
+    final _$$selfRef = reference;
     return _minWebSocketMessageToCompress(
-            reference.pointer, _id_minWebSocketMessageToCompress.pointer)
+            _$$selfRef.pointer, _id_minWebSocketMessageToCompress.pointer)
         .long;
   }
 
@@ -3001,7 +3105,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public final okhttp3.internal.connection.RouteDatabase getRouteDatabase()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject get routeDatabase {
-    return _get$routeDatabase(reference.pointer, _id_get$routeDatabase.pointer)
+    final _$$selfRef = reference;
+    return _get$routeDatabase(_$$selfRef.pointer, _id_get$routeDatabase.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -3026,8 +3131,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
   jni$_.JObject newCall(
     jni$_.JObject request,
   ) {
+    final _$$selfRef = reference;
     final _$request = request.reference;
-    return _newCall(reference.pointer, _id_newCall.pointer, _$request.pointer)
+    return _newCall(_$$selfRef.pointer, _id_newCall.pointer, _$request.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -3059,9 +3165,10 @@ extension OkHttpClient$$Methods on OkHttpClient {
     jni$_.JObject request,
     jni$_.JObject webSocketListener,
   ) {
+    final _$$selfRef = reference;
     final _$request = request.reference;
     final _$webSocketListener = webSocketListener.reference;
-    return _newWebSocket(reference.pointer, _id_newWebSocket.pointer,
+    return _newWebSocket(_$$selfRef.pointer, _id_newWebSocket.pointer,
             _$request.pointer, _$webSocketListener.pointer)
         .object<jni$_.JObject>();
   }
@@ -3086,7 +3193,8 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public fun newBuilder(): okhttp3.OkHttpClient.Builder`
   /// The returned object must be released after use, by calling the [release] method.
   OkHttpClient$Builder newBuilder() {
-    return _newBuilder(reference.pointer, _id_newBuilder.pointer)
+    final _$$selfRef = reference;
+    return _newBuilder(_$$selfRef.pointer, _id_newBuilder.pointer)
         .object<OkHttpClient$Builder>();
   }
 
@@ -3110,7 +3218,9 @@ extension OkHttpClient$$Methods on OkHttpClient {
   /// from: `public java.lang.Object clone()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject clone() {
-    return _clone(reference.pointer, _id_clone.pointer).object<jni$_.JObject>();
+    final _$$selfRef = reference;
+    return _clone(_$$selfRef.pointer, _id_clone.pointer)
+        .object<jni$_.JObject>();
   }
 }
 

--- a/pkgs/jnigen/example/notification_plugin/lib/notifications.dart
+++ b/pkgs/jnigen/example/notification_plugin/lib/notifications.dart
@@ -68,8 +68,8 @@ extension type Notifications._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory Notifications() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<Notifications>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<Notifications>();
   }
 
   static final _id_showNotification = _class.staticMethodId(
@@ -105,10 +105,11 @@ extension type Notifications._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JString? title,
     jni$_.JString? text,
   ) {
+    final _$$classRef = _class.reference;
     final _$context = context?.reference ?? jni$_.jNullReference;
     final _$title = title?.reference ?? jni$_.jNullReference;
     final _$text = text?.reference ?? jni$_.jNullReference;
-    _showNotification(_class.reference.pointer, _id_showNotification.pointer,
+    _showNotification(_$$classRef.pointer, _id_showNotification.pointer,
             _$context.pointer, notificationID, _$title.pointer, _$text.pointer)
         .check();
   }

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
@@ -89,8 +89,8 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
   /// Creates an empty PDF document.
   /// You need to add at least one page for the document to be valid.
   factory PDDocument() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<PDDocument>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<PDDocument>();
   }
 
   static final _id_new$1 = _class.constructorId(
@@ -117,10 +117,11 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
   factory PDDocument.new$1(
     jni$_.JObject? memUsageSetting,
   ) {
+    final _$$classRef = _class.reference;
     final _$memUsageSetting =
         memUsageSetting?.reference ?? jni$_.jNullReference;
-    return _new$1(_class.reference.pointer, _id_new$1.pointer,
-            _$memUsageSetting.pointer)
+    return _new$1(
+            _$$classRef.pointer, _id_new$1.pointer, _$memUsageSetting.pointer)
         .object<PDDocument>();
   }
 
@@ -147,8 +148,9 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
   factory PDDocument.new$2(
     jni$_.JObject? doc,
   ) {
+    final _$$classRef = _class.reference;
     final _$doc = doc?.reference ?? jni$_.jNullReference;
-    return _new$2(_class.reference.pointer, _id_new$2.pointer, _$doc.pointer)
+    return _new$2(_$$classRef.pointer, _id_new$2.pointer, _$doc.pointer)
         .object<PDDocument>();
   }
 
@@ -183,9 +185,10 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JObject? doc,
     jni$_.JObject? source,
   ) {
+    final _$$classRef = _class.reference;
     final _$doc = doc?.reference ?? jni$_.jNullReference;
     final _$source = source?.reference ?? jni$_.jNullReference;
-    return _new$3(_class.reference.pointer, _id_new$3.pointer, _$doc.pointer,
+    return _new$3(_$$classRef.pointer, _id_new$3.pointer, _$doc.pointer,
             _$source.pointer)
         .object<PDDocument>();
   }
@@ -225,10 +228,11 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JObject? source,
     jni$_.JObject? permission,
   ) {
+    final _$$classRef = _class.reference;
     final _$doc = doc?.reference ?? jni$_.jNullReference;
     final _$source = source?.reference ?? jni$_.jNullReference;
     final _$permission = permission?.reference ?? jni$_.jNullReference;
-    return _new$4(_class.reference.pointer, _id_new$4.pointer, _$doc.pointer,
+    return _new$4(_$$classRef.pointer, _id_new$4.pointer, _$doc.pointer,
             _$source.pointer, _$permission.pointer)
         .object<PDDocument>();
   }
@@ -260,8 +264,9 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
   static PDDocument? load(
     jni$_.JObject? file,
   ) {
+    final _$$classRef = _class.reference;
     final _$file = file?.reference ?? jni$_.jNullReference;
-    return _load(_class.reference.pointer, _id_load.pointer, _$file.pointer)
+    return _load(_$$classRef.pointer, _id_load.pointer, _$file.pointer)
         .object<PDDocument?>();
   }
 
@@ -300,10 +305,11 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JObject? file,
     jni$_.JObject? memUsageSetting,
   ) {
+    final _$$classRef = _class.reference;
     final _$file = file?.reference ?? jni$_.jNullReference;
     final _$memUsageSetting =
         memUsageSetting?.reference ?? jni$_.jNullReference;
-    return _load$1(_class.reference.pointer, _id_load$1.pointer, _$file.pointer,
+    return _load$1(_$$classRef.pointer, _id_load$1.pointer, _$file.pointer,
             _$memUsageSetting.pointer)
         .object<PDDocument?>();
   }
@@ -343,9 +349,10 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JObject? file,
     jni$_.JString? password,
   ) {
+    final _$$classRef = _class.reference;
     final _$file = file?.reference ?? jni$_.jNullReference;
     final _$password = password?.reference ?? jni$_.jNullReference;
-    return _load$2(_class.reference.pointer, _id_load$2.pointer, _$file.pointer,
+    return _load$2(_$$classRef.pointer, _id_load$2.pointer, _$file.pointer,
             _$password.pointer)
         .object<PDDocument?>();
   }
@@ -389,11 +396,12 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JString? password,
     jni$_.JObject? memUsageSetting,
   ) {
+    final _$$classRef = _class.reference;
     final _$file = file?.reference ?? jni$_.jNullReference;
     final _$password = password?.reference ?? jni$_.jNullReference;
     final _$memUsageSetting =
         memUsageSetting?.reference ?? jni$_.jNullReference;
-    return _load$3(_class.reference.pointer, _id_load$3.pointer, _$file.pointer,
+    return _load$3(_$$classRef.pointer, _id_load$3.pointer, _$file.pointer,
             _$password.pointer, _$memUsageSetting.pointer)
         .object<PDDocument?>();
   }
@@ -440,11 +448,12 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JObject? keyStore,
     jni$_.JString? alias,
   ) {
+    final _$$classRef = _class.reference;
     final _$file = file?.reference ?? jni$_.jNullReference;
     final _$password = password?.reference ?? jni$_.jNullReference;
     final _$keyStore = keyStore?.reference ?? jni$_.jNullReference;
     final _$alias = alias?.reference ?? jni$_.jNullReference;
-    return _load$4(_class.reference.pointer, _id_load$4.pointer, _$file.pointer,
+    return _load$4(_$$classRef.pointer, _id_load$4.pointer, _$file.pointer,
             _$password.pointer, _$keyStore.pointer, _$alias.pointer)
         .object<PDDocument?>();
   }
@@ -495,6 +504,7 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JString? alias,
     jni$_.JObject? memUsageSetting,
   ) {
+    final _$$classRef = _class.reference;
     final _$file = file?.reference ?? jni$_.jNullReference;
     final _$password = password?.reference ?? jni$_.jNullReference;
     final _$keyStore = keyStore?.reference ?? jni$_.jNullReference;
@@ -502,7 +512,7 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     final _$memUsageSetting =
         memUsageSetting?.reference ?? jni$_.jNullReference;
     return _load$5(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_load$5.pointer,
             _$file.pointer,
             _$password.pointer,
@@ -540,9 +550,9 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
   static PDDocument? load$6(
     jni$_.JObject? input,
   ) {
+    final _$$classRef = _class.reference;
     final _$input = input?.reference ?? jni$_.jNullReference;
-    return _load$6(
-            _class.reference.pointer, _id_load$6.pointer, _$input.pointer)
+    return _load$6(_$$classRef.pointer, _id_load$6.pointer, _$input.pointer)
         .object<PDDocument?>();
   }
 
@@ -582,11 +592,12 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JObject? input,
     jni$_.JObject? memUsageSetting,
   ) {
+    final _$$classRef = _class.reference;
     final _$input = input?.reference ?? jni$_.jNullReference;
     final _$memUsageSetting =
         memUsageSetting?.reference ?? jni$_.jNullReference;
-    return _load$7(_class.reference.pointer, _id_load$7.pointer,
-            _$input.pointer, _$memUsageSetting.pointer)
+    return _load$7(_$$classRef.pointer, _id_load$7.pointer, _$input.pointer,
+            _$memUsageSetting.pointer)
         .object<PDDocument?>();
   }
 
@@ -626,10 +637,11 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JObject? input,
     jni$_.JString? password,
   ) {
+    final _$$classRef = _class.reference;
     final _$input = input?.reference ?? jni$_.jNullReference;
     final _$password = password?.reference ?? jni$_.jNullReference;
-    return _load$8(_class.reference.pointer, _id_load$8.pointer,
-            _$input.pointer, _$password.pointer)
+    return _load$8(_$$classRef.pointer, _id_load$8.pointer, _$input.pointer,
+            _$password.pointer)
         .object<PDDocument?>();
   }
 
@@ -676,17 +688,13 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JObject? keyStore,
     jni$_.JString? alias,
   ) {
+    final _$$classRef = _class.reference;
     final _$input = input?.reference ?? jni$_.jNullReference;
     final _$password = password?.reference ?? jni$_.jNullReference;
     final _$keyStore = keyStore?.reference ?? jni$_.jNullReference;
     final _$alias = alias?.reference ?? jni$_.jNullReference;
-    return _load$9(
-            _class.reference.pointer,
-            _id_load$9.pointer,
-            _$input.pointer,
-            _$password.pointer,
-            _$keyStore.pointer,
-            _$alias.pointer)
+    return _load$9(_$$classRef.pointer, _id_load$9.pointer, _$input.pointer,
+            _$password.pointer, _$keyStore.pointer, _$alias.pointer)
         .object<PDDocument?>();
   }
 
@@ -730,12 +738,13 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JString? password,
     jni$_.JObject? memUsageSetting,
   ) {
+    final _$$classRef = _class.reference;
     final _$input = input?.reference ?? jni$_.jNullReference;
     final _$password = password?.reference ?? jni$_.jNullReference;
     final _$memUsageSetting =
         memUsageSetting?.reference ?? jni$_.jNullReference;
-    return _load$10(_class.reference.pointer, _id_load$10.pointer,
-            _$input.pointer, _$password.pointer, _$memUsageSetting.pointer)
+    return _load$10(_$$classRef.pointer, _id_load$10.pointer, _$input.pointer,
+            _$password.pointer, _$memUsageSetting.pointer)
         .object<PDDocument?>();
   }
 
@@ -787,6 +796,7 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JString? alias,
     jni$_.JObject? memUsageSetting,
   ) {
+    final _$$classRef = _class.reference;
     final _$input = input?.reference ?? jni$_.jNullReference;
     final _$password = password?.reference ?? jni$_.jNullReference;
     final _$keyStore = keyStore?.reference ?? jni$_.jNullReference;
@@ -794,7 +804,7 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     final _$memUsageSetting =
         memUsageSetting?.reference ?? jni$_.jNullReference;
     return _load$11(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_load$11.pointer,
             _$input.pointer,
             _$password.pointer,
@@ -831,9 +841,9 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
   static PDDocument? load$12(
     jni$_.JByteArray? input,
   ) {
+    final _$$classRef = _class.reference;
     final _$input = input?.reference ?? jni$_.jNullReference;
-    return _load$12(
-            _class.reference.pointer, _id_load$12.pointer, _$input.pointer)
+    return _load$12(_$$classRef.pointer, _id_load$12.pointer, _$input.pointer)
         .object<PDDocument?>();
   }
 
@@ -872,10 +882,11 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JByteArray? input,
     jni$_.JString? password,
   ) {
+    final _$$classRef = _class.reference;
     final _$input = input?.reference ?? jni$_.jNullReference;
     final _$password = password?.reference ?? jni$_.jNullReference;
-    return _load$13(_class.reference.pointer, _id_load$13.pointer,
-            _$input.pointer, _$password.pointer)
+    return _load$13(_$$classRef.pointer, _id_load$13.pointer, _$input.pointer,
+            _$password.pointer)
         .object<PDDocument?>();
   }
 
@@ -922,17 +933,13 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JObject? keyStore,
     jni$_.JString? alias,
   ) {
+    final _$$classRef = _class.reference;
     final _$input = input?.reference ?? jni$_.jNullReference;
     final _$password = password?.reference ?? jni$_.jNullReference;
     final _$keyStore = keyStore?.reference ?? jni$_.jNullReference;
     final _$alias = alias?.reference ?? jni$_.jNullReference;
-    return _load$14(
-            _class.reference.pointer,
-            _id_load$14.pointer,
-            _$input.pointer,
-            _$password.pointer,
-            _$keyStore.pointer,
-            _$alias.pointer)
+    return _load$14(_$$classRef.pointer, _id_load$14.pointer, _$input.pointer,
+            _$password.pointer, _$keyStore.pointer, _$alias.pointer)
         .object<PDDocument?>();
   }
 
@@ -983,6 +990,7 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JString? alias,
     jni$_.JObject? memUsageSetting,
   ) {
+    final _$$classRef = _class.reference;
     final _$input = input?.reference ?? jni$_.jNullReference;
     final _$password = password?.reference ?? jni$_.jNullReference;
     final _$keyStore = keyStore?.reference ?? jni$_.jNullReference;
@@ -990,7 +998,7 @@ extension type PDDocument._(jni$_.JObject _$this) implements jni$_.JObject {
     final _$memUsageSetting =
         memUsageSetting?.reference ?? jni$_.jNullReference;
     return _load$15(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_load$15.pointer,
             _$input.pointer,
             _$password.pointer,
@@ -1026,8 +1034,9 @@ extension PDDocument$$Methods on PDDocument {
   void addPage(
     jni$_.JObject? page,
   ) {
+    final _$$selfRef = reference;
     final _$page = page?.reference ?? jni$_.jNullReference;
-    _addPage(reference.pointer, _id_addPage.pointer, _$page.pointer).check();
+    _addPage(_$$selfRef.pointer, _id_addPage.pointer, _$page.pointer).check();
   }
 
   static final _id_addSignature = PDDocument._class.instanceMethodId(
@@ -1061,9 +1070,10 @@ extension PDDocument$$Methods on PDDocument {
   void addSignature(
     jni$_.JObject? sigObject,
   ) {
+    final _$$selfRef = reference;
     final _$sigObject = sigObject?.reference ?? jni$_.jNullReference;
     _addSignature(
-            reference.pointer, _id_addSignature.pointer, _$sigObject.pointer)
+            _$$selfRef.pointer, _id_addSignature.pointer, _$sigObject.pointer)
         .check();
   }
 
@@ -1106,9 +1116,10 @@ extension PDDocument$$Methods on PDDocument {
     jni$_.JObject? sigObject,
     jni$_.JObject? options,
   ) {
+    final _$$selfRef = reference;
     final _$sigObject = sigObject?.reference ?? jni$_.jNullReference;
     final _$options = options?.reference ?? jni$_.jNullReference;
-    _addSignature$1(reference.pointer, _id_addSignature$1.pointer,
+    _addSignature$1(_$$selfRef.pointer, _id_addSignature$1.pointer,
             _$sigObject.pointer, _$options.pointer)
         .check();
   }
@@ -1151,10 +1162,11 @@ extension PDDocument$$Methods on PDDocument {
     jni$_.JObject? sigObject,
     jni$_.JObject? signatureInterface,
   ) {
+    final _$$selfRef = reference;
     final _$sigObject = sigObject?.reference ?? jni$_.jNullReference;
     final _$signatureInterface =
         signatureInterface?.reference ?? jni$_.jNullReference;
-    _addSignature$2(reference.pointer, _id_addSignature$2.pointer,
+    _addSignature$2(_$$selfRef.pointer, _id_addSignature$2.pointer,
             _$sigObject.pointer, _$signatureInterface.pointer)
         .check();
   }
@@ -1203,12 +1215,13 @@ extension PDDocument$$Methods on PDDocument {
     jni$_.JObject? signatureInterface,
     jni$_.JObject? options,
   ) {
+    final _$$selfRef = reference;
     final _$sigObject = sigObject?.reference ?? jni$_.jNullReference;
     final _$signatureInterface =
         signatureInterface?.reference ?? jni$_.jNullReference;
     final _$options = options?.reference ?? jni$_.jNullReference;
     _addSignature$3(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_addSignature$3.pointer,
             _$sigObject.pointer,
             _$signatureInterface.pointer,
@@ -1255,12 +1268,13 @@ extension PDDocument$$Methods on PDDocument {
     jni$_.JObject? signatureInterface,
     jni$_.JObject? options,
   ) {
+    final _$$selfRef = reference;
     final _$sigFields = sigFields?.reference ?? jni$_.jNullReference;
     final _$signatureInterface =
         signatureInterface?.reference ?? jni$_.jNullReference;
     final _$options = options?.reference ?? jni$_.jNullReference;
     _addSignatureField(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_addSignatureField.pointer,
             _$sigFields.pointer,
             _$signatureInterface.pointer,
@@ -1291,8 +1305,9 @@ extension PDDocument$$Methods on PDDocument {
   void removePage(
     jni$_.JObject? page,
   ) {
+    final _$$selfRef = reference;
     final _$page = page?.reference ?? jni$_.jNullReference;
-    _removePage(reference.pointer, _id_removePage.pointer, _$page.pointer)
+    _removePage(_$$selfRef.pointer, _id_removePage.pointer, _$page.pointer)
         .check();
   }
 
@@ -1318,7 +1333,8 @@ extension PDDocument$$Methods on PDDocument {
   void removePage$1(
     core$_.int pageNumber,
   ) {
-    _removePage$1(reference.pointer, _id_removePage$1.pointer, pageNumber)
+    final _$$selfRef = reference;
+    _removePage$1(_$$selfRef.pointer, _id_removePage$1.pointer, pageNumber)
         .check();
   }
 
@@ -1365,9 +1381,10 @@ extension PDDocument$$Methods on PDDocument {
   jni$_.JObject? importPage(
     jni$_.JObject? page,
   ) {
+    final _$$selfRef = reference;
     final _$page = page?.reference ?? jni$_.jNullReference;
     return _importPage(
-            reference.pointer, _id_importPage.pointer, _$page.pointer)
+            _$$selfRef.pointer, _id_importPage.pointer, _$page.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1394,7 +1411,8 @@ extension PDDocument$$Methods on PDDocument {
   /// This will get the low level document.
   ///@return The document that this layer sits on top of.
   jni$_.JObject? get document {
-    return _get$document(reference.pointer, _id_get$document.pointer)
+    final _$$selfRef = reference;
+    return _get$document(_$$selfRef.pointer, _id_get$document.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1426,8 +1444,9 @@ extension PDDocument$$Methods on PDDocument {
   /// PDDocumentCatalog\#getMetadata().
   ///@return The documents /Info dictionary, never null.
   pddocumentinformation$_.PDDocumentInformation? get documentInformation {
+    final _$$selfRef = reference;
     return _get$documentInformation(
-            reference.pointer, _id_get$documentInformation.pointer)
+            _$$selfRef.pointer, _id_get$documentInformation.pointer)
         .object<pddocumentinformation$_.PDDocumentInformation?>();
   }
 
@@ -1456,8 +1475,9 @@ extension PDDocument$$Methods on PDDocument {
   /// PDDocumentCatalog\#setMetadata(org.apache.pdfbox.pdmodel.common.PDMetadata) PDDocumentCatalog\#setMetadata(PDMetadata).
   ///@param info The updated document information.
   set documentInformation(pddocumentinformation$_.PDDocumentInformation? info) {
+    final _$$selfRef = reference;
     final _$info = info?.reference ?? jni$_.jNullReference;
-    _set$documentInformation(reference.pointer,
+    _set$documentInformation(_$$selfRef.pointer,
             _id_set$documentInformation.pointer, _$info.pointer)
         .check();
   }
@@ -1485,8 +1505,9 @@ extension PDDocument$$Methods on PDDocument {
   /// This will get the document CATALOG. This is guaranteed to not return null.
   ///@return The documents /Root dictionary
   jni$_.JObject? get documentCatalog {
+    final _$$selfRef = reference;
     return _get$documentCatalog(
-            reference.pointer, _id_get$documentCatalog.pointer)
+            _$$selfRef.pointer, _id_get$documentCatalog.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1512,7 +1533,8 @@ extension PDDocument$$Methods on PDDocument {
   /// This will tell if this document is encrypted or not.
   ///@return true If this document is encrypted.
   core$_.bool get isEncrypted {
-    return _get$isEncrypted(reference.pointer, _id_get$isEncrypted.pointer)
+    final _$$selfRef = reference;
+    return _get$isEncrypted(_$$selfRef.pointer, _id_get$isEncrypted.pointer)
         .boolean;
   }
 
@@ -1542,7 +1564,8 @@ extension PDDocument$$Methods on PDDocument {
   /// PDStandardEncryption object.
   ///@return The encryption dictionary(most likely a PDStandardEncryption object)
   jni$_.JObject? get encryption {
-    return _get$encryption(reference.pointer, _id_get$encryption.pointer)
+    final _$$selfRef = reference;
+    return _get$encryption(_$$selfRef.pointer, _id_get$encryption.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1569,8 +1592,9 @@ extension PDDocument$$Methods on PDDocument {
   ///@param encryption The encryption dictionary(most likely a PDStandardEncryption object)
   ///@throws IOException If there is an error determining which security handler to use.
   set encryptionDictionary(jni$_.JObject? encryption) {
+    final _$$selfRef = reference;
     final _$encryption = encryption?.reference ?? jni$_.jNullReference;
-    _set$encryptionDictionary(reference.pointer,
+    _set$encryptionDictionary(_$$selfRef.pointer,
             _id_set$encryptionDictionary.pointer, _$encryption.pointer)
         .check();
   }
@@ -1602,8 +1626,9 @@ extension PDDocument$$Methods on PDDocument {
   ///@return the last signature as <code>PDSignatureField</code>.
   ///@throws IOException if no document catalog can be found.
   jni$_.JObject? get lastSignatureDictionary {
+    final _$$selfRef = reference;
     return _get$lastSignatureDictionary(
-            reference.pointer, _id_get$lastSignatureDictionary.pointer)
+            _$$selfRef.pointer, _id_get$lastSignatureDictionary.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1631,8 +1656,9 @@ extension PDDocument$$Methods on PDDocument {
   ///@return a <code>List</code> of <code>PDSignatureField</code>s
   ///@throws IOException if no document catalog can be found.
   jni$_.JList<jni$_.JObject?>? get signatureFields {
+    final _$$selfRef = reference;
     return _get$signatureFields(
-            reference.pointer, _id_get$signatureFields.pointer)
+            _$$selfRef.pointer, _id_get$signatureFields.pointer)
         .object<jni$_.JList<jni$_.JObject?>?>();
   }
 
@@ -1661,8 +1687,9 @@ extension PDDocument$$Methods on PDDocument {
   ///@return a <code>List</code> of <code>PDSignatureField</code>s
   ///@throws IOException if no document catalog can be found.
   jni$_.JList<jni$_.JObject?>? get signatureDictionaries {
+    final _$$selfRef = reference;
     return _get$signatureDictionaries(
-            reference.pointer, _id_get$signatureDictionaries.pointer)
+            _$$selfRef.pointer, _id_get$signatureDictionaries.pointer)
         .object<jni$_.JList<jni$_.JObject?>?>();
   }
 
@@ -1693,8 +1720,9 @@ extension PDDocument$$Methods on PDDocument {
   void registerTrueTypeFontForClosing(
     jni$_.JObject? ttf,
   ) {
+    final _$$selfRef = reference;
     final _$ttf = ttf?.reference ?? jni$_.jNullReference;
-    _registerTrueTypeFontForClosing(reference.pointer,
+    _registerTrueTypeFontForClosing(_$$selfRef.pointer,
             _id_registerTrueTypeFontForClosing.pointer, _$ttf.pointer)
         .check();
   }
@@ -1727,8 +1755,9 @@ extension PDDocument$$Methods on PDDocument {
   void save(
     jni$_.JString? fileName,
   ) {
+    final _$$selfRef = reference;
     final _$fileName = fileName?.reference ?? jni$_.jNullReference;
-    _save(reference.pointer, _id_save.pointer, _$fileName.pointer).check();
+    _save(_$$selfRef.pointer, _id_save.pointer, _$fileName.pointer).check();
   }
 
   static final _id_save$1 = PDDocument._class.instanceMethodId(
@@ -1759,8 +1788,9 @@ extension PDDocument$$Methods on PDDocument {
   void save$1(
     jni$_.JObject? file,
   ) {
+    final _$$selfRef = reference;
     final _$file = file?.reference ?? jni$_.jNullReference;
-    _save$1(reference.pointer, _id_save$1.pointer, _$file.pointer).check();
+    _save$1(_$$selfRef.pointer, _id_save$1.pointer, _$file.pointer).check();
   }
 
   static final _id_save$2 = PDDocument._class.instanceMethodId(
@@ -1792,8 +1822,9 @@ extension PDDocument$$Methods on PDDocument {
   void save$2(
     jni$_.JObject? output,
   ) {
+    final _$$selfRef = reference;
     final _$output = output?.reference ?? jni$_.jNullReference;
-    _save$2(reference.pointer, _id_save$2.pointer, _$output.pointer).check();
+    _save$2(_$$selfRef.pointer, _id_save$2.pointer, _$output.pointer).check();
   }
 
   static final _id_saveIncremental = PDDocument._class.instanceMethodId(
@@ -1830,9 +1861,10 @@ extension PDDocument$$Methods on PDDocument {
   void saveIncremental(
     jni$_.JObject? output,
   ) {
+    final _$$selfRef = reference;
     final _$output = output?.reference ?? jni$_.jNullReference;
     _saveIncremental(
-            reference.pointer, _id_saveIncremental.pointer, _$output.pointer)
+            _$$selfRef.pointer, _id_saveIncremental.pointer, _$output.pointer)
         .check();
   }
 
@@ -1882,9 +1914,10 @@ extension PDDocument$$Methods on PDDocument {
     jni$_.JObject? output,
     jni$_.JSet<jni$_.JObject?>? objectsToWrite,
   ) {
+    final _$$selfRef = reference;
     final _$output = output?.reference ?? jni$_.jNullReference;
     final _$objectsToWrite = objectsToWrite?.reference ?? jni$_.jNullReference;
-    _saveIncremental$1(reference.pointer, _id_saveIncremental$1.pointer,
+    _saveIncremental$1(_$$selfRef.pointer, _id_saveIncremental$1.pointer,
             _$output.pointer, _$objectsToWrite.pointer)
         .check();
   }
@@ -1950,8 +1983,9 @@ extension PDDocument$$Methods on PDDocument {
   jni$_.JObject? saveIncrementalForExternalSigning(
     jni$_.JObject? output,
   ) {
+    final _$$selfRef = reference;
     final _$output = output?.reference ?? jni$_.jNullReference;
-    return _saveIncrementalForExternalSigning(reference.pointer,
+    return _saveIncrementalForExternalSigning(_$$selfRef.pointer,
             _id_saveIncrementalForExternalSigning.pointer, _$output.pointer)
         .object<jni$_.JObject?>();
   }
@@ -1984,7 +2018,8 @@ extension PDDocument$$Methods on PDDocument {
   jni$_.JObject? getPage(
     core$_.int pageIndex,
   ) {
-    return _getPage(reference.pointer, _id_getPage.pointer, pageIndex)
+    final _$$selfRef = reference;
+    return _getPage(_$$selfRef.pointer, _id_getPage.pointer, pageIndex)
         .object<jni$_.JObject?>();
   }
 
@@ -2011,7 +2046,8 @@ extension PDDocument$$Methods on PDDocument {
   /// Returns the page tree.
   ///@return the page tree
   jni$_.JObject? get pages {
-    return _get$pages(reference.pointer, _id_get$pages.pointer)
+    final _$$selfRef = reference;
+    return _get$pages(_$$selfRef.pointer, _id_get$pages.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2037,7 +2073,8 @@ extension PDDocument$$Methods on PDDocument {
   /// This will return the total page count of the PDF document.
   ///@return The total number of pages in the PDF document.
   core$_.int get numberOfPages {
-    return _get$numberOfPages(reference.pointer, _id_get$numberOfPages.pointer)
+    final _$$selfRef = reference;
+    return _get$numberOfPages(_$$selfRef.pointer, _id_get$numberOfPages.pointer)
         .integer;
   }
 
@@ -2063,7 +2100,8 @@ extension PDDocument$$Methods on PDDocument {
   /// This will close the underlying COSDocument object.
   ///@throws IOException If there is an error releasing resources.
   void close() {
-    _close(reference.pointer, _id_close.pointer).check();
+    final _$$selfRef = reference;
+    _close(_$$selfRef.pointer, _id_close.pointer).check();
   }
 
   static final _id_protect = PDDocument._class.instanceMethodId(
@@ -2097,8 +2135,9 @@ extension PDDocument$$Methods on PDDocument {
   void protect(
     jni$_.JObject? policy,
   ) {
+    final _$$selfRef = reference;
     final _$policy = policy?.reference ?? jni$_.jNullReference;
-    _protect(reference.pointer, _id_protect.pointer, _$policy.pointer).check();
+    _protect(_$$selfRef.pointer, _id_protect.pointer, _$policy.pointer).check();
   }
 
   static final _id_get$currentAccessPermission =
@@ -2129,8 +2168,9 @@ extension PDDocument$$Methods on PDDocument {
   /// to verify if the current user is allowed to proceed.
   ///@return the access permissions for the current user on the document.
   jni$_.JObject? get currentAccessPermission {
+    final _$$selfRef = reference;
     return _get$currentAccessPermission(
-            reference.pointer, _id_get$currentAccessPermission.pointer)
+            _$$selfRef.pointer, _id_get$currentAccessPermission.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2158,8 +2198,9 @@ extension PDDocument$$Methods on PDDocument {
   /// Indicates if all security is removed or not when writing the pdf.
   ///@return returns true if all security shall be removed otherwise false
   core$_.bool get isAllSecurityToBeRemoved {
+    final _$$selfRef = reference;
     return _get$isAllSecurityToBeRemoved(
-            reference.pointer, _id_get$isAllSecurityToBeRemoved.pointer)
+            _$$selfRef.pointer, _id_get$isAllSecurityToBeRemoved.pointer)
         .boolean;
   }
 
@@ -2184,7 +2225,8 @@ extension PDDocument$$Methods on PDDocument {
   /// Activates/Deactivates the removal of all security when writing the pdf.
   ///@param removeAllSecurity remove all security if set to true
   set allSecurityToBeRemoved(core$_.bool removeAllSecurity) {
-    _set$allSecurityToBeRemoved(reference.pointer,
+    final _$$selfRef = reference;
+    _set$allSecurityToBeRemoved(_$$selfRef.pointer,
             _id_set$allSecurityToBeRemoved.pointer, removeAllSecurity ? 1 : 0)
         .check();
   }
@@ -2212,7 +2254,8 @@ extension PDDocument$$Methods on PDDocument {
   /// Provides the document ID.
   ///@return the document ID
   jni$_.JLong? get documentId {
-    return _get$documentId(reference.pointer, _id_get$documentId.pointer)
+    final _$$selfRef = reference;
+    return _get$documentId(_$$selfRef.pointer, _id_get$documentId.pointer)
         .object<jni$_.JLong?>();
   }
 
@@ -2237,9 +2280,10 @@ extension PDDocument$$Methods on PDDocument {
   /// Sets the document ID to the given value.
   ///@param docId the new document ID
   set documentId(jni$_.JLong? docId) {
+    final _$$selfRef = reference;
     final _$docId = docId?.reference ?? jni$_.jNullReference;
     _set$documentId(
-            reference.pointer, _id_set$documentId.pointer, _$docId.pointer)
+            _$$selfRef.pointer, _id_set$documentId.pointer, _$docId.pointer)
         .check();
   }
 
@@ -2265,7 +2309,8 @@ extension PDDocument$$Methods on PDDocument {
   /// Returns the PDF specification version this document conforms to.
   ///@return the PDF version (e.g. 1.4f)
   core$_.double get version {
-    return _get$version(reference.pointer, _id_get$version.pointer).float;
+    final _$$selfRef = reference;
+    return _get$version(_$$selfRef.pointer, _id_get$version.pointer).float;
   }
 
   static final _id_set$version = PDDocument._class.instanceMethodId(
@@ -2288,7 +2333,8 @@ extension PDDocument$$Methods on PDDocument {
   /// Sets the PDF specification version for this document.
   ///@param newVersion the new PDF version (e.g. 1.4f)
   set version(core$_.double newVersion) {
-    _set$version(reference.pointer, _id_set$version.pointer, newVersion)
+    final _$$selfRef = reference;
+    _set$version(_$$selfRef.pointer, _id_set$version.pointer, newVersion)
         .check();
   }
 
@@ -2315,7 +2361,8 @@ extension PDDocument$$Methods on PDDocument {
   /// Returns the resource cache associated with this document, or null if there is none.
   ///@return the resource cache or null.
   jni$_.JObject? get resourceCache {
-    return _get$resourceCache(reference.pointer, _id_get$resourceCache.pointer)
+    final _$$selfRef = reference;
+    return _get$resourceCache(_$$selfRef.pointer, _id_get$resourceCache.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2340,8 +2387,9 @@ extension PDDocument$$Methods on PDDocument {
   /// Sets the resource cache associated with this document.
   ///@param resourceCache A resource cache, or null.
   set resourceCache(jni$_.JObject? resourceCache) {
+    final _$$selfRef = reference;
     final _$resourceCache = resourceCache?.reference ?? jni$_.jNullReference;
-    _set$resourceCache(reference.pointer, _id_set$resourceCache.pointer,
+    _set$resourceCache(_$$selfRef.pointer, _id_set$resourceCache.pointer,
             _$resourceCache.pointer)
         .check();
   }

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocumentInformation.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocumentInformation.dart
@@ -90,7 +90,8 @@ extension type PDDocumentInformation._(jni$_.JObject _$this)
   ///
   /// Default Constructor.
   factory PDDocumentInformation() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<PDDocumentInformation>();
   }
 
@@ -117,8 +118,9 @@ extension type PDDocumentInformation._(jni$_.JObject _$this)
   factory PDDocumentInformation.new$1(
     jni$_.JObject? dic,
   ) {
+    final _$$classRef = _class.reference;
     final _$dic = dic?.reference ?? jni$_.jNullReference;
-    return _new$1(_class.reference.pointer, _id_new$1.pointer, _$dic.pointer)
+    return _new$1(_$$classRef.pointer, _id_new$1.pointer, _$dic.pointer)
         .object<PDDocumentInformation>();
   }
 }
@@ -148,7 +150,8 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will get the underlying dictionary that this object wraps.
   ///@return The underlying info dictionary.
   jni$_.JObject? get cOSObject {
-    return _get$cOSObject(reference.pointer, _id_get$cOSObject.pointer)
+    final _$$selfRef = reference;
+    return _get$cOSObject(_$$selfRef.pointer, _id_get$cOSObject.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -183,8 +186,9 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   jni$_.JObject? getPropertyStringValue(
     jni$_.JString? propertyKey,
   ) {
+    final _$$selfRef = reference;
     final _$propertyKey = propertyKey?.reference ?? jni$_.jNullReference;
-    return _getPropertyStringValue(reference.pointer,
+    return _getPropertyStringValue(_$$selfRef.pointer,
             _id_getPropertyStringValue.pointer, _$propertyKey.pointer)
         .object<jni$_.JObject?>();
   }
@@ -212,7 +216,8 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will get the title of the document.  This will return null if no title exists.
   ///@return The title of the document.
   jni$_.JString? get title {
-    return _get$title(reference.pointer, _id_get$title.pointer)
+    final _$$selfRef = reference;
+    return _get$title(_$$selfRef.pointer, _id_get$title.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -237,8 +242,9 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will set the title of the document.
   ///@param title The new title for the document.
   set title(jni$_.JString? title) {
+    final _$$selfRef = reference;
     final _$title = title?.reference ?? jni$_.jNullReference;
-    _set$title(reference.pointer, _id_set$title.pointer, _$title.pointer)
+    _set$title(_$$selfRef.pointer, _id_set$title.pointer, _$title.pointer)
         .check();
   }
 
@@ -265,7 +271,8 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will get the author of the document.  This will return null if no author exists.
   ///@return The author of the document.
   jni$_.JString? get author {
-    return _get$author(reference.pointer, _id_get$author.pointer)
+    final _$$selfRef = reference;
+    return _get$author(_$$selfRef.pointer, _id_get$author.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -290,8 +297,9 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will set the author of the document.
   ///@param author The new author for the document.
   set author(jni$_.JString? author) {
+    final _$$selfRef = reference;
     final _$author = author?.reference ?? jni$_.jNullReference;
-    _set$author(reference.pointer, _id_set$author.pointer, _$author.pointer)
+    _set$author(_$$selfRef.pointer, _id_set$author.pointer, _$author.pointer)
         .check();
   }
 
@@ -318,7 +326,8 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will get the subject of the document.  This will return null if no subject exists.
   ///@return The subject of the document.
   jni$_.JString? get subject {
-    return _get$subject(reference.pointer, _id_get$subject.pointer)
+    final _$$selfRef = reference;
+    return _get$subject(_$$selfRef.pointer, _id_get$subject.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -343,8 +352,9 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will set the subject of the document.
   ///@param subject The new subject for the document.
   set subject(jni$_.JString? subject) {
+    final _$$selfRef = reference;
     final _$subject = subject?.reference ?? jni$_.jNullReference;
-    _set$subject(reference.pointer, _id_set$subject.pointer, _$subject.pointer)
+    _set$subject(_$$selfRef.pointer, _id_set$subject.pointer, _$subject.pointer)
         .check();
   }
 
@@ -371,7 +381,8 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will get the keywords of the document.  This will return null if no keywords exists.
   ///@return The keywords of the document.
   jni$_.JString? get keywords {
-    return _get$keywords(reference.pointer, _id_get$keywords.pointer)
+    final _$$selfRef = reference;
+    return _get$keywords(_$$selfRef.pointer, _id_get$keywords.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -396,9 +407,10 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will set the keywords of the document.
   ///@param keywords The new keywords for the document.
   set keywords(jni$_.JString? keywords) {
+    final _$$selfRef = reference;
     final _$keywords = keywords?.reference ?? jni$_.jNullReference;
     _set$keywords(
-            reference.pointer, _id_set$keywords.pointer, _$keywords.pointer)
+            _$$selfRef.pointer, _id_set$keywords.pointer, _$keywords.pointer)
         .check();
   }
 
@@ -425,7 +437,8 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will get the creator of the document.  This will return null if no creator exists.
   ///@return The creator of the document.
   jni$_.JString? get creator {
-    return _get$creator(reference.pointer, _id_get$creator.pointer)
+    final _$$selfRef = reference;
+    return _get$creator(_$$selfRef.pointer, _id_get$creator.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -450,8 +463,9 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will set the creator of the document.
   ///@param creator The new creator for the document.
   set creator(jni$_.JString? creator) {
+    final _$$selfRef = reference;
     final _$creator = creator?.reference ?? jni$_.jNullReference;
-    _set$creator(reference.pointer, _id_set$creator.pointer, _$creator.pointer)
+    _set$creator(_$$selfRef.pointer, _id_set$creator.pointer, _$creator.pointer)
         .check();
   }
 
@@ -478,7 +492,8 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will get the producer of the document.  This will return null if no producer exists.
   ///@return The producer of the document.
   jni$_.JString? get producer {
-    return _get$producer(reference.pointer, _id_get$producer.pointer)
+    final _$$selfRef = reference;
+    return _get$producer(_$$selfRef.pointer, _id_get$producer.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -503,9 +518,10 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will set the producer of the document.
   ///@param producer The new producer for the document.
   set producer(jni$_.JString? producer) {
+    final _$$selfRef = reference;
     final _$producer = producer?.reference ?? jni$_.jNullReference;
     _set$producer(
-            reference.pointer, _id_set$producer.pointer, _$producer.pointer)
+            _$$selfRef.pointer, _id_set$producer.pointer, _$producer.pointer)
         .check();
   }
 
@@ -533,7 +549,8 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will get the creation date of the document.  This will return null if no creation date exists.
   ///@return The creation date of the document.
   jni$_.JObject? get creationDate {
-    return _get$creationDate(reference.pointer, _id_get$creationDate.pointer)
+    final _$$selfRef = reference;
+    return _get$creationDate(_$$selfRef.pointer, _id_get$creationDate.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -559,9 +576,10 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will set the creation date of the document.
   ///@param date The new creation date for the document.
   set creationDate(jni$_.JObject? date) {
+    final _$$selfRef = reference;
     final _$date = date?.reference ?? jni$_.jNullReference;
     _set$creationDate(
-            reference.pointer, _id_set$creationDate.pointer, _$date.pointer)
+            _$$selfRef.pointer, _id_set$creationDate.pointer, _$date.pointer)
         .check();
   }
 
@@ -589,8 +607,9 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will get the modification date of the document.  This will return null if no modification date exists.
   ///@return The modification date of the document.
   jni$_.JObject? get modificationDate {
+    final _$$selfRef = reference;
     return _get$modificationDate(
-            reference.pointer, _id_get$modificationDate.pointer)
+            _$$selfRef.pointer, _id_get$modificationDate.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -616,9 +635,10 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will set the modification date of the document.
   ///@param date The new modification date for the document.
   set modificationDate(jni$_.JObject? date) {
+    final _$$selfRef = reference;
     final _$date = date?.reference ?? jni$_.jNullReference;
-    _set$modificationDate(
-            reference.pointer, _id_set$modificationDate.pointer, _$date.pointer)
+    _set$modificationDate(_$$selfRef.pointer, _id_set$modificationDate.pointer,
+            _$date.pointer)
         .check();
   }
 
@@ -646,7 +666,8 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   /// This will return null if one is not found.
   ///@return The trapped value for the document.
   jni$_.JString? get trapped {
-    return _get$trapped(reference.pointer, _id_get$trapped.pointer)
+    final _$$selfRef = reference;
+    return _get$trapped(_$$selfRef.pointer, _id_get$trapped.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -675,7 +696,8 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   ///@return all metadata key strings.
   ///@since Apache PDFBox 1.3.0
   jni$_.JSet<jni$_.JString?>? get metadataKeys {
-    return _get$metadataKeys(reference.pointer, _id_get$metadataKeys.pointer)
+    final _$$selfRef = reference;
+    return _get$metadataKeys(_$$selfRef.pointer, _id_get$metadataKeys.pointer)
         .object<jni$_.JSet<jni$_.JString?>?>();
   }
 
@@ -706,8 +728,9 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   jni$_.JString? getCustomMetadataValue(
     jni$_.JString? fieldName,
   ) {
+    final _$$selfRef = reference;
     final _$fieldName = fieldName?.reference ?? jni$_.jNullReference;
-    return _getCustomMetadataValue(reference.pointer,
+    return _getCustomMetadataValue(_$$selfRef.pointer,
             _id_getCustomMetadataValue.pointer, _$fieldName.pointer)
         .object<jni$_.JString?>();
   }
@@ -744,10 +767,11 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
     jni$_.JString? fieldName,
     jni$_.JString? fieldValue,
   ) {
+    final _$$selfRef = reference;
     final _$fieldName = fieldName?.reference ?? jni$_.jNullReference;
     final _$fieldValue = fieldValue?.reference ?? jni$_.jNullReference;
     _setCustomMetadataValue(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_setCustomMetadataValue.pointer,
             _$fieldName.pointer,
             _$fieldValue.pointer)
@@ -777,8 +801,9 @@ extension PDDocumentInformation$$Methods on PDDocumentInformation {
   ///@param value The new trapped value for the document.
   ///@throws IllegalArgumentException if the parameter is invalid.
   set trapped(jni$_.JString? value) {
+    final _$$selfRef = reference;
     final _$value = value?.reference ?? jni$_.jNullReference;
-    _set$trapped(reference.pointer, _id_set$trapped.pointer, _$value.pointer)
+    _set$trapped(_$$selfRef.pointer, _id_set$trapped.pointer, _$value.pointer)
         .check();
   }
 }

--- a/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/text/PDFTextStripper.dart
+++ b/pkgs/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/text/PDFTextStripper.dart
@@ -94,7 +94,8 @@ extension type PDFTextStripper._(jni$_.JObject _$this)
   /// Instantiate a new PDFTextStripper object.
   ///@throws IOException If there is an error loading the properties.
   factory PDFTextStripper() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<PDFTextStripper>();
   }
 }
@@ -132,8 +133,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   jni$_.JString? getText(
     pddocument$_.PDDocument? doc,
   ) {
+    final _$$selfRef = reference;
     final _$doc = doc?.reference ?? jni$_.jNullReference;
-    return _getText(reference.pointer, _id_getText.pointer, _$doc.pointer)
+    return _getText(_$$selfRef.pointer, _id_getText.pointer, _$doc.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -169,9 +171,10 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
     pddocument$_.PDDocument? doc,
     jni$_.JObject? outputStream,
   ) {
+    final _$$selfRef = reference;
     final _$doc = doc?.reference ?? jni$_.jNullReference;
     final _$outputStream = outputStream?.reference ?? jni$_.jNullReference;
-    _writeText(reference.pointer, _id_writeText.pointer, _$doc.pointer,
+    _writeText(_$$selfRef.pointer, _id_writeText.pointer, _$doc.pointer,
             _$outputStream.pointer)
         .check();
   }
@@ -200,8 +203,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   void processPage(
     jni$_.JObject? page,
   ) {
+    final _$$selfRef = reference;
     final _$page = page?.reference ?? jni$_.jNullReference;
-    _processPage(reference.pointer, _id_processPage.pointer, _$page.pointer)
+    _processPage(_$$selfRef.pointer, _id_processPage.pointer, _$page.pointer)
         .check();
   }
 
@@ -229,7 +233,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// be extracted. The default value is 1.
   ///@return Value of property startPage.
   core$_.int get startPage {
-    return _get$startPage(reference.pointer, _id_get$startPage.pointer).integer;
+    final _$$selfRef = reference;
+    return _get$startPage(_$$selfRef.pointer, _id_get$startPage.pointer)
+        .integer;
   }
 
   static final _id_set$startPage = PDFTextStripper._class.instanceMethodId(
@@ -252,7 +258,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// This will set the first page to be extracted by this class.
   ///@param startPageValue New value of 1-based startPage property.
   set startPage(core$_.int startPageValue) {
-    _set$startPage(reference.pointer, _id_set$startPage.pointer, startPageValue)
+    final _$$selfRef = reference;
+    _set$startPage(
+            _$$selfRef.pointer, _id_set$startPage.pointer, startPageValue)
         .check();
   }
 
@@ -280,7 +288,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Integer.MAX_VALUE such that all pages of the pdf will be extracted.
   ///@return Value of property endPage.
   core$_.int get endPage {
-    return _get$endPage(reference.pointer, _id_get$endPage.pointer).integer;
+    final _$$selfRef = reference;
+    return _get$endPage(_$$selfRef.pointer, _id_get$endPage.pointer).integer;
   }
 
   static final _id_set$endPage = PDFTextStripper._class.instanceMethodId(
@@ -303,7 +312,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// This will set the last page to be extracted by this class.
   ///@param endPageValue New value of 1-based endPage property.
   set endPage(core$_.int endPageValue) {
-    _set$endPage(reference.pointer, _id_set$endPage.pointer, endPageValue)
+    final _$$selfRef = reference;
+    _set$endPage(_$$selfRef.pointer, _id_set$endPage.pointer, endPageValue)
         .check();
   }
 
@@ -329,8 +339,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// preference is not set explicitly using this method.
   ///@param separator The desired line separator string.
   set lineSeparator(jni$_.JString? separator) {
+    final _$$selfRef = reference;
     final _$separator = separator?.reference ?? jni$_.jNullReference;
-    _set$lineSeparator(reference.pointer, _id_set$lineSeparator.pointer,
+    _set$lineSeparator(_$$selfRef.pointer, _id_set$lineSeparator.pointer,
             _$separator.pointer)
         .check();
   }
@@ -358,7 +369,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// This will get the line separator.
   ///@return The desired line separator string.
   jni$_.JString? get lineSeparator {
-    return _get$lineSeparator(reference.pointer, _id_get$lineSeparator.pointer)
+    final _$$selfRef = reference;
+    return _get$lineSeparator(_$$selfRef.pointer, _id_get$lineSeparator.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -385,7 +397,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// This will get the word separator.
   ///@return The desired word separator string.
   jni$_.JString? get wordSeparator {
-    return _get$wordSeparator(reference.pointer, _id_get$wordSeparator.pointer)
+    final _$$selfRef = reference;
+    return _get$wordSeparator(_$$selfRef.pointer, _id_get$wordSeparator.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -413,8 +426,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// the empty string.
   ///@param separator The desired page separator string.
   set wordSeparator(jni$_.JString? separator) {
+    final _$$selfRef = reference;
     final _$separator = separator?.reference ?? jni$_.jNullReference;
-    _set$wordSeparator(reference.pointer, _id_set$wordSeparator.pointer,
+    _set$wordSeparator(_$$selfRef.pointer, _id_set$wordSeparator.pointer,
             _$separator.pointer)
         .check();
   }
@@ -442,8 +456,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   ///
   /// @return Returns the suppressDuplicateOverlappingText.
   core$_.bool get suppressDuplicateOverlappingText {
-    return _get$suppressDuplicateOverlappingText(
-            reference.pointer, _id_get$suppressDuplicateOverlappingText.pointer)
+    final _$$selfRef = reference;
+    return _get$suppressDuplicateOverlappingText(_$$selfRef.pointer,
+            _id_get$suppressDuplicateOverlappingText.pointer)
         .boolean;
   }
 
@@ -471,8 +486,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   ///@param suppressDuplicateOverlappingTextValue The suppressDuplicateOverlappingText to set.
   set suppressDuplicateOverlappingText(
       core$_.bool suppressDuplicateOverlappingTextValue) {
+    final _$$selfRef = reference;
     _set$suppressDuplicateOverlappingText(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_set$suppressDuplicateOverlappingText.pointer,
             suppressDuplicateOverlappingTextValue ? 1 : 0)
         .check();
@@ -501,8 +517,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// This will tell if the text stripper should separate by beads.
   ///@return If the text will be grouped by beads.
   core$_.bool get separateByBeads {
+    final _$$selfRef = reference;
     return _get$separateByBeads(
-            reference.pointer, _id_get$separateByBeads.pointer)
+            _$$selfRef.pointer, _id_get$separateByBeads.pointer)
         .boolean;
   }
 
@@ -527,8 +544,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Set if the text stripper should group the text output by a list of beads. The default value is true!
   ///@param aShouldSeparateByBeads The new grouping of beads.
   set shouldSeparateByBeads(core$_.bool aShouldSeparateByBeads) {
+    final _$$selfRef = reference;
     _set$shouldSeparateByBeads(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_set$shouldSeparateByBeads.pointer,
             aShouldSeparateByBeads ? 1 : 0)
         .check();
@@ -557,7 +575,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Get the bookmark where text extraction should end, inclusive. Default is null.
   ///@return The ending bookmark.
   jni$_.JObject? get endBookmark {
-    return _get$endBookmark(reference.pointer, _id_get$endBookmark.pointer)
+    final _$$selfRef = reference;
+    return _get$endBookmark(_$$selfRef.pointer, _id_get$endBookmark.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -582,8 +601,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Set the bookmark where the text extraction should stop.
   ///@param aEndBookmark The ending bookmark.
   set endBookmark(jni$_.JObject? aEndBookmark) {
+    final _$$selfRef = reference;
     final _$aEndBookmark = aEndBookmark?.reference ?? jni$_.jNullReference;
-    _set$endBookmark(reference.pointer, _id_set$endBookmark.pointer,
+    _set$endBookmark(_$$selfRef.pointer, _id_set$endBookmark.pointer,
             _$aEndBookmark.pointer)
         .check();
   }
@@ -611,7 +631,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Get the bookmark where text extraction should start, inclusive. Default is null.
   ///@return The starting bookmark.
   jni$_.JObject? get startBookmark {
-    return _get$startBookmark(reference.pointer, _id_get$startBookmark.pointer)
+    final _$$selfRef = reference;
+    return _get$startBookmark(_$$selfRef.pointer, _id_get$startBookmark.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -636,8 +657,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Set the bookmark where text extraction should start, inclusive.
   ///@param aStartBookmark The starting bookmark.
   set startBookmark(jni$_.JObject? aStartBookmark) {
+    final _$$selfRef = reference;
     final _$aStartBookmark = aStartBookmark?.reference ?? jni$_.jNullReference;
-    _set$startBookmark(reference.pointer, _id_set$startBookmark.pointer,
+    _set$startBookmark(_$$selfRef.pointer, _id_set$startBookmark.pointer,
             _$aStartBookmark.pointer)
         .check();
   }
@@ -665,8 +687,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// This will tell if the text stripper should add some more text formatting.
   ///@return true if some more text formatting will be added
   core$_.bool get addMoreFormatting {
+    final _$$selfRef = reference;
     return _get$addMoreFormatting(
-            reference.pointer, _id_get$addMoreFormatting.pointer)
+            _$$selfRef.pointer, _id_get$addMoreFormatting.pointer)
         .boolean;
   }
 
@@ -691,8 +714,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// There will some additional text formatting be added if addMoreFormatting is set to true. Default is false.
   ///@param newAddMoreFormatting Tell PDFBox to add some more text formatting
   set addMoreFormatting(core$_.bool newAddMoreFormatting) {
-    _set$addMoreFormatting(reference.pointer, _id_set$addMoreFormatting.pointer,
-            newAddMoreFormatting ? 1 : 0)
+    final _$$selfRef = reference;
+    _set$addMoreFormatting(_$$selfRef.pointer,
+            _id_set$addMoreFormatting.pointer, newAddMoreFormatting ? 1 : 0)
         .check();
   }
 
@@ -718,8 +742,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// This will tell if the text stripper should sort the text tokens before writing to the stream.
   ///@return true If the text tokens will be sorted before being written.
   core$_.bool get sortByPosition {
+    final _$$selfRef = reference;
     return _get$sortByPosition(
-            reference.pointer, _id_get$sortByPosition.pointer)
+            _$$selfRef.pointer, _id_get$sortByPosition.pointer)
         .boolean;
   }
 
@@ -749,7 +774,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// the text tokens before processing them due to performance reasons.
   ///@param newSortByPosition Tell PDFBox to sort the text positions.
   set sortByPosition(core$_.bool newSortByPosition) {
-    _set$sortByPosition(reference.pointer, _id_set$sortByPosition.pointer,
+    final _$$selfRef = reference;
+    _set$sortByPosition(_$$selfRef.pointer, _id_set$sortByPosition.pointer,
             newSortByPosition ? 1 : 0)
         .check();
   }
@@ -778,8 +804,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// added. Note that the default value for this has been determined from trial and error.
   ///@return The current tolerance / scaling factor
   core$_.double get spacingTolerance {
+    final _$$selfRef = reference;
     return _get$spacingTolerance(
-            reference.pointer, _id_get$spacingTolerance.pointer)
+            _$$selfRef.pointer, _id_get$spacingTolerance.pointer)
         .float;
   }
 
@@ -806,7 +833,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// the number of spaces added.
   ///@param spacingToleranceValue tolerance / scaling factor to use
   set spacingTolerance(core$_.double spacingToleranceValue) {
-    _set$spacingTolerance(reference.pointer, _id_set$spacingTolerance.pointer,
+    final _$$selfRef = reference;
+    _set$spacingTolerance(_$$selfRef.pointer, _id_set$spacingTolerance.pointer,
             spacingToleranceValue)
         .check();
   }
@@ -835,8 +863,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// be added. Note that the default value for this has been determined from trial and error.
   ///@return The current tolerance / scaling factor
   core$_.double get averageCharTolerance {
+    final _$$selfRef = reference;
     return _get$averageCharTolerance(
-            reference.pointer, _id_get$averageCharTolerance.pointer)
+            _$$selfRef.pointer, _id_get$averageCharTolerance.pointer)
         .float;
   }
 
@@ -863,7 +892,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// the number of spaces added.
   ///@param averageCharToleranceValue average tolerance / scaling factor to use
   set averageCharTolerance(core$_.double averageCharToleranceValue) {
-    _set$averageCharTolerance(reference.pointer,
+    final _$$selfRef = reference;
+    _set$averageCharTolerance(_$$selfRef.pointer,
             _id_set$averageCharTolerance.pointer, averageCharToleranceValue)
         .check();
   }
@@ -892,8 +922,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// indented from the previous line start beyond which the current line start is considered to be a paragraph start.
   ///@return the number of whitespace character widths to use when detecting paragraph indents.
   core$_.double get indentThreshold {
+    final _$$selfRef = reference;
     return _get$indentThreshold(
-            reference.pointer, _id_get$indentThreshold.pointer)
+            _$$selfRef.pointer, _id_get$indentThreshold.pointer)
         .float;
   }
 
@@ -920,7 +951,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// The default value is 2.0.
   ///@param indentThresholdValue the number of whitespace character widths to use when detecting paragraph indents.
   set indentThreshold(core$_.double indentThresholdValue) {
-    _set$indentThreshold(reference.pointer, _id_set$indentThreshold.pointer,
+    final _$$selfRef = reference;
+    _set$indentThreshold(_$$selfRef.pointer, _id_set$indentThreshold.pointer,
             indentThresholdValue)
         .check();
   }
@@ -948,7 +980,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// start is considered to be a paragraph start.
   ///@return the character height multiple for max allowed whitespace between lines in the same paragraph.
   core$_.double get dropThreshold {
-    return _get$dropThreshold(reference.pointer, _id_get$dropThreshold.pointer)
+    final _$$selfRef = reference;
+    return _get$dropThreshold(_$$selfRef.pointer, _id_get$dropThreshold.pointer)
         .float;
   }
 
@@ -974,7 +1007,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   ///@param dropThresholdValue the character height multiple for max allowed whitespace between lines in the same
   /// paragraph.
   set dropThreshold(core$_.double dropThresholdValue) {
-    _set$dropThreshold(reference.pointer, _id_set$dropThreshold.pointer,
+    final _$$selfRef = reference;
+    _set$dropThreshold(_$$selfRef.pointer, _id_set$dropThreshold.pointer,
             dropThresholdValue)
         .check();
   }
@@ -1002,8 +1036,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Returns the string which will be used at the beginning of a paragraph.
   ///@return the paragraph start string
   jni$_.JString? get paragraphStart {
+    final _$$selfRef = reference;
     return _get$paragraphStart(
-            reference.pointer, _id_get$paragraphStart.pointer)
+            _$$selfRef.pointer, _id_get$paragraphStart.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -1028,9 +1063,10 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Sets the string which will be used at the beginning of a paragraph.
   ///@param s the paragraph start string
   set paragraphStart(jni$_.JString? s) {
+    final _$$selfRef = reference;
     final _$s = s?.reference ?? jni$_.jNullReference;
     _set$paragraphStart(
-            reference.pointer, _id_set$paragraphStart.pointer, _$s.pointer)
+            _$$selfRef.pointer, _id_set$paragraphStart.pointer, _$s.pointer)
         .check();
   }
 
@@ -1057,7 +1093,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Returns the string which will be used at the end of a paragraph.
   ///@return the paragraph end string
   jni$_.JString? get paragraphEnd {
-    return _get$paragraphEnd(reference.pointer, _id_get$paragraphEnd.pointer)
+    final _$$selfRef = reference;
+    return _get$paragraphEnd(_$$selfRef.pointer, _id_get$paragraphEnd.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -1082,9 +1119,10 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Sets the string which will be used at the end of a paragraph.
   ///@param s the paragraph end string
   set paragraphEnd(jni$_.JString? s) {
+    final _$$selfRef = reference;
     final _$s = s?.reference ?? jni$_.jNullReference;
     _set$paragraphEnd(
-            reference.pointer, _id_set$paragraphEnd.pointer, _$s.pointer)
+            _$$selfRef.pointer, _id_set$paragraphEnd.pointer, _$s.pointer)
         .check();
   }
 
@@ -1111,7 +1149,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Returns the string which will be used at the beginning of a page.
   ///@return the page start string
   jni$_.JString? get pageStart {
-    return _get$pageStart(reference.pointer, _id_get$pageStart.pointer)
+    final _$$selfRef = reference;
+    return _get$pageStart(_$$selfRef.pointer, _id_get$pageStart.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -1136,8 +1175,9 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Sets the string which will be used at the beginning of a page.
   ///@param pageStartValue the page start string
   set pageStart(jni$_.JString? pageStartValue) {
+    final _$$selfRef = reference;
     final _$pageStartValue = pageStartValue?.reference ?? jni$_.jNullReference;
-    _set$pageStart(reference.pointer, _id_set$pageStart.pointer,
+    _set$pageStart(_$$selfRef.pointer, _id_set$pageStart.pointer,
             _$pageStartValue.pointer)
         .check();
   }
@@ -1165,7 +1205,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Returns the string which will be used at the end of a page.
   ///@return the page end string
   jni$_.JString? get pageEnd {
-    return _get$pageEnd(reference.pointer, _id_get$pageEnd.pointer)
+    final _$$selfRef = reference;
+    return _get$pageEnd(_$$selfRef.pointer, _id_get$pageEnd.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -1190,9 +1231,10 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Sets the string which will be used at the end of a page.
   ///@param pageEndValue the page end string
   set pageEnd(jni$_.JString? pageEndValue) {
+    final _$$selfRef = reference;
     final _$pageEndValue = pageEndValue?.reference ?? jni$_.jNullReference;
     _set$pageEnd(
-            reference.pointer, _id_set$pageEnd.pointer, _$pageEndValue.pointer)
+            _$$selfRef.pointer, _id_set$pageEnd.pointer, _$pageEndValue.pointer)
         .check();
   }
 
@@ -1219,7 +1261,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Returns the string which will be used at the beginning of an article.
   ///@return the article start string
   jni$_.JString? get articleStart {
-    return _get$articleStart(reference.pointer, _id_get$articleStart.pointer)
+    final _$$selfRef = reference;
+    return _get$articleStart(_$$selfRef.pointer, _id_get$articleStart.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -1244,9 +1287,10 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Sets the string which will be used at the beginning of an article.
   ///@param articleStartValue the article start string
   set articleStart(jni$_.JString? articleStartValue) {
+    final _$$selfRef = reference;
     final _$articleStartValue =
         articleStartValue?.reference ?? jni$_.jNullReference;
-    _set$articleStart(reference.pointer, _id_set$articleStart.pointer,
+    _set$articleStart(_$$selfRef.pointer, _id_set$articleStart.pointer,
             _$articleStartValue.pointer)
         .check();
   }
@@ -1274,7 +1318,8 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Returns the string which will be used at the end of an article.
   ///@return the article end string
   jni$_.JString? get articleEnd {
-    return _get$articleEnd(reference.pointer, _id_get$articleEnd.pointer)
+    final _$$selfRef = reference;
+    return _get$articleEnd(_$$selfRef.pointer, _id_get$articleEnd.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -1299,9 +1344,10 @@ extension PDFTextStripper$$Methods on PDFTextStripper {
   /// Sets the string which will be used at the end of an article.
   ///@param articleEndValue the article end string
   set articleEnd(jni$_.JString? articleEndValue) {
+    final _$$selfRef = reference;
     final _$articleEndValue =
         articleEndValue?.reference ?? jni$_.jNullReference;
-    _set$articleEnd(reference.pointer, _id_set$articleEnd.pointer,
+    _set$articleEnd(_$$selfRef.pointer, _id_set$articleEnd.pointer,
             _$articleEndValue.pointer)
         .check();
   }

--- a/pkgs/jnigen/lib/src/bindings/dart_generator.dart
+++ b/pkgs/jnigen/lib/src/bindings/dart_generator.dart
@@ -53,6 +53,10 @@ const _typeParamPrefix = '\$';
 /// Used for Dart-only bindings.
 const _self = 'this';
 
+// Local variable names for references.
+const _classRefVar = r'_$$classRef';
+const _selfRefVar = r'_$$selfRef';
+
 // Docs.
 const _releaseInstruction =
     '  /// The returned object must be released after use, '
@@ -1159,7 +1163,7 @@ ${modifier}final _$idName = $_protectedExtension
   String constructor(Method node) {
     final idName = _idName(node);
     final params = [
-      '$classRef.reference.pointer',
+      '$_classRefVar.pointer',
       '_id_$idName.pointer',
       ...node.params.accept(const _ParamCall()),
     ].join(', ');
@@ -1174,7 +1178,7 @@ ${modifier}final _$idName = $_protectedExtension
   String methodCall(Method node) {
     final idName = _idName(node);
     final params = [
-      node.isStatic ? '$classRef.reference.pointer' : 'reference.pointer',
+      node.isStatic ? '$_classRefVar.pointer' : '$_selfRefVar.pointer',
       '_id_$idName.pointer',
       ...node.params.accept(const _ParamCall()),
     ].join(', ');
@@ -1205,10 +1209,18 @@ ${modifier}final _$idName = $_protectedExtension
 
     // This is needed to keep the references alive in the scope while waiting
     // for the FFI call.
-    final localReferences = node.params
+    final paramsForReferences = node.isSuspendFun
+        ? node.params.sublist(0, node.params.length - 1)
+        : node.params;
+    final localReferences = paramsForReferences
         .accept(const _ParamReference())
         .where((ref) => ref.isNotEmpty)
         .toList();
+    if (node.isStatic || node.isConstructor) {
+      localReferences.insert(0, 'final $_classRefVar = $classRef.reference;');
+    } else {
+      localReferences.insert(0, 'final $_selfRefVar = reference;');
+    }
     if (node.isConstructor && node.typeParams.isEmpty) {
       final className = node.classDecl.finalName;
       final name = node.finalName;
@@ -1245,7 +1257,6 @@ ${modifier}final _$idName = $_protectedExtension
     ].accept(const _TypeParamDef()).join(', ').encloseIfNotEmpty('<', '>');
     if (node.isSuspendFun) {
       defArgs.removeLast();
-      localReferences.removeLast();
     }
     final params = defArgs.delimited(', ');
     if (node.methodKind == MethodKind.getter) {

--- a/pkgs/jnigen/lib/src/bindings/dart_generator.dart
+++ b/pkgs/jnigen/lib/src/bindings/dart_generator.dart
@@ -1216,6 +1216,8 @@ ${modifier}final _$idName = $_protectedExtension
         .accept(const _ParamReference())
         .where((ref) => ref.isNotEmpty)
         .toList();
+    // We store object.reference in a local variable to work around a limitation
+    // of Finalizable. See https://dartbug.com/63348 for context.
     if (node.isStatic || node.isConstructor) {
       localReferences.insert(0, 'final $_classRefVar = $classRef.reference;');
     } else {

--- a/pkgs/jnigen/lib/src/bindings/dart_generator.dart
+++ b/pkgs/jnigen/lib/src/bindings/dart_generator.dart
@@ -1656,7 +1656,8 @@ class _InterfaceMethodIf extends Visitor<Method, void> {
       node.params.last.accept(_InterfaceParamCast(resolver, contArg,
           paramIndex: node.params.length - 1));
       s.write('''
-          final \$r = $_jni.KotlinContinuation.fromReference($contArg.reference)
+          final _\$\$contRef = $contArg.reference;
+          final \$r = $_jni.KotlinContinuation.fromReference(_\$\$contRef)
               .$resume($result);
           return $returnValue;
 ''');

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonFactory.dart
@@ -177,7 +177,8 @@ extension type JsonFactory$Feature._(jni$_.JObject _$this)
   /// from: `static public com.fasterxml.jackson.core.JsonFactory$Feature[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<JsonFactory$Feature?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<JsonFactory$Feature?>?>();
   }
 
@@ -202,9 +203,9 @@ extension type JsonFactory$Feature._(jni$_.JObject _$this)
   static JsonFactory$Feature? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<JsonFactory$Feature?>();
   }
 
@@ -231,8 +232,8 @@ extension type JsonFactory$Feature._(jni$_.JObject _$this)
   /// are enabled by default.
   ///@return Bit field of features enabled by default
   static core$_.int collectDefaults() {
-    return _collectDefaults(
-            _class.reference.pointer, _id_collectDefaults.pointer)
+    final _$$classRef = _class.reference;
+    return _collectDefaults(_$$classRef.pointer, _id_collectDefaults.pointer)
         .integer;
   }
 }
@@ -258,7 +259,8 @@ extension JsonFactory$Feature$$Methods on JsonFactory$Feature {
 
   /// from: `public boolean enabledByDefault()`
   core$_.bool enabledByDefault() {
-    return _enabledByDefault(reference.pointer, _id_enabledByDefault.pointer)
+    final _$$selfRef = reference;
+    return _enabledByDefault(_$$selfRef.pointer, _id_enabledByDefault.pointer)
         .boolean;
   }
 
@@ -282,7 +284,8 @@ extension JsonFactory$Feature$$Methods on JsonFactory$Feature {
   core$_.bool enabledIn(
     core$_.int flags,
   ) {
-    return _enabledIn(reference.pointer, _id_enabledIn.pointer, flags).boolean;
+    final _$$selfRef = reference;
+    return _enabledIn(_$$selfRef.pointer, _id_enabledIn.pointer, flags).boolean;
   }
 
   static final _id_get$mask = JsonFactory$Feature._class.instanceMethodId(
@@ -304,7 +307,8 @@ extension JsonFactory$Feature$$Methods on JsonFactory$Feature {
 
   /// from: `public int getMask()`
   core$_.int get mask {
-    return _get$mask(reference.pointer, _id_get$mask.pointer).integer;
+    final _$$selfRef = reference;
+    return _get$mask(_$$selfRef.pointer, _id_get$mask.pointer).integer;
   }
 }
 
@@ -400,8 +404,8 @@ extension type JsonFactory._(jni$_.JObject _$this) implements jni$_.JObject {
   /// and this reuse only works within context of a single
   /// factory instance.
   factory JsonFactory() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<JsonFactory>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<JsonFactory>();
   }
 
   static final _id_new$1 = _class.constructorId(
@@ -424,8 +428,9 @@ extension type JsonFactory._(jni$_.JObject _$this) implements jni$_.JObject {
   factory JsonFactory.new$1(
     jni$_.JObject? oc,
   ) {
+    final _$$classRef = _class.reference;
     final _$oc = oc?.reference ?? jni$_.jNullReference;
-    return _new$1(_class.reference.pointer, _id_new$1.pointer, _$oc.pointer)
+    return _new$1(_$$classRef.pointer, _id_new$1.pointer, _$oc.pointer)
         .object<JsonFactory>();
   }
 
@@ -453,8 +458,9 @@ extension type JsonFactory._(jni$_.JObject _$this) implements jni$_.JObject {
   factory JsonFactory.new$2(
     jni$_.JObject? b,
   ) {
+    final _$$classRef = _class.reference;
     final _$b = b?.reference ?? jni$_.jNullReference;
-    return _new$2(_class.reference.pointer, _id_new$2.pointer, _$b.pointer)
+    return _new$2(_$$classRef.pointer, _id_new$2.pointer, _$b.pointer)
         .object<JsonFactory>();
   }
 
@@ -487,7 +493,8 @@ extension type JsonFactory._(jni$_.JObject _$this) implements jni$_.JObject {
   /// will be fixed in 3.0.
   ///@return Builder instance to use
   static jni$_.JObject? builder() {
-    return _builder(_class.reference.pointer, _id_builder.pointer)
+    final _$$classRef = _class.reference;
+    return _builder(_$$classRef.pointer, _id_builder.pointer)
         .object<jni$_.JObject?>();
   }
 }
@@ -518,7 +525,8 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@return Builder instance to use
   ///@since 2.10
   jni$_.JObject? rebuild() {
-    return _rebuild(reference.pointer, _id_rebuild.pointer)
+    final _$$selfRef = reference;
+    return _rebuild(_$$selfRef.pointer, _id_rebuild.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -555,7 +563,8 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@return Copy of this factory instance
   ///@since 2.1
   JsonFactory? copy() {
-    return _copy(reference.pointer, _id_copy.pointer).object<JsonFactory?>();
+    final _$$selfRef = reference;
+    return _copy(_$$selfRef.pointer, _id_copy.pointer).object<JsonFactory?>();
   }
 
   static final _id_requiresPropertyOrdering =
@@ -593,8 +602,9 @@ extension JsonFactory$$Methods on JsonFactory {
   ///   requires Object properties to be ordered.
   ///@since 2.3
   core$_.bool requiresPropertyOrdering() {
+    final _$$selfRef = reference;
     return _requiresPropertyOrdering(
-            reference.pointer, _id_requiresPropertyOrdering.pointer)
+            _$$selfRef.pointer, _id_requiresPropertyOrdering.pointer)
         .boolean;
   }
 
@@ -630,8 +640,9 @@ extension JsonFactory$$Methods on JsonFactory {
   ///    supports native binary content
   ///@since 2.3
   core$_.bool canHandleBinaryNatively() {
+    final _$$selfRef = reference;
     return _canHandleBinaryNatively(
-            reference.pointer, _id_canHandleBinaryNatively.pointer)
+            _$$selfRef.pointer, _id_canHandleBinaryNatively.pointer)
         .boolean;
   }
 
@@ -666,7 +677,8 @@ extension JsonFactory$$Methods on JsonFactory {
   ///   accessed using parser method {@code getTextCharacters()}.
   ///@since 2.4
   core$_.bool canUseCharArrays() {
-    return _canUseCharArrays(reference.pointer, _id_canUseCharArrays.pointer)
+    final _$$selfRef = reference;
+    return _canUseCharArrays(_$$selfRef.pointer, _id_canUseCharArrays.pointer)
         .boolean;
   }
 
@@ -697,7 +709,9 @@ extension JsonFactory$$Methods on JsonFactory {
   ///    not (and consequently whether {@code createNonBlockingXxx()} method(s) work)
   ///@since 2.9
   core$_.bool canParseAsync() {
-    return _canParseAsync(reference.pointer, _id_canParseAsync.pointer).boolean;
+    final _$$selfRef = reference;
+    return _canParseAsync(_$$selfRef.pointer, _id_canParseAsync.pointer)
+        .boolean;
   }
 
   static final _id_get$formatReadFeatureType =
@@ -721,8 +735,9 @@ extension JsonFactory$$Methods on JsonFactory {
   /// from: `public java.lang.Class<? extends com.fasterxml.jackson.core.FormatFeature> getFormatReadFeatureType()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? get formatReadFeatureType {
+    final _$$selfRef = reference;
     return _get$formatReadFeatureType(
-            reference.pointer, _id_get$formatReadFeatureType.pointer)
+            _$$selfRef.pointer, _id_get$formatReadFeatureType.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -748,8 +763,9 @@ extension JsonFactory$$Methods on JsonFactory {
   /// from: `public java.lang.Class<? extends com.fasterxml.jackson.core.FormatFeature> getFormatWriteFeatureType()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? get formatWriteFeatureType {
+    final _$$selfRef = reference;
     return _get$formatWriteFeatureType(
-            reference.pointer, _id_get$formatWriteFeatureType.pointer)
+            _$$selfRef.pointer, _id_get$formatWriteFeatureType.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -783,9 +799,10 @@ extension JsonFactory$$Methods on JsonFactory {
   core$_.bool canUseSchema(
     jni$_.JObject? schema,
   ) {
+    final _$$selfRef = reference;
     final _$schema = schema?.reference ?? jni$_.jNullReference;
     return _canUseSchema(
-            reference.pointer, _id_canUseSchema.pointer, _$schema.pointer)
+            _$$selfRef.pointer, _id_canUseSchema.pointer, _$schema.pointer)
         .boolean;
   }
 
@@ -816,7 +833,8 @@ extension JsonFactory$$Methods on JsonFactory {
   /// implementation will return null for all sub-classes
   ///@return Name of the format handled by parsers, generators this factory creates
   jni$_.JString? get formatName {
-    return _get$formatName(reference.pointer, _id_get$formatName.pointer)
+    final _$$selfRef = reference;
+    return _get$formatName(_$$selfRef.pointer, _id_get$formatName.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -841,8 +859,9 @@ extension JsonFactory$$Methods on JsonFactory {
   jni$_.JObject? hasFormat(
     jni$_.JObject? acc,
   ) {
+    final _$$selfRef = reference;
     final _$acc = acc?.reference ?? jni$_.jNullReference;
-    return _hasFormat(reference.pointer, _id_hasFormat.pointer, _$acc.pointer)
+    return _hasFormat(_$$selfRef.pointer, _id_hasFormat.pointer, _$acc.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -875,8 +894,9 @@ extension JsonFactory$$Methods on JsonFactory {
   ///   ObjectCodec is enough
   ///@since 2.1
   core$_.bool requiresCustomCodec() {
+    final _$$selfRef = reference;
     return _requiresCustomCodec(
-            reference.pointer, _id_requiresCustomCodec.pointer)
+            _$$selfRef.pointer, _id_requiresCustomCodec.pointer)
         .boolean;
   }
 
@@ -900,7 +920,8 @@ extension JsonFactory$$Methods on JsonFactory {
   /// from: `public com.fasterxml.jackson.core.Version version()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? version() {
-    return _version(reference.pointer, _id_version.pointer)
+    final _$$selfRef = reference;
+    return _version(_$$selfRef.pointer, _id_version.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -934,8 +955,9 @@ extension JsonFactory$$Methods on JsonFactory {
     JsonFactory$Feature? f,
     core$_.bool state,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _configure(reference.pointer, _id_configure.pointer, _$f.pointer,
+    return _configure(_$$selfRef.pointer, _id_configure.pointer, _$f.pointer,
             state ? 1 : 0)
         .object<JsonFactory?>();
   }
@@ -967,8 +989,9 @@ extension JsonFactory$$Methods on JsonFactory {
   JsonFactory? enable(
     JsonFactory$Feature? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _enable(reference.pointer, _id_enable.pointer, _$f.pointer)
+    return _enable(_$$selfRef.pointer, _id_enable.pointer, _$f.pointer)
         .object<JsonFactory?>();
   }
 
@@ -999,8 +1022,9 @@ extension JsonFactory$$Methods on JsonFactory {
   JsonFactory? disable(
     JsonFactory$Feature? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _disable(reference.pointer, _id_disable.pointer, _$f.pointer)
+    return _disable(_$$selfRef.pointer, _id_disable.pointer, _$f.pointer)
         .object<JsonFactory?>();
   }
 
@@ -1028,8 +1052,9 @@ extension JsonFactory$$Methods on JsonFactory {
   core$_.bool isEnabled(
     JsonFactory$Feature? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _isEnabled(reference.pointer, _id_isEnabled.pointer, _$f.pointer)
+    return _isEnabled(_$$selfRef.pointer, _id_isEnabled.pointer, _$f.pointer)
         .boolean;
   }
 
@@ -1052,8 +1077,9 @@ extension JsonFactory$$Methods on JsonFactory {
 
   /// from: `public final int getParserFeatures()`
   core$_.int get parserFeatures {
+    final _$$selfRef = reference;
     return _get$parserFeatures(
-            reference.pointer, _id_get$parserFeatures.pointer)
+            _$$selfRef.pointer, _id_get$parserFeatures.pointer)
         .integer;
   }
 
@@ -1076,8 +1102,9 @@ extension JsonFactory$$Methods on JsonFactory {
 
   /// from: `public final int getGeneratorFeatures()`
   core$_.int get generatorFeatures {
+    final _$$selfRef = reference;
     return _get$generatorFeatures(
-            reference.pointer, _id_get$generatorFeatures.pointer)
+            _$$selfRef.pointer, _id_get$generatorFeatures.pointer)
         .integer;
   }
 
@@ -1101,8 +1128,9 @@ extension JsonFactory$$Methods on JsonFactory {
 
   /// from: `public int getFormatParserFeatures()`
   core$_.int get formatParserFeatures {
+    final _$$selfRef = reference;
     return _get$formatParserFeatures(
-            reference.pointer, _id_get$formatParserFeatures.pointer)
+            _$$selfRef.pointer, _id_get$formatParserFeatures.pointer)
         .integer;
   }
 
@@ -1127,8 +1155,9 @@ extension JsonFactory$$Methods on JsonFactory {
 
   /// from: `public int getFormatGeneratorFeatures()`
   core$_.int get formatGeneratorFeatures {
+    final _$$selfRef = reference;
     return _get$formatGeneratorFeatures(
-            reference.pointer, _id_get$formatGeneratorFeatures.pointer)
+            _$$selfRef.pointer, _id_get$formatGeneratorFeatures.pointer)
         .integer;
   }
 
@@ -1161,9 +1190,10 @@ extension JsonFactory$$Methods on JsonFactory {
     jsonparser$_.JsonParser$Feature? f,
     core$_.bool state,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _configure$1(reference.pointer, _id_configure$1.pointer, _$f.pointer,
-            state ? 1 : 0)
+    return _configure$1(_$$selfRef.pointer, _id_configure$1.pointer,
+            _$f.pointer, state ? 1 : 0)
         .object<JsonFactory?>();
   }
 
@@ -1193,8 +1223,9 @@ extension JsonFactory$$Methods on JsonFactory {
   JsonFactory? enable$1(
     jsonparser$_.JsonParser$Feature? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _enable$1(reference.pointer, _id_enable$1.pointer, _$f.pointer)
+    return _enable$1(_$$selfRef.pointer, _id_enable$1.pointer, _$f.pointer)
         .object<JsonFactory?>();
   }
 
@@ -1224,8 +1255,9 @@ extension JsonFactory$$Methods on JsonFactory {
   JsonFactory? disable$1(
     jsonparser$_.JsonParser$Feature? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _disable$1(reference.pointer, _id_disable$1.pointer, _$f.pointer)
+    return _disable$1(_$$selfRef.pointer, _id_disable$1.pointer, _$f.pointer)
         .object<JsonFactory?>();
   }
 
@@ -1253,8 +1285,10 @@ extension JsonFactory$$Methods on JsonFactory {
   core$_.bool isEnabled$1(
     jsonparser$_.JsonParser$Feature? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _isEnabled$1(reference.pointer, _id_isEnabled$1.pointer, _$f.pointer)
+    return _isEnabled$1(
+            _$$selfRef.pointer, _id_isEnabled$1.pointer, _$f.pointer)
         .boolean;
   }
 
@@ -1283,8 +1317,10 @@ extension JsonFactory$$Methods on JsonFactory {
   core$_.bool isEnabled$2(
     jni$_.JObject? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _isEnabled$2(reference.pointer, _id_isEnabled$2.pointer, _$f.pointer)
+    return _isEnabled$2(
+            _$$selfRef.pointer, _id_isEnabled$2.pointer, _$f.pointer)
         .boolean;
   }
 
@@ -1312,8 +1348,9 @@ extension JsonFactory$$Methods on JsonFactory {
   /// there is no default decorator).
   ///@return InputDecorator configured, if any
   jni$_.JObject? get inputDecorator {
+    final _$$selfRef = reference;
     return _get$inputDecorator(
-            reference.pointer, _id_get$inputDecorator.pointer)
+            _$$selfRef.pointer, _id_get$inputDecorator.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1343,9 +1380,10 @@ extension JsonFactory$$Methods on JsonFactory {
   JsonFactory? setInputDecorator(
     jni$_.JObject? d,
   ) {
+    final _$$selfRef = reference;
     final _$d = d?.reference ?? jni$_.jNullReference;
     return _setInputDecorator(
-            reference.pointer, _id_setInputDecorator.pointer, _$d.pointer)
+            _$$selfRef.pointer, _id_setInputDecorator.pointer, _$d.pointer)
         .object<JsonFactory?>();
   }
 
@@ -1378,9 +1416,10 @@ extension JsonFactory$$Methods on JsonFactory {
     jni$_.JObject? f,
     core$_.bool state,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _configure$2(reference.pointer, _id_configure$2.pointer, _$f.pointer,
-            state ? 1 : 0)
+    return _configure$2(_$$selfRef.pointer, _id_configure$2.pointer,
+            _$f.pointer, state ? 1 : 0)
         .object<JsonFactory?>();
   }
 
@@ -1410,8 +1449,9 @@ extension JsonFactory$$Methods on JsonFactory {
   JsonFactory? enable$2(
     jni$_.JObject? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _enable$2(reference.pointer, _id_enable$2.pointer, _$f.pointer)
+    return _enable$2(_$$selfRef.pointer, _id_enable$2.pointer, _$f.pointer)
         .object<JsonFactory?>();
   }
 
@@ -1441,8 +1481,9 @@ extension JsonFactory$$Methods on JsonFactory {
   JsonFactory? disable$2(
     jni$_.JObject? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _disable$2(reference.pointer, _id_disable$2.pointer, _$f.pointer)
+    return _disable$2(_$$selfRef.pointer, _id_disable$2.pointer, _$f.pointer)
         .object<JsonFactory?>();
   }
 
@@ -1470,8 +1511,10 @@ extension JsonFactory$$Methods on JsonFactory {
   core$_.bool isEnabled$3(
     jni$_.JObject? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _isEnabled$3(reference.pointer, _id_isEnabled$3.pointer, _$f.pointer)
+    return _isEnabled$3(
+            _$$selfRef.pointer, _id_isEnabled$3.pointer, _$f.pointer)
         .boolean;
   }
 
@@ -1500,8 +1543,10 @@ extension JsonFactory$$Methods on JsonFactory {
   core$_.bool isEnabled$4(
     jni$_.JObject? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _isEnabled$4(reference.pointer, _id_isEnabled$4.pointer, _$f.pointer)
+    return _isEnabled$4(
+            _$$selfRef.pointer, _id_isEnabled$4.pointer, _$f.pointer)
         .boolean;
   }
 
@@ -1529,8 +1574,9 @@ extension JsonFactory$$Methods on JsonFactory {
   /// it creates.
   ///@return Configured {@code CharacterEscapes}, if any; {@code null} if none
   jni$_.JObject? get characterEscapes {
+    final _$$selfRef = reference;
     return _get$characterEscapes(
-            reference.pointer, _id_get$characterEscapes.pointer)
+            _$$selfRef.pointer, _id_get$characterEscapes.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1560,9 +1606,10 @@ extension JsonFactory$$Methods on JsonFactory {
   JsonFactory? setCharacterEscapes(
     jni$_.JObject? esc,
   ) {
+    final _$$selfRef = reference;
     final _$esc = esc?.reference ?? jni$_.jNullReference;
     return _setCharacterEscapes(
-            reference.pointer, _id_setCharacterEscapes.pointer, _$esc.pointer)
+            _$$selfRef.pointer, _id_setCharacterEscapes.pointer, _$esc.pointer)
         .object<JsonFactory?>();
   }
 
@@ -1591,8 +1638,9 @@ extension JsonFactory$$Methods on JsonFactory {
   ///@return OutputDecorator configured for generators factory creates, if any;
   ///    {@code null} if none.
   jni$_.JObject? get outputDecorator {
+    final _$$selfRef = reference;
     return _get$outputDecorator(
-            reference.pointer, _id_get$outputDecorator.pointer)
+            _$$selfRef.pointer, _id_get$outputDecorator.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1622,9 +1670,10 @@ extension JsonFactory$$Methods on JsonFactory {
   JsonFactory? setOutputDecorator(
     jni$_.JObject? d,
   ) {
+    final _$$selfRef = reference;
     final _$d = d?.reference ?? jni$_.jNullReference;
     return _setOutputDecorator(
-            reference.pointer, _id_setOutputDecorator.pointer, _$d.pointer)
+            _$$selfRef.pointer, _id_setOutputDecorator.pointer, _$d.pointer)
         .object<JsonFactory?>();
   }
 
@@ -1655,9 +1704,10 @@ extension JsonFactory$$Methods on JsonFactory {
   JsonFactory? setRootValueSeparator(
     jni$_.JString? sep,
   ) {
+    final _$$selfRef = reference;
     final _$sep = sep?.reference ?? jni$_.jNullReference;
-    return _setRootValueSeparator(
-            reference.pointer, _id_setRootValueSeparator.pointer, _$sep.pointer)
+    return _setRootValueSeparator(_$$selfRef.pointer,
+            _id_setRootValueSeparator.pointer, _$sep.pointer)
         .object<JsonFactory?>();
   }
 
@@ -1683,8 +1733,9 @@ extension JsonFactory$$Methods on JsonFactory {
   ///
   /// @return Root value separator configured, if any
   jni$_.JString? get rootValueSeparator {
+    final _$$selfRef = reference;
     return _get$rootValueSeparator(
-            reference.pointer, _id_get$rootValueSeparator.pointer)
+            _$$selfRef.pointer, _id_get$rootValueSeparator.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -1717,8 +1768,9 @@ extension JsonFactory$$Methods on JsonFactory {
   JsonFactory? setCodec(
     jni$_.JObject? oc,
   ) {
+    final _$$selfRef = reference;
     final _$oc = oc?.reference ?? jni$_.jNullReference;
-    return _setCodec(reference.pointer, _id_setCodec.pointer, _$oc.pointer)
+    return _setCodec(_$$selfRef.pointer, _id_setCodec.pointer, _$oc.pointer)
         .object<JsonFactory?>();
   }
 
@@ -1742,7 +1794,8 @@ extension JsonFactory$$Methods on JsonFactory {
   /// from: `public com.fasterxml.jackson.core.ObjectCodec getCodec()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? get codec {
-    return _get$codec(reference.pointer, _id_get$codec.pointer)
+    final _$$selfRef = reference;
+    return _get$codec(_$$selfRef.pointer, _id_get$codec.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1784,9 +1837,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jsonparser$_.JsonParser? createParser(
     jni$_.JObject? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _createParser(
-            reference.pointer, _id_createParser.pointer, _$f.pointer)
+            _$$selfRef.pointer, _id_createParser.pointer, _$f.pointer)
         .object<jsonparser$_.JsonParser?>();
   }
 
@@ -1826,9 +1880,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jsonparser$_.JsonParser? createParser$1(
     jni$_.JObject? url,
   ) {
+    final _$$selfRef = reference;
     final _$url = url?.reference ?? jni$_.jNullReference;
     return _createParser$1(
-            reference.pointer, _id_createParser$1.pointer, _$url.pointer)
+            _$$selfRef.pointer, _id_createParser$1.pointer, _$url.pointer)
         .object<jsonparser$_.JsonParser?>();
   }
 
@@ -1871,9 +1926,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jsonparser$_.JsonParser? createParser$2(
     jni$_.JObject? in$,
   ) {
+    final _$$selfRef = reference;
     final _$in$ = in$?.reference ?? jni$_.jNullReference;
     return _createParser$2(
-            reference.pointer, _id_createParser$2.pointer, _$in$.pointer)
+            _$$selfRef.pointer, _id_createParser$2.pointer, _$in$.pointer)
         .object<jsonparser$_.JsonParser?>();
   }
 
@@ -1909,9 +1965,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jsonparser$_.JsonParser? createParser$3(
     jni$_.JObject? r,
   ) {
+    final _$$selfRef = reference;
     final _$r = r?.reference ?? jni$_.jNullReference;
     return _createParser$3(
-            reference.pointer, _id_createParser$3.pointer, _$r.pointer)
+            _$$selfRef.pointer, _id_createParser$3.pointer, _$r.pointer)
         .object<jsonparser$_.JsonParser?>();
   }
 
@@ -1940,9 +1997,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jsonparser$_.JsonParser? createParser$4(
     jni$_.JByteArray? data,
   ) {
+    final _$$selfRef = reference;
     final _$data = data?.reference ?? jni$_.jNullReference;
     return _createParser$4(
-            reference.pointer, _id_createParser$4.pointer, _$data.pointer)
+            _$$selfRef.pointer, _id_createParser$4.pointer, _$data.pointer)
         .object<jsonparser$_.JsonParser?>();
   }
 
@@ -1984,8 +2042,9 @@ extension JsonFactory$$Methods on JsonFactory {
     core$_.int offset,
     core$_.int len,
   ) {
+    final _$$selfRef = reference;
     final _$data = data?.reference ?? jni$_.jNullReference;
-    return _createParser$5(reference.pointer, _id_createParser$5.pointer,
+    return _createParser$5(_$$selfRef.pointer, _id_createParser$5.pointer,
             _$data.pointer, offset, len)
         .object<jsonparser$_.JsonParser?>();
   }
@@ -2015,9 +2074,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jsonparser$_.JsonParser? createParser$6(
     jni$_.JString? content,
   ) {
+    final _$$selfRef = reference;
     final _$content = content?.reference ?? jni$_.jNullReference;
     return _createParser$6(
-            reference.pointer, _id_createParser$6.pointer, _$content.pointer)
+            _$$selfRef.pointer, _id_createParser$6.pointer, _$content.pointer)
         .object<jsonparser$_.JsonParser?>();
   }
 
@@ -2046,9 +2106,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jsonparser$_.JsonParser? createParser$7(
     jni$_.JCharArray? content,
   ) {
+    final _$$selfRef = reference;
     final _$content = content?.reference ?? jni$_.jNullReference;
     return _createParser$7(
-            reference.pointer, _id_createParser$7.pointer, _$content.pointer)
+            _$$selfRef.pointer, _id_createParser$7.pointer, _$content.pointer)
         .object<jsonparser$_.JsonParser?>();
   }
 
@@ -2086,8 +2147,9 @@ extension JsonFactory$$Methods on JsonFactory {
     core$_.int offset,
     core$_.int len,
   ) {
+    final _$$selfRef = reference;
     final _$content = content?.reference ?? jni$_.jNullReference;
-    return _createParser$8(reference.pointer, _id_createParser$8.pointer,
+    return _createParser$8(_$$selfRef.pointer, _id_createParser$8.pointer,
             _$content.pointer, offset, len)
         .object<jsonparser$_.JsonParser?>();
   }
@@ -2120,9 +2182,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jsonparser$_.JsonParser? createParser$9(
     jni$_.JObject? in$,
   ) {
+    final _$$selfRef = reference;
     final _$in$ = in$?.reference ?? jni$_.jNullReference;
     return _createParser$9(
-            reference.pointer, _id_createParser$9.pointer, _$in$.pointer)
+            _$$selfRef.pointer, _id_createParser$9.pointer, _$in$.pointer)
         .object<jsonparser$_.JsonParser?>();
   }
 
@@ -2162,8 +2225,9 @@ extension JsonFactory$$Methods on JsonFactory {
   /// at this point.
   ///@since 2.9
   jsonparser$_.JsonParser? createNonBlockingByteArrayParser() {
+    final _$$selfRef = reference;
     return _createNonBlockingByteArrayParser(
-            reference.pointer, _id_createNonBlockingByteArrayParser.pointer)
+            _$$selfRef.pointer, _id_createNonBlockingByteArrayParser.pointer)
         .object<jsonparser$_.JsonParser?>();
   }
 
@@ -2214,9 +2278,10 @@ extension JsonFactory$$Methods on JsonFactory {
     jni$_.JObject? out,
     jni$_.JObject? enc,
   ) {
+    final _$$selfRef = reference;
     final _$out = out?.reference ?? jni$_.jNullReference;
     final _$enc = enc?.reference ?? jni$_.jNullReference;
-    return _createGenerator(reference.pointer, _id_createGenerator.pointer,
+    return _createGenerator(_$$selfRef.pointer, _id_createGenerator.pointer,
             _$out.pointer, _$enc.pointer)
         .object<jni$_.JObject?>();
   }
@@ -2248,9 +2313,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jni$_.JObject? createGenerator$1(
     jni$_.JObject? out,
   ) {
+    final _$$selfRef = reference;
     final _$out = out?.reference ?? jni$_.jNullReference;
     return _createGenerator$1(
-            reference.pointer, _id_createGenerator$1.pointer, _$out.pointer)
+            _$$selfRef.pointer, _id_createGenerator$1.pointer, _$out.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2287,9 +2353,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jni$_.JObject? createGenerator$2(
     jni$_.JObject? w,
   ) {
+    final _$$selfRef = reference;
     final _$w = w?.reference ?? jni$_.jNullReference;
     return _createGenerator$2(
-            reference.pointer, _id_createGenerator$2.pointer, _$w.pointer)
+            _$$selfRef.pointer, _id_createGenerator$2.pointer, _$w.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2334,9 +2401,10 @@ extension JsonFactory$$Methods on JsonFactory {
     jni$_.JObject? f,
     jni$_.JObject? enc,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
     final _$enc = enc?.reference ?? jni$_.jNullReference;
-    return _createGenerator$3(reference.pointer, _id_createGenerator$3.pointer,
+    return _createGenerator$3(_$$selfRef.pointer, _id_createGenerator$3.pointer,
             _$f.pointer, _$enc.pointer)
         .object<jni$_.JObject?>();
   }
@@ -2373,9 +2441,10 @@ extension JsonFactory$$Methods on JsonFactory {
     jni$_.JObject? out,
     jni$_.JObject? enc,
   ) {
+    final _$$selfRef = reference;
     final _$out = out?.reference ?? jni$_.jNullReference;
     final _$enc = enc?.reference ?? jni$_.jNullReference;
-    return _createGenerator$4(reference.pointer, _id_createGenerator$4.pointer,
+    return _createGenerator$4(_$$selfRef.pointer, _id_createGenerator$4.pointer,
             _$out.pointer, _$enc.pointer)
         .object<jni$_.JObject?>();
   }
@@ -2407,9 +2476,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jni$_.JObject? createGenerator$5(
     jni$_.JObject? out,
   ) {
+    final _$$selfRef = reference;
     final _$out = out?.reference ?? jni$_.jNullReference;
     return _createGenerator$5(
-            reference.pointer, _id_createGenerator$5.pointer, _$out.pointer)
+            _$$selfRef.pointer, _id_createGenerator$5.pointer, _$out.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2453,9 +2523,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jsonparser$_.JsonParser? createJsonParser(
     jni$_.JObject? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
     return _createJsonParser(
-            reference.pointer, _id_createJsonParser.pointer, _$f.pointer)
+            _$$selfRef.pointer, _id_createJsonParser.pointer, _$f.pointer)
         .object<jsonparser$_.JsonParser?>();
   }
 
@@ -2498,9 +2569,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jsonparser$_.JsonParser? createJsonParser$1(
     jni$_.JObject? url,
   ) {
+    final _$$selfRef = reference;
     final _$url = url?.reference ?? jni$_.jNullReference;
     return _createJsonParser$1(
-            reference.pointer, _id_createJsonParser$1.pointer, _$url.pointer)
+            _$$selfRef.pointer, _id_createJsonParser$1.pointer, _$url.pointer)
         .object<jsonparser$_.JsonParser?>();
   }
 
@@ -2546,9 +2618,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jsonparser$_.JsonParser? createJsonParser$2(
     jni$_.JObject? in$,
   ) {
+    final _$$selfRef = reference;
     final _$in$ = in$?.reference ?? jni$_.jNullReference;
     return _createJsonParser$2(
-            reference.pointer, _id_createJsonParser$2.pointer, _$in$.pointer)
+            _$$selfRef.pointer, _id_createJsonParser$2.pointer, _$in$.pointer)
         .object<jsonparser$_.JsonParser?>();
   }
 
@@ -2587,9 +2660,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jsonparser$_.JsonParser? createJsonParser$3(
     jni$_.JObject? r,
   ) {
+    final _$$selfRef = reference;
     final _$r = r?.reference ?? jni$_.jNullReference;
     return _createJsonParser$3(
-            reference.pointer, _id_createJsonParser$3.pointer, _$r.pointer)
+            _$$selfRef.pointer, _id_createJsonParser$3.pointer, _$r.pointer)
         .object<jsonparser$_.JsonParser?>();
   }
 
@@ -2621,9 +2695,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jsonparser$_.JsonParser? createJsonParser$4(
     jni$_.JByteArray? data,
   ) {
+    final _$$selfRef = reference;
     final _$data = data?.reference ?? jni$_.jNullReference;
     return _createJsonParser$4(
-            reference.pointer, _id_createJsonParser$4.pointer, _$data.pointer)
+            _$$selfRef.pointer, _id_createJsonParser$4.pointer, _$data.pointer)
         .object<jsonparser$_.JsonParser?>();
   }
 
@@ -2668,8 +2743,9 @@ extension JsonFactory$$Methods on JsonFactory {
     core$_.int offset,
     core$_.int len,
   ) {
+    final _$$selfRef = reference;
     final _$data = data?.reference ?? jni$_.jNullReference;
-    return _createJsonParser$5(reference.pointer,
+    return _createJsonParser$5(_$$selfRef.pointer,
             _id_createJsonParser$5.pointer, _$data.pointer, offset, len)
         .object<jsonparser$_.JsonParser?>();
   }
@@ -2703,8 +2779,9 @@ extension JsonFactory$$Methods on JsonFactory {
   jsonparser$_.JsonParser? createJsonParser$6(
     jni$_.JString? content,
   ) {
+    final _$$selfRef = reference;
     final _$content = content?.reference ?? jni$_.jNullReference;
-    return _createJsonParser$6(reference.pointer,
+    return _createJsonParser$6(_$$selfRef.pointer,
             _id_createJsonParser$6.pointer, _$content.pointer)
         .object<jsonparser$_.JsonParser?>();
   }
@@ -2758,9 +2835,10 @@ extension JsonFactory$$Methods on JsonFactory {
     jni$_.JObject? out,
     jni$_.JObject? enc,
   ) {
+    final _$$selfRef = reference;
     final _$out = out?.reference ?? jni$_.jNullReference;
     final _$enc = enc?.reference ?? jni$_.jNullReference;
-    return _createJsonGenerator(reference.pointer,
+    return _createJsonGenerator(_$$selfRef.pointer,
             _id_createJsonGenerator.pointer, _$out.pointer, _$enc.pointer)
         .object<jni$_.JObject?>();
   }
@@ -2800,9 +2878,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jni$_.JObject? createJsonGenerator$1(
     jni$_.JObject? out,
   ) {
+    final _$$selfRef = reference;
     final _$out = out?.reference ?? jni$_.jNullReference;
-    return _createJsonGenerator$1(
-            reference.pointer, _id_createJsonGenerator$1.pointer, _$out.pointer)
+    return _createJsonGenerator$1(_$$selfRef.pointer,
+            _id_createJsonGenerator$1.pointer, _$out.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2836,9 +2915,10 @@ extension JsonFactory$$Methods on JsonFactory {
   jni$_.JObject? createJsonGenerator$2(
     jni$_.JObject? out,
   ) {
+    final _$$selfRef = reference;
     final _$out = out?.reference ?? jni$_.jNullReference;
-    return _createJsonGenerator$2(
-            reference.pointer, _id_createJsonGenerator$2.pointer, _$out.pointer)
+    return _createJsonGenerator$2(_$$selfRef.pointer,
+            _id_createJsonGenerator$2.pointer, _$out.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2868,8 +2948,9 @@ extension JsonFactory$$Methods on JsonFactory {
   /// Note: only public to give access for {@code ObjectMapper}
   ///@return Buffer recycler instance to use
   jni$_.JObject? $_getBufferRecycler() {
+    final _$$selfRef = reference;
     return _$_getBufferRecycler(
-            reference.pointer, _id_$_getBufferRecycler.pointer)
+            _$$selfRef.pointer, _id_$_getBufferRecycler.pointer)
         .object<jni$_.JObject?>();
   }
 }

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonParser.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonParser.dart
@@ -452,7 +452,8 @@ extension type JsonParser$Feature._(jni$_.JObject _$this)
   /// from: `static public com.fasterxml.jackson.core.JsonParser$Feature[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<JsonParser$Feature?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<JsonParser$Feature?>?>();
   }
 
@@ -477,9 +478,9 @@ extension type JsonParser$Feature._(jni$_.JObject _$this)
   static JsonParser$Feature? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<JsonParser$Feature?>();
   }
 
@@ -506,8 +507,8 @@ extension type JsonParser$Feature._(jni$_.JObject _$this)
   /// are enabled by default.
   ///@return Bit mask of all features that are enabled by default
   static core$_.int collectDefaults() {
-    return _collectDefaults(
-            _class.reference.pointer, _id_collectDefaults.pointer)
+    final _$$classRef = _class.reference;
+    return _collectDefaults(_$$classRef.pointer, _id_collectDefaults.pointer)
         .integer;
   }
 }
@@ -533,7 +534,8 @@ extension JsonParser$Feature$$Methods on JsonParser$Feature {
 
   /// from: `public boolean enabledByDefault()`
   core$_.bool enabledByDefault() {
-    return _enabledByDefault(reference.pointer, _id_enabledByDefault.pointer)
+    final _$$selfRef = reference;
+    return _enabledByDefault(_$$selfRef.pointer, _id_enabledByDefault.pointer)
         .boolean;
   }
 
@@ -557,7 +559,8 @@ extension JsonParser$Feature$$Methods on JsonParser$Feature {
   core$_.bool enabledIn(
     core$_.int flags,
   ) {
-    return _enabledIn(reference.pointer, _id_enabledIn.pointer, flags).boolean;
+    final _$$selfRef = reference;
+    return _enabledIn(_$$selfRef.pointer, _id_enabledIn.pointer, flags).boolean;
   }
 
   static final _id_get$mask = JsonParser$Feature._class.instanceMethodId(
@@ -579,7 +582,8 @@ extension JsonParser$Feature$$Methods on JsonParser$Feature {
 
   /// from: `public int getMask()`
   core$_.int get mask {
-    return _get$mask(reference.pointer, _id_get$mask.pointer).integer;
+    final _$$selfRef = reference;
+    return _get$mask(_$$selfRef.pointer, _id_get$mask.pointer).integer;
   }
 }
 
@@ -688,7 +692,8 @@ extension type JsonParser$NumberType._(jni$_.JObject _$this)
   /// from: `static public com.fasterxml.jackson.core.JsonParser$NumberType[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<JsonParser$NumberType?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<JsonParser$NumberType?>?>();
   }
 
@@ -713,9 +718,9 @@ extension type JsonParser$NumberType._(jni$_.JObject _$this)
   static JsonParser$NumberType? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<JsonParser$NumberType?>();
   }
 }
@@ -770,7 +775,8 @@ extension JsonParser$$Methods on JsonParser {
   /// method (and its variants).
   ///@return Codec assigned to this parser, if any; {@code null} if none
   jni$_.JObject? get codec {
-    return _get$codec(reference.pointer, _id_get$codec.pointer)
+    final _$$selfRef = reference;
+    return _get$codec(_$$selfRef.pointer, _id_get$codec.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -797,8 +803,9 @@ extension JsonParser$$Methods on JsonParser {
   /// method (and its variants).
   ///@param oc Codec to assign, if any; {@code null} if none
   set codec(jni$_.JObject? oc) {
+    final _$$selfRef = reference;
     final _$oc = oc?.reference ?? jni$_.jNullReference;
-    _set$codec(reference.pointer, _id_set$codec.pointer, _$oc.pointer).check();
+    _set$codec(_$$selfRef.pointer, _id_set$codec.pointer, _$oc.pointer).check();
   }
 
   static final _id_get$inputSource = JsonParser._class.instanceMethodId(
@@ -836,7 +843,8 @@ extension JsonParser$$Methods on JsonParser {
   /// "last effort", i.e. only used if no other mechanism is applicable.
   ///@return Input source this parser was configured with
   jni$_.JObject? get inputSource {
-    return _get$inputSource(reference.pointer, _id_get$inputSource.pointer)
+    final _$$selfRef = reference;
+    return _get$inputSource(_$$selfRef.pointer, _id_get$inputSource.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -863,8 +871,9 @@ extension JsonParser$$Methods on JsonParser {
   ///@param payload Payload to pass
   ///@since 2.8
   set requestPayloadOnError(jni$_.JObject? payload) {
+    final _$$selfRef = reference;
     final _$payload = payload?.reference ?? jni$_.jNullReference;
-    _set$requestPayloadOnError(reference.pointer,
+    _set$requestPayloadOnError(_$$selfRef.pointer,
             _id_set$requestPayloadOnError.pointer, _$payload.pointer)
         .check();
   }
@@ -902,10 +911,11 @@ extension JsonParser$$Methods on JsonParser {
     jni$_.JByteArray? payload,
     jni$_.JString? charset,
   ) {
+    final _$$selfRef = reference;
     final _$payload = payload?.reference ?? jni$_.jNullReference;
     final _$charset = charset?.reference ?? jni$_.jNullReference;
     _setRequestPayloadOnError(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_setRequestPayloadOnError.pointer,
             _$payload.pointer,
             _$charset.pointer)
@@ -936,8 +946,9 @@ extension JsonParser$$Methods on JsonParser {
   ///@param payload Payload to pass
   ///@since 2.8
   set requestPayloadOnError$1(jni$_.JString? payload) {
+    final _$$selfRef = reference;
     final _$payload = payload?.reference ?? jni$_.jNullReference;
-    _set$requestPayloadOnError$1(reference.pointer,
+    _set$requestPayloadOnError$1(_$$selfRef.pointer,
             _id_set$requestPayloadOnError$1.pointer, _$payload.pointer)
         .check();
   }
@@ -971,8 +982,9 @@ extension JsonParser$$Methods on JsonParser {
   ///@param schema Schema to use
   ///@throws UnsupportedOperationException if parser does not support schema
   set schema(jni$_.JObject? schema) {
+    final _$$selfRef = reference;
     final _$schema = schema?.reference ?? jni$_.jNullReference;
-    _set$schema(reference.pointer, _id_set$schema.pointer, _$schema.pointer)
+    _set$schema(_$$selfRef.pointer, _id_set$schema.pointer, _$schema.pointer)
         .check();
   }
 
@@ -1001,7 +1013,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@return Schema in use by this parser, if any; {@code null} if none
   ///@since 2.1
   jni$_.JObject? get schema {
-    return _get$schema(reference.pointer, _id_get$schema.pointer)
+    final _$$selfRef = reference;
+    return _get$schema(_$$selfRef.pointer, _id_get$schema.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1030,9 +1043,10 @@ extension JsonParser$$Methods on JsonParser {
   core$_.bool canUseSchema(
     jni$_.JObject? schema,
   ) {
+    final _$$selfRef = reference;
     final _$schema = schema?.reference ?? jni$_.jNullReference;
     return _canUseSchema(
-            reference.pointer, _id_canUseSchema.pointer, _$schema.pointer)
+            _$$selfRef.pointer, _id_canUseSchema.pointer, _$schema.pointer)
         .boolean;
   }
 
@@ -1064,8 +1078,9 @@ extension JsonParser$$Methods on JsonParser {
   ///   ObjectCodec is enough
   ///@since 2.1
   core$_.bool requiresCustomCodec() {
+    final _$$selfRef = reference;
     return _requiresCustomCodec(
-            reference.pointer, _id_requiresCustomCodec.pointer)
+            _$$selfRef.pointer, _id_requiresCustomCodec.pointer)
         .boolean;
   }
 
@@ -1100,7 +1115,9 @@ extension JsonParser$$Methods on JsonParser {
   ///@return True if this is a non-blocking ("asynchronous") parser
   ///@since 2.9
   core$_.bool canParseAsync() {
-    return _canParseAsync(reference.pointer, _id_canParseAsync.pointer).boolean;
+    final _$$selfRef = reference;
+    return _canParseAsync(_$$selfRef.pointer, _id_canParseAsync.pointer)
+        .boolean;
   }
 
   static final _id_get$nonBlockingInputFeeder =
@@ -1131,8 +1148,9 @@ extension JsonParser$$Methods on JsonParser {
   ///@return Input feeder to use with non-blocking (async) parsing
   ///@since 2.9
   jni$_.JObject? get nonBlockingInputFeeder {
+    final _$$selfRef = reference;
     return _get$nonBlockingInputFeeder(
-            reference.pointer, _id_get$nonBlockingInputFeeder.pointer)
+            _$$selfRef.pointer, _id_get$nonBlockingInputFeeder.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1161,8 +1179,9 @@ extension JsonParser$$Methods on JsonParser {
   ///@return Set of read capabilities for content to read via this parser
   ///@since 2.12
   jni$_.JObject? get readCapabilities {
+    final _$$selfRef = reference;
     return _get$readCapabilities(
-            reference.pointer, _id_get$readCapabilities.pointer)
+            _$$selfRef.pointer, _id_get$readCapabilities.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1191,7 +1210,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@return Version of this generator (derived from version declared for
   ///   {@code jackson-core} jar that contains the class
   jni$_.JObject? version() {
-    return _version(reference.pointer, _id_version.pointer)
+    final _$$selfRef = reference;
+    return _version(_$$selfRef.pointer, _id_version.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1229,7 +1249,8 @@ extension JsonParser$$Methods on JsonParser {
   /// stream or reader it does own them.
   ///@throws IOException if there is either an underlying I/O problem
   void close() {
-    _close(reference.pointer, _id_close.pointer).check();
+    final _$$selfRef = reference;
+    _close(_$$selfRef.pointer, _id_close.pointer).check();
   }
 
   static final _id_get$isClosed = JsonParser._class.instanceMethodId(
@@ -1259,7 +1280,8 @@ extension JsonParser$$Methods on JsonParser {
   /// end of input.
   ///@return {@code True} if this parser instance has been closed
   core$_.bool get isClosed {
-    return _get$isClosed(reference.pointer, _id_get$isClosed.pointer).boolean;
+    final _$$selfRef = reference;
+    return _get$isClosed(_$$selfRef.pointer, _id_get$isClosed.pointer).boolean;
   }
 
   static final _id_get$parsingContext = JsonParser._class.instanceMethodId(
@@ -1292,8 +1314,9 @@ extension JsonParser$$Methods on JsonParser {
   /// input, if so desired.
   ///@return Stream input context (JsonStreamContext) associated with this parser
   jni$_.JObject? get parsingContext {
+    final _$$selfRef = reference;
     return _get$parsingContext(
-            reference.pointer, _id_get$parsingContext.pointer)
+            _$$selfRef.pointer, _id_get$parsingContext.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1330,7 +1353,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@return Location of the last processed input unit (byte or character)
   ///@since 2.13
   jni$_.JObject? currentLocation() {
-    return _currentLocation(reference.pointer, _id_currentLocation.pointer)
+    final _$$selfRef = reference;
+    return _currentLocation(_$$selfRef.pointer, _id_currentLocation.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1367,8 +1391,9 @@ extension JsonParser$$Methods on JsonParser {
   ///@return Starting location of the token parser currently points to
   ///@since 2.13 (will eventually replace \#getTokenLocation)
   jni$_.JObject? currentTokenLocation() {
+    final _$$selfRef = reference;
     return _currentTokenLocation(
-            reference.pointer, _id_currentTokenLocation.pointer)
+            _$$selfRef.pointer, _id_currentTokenLocation.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1396,8 +1421,9 @@ extension JsonParser$$Methods on JsonParser {
   /// Jackson 2.x versions (and removed from Jackson 3.0).
   ///@return Location of the last processed input unit (byte or character)
   jni$_.JObject? get currentLocation$1 {
+    final _$$selfRef = reference;
     return _get$currentLocation$1(
-            reference.pointer, _id_get$currentLocation$1.pointer)
+            _$$selfRef.pointer, _id_get$currentLocation$1.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1425,7 +1451,8 @@ extension JsonParser$$Methods on JsonParser {
   /// Jackson 2.x versions (and removed from Jackson 3.0).
   ///@return Starting location of the token parser currently points to
   jni$_.JObject? get tokenLocation {
-    return _get$tokenLocation(reference.pointer, _id_get$tokenLocation.pointer)
+    final _$$selfRef = reference;
+    return _get$tokenLocation(_$$selfRef.pointer, _id_get$tokenLocation.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1461,7 +1488,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@return "Current value" associated with the current input context (state) of this parser
   ///@since 2.13 (added as replacement for older \#getCurrentValue()
   jni$_.JObject? currentValue() {
-    return _currentValue(reference.pointer, _id_currentValue.pointer)
+    final _$$selfRef = reference;
+    return _currentValue(_$$selfRef.pointer, _id_currentValue.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1492,9 +1520,10 @@ extension JsonParser$$Methods on JsonParser {
   void assignCurrentValue(
     jni$_.JObject? v,
   ) {
+    final _$$selfRef = reference;
     final _$v = v?.reference ?? jni$_.jNullReference;
     _assignCurrentValue(
-            reference.pointer, _id_assignCurrentValue.pointer, _$v.pointer)
+            _$$selfRef.pointer, _id_assignCurrentValue.pointer, _$v.pointer)
         .check();
   }
 
@@ -1522,8 +1551,9 @@ extension JsonParser$$Methods on JsonParser {
   /// Jackson 2.x versions (and removed from Jackson 3.0).
   ///@return Location of the last processed input unit (byte or character)
   jni$_.JObject? get currentValue$1 {
+    final _$$selfRef = reference;
     return _get$currentValue$1(
-            reference.pointer, _id_get$currentValue$1.pointer)
+            _$$selfRef.pointer, _id_get$currentValue$1.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1549,9 +1579,10 @@ extension JsonParser$$Methods on JsonParser {
   /// Jackson 2.x versions (and removed from Jackson 3.0).
   ///@param v Current value to assign for the current input context of this parser
   set currentValue$1(jni$_.JObject? v) {
+    final _$$selfRef = reference;
     final _$v = v?.reference ?? jni$_.jNullReference;
     _set$currentValue$1(
-            reference.pointer, _id_set$currentValue$1.pointer, _$v.pointer)
+            _$$selfRef.pointer, _id_set$currentValue$1.pointer, _$v.pointer)
         .check();
   }
 
@@ -1587,9 +1618,10 @@ extension JsonParser$$Methods on JsonParser {
   core$_.int releaseBuffered(
     jni$_.JObject? out,
   ) {
+    final _$$selfRef = reference;
     final _$out = out?.reference ?? jni$_.jNullReference;
     return _releaseBuffered(
-            reference.pointer, _id_releaseBuffered.pointer, _$out.pointer)
+            _$$selfRef.pointer, _id_releaseBuffered.pointer, _$out.pointer)
         .integer;
   }
 
@@ -1626,9 +1658,10 @@ extension JsonParser$$Methods on JsonParser {
   core$_.int releaseBuffered$1(
     jni$_.JObject? w,
   ) {
+    final _$$selfRef = reference;
     final _$w = w?.reference ?? jni$_.jNullReference;
     return _releaseBuffered$1(
-            reference.pointer, _id_releaseBuffered$1.pointer, _$w.pointer)
+            _$$selfRef.pointer, _id_releaseBuffered$1.pointer, _$w.pointer)
         .integer;
   }
 
@@ -1658,8 +1691,9 @@ extension JsonParser$$Methods on JsonParser {
   JsonParser? enable(
     JsonParser$Feature? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _enable(reference.pointer, _id_enable.pointer, _$f.pointer)
+    return _enable(_$$selfRef.pointer, _id_enable.pointer, _$f.pointer)
         .object<JsonParser?>();
   }
 
@@ -1689,8 +1723,9 @@ extension JsonParser$$Methods on JsonParser {
   JsonParser? disable(
     JsonParser$Feature? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _disable(reference.pointer, _id_disable.pointer, _$f.pointer)
+    return _disable(_$$selfRef.pointer, _id_disable.pointer, _$f.pointer)
         .object<JsonParser?>();
   }
 
@@ -1723,8 +1758,9 @@ extension JsonParser$$Methods on JsonParser {
     JsonParser$Feature? f,
     core$_.bool state,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _configure(reference.pointer, _id_configure.pointer, _$f.pointer,
+    return _configure(_$$selfRef.pointer, _id_configure.pointer, _$f.pointer,
             state ? 1 : 0)
         .object<JsonParser?>();
   }
@@ -1753,8 +1789,9 @@ extension JsonParser$$Methods on JsonParser {
   core$_.bool isEnabled(
     JsonParser$Feature? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _isEnabled(reference.pointer, _id_isEnabled.pointer, _$f.pointer)
+    return _isEnabled(_$$selfRef.pointer, _id_isEnabled.pointer, _$f.pointer)
         .boolean;
   }
 
@@ -1783,8 +1820,10 @@ extension JsonParser$$Methods on JsonParser {
   core$_.bool isEnabled$1(
     jni$_.JObject? f,
   ) {
+    final _$$selfRef = reference;
     final _$f = f?.reference ?? jni$_.jNullReference;
-    return _isEnabled$1(reference.pointer, _id_isEnabled$1.pointer, _$f.pointer)
+    return _isEnabled$1(
+            _$$selfRef.pointer, _id_isEnabled$1.pointer, _$f.pointer)
         .boolean;
   }
 
@@ -1811,7 +1850,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@return Bit mask that defines current states of all standard Features.
   ///@since 2.3
   core$_.int get featureMask {
-    return _get$featureMask(reference.pointer, _id_get$featureMask.pointer)
+    final _$$selfRef = reference;
+    return _get$featureMask(_$$selfRef.pointer, _id_get$featureMask.pointer)
         .integer;
   }
 
@@ -1841,7 +1881,8 @@ extension JsonParser$$Methods on JsonParser {
   JsonParser? setFeatureMask(
     core$_.int mask,
   ) {
-    return _setFeatureMask(reference.pointer, _id_setFeatureMask.pointer, mask)
+    final _$$selfRef = reference;
+    return _setFeatureMask(_$$selfRef.pointer, _id_setFeatureMask.pointer, mask)
         .object<JsonParser?>();
   }
 
@@ -1880,8 +1921,9 @@ extension JsonParser$$Methods on JsonParser {
     core$_.int values,
     core$_.int mask,
   ) {
+    final _$$selfRef = reference;
     return _overrideStdFeatures(
-            reference.pointer, _id_overrideStdFeatures.pointer, values, mask)
+            _$$selfRef.pointer, _id_overrideStdFeatures.pointer, values, mask)
         .object<JsonParser?>();
   }
 
@@ -1909,8 +1951,9 @@ extension JsonParser$$Methods on JsonParser {
   ///@return Bit mask that defines current states of all standard FormatFeatures.
   ///@since 2.6
   core$_.int get formatFeatures {
+    final _$$selfRef = reference;
     return _get$formatFeatures(
-            reference.pointer, _id_get$formatFeatures.pointer)
+            _$$selfRef.pointer, _id_get$formatFeatures.pointer)
         .integer;
   }
 
@@ -1947,8 +1990,9 @@ extension JsonParser$$Methods on JsonParser {
     core$_.int values,
     core$_.int mask,
   ) {
-    return _overrideFormatFeatures(
-            reference.pointer, _id_overrideFormatFeatures.pointer, values, mask)
+    final _$$selfRef = reference;
+    return _overrideFormatFeatures(_$$selfRef.pointer,
+            _id_overrideFormatFeatures.pointer, values, mask)
         .object<JsonParser?>();
   }
 
@@ -1981,7 +2025,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jsontoken$_.JsonToken? nextToken() {
-    return _nextToken(reference.pointer, _id_nextToken.pointer)
+    final _$$selfRef = reference;
+    return _nextToken(_$$selfRef.pointer, _id_nextToken.pointer)
         .object<jsontoken$_.JsonToken?>();
   }
 
@@ -2022,7 +2067,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jsontoken$_.JsonToken? nextValue() {
-    return _nextValue(reference.pointer, _id_nextValue.pointer)
+    final _$$selfRef = reference;
+    return _nextValue(_$$selfRef.pointer, _id_nextValue.pointer)
         .object<jsontoken$_.JsonToken?>();
   }
 
@@ -2062,9 +2108,10 @@ extension JsonParser$$Methods on JsonParser {
   core$_.bool nextFieldName(
     jni$_.JObject? str,
   ) {
+    final _$$selfRef = reference;
     final _$str = str?.reference ?? jni$_.jNullReference;
     return _nextFieldName(
-            reference.pointer, _id_nextFieldName.pointer, _$str.pointer)
+            _$$selfRef.pointer, _id_nextFieldName.pointer, _$str.pointer)
         .boolean;
   }
 
@@ -2097,7 +2144,8 @@ extension JsonParser$$Methods on JsonParser {
   ///   JsonParseException for decoding problems
   ///@since 2.5
   jni$_.JString? nextFieldName$1() {
-    return _nextFieldName$1(reference.pointer, _id_nextFieldName$1.pointer)
+    final _$$selfRef = reference;
+    return _nextFieldName$1(_$$selfRef.pointer, _id_nextFieldName$1.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -2135,7 +2183,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni$_.JString? nextTextValue() {
-    return _nextTextValue(reference.pointer, _id_nextTextValue.pointer)
+    final _$$selfRef = reference;
+    return _nextTextValue(_$$selfRef.pointer, _id_nextTextValue.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -2176,8 +2225,9 @@ extension JsonParser$$Methods on JsonParser {
   core$_.int nextIntValue(
     core$_.int defaultValue,
   ) {
+    final _$$selfRef = reference;
     return _nextIntValue(
-            reference.pointer, _id_nextIntValue.pointer, defaultValue)
+            _$$selfRef.pointer, _id_nextIntValue.pointer, defaultValue)
         .integer;
   }
 
@@ -2218,8 +2268,9 @@ extension JsonParser$$Methods on JsonParser {
   core$_.int nextLongValue(
     core$_.int defaultValue,
   ) {
+    final _$$selfRef = reference;
     return _nextLongValue(
-            reference.pointer, _id_nextLongValue.pointer, defaultValue)
+            _$$selfRef.pointer, _id_nextLongValue.pointer, defaultValue)
         .long;
   }
 
@@ -2260,7 +2311,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni$_.JBoolean? nextBooleanValue() {
-    return _nextBooleanValue(reference.pointer, _id_nextBooleanValue.pointer)
+    final _$$selfRef = reference;
+    return _nextBooleanValue(_$$selfRef.pointer, _id_nextBooleanValue.pointer)
         .object<jni$_.JBoolean?>();
   }
 
@@ -2300,7 +2352,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   JsonParser? skipChildren() {
-    return _skipChildren(reference.pointer, _id_skipChildren.pointer)
+    final _$$selfRef = reference;
+    return _skipChildren(_$$selfRef.pointer, _id_skipChildren.pointer)
         .object<JsonParser?>();
   }
 
@@ -2337,7 +2390,8 @@ extension JsonParser$$Methods on JsonParser {
   ///   JsonParseException for decoding problems
   ///@since 2.8
   void finishToken() {
-    _finishToken(reference.pointer, _id_finishToken.pointer).check();
+    final _$$selfRef = reference;
+    _finishToken(_$$selfRef.pointer, _id_finishToken.pointer).check();
   }
 
   static final _id_currentToken = JsonParser._class.instanceMethodId(
@@ -2370,7 +2424,8 @@ extension JsonParser$$Methods on JsonParser {
   ///   if the current token has been explicitly cleared.
   ///@since 2.8
   jsontoken$_.JsonToken? currentToken() {
-    return _currentToken(reference.pointer, _id_currentToken.pointer)
+    final _$$selfRef = reference;
+    return _currentToken(_$$selfRef.pointer, _id_currentToken.pointer)
         .object<jsontoken$_.JsonToken?>();
   }
 
@@ -2403,7 +2458,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@since 2.8
   ///@return {@code int} matching one of constants from JsonTokenId.
   core$_.int currentTokenId() {
-    return _currentTokenId(reference.pointer, _id_currentTokenId.pointer)
+    final _$$selfRef = reference;
+    return _currentTokenId(_$$selfRef.pointer, _id_currentTokenId.pointer)
         .integer;
   }
 
@@ -2432,8 +2488,9 @@ extension JsonParser$$Methods on JsonParser {
   ///@return Type of the token this parser currently points to,
   ///   if any: null before any tokens have been read, and
   jsontoken$_.JsonToken? get currentToken$1 {
+    final _$$selfRef = reference;
     return _get$currentToken$1(
-            reference.pointer, _id_get$currentToken$1.pointer)
+            _$$selfRef.pointer, _id_get$currentToken$1.pointer)
         .object<jsontoken$_.JsonToken?>();
   }
 
@@ -2460,8 +2517,9 @@ extension JsonParser$$Methods on JsonParser {
   ///@return {@code int} matching one of constants from JsonTokenId.
   ///@deprecated Since 2.12 use \#currentTokenId instead
   core$_.int get currentTokenId$1 {
+    final _$$selfRef = reference;
     return _get$currentTokenId$1(
-            reference.pointer, _id_get$currentTokenId$1.pointer)
+            _$$selfRef.pointer, _id_get$currentTokenId$1.pointer)
         .integer;
   }
 
@@ -2493,7 +2551,8 @@ extension JsonParser$$Methods on JsonParser {
   ///   and returned null from \#nextToken, or the token
   ///   has been consumed)
   core$_.bool hasCurrentToken() {
-    return _hasCurrentToken(reference.pointer, _id_hasCurrentToken.pointer)
+    final _$$selfRef = reference;
+    return _hasCurrentToken(_$$selfRef.pointer, _id_hasCurrentToken.pointer)
         .boolean;
   }
 
@@ -2530,7 +2589,8 @@ extension JsonParser$$Methods on JsonParser {
   core$_.bool hasTokenId(
     core$_.int id,
   ) {
-    return _hasTokenId(reference.pointer, _id_hasTokenId.pointer, id).boolean;
+    final _$$selfRef = reference;
+    return _hasTokenId(_$$selfRef.pointer, _id_hasTokenId.pointer, id).boolean;
   }
 
   static final _id_hasToken = JsonParser._class.instanceMethodId(
@@ -2566,8 +2626,9 @@ extension JsonParser$$Methods on JsonParser {
   core$_.bool hasToken(
     jsontoken$_.JsonToken? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
-    return _hasToken(reference.pointer, _id_hasToken.pointer, _$t.pointer)
+    return _hasToken(_$$selfRef.pointer, _id_hasToken.pointer, _$t.pointer)
         .boolean;
   }
 
@@ -2609,8 +2670,9 @@ extension JsonParser$$Methods on JsonParser {
   ///   start-array marker (such JsonToken\#START_ARRAY);
   ///   {@code false} if not
   core$_.bool get isExpectedStartArrayToken {
+    final _$$selfRef = reference;
     return _get$isExpectedStartArrayToken(
-            reference.pointer, _id_get$isExpectedStartArrayToken.pointer)
+            _$$selfRef.pointer, _id_get$isExpectedStartArrayToken.pointer)
         .boolean;
   }
 
@@ -2642,8 +2704,9 @@ extension JsonParser$$Methods on JsonParser {
   ///   {@code false} if not
   ///@since 2.5
   core$_.bool get isExpectedStartObjectToken {
+    final _$$selfRef = reference;
     return _get$isExpectedStartObjectToken(
-            reference.pointer, _id_get$isExpectedStartObjectToken.pointer)
+            _$$selfRef.pointer, _id_get$isExpectedStartObjectToken.pointer)
         .boolean;
   }
 
@@ -2678,8 +2741,9 @@ extension JsonParser$$Methods on JsonParser {
   ///   {@code false} if not
   ///@since 2.12
   core$_.bool get isExpectedNumberIntToken {
+    final _$$selfRef = reference;
     return _get$isExpectedNumberIntToken(
-            reference.pointer, _id_get$isExpectedNumberIntToken.pointer)
+            _$$selfRef.pointer, _id_get$isExpectedNumberIntToken.pointer)
         .boolean;
   }
 
@@ -2715,7 +2779,8 @@ extension JsonParser$$Methods on JsonParser {
   ///   JsonParseException for decoding problems
   ///@since 2.9
   core$_.bool get isNaN {
-    return _get$isNaN(reference.pointer, _id_get$isNaN.pointer).boolean;
+    final _$$selfRef = reference;
+    return _get$isNaN(_$$selfRef.pointer, _id_get$isNaN.pointer).boolean;
   }
 
   static final _id_clearCurrentToken = JsonParser._class.instanceMethodId(
@@ -2748,7 +2813,8 @@ extension JsonParser$$Methods on JsonParser {
   /// it has to be able to consume last token used for binding (so that
   /// it will not be used again).
   void clearCurrentToken() {
-    _clearCurrentToken(reference.pointer, _id_clearCurrentToken.pointer)
+    final _$$selfRef = reference;
+    _clearCurrentToken(_$$selfRef.pointer, _id_clearCurrentToken.pointer)
         .check();
   }
 
@@ -2779,8 +2845,9 @@ extension JsonParser$$Methods on JsonParser {
   /// or if parser has been closed.
   ///@return Last cleared token, if any; {@code null} otherwise
   jsontoken$_.JsonToken? get lastClearedToken {
+    final _$$selfRef = reference;
     return _get$lastClearedToken(
-            reference.pointer, _id_get$lastClearedToken.pointer)
+            _$$selfRef.pointer, _id_get$lastClearedToken.pointer)
         .object<jsontoken$_.JsonToken?>();
   }
 
@@ -2813,9 +2880,10 @@ extension JsonParser$$Methods on JsonParser {
   void overrideCurrentName(
     jni$_.JString? name,
   ) {
+    final _$$selfRef = reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
     _overrideCurrentName(
-            reference.pointer, _id_overrideCurrentName.pointer, _$name.pointer)
+            _$$selfRef.pointer, _id_overrideCurrentName.pointer, _$name.pointer)
         .check();
   }
 
@@ -2844,7 +2912,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni$_.JString? get currentName {
-    return _get$currentName(reference.pointer, _id_get$currentName.pointer)
+    final _$$selfRef = reference;
+    return _get$currentName(_$$selfRef.pointer, _id_get$currentName.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -2878,7 +2947,8 @@ extension JsonParser$$Methods on JsonParser {
   ///   JsonParseException for decoding problems
   ///@since 2.10
   jni$_.JString? currentName$1() {
-    return _currentName$1(reference.pointer, _id_currentName$1.pointer)
+    final _$$selfRef = reference;
+    return _currentName$1(_$$selfRef.pointer, _id_currentName$1.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -2911,7 +2981,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni$_.JString? get text {
-    return _get$text(reference.pointer, _id_get$text.pointer)
+    final _$$selfRef = reference;
+    return _get$text(_$$selfRef.pointer, _id_get$text.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -2951,8 +3022,9 @@ extension JsonParser$$Methods on JsonParser {
   core$_.int getText(
     jni$_.JObject? writer,
   ) {
+    final _$$selfRef = reference;
     final _$writer = writer?.reference ?? jni$_.jNullReference;
-    return _getText(reference.pointer, _id_getText.pointer, _$writer.pointer)
+    return _getText(_$$selfRef.pointer, _id_getText.pointer, _$writer.pointer)
         .integer;
   }
 
@@ -3004,8 +3076,9 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni$_.JCharArray? get textCharacters {
+    final _$$selfRef = reference;
     return _get$textCharacters(
-            reference.pointer, _id_get$textCharacters.pointer)
+            _$$selfRef.pointer, _id_get$textCharacters.pointer)
         .object<jni$_.JCharArray?>();
   }
 
@@ -3036,7 +3109,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   core$_.int get textLength {
-    return _get$textLength(reference.pointer, _id_get$textLength.pointer)
+    final _$$selfRef = reference;
+    return _get$textLength(_$$selfRef.pointer, _id_get$textLength.pointer)
         .integer;
   }
 
@@ -3067,7 +3141,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   core$_.int get textOffset {
-    return _get$textOffset(reference.pointer, _id_get$textOffset.pointer)
+    final _$$selfRef = reference;
+    return _get$textOffset(_$$selfRef.pointer, _id_get$textOffset.pointer)
         .integer;
   }
 
@@ -3105,7 +3180,8 @@ extension JsonParser$$Methods on JsonParser {
   ///   be efficiently returned via \#getTextCharacters; false
   ///   means that it may or may not exist
   core$_.bool hasTextCharacters() {
-    return _hasTextCharacters(reference.pointer, _id_hasTextCharacters.pointer)
+    final _$$selfRef = reference;
+    return _hasTextCharacters(_$$selfRef.pointer, _id_hasTextCharacters.pointer)
         .boolean;
   }
 
@@ -3140,7 +3216,8 @@ extension JsonParser$$Methods on JsonParser {
   ///    (invalid format for numbers); plain IOException if underlying
   ///    content read fails (possible if values are extracted lazily)
   jni$_.JNumber? get numberValue {
-    return _get$numberValue(reference.pointer, _id_get$numberValue.pointer)
+    final _$$selfRef = reference;
+    return _get$numberValue(_$$selfRef.pointer, _id_get$numberValue.pointer)
         .object<jni$_.JNumber?>();
   }
 
@@ -3179,8 +3256,9 @@ extension JsonParser$$Methods on JsonParser {
   ///    content read fails (possible if values are extracted lazily)
   ///@since 2.12
   jni$_.JNumber? get numberValueExact {
+    final _$$selfRef = reference;
     return _get$numberValueExact(
-            reference.pointer, _id_get$numberValueExact.pointer)
+            _$$selfRef.pointer, _id_get$numberValueExact.pointer)
         .object<jni$_.JNumber?>();
   }
 
@@ -3212,7 +3290,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   JsonParser$NumberType? get numberType {
-    return _get$numberType(reference.pointer, _id_get$numberType.pointer)
+    final _$$selfRef = reference;
+    return _get$numberType(_$$selfRef.pointer, _id_get$numberType.pointer)
         .object<JsonParser$NumberType?>();
   }
 
@@ -3257,7 +3336,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   core$_.int get byteValue {
-    return _get$byteValue(reference.pointer, _id_get$byteValue.pointer).byte;
+    final _$$selfRef = reference;
+    return _get$byteValue(_$$selfRef.pointer, _id_get$byteValue.pointer).byte;
   }
 
   static final _id_get$shortValue = JsonParser._class.instanceMethodId(
@@ -3295,7 +3375,9 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   core$_.int get shortValue {
-    return _get$shortValue(reference.pointer, _id_get$shortValue.pointer).short;
+    final _$$selfRef = reference;
+    return _get$shortValue(_$$selfRef.pointer, _id_get$shortValue.pointer)
+        .short;
   }
 
   static final _id_get$intValue = JsonParser._class.instanceMethodId(
@@ -3333,7 +3415,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   core$_.int get intValue {
-    return _get$intValue(reference.pointer, _id_get$intValue.pointer).integer;
+    final _$$selfRef = reference;
+    return _get$intValue(_$$selfRef.pointer, _id_get$intValue.pointer).integer;
   }
 
   static final _id_get$longValue = JsonParser._class.instanceMethodId(
@@ -3371,7 +3454,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   core$_.int get longValue {
-    return _get$longValue(reference.pointer, _id_get$longValue.pointer).long;
+    final _$$selfRef = reference;
+    return _get$longValue(_$$selfRef.pointer, _id_get$longValue.pointer).long;
   }
 
   static final _id_get$bigIntegerValue = JsonParser._class.instanceMethodId(
@@ -3406,8 +3490,9 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni$_.JObject? get bigIntegerValue {
+    final _$$selfRef = reference;
     return _get$bigIntegerValue(
-            reference.pointer, _id_get$bigIntegerValue.pointer)
+            _$$selfRef.pointer, _id_get$bigIntegerValue.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -3446,7 +3531,9 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   core$_.double get floatValue {
-    return _get$floatValue(reference.pointer, _id_get$floatValue.pointer).float;
+    final _$$selfRef = reference;
+    return _get$floatValue(_$$selfRef.pointer, _id_get$floatValue.pointer)
+        .float;
   }
 
   static final _id_get$doubleValue = JsonParser._class.instanceMethodId(
@@ -3484,7 +3571,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   core$_.double get doubleValue {
-    return _get$doubleValue(reference.pointer, _id_get$doubleValue.pointer)
+    final _$$selfRef = reference;
+    return _get$doubleValue(_$$selfRef.pointer, _id_get$doubleValue.pointer)
         .doubleFloat;
   }
 
@@ -3517,7 +3605,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni$_.JObject? get decimalValue {
-    return _get$decimalValue(reference.pointer, _id_get$decimalValue.pointer)
+    final _$$selfRef = reference;
+    return _get$decimalValue(_$$selfRef.pointer, _id_get$decimalValue.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -3552,7 +3641,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   core$_.bool get booleanValue {
-    return _get$booleanValue(reference.pointer, _id_get$booleanValue.pointer)
+    final _$$selfRef = reference;
+    return _get$booleanValue(_$$selfRef.pointer, _id_get$booleanValue.pointer)
         .boolean;
   }
 
@@ -3591,8 +3681,9 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni$_.JObject? get embeddedObject {
+    final _$$selfRef = reference;
     return _get$embeddedObject(
-            reference.pointer, _id_get$embeddedObject.pointer)
+            _$$selfRef.pointer, _id_get$embeddedObject.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -3638,9 +3729,10 @@ extension JsonParser$$Methods on JsonParser {
   jni$_.JByteArray? getBinaryValue(
     jni$_.JObject? bv,
   ) {
+    final _$$selfRef = reference;
     final _$bv = bv?.reference ?? jni$_.jNullReference;
     return _getBinaryValue(
-            reference.pointer, _id_getBinaryValue.pointer, _$bv.pointer)
+            _$$selfRef.pointer, _id_getBinaryValue.pointer, _$bv.pointer)
         .object<jni$_.JByteArray?>();
   }
 
@@ -3671,7 +3763,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   jni$_.JByteArray? get binaryValue {
-    return _get$binaryValue(reference.pointer, _id_get$binaryValue.pointer)
+    final _$$selfRef = reference;
+    return _get$binaryValue(_$$selfRef.pointer, _id_get$binaryValue.pointer)
         .object<jni$_.JByteArray?>();
   }
 
@@ -3707,9 +3800,10 @@ extension JsonParser$$Methods on JsonParser {
   core$_.int readBinaryValue(
     jni$_.JObject? out,
   ) {
+    final _$$selfRef = reference;
     final _$out = out?.reference ?? jni$_.jNullReference;
     return _readBinaryValue(
-            reference.pointer, _id_readBinaryValue.pointer, _$out.pointer)
+            _$$selfRef.pointer, _id_readBinaryValue.pointer, _$out.pointer)
         .integer;
   }
 
@@ -3749,9 +3843,10 @@ extension JsonParser$$Methods on JsonParser {
     jni$_.JObject? bv,
     jni$_.JObject? out,
   ) {
+    final _$$selfRef = reference;
     final _$bv = bv?.reference ?? jni$_.jNullReference;
     final _$out = out?.reference ?? jni$_.jNullReference;
-    return _readBinaryValue$1(reference.pointer, _id_readBinaryValue$1.pointer,
+    return _readBinaryValue$1(_$$selfRef.pointer, _id_readBinaryValue$1.pointer,
             _$bv.pointer, _$out.pointer)
         .integer;
   }
@@ -3789,7 +3884,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   core$_.int get valueAsInt {
-    return _get$valueAsInt(reference.pointer, _id_get$valueAsInt.pointer)
+    final _$$selfRef = reference;
+    return _get$valueAsInt(_$$selfRef.pointer, _id_get$valueAsInt.pointer)
         .integer;
   }
 
@@ -3826,7 +3922,8 @@ extension JsonParser$$Methods on JsonParser {
   core$_.int getValueAsInt(
     core$_.int def,
   ) {
-    return _getValueAsInt(reference.pointer, _id_getValueAsInt.pointer, def)
+    final _$$selfRef = reference;
+    return _getValueAsInt(_$$selfRef.pointer, _id_getValueAsInt.pointer, def)
         .integer;
   }
 
@@ -3863,7 +3960,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   core$_.int get valueAsLong {
-    return _get$valueAsLong(reference.pointer, _id_get$valueAsLong.pointer)
+    final _$$selfRef = reference;
+    return _get$valueAsLong(_$$selfRef.pointer, _id_get$valueAsLong.pointer)
         .long;
   }
 
@@ -3900,7 +3998,8 @@ extension JsonParser$$Methods on JsonParser {
   core$_.int getValueAsLong(
     core$_.int def,
   ) {
-    return _getValueAsLong(reference.pointer, _id_getValueAsLong.pointer, def)
+    final _$$selfRef = reference;
+    return _getValueAsLong(_$$selfRef.pointer, _id_getValueAsLong.pointer, def)
         .long;
   }
 
@@ -3937,7 +4036,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   core$_.double get valueAsDouble {
-    return _get$valueAsDouble(reference.pointer, _id_get$valueAsDouble.pointer)
+    final _$$selfRef = reference;
+    return _get$valueAsDouble(_$$selfRef.pointer, _id_get$valueAsDouble.pointer)
         .doubleFloat;
   }
 
@@ -3975,8 +4075,9 @@ extension JsonParser$$Methods on JsonParser {
   core$_.double getValueAsDouble(
     core$_.double def,
   ) {
+    final _$$selfRef = reference;
     return _getValueAsDouble(
-            reference.pointer, _id_getValueAsDouble.pointer, def)
+            _$$selfRef.pointer, _id_getValueAsDouble.pointer, def)
         .doubleFloat;
   }
 
@@ -4013,8 +4114,9 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException for low-level read issues, or
   ///   JsonParseException for decoding problems
   core$_.bool get valueAsBoolean {
+    final _$$selfRef = reference;
     return _get$valueAsBoolean(
-            reference.pointer, _id_get$valueAsBoolean.pointer)
+            _$$selfRef.pointer, _id_get$valueAsBoolean.pointer)
         .boolean;
   }
 
@@ -4052,8 +4154,9 @@ extension JsonParser$$Methods on JsonParser {
   core$_.bool getValueAsBoolean(
     core$_.bool def,
   ) {
+    final _$$selfRef = reference;
     return _getValueAsBoolean(
-            reference.pointer, _id_getValueAsBoolean.pointer, def ? 1 : 0)
+            _$$selfRef.pointer, _id_getValueAsBoolean.pointer, def ? 1 : 0)
         .boolean;
   }
 
@@ -4089,7 +4192,8 @@ extension JsonParser$$Methods on JsonParser {
   ///   JsonParseException for decoding problems
   ///@since 2.1
   jni$_.JString? get valueAsString {
-    return _get$valueAsString(reference.pointer, _id_get$valueAsString.pointer)
+    final _$$selfRef = reference;
+    return _get$valueAsString(_$$selfRef.pointer, _id_get$valueAsString.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -4127,9 +4231,10 @@ extension JsonParser$$Methods on JsonParser {
   jni$_.JString? getValueAsString(
     jni$_.JString? def,
   ) {
+    final _$$selfRef = reference;
     final _$def = def?.reference ?? jni$_.jNullReference;
     return _getValueAsString(
-            reference.pointer, _id_getValueAsString.pointer, _$def.pointer)
+            _$$selfRef.pointer, _id_getValueAsString.pointer, _$def.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -4164,7 +4269,8 @@ extension JsonParser$$Methods on JsonParser {
   ///    {@code false} if not
   ///@since 2.3
   core$_.bool canReadObjectId() {
-    return _canReadObjectId(reference.pointer, _id_canReadObjectId.pointer)
+    final _$$selfRef = reference;
+    return _canReadObjectId(_$$selfRef.pointer, _id_canReadObjectId.pointer)
         .boolean;
   }
 
@@ -4199,7 +4305,9 @@ extension JsonParser$$Methods on JsonParser {
   ///    {@code false} if not
   ///@since 2.3
   core$_.bool canReadTypeId() {
-    return _canReadTypeId(reference.pointer, _id_canReadTypeId.pointer).boolean;
+    final _$$selfRef = reference;
+    return _canReadTypeId(_$$selfRef.pointer, _id_canReadTypeId.pointer)
+        .boolean;
   }
 
   static final _id_get$objectId = JsonParser._class.instanceMethodId(
@@ -4236,7 +4344,8 @@ extension JsonParser$$Methods on JsonParser {
   ///   JsonParseException for decoding problems
   ///@since 2.3
   jni$_.JObject? get objectId {
-    return _get$objectId(reference.pointer, _id_get$objectId.pointer)
+    final _$$selfRef = reference;
+    return _get$objectId(_$$selfRef.pointer, _id_get$objectId.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -4274,7 +4383,8 @@ extension JsonParser$$Methods on JsonParser {
   ///   JsonParseException for decoding problems
   ///@since 2.3
   jni$_.JObject? get typeId {
-    return _get$typeId(reference.pointer, _id_get$typeId.pointer)
+    final _$$selfRef = reference;
+    return _get$typeId(_$$selfRef.pointer, _id_get$typeId.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -4325,9 +4435,10 @@ extension JsonParser$$Methods on JsonParser {
   $T? readValueAs<$T extends jni$_.JObject?>(
     jni$_.JObject? valueType,
   ) {
+    final _$$selfRef = reference;
     final _$valueType = valueType?.reference ?? jni$_.jNullReference;
     return _readValueAs(
-            reference.pointer, _id_readValueAs.pointer, _$valueType.pointer)
+            _$$selfRef.pointer, _id_readValueAs.pointer, _$valueType.pointer)
         .object<$T?>();
   }
 
@@ -4375,8 +4486,9 @@ extension JsonParser$$Methods on JsonParser {
   $T? readValueAs$1<$T extends jni$_.JObject?>(
     jni$_.JObject? valueTypeRef,
   ) {
+    final _$$selfRef = reference;
     final _$valueTypeRef = valueTypeRef?.reference ?? jni$_.jNullReference;
-    return _readValueAs$1(reference.pointer, _id_readValueAs$1.pointer,
+    return _readValueAs$1(_$$selfRef.pointer, _id_readValueAs$1.pointer,
             _$valueTypeRef.pointer)
         .object<$T?>();
   }
@@ -4411,9 +4523,10 @@ extension JsonParser$$Methods on JsonParser {
   jni$_.JIterator<$T?>? readValuesAs<$T extends jni$_.JObject?>(
     jni$_.JObject? valueType,
   ) {
+    final _$$selfRef = reference;
     final _$valueType = valueType?.reference ?? jni$_.jNullReference;
     return _readValuesAs(
-            reference.pointer, _id_readValuesAs.pointer, _$valueType.pointer)
+            _$$selfRef.pointer, _id_readValuesAs.pointer, _$valueType.pointer)
         .object<jni$_.JIterator<$T?>?>();
   }
 
@@ -4447,8 +4560,9 @@ extension JsonParser$$Methods on JsonParser {
   jni$_.JIterator<$T?>? readValuesAs$1<$T extends jni$_.JObject?>(
     jni$_.JObject? valueTypeRef,
   ) {
+    final _$$selfRef = reference;
     final _$valueTypeRef = valueTypeRef?.reference ?? jni$_.jNullReference;
-    return _readValuesAs$1(reference.pointer, _id_readValuesAs$1.pointer,
+    return _readValuesAs$1(_$$selfRef.pointer, _id_readValuesAs$1.pointer,
             _$valueTypeRef.pointer)
         .object<jni$_.JIterator<$T?>?>();
   }
@@ -4483,7 +4597,8 @@ extension JsonParser$$Methods on JsonParser {
   ///@throws IOException if there is either an underlying I/O problem or decoding
   ///    issue at format layer
   $T? readValueAsTree<$T extends jni$_.JObject?>() {
-    return _readValueAsTree(reference.pointer, _id_readValueAsTree.pointer)
+    final _$$selfRef = reference;
+    return _readValueAsTree(_$$selfRef.pointer, _id_readValueAsTree.pointer)
         .object<$T?>();
   }
 }

--- a/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonToken.dart
+++ b/pkgs/jnigen/test/jackson_core_test/third_party/bindings/com/fasterxml/jackson/core/JsonToken.dart
@@ -271,7 +271,8 @@ extension type JsonToken._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public com.fasterxml.jackson.core.JsonToken[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<JsonToken?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<JsonToken?>?>();
   }
 
@@ -296,9 +297,9 @@ extension type JsonToken._(jni$_.JObject _$this) implements jni$_.JObject {
   static JsonToken? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<JsonToken?>();
   }
 }
@@ -323,7 +324,8 @@ extension JsonToken$$Methods on JsonToken {
 
   /// from: `public final int id()`
   core$_.int id() {
-    return _id(reference.pointer, _id_id.pointer).integer;
+    final _$$selfRef = reference;
+    return _id(_$$selfRef.pointer, _id_id.pointer).integer;
   }
 
   static final _id_asString = JsonToken._class.instanceMethodId(
@@ -346,7 +348,8 @@ extension JsonToken$$Methods on JsonToken {
   /// from: `public final java.lang.String asString()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? asString() {
-    return _asString(reference.pointer, _id_asString.pointer)
+    final _$$selfRef = reference;
+    return _asString(_$$selfRef.pointer, _id_asString.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -370,7 +373,8 @@ extension JsonToken$$Methods on JsonToken {
   /// from: `public final char[] asCharArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JCharArray? asCharArray() {
-    return _asCharArray(reference.pointer, _id_asCharArray.pointer)
+    final _$$selfRef = reference;
+    return _asCharArray(_$$selfRef.pointer, _id_asCharArray.pointer)
         .object<jni$_.JCharArray?>();
   }
 
@@ -394,7 +398,8 @@ extension JsonToken$$Methods on JsonToken {
   /// from: `public final byte[] asByteArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JByteArray? asByteArray() {
-    return _asByteArray(reference.pointer, _id_asByteArray.pointer)
+    final _$$selfRef = reference;
+    return _asByteArray(_$$selfRef.pointer, _id_asByteArray.pointer)
         .object<jni$_.JByteArray?>();
   }
 
@@ -420,7 +425,9 @@ extension JsonToken$$Methods on JsonToken {
   /// @return {@code True} if this token is {@code VALUE_NUMBER_INT} or {@code VALUE_NUMBER_FLOAT},
   ///   {@code false} otherwise
   core$_.bool get isNumeric {
-    return _get$isNumeric(reference.pointer, _id_get$isNumeric.pointer).boolean;
+    final _$$selfRef = reference;
+    return _get$isNumeric(_$$selfRef.pointer, _id_get$isNumeric.pointer)
+        .boolean;
   }
 
   static final _id_get$isStructStart = JsonToken._class.instanceMethodId(
@@ -450,7 +457,8 @@ extension JsonToken$$Methods on JsonToken {
   ///   {@code false} otherwise
   ///@since 2.3
   core$_.bool get isStructStart {
-    return _get$isStructStart(reference.pointer, _id_get$isStructStart.pointer)
+    final _$$selfRef = reference;
+    return _get$isStructStart(_$$selfRef.pointer, _id_get$isStructStart.pointer)
         .boolean;
   }
 
@@ -481,7 +489,8 @@ extension JsonToken$$Methods on JsonToken {
   ///   {@code false} otherwise
   ///@since 2.3
   core$_.bool get isStructEnd {
-    return _get$isStructEnd(reference.pointer, _id_get$isStructEnd.pointer)
+    final _$$selfRef = reference;
+    return _get$isStructEnd(_$$selfRef.pointer, _id_get$isStructEnd.pointer)
         .boolean;
   }
 
@@ -511,7 +520,8 @@ extension JsonToken$$Methods on JsonToken {
   ///@return {@code True} if this token is a scalar value token (one of
   ///   {@code VALUE_xxx} tokens), {@code false} otherwise
   core$_.bool get isScalarValue {
-    return _get$isScalarValue(reference.pointer, _id_get$isScalarValue.pointer)
+    final _$$selfRef = reference;
+    return _get$isScalarValue(_$$selfRef.pointer, _id_get$isScalarValue.pointer)
         .boolean;
   }
 
@@ -537,7 +547,9 @@ extension JsonToken$$Methods on JsonToken {
   /// @return {@code True} if this token is {@code VALUE_TRUE} or {@code VALUE_FALSE},
   ///   {@code false} otherwise
   core$_.bool get isBoolean {
-    return _get$isBoolean(reference.pointer, _id_get$isBoolean.pointer).boolean;
+    final _$$selfRef = reference;
+    return _get$isBoolean(_$$selfRef.pointer, _id_get$isBoolean.pointer)
+        .boolean;
   }
 }
 

--- a/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
+++ b/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
@@ -8923,8 +8923,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'noopAsync(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![0] as jni$_.JObject).reference)
+        final _$$contRef = ($a![0] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithVoidFuture(_$impls[$p]!.noopAsync());
         return ($r as jni$_.JObject?)
                 ?.as(const jni$_.$JObject$Type$())
@@ -8934,8 +8934,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'throwFlutterErrorAsync(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![0] as jni$_.JObject).reference)
+        final _$$contRef = ($a![0] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.throwFlutterErrorAsync());
         return ($r as jni$_.JObject?)
                 ?.as(const jni$_.$JObject$Type$())
@@ -8945,8 +8945,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNIAllTypes(Lcom/github/dart_lang/jnigen/NIAllTypes;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNIAllTypes(
           ($a![0] as NIAllTypes),
         ));
@@ -8958,8 +8958,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableNIAllNullableTypes(Lcom/github/dart_lang/jnigen/NIAllNullableTypes;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableNIAllNullableTypes(
           ($a![0] as NIAllNullableTypes?),
         ));
@@ -8971,8 +8971,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableNIAllNullableTypesWithoutRecursion(Lcom/github/dart_lang/jnigen/NIAllNullableTypesWithoutRecursion;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!
                 .echoAsyncNullableNIAllNullableTypesWithoutRecursion(
           ($a![0] as NIAllNullableTypesWithoutRecursion?),
@@ -8985,8 +8985,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncBool(ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncBool(
           ($a![0] as jni$_.JBoolean).toDartBool(releaseOriginal: true),
         ));
@@ -8998,8 +8998,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncInt(JLkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncInt(
           ($a![0] as jni$_.JLong).toDartInt(releaseOriginal: true),
         ));
@@ -9011,8 +9011,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncDouble(DLkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncDouble(
           ($a![0] as jni$_.JDouble).toDartDouble(releaseOriginal: true),
         ));
@@ -9024,8 +9024,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncString(Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncString(
           ($a![0] as jni$_.JString),
         ));
@@ -9037,8 +9037,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncUint8List([BLkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncUint8List(
           ($a![0] as jni$_.JByteArray),
         ));
@@ -9050,8 +9050,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncInt32List([ILkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncInt32List(
           ($a![0] as jni$_.JIntArray),
         ));
@@ -9063,8 +9063,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncInt64List([JLkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncInt64List(
           ($a![0] as jni$_.JLongArray),
         ));
@@ -9076,8 +9076,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncFloat64List([DLkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncFloat64List(
           ($a![0] as jni$_.JDoubleArray),
         ));
@@ -9089,8 +9089,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncObject(Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncObject(
           ($a![0] as jni$_.JObject),
         ));
@@ -9102,8 +9102,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncList(Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncList(
           ($a![0] as jni$_.JList<jni$_.JObject?>),
         ));
@@ -9115,8 +9115,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncEnumList(Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncEnumList(
           ($a![0] as jni$_.JList<NIAnEnum?>),
         ));
@@ -9128,8 +9128,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncClassList(Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncClassList(
           ($a![0] as jni$_.JList<NIAllNullableTypes?>),
         ));
@@ -9141,8 +9141,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNonNullEnumList(Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNonNullEnumList(
           ($a![0] as jni$_.JList<NIAnEnum?>),
         ));
@@ -9154,8 +9154,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNonNullClassList(Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNonNullClassList(
           ($a![0] as jni$_.JList<NIAllNullableTypes?>),
         ));
@@ -9167,8 +9167,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncMap(Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncMap(
           ($a![0] as jni$_.JMap<jni$_.JObject?, jni$_.JObject?>),
         ));
@@ -9180,8 +9180,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncStringMap(Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncStringMap(
           ($a![0] as jni$_.JMap<jni$_.JString?, jni$_.JString?>),
         ));
@@ -9193,8 +9193,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncIntMap(Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncIntMap(
           ($a![0] as jni$_.JMap<jni$_.JLong?, jni$_.JLong?>),
         ));
@@ -9206,8 +9206,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncEnumMap(Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncEnumMap(
           ($a![0] as jni$_.JMap<NIAnEnum?, NIAnEnum?>),
         ));
@@ -9219,8 +9219,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncClassMap(Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncClassMap(
           ($a![0] as jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>),
         ));
@@ -9232,8 +9232,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncEnum(Lcom/github/dart_lang/jnigen/NIAnEnum;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncEnum(
           ($a![0] as NIAnEnum),
         ));
@@ -9245,8 +9245,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAnotherAsyncEnum(Lcom/github/dart_lang/jnigen/NIAnotherEnum;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAnotherAsyncEnum(
           ($a![0] as NIAnotherEnum),
         ));
@@ -9258,8 +9258,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableBool(Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableBool(
           ($a![0] as jni$_.JBoolean?),
         ));
@@ -9271,8 +9271,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableInt(Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableInt(
           ($a![0] as jni$_.JLong?),
         ));
@@ -9284,8 +9284,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableDouble(Ljava/lang/Double;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableDouble(
           ($a![0] as jni$_.JDouble?),
         ));
@@ -9297,8 +9297,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableString(Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableString(
           ($a![0] as jni$_.JString?),
         ));
@@ -9310,8 +9310,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableUint8List([BLkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableUint8List(
           ($a![0] as jni$_.JByteArray?),
         ));
@@ -9323,8 +9323,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableInt32List([ILkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableInt32List(
           ($a![0] as jni$_.JIntArray?),
         ));
@@ -9336,8 +9336,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableInt64List([JLkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableInt64List(
           ($a![0] as jni$_.JLongArray?),
         ));
@@ -9349,8 +9349,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableFloat64List([DLkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableFloat64List(
           ($a![0] as jni$_.JDoubleArray?),
         ));
@@ -9362,8 +9362,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableObject(Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableObject(
           ($a![0] as jni$_.JObject?),
         ));
@@ -9375,8 +9375,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableList(Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableList(
           ($a![0] as jni$_.JList<jni$_.JObject?>?),
         ));
@@ -9388,8 +9388,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableEnumList(Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableEnumList(
           ($a![0] as jni$_.JList<NIAnEnum?>?),
         ));
@@ -9401,8 +9401,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableClassList(Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableClassList(
           ($a![0] as jni$_.JList<NIAllNullableTypes?>?),
         ));
@@ -9414,8 +9414,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableNonNullEnumList(Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableNonNullEnumList(
           ($a![0] as jni$_.JList<NIAnEnum?>?),
         ));
@@ -9427,8 +9427,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableNonNullClassList(Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableNonNullClassList(
           ($a![0] as jni$_.JList<NIAllNullableTypes?>?),
         ));
@@ -9440,8 +9440,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableMap(Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableMap(
           ($a![0] as jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?),
         ));
@@ -9453,8 +9453,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableStringMap(Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableStringMap(
           ($a![0] as jni$_.JMap<jni$_.JString?, jni$_.JString?>?),
         ));
@@ -9466,8 +9466,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableIntMap(Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableIntMap(
           ($a![0] as jni$_.JMap<jni$_.JLong?, jni$_.JLong?>?),
         ));
@@ -9479,8 +9479,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableEnumMap(Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableEnumMap(
           ($a![0] as jni$_.JMap<NIAnEnum?, NIAnEnum?>?),
         ));
@@ -9492,8 +9492,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableClassMap(Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableClassMap(
           ($a![0] as jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>?),
         ));
@@ -9505,8 +9505,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAsyncNullableEnum(Lcom/github/dart_lang/jnigen/NIAnEnum;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAsyncNullableEnum(
           ($a![0] as NIAnEnum?),
         ));
@@ -9518,8 +9518,8 @@ extension type NIFlutterIntegrationCoreApi._(jni$_.JObject _$this)
       }
       if ($d ==
           r'echoAnotherAsyncNullableEnum(Lcom/github/dart_lang/jnigen/NIAnotherEnum;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.echoAnotherAsyncNullableEnum(
           ($a![0] as NIAnotherEnum?),
         ));
@@ -38005,8 +38005,8 @@ extension type SuspendInterface._(jni$_.JObject _$this)
       final $a = $i.args;
       if ($d ==
           r'sayHello(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![0] as jni$_.JObject).reference)
+        final _$$contRef = ($a![0] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.sayHello());
         return ($r as jni$_.JObject?)
                 ?.as(const jni$_.$JObject$Type$())
@@ -38016,8 +38016,8 @@ extension type SuspendInterface._(jni$_.JObject _$this)
       }
       if ($d ==
           r'sayHello(Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.sayHello$1(
           ($a![0] as jni$_.JString),
         ));
@@ -38029,8 +38029,8 @@ extension type SuspendInterface._(jni$_.JObject _$this)
       }
       if ($d ==
           r'nullableHello(ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.nullableHello(
           ($a![0] as jni$_.JBoolean).toDartBool(releaseOriginal: true),
         ));
@@ -38041,8 +38041,8 @@ extension type SuspendInterface._(jni$_.JObject _$this)
             jni$_.nullptr;
       }
       if ($d == r'sayInt(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![0] as jni$_.JObject).reference)
+        final _$$contRef = ($a![0] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.sayInt());
         return ($r as jni$_.JObject?)
                 ?.as(const jni$_.$JObject$Type$())
@@ -38052,8 +38052,8 @@ extension type SuspendInterface._(jni$_.JObject _$this)
       }
       if ($d ==
           r'sayInt(Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.sayInt$1(
           ($a![0] as jni$_.JInteger),
         ));
@@ -38065,8 +38065,8 @@ extension type SuspendInterface._(jni$_.JObject _$this)
       }
       if ($d ==
           r'nullableInt(ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.nullableInt(
           ($a![0] as jni$_.JBoolean).toDartBool(releaseOriginal: true),
         ));
@@ -38078,8 +38078,8 @@ extension type SuspendInterface._(jni$_.JObject _$this)
       }
       if ($d ==
           r'nullableList(Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![1] as jni$_.JObject).reference)
+        final _$$contRef = ($a![1] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithFuture(_$impls[$p]!.nullableList(
           ($a![0] as jni$_.JList<jni$_.JString?>?),
         ));
@@ -38091,8 +38091,8 @@ extension type SuspendInterface._(jni$_.JObject _$this)
       }
       if ($d ==
           r'noReturn(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;') {
-        final $r = jni$_.KotlinContinuation.fromReference(
-                ($a![0] as jni$_.JObject).reference)
+        final _$$contRef = ($a![0] as jni$_.JObject).reference;
+        final $r = jni$_.KotlinContinuation.fromReference(_$$contRef)
             .resumeWithVoidFuture(_$impls[$p]!.noReturn());
         return ($r as jni$_.JObject?)
                 ?.as(const jni$_.$JObject$Type$())

--- a/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
+++ b/pkgs/jnigen/test/kotlin_test/bindings/kotlin.dart
@@ -146,7 +146,8 @@ extension CanDoA$$Methods on CanDoA {
 
   /// from: `public fun doA(): kotlin.Unit`
   void doA() {
-    _doA(reference.pointer, _id_doA.pointer).check();
+    final _$$selfRef = reference;
+    _doA(_$$selfRef.pointer, _id_doA.pointer).check();
   }
 }
 
@@ -287,7 +288,8 @@ extension CanDoB$$Methods on CanDoB {
 
   /// from: `public fun doB(): kotlin.Unit`
   void doB() {
-    _doB(reference.pointer, _id_doB.pointer).check();
+    final _$$selfRef = reference;
+    _doB(_$$selfRef.pointer, _id_doB.pointer).check();
   }
 }
 
@@ -354,7 +356,8 @@ extension Measure$$Methods<$T extends jni$_.JObject> on Measure<$T> {
 
   /// from: `public float getValue()`
   core$_.double get value {
-    return _get$value(reference.pointer, _id_get$value.pointer).float;
+    final _$$selfRef = reference;
+    return _get$value(_$$selfRef.pointer, _id_get$value.pointer).float;
   }
 
   static final _id_get$unit = Measure._class.instanceMethodId(
@@ -377,7 +380,8 @@ extension Measure$$Methods<$T extends jni$_.JObject> on Measure<$T> {
   /// from: `public T getUnit()`
   /// The returned object must be released after use, by calling the [release] method.
   $T get unit {
-    return _get$unit(reference.pointer, _id_get$unit.pointer).object<$T>();
+    final _$$selfRef = reference;
+    return _get$unit(_$$selfRef.pointer, _id_get$unit.pointer).object<$T>();
   }
 
   static final _id_convertValue = Measure._class.instanceMethodId(
@@ -400,9 +404,10 @@ extension Measure$$Methods<$T extends jni$_.JObject> on Measure<$T> {
   core$_.double convertValue(
     $T measureUnit,
   ) {
+    final _$$selfRef = reference;
     final _$measureUnit = measureUnit.reference;
     return _convertValue(
-            reference.pointer, _id_convertValue.pointer, _$measureUnit.pointer)
+            _$$selfRef.pointer, _id_convertValue.pointer, _$measureUnit.pointer)
         .float;
   }
 }
@@ -527,7 +532,8 @@ extension MeasureUnit$$Methods on MeasureUnit {
   /// from: `public abstract java.lang.String getSign()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString getSign() {
-    return _getSign(reference.pointer, _id_getSign.pointer)
+    final _$$selfRef = reference;
+    return _getSign(_$$selfRef.pointer, _id_getSign.pointer)
         .object<jni$_.JString>();
   }
 
@@ -550,7 +556,9 @@ extension MeasureUnit$$Methods on MeasureUnit {
 
   /// from: `public abstract float getCoefficient()`
   core$_.double getCoefficient() {
-    return _getCoefficient(reference.pointer, _id_getCoefficient.pointer).float;
+    final _$$selfRef = reference;
+    return _getCoefficient(_$$selfRef.pointer, _id_getCoefficient.pointer)
+        .float;
   }
 }
 
@@ -621,9 +629,10 @@ extension type NIAllClassesWrapper$Companion._(jni$_.JObject _$this)
   factory NIAllClassesWrapper$Companion(
     jni$_.JObject? defaultConstructorMarker,
   ) {
+    final _$$classRef = _class.reference;
     final _$defaultConstructorMarker =
         defaultConstructorMarker?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer,
+    return _new$(_$$classRef.pointer, _id_new$.pointer,
             _$defaultConstructorMarker.pointer)
         .object<NIAllClassesWrapper$Companion>();
   }
@@ -653,8 +662,9 @@ extension NIAllClassesWrapper$Companion$$Methods
   NIAllClassesWrapper fromList(
     jni$_.JList<jni$_.JObject?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _fromList(reference.pointer, _id_fromList.pointer, _$list.pointer)
+    return _fromList(_$$selfRef.pointer, _id_fromList.pointer, _$list.pointer)
         .object<NIAllClassesWrapper>();
   }
 }
@@ -732,6 +742,7 @@ extension type NIAllClassesWrapper._(jni$_.JObject _$this)
     jni$_.JMap<jni$_.JLong?, NIAllTypes?> map,
     jni$_.JMap<jni$_.JLong?, NIAllNullableTypesWithoutRecursion?>? map1,
   ) {
+    final _$$classRef = _class.reference;
     final _$nIAllNullableTypes = nIAllNullableTypes.reference;
     final _$nIAllNullableTypesWithoutRecursion =
         nIAllNullableTypesWithoutRecursion?.reference ?? jni$_.jNullReference;
@@ -741,7 +752,7 @@ extension type NIAllClassesWrapper._(jni$_.JObject _$this)
     final _$map = map.reference;
     final _$map1 = map1?.reference ?? jni$_.jNullReference;
     return _new$(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_new$.pointer,
             _$nIAllNullableTypes.pointer,
             _$nIAllNullableTypesWithoutRecursion.pointer,
@@ -801,6 +812,7 @@ extension type NIAllClassesWrapper._(jni$_.JObject _$this)
     core$_.int i,
     jni$_.JObject? defaultConstructorMarker,
   ) {
+    final _$$classRef = _class.reference;
     final _$nIAllNullableTypes =
         nIAllNullableTypes?.reference ?? jni$_.jNullReference;
     final _$nIAllNullableTypesWithoutRecursion =
@@ -813,7 +825,7 @@ extension type NIAllClassesWrapper._(jni$_.JObject _$this)
     final _$defaultConstructorMarker =
         defaultConstructorMarker?.reference ?? jni$_.jNullReference;
     return _new$1(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_new$1.pointer,
             _$nIAllNullableTypes.pointer,
             _$nIAllNullableTypesWithoutRecursion.pointer,
@@ -850,8 +862,9 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   /// from: `public final com.github.dart_lang.jnigen.NIAllNullableTypes getAllNullableTypes()`
   /// The returned object must be released after use, by calling the [release] method.
   NIAllNullableTypes get allNullableTypes {
+    final _$$selfRef = reference;
     return _get$allNullableTypes(
-            reference.pointer, _id_get$allNullableTypes.pointer)
+            _$$selfRef.pointer, _id_get$allNullableTypes.pointer)
         .object<NIAllNullableTypes>();
   }
 
@@ -877,8 +890,9 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   /// from: `public final com.github.dart_lang.jnigen.NIAllNullableTypesWithoutRecursion getAllNullableTypesWithoutRecursion()`
   /// The returned object must be released after use, by calling the [release] method.
   NIAllNullableTypesWithoutRecursion? get allNullableTypesWithoutRecursion {
-    return _get$allNullableTypesWithoutRecursion(
-            reference.pointer, _id_get$allNullableTypesWithoutRecursion.pointer)
+    final _$$selfRef = reference;
+    return _get$allNullableTypesWithoutRecursion(_$$selfRef.pointer,
+            _id_get$allNullableTypesWithoutRecursion.pointer)
         .object<NIAllNullableTypesWithoutRecursion?>();
   }
 
@@ -902,7 +916,8 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   /// from: `public final com.github.dart_lang.jnigen.NIAllTypes getAllTypes()`
   /// The returned object must be released after use, by calling the [release] method.
   NIAllTypes? get allTypes {
-    return _get$allTypes(reference.pointer, _id_get$allTypes.pointer)
+    final _$$selfRef = reference;
+    return _get$allTypes(_$$selfRef.pointer, _id_get$allTypes.pointer)
         .object<NIAllTypes?>();
   }
 
@@ -926,7 +941,8 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   /// from: `public final java.util.List<com.github.dart_lang.jnigen.NIAllTypes> getClassList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<NIAllTypes?> get classList {
-    return _get$classList(reference.pointer, _id_get$classList.pointer)
+    final _$$selfRef = reference;
+    return _get$classList(_$$selfRef.pointer, _id_get$classList.pointer)
         .object<jni$_.JList<NIAllTypes?>>();
   }
 
@@ -951,8 +967,9 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   /// from: `public final java.util.List<com.github.dart_lang.jnigen.NIAllNullableTypesWithoutRecursion> getNullableClassList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<NIAllNullableTypesWithoutRecursion?>? get nullableClassList {
+    final _$$selfRef = reference;
     return _get$nullableClassList(
-            reference.pointer, _id_get$nullableClassList.pointer)
+            _$$selfRef.pointer, _id_get$nullableClassList.pointer)
         .object<jni$_.JList<NIAllNullableTypesWithoutRecursion?>?>();
   }
 
@@ -976,7 +993,8 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   /// from: `public final java.util.Map<java.lang.Long, com.github.dart_lang.jnigen.NIAllTypes> getClassMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, NIAllTypes?> get classMap {
-    return _get$classMap(reference.pointer, _id_get$classMap.pointer)
+    final _$$selfRef = reference;
+    return _get$classMap(_$$selfRef.pointer, _id_get$classMap.pointer)
         .object<jni$_.JMap<jni$_.JLong?, NIAllTypes?>>();
   }
 
@@ -1002,8 +1020,9 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, NIAllNullableTypesWithoutRecursion?>?
       get nullableClassMap {
+    final _$$selfRef = reference;
     return _get$nullableClassMap(
-            reference.pointer, _id_get$nullableClassMap.pointer)
+            _$$selfRef.pointer, _id_get$nullableClassMap.pointer)
         .object<
             jni$_.JMap<jni$_.JLong?, NIAllNullableTypesWithoutRecursion?>?>();
   }
@@ -1028,7 +1047,8 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   /// from: `public fun toList(): kotlin.collections.List<kotlin.Any?>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject?> toList() {
-    return _toList(reference.pointer, _id_toList.pointer)
+    final _$$selfRef = reference;
+    return _toList(_$$selfRef.pointer, _id_toList.pointer)
         .object<jni$_.JList<jni$_.JObject?>>();
   }
 
@@ -1052,8 +1072,9 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -1076,7 +1097,8 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
 
   /// from: `public fun hashCode(): kotlin.Int`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_component1 = NIAllClassesWrapper._class.instanceMethodId(
@@ -1099,7 +1121,8 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   /// from: `public operator fun component1(): com.github.dart_lang.jnigen.NIAllNullableTypes`
   /// The returned object must be released after use, by calling the [release] method.
   NIAllNullableTypes component1() {
-    return _component1(reference.pointer, _id_component1.pointer)
+    final _$$selfRef = reference;
+    return _component1(_$$selfRef.pointer, _id_component1.pointer)
         .object<NIAllNullableTypes>();
   }
 
@@ -1123,7 +1146,8 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   /// from: `public operator fun component2(): com.github.dart_lang.jnigen.NIAllNullableTypesWithoutRecursion?`
   /// The returned object must be released after use, by calling the [release] method.
   NIAllNullableTypesWithoutRecursion? component2() {
-    return _component2(reference.pointer, _id_component2.pointer)
+    final _$$selfRef = reference;
+    return _component2(_$$selfRef.pointer, _id_component2.pointer)
         .object<NIAllNullableTypesWithoutRecursion?>();
   }
 
@@ -1147,7 +1171,8 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   /// from: `public operator fun component3(): com.github.dart_lang.jnigen.NIAllTypes?`
   /// The returned object must be released after use, by calling the [release] method.
   NIAllTypes? component3() {
-    return _component3(reference.pointer, _id_component3.pointer)
+    final _$$selfRef = reference;
+    return _component3(_$$selfRef.pointer, _id_component3.pointer)
         .object<NIAllTypes?>();
   }
 
@@ -1171,7 +1196,8 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   /// from: `public operator fun component4(): kotlin.collections.List<com.github.dart_lang.jnigen.NIAllTypes?>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<NIAllTypes?> component4() {
-    return _component4(reference.pointer, _id_component4.pointer)
+    final _$$selfRef = reference;
+    return _component4(_$$selfRef.pointer, _id_component4.pointer)
         .object<jni$_.JList<NIAllTypes?>>();
   }
 
@@ -1195,7 +1221,8 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   /// from: `public operator fun component5(): kotlin.collections.List<com.github.dart_lang.jnigen.NIAllNullableTypesWithoutRecursion?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<NIAllNullableTypesWithoutRecursion?>? component5() {
-    return _component5(reference.pointer, _id_component5.pointer)
+    final _$$selfRef = reference;
+    return _component5(_$$selfRef.pointer, _id_component5.pointer)
         .object<jni$_.JList<NIAllNullableTypesWithoutRecursion?>?>();
   }
 
@@ -1219,7 +1246,8 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   /// from: `public operator fun component6(): kotlin.collections.Map<kotlin.Long?, com.github.dart_lang.jnigen.NIAllTypes?>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, NIAllTypes?> component6() {
-    return _component6(reference.pointer, _id_component6.pointer)
+    final _$$selfRef = reference;
+    return _component6(_$$selfRef.pointer, _id_component6.pointer)
         .object<jni$_.JMap<jni$_.JLong?, NIAllTypes?>>();
   }
 
@@ -1243,7 +1271,8 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   /// from: `public operator fun component7(): kotlin.collections.Map<kotlin.Long?, com.github.dart_lang.jnigen.NIAllNullableTypesWithoutRecursion?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, NIAllNullableTypesWithoutRecursion?>? component7() {
-    return _component7(reference.pointer, _id_component7.pointer).object<
+    final _$$selfRef = reference;
+    return _component7(_$$selfRef.pointer, _id_component7.pointer).object<
         jni$_.JMap<jni$_.JLong?, NIAllNullableTypesWithoutRecursion?>?>();
   }
 
@@ -1290,6 +1319,7 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
     jni$_.JMap<jni$_.JLong?, NIAllTypes?> map,
     jni$_.JMap<jni$_.JLong?, NIAllNullableTypesWithoutRecursion?>? map1,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllNullableTypes = nIAllNullableTypes.reference;
     final _$nIAllNullableTypesWithoutRecursion =
         nIAllNullableTypesWithoutRecursion?.reference ?? jni$_.jNullReference;
@@ -1299,7 +1329,7 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
     final _$map = map.reference;
     final _$map1 = map1?.reference ?? jni$_.jNullReference;
     return _copy(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_copy.pointer,
             _$nIAllNullableTypes.pointer,
             _$nIAllNullableTypesWithoutRecursion.pointer,
@@ -1331,7 +1361,8 @@ extension NIAllClassesWrapper$$Methods on NIAllClassesWrapper {
   /// from: `public fun toString(): kotlin.String`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<jni$_.JString>();
   }
 }
@@ -1375,9 +1406,10 @@ extension type NIAllNullableTypes$Companion._(jni$_.JObject _$this)
   factory NIAllNullableTypes$Companion(
     jni$_.JObject? defaultConstructorMarker,
   ) {
+    final _$$classRef = _class.reference;
     final _$defaultConstructorMarker =
         defaultConstructorMarker?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer,
+    return _new$(_$$classRef.pointer, _id_new$.pointer,
             _$defaultConstructorMarker.pointer)
         .object<NIAllNullableTypes$Companion>();
   }
@@ -1407,8 +1439,9 @@ extension NIAllNullableTypes$Companion$$Methods
   NIAllNullableTypes fromList(
     jni$_.JList<jni$_.JObject?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _fromList(reference.pointer, _id_fromList.pointer, _$list.pointer)
+    return _fromList(_$$selfRef.pointer, _id_fromList.pointer, _$list.pointer)
         .object<NIAllNullableTypes>();
   }
 }
@@ -1558,6 +1591,7 @@ extension type NIAllNullableTypes._(jni$_.JObject _$this)
     jni$_.JMap<jni$_.JLong?, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>? map6,
     jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>? map7,
   ) {
+    final _$$classRef = _class.reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final _$long1 = long1?.reference ?? jni$_.jNullReference;
@@ -1591,7 +1625,7 @@ extension type NIAllNullableTypes._(jni$_.JObject _$this)
     final _$map6 = map6?.reference ?? jni$_.jNullReference;
     final _$map7 = map7?.reference ?? jni$_.jNullReference;
     return _new$(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_new$.pointer,
             _$boolean.pointer,
             _$long.pointer,
@@ -1747,6 +1781,7 @@ extension type NIAllNullableTypes._(jni$_.JObject _$this)
     core$_.int i,
     jni$_.JObject? defaultConstructorMarker,
   ) {
+    final _$$classRef = _class.reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final _$long1 = long1?.reference ?? jni$_.jNullReference;
@@ -1782,7 +1817,7 @@ extension type NIAllNullableTypes._(jni$_.JObject _$this)
     final _$defaultConstructorMarker =
         defaultConstructorMarker?.reference ?? jni$_.jNullReference;
     return _new$1(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_new$1.pointer,
             _$boolean.pointer,
             _$long.pointer,
@@ -1839,7 +1874,8 @@ extension type NIAllNullableTypes._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory NIAllNullableTypes.new$2() {
-    return _new$2(_class.reference.pointer, _id_new$2.pointer)
+    final _$$classRef = _class.reference;
+    return _new$2(_$$classRef.pointer, _id_new$2.pointer)
         .object<NIAllNullableTypes>();
   }
 }
@@ -1866,7 +1902,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.lang.Boolean getANullableBool()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JBoolean? get aNullableBool {
-    return _get$aNullableBool(reference.pointer, _id_get$aNullableBool.pointer)
+    final _$$selfRef = reference;
+    return _get$aNullableBool(_$$selfRef.pointer, _id_get$aNullableBool.pointer)
         .object<jni$_.JBoolean?>();
   }
 
@@ -1891,7 +1928,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.lang.Long getANullableInt()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JLong? get aNullableInt {
-    return _get$aNullableInt(reference.pointer, _id_get$aNullableInt.pointer)
+    final _$$selfRef = reference;
+    return _get$aNullableInt(_$$selfRef.pointer, _id_get$aNullableInt.pointer)
         .object<jni$_.JLong?>();
   }
 
@@ -1916,8 +1954,9 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.lang.Long getANullableInt64()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JLong? get aNullableInt64 {
+    final _$$selfRef = reference;
     return _get$aNullableInt64(
-            reference.pointer, _id_get$aNullableInt64.pointer)
+            _$$selfRef.pointer, _id_get$aNullableInt64.pointer)
         .object<jni$_.JLong?>();
   }
 
@@ -1942,8 +1981,9 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.lang.Double getANullableDouble()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JDouble? get aNullableDouble {
+    final _$$selfRef = reference;
     return _get$aNullableDouble(
-            reference.pointer, _id_get$aNullableDouble.pointer)
+            _$$selfRef.pointer, _id_get$aNullableDouble.pointer)
         .object<jni$_.JDouble?>();
   }
 
@@ -1968,8 +2008,9 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final byte[] getANullableByteArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JByteArray? get aNullableByteArray {
+    final _$$selfRef = reference;
     return _get$aNullableByteArray(
-            reference.pointer, _id_get$aNullableByteArray.pointer)
+            _$$selfRef.pointer, _id_get$aNullableByteArray.pointer)
         .object<jni$_.JByteArray?>();
   }
 
@@ -1994,8 +2035,9 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final int[] getANullable4ByteArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JIntArray? get aNullable4ByteArray {
+    final _$$selfRef = reference;
     return _get$aNullable4ByteArray(
-            reference.pointer, _id_get$aNullable4ByteArray.pointer)
+            _$$selfRef.pointer, _id_get$aNullable4ByteArray.pointer)
         .object<jni$_.JIntArray?>();
   }
 
@@ -2020,8 +2062,9 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final long[] getANullable8ByteArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JLongArray? get aNullable8ByteArray {
+    final _$$selfRef = reference;
     return _get$aNullable8ByteArray(
-            reference.pointer, _id_get$aNullable8ByteArray.pointer)
+            _$$selfRef.pointer, _id_get$aNullable8ByteArray.pointer)
         .object<jni$_.JLongArray?>();
   }
 
@@ -2046,8 +2089,9 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final double[] getANullableFloatArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JDoubleArray? get aNullableFloatArray {
+    final _$$selfRef = reference;
     return _get$aNullableFloatArray(
-            reference.pointer, _id_get$aNullableFloatArray.pointer)
+            _$$selfRef.pointer, _id_get$aNullableFloatArray.pointer)
         .object<jni$_.JDoubleArray?>();
   }
 
@@ -2072,7 +2116,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final com.github.dart_lang.jnigen.NIAnEnum getANullableEnum()`
   /// The returned object must be released after use, by calling the [release] method.
   NIAnEnum? get aNullableEnum {
-    return _get$aNullableEnum(reference.pointer, _id_get$aNullableEnum.pointer)
+    final _$$selfRef = reference;
+    return _get$aNullableEnum(_$$selfRef.pointer, _id_get$aNullableEnum.pointer)
         .object<NIAnEnum?>();
   }
 
@@ -2097,8 +2142,9 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final com.github.dart_lang.jnigen.NIAnotherEnum getAnotherNullableEnum()`
   /// The returned object must be released after use, by calling the [release] method.
   NIAnotherEnum? get anotherNullableEnum {
+    final _$$selfRef = reference;
     return _get$anotherNullableEnum(
-            reference.pointer, _id_get$anotherNullableEnum.pointer)
+            _$$selfRef.pointer, _id_get$anotherNullableEnum.pointer)
         .object<NIAnotherEnum?>();
   }
 
@@ -2123,8 +2169,9 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.lang.String getANullableString()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? get aNullableString {
+    final _$$selfRef = reference;
     return _get$aNullableString(
-            reference.pointer, _id_get$aNullableString.pointer)
+            _$$selfRef.pointer, _id_get$aNullableString.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -2149,8 +2196,9 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.lang.Object getANullableObject()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? get aNullableObject {
+    final _$$selfRef = reference;
     return _get$aNullableObject(
-            reference.pointer, _id_get$aNullableObject.pointer)
+            _$$selfRef.pointer, _id_get$aNullableObject.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2175,8 +2223,9 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final com.github.dart_lang.jnigen.NIAllNullableTypes getAllNullableTypes()`
   /// The returned object must be released after use, by calling the [release] method.
   NIAllNullableTypes? get allNullableTypes {
+    final _$$selfRef = reference;
     return _get$allNullableTypes(
-            reference.pointer, _id_get$allNullableTypes.pointer)
+            _$$selfRef.pointer, _id_get$allNullableTypes.pointer)
         .object<NIAllNullableTypes?>();
   }
 
@@ -2200,7 +2249,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.List<java.lang.Object> getList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject?>? get list {
-    return _get$list(reference.pointer, _id_get$list.pointer)
+    final _$$selfRef = reference;
+    return _get$list(_$$selfRef.pointer, _id_get$list.pointer)
         .object<jni$_.JList<jni$_.JObject?>?>();
   }
 
@@ -2224,7 +2274,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.List<java.lang.String> getStringList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JString?>? get stringList {
-    return _get$stringList(reference.pointer, _id_get$stringList.pointer)
+    final _$$selfRef = reference;
+    return _get$stringList(_$$selfRef.pointer, _id_get$stringList.pointer)
         .object<jni$_.JList<jni$_.JString?>?>();
   }
 
@@ -2248,7 +2299,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.List<java.lang.Long> getIntList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JLong?>? get intList {
-    return _get$intList(reference.pointer, _id_get$intList.pointer)
+    final _$$selfRef = reference;
+    return _get$intList(_$$selfRef.pointer, _id_get$intList.pointer)
         .object<jni$_.JList<jni$_.JLong?>?>();
   }
 
@@ -2272,7 +2324,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.List<java.lang.Double> getDoubleList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JDouble?>? get doubleList {
-    return _get$doubleList(reference.pointer, _id_get$doubleList.pointer)
+    final _$$selfRef = reference;
+    return _get$doubleList(_$$selfRef.pointer, _id_get$doubleList.pointer)
         .object<jni$_.JList<jni$_.JDouble?>?>();
   }
 
@@ -2296,7 +2349,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.List<java.lang.Boolean> getBoolList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JBoolean?>? get boolList {
-    return _get$boolList(reference.pointer, _id_get$boolList.pointer)
+    final _$$selfRef = reference;
+    return _get$boolList(_$$selfRef.pointer, _id_get$boolList.pointer)
         .object<jni$_.JList<jni$_.JBoolean?>?>();
   }
 
@@ -2320,7 +2374,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.List<com.github.dart_lang.jnigen.NIAnEnum> getEnumList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<NIAnEnum?>? get enumList {
-    return _get$enumList(reference.pointer, _id_get$enumList.pointer)
+    final _$$selfRef = reference;
+    return _get$enumList(_$$selfRef.pointer, _id_get$enumList.pointer)
         .object<jni$_.JList<NIAnEnum?>?>();
   }
 
@@ -2344,7 +2399,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.List<java.lang.Object> getObjectList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject?>? get objectList {
-    return _get$objectList(reference.pointer, _id_get$objectList.pointer)
+    final _$$selfRef = reference;
+    return _get$objectList(_$$selfRef.pointer, _id_get$objectList.pointer)
         .object<jni$_.JList<jni$_.JObject?>?>();
   }
 
@@ -2368,7 +2424,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.List<java.util.List<java.lang.Object>> getListList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JList<jni$_.JObject?>?>? get listList {
-    return _get$listList(reference.pointer, _id_get$listList.pointer)
+    final _$$selfRef = reference;
+    return _get$listList(_$$selfRef.pointer, _id_get$listList.pointer)
         .object<jni$_.JList<jni$_.JList<jni$_.JObject?>?>?>();
   }
 
@@ -2392,7 +2449,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.List<java.util.Map<java.lang.Object, java.lang.Object>> getMapList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>? get mapList {
-    return _get$mapList(reference.pointer, _id_get$mapList.pointer)
+    final _$$selfRef = reference;
+    return _get$mapList(_$$selfRef.pointer, _id_get$mapList.pointer)
         .object<jni$_.JList<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>?>();
   }
 
@@ -2417,8 +2475,9 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.List<com.github.dart_lang.jnigen.NIAllNullableTypes> getRecursiveClassList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<NIAllNullableTypes?>? get recursiveClassList {
+    final _$$selfRef = reference;
     return _get$recursiveClassList(
-            reference.pointer, _id_get$recursiveClassList.pointer)
+            _$$selfRef.pointer, _id_get$recursiveClassList.pointer)
         .object<jni$_.JList<NIAllNullableTypes?>?>();
   }
 
@@ -2442,7 +2501,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.Map<java.lang.Object, java.lang.Object> getMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JObject, jni$_.JObject?>? get map {
-    return _get$map(reference.pointer, _id_get$map.pointer)
+    final _$$selfRef = reference;
+    return _get$map(_$$selfRef.pointer, _id_get$map.pointer)
         .object<jni$_.JMap<jni$_.JObject, jni$_.JObject?>?>();
   }
 
@@ -2466,7 +2526,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.Map<java.lang.String, java.lang.String> getStringMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JString?, jni$_.JString?>? get stringMap {
-    return _get$stringMap(reference.pointer, _id_get$stringMap.pointer)
+    final _$$selfRef = reference;
+    return _get$stringMap(_$$selfRef.pointer, _id_get$stringMap.pointer)
         .object<jni$_.JMap<jni$_.JString?, jni$_.JString?>?>();
   }
 
@@ -2490,7 +2551,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.Map<java.lang.Long, java.lang.Long> getIntMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, jni$_.JLong?>? get intMap {
-    return _get$intMap(reference.pointer, _id_get$intMap.pointer)
+    final _$$selfRef = reference;
+    return _get$intMap(_$$selfRef.pointer, _id_get$intMap.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JLong?>?>();
   }
 
@@ -2514,7 +2576,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.Map<com.github.dart_lang.jnigen.NIAnEnum, com.github.dart_lang.jnigen.NIAnEnum> getEnumMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<NIAnEnum?, NIAnEnum?>? get enumMap {
-    return _get$enumMap(reference.pointer, _id_get$enumMap.pointer)
+    final _$$selfRef = reference;
+    return _get$enumMap(_$$selfRef.pointer, _id_get$enumMap.pointer)
         .object<jni$_.JMap<NIAnEnum?, NIAnEnum?>?>();
   }
 
@@ -2538,7 +2601,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.Map<java.lang.Object, java.lang.Object> getObjectMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JObject?, jni$_.JObject?>? get objectMap {
-    return _get$objectMap(reference.pointer, _id_get$objectMap.pointer)
+    final _$$selfRef = reference;
+    return _get$objectMap(_$$selfRef.pointer, _id_get$objectMap.pointer)
         .object<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>();
   }
 
@@ -2562,7 +2626,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.Map<java.lang.Long, java.util.List<java.lang.Object>> getListMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, jni$_.JList<jni$_.JObject?>?>? get listMap {
-    return _get$listMap(reference.pointer, _id_get$listMap.pointer)
+    final _$$selfRef = reference;
+    return _get$listMap(_$$selfRef.pointer, _id_get$listMap.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JList<jni$_.JObject?>?>?>();
   }
 
@@ -2587,7 +2652,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>?
       get mapMap {
-    return _get$mapMap(reference.pointer, _id_get$mapMap.pointer).object<
+    final _$$selfRef = reference;
+    return _get$mapMap(_$$selfRef.pointer, _id_get$mapMap.pointer).object<
         jni$_
         .JMap<jni$_.JLong?, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>?>();
   }
@@ -2613,8 +2679,9 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public final java.util.Map<java.lang.Long, com.github.dart_lang.jnigen.NIAllNullableTypes> getRecursiveClassMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>? get recursiveClassMap {
+    final _$$selfRef = reference;
     return _get$recursiveClassMap(
-            reference.pointer, _id_get$recursiveClassMap.pointer)
+            _$$selfRef.pointer, _id_get$recursiveClassMap.pointer)
         .object<jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>?>();
   }
 
@@ -2638,7 +2705,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public fun toList(): kotlin.collections.List<kotlin.Any?>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject?> toList() {
-    return _toList(reference.pointer, _id_toList.pointer)
+    final _$$selfRef = reference;
+    return _toList(_$$selfRef.pointer, _id_toList.pointer)
         .object<jni$_.JList<jni$_.JObject?>>();
   }
 
@@ -2662,8 +2730,9 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -2686,7 +2755,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
 
   /// from: `public fun hashCode(): kotlin.Int`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_component1 = NIAllNullableTypes._class.instanceMethodId(
@@ -2709,7 +2779,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component1(): kotlin.Boolean?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JBoolean? component1() {
-    return _component1(reference.pointer, _id_component1.pointer)
+    final _$$selfRef = reference;
+    return _component1(_$$selfRef.pointer, _id_component1.pointer)
         .object<jni$_.JBoolean?>();
   }
 
@@ -2733,7 +2804,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component2(): kotlin.Long?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JLong? component2() {
-    return _component2(reference.pointer, _id_component2.pointer)
+    final _$$selfRef = reference;
+    return _component2(_$$selfRef.pointer, _id_component2.pointer)
         .object<jni$_.JLong?>();
   }
 
@@ -2757,7 +2829,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component3(): kotlin.Long?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JLong? component3() {
-    return _component3(reference.pointer, _id_component3.pointer)
+    final _$$selfRef = reference;
+    return _component3(_$$selfRef.pointer, _id_component3.pointer)
         .object<jni$_.JLong?>();
   }
 
@@ -2781,7 +2854,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component4(): kotlin.Double?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JDouble? component4() {
-    return _component4(reference.pointer, _id_component4.pointer)
+    final _$$selfRef = reference;
+    return _component4(_$$selfRef.pointer, _id_component4.pointer)
         .object<jni$_.JDouble?>();
   }
 
@@ -2805,7 +2879,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component5(): kotlin.ByteArray?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JByteArray? component5() {
-    return _component5(reference.pointer, _id_component5.pointer)
+    final _$$selfRef = reference;
+    return _component5(_$$selfRef.pointer, _id_component5.pointer)
         .object<jni$_.JByteArray?>();
   }
 
@@ -2829,7 +2904,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component6(): kotlin.IntArray?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JIntArray? component6() {
-    return _component6(reference.pointer, _id_component6.pointer)
+    final _$$selfRef = reference;
+    return _component6(_$$selfRef.pointer, _id_component6.pointer)
         .object<jni$_.JIntArray?>();
   }
 
@@ -2853,7 +2929,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component7(): kotlin.LongArray?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JLongArray? component7() {
-    return _component7(reference.pointer, _id_component7.pointer)
+    final _$$selfRef = reference;
+    return _component7(_$$selfRef.pointer, _id_component7.pointer)
         .object<jni$_.JLongArray?>();
   }
 
@@ -2877,7 +2954,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component8(): kotlin.DoubleArray?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JDoubleArray? component8() {
-    return _component8(reference.pointer, _id_component8.pointer)
+    final _$$selfRef = reference;
+    return _component8(_$$selfRef.pointer, _id_component8.pointer)
         .object<jni$_.JDoubleArray?>();
   }
 
@@ -2901,7 +2979,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component9(): com.github.dart_lang.jnigen.NIAnEnum?`
   /// The returned object must be released after use, by calling the [release] method.
   NIAnEnum? component9() {
-    return _component9(reference.pointer, _id_component9.pointer)
+    final _$$selfRef = reference;
+    return _component9(_$$selfRef.pointer, _id_component9.pointer)
         .object<NIAnEnum?>();
   }
 
@@ -2925,7 +3004,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component10(): com.github.dart_lang.jnigen.NIAnotherEnum?`
   /// The returned object must be released after use, by calling the [release] method.
   NIAnotherEnum? component10() {
-    return _component10(reference.pointer, _id_component10.pointer)
+    final _$$selfRef = reference;
+    return _component10(_$$selfRef.pointer, _id_component10.pointer)
         .object<NIAnotherEnum?>();
   }
 
@@ -2949,7 +3029,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component11(): kotlin.String?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? component11() {
-    return _component11(reference.pointer, _id_component11.pointer)
+    final _$$selfRef = reference;
+    return _component11(_$$selfRef.pointer, _id_component11.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -2973,7 +3054,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component12(): kotlin.Any?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? component12() {
-    return _component12(reference.pointer, _id_component12.pointer)
+    final _$$selfRef = reference;
+    return _component12(_$$selfRef.pointer, _id_component12.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2997,7 +3079,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component13(): com.github.dart_lang.jnigen.NIAllNullableTypes?`
   /// The returned object must be released after use, by calling the [release] method.
   NIAllNullableTypes? component13() {
-    return _component13(reference.pointer, _id_component13.pointer)
+    final _$$selfRef = reference;
+    return _component13(_$$selfRef.pointer, _id_component13.pointer)
         .object<NIAllNullableTypes?>();
   }
 
@@ -3021,7 +3104,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component14(): kotlin.collections.List<kotlin.Any?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject?>? component14() {
-    return _component14(reference.pointer, _id_component14.pointer)
+    final _$$selfRef = reference;
+    return _component14(_$$selfRef.pointer, _id_component14.pointer)
         .object<jni$_.JList<jni$_.JObject?>?>();
   }
 
@@ -3045,7 +3129,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component15(): kotlin.collections.List<kotlin.String?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JString?>? component15() {
-    return _component15(reference.pointer, _id_component15.pointer)
+    final _$$selfRef = reference;
+    return _component15(_$$selfRef.pointer, _id_component15.pointer)
         .object<jni$_.JList<jni$_.JString?>?>();
   }
 
@@ -3069,7 +3154,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component16(): kotlin.collections.List<kotlin.Long?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JLong?>? component16() {
-    return _component16(reference.pointer, _id_component16.pointer)
+    final _$$selfRef = reference;
+    return _component16(_$$selfRef.pointer, _id_component16.pointer)
         .object<jni$_.JList<jni$_.JLong?>?>();
   }
 
@@ -3093,7 +3179,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component17(): kotlin.collections.List<kotlin.Double?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JDouble?>? component17() {
-    return _component17(reference.pointer, _id_component17.pointer)
+    final _$$selfRef = reference;
+    return _component17(_$$selfRef.pointer, _id_component17.pointer)
         .object<jni$_.JList<jni$_.JDouble?>?>();
   }
 
@@ -3117,7 +3204,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component18(): kotlin.collections.List<kotlin.Boolean?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JBoolean?>? component18() {
-    return _component18(reference.pointer, _id_component18.pointer)
+    final _$$selfRef = reference;
+    return _component18(_$$selfRef.pointer, _id_component18.pointer)
         .object<jni$_.JList<jni$_.JBoolean?>?>();
   }
 
@@ -3141,7 +3229,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component19(): kotlin.collections.List<com.github.dart_lang.jnigen.NIAnEnum?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<NIAnEnum?>? component19() {
-    return _component19(reference.pointer, _id_component19.pointer)
+    final _$$selfRef = reference;
+    return _component19(_$$selfRef.pointer, _id_component19.pointer)
         .object<jni$_.JList<NIAnEnum?>?>();
   }
 
@@ -3165,7 +3254,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component20(): kotlin.collections.List<kotlin.Any?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject?>? component20() {
-    return _component20(reference.pointer, _id_component20.pointer)
+    final _$$selfRef = reference;
+    return _component20(_$$selfRef.pointer, _id_component20.pointer)
         .object<jni$_.JList<jni$_.JObject?>?>();
   }
 
@@ -3189,7 +3279,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component21(): kotlin.collections.List<kotlin.collections.List<kotlin.Any?>?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JList<jni$_.JObject?>?>? component21() {
-    return _component21(reference.pointer, _id_component21.pointer)
+    final _$$selfRef = reference;
+    return _component21(_$$selfRef.pointer, _id_component21.pointer)
         .object<jni$_.JList<jni$_.JList<jni$_.JObject?>?>?>();
   }
 
@@ -3213,7 +3304,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component22(): kotlin.collections.List<kotlin.collections.Map<kotlin.Any?, kotlin.Any?>?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>? component22() {
-    return _component22(reference.pointer, _id_component22.pointer)
+    final _$$selfRef = reference;
+    return _component22(_$$selfRef.pointer, _id_component22.pointer)
         .object<jni$_.JList<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>?>();
   }
 
@@ -3237,7 +3329,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component23(): kotlin.collections.List<com.github.dart_lang.jnigen.NIAllNullableTypes?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<NIAllNullableTypes?>? component23() {
-    return _component23(reference.pointer, _id_component23.pointer)
+    final _$$selfRef = reference;
+    return _component23(_$$selfRef.pointer, _id_component23.pointer)
         .object<jni$_.JList<NIAllNullableTypes?>?>();
   }
 
@@ -3261,7 +3354,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component24(): kotlin.collections.Map<kotlin.Any, kotlin.Any?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JObject, jni$_.JObject?>? component24() {
-    return _component24(reference.pointer, _id_component24.pointer)
+    final _$$selfRef = reference;
+    return _component24(_$$selfRef.pointer, _id_component24.pointer)
         .object<jni$_.JMap<jni$_.JObject, jni$_.JObject?>?>();
   }
 
@@ -3285,7 +3379,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component25(): kotlin.collections.Map<kotlin.String?, kotlin.String?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JString?, jni$_.JString?>? component25() {
-    return _component25(reference.pointer, _id_component25.pointer)
+    final _$$selfRef = reference;
+    return _component25(_$$selfRef.pointer, _id_component25.pointer)
         .object<jni$_.JMap<jni$_.JString?, jni$_.JString?>?>();
   }
 
@@ -3309,7 +3404,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component26(): kotlin.collections.Map<kotlin.Long?, kotlin.Long?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, jni$_.JLong?>? component26() {
-    return _component26(reference.pointer, _id_component26.pointer)
+    final _$$selfRef = reference;
+    return _component26(_$$selfRef.pointer, _id_component26.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JLong?>?>();
   }
 
@@ -3333,7 +3429,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component27(): kotlin.collections.Map<com.github.dart_lang.jnigen.NIAnEnum?, com.github.dart_lang.jnigen.NIAnEnum?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<NIAnEnum?, NIAnEnum?>? component27() {
-    return _component27(reference.pointer, _id_component27.pointer)
+    final _$$selfRef = reference;
+    return _component27(_$$selfRef.pointer, _id_component27.pointer)
         .object<jni$_.JMap<NIAnEnum?, NIAnEnum?>?>();
   }
 
@@ -3357,7 +3454,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component28(): kotlin.collections.Map<kotlin.Any?, kotlin.Any?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JObject?, jni$_.JObject?>? component28() {
-    return _component28(reference.pointer, _id_component28.pointer)
+    final _$$selfRef = reference;
+    return _component28(_$$selfRef.pointer, _id_component28.pointer)
         .object<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>();
   }
 
@@ -3381,7 +3479,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component29(): kotlin.collections.Map<kotlin.Long?, kotlin.collections.List<kotlin.Any?>?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, jni$_.JList<jni$_.JObject?>?>? component29() {
-    return _component29(reference.pointer, _id_component29.pointer)
+    final _$$selfRef = reference;
+    return _component29(_$$selfRef.pointer, _id_component29.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JList<jni$_.JObject?>?>?>();
   }
 
@@ -3406,7 +3505,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>?
       component30() {
-    return _component30(reference.pointer, _id_component30.pointer).object<
+    final _$$selfRef = reference;
+    return _component30(_$$selfRef.pointer, _id_component30.pointer).object<
         jni$_
         .JMap<jni$_.JLong?, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>?>();
   }
@@ -3431,7 +3531,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public operator fun component31(): kotlin.collections.Map<kotlin.Long?, com.github.dart_lang.jnigen.NIAllNullableTypes?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>? component31() {
-    return _component31(reference.pointer, _id_component31.pointer)
+    final _$$selfRef = reference;
+    return _component31(_$$selfRef.pointer, _id_component31.pointer)
         .object<jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>?>();
   }
 
@@ -3550,6 +3651,7 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
     jni$_.JMap<jni$_.JLong?, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>? map6,
     jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>? map7,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final _$long1 = long1?.reference ?? jni$_.jNullReference;
@@ -3583,7 +3685,7 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
     final _$map6 = map6?.reference ?? jni$_.jNullReference;
     final _$map7 = map7?.reference ?? jni$_.jNullReference;
     return _copy(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_copy.pointer,
             _$boolean.pointer,
             _$long.pointer,
@@ -3639,7 +3741,8 @@ extension NIAllNullableTypes$$Methods on NIAllNullableTypes {
   /// from: `public fun toString(): kotlin.String`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<jni$_.JString>();
   }
 }
@@ -3682,9 +3785,10 @@ extension type NIAllNullableTypesWithoutRecursion$Companion._(
   factory NIAllNullableTypesWithoutRecursion$Companion(
     jni$_.JObject? defaultConstructorMarker,
   ) {
+    final _$$classRef = _class.reference;
     final _$defaultConstructorMarker =
         defaultConstructorMarker?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer,
+    return _new$(_$$classRef.pointer, _id_new$.pointer,
             _$defaultConstructorMarker.pointer)
         .object<NIAllNullableTypesWithoutRecursion$Companion>();
   }
@@ -3714,8 +3818,9 @@ extension NIAllNullableTypesWithoutRecursion$Companion$$Methods
   NIAllNullableTypesWithoutRecursion fromList(
     jni$_.JList<jni$_.JObject?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _fromList(reference.pointer, _id_fromList.pointer, _$list.pointer)
+    return _fromList(_$$selfRef.pointer, _id_fromList.pointer, _$list.pointer)
         .object<NIAllNullableTypesWithoutRecursion>();
   }
 }
@@ -3857,6 +3962,7 @@ extension type NIAllNullableTypesWithoutRecursion._(jni$_.JObject _$this)
     jni$_.JMap<jni$_.JLong?, jni$_.JList<jni$_.JObject?>?>? map5,
     jni$_.JMap<jni$_.JLong?, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>? map6,
   ) {
+    final _$$classRef = _class.reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final _$long1 = long1?.reference ?? jni$_.jNullReference;
@@ -3886,7 +3992,7 @@ extension type NIAllNullableTypesWithoutRecursion._(jni$_.JObject _$this)
     final _$map5 = map5?.reference ?? jni$_.jNullReference;
     final _$map6 = map6?.reference ?? jni$_.jNullReference;
     return _new$(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_new$.pointer,
             _$boolean.pointer,
             _$long.pointer,
@@ -4030,6 +4136,7 @@ extension type NIAllNullableTypesWithoutRecursion._(jni$_.JObject _$this)
     core$_.int i,
     jni$_.JObject? defaultConstructorMarker,
   ) {
+    final _$$classRef = _class.reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final _$long1 = long1?.reference ?? jni$_.jNullReference;
@@ -4061,7 +4168,7 @@ extension type NIAllNullableTypesWithoutRecursion._(jni$_.JObject _$this)
     final _$defaultConstructorMarker =
         defaultConstructorMarker?.reference ?? jni$_.jNullReference;
     return _new$1(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_new$1.pointer,
             _$boolean.pointer,
             _$long.pointer,
@@ -4115,7 +4222,8 @@ extension type NIAllNullableTypesWithoutRecursion._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory NIAllNullableTypesWithoutRecursion.new$2() {
-    return _new$2(_class.reference.pointer, _id_new$2.pointer)
+    final _$$classRef = _class.reference;
+    return _new$2(_$$classRef.pointer, _id_new$2.pointer)
         .object<NIAllNullableTypesWithoutRecursion>();
   }
 }
@@ -4143,7 +4251,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.lang.Boolean getANullableBool()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JBoolean? get aNullableBool {
-    return _get$aNullableBool(reference.pointer, _id_get$aNullableBool.pointer)
+    final _$$selfRef = reference;
+    return _get$aNullableBool(_$$selfRef.pointer, _id_get$aNullableBool.pointer)
         .object<jni$_.JBoolean?>();
   }
 
@@ -4168,7 +4277,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.lang.Long getANullableInt()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JLong? get aNullableInt {
-    return _get$aNullableInt(reference.pointer, _id_get$aNullableInt.pointer)
+    final _$$selfRef = reference;
+    return _get$aNullableInt(_$$selfRef.pointer, _id_get$aNullableInt.pointer)
         .object<jni$_.JLong?>();
   }
 
@@ -4193,8 +4303,9 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.lang.Long getANullableInt64()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JLong? get aNullableInt64 {
+    final _$$selfRef = reference;
     return _get$aNullableInt64(
-            reference.pointer, _id_get$aNullableInt64.pointer)
+            _$$selfRef.pointer, _id_get$aNullableInt64.pointer)
         .object<jni$_.JLong?>();
   }
 
@@ -4219,8 +4330,9 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.lang.Double getANullableDouble()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JDouble? get aNullableDouble {
+    final _$$selfRef = reference;
     return _get$aNullableDouble(
-            reference.pointer, _id_get$aNullableDouble.pointer)
+            _$$selfRef.pointer, _id_get$aNullableDouble.pointer)
         .object<jni$_.JDouble?>();
   }
 
@@ -4245,8 +4357,9 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final byte[] getANullableByteArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JByteArray? get aNullableByteArray {
+    final _$$selfRef = reference;
     return _get$aNullableByteArray(
-            reference.pointer, _id_get$aNullableByteArray.pointer)
+            _$$selfRef.pointer, _id_get$aNullableByteArray.pointer)
         .object<jni$_.JByteArray?>();
   }
 
@@ -4271,8 +4384,9 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final int[] getANullable4ByteArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JIntArray? get aNullable4ByteArray {
+    final _$$selfRef = reference;
     return _get$aNullable4ByteArray(
-            reference.pointer, _id_get$aNullable4ByteArray.pointer)
+            _$$selfRef.pointer, _id_get$aNullable4ByteArray.pointer)
         .object<jni$_.JIntArray?>();
   }
 
@@ -4297,8 +4411,9 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final long[] getANullable8ByteArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JLongArray? get aNullable8ByteArray {
+    final _$$selfRef = reference;
     return _get$aNullable8ByteArray(
-            reference.pointer, _id_get$aNullable8ByteArray.pointer)
+            _$$selfRef.pointer, _id_get$aNullable8ByteArray.pointer)
         .object<jni$_.JLongArray?>();
   }
 
@@ -4323,8 +4438,9 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final double[] getANullableFloatArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JDoubleArray? get aNullableFloatArray {
+    final _$$selfRef = reference;
     return _get$aNullableFloatArray(
-            reference.pointer, _id_get$aNullableFloatArray.pointer)
+            _$$selfRef.pointer, _id_get$aNullableFloatArray.pointer)
         .object<jni$_.JDoubleArray?>();
   }
 
@@ -4349,7 +4465,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final com.github.dart_lang.jnigen.NIAnEnum getANullableEnum()`
   /// The returned object must be released after use, by calling the [release] method.
   NIAnEnum? get aNullableEnum {
-    return _get$aNullableEnum(reference.pointer, _id_get$aNullableEnum.pointer)
+    final _$$selfRef = reference;
+    return _get$aNullableEnum(_$$selfRef.pointer, _id_get$aNullableEnum.pointer)
         .object<NIAnEnum?>();
   }
 
@@ -4374,8 +4491,9 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final com.github.dart_lang.jnigen.NIAnotherEnum getAnotherNullableEnum()`
   /// The returned object must be released after use, by calling the [release] method.
   NIAnotherEnum? get anotherNullableEnum {
+    final _$$selfRef = reference;
     return _get$anotherNullableEnum(
-            reference.pointer, _id_get$anotherNullableEnum.pointer)
+            _$$selfRef.pointer, _id_get$anotherNullableEnum.pointer)
         .object<NIAnotherEnum?>();
   }
 
@@ -4400,8 +4518,9 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.lang.String getANullableString()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? get aNullableString {
+    final _$$selfRef = reference;
     return _get$aNullableString(
-            reference.pointer, _id_get$aNullableString.pointer)
+            _$$selfRef.pointer, _id_get$aNullableString.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -4426,8 +4545,9 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.lang.Object getANullableObject()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? get aNullableObject {
+    final _$$selfRef = reference;
     return _get$aNullableObject(
-            reference.pointer, _id_get$aNullableObject.pointer)
+            _$$selfRef.pointer, _id_get$aNullableObject.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -4452,7 +4572,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.util.List<java.lang.Object> getList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject?>? get list {
-    return _get$list(reference.pointer, _id_get$list.pointer)
+    final _$$selfRef = reference;
+    return _get$list(_$$selfRef.pointer, _id_get$list.pointer)
         .object<jni$_.JList<jni$_.JObject?>?>();
   }
 
@@ -4477,7 +4598,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.util.List<java.lang.String> getStringList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JString?>? get stringList {
-    return _get$stringList(reference.pointer, _id_get$stringList.pointer)
+    final _$$selfRef = reference;
+    return _get$stringList(_$$selfRef.pointer, _id_get$stringList.pointer)
         .object<jni$_.JList<jni$_.JString?>?>();
   }
 
@@ -4502,7 +4624,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.util.List<java.lang.Long> getIntList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JLong?>? get intList {
-    return _get$intList(reference.pointer, _id_get$intList.pointer)
+    final _$$selfRef = reference;
+    return _get$intList(_$$selfRef.pointer, _id_get$intList.pointer)
         .object<jni$_.JList<jni$_.JLong?>?>();
   }
 
@@ -4527,7 +4650,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.util.List<java.lang.Double> getDoubleList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JDouble?>? get doubleList {
-    return _get$doubleList(reference.pointer, _id_get$doubleList.pointer)
+    final _$$selfRef = reference;
+    return _get$doubleList(_$$selfRef.pointer, _id_get$doubleList.pointer)
         .object<jni$_.JList<jni$_.JDouble?>?>();
   }
 
@@ -4552,7 +4676,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.util.List<java.lang.Boolean> getBoolList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JBoolean?>? get boolList {
-    return _get$boolList(reference.pointer, _id_get$boolList.pointer)
+    final _$$selfRef = reference;
+    return _get$boolList(_$$selfRef.pointer, _id_get$boolList.pointer)
         .object<jni$_.JList<jni$_.JBoolean?>?>();
   }
 
@@ -4577,7 +4702,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.util.List<com.github.dart_lang.jnigen.NIAnEnum> getEnumList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<NIAnEnum?>? get enumList {
-    return _get$enumList(reference.pointer, _id_get$enumList.pointer)
+    final _$$selfRef = reference;
+    return _get$enumList(_$$selfRef.pointer, _id_get$enumList.pointer)
         .object<jni$_.JList<NIAnEnum?>?>();
   }
 
@@ -4602,7 +4728,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.util.List<java.lang.Object> getObjectList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject?>? get objectList {
-    return _get$objectList(reference.pointer, _id_get$objectList.pointer)
+    final _$$selfRef = reference;
+    return _get$objectList(_$$selfRef.pointer, _id_get$objectList.pointer)
         .object<jni$_.JList<jni$_.JObject?>?>();
   }
 
@@ -4627,7 +4754,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.util.List<java.util.List<java.lang.Object>> getListList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JList<jni$_.JObject?>?>? get listList {
-    return _get$listList(reference.pointer, _id_get$listList.pointer)
+    final _$$selfRef = reference;
+    return _get$listList(_$$selfRef.pointer, _id_get$listList.pointer)
         .object<jni$_.JList<jni$_.JList<jni$_.JObject?>?>?>();
   }
 
@@ -4652,7 +4780,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.util.List<java.util.Map<java.lang.Object, java.lang.Object>> getMapList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>? get mapList {
-    return _get$mapList(reference.pointer, _id_get$mapList.pointer)
+    final _$$selfRef = reference;
+    return _get$mapList(_$$selfRef.pointer, _id_get$mapList.pointer)
         .object<jni$_.JList<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>?>();
   }
 
@@ -4677,7 +4806,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.util.Map<java.lang.Object, java.lang.Object> getMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JObject, jni$_.JObject?>? get map {
-    return _get$map(reference.pointer, _id_get$map.pointer)
+    final _$$selfRef = reference;
+    return _get$map(_$$selfRef.pointer, _id_get$map.pointer)
         .object<jni$_.JMap<jni$_.JObject, jni$_.JObject?>?>();
   }
 
@@ -4702,7 +4832,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.util.Map<java.lang.String, java.lang.String> getStringMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JString?, jni$_.JString?>? get stringMap {
-    return _get$stringMap(reference.pointer, _id_get$stringMap.pointer)
+    final _$$selfRef = reference;
+    return _get$stringMap(_$$selfRef.pointer, _id_get$stringMap.pointer)
         .object<jni$_.JMap<jni$_.JString?, jni$_.JString?>?>();
   }
 
@@ -4727,7 +4858,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.util.Map<java.lang.Long, java.lang.Long> getIntMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, jni$_.JLong?>? get intMap {
-    return _get$intMap(reference.pointer, _id_get$intMap.pointer)
+    final _$$selfRef = reference;
+    return _get$intMap(_$$selfRef.pointer, _id_get$intMap.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JLong?>?>();
   }
 
@@ -4752,7 +4884,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.util.Map<com.github.dart_lang.jnigen.NIAnEnum, com.github.dart_lang.jnigen.NIAnEnum> getEnumMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<NIAnEnum?, NIAnEnum?>? get enumMap {
-    return _get$enumMap(reference.pointer, _id_get$enumMap.pointer)
+    final _$$selfRef = reference;
+    return _get$enumMap(_$$selfRef.pointer, _id_get$enumMap.pointer)
         .object<jni$_.JMap<NIAnEnum?, NIAnEnum?>?>();
   }
 
@@ -4777,7 +4910,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.util.Map<java.lang.Object, java.lang.Object> getObjectMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JObject?, jni$_.JObject?>? get objectMap {
-    return _get$objectMap(reference.pointer, _id_get$objectMap.pointer)
+    final _$$selfRef = reference;
+    return _get$objectMap(_$$selfRef.pointer, _id_get$objectMap.pointer)
         .object<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>();
   }
 
@@ -4802,7 +4936,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public final java.util.Map<java.lang.Long, java.util.List<java.lang.Object>> getListMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, jni$_.JList<jni$_.JObject?>?>? get listMap {
-    return _get$listMap(reference.pointer, _id_get$listMap.pointer)
+    final _$$selfRef = reference;
+    return _get$listMap(_$$selfRef.pointer, _id_get$listMap.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JList<jni$_.JObject?>?>?>();
   }
 
@@ -4828,7 +4963,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>?
       get mapMap {
-    return _get$mapMap(reference.pointer, _id_get$mapMap.pointer).object<
+    final _$$selfRef = reference;
+    return _get$mapMap(_$$selfRef.pointer, _id_get$mapMap.pointer).object<
         jni$_
         .JMap<jni$_.JLong?, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>?>();
   }
@@ -4854,7 +4990,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public fun toList(): kotlin.collections.List<kotlin.Any?>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject?> toList() {
-    return _toList(reference.pointer, _id_toList.pointer)
+    final _$$selfRef = reference;
+    return _toList(_$$selfRef.pointer, _id_toList.pointer)
         .object<jni$_.JList<jni$_.JObject?>>();
   }
 
@@ -4879,8 +5016,9 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -4904,7 +5042,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
 
   /// from: `public fun hashCode(): kotlin.Int`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_component1 =
@@ -4928,7 +5067,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component1(): kotlin.Boolean?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JBoolean? component1() {
-    return _component1(reference.pointer, _id_component1.pointer)
+    final _$$selfRef = reference;
+    return _component1(_$$selfRef.pointer, _id_component1.pointer)
         .object<jni$_.JBoolean?>();
   }
 
@@ -4953,7 +5093,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component2(): kotlin.Long?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JLong? component2() {
-    return _component2(reference.pointer, _id_component2.pointer)
+    final _$$selfRef = reference;
+    return _component2(_$$selfRef.pointer, _id_component2.pointer)
         .object<jni$_.JLong?>();
   }
 
@@ -4978,7 +5119,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component3(): kotlin.Long?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JLong? component3() {
-    return _component3(reference.pointer, _id_component3.pointer)
+    final _$$selfRef = reference;
+    return _component3(_$$selfRef.pointer, _id_component3.pointer)
         .object<jni$_.JLong?>();
   }
 
@@ -5003,7 +5145,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component4(): kotlin.Double?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JDouble? component4() {
-    return _component4(reference.pointer, _id_component4.pointer)
+    final _$$selfRef = reference;
+    return _component4(_$$selfRef.pointer, _id_component4.pointer)
         .object<jni$_.JDouble?>();
   }
 
@@ -5028,7 +5171,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component5(): kotlin.ByteArray?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JByteArray? component5() {
-    return _component5(reference.pointer, _id_component5.pointer)
+    final _$$selfRef = reference;
+    return _component5(_$$selfRef.pointer, _id_component5.pointer)
         .object<jni$_.JByteArray?>();
   }
 
@@ -5053,7 +5197,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component6(): kotlin.IntArray?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JIntArray? component6() {
-    return _component6(reference.pointer, _id_component6.pointer)
+    final _$$selfRef = reference;
+    return _component6(_$$selfRef.pointer, _id_component6.pointer)
         .object<jni$_.JIntArray?>();
   }
 
@@ -5078,7 +5223,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component7(): kotlin.LongArray?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JLongArray? component7() {
-    return _component7(reference.pointer, _id_component7.pointer)
+    final _$$selfRef = reference;
+    return _component7(_$$selfRef.pointer, _id_component7.pointer)
         .object<jni$_.JLongArray?>();
   }
 
@@ -5103,7 +5249,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component8(): kotlin.DoubleArray?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JDoubleArray? component8() {
-    return _component8(reference.pointer, _id_component8.pointer)
+    final _$$selfRef = reference;
+    return _component8(_$$selfRef.pointer, _id_component8.pointer)
         .object<jni$_.JDoubleArray?>();
   }
 
@@ -5128,7 +5275,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component9(): com.github.dart_lang.jnigen.NIAnEnum?`
   /// The returned object must be released after use, by calling the [release] method.
   NIAnEnum? component9() {
-    return _component9(reference.pointer, _id_component9.pointer)
+    final _$$selfRef = reference;
+    return _component9(_$$selfRef.pointer, _id_component9.pointer)
         .object<NIAnEnum?>();
   }
 
@@ -5153,7 +5301,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component10(): com.github.dart_lang.jnigen.NIAnotherEnum?`
   /// The returned object must be released after use, by calling the [release] method.
   NIAnotherEnum? component10() {
-    return _component10(reference.pointer, _id_component10.pointer)
+    final _$$selfRef = reference;
+    return _component10(_$$selfRef.pointer, _id_component10.pointer)
         .object<NIAnotherEnum?>();
   }
 
@@ -5178,7 +5327,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component11(): kotlin.String?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? component11() {
-    return _component11(reference.pointer, _id_component11.pointer)
+    final _$$selfRef = reference;
+    return _component11(_$$selfRef.pointer, _id_component11.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -5203,7 +5353,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component12(): kotlin.Any?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? component12() {
-    return _component12(reference.pointer, _id_component12.pointer)
+    final _$$selfRef = reference;
+    return _component12(_$$selfRef.pointer, _id_component12.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -5228,7 +5379,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component13(): kotlin.collections.List<kotlin.Any?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject?>? component13() {
-    return _component13(reference.pointer, _id_component13.pointer)
+    final _$$selfRef = reference;
+    return _component13(_$$selfRef.pointer, _id_component13.pointer)
         .object<jni$_.JList<jni$_.JObject?>?>();
   }
 
@@ -5253,7 +5405,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component14(): kotlin.collections.List<kotlin.String?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JString?>? component14() {
-    return _component14(reference.pointer, _id_component14.pointer)
+    final _$$selfRef = reference;
+    return _component14(_$$selfRef.pointer, _id_component14.pointer)
         .object<jni$_.JList<jni$_.JString?>?>();
   }
 
@@ -5278,7 +5431,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component15(): kotlin.collections.List<kotlin.Long?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JLong?>? component15() {
-    return _component15(reference.pointer, _id_component15.pointer)
+    final _$$selfRef = reference;
+    return _component15(_$$selfRef.pointer, _id_component15.pointer)
         .object<jni$_.JList<jni$_.JLong?>?>();
   }
 
@@ -5303,7 +5457,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component16(): kotlin.collections.List<kotlin.Double?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JDouble?>? component16() {
-    return _component16(reference.pointer, _id_component16.pointer)
+    final _$$selfRef = reference;
+    return _component16(_$$selfRef.pointer, _id_component16.pointer)
         .object<jni$_.JList<jni$_.JDouble?>?>();
   }
 
@@ -5328,7 +5483,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component17(): kotlin.collections.List<kotlin.Boolean?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JBoolean?>? component17() {
-    return _component17(reference.pointer, _id_component17.pointer)
+    final _$$selfRef = reference;
+    return _component17(_$$selfRef.pointer, _id_component17.pointer)
         .object<jni$_.JList<jni$_.JBoolean?>?>();
   }
 
@@ -5353,7 +5509,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component18(): kotlin.collections.List<com.github.dart_lang.jnigen.NIAnEnum?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<NIAnEnum?>? component18() {
-    return _component18(reference.pointer, _id_component18.pointer)
+    final _$$selfRef = reference;
+    return _component18(_$$selfRef.pointer, _id_component18.pointer)
         .object<jni$_.JList<NIAnEnum?>?>();
   }
 
@@ -5378,7 +5535,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component19(): kotlin.collections.List<kotlin.Any?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject?>? component19() {
-    return _component19(reference.pointer, _id_component19.pointer)
+    final _$$selfRef = reference;
+    return _component19(_$$selfRef.pointer, _id_component19.pointer)
         .object<jni$_.JList<jni$_.JObject?>?>();
   }
 
@@ -5403,7 +5561,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component20(): kotlin.collections.List<kotlin.collections.List<kotlin.Any?>?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JList<jni$_.JObject?>?>? component20() {
-    return _component20(reference.pointer, _id_component20.pointer)
+    final _$$selfRef = reference;
+    return _component20(_$$selfRef.pointer, _id_component20.pointer)
         .object<jni$_.JList<jni$_.JList<jni$_.JObject?>?>?>();
   }
 
@@ -5428,7 +5587,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component21(): kotlin.collections.List<kotlin.collections.Map<kotlin.Any?, kotlin.Any?>?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>? component21() {
-    return _component21(reference.pointer, _id_component21.pointer)
+    final _$$selfRef = reference;
+    return _component21(_$$selfRef.pointer, _id_component21.pointer)
         .object<jni$_.JList<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>?>();
   }
 
@@ -5453,7 +5613,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component22(): kotlin.collections.Map<kotlin.Any, kotlin.Any?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JObject, jni$_.JObject?>? component22() {
-    return _component22(reference.pointer, _id_component22.pointer)
+    final _$$selfRef = reference;
+    return _component22(_$$selfRef.pointer, _id_component22.pointer)
         .object<jni$_.JMap<jni$_.JObject, jni$_.JObject?>?>();
   }
 
@@ -5478,7 +5639,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component23(): kotlin.collections.Map<kotlin.String?, kotlin.String?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JString?, jni$_.JString?>? component23() {
-    return _component23(reference.pointer, _id_component23.pointer)
+    final _$$selfRef = reference;
+    return _component23(_$$selfRef.pointer, _id_component23.pointer)
         .object<jni$_.JMap<jni$_.JString?, jni$_.JString?>?>();
   }
 
@@ -5503,7 +5665,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component24(): kotlin.collections.Map<kotlin.Long?, kotlin.Long?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, jni$_.JLong?>? component24() {
-    return _component24(reference.pointer, _id_component24.pointer)
+    final _$$selfRef = reference;
+    return _component24(_$$selfRef.pointer, _id_component24.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JLong?>?>();
   }
 
@@ -5528,7 +5691,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component25(): kotlin.collections.Map<com.github.dart_lang.jnigen.NIAnEnum?, com.github.dart_lang.jnigen.NIAnEnum?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<NIAnEnum?, NIAnEnum?>? component25() {
-    return _component25(reference.pointer, _id_component25.pointer)
+    final _$$selfRef = reference;
+    return _component25(_$$selfRef.pointer, _id_component25.pointer)
         .object<jni$_.JMap<NIAnEnum?, NIAnEnum?>?>();
   }
 
@@ -5553,7 +5717,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component26(): kotlin.collections.Map<kotlin.Any?, kotlin.Any?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JObject?, jni$_.JObject?>? component26() {
-    return _component26(reference.pointer, _id_component26.pointer)
+    final _$$selfRef = reference;
+    return _component26(_$$selfRef.pointer, _id_component26.pointer)
         .object<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>();
   }
 
@@ -5578,7 +5743,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public operator fun component27(): kotlin.collections.Map<kotlin.Long?, kotlin.collections.List<kotlin.Any?>?>?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, jni$_.JList<jni$_.JObject?>?>? component27() {
-    return _component27(reference.pointer, _id_component27.pointer)
+    final _$$selfRef = reference;
+    return _component27(_$$selfRef.pointer, _id_component27.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JList<jni$_.JObject?>?>?>();
   }
 
@@ -5604,7 +5770,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong?, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>?
       component28() {
-    return _component28(reference.pointer, _id_component28.pointer).object<
+    final _$$selfRef = reference;
+    return _component28(_$$selfRef.pointer, _id_component28.pointer).object<
         jni$_
         .JMap<jni$_.JLong?, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>?>();
   }
@@ -5716,6 +5883,7 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
     jni$_.JMap<jni$_.JLong?, jni$_.JList<jni$_.JObject?>?>? map5,
     jni$_.JMap<jni$_.JLong?, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>? map6,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final _$long1 = long1?.reference ?? jni$_.jNullReference;
@@ -5745,7 +5913,7 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
     final _$map5 = map5?.reference ?? jni$_.jNullReference;
     final _$map6 = map6?.reference ?? jni$_.jNullReference;
     return _copy(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_copy.pointer,
             _$boolean.pointer,
             _$long.pointer,
@@ -5799,7 +5967,8 @@ extension NIAllNullableTypesWithoutRecursion$$Methods
   /// from: `public fun toString(): kotlin.String`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<jni$_.JString>();
   }
 }
@@ -5844,9 +6013,10 @@ extension type NIAllTypes$Companion._(jni$_.JObject _$this)
   factory NIAllTypes$Companion(
     jni$_.JObject? defaultConstructorMarker,
   ) {
+    final _$$classRef = _class.reference;
     final _$defaultConstructorMarker =
         defaultConstructorMarker?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer,
+    return _new$(_$$classRef.pointer, _id_new$.pointer,
             _$defaultConstructorMarker.pointer)
         .object<NIAllTypes$Companion>();
   }
@@ -5874,8 +6044,9 @@ extension NIAllTypes$Companion$$Methods on NIAllTypes$Companion {
   NIAllTypes fromList(
     jni$_.JList<jni$_.JObject?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _fromList(reference.pointer, _id_fromList.pointer, _$list.pointer)
+    return _fromList(_$$selfRef.pointer, _id_fromList.pointer, _$list.pointer)
         .object<NIAllTypes>();
   }
 }
@@ -6013,6 +6184,7 @@ extension type NIAllTypes._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JMap<jni$_.JLong, jni$_.JList<jni$_.JObject?>> map5,
     jni$_.JMap<jni$_.JLong, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>> map6,
   ) {
+    final _$$classRef = _class.reference;
     final _$bs = bs.reference;
     final _$is$ = is$.reference;
     final _$js = js.reference;
@@ -6038,7 +6210,7 @@ extension type NIAllTypes._(jni$_.JObject _$this) implements jni$_.JObject {
     final _$map5 = map5.reference;
     final _$map6 = map6.reference;
     return _new$(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_new$.pointer,
             z ? 1 : 0,
             j,
@@ -6092,7 +6264,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
 
   /// from: `public final boolean getABool()`
   core$_.bool get aBool {
-    return _get$aBool(reference.pointer, _id_get$aBool.pointer).boolean;
+    final _$$selfRef = reference;
+    return _get$aBool(_$$selfRef.pointer, _id_get$aBool.pointer).boolean;
   }
 
   static final _id_get$anInt = NIAllTypes._class.instanceMethodId(
@@ -6114,7 +6287,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
 
   /// from: `public final long getAnInt()`
   core$_.int get anInt {
-    return _get$anInt(reference.pointer, _id_get$anInt.pointer).long;
+    final _$$selfRef = reference;
+    return _get$anInt(_$$selfRef.pointer, _id_get$anInt.pointer).long;
   }
 
   static final _id_get$anInt64 = NIAllTypes._class.instanceMethodId(
@@ -6136,7 +6310,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
 
   /// from: `public final long getAnInt64()`
   core$_.int get anInt64 {
-    return _get$anInt64(reference.pointer, _id_get$anInt64.pointer).long;
+    final _$$selfRef = reference;
+    return _get$anInt64(_$$selfRef.pointer, _id_get$anInt64.pointer).long;
   }
 
   static final _id_get$aDouble = NIAllTypes._class.instanceMethodId(
@@ -6158,7 +6333,9 @@ extension NIAllTypes$$Methods on NIAllTypes {
 
   /// from: `public final double getADouble()`
   core$_.double get aDouble {
-    return _get$aDouble(reference.pointer, _id_get$aDouble.pointer).doubleFloat;
+    final _$$selfRef = reference;
+    return _get$aDouble(_$$selfRef.pointer, _id_get$aDouble.pointer)
+        .doubleFloat;
   }
 
   static final _id_get$aByteArray = NIAllTypes._class.instanceMethodId(
@@ -6181,7 +6358,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final byte[] getAByteArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JByteArray get aByteArray {
-    return _get$aByteArray(reference.pointer, _id_get$aByteArray.pointer)
+    final _$$selfRef = reference;
+    return _get$aByteArray(_$$selfRef.pointer, _id_get$aByteArray.pointer)
         .object<jni$_.JByteArray>();
   }
 
@@ -6205,7 +6383,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final int[] getA4ByteArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JIntArray get a4ByteArray {
-    return _get$a4ByteArray(reference.pointer, _id_get$a4ByteArray.pointer)
+    final _$$selfRef = reference;
+    return _get$a4ByteArray(_$$selfRef.pointer, _id_get$a4ByteArray.pointer)
         .object<jni$_.JIntArray>();
   }
 
@@ -6229,7 +6408,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final long[] getA8ByteArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JLongArray get a8ByteArray {
-    return _get$a8ByteArray(reference.pointer, _id_get$a8ByteArray.pointer)
+    final _$$selfRef = reference;
+    return _get$a8ByteArray(_$$selfRef.pointer, _id_get$a8ByteArray.pointer)
         .object<jni$_.JLongArray>();
   }
 
@@ -6253,7 +6433,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final double[] getAFloatArray()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JDoubleArray get aFloatArray {
-    return _get$aFloatArray(reference.pointer, _id_get$aFloatArray.pointer)
+    final _$$selfRef = reference;
+    return _get$aFloatArray(_$$selfRef.pointer, _id_get$aFloatArray.pointer)
         .object<jni$_.JDoubleArray>();
   }
 
@@ -6277,7 +6458,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final com.github.dart_lang.jnigen.NIAnEnum getAnEnum()`
   /// The returned object must be released after use, by calling the [release] method.
   NIAnEnum get anEnum {
-    return _get$anEnum(reference.pointer, _id_get$anEnum.pointer)
+    final _$$selfRef = reference;
+    return _get$anEnum(_$$selfRef.pointer, _id_get$anEnum.pointer)
         .object<NIAnEnum>();
   }
 
@@ -6301,7 +6483,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final com.github.dart_lang.jnigen.NIAnotherEnum getAnotherEnum()`
   /// The returned object must be released after use, by calling the [release] method.
   NIAnotherEnum get anotherEnum {
-    return _get$anotherEnum(reference.pointer, _id_get$anotherEnum.pointer)
+    final _$$selfRef = reference;
+    return _get$anotherEnum(_$$selfRef.pointer, _id_get$anotherEnum.pointer)
         .object<NIAnotherEnum>();
   }
 
@@ -6325,7 +6508,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.lang.String getAString()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString get aString {
-    return _get$aString(reference.pointer, _id_get$aString.pointer)
+    final _$$selfRef = reference;
+    return _get$aString(_$$selfRef.pointer, _id_get$aString.pointer)
         .object<jni$_.JString>();
   }
 
@@ -6349,7 +6533,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.lang.Object getAnObject()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject get anObject {
-    return _get$anObject(reference.pointer, _id_get$anObject.pointer)
+    final _$$selfRef = reference;
+    return _get$anObject(_$$selfRef.pointer, _id_get$anObject.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -6373,7 +6558,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.util.List<java.lang.Object> getList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject?> get list {
-    return _get$list(reference.pointer, _id_get$list.pointer)
+    final _$$selfRef = reference;
+    return _get$list(_$$selfRef.pointer, _id_get$list.pointer)
         .object<jni$_.JList<jni$_.JObject?>>();
   }
 
@@ -6397,7 +6583,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.util.List<java.lang.String> getStringList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JString> get stringList {
-    return _get$stringList(reference.pointer, _id_get$stringList.pointer)
+    final _$$selfRef = reference;
+    return _get$stringList(_$$selfRef.pointer, _id_get$stringList.pointer)
         .object<jni$_.JList<jni$_.JString>>();
   }
 
@@ -6421,7 +6608,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.util.List<java.lang.Long> getIntList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JLong> get intList {
-    return _get$intList(reference.pointer, _id_get$intList.pointer)
+    final _$$selfRef = reference;
+    return _get$intList(_$$selfRef.pointer, _id_get$intList.pointer)
         .object<jni$_.JList<jni$_.JLong>>();
   }
 
@@ -6445,7 +6633,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.util.List<java.lang.Double> getDoubleList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JDouble> get doubleList {
-    return _get$doubleList(reference.pointer, _id_get$doubleList.pointer)
+    final _$$selfRef = reference;
+    return _get$doubleList(_$$selfRef.pointer, _id_get$doubleList.pointer)
         .object<jni$_.JList<jni$_.JDouble>>();
   }
 
@@ -6469,7 +6658,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.util.List<java.lang.Boolean> getBoolList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JBoolean> get boolList {
-    return _get$boolList(reference.pointer, _id_get$boolList.pointer)
+    final _$$selfRef = reference;
+    return _get$boolList(_$$selfRef.pointer, _id_get$boolList.pointer)
         .object<jni$_.JList<jni$_.JBoolean>>();
   }
 
@@ -6493,7 +6683,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.util.List<com.github.dart_lang.jnigen.NIAnEnum> getEnumList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<NIAnEnum> get enumList {
-    return _get$enumList(reference.pointer, _id_get$enumList.pointer)
+    final _$$selfRef = reference;
+    return _get$enumList(_$$selfRef.pointer, _id_get$enumList.pointer)
         .object<jni$_.JList<NIAnEnum>>();
   }
 
@@ -6517,7 +6708,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.util.List<java.lang.Object> getObjectList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject> get objectList {
-    return _get$objectList(reference.pointer, _id_get$objectList.pointer)
+    final _$$selfRef = reference;
+    return _get$objectList(_$$selfRef.pointer, _id_get$objectList.pointer)
         .object<jni$_.JList<jni$_.JObject>>();
   }
 
@@ -6541,7 +6733,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.util.List<java.util.List<java.lang.Object>> getListList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JList<jni$_.JObject?>> get listList {
-    return _get$listList(reference.pointer, _id_get$listList.pointer)
+    final _$$selfRef = reference;
+    return _get$listList(_$$selfRef.pointer, _id_get$listList.pointer)
         .object<jni$_.JList<jni$_.JList<jni$_.JObject?>>>();
   }
 
@@ -6565,7 +6758,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.util.List<java.util.Map<java.lang.Object, java.lang.Object>> getMapList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>> get mapList {
-    return _get$mapList(reference.pointer, _id_get$mapList.pointer)
+    final _$$selfRef = reference;
+    return _get$mapList(_$$selfRef.pointer, _id_get$mapList.pointer)
         .object<jni$_.JList<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>>>();
   }
 
@@ -6589,7 +6783,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.util.Map<java.lang.Object, java.lang.Object> getMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JObject, jni$_.JObject?> get map {
-    return _get$map(reference.pointer, _id_get$map.pointer)
+    final _$$selfRef = reference;
+    return _get$map(_$$selfRef.pointer, _id_get$map.pointer)
         .object<jni$_.JMap<jni$_.JObject, jni$_.JObject?>>();
   }
 
@@ -6613,7 +6808,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.util.Map<java.lang.String, java.lang.String> getStringMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JString, jni$_.JString> get stringMap {
-    return _get$stringMap(reference.pointer, _id_get$stringMap.pointer)
+    final _$$selfRef = reference;
+    return _get$stringMap(_$$selfRef.pointer, _id_get$stringMap.pointer)
         .object<jni$_.JMap<jni$_.JString, jni$_.JString>>();
   }
 
@@ -6637,7 +6833,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.util.Map<java.lang.Long, java.lang.Long> getIntMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong, jni$_.JLong> get intMap {
-    return _get$intMap(reference.pointer, _id_get$intMap.pointer)
+    final _$$selfRef = reference;
+    return _get$intMap(_$$selfRef.pointer, _id_get$intMap.pointer)
         .object<jni$_.JMap<jni$_.JLong, jni$_.JLong>>();
   }
 
@@ -6661,7 +6858,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.util.Map<com.github.dart_lang.jnigen.NIAnEnum, com.github.dart_lang.jnigen.NIAnEnum> getEnumMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<NIAnEnum, NIAnEnum> get enumMap {
-    return _get$enumMap(reference.pointer, _id_get$enumMap.pointer)
+    final _$$selfRef = reference;
+    return _get$enumMap(_$$selfRef.pointer, _id_get$enumMap.pointer)
         .object<jni$_.JMap<NIAnEnum, NIAnEnum>>();
   }
 
@@ -6685,7 +6883,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.util.Map<java.lang.Object, java.lang.Object> getObjectMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JObject, jni$_.JObject> get objectMap {
-    return _get$objectMap(reference.pointer, _id_get$objectMap.pointer)
+    final _$$selfRef = reference;
+    return _get$objectMap(_$$selfRef.pointer, _id_get$objectMap.pointer)
         .object<jni$_.JMap<jni$_.JObject, jni$_.JObject>>();
   }
 
@@ -6709,7 +6908,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public final java.util.Map<java.lang.Long, java.util.List<java.lang.Object>> getListMap()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong, jni$_.JList<jni$_.JObject?>> get listMap {
-    return _get$listMap(reference.pointer, _id_get$listMap.pointer)
+    final _$$selfRef = reference;
+    return _get$listMap(_$$selfRef.pointer, _id_get$listMap.pointer)
         .object<jni$_.JMap<jni$_.JLong, jni$_.JList<jni$_.JObject?>>>();
   }
 
@@ -6734,7 +6934,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>>
       get mapMap {
-    return _get$mapMap(reference.pointer, _id_get$mapMap.pointer).object<
+    final _$$selfRef = reference;
+    return _get$mapMap(_$$selfRef.pointer, _id_get$mapMap.pointer).object<
         jni$_.JMap<jni$_.JLong, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>>>();
   }
 
@@ -6758,7 +6959,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public fun toList(): kotlin.collections.List<kotlin.Any?>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject?> toList() {
-    return _toList(reference.pointer, _id_toList.pointer)
+    final _$$selfRef = reference;
+    return _toList(_$$selfRef.pointer, _id_toList.pointer)
         .object<jni$_.JList<jni$_.JObject?>>();
   }
 
@@ -6782,8 +6984,9 @@ extension NIAllTypes$$Methods on NIAllTypes {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -6806,7 +7009,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
 
   /// from: `public fun hashCode(): kotlin.Int`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_component1 = NIAllTypes._class.instanceMethodId(
@@ -6828,7 +7032,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
 
   /// from: `public operator fun component1(): kotlin.Boolean`
   core$_.bool component1() {
-    return _component1(reference.pointer, _id_component1.pointer).boolean;
+    final _$$selfRef = reference;
+    return _component1(_$$selfRef.pointer, _id_component1.pointer).boolean;
   }
 
   static final _id_component2 = NIAllTypes._class.instanceMethodId(
@@ -6850,7 +7055,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
 
   /// from: `public operator fun component2(): kotlin.Long`
   core$_.int component2() {
-    return _component2(reference.pointer, _id_component2.pointer).long;
+    final _$$selfRef = reference;
+    return _component2(_$$selfRef.pointer, _id_component2.pointer).long;
   }
 
   static final _id_component3 = NIAllTypes._class.instanceMethodId(
@@ -6872,7 +7078,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
 
   /// from: `public operator fun component3(): kotlin.Long`
   core$_.int component3() {
-    return _component3(reference.pointer, _id_component3.pointer).long;
+    final _$$selfRef = reference;
+    return _component3(_$$selfRef.pointer, _id_component3.pointer).long;
   }
 
   static final _id_component4 = NIAllTypes._class.instanceMethodId(
@@ -6894,7 +7101,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
 
   /// from: `public operator fun component4(): kotlin.Double`
   core$_.double component4() {
-    return _component4(reference.pointer, _id_component4.pointer).doubleFloat;
+    final _$$selfRef = reference;
+    return _component4(_$$selfRef.pointer, _id_component4.pointer).doubleFloat;
   }
 
   static final _id_component5 = NIAllTypes._class.instanceMethodId(
@@ -6917,7 +7125,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component5(): kotlin.ByteArray`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JByteArray component5() {
-    return _component5(reference.pointer, _id_component5.pointer)
+    final _$$selfRef = reference;
+    return _component5(_$$selfRef.pointer, _id_component5.pointer)
         .object<jni$_.JByteArray>();
   }
 
@@ -6941,7 +7150,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component6(): kotlin.IntArray`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JIntArray component6() {
-    return _component6(reference.pointer, _id_component6.pointer)
+    final _$$selfRef = reference;
+    return _component6(_$$selfRef.pointer, _id_component6.pointer)
         .object<jni$_.JIntArray>();
   }
 
@@ -6965,7 +7175,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component7(): kotlin.LongArray`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JLongArray component7() {
-    return _component7(reference.pointer, _id_component7.pointer)
+    final _$$selfRef = reference;
+    return _component7(_$$selfRef.pointer, _id_component7.pointer)
         .object<jni$_.JLongArray>();
   }
 
@@ -6989,7 +7200,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component8(): kotlin.DoubleArray`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JDoubleArray component8() {
-    return _component8(reference.pointer, _id_component8.pointer)
+    final _$$selfRef = reference;
+    return _component8(_$$selfRef.pointer, _id_component8.pointer)
         .object<jni$_.JDoubleArray>();
   }
 
@@ -7013,7 +7225,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component9(): com.github.dart_lang.jnigen.NIAnEnum`
   /// The returned object must be released after use, by calling the [release] method.
   NIAnEnum component9() {
-    return _component9(reference.pointer, _id_component9.pointer)
+    final _$$selfRef = reference;
+    return _component9(_$$selfRef.pointer, _id_component9.pointer)
         .object<NIAnEnum>();
   }
 
@@ -7037,7 +7250,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component10(): com.github.dart_lang.jnigen.NIAnotherEnum`
   /// The returned object must be released after use, by calling the [release] method.
   NIAnotherEnum component10() {
-    return _component10(reference.pointer, _id_component10.pointer)
+    final _$$selfRef = reference;
+    return _component10(_$$selfRef.pointer, _id_component10.pointer)
         .object<NIAnotherEnum>();
   }
 
@@ -7061,7 +7275,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component11(): kotlin.String`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString component11() {
-    return _component11(reference.pointer, _id_component11.pointer)
+    final _$$selfRef = reference;
+    return _component11(_$$selfRef.pointer, _id_component11.pointer)
         .object<jni$_.JString>();
   }
 
@@ -7085,7 +7300,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component12(): kotlin.Any`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject component12() {
-    return _component12(reference.pointer, _id_component12.pointer)
+    final _$$selfRef = reference;
+    return _component12(_$$selfRef.pointer, _id_component12.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -7109,7 +7325,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component13(): kotlin.collections.List<kotlin.Any?>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject?> component13() {
-    return _component13(reference.pointer, _id_component13.pointer)
+    final _$$selfRef = reference;
+    return _component13(_$$selfRef.pointer, _id_component13.pointer)
         .object<jni$_.JList<jni$_.JObject?>>();
   }
 
@@ -7133,7 +7350,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component14(): kotlin.collections.List<kotlin.String>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JString> component14() {
-    return _component14(reference.pointer, _id_component14.pointer)
+    final _$$selfRef = reference;
+    return _component14(_$$selfRef.pointer, _id_component14.pointer)
         .object<jni$_.JList<jni$_.JString>>();
   }
 
@@ -7157,7 +7375,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component15(): kotlin.collections.List<kotlin.Long>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JLong> component15() {
-    return _component15(reference.pointer, _id_component15.pointer)
+    final _$$selfRef = reference;
+    return _component15(_$$selfRef.pointer, _id_component15.pointer)
         .object<jni$_.JList<jni$_.JLong>>();
   }
 
@@ -7181,7 +7400,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component16(): kotlin.collections.List<kotlin.Double>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JDouble> component16() {
-    return _component16(reference.pointer, _id_component16.pointer)
+    final _$$selfRef = reference;
+    return _component16(_$$selfRef.pointer, _id_component16.pointer)
         .object<jni$_.JList<jni$_.JDouble>>();
   }
 
@@ -7205,7 +7425,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component17(): kotlin.collections.List<kotlin.Boolean>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JBoolean> component17() {
-    return _component17(reference.pointer, _id_component17.pointer)
+    final _$$selfRef = reference;
+    return _component17(_$$selfRef.pointer, _id_component17.pointer)
         .object<jni$_.JList<jni$_.JBoolean>>();
   }
 
@@ -7229,7 +7450,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component18(): kotlin.collections.List<com.github.dart_lang.jnigen.NIAnEnum>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<NIAnEnum> component18() {
-    return _component18(reference.pointer, _id_component18.pointer)
+    final _$$selfRef = reference;
+    return _component18(_$$selfRef.pointer, _id_component18.pointer)
         .object<jni$_.JList<NIAnEnum>>();
   }
 
@@ -7253,7 +7475,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component19(): kotlin.collections.List<kotlin.Any>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject> component19() {
-    return _component19(reference.pointer, _id_component19.pointer)
+    final _$$selfRef = reference;
+    return _component19(_$$selfRef.pointer, _id_component19.pointer)
         .object<jni$_.JList<jni$_.JObject>>();
   }
 
@@ -7277,7 +7500,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component20(): kotlin.collections.List<kotlin.collections.List<kotlin.Any?>>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JList<jni$_.JObject?>> component20() {
-    return _component20(reference.pointer, _id_component20.pointer)
+    final _$$selfRef = reference;
+    return _component20(_$$selfRef.pointer, _id_component20.pointer)
         .object<jni$_.JList<jni$_.JList<jni$_.JObject?>>>();
   }
 
@@ -7301,7 +7525,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component21(): kotlin.collections.List<kotlin.collections.Map<kotlin.Any?, kotlin.Any?>>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>> component21() {
-    return _component21(reference.pointer, _id_component21.pointer)
+    final _$$selfRef = reference;
+    return _component21(_$$selfRef.pointer, _id_component21.pointer)
         .object<jni$_.JList<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>>>();
   }
 
@@ -7325,7 +7550,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component22(): kotlin.collections.Map<kotlin.Any, kotlin.Any?>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JObject, jni$_.JObject?> component22() {
-    return _component22(reference.pointer, _id_component22.pointer)
+    final _$$selfRef = reference;
+    return _component22(_$$selfRef.pointer, _id_component22.pointer)
         .object<jni$_.JMap<jni$_.JObject, jni$_.JObject?>>();
   }
 
@@ -7349,7 +7575,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component23(): kotlin.collections.Map<kotlin.String, kotlin.String>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JString, jni$_.JString> component23() {
-    return _component23(reference.pointer, _id_component23.pointer)
+    final _$$selfRef = reference;
+    return _component23(_$$selfRef.pointer, _id_component23.pointer)
         .object<jni$_.JMap<jni$_.JString, jni$_.JString>>();
   }
 
@@ -7373,7 +7600,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component24(): kotlin.collections.Map<kotlin.Long, kotlin.Long>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong, jni$_.JLong> component24() {
-    return _component24(reference.pointer, _id_component24.pointer)
+    final _$$selfRef = reference;
+    return _component24(_$$selfRef.pointer, _id_component24.pointer)
         .object<jni$_.JMap<jni$_.JLong, jni$_.JLong>>();
   }
 
@@ -7397,7 +7625,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component25(): kotlin.collections.Map<com.github.dart_lang.jnigen.NIAnEnum, com.github.dart_lang.jnigen.NIAnEnum>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<NIAnEnum, NIAnEnum> component25() {
-    return _component25(reference.pointer, _id_component25.pointer)
+    final _$$selfRef = reference;
+    return _component25(_$$selfRef.pointer, _id_component25.pointer)
         .object<jni$_.JMap<NIAnEnum, NIAnEnum>>();
   }
 
@@ -7421,7 +7650,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component26(): kotlin.collections.Map<kotlin.Any, kotlin.Any>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JObject, jni$_.JObject> component26() {
-    return _component26(reference.pointer, _id_component26.pointer)
+    final _$$selfRef = reference;
+    return _component26(_$$selfRef.pointer, _id_component26.pointer)
         .object<jni$_.JMap<jni$_.JObject, jni$_.JObject>>();
   }
 
@@ -7445,7 +7675,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public operator fun component27(): kotlin.collections.Map<kotlin.Long, kotlin.collections.List<kotlin.Any?>>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong, jni$_.JList<jni$_.JObject?>> component27() {
-    return _component27(reference.pointer, _id_component27.pointer)
+    final _$$selfRef = reference;
+    return _component27(_$$selfRef.pointer, _id_component27.pointer)
         .object<jni$_.JMap<jni$_.JLong, jni$_.JList<jni$_.JObject?>>>();
   }
 
@@ -7470,7 +7701,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JMap<jni$_.JLong, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>>
       component28() {
-    return _component28(reference.pointer, _id_component28.pointer).object<
+    final _$$selfRef = reference;
+    return _component28(_$$selfRef.pointer, _id_component28.pointer).object<
         jni$_.JMap<jni$_.JLong, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>>>();
   }
 
@@ -7580,6 +7812,7 @@ extension NIAllTypes$$Methods on NIAllTypes {
     jni$_.JMap<jni$_.JLong, jni$_.JList<jni$_.JObject?>> map5,
     jni$_.JMap<jni$_.JLong, jni$_.JMap<jni$_.JObject?, jni$_.JObject?>> map6,
   ) {
+    final _$$selfRef = reference;
     final _$bs = bs.reference;
     final _$is$ = is$.reference;
     final _$js = js.reference;
@@ -7605,7 +7838,7 @@ extension NIAllTypes$$Methods on NIAllTypes {
     final _$map5 = map5.reference;
     final _$map6 = map6.reference;
     return _copy(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_copy.pointer,
             z ? 1 : 0,
             j,
@@ -7658,7 +7891,8 @@ extension NIAllTypes$$Methods on NIAllTypes {
   /// from: `public fun toString(): kotlin.String`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<jni$_.JString>();
   }
 }
@@ -7701,9 +7935,10 @@ extension type NIAnEnum$Companion._(jni$_.JObject _$this)
   factory NIAnEnum$Companion(
     jni$_.JObject? defaultConstructorMarker,
   ) {
+    final _$$classRef = _class.reference;
     final _$defaultConstructorMarker =
         defaultConstructorMarker?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer,
+    return _new$(_$$classRef.pointer, _id_new$.pointer,
             _$defaultConstructorMarker.pointer)
         .object<NIAnEnum$Companion>();
   }
@@ -7730,7 +7965,8 @@ extension NIAnEnum$Companion$$Methods on NIAnEnum$Companion {
   NIAnEnum? ofRaw(
     core$_.int i,
   ) {
-    return _ofRaw(reference.pointer, _id_ofRaw.pointer, i).object<NIAnEnum?>();
+    final _$$selfRef = reference;
+    return _ofRaw(_$$selfRef.pointer, _id_ofRaw.pointer, i).object<NIAnEnum?>();
   }
 }
 
@@ -7827,7 +8063,8 @@ extension type NIAnEnum._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public com.github.dart_lang.jnigen.NIAnEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<NIAnEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<NIAnEnum?>?>();
   }
 
@@ -7852,9 +8089,9 @@ extension type NIAnEnum._(jni$_.JObject _$this) implements jni$_.JObject {
   static NIAnEnum? valueOf(
     jni$_.JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$string.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$string.pointer)
         .object<NIAnEnum?>();
   }
 }
@@ -7879,7 +8116,8 @@ extension NIAnEnum$$Methods on NIAnEnum {
 
   /// from: `public final int getRaw()`
   core$_.int get raw {
-    return _get$raw(reference.pointer, _id_get$raw.pointer).integer;
+    final _$$selfRef = reference;
+    return _get$raw(_$$selfRef.pointer, _id_get$raw.pointer).integer;
   }
 }
 
@@ -7921,9 +8159,10 @@ extension type NIAnotherEnum$Companion._(jni$_.JObject _$this)
   factory NIAnotherEnum$Companion(
     jni$_.JObject? defaultConstructorMarker,
   ) {
+    final _$$classRef = _class.reference;
     final _$defaultConstructorMarker =
         defaultConstructorMarker?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer,
+    return _new$(_$$classRef.pointer, _id_new$.pointer,
             _$defaultConstructorMarker.pointer)
         .object<NIAnotherEnum$Companion>();
   }
@@ -7950,7 +8189,8 @@ extension NIAnotherEnum$Companion$$Methods on NIAnotherEnum$Companion {
   NIAnotherEnum? ofRaw(
     core$_.int i,
   ) {
-    return _ofRaw(reference.pointer, _id_ofRaw.pointer, i)
+    final _$$selfRef = reference;
+    return _ofRaw(_$$selfRef.pointer, _id_ofRaw.pointer, i)
         .object<NIAnotherEnum?>();
   }
 }
@@ -8014,7 +8254,8 @@ extension type NIAnotherEnum._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public com.github.dart_lang.jnigen.NIAnotherEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<NIAnotherEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<NIAnotherEnum?>?>();
   }
 
@@ -8039,9 +8280,9 @@ extension type NIAnotherEnum._(jni$_.JObject _$this) implements jni$_.JObject {
   static NIAnotherEnum? valueOf(
     jni$_.JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$string.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$string.pointer)
         .object<NIAnotherEnum?>();
   }
 }
@@ -8066,7 +8307,8 @@ extension NIAnotherEnum$$Methods on NIAnotherEnum {
 
   /// from: `public final int getRaw()`
   core$_.int get raw {
-    return _get$raw(reference.pointer, _id_get$raw.pointer).integer;
+    final _$$selfRef = reference;
+    return _get$raw(_$$selfRef.pointer, _id_get$raw.pointer).integer;
   }
 }
 
@@ -9350,7 +9592,8 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
 
   /// from: `public fun noop(): kotlin.Unit`
   void noop() {
-    _noop(reference.pointer, _id_noop.pointer).check();
+    final _$$selfRef = reference;
+    _noop(_$$selfRef.pointer, _id_noop.pointer).check();
   }
 
   static final _id_throwFlutterError =
@@ -9374,7 +9617,8 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   /// from: `public fun throwFlutterError(): kotlin.Any?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? throwFlutterError() {
-    return _throwFlutterError(reference.pointer, _id_throwFlutterError.pointer)
+    final _$$selfRef = reference;
+    return _throwFlutterError(_$$selfRef.pointer, _id_throwFlutterError.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -9399,7 +9643,8 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   /// from: `public fun throwError(): kotlin.Any?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? throwError() {
-    return _throwError(reference.pointer, _id_throwError.pointer)
+    final _$$selfRef = reference;
+    return _throwError(_$$selfRef.pointer, _id_throwError.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -9423,7 +9668,8 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
 
   /// from: `public fun throwErrorFromVoid(): kotlin.Unit`
   void throwErrorFromVoid() {
-    _throwErrorFromVoid(reference.pointer, _id_throwErrorFromVoid.pointer)
+    final _$$selfRef = reference;
+    _throwErrorFromVoid(_$$selfRef.pointer, _id_throwErrorFromVoid.pointer)
         .check();
   }
 
@@ -9449,9 +9695,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   NIAllTypes echoNIAllTypes(
     NIAllTypes nIAllTypes,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllTypes = nIAllTypes.reference;
-    return _echoNIAllTypes(
-            reference.pointer, _id_echoNIAllTypes.pointer, _$nIAllTypes.pointer)
+    return _echoNIAllTypes(_$$selfRef.pointer, _id_echoNIAllTypes.pointer,
+            _$nIAllTypes.pointer)
         .object<NIAllTypes>();
   }
 
@@ -9477,9 +9724,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   NIAllNullableTypes? echoNIAllNullableTypes(
     NIAllNullableTypes? nIAllNullableTypes,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllNullableTypes =
         nIAllNullableTypes?.reference ?? jni$_.jNullReference;
-    return _echoNIAllNullableTypes(reference.pointer,
+    return _echoNIAllNullableTypes(_$$selfRef.pointer,
             _id_echoNIAllNullableTypes.pointer, _$nIAllNullableTypes.pointer)
         .object<NIAllNullableTypes?>();
   }
@@ -9516,11 +9764,12 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
     jni$_.JLong? long,
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _sendMultipleNullableTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_sendMultipleNullableTypes.pointer,
             _$boolean.pointer,
             _$long.pointer,
@@ -9551,10 +9800,11 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   NIAllNullableTypesWithoutRecursion? echoNIAllNullableTypesWithoutRecursion(
     NIAllNullableTypesWithoutRecursion? nIAllNullableTypesWithoutRecursion,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllNullableTypesWithoutRecursion =
         nIAllNullableTypesWithoutRecursion?.reference ?? jni$_.jNullReference;
     return _echoNIAllNullableTypesWithoutRecursion(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoNIAllNullableTypesWithoutRecursion.pointer,
             _$nIAllNullableTypesWithoutRecursion.pointer)
         .object<NIAllNullableTypesWithoutRecursion?>();
@@ -9593,11 +9843,12 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
     jni$_.JLong? long,
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _sendMultipleNullableTypesWithoutRecursion(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_sendMultipleNullableTypesWithoutRecursion.pointer,
             _$boolean.pointer,
             _$long.pointer,
@@ -9626,7 +9877,8 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   core$_.bool echoBool(
     core$_.bool z,
   ) {
-    return _echoBool(reference.pointer, _id_echoBool.pointer, z ? 1 : 0)
+    final _$$selfRef = reference;
+    return _echoBool(_$$selfRef.pointer, _id_echoBool.pointer, z ? 1 : 0)
         .boolean;
   }
 
@@ -9650,7 +9902,8 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   core$_.int echoInt(
     core$_.int j,
   ) {
-    return _echoInt(reference.pointer, _id_echoInt.pointer, j).long;
+    final _$$selfRef = reference;
+    return _echoInt(_$$selfRef.pointer, _id_echoInt.pointer, j).long;
   }
 
   static final _id_echoDouble =
@@ -9674,7 +9927,8 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   core$_.double echoDouble(
     core$_.double d,
   ) {
-    return _echoDouble(reference.pointer, _id_echoDouble.pointer, d)
+    final _$$selfRef = reference;
+    return _echoDouble(_$$selfRef.pointer, _id_echoDouble.pointer, d)
         .doubleFloat;
   }
 
@@ -9700,9 +9954,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JString echoString(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
     return _echoString(
-            reference.pointer, _id_echoString.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_echoString.pointer, _$string.pointer)
         .object<jni$_.JString>();
   }
 
@@ -9728,9 +9983,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JByteArray echoUint8List(
     jni$_.JByteArray bs,
   ) {
+    final _$$selfRef = reference;
     final _$bs = bs.reference;
     return _echoUint8List(
-            reference.pointer, _id_echoUint8List.pointer, _$bs.pointer)
+            _$$selfRef.pointer, _id_echoUint8List.pointer, _$bs.pointer)
         .object<jni$_.JByteArray>();
   }
 
@@ -9756,9 +10012,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JIntArray echoInt32List(
     jni$_.JIntArray is$,
   ) {
+    final _$$selfRef = reference;
     final _$is$ = is$.reference;
     return _echoInt32List(
-            reference.pointer, _id_echoInt32List.pointer, _$is$.pointer)
+            _$$selfRef.pointer, _id_echoInt32List.pointer, _$is$.pointer)
         .object<jni$_.JIntArray>();
   }
 
@@ -9784,9 +10041,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JLongArray echoInt64List(
     jni$_.JLongArray js,
   ) {
+    final _$$selfRef = reference;
     final _$js = js.reference;
     return _echoInt64List(
-            reference.pointer, _id_echoInt64List.pointer, _$js.pointer)
+            _$$selfRef.pointer, _id_echoInt64List.pointer, _$js.pointer)
         .object<jni$_.JLongArray>();
   }
 
@@ -9812,9 +10070,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JDoubleArray echoFloat64List(
     jni$_.JDoubleArray ds,
   ) {
+    final _$$selfRef = reference;
     final _$ds = ds.reference;
     return _echoFloat64List(
-            reference.pointer, _id_echoFloat64List.pointer, _$ds.pointer)
+            _$$selfRef.pointer, _id_echoFloat64List.pointer, _$ds.pointer)
         .object<jni$_.JDoubleArray>();
   }
 
@@ -9840,8 +10099,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JList<jni$_.JObject?> echoList(
     jni$_.JList<jni$_.JObject?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _echoList(reference.pointer, _id_echoList.pointer, _$list.pointer)
+    return _echoList(_$$selfRef.pointer, _id_echoList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JObject?>>();
   }
 
@@ -9867,9 +10127,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JList<NIAnEnum?> echoEnumList(
     jni$_.JList<NIAnEnum?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoEnumList(
-            reference.pointer, _id_echoEnumList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum?>>();
   }
 
@@ -9895,9 +10156,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JList<NIAllNullableTypes?> echoClassList(
     jni$_.JList<NIAllNullableTypes?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoClassList(
-            reference.pointer, _id_echoClassList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes?>>();
   }
 
@@ -9923,9 +10185,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JList<NIAnEnum> echoNonNullEnumList(
     jni$_.JList<NIAnEnum> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoNonNullEnumList(
-            reference.pointer, _id_echoNonNullEnumList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoNonNullEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum>>();
   }
 
@@ -9951,9 +10214,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JList<NIAllNullableTypes> echoNonNullClassList(
     jni$_.JList<NIAllNullableTypes> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _echoNonNullClassList(
-            reference.pointer, _id_echoNonNullClassList.pointer, _$list.pointer)
+    return _echoNonNullClassList(_$$selfRef.pointer,
+            _id_echoNonNullClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes>>();
   }
 
@@ -9979,8 +10243,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<jni$_.JObject?, jni$_.JObject?> echoMap(
     jni$_.JMap<jni$_.JObject?, jni$_.JObject?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _echoMap(reference.pointer, _id_echoMap.pointer, _$map.pointer)
+    return _echoMap(_$$selfRef.pointer, _id_echoMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>>();
   }
 
@@ -10006,9 +10271,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<jni$_.JString?, jni$_.JString?> echoStringMap(
     jni$_.JMap<jni$_.JString?, jni$_.JString?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoStringMap(
-            reference.pointer, _id_echoStringMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString?, jni$_.JString?>>();
   }
 
@@ -10034,8 +10300,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong?, jni$_.JLong?> echoIntMap(
     jni$_.JMap<jni$_.JLong?, jni$_.JLong?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _echoIntMap(reference.pointer, _id_echoIntMap.pointer, _$map.pointer)
+    return _echoIntMap(
+            _$$selfRef.pointer, _id_echoIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JLong?>>();
   }
 
@@ -10061,9 +10329,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<NIAnEnum?, NIAnEnum?> echoEnumMap(
     jni$_.JMap<NIAnEnum?, NIAnEnum?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoEnumMap(
-            reference.pointer, _id_echoEnumMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum?, NIAnEnum?>>();
   }
 
@@ -10089,9 +10358,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?> echoClassMap(
     jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoClassMap(
-            reference.pointer, _id_echoClassMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>>();
   }
 
@@ -10117,9 +10387,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<jni$_.JString, jni$_.JString> echoNonNullStringMap(
     jni$_.JMap<jni$_.JString, jni$_.JString> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoNonNullStringMap(
-            reference.pointer, _id_echoNonNullStringMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNonNullStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString, jni$_.JString>>();
   }
 
@@ -10145,9 +10416,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong, jni$_.JLong> echoNonNullIntMap(
     jni$_.JMap<jni$_.JLong, jni$_.JLong> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoNonNullIntMap(
-            reference.pointer, _id_echoNonNullIntMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNonNullIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, jni$_.JLong>>();
   }
 
@@ -10173,9 +10445,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<NIAnEnum, NIAnEnum> echoNonNullEnumMap(
     jni$_.JMap<NIAnEnum, NIAnEnum> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoNonNullEnumMap(
-            reference.pointer, _id_echoNonNullEnumMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNonNullEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum, NIAnEnum>>();
   }
 
@@ -10201,9 +10474,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong, NIAllNullableTypes> echoNonNullClassMap(
     jni$_.JMap<jni$_.JLong, NIAllNullableTypes> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoNonNullClassMap(
-            reference.pointer, _id_echoNonNullClassMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNonNullClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, NIAllNullableTypes>>();
   }
 
@@ -10229,9 +10503,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   NIAnEnum echoEnum(
     NIAnEnum nIAnEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum.reference;
     return _echoEnum(
-            reference.pointer, _id_echoEnum.pointer, _$nIAnEnum.pointer)
+            _$$selfRef.pointer, _id_echoEnum.pointer, _$nIAnEnum.pointer)
         .object<NIAnEnum>();
   }
 
@@ -10257,8 +10532,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   NIAnotherEnum echoNIAnotherEnum(
     NIAnotherEnum nIAnotherEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum.reference;
-    return _echoNIAnotherEnum(reference.pointer, _id_echoNIAnotherEnum.pointer,
+    return _echoNIAnotherEnum(_$$selfRef.pointer, _id_echoNIAnotherEnum.pointer,
             _$nIAnotherEnum.pointer)
         .object<NIAnotherEnum>();
   }
@@ -10285,9 +10561,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JBoolean? echoNullableBool(
     jni$_.JBoolean? boolean,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     return _echoNullableBool(
-            reference.pointer, _id_echoNullableBool.pointer, _$boolean.pointer)
+            _$$selfRef.pointer, _id_echoNullableBool.pointer, _$boolean.pointer)
         .object<jni$_.JBoolean?>();
   }
 
@@ -10313,9 +10590,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JLong? echoNullableInt(
     jni$_.JLong? long,
   ) {
+    final _$$selfRef = reference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     return _echoNullableInt(
-            reference.pointer, _id_echoNullableInt.pointer, _$long.pointer)
+            _$$selfRef.pointer, _id_echoNullableInt.pointer, _$long.pointer)
         .object<jni$_.JLong?>();
   }
 
@@ -10341,9 +10619,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JDouble? echoNullableDouble(
     jni$_.JDouble? double,
   ) {
+    final _$$selfRef = reference;
     final _$double = double?.reference ?? jni$_.jNullReference;
-    return _echoNullableDouble(
-            reference.pointer, _id_echoNullableDouble.pointer, _$double.pointer)
+    return _echoNullableDouble(_$$selfRef.pointer,
+            _id_echoNullableDouble.pointer, _$double.pointer)
         .object<jni$_.JDouble?>();
   }
 
@@ -10369,9 +10648,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JString? echoNullableString(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _echoNullableString(
-            reference.pointer, _id_echoNullableString.pointer, _$string.pointer)
+    return _echoNullableString(_$$selfRef.pointer,
+            _id_echoNullableString.pointer, _$string.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -10397,9 +10677,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JByteArray? echoNullableUint8List(
     jni$_.JByteArray? bs,
   ) {
+    final _$$selfRef = reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
     return _echoNullableUint8List(
-            reference.pointer, _id_echoNullableUint8List.pointer, _$bs.pointer)
+            _$$selfRef.pointer, _id_echoNullableUint8List.pointer, _$bs.pointer)
         .object<jni$_.JByteArray?>();
   }
 
@@ -10425,9 +10706,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JIntArray? echoNullableInt32List(
     jni$_.JIntArray? is$,
   ) {
+    final _$$selfRef = reference;
     final _$is$ = is$?.reference ?? jni$_.jNullReference;
-    return _echoNullableInt32List(
-            reference.pointer, _id_echoNullableInt32List.pointer, _$is$.pointer)
+    return _echoNullableInt32List(_$$selfRef.pointer,
+            _id_echoNullableInt32List.pointer, _$is$.pointer)
         .object<jni$_.JIntArray?>();
   }
 
@@ -10453,9 +10735,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JLongArray? echoNullableInt64List(
     jni$_.JLongArray? js,
   ) {
+    final _$$selfRef = reference;
     final _$js = js?.reference ?? jni$_.jNullReference;
     return _echoNullableInt64List(
-            reference.pointer, _id_echoNullableInt64List.pointer, _$js.pointer)
+            _$$selfRef.pointer, _id_echoNullableInt64List.pointer, _$js.pointer)
         .object<jni$_.JLongArray?>();
   }
 
@@ -10481,8 +10764,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JDoubleArray? echoNullableFloat64List(
     jni$_.JDoubleArray? ds,
   ) {
+    final _$$selfRef = reference;
     final _$ds = ds?.reference ?? jni$_.jNullReference;
-    return _echoNullableFloat64List(reference.pointer,
+    return _echoNullableFloat64List(_$$selfRef.pointer,
             _id_echoNullableFloat64List.pointer, _$ds.pointer)
         .object<jni$_.JDoubleArray?>();
   }
@@ -10509,9 +10793,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JList<jni$_.JObject?>? echoNullableList(
     jni$_.JList<jni$_.JObject?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     return _echoNullableList(
-            reference.pointer, _id_echoNullableList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoNullableList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JObject?>?>();
   }
 
@@ -10537,9 +10822,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JList<NIAnEnum?>? echoNullableEnumList(
     jni$_.JList<NIAnEnum?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _echoNullableEnumList(
-            reference.pointer, _id_echoNullableEnumList.pointer, _$list.pointer)
+    return _echoNullableEnumList(_$$selfRef.pointer,
+            _id_echoNullableEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum?>?>();
   }
 
@@ -10565,8 +10851,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JList<NIAllNullableTypes?>? echoNullableClassList(
     jni$_.JList<NIAllNullableTypes?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _echoNullableClassList(reference.pointer,
+    return _echoNullableClassList(_$$selfRef.pointer,
             _id_echoNullableClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes?>?>();
   }
@@ -10594,8 +10881,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JList<NIAnEnum>? echoNullableNonNullEnumList(
     jni$_.JList<NIAnEnum>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullEnumList(reference.pointer,
+    return _echoNullableNonNullEnumList(_$$selfRef.pointer,
             _id_echoNullableNonNullEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum>?>();
   }
@@ -10623,8 +10911,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JList<NIAllNullableTypes>? echoNullableNonNullClassList(
     jni$_.JList<NIAllNullableTypes>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullClassList(reference.pointer,
+    return _echoNullableNonNullClassList(_$$selfRef.pointer,
             _id_echoNullableNonNullClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes>?>();
   }
@@ -10651,9 +10940,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<jni$_.JObject?, jni$_.JObject?>? echoNullableMap(
     jni$_.JMap<jni$_.JObject?, jni$_.JObject?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     return _echoNullableMap(
-            reference.pointer, _id_echoNullableMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNullableMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>();
   }
 
@@ -10679,9 +10969,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<jni$_.JString?, jni$_.JString?>? echoNullableStringMap(
     jni$_.JMap<jni$_.JString?, jni$_.JString?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _echoNullableStringMap(
-            reference.pointer, _id_echoNullableStringMap.pointer, _$map.pointer)
+    return _echoNullableStringMap(_$$selfRef.pointer,
+            _id_echoNullableStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString?, jni$_.JString?>?>();
   }
 
@@ -10707,9 +10998,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong?, jni$_.JLong?>? echoNullableIntMap(
     jni$_.JMap<jni$_.JLong?, jni$_.JLong?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     return _echoNullableIntMap(
-            reference.pointer, _id_echoNullableIntMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNullableIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JLong?>?>();
   }
 
@@ -10735,9 +11027,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<NIAnEnum?, NIAnEnum?>? echoNullableEnumMap(
     jni$_.JMap<NIAnEnum?, NIAnEnum?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     return _echoNullableEnumMap(
-            reference.pointer, _id_echoNullableEnumMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNullableEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum?, NIAnEnum?>?>();
   }
 
@@ -10763,9 +11056,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>? echoNullableClassMap(
     jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     return _echoNullableClassMap(
-            reference.pointer, _id_echoNullableClassMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNullableClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>?>();
   }
 
@@ -10792,8 +11086,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<jni$_.JString, jni$_.JString>? echoNullableNonNullStringMap(
     jni$_.JMap<jni$_.JString, jni$_.JString>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullStringMap(reference.pointer,
+    return _echoNullableNonNullStringMap(_$$selfRef.pointer,
             _id_echoNullableNonNullStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString, jni$_.JString>?>();
   }
@@ -10820,8 +11115,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong, jni$_.JLong>? echoNullableNonNullIntMap(
     jni$_.JMap<jni$_.JLong, jni$_.JLong>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullIntMap(reference.pointer,
+    return _echoNullableNonNullIntMap(_$$selfRef.pointer,
             _id_echoNullableNonNullIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, jni$_.JLong>?>();
   }
@@ -10849,8 +11145,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<NIAnEnum, NIAnEnum>? echoNullableNonNullEnumMap(
     jni$_.JMap<NIAnEnum, NIAnEnum>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullEnumMap(reference.pointer,
+    return _echoNullableNonNullEnumMap(_$$selfRef.pointer,
             _id_echoNullableNonNullEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum, NIAnEnum>?>();
   }
@@ -10878,8 +11175,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong, NIAllNullableTypes>? echoNullableNonNullClassMap(
     jni$_.JMap<jni$_.JLong, NIAllNullableTypes>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullClassMap(reference.pointer,
+    return _echoNullableNonNullClassMap(_$$selfRef.pointer,
             _id_echoNullableNonNullClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, NIAllNullableTypes>?>();
   }
@@ -10906,9 +11204,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   NIAnEnum? echoNullableEnum(
     NIAnEnum? nIAnEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum?.reference ?? jni$_.jNullReference;
-    return _echoNullableEnum(
-            reference.pointer, _id_echoNullableEnum.pointer, _$nIAnEnum.pointer)
+    return _echoNullableEnum(_$$selfRef.pointer, _id_echoNullableEnum.pointer,
+            _$nIAnEnum.pointer)
         .object<NIAnEnum?>();
   }
 
@@ -10934,8 +11233,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   NIAnotherEnum? echoAnotherNullableEnum(
     NIAnotherEnum? nIAnotherEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum?.reference ?? jni$_.jNullReference;
-    return _echoAnotherNullableEnum(reference.pointer,
+    return _echoAnotherNullableEnum(_$$selfRef.pointer,
             _id_echoAnotherNullableEnum.pointer, _$nIAnotherEnum.pointer)
         .object<NIAnotherEnum?>();
   }
@@ -10962,9 +11262,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   core$_.Future<void> noopAsync() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
+    final _$$selfRef = reference;
     final $r = _noopAsync(
-            reference.pointer, _id_noopAsync.pointer, _$continuation.pointer)
+            _$$selfRef.pointer, _id_noopAsync.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
     jni$_.JObject $o;
@@ -11009,8 +11309,8 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   core$_.Future<jni$_.JObject?> throwFlutterErrorAsync() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _throwFlutterErrorAsync(reference.pointer,
+    final _$$selfRef = reference;
+    final $r = _throwFlutterErrorAsync(_$$selfRef.pointer,
             _id_throwFlutterErrorAsync.pointer, _$continuation.pointer)
         .object<jni$_.JObject?>();
     _$continuation.release();
@@ -11069,9 +11369,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAllTypes = nIAllTypes.reference;
     final $r = _echoAsyncNIAllTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNIAllTypes.pointer,
             _$nIAllTypes.pointer,
             _$continuation.pointer)
@@ -11131,10 +11432,11 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAllNullableTypes =
         nIAllNullableTypes?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableNIAllNullableTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableNIAllNullableTypes.pointer,
             _$nIAllNullableTypes.pointer,
             _$continuation.pointer)
@@ -11197,10 +11499,11 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAllNullableTypesWithoutRecursion =
         nIAllNullableTypesWithoutRecursion?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableNIAllNullableTypesWithoutRecursion(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableNIAllNullableTypesWithoutRecursion.pointer,
             _$nIAllNullableTypesWithoutRecursion.pointer,
             _$continuation.pointer)
@@ -11256,8 +11559,8 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _echoAsyncBool(reference.pointer, _id_echoAsyncBool.pointer,
+    final _$$selfRef = reference;
+    final $r = _echoAsyncBool(_$$selfRef.pointer, _id_echoAsyncBool.pointer,
             z ? 1 : 0, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -11309,8 +11612,8 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _echoAsyncInt(reference.pointer, _id_echoAsyncInt.pointer, j,
+    final _$$selfRef = reference;
+    final $r = _echoAsyncInt(_$$selfRef.pointer, _id_echoAsyncInt.pointer, j,
             _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -11364,8 +11667,8 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _echoAsyncDouble(reference.pointer, _id_echoAsyncDouble.pointer,
+    final _$$selfRef = reference;
+    final $r = _echoAsyncDouble(_$$selfRef.pointer, _id_echoAsyncDouble.pointer,
             d, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -11422,8 +11725,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$string = string.reference;
-    final $r = _echoAsyncString(reference.pointer, _id_echoAsyncString.pointer,
+    final $r = _echoAsyncString(_$$selfRef.pointer, _id_echoAsyncString.pointer,
             _$string.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -11480,9 +11784,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$bs = bs.reference;
     final $r = _echoAsyncUint8List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncUint8List.pointer,
             _$bs.pointer,
             _$continuation.pointer)
@@ -11541,9 +11846,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$is$ = is$.reference;
     final $r = _echoAsyncInt32List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncInt32List.pointer,
             _$is$.pointer,
             _$continuation.pointer)
@@ -11602,9 +11908,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$js = js.reference;
     final $r = _echoAsyncInt64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncInt64List.pointer,
             _$js.pointer,
             _$continuation.pointer)
@@ -11663,9 +11970,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$ds = ds.reference;
     final $r = _echoAsyncFloat64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncFloat64List.pointer,
             _$ds.pointer,
             _$continuation.pointer)
@@ -11724,8 +12032,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$object = object.reference;
-    final $r = _echoAsyncObject(reference.pointer, _id_echoAsyncObject.pointer,
+    final $r = _echoAsyncObject(_$$selfRef.pointer, _id_echoAsyncObject.pointer,
             _$object.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -11782,8 +12091,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    final $r = _echoAsyncList(reference.pointer, _id_echoAsyncList.pointer,
+    final $r = _echoAsyncList(_$$selfRef.pointer, _id_echoAsyncList.pointer,
             _$list.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -11840,9 +12150,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _echoAsyncEnumList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncEnumList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -11901,9 +12212,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _echoAsyncClassList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncClassList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -11962,9 +12274,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _echoAsyncNonNullEnumList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNonNullEnumList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -12023,9 +12336,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _echoAsyncNonNullClassList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNonNullClassList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -12084,8 +12398,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    final $r = _echoAsyncMap(reference.pointer, _id_echoAsyncMap.pointer,
+    final $r = _echoAsyncMap(_$$selfRef.pointer, _id_echoAsyncMap.pointer,
             _$map.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -12142,9 +12457,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
     final $r = _echoAsyncStringMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncStringMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -12203,8 +12519,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    final $r = _echoAsyncIntMap(reference.pointer, _id_echoAsyncIntMap.pointer,
+    final $r = _echoAsyncIntMap(_$$selfRef.pointer, _id_echoAsyncIntMap.pointer,
             _$map.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -12261,8 +12578,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    final $r = _echoAsyncEnumMap(reference.pointer,
+    final $r = _echoAsyncEnumMap(_$$selfRef.pointer,
             _id_echoAsyncEnumMap.pointer, _$map.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -12320,9 +12638,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
     final $r = _echoAsyncClassMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncClassMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -12381,8 +12700,9 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum.reference;
-    final $r = _echoAsyncEnum(reference.pointer, _id_echoAsyncEnum.pointer,
+    final $r = _echoAsyncEnum(_$$selfRef.pointer, _id_echoAsyncEnum.pointer,
             _$nIAnEnum.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -12439,9 +12759,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum.reference;
     final $r = _echoAnotherAsyncEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAnotherAsyncEnum.pointer,
             _$nIAnotherEnum.pointer,
             _$continuation.pointer)
@@ -12500,9 +12821,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableBool(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableBool.pointer,
             _$boolean.pointer,
             _$continuation.pointer)
@@ -12563,9 +12885,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableInt(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableInt.pointer,
             _$long.pointer,
             _$continuation.pointer)
@@ -12626,9 +12949,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$double = double?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableDouble(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableDouble.pointer,
             _$double.pointer,
             _$continuation.pointer)
@@ -12689,9 +13013,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableString(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableString.pointer,
             _$string.pointer,
             _$continuation.pointer)
@@ -12753,9 +13078,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableUint8List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableUint8List.pointer,
             _$bs.pointer,
             _$continuation.pointer)
@@ -12817,9 +13143,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$is$ = is$?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableInt32List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableInt32List.pointer,
             _$is$.pointer,
             _$continuation.pointer)
@@ -12881,9 +13208,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$js = js?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableInt64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableInt64List.pointer,
             _$js.pointer,
             _$continuation.pointer)
@@ -12945,9 +13273,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$ds = ds?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableFloat64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableFloat64List.pointer,
             _$ds.pointer,
             _$continuation.pointer)
@@ -13008,9 +13337,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableObject(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableObject.pointer,
             _$object.pointer,
             _$continuation.pointer)
@@ -13071,9 +13401,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -13134,9 +13465,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableEnumList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableEnumList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -13198,9 +13530,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableClassList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableClassList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -13262,9 +13595,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableNonNullEnumList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableNonNullEnumList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -13327,9 +13661,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableNonNullClassList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableNonNullClassList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -13391,9 +13726,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -13456,9 +13792,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableStringMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableStringMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -13520,9 +13857,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableIntMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableIntMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -13583,9 +13921,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableEnumMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableEnumMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -13647,9 +13986,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableClassMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableClassMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -13710,9 +14050,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableEnum.pointer,
             _$nIAnEnum.pointer,
             _$continuation.pointer)
@@ -13774,9 +14115,10 @@ extension NIFlutterIntegrationCoreApi$$Methods on NIFlutterIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum?.reference ?? jni$_.jNullReference;
     final $r = _echoAnotherAsyncNullableEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAnotherAsyncNullableEnum.pointer,
             _$nIAnotherEnum.pointer,
             _$continuation.pointer)
@@ -15286,7 +15628,8 @@ extension type NIFlutterIntegrationCoreApiRegistrar._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory NIFlutterIntegrationCoreApiRegistrar() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<NIFlutterIntegrationCoreApiRegistrar>();
   }
 }
@@ -15321,9 +15664,10 @@ extension NIFlutterIntegrationCoreApiRegistrar$$Methods
     NIFlutterIntegrationCoreApi nIFlutterIntegrationCoreApi,
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$nIFlutterIntegrationCoreApi = nIFlutterIntegrationCoreApi.reference;
     final _$string = string.reference;
-    _registerInstance(reference.pointer, _id_registerInstance.pointer,
+    _registerInstance(_$$selfRef.pointer, _id_registerInstance.pointer,
             _$nIFlutterIntegrationCoreApi.pointer, _$string.pointer)
         .check();
   }
@@ -15350,9 +15694,10 @@ extension NIFlutterIntegrationCoreApiRegistrar$$Methods
   NIFlutterIntegrationCoreApi? getInstance(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
     return _getInstance(
-            reference.pointer, _id_getInstance.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_getInstance.pointer, _$string.pointer)
         .object<NIFlutterIntegrationCoreApi?>();
   }
 }
@@ -15399,7 +15744,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
 
   /// from: `public fun noop(): kotlin.Unit`
   void noop() {
-    _noop(reference.pointer, _id_noop.pointer).check();
+    final _$$selfRef = reference;
+    _noop(_$$selfRef.pointer, _id_noop.pointer).check();
   }
 
   static final _id_echoAllTypes =
@@ -15424,9 +15770,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   NIAllTypes echoAllTypes(
     NIAllTypes nIAllTypes,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllTypes = nIAllTypes.reference;
     return _echoAllTypes(
-            reference.pointer, _id_echoAllTypes.pointer, _$nIAllTypes.pointer)
+            _$$selfRef.pointer, _id_echoAllTypes.pointer, _$nIAllTypes.pointer)
         .object<NIAllTypes>();
   }
 
@@ -15451,7 +15798,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   /// from: `public fun throwError(): kotlin.Any?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? throwError() {
-    return _throwError(reference.pointer, _id_throwError.pointer)
+    final _$$selfRef = reference;
+    return _throwError(_$$selfRef.pointer, _id_throwError.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -15475,7 +15823,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
 
   /// from: `public fun throwErrorFromVoid(): kotlin.Unit`
   void throwErrorFromVoid() {
-    _throwErrorFromVoid(reference.pointer, _id_throwErrorFromVoid.pointer)
+    final _$$selfRef = reference;
+    _throwErrorFromVoid(_$$selfRef.pointer, _id_throwErrorFromVoid.pointer)
         .check();
   }
 
@@ -15500,7 +15849,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   /// from: `public fun throwFlutterError(): kotlin.Any?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? throwFlutterError() {
-    return _throwFlutterError(reference.pointer, _id_throwFlutterError.pointer)
+    final _$$selfRef = reference;
+    return _throwFlutterError(_$$selfRef.pointer, _id_throwFlutterError.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -15523,7 +15873,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   core$_.int echoInt(
     core$_.int j,
   ) {
-    return _echoInt(reference.pointer, _id_echoInt.pointer, j).long;
+    final _$$selfRef = reference;
+    return _echoInt(_$$selfRef.pointer, _id_echoInt.pointer, j).long;
   }
 
   static final _id_echoDouble =
@@ -15547,7 +15898,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   core$_.double echoDouble(
     core$_.double d,
   ) {
-    return _echoDouble(reference.pointer, _id_echoDouble.pointer, d)
+    final _$$selfRef = reference;
+    return _echoDouble(_$$selfRef.pointer, _id_echoDouble.pointer, d)
         .doubleFloat;
   }
 
@@ -15571,7 +15923,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   core$_.bool echoBool(
     core$_.bool z,
   ) {
-    return _echoBool(reference.pointer, _id_echoBool.pointer, z ? 1 : 0)
+    final _$$selfRef = reference;
+    return _echoBool(_$$selfRef.pointer, _id_echoBool.pointer, z ? 1 : 0)
         .boolean;
   }
 
@@ -15597,9 +15950,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JString echoString(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
     return _echoString(
-            reference.pointer, _id_echoString.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_echoString.pointer, _$string.pointer)
         .object<jni$_.JString>();
   }
 
@@ -15625,9 +15979,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JByteArray echoUint8List(
     jni$_.JByteArray bs,
   ) {
+    final _$$selfRef = reference;
     final _$bs = bs.reference;
     return _echoUint8List(
-            reference.pointer, _id_echoUint8List.pointer, _$bs.pointer)
+            _$$selfRef.pointer, _id_echoUint8List.pointer, _$bs.pointer)
         .object<jni$_.JByteArray>();
   }
 
@@ -15653,9 +16008,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JIntArray echoInt32List(
     jni$_.JIntArray is$,
   ) {
+    final _$$selfRef = reference;
     final _$is$ = is$.reference;
     return _echoInt32List(
-            reference.pointer, _id_echoInt32List.pointer, _$is$.pointer)
+            _$$selfRef.pointer, _id_echoInt32List.pointer, _$is$.pointer)
         .object<jni$_.JIntArray>();
   }
 
@@ -15681,9 +16037,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JLongArray echoInt64List(
     jni$_.JLongArray js,
   ) {
+    final _$$selfRef = reference;
     final _$js = js.reference;
     return _echoInt64List(
-            reference.pointer, _id_echoInt64List.pointer, _$js.pointer)
+            _$$selfRef.pointer, _id_echoInt64List.pointer, _$js.pointer)
         .object<jni$_.JLongArray>();
   }
 
@@ -15709,9 +16066,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JDoubleArray echoFloat64List(
     jni$_.JDoubleArray ds,
   ) {
+    final _$$selfRef = reference;
     final _$ds = ds.reference;
     return _echoFloat64List(
-            reference.pointer, _id_echoFloat64List.pointer, _$ds.pointer)
+            _$$selfRef.pointer, _id_echoFloat64List.pointer, _$ds.pointer)
         .object<jni$_.JDoubleArray>();
   }
 
@@ -15737,9 +16095,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JObject echoObject(
     jni$_.JObject object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object.reference;
     return _echoObject(
-            reference.pointer, _id_echoObject.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_echoObject.pointer, _$object.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -15764,8 +16123,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<jni$_.JObject?> echoList(
     jni$_.JList<jni$_.JObject?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _echoList(reference.pointer, _id_echoList.pointer, _$list.pointer)
+    return _echoList(_$$selfRef.pointer, _id_echoList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JObject?>>();
   }
 
@@ -15791,9 +16151,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<jni$_.JString?> echoStringList(
     jni$_.JList<jni$_.JString?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoStringList(
-            reference.pointer, _id_echoStringList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoStringList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JString?>>();
   }
 
@@ -15819,9 +16180,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<jni$_.JLong?> echoIntList(
     jni$_.JList<jni$_.JLong?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoIntList(
-            reference.pointer, _id_echoIntList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoIntList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JLong?>>();
   }
 
@@ -15847,9 +16209,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<jni$_.JDouble?> echoDoubleList(
     jni$_.JList<jni$_.JDouble?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoDoubleList(
-            reference.pointer, _id_echoDoubleList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoDoubleList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JDouble?>>();
   }
 
@@ -15875,9 +16238,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<jni$_.JBoolean?> echoBoolList(
     jni$_.JList<jni$_.JBoolean?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoBoolList(
-            reference.pointer, _id_echoBoolList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoBoolList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JBoolean?>>();
   }
 
@@ -15903,9 +16267,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<NIAnEnum?> echoEnumList(
     jni$_.JList<NIAnEnum?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoEnumList(
-            reference.pointer, _id_echoEnumList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum?>>();
   }
 
@@ -15931,9 +16296,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<NIAllNullableTypes?> echoClassList(
     jni$_.JList<NIAllNullableTypes?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoClassList(
-            reference.pointer, _id_echoClassList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes?>>();
   }
 
@@ -15959,9 +16325,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<NIAnEnum> echoNonNullEnumList(
     jni$_.JList<NIAnEnum> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoNonNullEnumList(
-            reference.pointer, _id_echoNonNullEnumList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoNonNullEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum>>();
   }
 
@@ -15987,9 +16354,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<NIAllNullableTypes> echoNonNullClassList(
     jni$_.JList<NIAllNullableTypes> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _echoNonNullClassList(
-            reference.pointer, _id_echoNonNullClassList.pointer, _$list.pointer)
+    return _echoNonNullClassList(_$$selfRef.pointer,
+            _id_echoNonNullClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes>>();
   }
 
@@ -16014,8 +16382,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JObject?, jni$_.JObject?> echoMap(
     jni$_.JMap<jni$_.JObject?, jni$_.JObject?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _echoMap(reference.pointer, _id_echoMap.pointer, _$map.pointer)
+    return _echoMap(_$$selfRef.pointer, _id_echoMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>>();
   }
 
@@ -16041,9 +16410,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JString?, jni$_.JString?> echoStringMap(
     jni$_.JMap<jni$_.JString?, jni$_.JString?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoStringMap(
-            reference.pointer, _id_echoStringMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString?, jni$_.JString?>>();
   }
 
@@ -16069,8 +16439,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong?, jni$_.JLong?> echoIntMap(
     jni$_.JMap<jni$_.JLong?, jni$_.JLong?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _echoIntMap(reference.pointer, _id_echoIntMap.pointer, _$map.pointer)
+    return _echoIntMap(
+            _$$selfRef.pointer, _id_echoIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JLong?>>();
   }
 
@@ -16096,9 +16468,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<NIAnEnum?, NIAnEnum?> echoEnumMap(
     jni$_.JMap<NIAnEnum?, NIAnEnum?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoEnumMap(
-            reference.pointer, _id_echoEnumMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum?, NIAnEnum?>>();
   }
 
@@ -16124,9 +16497,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?> echoClassMap(
     jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoClassMap(
-            reference.pointer, _id_echoClassMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>>();
   }
 
@@ -16152,9 +16526,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JString, jni$_.JString> echoNonNullStringMap(
     jni$_.JMap<jni$_.JString, jni$_.JString> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoNonNullStringMap(
-            reference.pointer, _id_echoNonNullStringMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNonNullStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString, jni$_.JString>>();
   }
 
@@ -16180,9 +16555,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong, jni$_.JLong> echoNonNullIntMap(
     jni$_.JMap<jni$_.JLong, jni$_.JLong> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoNonNullIntMap(
-            reference.pointer, _id_echoNonNullIntMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNonNullIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, jni$_.JLong>>();
   }
 
@@ -16208,9 +16584,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<NIAnEnum, NIAnEnum> echoNonNullEnumMap(
     jni$_.JMap<NIAnEnum, NIAnEnum> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoNonNullEnumMap(
-            reference.pointer, _id_echoNonNullEnumMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNonNullEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum, NIAnEnum>>();
   }
 
@@ -16236,9 +16613,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong, NIAllNullableTypes> echoNonNullClassMap(
     jni$_.JMap<jni$_.JLong, NIAllNullableTypes> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoNonNullClassMap(
-            reference.pointer, _id_echoNonNullClassMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNonNullClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, NIAllNullableTypes>>();
   }
 
@@ -16264,8 +16642,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   NIAllClassesWrapper echoClassWrapper(
     NIAllClassesWrapper nIAllClassesWrapper,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllClassesWrapper = nIAllClassesWrapper.reference;
-    return _echoClassWrapper(reference.pointer, _id_echoClassWrapper.pointer,
+    return _echoClassWrapper(_$$selfRef.pointer, _id_echoClassWrapper.pointer,
             _$nIAllClassesWrapper.pointer)
         .object<NIAllClassesWrapper>();
   }
@@ -16291,9 +16670,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   NIAnEnum echoEnum(
     NIAnEnum nIAnEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum.reference;
     return _echoEnum(
-            reference.pointer, _id_echoEnum.pointer, _$nIAnEnum.pointer)
+            _$$selfRef.pointer, _id_echoEnum.pointer, _$nIAnEnum.pointer)
         .object<NIAnEnum>();
   }
 
@@ -16319,8 +16699,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   NIAnotherEnum echoAnotherEnum(
     NIAnotherEnum nIAnotherEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum.reference;
-    return _echoAnotherEnum(reference.pointer, _id_echoAnotherEnum.pointer,
+    return _echoAnotherEnum(_$$selfRef.pointer, _id_echoAnotherEnum.pointer,
             _$nIAnotherEnum.pointer)
         .object<NIAnotherEnum>();
   }
@@ -16347,8 +16728,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JString echoNamedDefaultString(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
-    return _echoNamedDefaultString(reference.pointer,
+    return _echoNamedDefaultString(_$$selfRef.pointer,
             _id_echoNamedDefaultString.pointer, _$string.pointer)
         .object<jni$_.JString>();
   }
@@ -16374,8 +16756,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   core$_.double echoOptionalDefaultDouble(
     core$_.double d,
   ) {
+    final _$$selfRef = reference;
     return _echoOptionalDefaultDouble(
-            reference.pointer, _id_echoOptionalDefaultDouble.pointer, d)
+            _$$selfRef.pointer, _id_echoOptionalDefaultDouble.pointer, d)
         .doubleFloat;
   }
 
@@ -16399,7 +16782,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   core$_.int echoRequiredInt(
     core$_.int j,
   ) {
-    return _echoRequiredInt(reference.pointer, _id_echoRequiredInt.pointer, j)
+    final _$$selfRef = reference;
+    return _echoRequiredInt(_$$selfRef.pointer, _id_echoRequiredInt.pointer, j)
         .long;
   }
 
@@ -16425,9 +16809,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   NIAllNullableTypes? echoAllNullableTypes(
     NIAllNullableTypes? nIAllNullableTypes,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllNullableTypes =
         nIAllNullableTypes?.reference ?? jni$_.jNullReference;
-    return _echoAllNullableTypes(reference.pointer,
+    return _echoAllNullableTypes(_$$selfRef.pointer,
             _id_echoAllNullableTypes.pointer, _$nIAllNullableTypes.pointer)
         .object<NIAllNullableTypes?>();
   }
@@ -16455,10 +16840,11 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   NIAllNullableTypesWithoutRecursion? echoAllNullableTypesWithoutRecursion(
     NIAllNullableTypesWithoutRecursion? nIAllNullableTypesWithoutRecursion,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllNullableTypesWithoutRecursion =
         nIAllNullableTypesWithoutRecursion?.reference ?? jni$_.jNullReference;
     return _echoAllNullableTypesWithoutRecursion(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAllNullableTypesWithoutRecursion.pointer,
             _$nIAllNullableTypesWithoutRecursion.pointer)
         .object<NIAllNullableTypesWithoutRecursion?>();
@@ -16487,9 +16873,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JString? extractNestedNullableString(
     NIAllClassesWrapper nIAllClassesWrapper,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllClassesWrapper = nIAllClassesWrapper.reference;
     return _extractNestedNullableString(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_extractNestedNullableString.pointer,
             _$nIAllClassesWrapper.pointer)
         .object<jni$_.JString?>();
@@ -16518,8 +16905,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   NIAllClassesWrapper createNestedNullableString(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _createNestedNullableString(reference.pointer,
+    return _createNestedNullableString(_$$selfRef.pointer,
             _id_createNestedNullableString.pointer, _$string.pointer)
         .object<NIAllClassesWrapper>();
   }
@@ -16556,11 +16944,12 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     jni$_.JLong? long,
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _sendMultipleNullableTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_sendMultipleNullableTypes.pointer,
             _$boolean.pointer,
             _$long.pointer,
@@ -16601,11 +16990,12 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     jni$_.JLong? long,
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _sendMultipleNullableTypesWithoutRecursion(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_sendMultipleNullableTypesWithoutRecursion.pointer,
             _$boolean.pointer,
             _$long.pointer,
@@ -16635,9 +17025,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JLong? echoNullableInt(
     jni$_.JLong? long,
   ) {
+    final _$$selfRef = reference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     return _echoNullableInt(
-            reference.pointer, _id_echoNullableInt.pointer, _$long.pointer)
+            _$$selfRef.pointer, _id_echoNullableInt.pointer, _$long.pointer)
         .object<jni$_.JLong?>();
   }
 
@@ -16663,9 +17054,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JDouble? echoNullableDouble(
     jni$_.JDouble? double,
   ) {
+    final _$$selfRef = reference;
     final _$double = double?.reference ?? jni$_.jNullReference;
-    return _echoNullableDouble(
-            reference.pointer, _id_echoNullableDouble.pointer, _$double.pointer)
+    return _echoNullableDouble(_$$selfRef.pointer,
+            _id_echoNullableDouble.pointer, _$double.pointer)
         .object<jni$_.JDouble?>();
   }
 
@@ -16691,9 +17083,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JBoolean? echoNullableBool(
     jni$_.JBoolean? boolean,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     return _echoNullableBool(
-            reference.pointer, _id_echoNullableBool.pointer, _$boolean.pointer)
+            _$$selfRef.pointer, _id_echoNullableBool.pointer, _$boolean.pointer)
         .object<jni$_.JBoolean?>();
   }
 
@@ -16719,9 +17112,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JString? echoNullableString(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _echoNullableString(
-            reference.pointer, _id_echoNullableString.pointer, _$string.pointer)
+    return _echoNullableString(_$$selfRef.pointer,
+            _id_echoNullableString.pointer, _$string.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -16747,9 +17141,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JByteArray? echoNullableUint8List(
     jni$_.JByteArray? bs,
   ) {
+    final _$$selfRef = reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
     return _echoNullableUint8List(
-            reference.pointer, _id_echoNullableUint8List.pointer, _$bs.pointer)
+            _$$selfRef.pointer, _id_echoNullableUint8List.pointer, _$bs.pointer)
         .object<jni$_.JByteArray?>();
   }
 
@@ -16775,9 +17170,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JIntArray? echoNullableInt32List(
     jni$_.JIntArray? is$,
   ) {
+    final _$$selfRef = reference;
     final _$is$ = is$?.reference ?? jni$_.jNullReference;
-    return _echoNullableInt32List(
-            reference.pointer, _id_echoNullableInt32List.pointer, _$is$.pointer)
+    return _echoNullableInt32List(_$$selfRef.pointer,
+            _id_echoNullableInt32List.pointer, _$is$.pointer)
         .object<jni$_.JIntArray?>();
   }
 
@@ -16803,9 +17199,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JLongArray? echoNullableInt64List(
     jni$_.JLongArray? js,
   ) {
+    final _$$selfRef = reference;
     final _$js = js?.reference ?? jni$_.jNullReference;
     return _echoNullableInt64List(
-            reference.pointer, _id_echoNullableInt64List.pointer, _$js.pointer)
+            _$$selfRef.pointer, _id_echoNullableInt64List.pointer, _$js.pointer)
         .object<jni$_.JLongArray?>();
   }
 
@@ -16831,8 +17228,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JDoubleArray? echoNullableFloat64List(
     jni$_.JDoubleArray? ds,
   ) {
+    final _$$selfRef = reference;
     final _$ds = ds?.reference ?? jni$_.jNullReference;
-    return _echoNullableFloat64List(reference.pointer,
+    return _echoNullableFloat64List(_$$selfRef.pointer,
             _id_echoNullableFloat64List.pointer, _$ds.pointer)
         .object<jni$_.JDoubleArray?>();
   }
@@ -16859,9 +17257,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JObject? echoNullableObject(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _echoNullableObject(
-            reference.pointer, _id_echoNullableObject.pointer, _$object.pointer)
+    return _echoNullableObject(_$$selfRef.pointer,
+            _id_echoNullableObject.pointer, _$object.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -16887,9 +17286,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<jni$_.JObject?>? echoNullableList(
     jni$_.JList<jni$_.JObject?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     return _echoNullableList(
-            reference.pointer, _id_echoNullableList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoNullableList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JObject?>?>();
   }
 
@@ -16915,9 +17315,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<NIAnEnum?>? echoNullableEnumList(
     jni$_.JList<NIAnEnum?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _echoNullableEnumList(
-            reference.pointer, _id_echoNullableEnumList.pointer, _$list.pointer)
+    return _echoNullableEnumList(_$$selfRef.pointer,
+            _id_echoNullableEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum?>?>();
   }
 
@@ -16943,8 +17344,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<NIAllNullableTypes?>? echoNullableClassList(
     jni$_.JList<NIAllNullableTypes?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _echoNullableClassList(reference.pointer,
+    return _echoNullableClassList(_$$selfRef.pointer,
             _id_echoNullableClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes?>?>();
   }
@@ -16972,8 +17374,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<NIAnEnum>? echoNullableNonNullEnumList(
     jni$_.JList<NIAnEnum>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullEnumList(reference.pointer,
+    return _echoNullableNonNullEnumList(_$$selfRef.pointer,
             _id_echoNullableNonNullEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum>?>();
   }
@@ -17001,8 +17404,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<NIAllNullableTypes>? echoNullableNonNullClassList(
     jni$_.JList<NIAllNullableTypes>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullClassList(reference.pointer,
+    return _echoNullableNonNullClassList(_$$selfRef.pointer,
             _id_echoNullableNonNullClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes>?>();
   }
@@ -17029,9 +17433,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JObject?, jni$_.JObject?>? echoNullableMap(
     jni$_.JMap<jni$_.JObject?, jni$_.JObject?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     return _echoNullableMap(
-            reference.pointer, _id_echoNullableMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNullableMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>();
   }
 
@@ -17057,9 +17462,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JString?, jni$_.JString?>? echoNullableStringMap(
     jni$_.JMap<jni$_.JString?, jni$_.JString?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _echoNullableStringMap(
-            reference.pointer, _id_echoNullableStringMap.pointer, _$map.pointer)
+    return _echoNullableStringMap(_$$selfRef.pointer,
+            _id_echoNullableStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString?, jni$_.JString?>?>();
   }
 
@@ -17085,9 +17491,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong?, jni$_.JLong?>? echoNullableIntMap(
     jni$_.JMap<jni$_.JLong?, jni$_.JLong?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     return _echoNullableIntMap(
-            reference.pointer, _id_echoNullableIntMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNullableIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JLong?>?>();
   }
 
@@ -17113,9 +17520,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<NIAnEnum?, NIAnEnum?>? echoNullableEnumMap(
     jni$_.JMap<NIAnEnum?, NIAnEnum?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     return _echoNullableEnumMap(
-            reference.pointer, _id_echoNullableEnumMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNullableEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum?, NIAnEnum?>?>();
   }
 
@@ -17141,9 +17549,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>? echoNullableClassMap(
     jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     return _echoNullableClassMap(
-            reference.pointer, _id_echoNullableClassMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNullableClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>?>();
   }
 
@@ -17170,8 +17579,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JString, jni$_.JString>? echoNullableNonNullStringMap(
     jni$_.JMap<jni$_.JString, jni$_.JString>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullStringMap(reference.pointer,
+    return _echoNullableNonNullStringMap(_$$selfRef.pointer,
             _id_echoNullableNonNullStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString, jni$_.JString>?>();
   }
@@ -17198,8 +17608,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong, jni$_.JLong>? echoNullableNonNullIntMap(
     jni$_.JMap<jni$_.JLong, jni$_.JLong>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullIntMap(reference.pointer,
+    return _echoNullableNonNullIntMap(_$$selfRef.pointer,
             _id_echoNullableNonNullIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, jni$_.JLong>?>();
   }
@@ -17227,8 +17638,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<NIAnEnum, NIAnEnum>? echoNullableNonNullEnumMap(
     jni$_.JMap<NIAnEnum, NIAnEnum>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullEnumMap(reference.pointer,
+    return _echoNullableNonNullEnumMap(_$$selfRef.pointer,
             _id_echoNullableNonNullEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum, NIAnEnum>?>();
   }
@@ -17256,8 +17668,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong, NIAllNullableTypes>? echoNullableNonNullClassMap(
     jni$_.JMap<jni$_.JLong, NIAllNullableTypes>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullClassMap(reference.pointer,
+    return _echoNullableNonNullClassMap(_$$selfRef.pointer,
             _id_echoNullableNonNullClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, NIAllNullableTypes>?>();
   }
@@ -17284,9 +17697,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   NIAnEnum? echoNullableEnum(
     NIAnEnum? nIAnEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum?.reference ?? jni$_.jNullReference;
-    return _echoNullableEnum(
-            reference.pointer, _id_echoNullableEnum.pointer, _$nIAnEnum.pointer)
+    return _echoNullableEnum(_$$selfRef.pointer, _id_echoNullableEnum.pointer,
+            _$nIAnEnum.pointer)
         .object<NIAnEnum?>();
   }
 
@@ -17312,8 +17726,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   NIAnotherEnum? echoAnotherNullableEnum(
     NIAnotherEnum? nIAnotherEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum?.reference ?? jni$_.jNullReference;
-    return _echoAnotherNullableEnum(reference.pointer,
+    return _echoAnotherNullableEnum(_$$selfRef.pointer,
             _id_echoAnotherNullableEnum.pointer, _$nIAnotherEnum.pointer)
         .object<NIAnotherEnum?>();
   }
@@ -17340,8 +17755,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JLong? echoOptionalNullableInt(
     jni$_.JLong? long,
   ) {
+    final _$$selfRef = reference;
     final _$long = long?.reference ?? jni$_.jNullReference;
-    return _echoOptionalNullableInt(reference.pointer,
+    return _echoOptionalNullableInt(_$$selfRef.pointer,
             _id_echoOptionalNullableInt.pointer, _$long.pointer)
         .object<jni$_.JLong?>();
   }
@@ -17368,8 +17784,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JString? echoNamedNullableString(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _echoNamedNullableString(reference.pointer,
+    return _echoNamedNullableString(_$$selfRef.pointer,
             _id_echoNamedNullableString.pointer, _$string.pointer)
         .object<jni$_.JString?>();
   }
@@ -17395,9 +17812,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   core$_.Future<void> noopAsync() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
+    final _$$selfRef = reference;
     final $r = _noopAsync(
-            reference.pointer, _id_noopAsync.pointer, _$continuation.pointer)
+            _$$selfRef.pointer, _id_noopAsync.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
     jni$_.JObject $o;
@@ -17445,8 +17862,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _echoAsyncInt(reference.pointer, _id_echoAsyncInt.pointer, j,
+    final _$$selfRef = reference;
+    final $r = _echoAsyncInt(_$$selfRef.pointer, _id_echoAsyncInt.pointer, j,
             _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -17500,8 +17917,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _echoAsyncDouble(reference.pointer, _id_echoAsyncDouble.pointer,
+    final _$$selfRef = reference;
+    final $r = _echoAsyncDouble(_$$selfRef.pointer, _id_echoAsyncDouble.pointer,
             d, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -17553,8 +17970,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _echoAsyncBool(reference.pointer, _id_echoAsyncBool.pointer,
+    final _$$selfRef = reference;
+    final $r = _echoAsyncBool(_$$selfRef.pointer, _id_echoAsyncBool.pointer,
             z ? 1 : 0, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -17611,8 +18028,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$string = string.reference;
-    final $r = _echoAsyncString(reference.pointer, _id_echoAsyncString.pointer,
+    final $r = _echoAsyncString(_$$selfRef.pointer, _id_echoAsyncString.pointer,
             _$string.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -17669,9 +18087,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$bs = bs.reference;
     final $r = _echoAsyncUint8List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncUint8List.pointer,
             _$bs.pointer,
             _$continuation.pointer)
@@ -17730,9 +18149,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$is$ = is$.reference;
     final $r = _echoAsyncInt32List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncInt32List.pointer,
             _$is$.pointer,
             _$continuation.pointer)
@@ -17791,9 +18211,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$js = js.reference;
     final $r = _echoAsyncInt64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncInt64List.pointer,
             _$js.pointer,
             _$continuation.pointer)
@@ -17852,9 +18273,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$ds = ds.reference;
     final $r = _echoAsyncFloat64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncFloat64List.pointer,
             _$ds.pointer,
             _$continuation.pointer)
@@ -17913,8 +18335,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$object = object.reference;
-    final $r = _echoAsyncObject(reference.pointer, _id_echoAsyncObject.pointer,
+    final $r = _echoAsyncObject(_$$selfRef.pointer, _id_echoAsyncObject.pointer,
             _$object.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -17971,8 +18394,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    final $r = _echoAsyncList(reference.pointer, _id_echoAsyncList.pointer,
+    final $r = _echoAsyncList(_$$selfRef.pointer, _id_echoAsyncList.pointer,
             _$list.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -18029,9 +18453,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _echoAsyncEnumList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncEnumList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -18090,9 +18515,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _echoAsyncClassList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncClassList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -18151,8 +18577,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    final $r = _echoAsyncMap(reference.pointer, _id_echoAsyncMap.pointer,
+    final $r = _echoAsyncMap(_$$selfRef.pointer, _id_echoAsyncMap.pointer,
             _$map.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -18209,9 +18636,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
     final $r = _echoAsyncStringMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncStringMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -18270,8 +18698,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    final $r = _echoAsyncIntMap(reference.pointer, _id_echoAsyncIntMap.pointer,
+    final $r = _echoAsyncIntMap(_$$selfRef.pointer, _id_echoAsyncIntMap.pointer,
             _$map.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -18328,8 +18757,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    final $r = _echoAsyncEnumMap(reference.pointer,
+    final $r = _echoAsyncEnumMap(_$$selfRef.pointer,
             _id_echoAsyncEnumMap.pointer, _$map.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -18387,9 +18817,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
     final $r = _echoAsyncClassMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncClassMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -18448,8 +18879,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum.reference;
-    final $r = _echoAsyncEnum(reference.pointer, _id_echoAsyncEnum.pointer,
+    final $r = _echoAsyncEnum(_$$selfRef.pointer, _id_echoAsyncEnum.pointer,
             _$nIAnEnum.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -18506,9 +18938,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum.reference;
     final $r = _echoAnotherAsyncEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAnotherAsyncEnum.pointer,
             _$nIAnotherEnum.pointer,
             _$continuation.pointer)
@@ -18559,8 +18992,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   core$_.Future<jni$_.JObject?> throwAsyncError() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _throwAsyncError(reference.pointer, _id_throwAsyncError.pointer,
+    final _$$selfRef = reference;
+    final $r = _throwAsyncError(_$$selfRef.pointer, _id_throwAsyncError.pointer,
             _$continuation.pointer)
         .object<jni$_.JObject?>();
     _$continuation.release();
@@ -18611,8 +19044,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   core$_.Future<void> throwAsyncErrorFromVoid() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _throwAsyncErrorFromVoid(reference.pointer,
+    final _$$selfRef = reference;
+    final $r = _throwAsyncErrorFromVoid(_$$selfRef.pointer,
             _id_throwAsyncErrorFromVoid.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -18658,8 +19091,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   core$_.Future<jni$_.JObject?> throwAsyncFlutterError() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _throwAsyncFlutterError(reference.pointer,
+    final _$$selfRef = reference;
+    final $r = _throwAsyncFlutterError(_$$selfRef.pointer,
             _id_throwAsyncFlutterError.pointer, _$continuation.pointer)
         .object<jni$_.JObject?>();
     _$continuation.release();
@@ -18718,9 +19151,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAllTypes = nIAllTypes.reference;
     final $r = _echoAsyncNIAllTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNIAllTypes.pointer,
             _$nIAllTypes.pointer,
             _$continuation.pointer)
@@ -18780,10 +19214,11 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAllNullableTypes =
         nIAllNullableTypes?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableNIAllNullableTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableNIAllNullableTypes.pointer,
             _$nIAllNullableTypes.pointer,
             _$continuation.pointer)
@@ -18846,10 +19281,11 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAllNullableTypesWithoutRecursion =
         nIAllNullableTypesWithoutRecursion?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableNIAllNullableTypesWithoutRecursion(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableNIAllNullableTypesWithoutRecursion.pointer,
             _$nIAllNullableTypesWithoutRecursion.pointer,
             _$continuation.pointer)
@@ -18910,9 +19346,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableInt(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableInt.pointer,
             _$long.pointer,
             _$continuation.pointer)
@@ -18973,9 +19410,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$double = double?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableDouble(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableDouble.pointer,
             _$double.pointer,
             _$continuation.pointer)
@@ -19036,9 +19474,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableBool(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableBool.pointer,
             _$boolean.pointer,
             _$continuation.pointer)
@@ -19099,9 +19538,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableString(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableString.pointer,
             _$string.pointer,
             _$continuation.pointer)
@@ -19163,9 +19603,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableUint8List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableUint8List.pointer,
             _$bs.pointer,
             _$continuation.pointer)
@@ -19227,9 +19668,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$is$ = is$?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableInt32List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableInt32List.pointer,
             _$is$.pointer,
             _$continuation.pointer)
@@ -19291,9 +19733,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$js = js?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableInt64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableInt64List.pointer,
             _$js.pointer,
             _$continuation.pointer)
@@ -19355,9 +19798,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$ds = ds?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableFloat64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableFloat64List.pointer,
             _$ds.pointer,
             _$continuation.pointer)
@@ -19418,9 +19862,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableObject(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableObject.pointer,
             _$object.pointer,
             _$continuation.pointer)
@@ -19481,9 +19926,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -19544,9 +19990,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableEnumList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableEnumList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -19608,9 +20055,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableClassList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableClassList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -19672,9 +20120,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -19737,9 +20186,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableStringMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableStringMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -19801,9 +20251,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableIntMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableIntMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -19864,9 +20315,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableEnumMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableEnumMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -19928,9 +20380,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableClassMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableClassMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -19991,9 +20444,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableEnum.pointer,
             _$nIAnEnum.pointer,
             _$continuation.pointer)
@@ -20055,9 +20509,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum?.reference ?? jni$_.jNullReference;
     final $r = _echoAnotherAsyncNullableEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAnotherAsyncNullableEnum.pointer,
             _$nIAnotherEnum.pointer,
             _$continuation.pointer)
@@ -20108,7 +20563,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
 
   /// from: `public fun callFlutterNoop(): kotlin.Unit`
   void callFlutterNoop() {
-    _callFlutterNoop(reference.pointer, _id_callFlutterNoop.pointer).check();
+    final _$$selfRef = reference;
+    _callFlutterNoop(_$$selfRef.pointer, _id_callFlutterNoop.pointer).check();
   }
 
   static final _id_callFlutterThrowError =
@@ -20132,8 +20588,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   /// from: `public fun callFlutterThrowError(): kotlin.Any?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? callFlutterThrowError() {
+    final _$$selfRef = reference;
     return _callFlutterThrowError(
-            reference.pointer, _id_callFlutterThrowError.pointer)
+            _$$selfRef.pointer, _id_callFlutterThrowError.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -20158,8 +20615,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
 
   /// from: `public fun callFlutterThrowErrorFromVoid(): kotlin.Unit`
   void callFlutterThrowErrorFromVoid() {
+    final _$$selfRef = reference;
     _callFlutterThrowErrorFromVoid(
-            reference.pointer, _id_callFlutterThrowErrorFromVoid.pointer)
+            _$$selfRef.pointer, _id_callFlutterThrowErrorFromVoid.pointer)
         .check();
   }
 
@@ -20185,8 +20643,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   NIAllTypes callFlutterEchoNIAllTypes(
     NIAllTypes nIAllTypes,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllTypes = nIAllTypes.reference;
-    return _callFlutterEchoNIAllTypes(reference.pointer,
+    return _callFlutterEchoNIAllTypes(_$$selfRef.pointer,
             _id_callFlutterEchoNIAllTypes.pointer, _$nIAllTypes.pointer)
         .object<NIAllTypes>();
   }
@@ -20214,10 +20673,11 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   NIAllNullableTypes? callFlutterEchoNIAllNullableTypes(
     NIAllNullableTypes? nIAllNullableTypes,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllNullableTypes =
         nIAllNullableTypes?.reference ?? jni$_.jNullReference;
     return _callFlutterEchoNIAllNullableTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoNIAllNullableTypes.pointer,
             _$nIAllNullableTypes.pointer)
         .object<NIAllNullableTypes?>();
@@ -20256,11 +20716,12 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     jni$_.JLong? long,
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _callFlutterSendMultipleNullableTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterSendMultipleNullableTypes.pointer,
             _$boolean.pointer,
             _$long.pointer,
@@ -20292,10 +20753,11 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
       callFlutterEchoNIAllNullableTypesWithoutRecursion(
     NIAllNullableTypesWithoutRecursion? nIAllNullableTypesWithoutRecursion,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllNullableTypesWithoutRecursion =
         nIAllNullableTypesWithoutRecursion?.reference ?? jni$_.jNullReference;
     return _callFlutterEchoNIAllNullableTypesWithoutRecursion(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoNIAllNullableTypesWithoutRecursion.pointer,
             _$nIAllNullableTypesWithoutRecursion.pointer)
         .object<NIAllNullableTypesWithoutRecursion?>();
@@ -20335,11 +20797,12 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
     jni$_.JLong? long,
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _callFlutterSendMultipleNullableTypesWithoutRecursion(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterSendMultipleNullableTypesWithoutRecursion.pointer,
             _$boolean.pointer,
             _$long.pointer,
@@ -20368,8 +20831,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   core$_.bool callFlutterEchoBool(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _callFlutterEchoBool(
-            reference.pointer, _id_callFlutterEchoBool.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_callFlutterEchoBool.pointer, z ? 1 : 0)
         .boolean;
   }
 
@@ -20393,8 +20857,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   core$_.int callFlutterEchoInt(
     core$_.int j,
   ) {
+    final _$$selfRef = reference;
     return _callFlutterEchoInt(
-            reference.pointer, _id_callFlutterEchoInt.pointer, j)
+            _$$selfRef.pointer, _id_callFlutterEchoInt.pointer, j)
         .long;
   }
 
@@ -20419,8 +20884,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   core$_.double callFlutterEchoDouble(
     core$_.double d,
   ) {
+    final _$$selfRef = reference;
     return _callFlutterEchoDouble(
-            reference.pointer, _id_callFlutterEchoDouble.pointer, d)
+            _$$selfRef.pointer, _id_callFlutterEchoDouble.pointer, d)
         .doubleFloat;
   }
 
@@ -20446,8 +20912,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JString callFlutterEchoString(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
-    return _callFlutterEchoString(reference.pointer,
+    return _callFlutterEchoString(_$$selfRef.pointer,
             _id_callFlutterEchoString.pointer, _$string.pointer)
         .object<jni$_.JString>();
   }
@@ -20474,8 +20941,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JByteArray callFlutterEchoUint8List(
     jni$_.JByteArray bs,
   ) {
+    final _$$selfRef = reference;
     final _$bs = bs.reference;
-    return _callFlutterEchoUint8List(reference.pointer,
+    return _callFlutterEchoUint8List(_$$selfRef.pointer,
             _id_callFlutterEchoUint8List.pointer, _$bs.pointer)
         .object<jni$_.JByteArray>();
   }
@@ -20502,8 +20970,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JIntArray callFlutterEchoInt32List(
     jni$_.JIntArray is$,
   ) {
+    final _$$selfRef = reference;
     final _$is$ = is$.reference;
-    return _callFlutterEchoInt32List(reference.pointer,
+    return _callFlutterEchoInt32List(_$$selfRef.pointer,
             _id_callFlutterEchoInt32List.pointer, _$is$.pointer)
         .object<jni$_.JIntArray>();
   }
@@ -20530,8 +20999,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JLongArray callFlutterEchoInt64List(
     jni$_.JLongArray js,
   ) {
+    final _$$selfRef = reference;
     final _$js = js.reference;
-    return _callFlutterEchoInt64List(reference.pointer,
+    return _callFlutterEchoInt64List(_$$selfRef.pointer,
             _id_callFlutterEchoInt64List.pointer, _$js.pointer)
         .object<jni$_.JLongArray>();
   }
@@ -20559,8 +21029,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JDoubleArray callFlutterEchoFloat64List(
     jni$_.JDoubleArray ds,
   ) {
+    final _$$selfRef = reference;
     final _$ds = ds.reference;
-    return _callFlutterEchoFloat64List(reference.pointer,
+    return _callFlutterEchoFloat64List(_$$selfRef.pointer,
             _id_callFlutterEchoFloat64List.pointer, _$ds.pointer)
         .object<jni$_.JDoubleArray>();
   }
@@ -20587,9 +21058,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<jni$_.JObject?> callFlutterEchoList(
     jni$_.JList<jni$_.JObject?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _callFlutterEchoList(
-            reference.pointer, _id_callFlutterEchoList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_callFlutterEchoList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JObject?>>();
   }
 
@@ -20615,8 +21087,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<NIAnEnum?> callFlutterEchoEnumList(
     jni$_.JList<NIAnEnum?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _callFlutterEchoEnumList(reference.pointer,
+    return _callFlutterEchoEnumList(_$$selfRef.pointer,
             _id_callFlutterEchoEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum?>>();
   }
@@ -20643,8 +21116,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<NIAllNullableTypes?> callFlutterEchoClassList(
     jni$_.JList<NIAllNullableTypes?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _callFlutterEchoClassList(reference.pointer,
+    return _callFlutterEchoClassList(_$$selfRef.pointer,
             _id_callFlutterEchoClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes?>>();
   }
@@ -20672,8 +21146,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<NIAnEnum> callFlutterEchoNonNullEnumList(
     jni$_.JList<NIAnEnum> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _callFlutterEchoNonNullEnumList(reference.pointer,
+    return _callFlutterEchoNonNullEnumList(_$$selfRef.pointer,
             _id_callFlutterEchoNonNullEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum>>();
   }
@@ -20701,8 +21176,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<NIAllNullableTypes> callFlutterEchoNonNullClassList(
     jni$_.JList<NIAllNullableTypes> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _callFlutterEchoNonNullClassList(reference.pointer,
+    return _callFlutterEchoNonNullClassList(_$$selfRef.pointer,
             _id_callFlutterEchoNonNullClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes>>();
   }
@@ -20729,9 +21205,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JObject?, jni$_.JObject?> callFlutterEchoMap(
     jni$_.JMap<jni$_.JObject?, jni$_.JObject?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _callFlutterEchoMap(
-            reference.pointer, _id_callFlutterEchoMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_callFlutterEchoMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>>();
   }
 
@@ -20757,8 +21234,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JString?, jni$_.JString?> callFlutterEchoStringMap(
     jni$_.JMap<jni$_.JString?, jni$_.JString?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _callFlutterEchoStringMap(reference.pointer,
+    return _callFlutterEchoStringMap(_$$selfRef.pointer,
             _id_callFlutterEchoStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString?, jni$_.JString?>>();
   }
@@ -20785,9 +21263,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong?, jni$_.JLong?> callFlutterEchoIntMap(
     jni$_.JMap<jni$_.JLong?, jni$_.JLong?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _callFlutterEchoIntMap(
-            reference.pointer, _id_callFlutterEchoIntMap.pointer, _$map.pointer)
+    return _callFlutterEchoIntMap(_$$selfRef.pointer,
+            _id_callFlutterEchoIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JLong?>>();
   }
 
@@ -20813,8 +21292,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<NIAnEnum?, NIAnEnum?> callFlutterEchoEnumMap(
     jni$_.JMap<NIAnEnum?, NIAnEnum?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _callFlutterEchoEnumMap(reference.pointer,
+    return _callFlutterEchoEnumMap(_$$selfRef.pointer,
             _id_callFlutterEchoEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum?, NIAnEnum?>>();
   }
@@ -20841,8 +21321,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?> callFlutterEchoClassMap(
     jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _callFlutterEchoClassMap(reference.pointer,
+    return _callFlutterEchoClassMap(_$$selfRef.pointer,
             _id_callFlutterEchoClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>>();
   }
@@ -20870,8 +21351,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JString, jni$_.JString> callFlutterEchoNonNullStringMap(
     jni$_.JMap<jni$_.JString, jni$_.JString> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _callFlutterEchoNonNullStringMap(reference.pointer,
+    return _callFlutterEchoNonNullStringMap(_$$selfRef.pointer,
             _id_callFlutterEchoNonNullStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString, jni$_.JString>>();
   }
@@ -20899,8 +21381,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong, jni$_.JLong> callFlutterEchoNonNullIntMap(
     jni$_.JMap<jni$_.JLong, jni$_.JLong> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _callFlutterEchoNonNullIntMap(reference.pointer,
+    return _callFlutterEchoNonNullIntMap(_$$selfRef.pointer,
             _id_callFlutterEchoNonNullIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, jni$_.JLong>>();
   }
@@ -20928,8 +21411,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<NIAnEnum, NIAnEnum> callFlutterEchoNonNullEnumMap(
     jni$_.JMap<NIAnEnum, NIAnEnum> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _callFlutterEchoNonNullEnumMap(reference.pointer,
+    return _callFlutterEchoNonNullEnumMap(_$$selfRef.pointer,
             _id_callFlutterEchoNonNullEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum, NIAnEnum>>();
   }
@@ -20957,8 +21441,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong, NIAllNullableTypes> callFlutterEchoNonNullClassMap(
     jni$_.JMap<jni$_.JLong, NIAllNullableTypes> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _callFlutterEchoNonNullClassMap(reference.pointer,
+    return _callFlutterEchoNonNullClassMap(_$$selfRef.pointer,
             _id_callFlutterEchoNonNullClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, NIAllNullableTypes>>();
   }
@@ -20985,8 +21470,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   NIAnEnum callFlutterEchoEnum(
     NIAnEnum nIAnEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum.reference;
-    return _callFlutterEchoEnum(reference.pointer,
+    return _callFlutterEchoEnum(_$$selfRef.pointer,
             _id_callFlutterEchoEnum.pointer, _$nIAnEnum.pointer)
         .object<NIAnEnum>();
   }
@@ -21014,8 +21500,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   NIAnotherEnum callFlutterEchoNIAnotherEnum(
     NIAnotherEnum nIAnotherEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum.reference;
-    return _callFlutterEchoNIAnotherEnum(reference.pointer,
+    return _callFlutterEchoNIAnotherEnum(_$$selfRef.pointer,
             _id_callFlutterEchoNIAnotherEnum.pointer, _$nIAnotherEnum.pointer)
         .object<NIAnotherEnum>();
   }
@@ -21043,8 +21530,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JBoolean? callFlutterEchoNullableBool(
     jni$_.JBoolean? boolean,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableBool(reference.pointer,
+    return _callFlutterEchoNullableBool(_$$selfRef.pointer,
             _id_callFlutterEchoNullableBool.pointer, _$boolean.pointer)
         .object<jni$_.JBoolean?>();
   }
@@ -21072,8 +21560,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JLong? callFlutterEchoNullableInt(
     jni$_.JLong? long,
   ) {
+    final _$$selfRef = reference;
     final _$long = long?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableInt(reference.pointer,
+    return _callFlutterEchoNullableInt(_$$selfRef.pointer,
             _id_callFlutterEchoNullableInt.pointer, _$long.pointer)
         .object<jni$_.JLong?>();
   }
@@ -21101,8 +21590,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JDouble? callFlutterEchoNullableDouble(
     jni$_.JDouble? double,
   ) {
+    final _$$selfRef = reference;
     final _$double = double?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableDouble(reference.pointer,
+    return _callFlutterEchoNullableDouble(_$$selfRef.pointer,
             _id_callFlutterEchoNullableDouble.pointer, _$double.pointer)
         .object<jni$_.JDouble?>();
   }
@@ -21130,8 +21620,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JString? callFlutterEchoNullableString(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableString(reference.pointer,
+    return _callFlutterEchoNullableString(_$$selfRef.pointer,
             _id_callFlutterEchoNullableString.pointer, _$string.pointer)
         .object<jni$_.JString?>();
   }
@@ -21159,8 +21650,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JByteArray? callFlutterEchoNullableUint8List(
     jni$_.JByteArray? bs,
   ) {
+    final _$$selfRef = reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableUint8List(reference.pointer,
+    return _callFlutterEchoNullableUint8List(_$$selfRef.pointer,
             _id_callFlutterEchoNullableUint8List.pointer, _$bs.pointer)
         .object<jni$_.JByteArray?>();
   }
@@ -21188,8 +21680,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JIntArray? callFlutterEchoNullableInt32List(
     jni$_.JIntArray? is$,
   ) {
+    final _$$selfRef = reference;
     final _$is$ = is$?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableInt32List(reference.pointer,
+    return _callFlutterEchoNullableInt32List(_$$selfRef.pointer,
             _id_callFlutterEchoNullableInt32List.pointer, _$is$.pointer)
         .object<jni$_.JIntArray?>();
   }
@@ -21217,8 +21710,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JLongArray? callFlutterEchoNullableInt64List(
     jni$_.JLongArray? js,
   ) {
+    final _$$selfRef = reference;
     final _$js = js?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableInt64List(reference.pointer,
+    return _callFlutterEchoNullableInt64List(_$$selfRef.pointer,
             _id_callFlutterEchoNullableInt64List.pointer, _$js.pointer)
         .object<jni$_.JLongArray?>();
   }
@@ -21246,8 +21740,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JDoubleArray? callFlutterEchoNullableFloat64List(
     jni$_.JDoubleArray? ds,
   ) {
+    final _$$selfRef = reference;
     final _$ds = ds?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableFloat64List(reference.pointer,
+    return _callFlutterEchoNullableFloat64List(_$$selfRef.pointer,
             _id_callFlutterEchoNullableFloat64List.pointer, _$ds.pointer)
         .object<jni$_.JDoubleArray?>();
   }
@@ -21275,8 +21770,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<jni$_.JObject?>? callFlutterEchoNullableList(
     jni$_.JList<jni$_.JObject?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableList(reference.pointer,
+    return _callFlutterEchoNullableList(_$$selfRef.pointer,
             _id_callFlutterEchoNullableList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JObject?>?>();
   }
@@ -21304,8 +21800,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<NIAnEnum?>? callFlutterEchoNullableEnumList(
     jni$_.JList<NIAnEnum?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableEnumList(reference.pointer,
+    return _callFlutterEchoNullableEnumList(_$$selfRef.pointer,
             _id_callFlutterEchoNullableEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum?>?>();
   }
@@ -21333,8 +21830,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<NIAllNullableTypes?>? callFlutterEchoNullableClassList(
     jni$_.JList<NIAllNullableTypes?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableClassList(reference.pointer,
+    return _callFlutterEchoNullableClassList(_$$selfRef.pointer,
             _id_callFlutterEchoNullableClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes?>?>();
   }
@@ -21362,8 +21860,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<NIAnEnum>? callFlutterEchoNullableNonNullEnumList(
     jni$_.JList<NIAnEnum>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableNonNullEnumList(reference.pointer,
+    return _callFlutterEchoNullableNonNullEnumList(_$$selfRef.pointer,
             _id_callFlutterEchoNullableNonNullEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum>?>();
   }
@@ -21391,8 +21890,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JList<NIAllNullableTypes>? callFlutterEchoNullableNonNullClassList(
     jni$_.JList<NIAllNullableTypes>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableNonNullClassList(reference.pointer,
+    return _callFlutterEchoNullableNonNullClassList(_$$selfRef.pointer,
             _id_callFlutterEchoNullableNonNullClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes>?>();
   }
@@ -21420,8 +21920,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JObject?, jni$_.JObject?>? callFlutterEchoNullableMap(
     jni$_.JMap<jni$_.JObject?, jni$_.JObject?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableMap(reference.pointer,
+    return _callFlutterEchoNullableMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>();
   }
@@ -21449,8 +21950,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JString?, jni$_.JString?>? callFlutterEchoNullableStringMap(
     jni$_.JMap<jni$_.JString?, jni$_.JString?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableStringMap(reference.pointer,
+    return _callFlutterEchoNullableStringMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString?, jni$_.JString?>?>();
   }
@@ -21478,8 +21980,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong?, jni$_.JLong?>? callFlutterEchoNullableIntMap(
     jni$_.JMap<jni$_.JLong?, jni$_.JLong?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableIntMap(reference.pointer,
+    return _callFlutterEchoNullableIntMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JLong?>?>();
   }
@@ -21507,8 +22010,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<NIAnEnum?, NIAnEnum?>? callFlutterEchoNullableEnumMap(
     jni$_.JMap<NIAnEnum?, NIAnEnum?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableEnumMap(reference.pointer,
+    return _callFlutterEchoNullableEnumMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum?, NIAnEnum?>?>();
   }
@@ -21537,8 +22041,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
       callFlutterEchoNullableClassMap(
     jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableClassMap(reference.pointer,
+    return _callFlutterEchoNullableClassMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>?>();
   }
@@ -21567,8 +22072,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
       callFlutterEchoNullableNonNullStringMap(
     jni$_.JMap<jni$_.JString, jni$_.JString>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableNonNullStringMap(reference.pointer,
+    return _callFlutterEchoNullableNonNullStringMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableNonNullStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString, jni$_.JString>?>();
   }
@@ -21596,8 +22102,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<jni$_.JLong, jni$_.JLong>? callFlutterEchoNullableNonNullIntMap(
     jni$_.JMap<jni$_.JLong, jni$_.JLong>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableNonNullIntMap(reference.pointer,
+    return _callFlutterEchoNullableNonNullIntMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableNonNullIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, jni$_.JLong>?>();
   }
@@ -21625,8 +22132,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   jni$_.JMap<NIAnEnum, NIAnEnum>? callFlutterEchoNullableNonNullEnumMap(
     jni$_.JMap<NIAnEnum, NIAnEnum>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableNonNullEnumMap(reference.pointer,
+    return _callFlutterEchoNullableNonNullEnumMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableNonNullEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum, NIAnEnum>?>();
   }
@@ -21655,8 +22163,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
       callFlutterEchoNullableNonNullClassMap(
     jni$_.JMap<jni$_.JLong, NIAllNullableTypes>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableNonNullClassMap(reference.pointer,
+    return _callFlutterEchoNullableNonNullClassMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableNonNullClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, NIAllNullableTypes>?>();
   }
@@ -21684,8 +22193,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   NIAnEnum? callFlutterEchoNullableEnum(
     NIAnEnum? nIAnEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableEnum(reference.pointer,
+    return _callFlutterEchoNullableEnum(_$$selfRef.pointer,
             _id_callFlutterEchoNullableEnum.pointer, _$nIAnEnum.pointer)
         .object<NIAnEnum?>();
   }
@@ -21713,9 +22223,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   NIAnotherEnum? callFlutterEchoAnotherNullableEnum(
     NIAnotherEnum? nIAnotherEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum?.reference ?? jni$_.jNullReference;
     return _callFlutterEchoAnotherNullableEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAnotherNullableEnum.pointer,
             _$nIAnotherEnum.pointer)
         .object<NIAnotherEnum?>();
@@ -21743,8 +22254,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   core$_.Future<void> callFlutterNoopAsync() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _callFlutterNoopAsync(reference.pointer,
+    final _$$selfRef = reference;
+    final $r = _callFlutterNoopAsync(_$$selfRef.pointer,
             _id_callFlutterNoopAsync.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -21799,9 +22310,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAllTypes = nIAllTypes.reference;
     final $r = _callFlutterEchoAsyncNIAllTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNIAllTypes.pointer,
             _$nIAllTypes.pointer,
             _$continuation.pointer)
@@ -21862,10 +22374,11 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAllNullableTypes =
         nIAllNullableTypes?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableNIAllNullableTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableNIAllNullableTypes.pointer,
             _$nIAllNullableTypes.pointer,
             _$continuation.pointer)
@@ -21928,10 +22441,11 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAllNullableTypesWithoutRecursion =
         nIAllNullableTypesWithoutRecursion?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableNIAllNullableTypesWithoutRecursion(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableNIAllNullableTypesWithoutRecursion
                 .pointer,
             _$nIAllNullableTypesWithoutRecursion.pointer,
@@ -21988,9 +22502,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
+    final _$$selfRef = reference;
     final $r = _callFlutterEchoAsyncBool(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncBool.pointer,
             z ? 1 : 0,
             _$continuation.pointer)
@@ -22044,8 +22558,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _callFlutterEchoAsyncInt(reference.pointer,
+    final _$$selfRef = reference;
+    final $r = _callFlutterEchoAsyncInt(_$$selfRef.pointer,
             _id_callFlutterEchoAsyncInt.pointer, j, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -22103,8 +22617,8 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _callFlutterEchoAsyncDouble(reference.pointer,
+    final _$$selfRef = reference;
+    final $r = _callFlutterEchoAsyncDouble(_$$selfRef.pointer,
             _id_callFlutterEchoAsyncDouble.pointer, d, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -22162,9 +22676,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$string = string.reference;
     final $r = _callFlutterEchoAsyncString(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncString.pointer,
             _$string.pointer,
             _$continuation.pointer)
@@ -22224,9 +22739,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$bs = bs.reference;
     final $r = _callFlutterEchoAsyncUint8List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncUint8List.pointer,
             _$bs.pointer,
             _$continuation.pointer)
@@ -22286,9 +22802,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$is$ = is$.reference;
     final $r = _callFlutterEchoAsyncInt32List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncInt32List.pointer,
             _$is$.pointer,
             _$continuation.pointer)
@@ -22348,9 +22865,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$js = js.reference;
     final $r = _callFlutterEchoAsyncInt64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncInt64List.pointer,
             _$js.pointer,
             _$continuation.pointer)
@@ -22410,9 +22928,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$ds = ds.reference;
     final $r = _callFlutterEchoAsyncFloat64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncFloat64List.pointer,
             _$ds.pointer,
             _$continuation.pointer)
@@ -22472,9 +22991,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$object = object.reference;
     final $r = _callFlutterEchoAsyncObject(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncObject.pointer,
             _$object.pointer,
             _$continuation.pointer)
@@ -22533,9 +23053,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _callFlutterEchoAsyncList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -22595,9 +23116,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _callFlutterEchoAsyncEnumList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncEnumList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -22657,9 +23179,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _callFlutterEchoAsyncClassList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncClassList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -22719,9 +23242,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _callFlutterEchoAsyncNonNullEnumList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNonNullEnumList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -22782,9 +23306,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _callFlutterEchoAsyncNonNullClassList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNonNullClassList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -22844,9 +23369,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
     final $r = _callFlutterEchoAsyncMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -22907,9 +23433,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
     final $r = _callFlutterEchoAsyncStringMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncStringMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -22970,9 +23497,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
     final $r = _callFlutterEchoAsyncIntMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncIntMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -23032,9 +23560,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
     final $r = _callFlutterEchoAsyncEnumMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncEnumMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -23095,9 +23624,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
     final $r = _callFlutterEchoAsyncClassMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncClassMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -23156,9 +23686,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum.reference;
     final $r = _callFlutterEchoAsyncEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncEnum.pointer,
             _$nIAnEnum.pointer,
             _$continuation.pointer)
@@ -23218,9 +23749,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum.reference;
     final $r = _callFlutterEchoAnotherAsyncEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAnotherAsyncEnum.pointer,
             _$nIAnotherEnum.pointer,
             _$continuation.pointer)
@@ -23280,9 +23812,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableBool(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableBool.pointer,
             _$boolean.pointer,
             _$continuation.pointer)
@@ -23344,9 +23877,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableInt(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableInt.pointer,
             _$long.pointer,
             _$continuation.pointer)
@@ -23408,9 +23942,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$double = double?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableDouble(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableDouble.pointer,
             _$double.pointer,
             _$continuation.pointer)
@@ -23472,9 +24007,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableString(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableString.pointer,
             _$string.pointer,
             _$continuation.pointer)
@@ -23536,9 +24072,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableUint8List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableUint8List.pointer,
             _$bs.pointer,
             _$continuation.pointer)
@@ -23600,9 +24137,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$is$ = is$?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableInt32List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableInt32List.pointer,
             _$is$.pointer,
             _$continuation.pointer)
@@ -23664,9 +24202,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$js = js?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableInt64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableInt64List.pointer,
             _$js.pointer,
             _$continuation.pointer)
@@ -23728,9 +24267,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$ds = ds?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableFloat64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableFloat64List.pointer,
             _$ds.pointer,
             _$continuation.pointer)
@@ -23784,9 +24324,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   core$_.Future<jni$_.JObject?> callFlutterThrowFlutterErrorAsync() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
+    final _$$selfRef = reference;
     final $r = _callFlutterThrowFlutterErrorAsync(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterThrowFlutterErrorAsync.pointer,
             _$continuation.pointer)
         .object<jni$_.JObject?>();
@@ -23847,9 +24387,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableObject(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableObject.pointer,
             _$object.pointer,
             _$continuation.pointer)
@@ -23911,9 +24452,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -23975,9 +24517,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableEnumList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableEnumList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -24040,9 +24583,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableClassList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableClassList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -24105,9 +24649,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableNonNullEnumList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableNonNullEnumList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -24170,9 +24715,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableNonNullClassList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableNonNullClassList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -24235,9 +24781,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -24300,9 +24847,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableStringMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableStringMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -24365,9 +24913,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableIntMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableIntMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -24430,9 +24979,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableEnumMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableEnumMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -24495,9 +25045,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableClassMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableClassMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -24559,9 +25110,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableEnum.pointer,
             _$nIAnEnum.pointer,
             _$continuation.pointer)
@@ -24623,9 +25175,10 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAnotherAsyncNullableEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAnotherAsyncNullableEnum.pointer,
             _$nIAnotherEnum.pointer,
             _$continuation.pointer)
@@ -24676,8 +25229,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
 
   /// from: `public fun defaultIsMainThread(): kotlin.Boolean`
   core$_.bool defaultIsMainThread() {
+    final _$$selfRef = reference;
     return _defaultIsMainThread(
-            reference.pointer, _id_defaultIsMainThread.pointer)
+            _$$selfRef.pointer, _id_defaultIsMainThread.pointer)
         .boolean;
   }
 
@@ -24704,9 +25258,9 @@ extension NIHostIntegrationCoreApi$$Methods on NIHostIntegrationCoreApi {
   core$_.Future<jni$_.JBoolean> callFlutterNoopOnBackgroundThread() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
+    final _$$selfRef = reference;
     final $r = _callFlutterNoopOnBackgroundThread(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterNoopOnBackgroundThread.pointer,
             _$continuation.pointer)
         .object<jni$_.JObject>();
@@ -24774,7 +25328,8 @@ extension type NIHostIntegrationCoreApiRegistrar._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory NIHostIntegrationCoreApiRegistrar() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<NIHostIntegrationCoreApiRegistrar>();
   }
 }
@@ -24802,7 +25357,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   /// from: `public final com.github.dart_lang.jnigen.NIHostIntegrationCoreApi getApi()`
   /// The returned object must be released after use, by calling the [release] method.
   NIHostIntegrationCoreApi? get api {
-    return _get$api(reference.pointer, _id_get$api.pointer)
+    final _$$selfRef = reference;
+    return _get$api(_$$selfRef.pointer, _id_get$api.pointer)
         .object<NIHostIntegrationCoreApi?>();
   }
 
@@ -24825,9 +25381,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
 
   /// from: `public final void setApi(com.github.dart_lang.jnigen.NIHostIntegrationCoreApi nIHostIntegrationCoreApi)`
   set api(NIHostIntegrationCoreApi? nIHostIntegrationCoreApi) {
+    final _$$selfRef = reference;
     final _$nIHostIntegrationCoreApi =
         nIHostIntegrationCoreApi?.reference ?? jni$_.jNullReference;
-    _set$api(reference.pointer, _id_set$api.pointer,
+    _set$api(_$$selfRef.pointer, _id_set$api.pointer,
             _$nIHostIntegrationCoreApi.pointer)
         .check();
   }
@@ -24861,9 +25418,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     NIHostIntegrationCoreApi nIHostIntegrationCoreApi,
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$nIHostIntegrationCoreApi = nIHostIntegrationCoreApi.reference;
     final _$string = string.reference;
-    return _register(reference.pointer, _id_register.pointer,
+    return _register(_$$selfRef.pointer, _id_register.pointer,
             _$nIHostIntegrationCoreApi.pointer, _$string.pointer)
         .object<NIHostIntegrationCoreApiRegistrar>();
   }
@@ -24890,9 +25448,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   NIHostIntegrationCoreApiRegistrar? getInstance(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
     return _getInstance(
-            reference.pointer, _id_getInstance.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_getInstance.pointer, _$string.pointer)
         .object<NIHostIntegrationCoreApiRegistrar?>();
   }
 
@@ -24916,7 +25475,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
 
   /// from: `public fun noop(): kotlin.Unit`
   void noop() {
-    _noop(reference.pointer, _id_noop.pointer).check();
+    final _$$selfRef = reference;
+    _noop(_$$selfRef.pointer, _id_noop.pointer).check();
   }
 
   static final _id_echoAllTypes =
@@ -24941,9 +25501,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   NIAllTypes echoAllTypes(
     NIAllTypes nIAllTypes,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllTypes = nIAllTypes.reference;
     return _echoAllTypes(
-            reference.pointer, _id_echoAllTypes.pointer, _$nIAllTypes.pointer)
+            _$$selfRef.pointer, _id_echoAllTypes.pointer, _$nIAllTypes.pointer)
         .object<NIAllTypes>();
   }
 
@@ -24968,7 +25529,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   /// from: `public fun throwError(): kotlin.Any?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? throwError() {
-    return _throwError(reference.pointer, _id_throwError.pointer)
+    final _$$selfRef = reference;
+    return _throwError(_$$selfRef.pointer, _id_throwError.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -24992,7 +25554,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
 
   /// from: `public fun throwErrorFromVoid(): kotlin.Unit`
   void throwErrorFromVoid() {
-    _throwErrorFromVoid(reference.pointer, _id_throwErrorFromVoid.pointer)
+    final _$$selfRef = reference;
+    _throwErrorFromVoid(_$$selfRef.pointer, _id_throwErrorFromVoid.pointer)
         .check();
   }
 
@@ -25017,7 +25580,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   /// from: `public fun throwFlutterError(): kotlin.Any?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? throwFlutterError() {
-    return _throwFlutterError(reference.pointer, _id_throwFlutterError.pointer)
+    final _$$selfRef = reference;
+    return _throwFlutterError(_$$selfRef.pointer, _id_throwFlutterError.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -25041,7 +25605,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   core$_.int echoInt(
     core$_.int j,
   ) {
-    return _echoInt(reference.pointer, _id_echoInt.pointer, j).long;
+    final _$$selfRef = reference;
+    return _echoInt(_$$selfRef.pointer, _id_echoInt.pointer, j).long;
   }
 
   static final _id_echoDouble =
@@ -25065,7 +25630,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   core$_.double echoDouble(
     core$_.double d,
   ) {
-    return _echoDouble(reference.pointer, _id_echoDouble.pointer, d)
+    final _$$selfRef = reference;
+    return _echoDouble(_$$selfRef.pointer, _id_echoDouble.pointer, d)
         .doubleFloat;
   }
 
@@ -25090,7 +25656,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   core$_.bool echoBool(
     core$_.bool z,
   ) {
-    return _echoBool(reference.pointer, _id_echoBool.pointer, z ? 1 : 0)
+    final _$$selfRef = reference;
+    return _echoBool(_$$selfRef.pointer, _id_echoBool.pointer, z ? 1 : 0)
         .boolean;
   }
 
@@ -25116,9 +25683,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JString echoString(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
     return _echoString(
-            reference.pointer, _id_echoString.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_echoString.pointer, _$string.pointer)
         .object<jni$_.JString>();
   }
 
@@ -25144,9 +25712,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JByteArray echoUint8List(
     jni$_.JByteArray bs,
   ) {
+    final _$$selfRef = reference;
     final _$bs = bs.reference;
     return _echoUint8List(
-            reference.pointer, _id_echoUint8List.pointer, _$bs.pointer)
+            _$$selfRef.pointer, _id_echoUint8List.pointer, _$bs.pointer)
         .object<jni$_.JByteArray>();
   }
 
@@ -25172,9 +25741,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JIntArray echoInt32List(
     jni$_.JIntArray is$,
   ) {
+    final _$$selfRef = reference;
     final _$is$ = is$.reference;
     return _echoInt32List(
-            reference.pointer, _id_echoInt32List.pointer, _$is$.pointer)
+            _$$selfRef.pointer, _id_echoInt32List.pointer, _$is$.pointer)
         .object<jni$_.JIntArray>();
   }
 
@@ -25200,9 +25770,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JLongArray echoInt64List(
     jni$_.JLongArray js,
   ) {
+    final _$$selfRef = reference;
     final _$js = js.reference;
     return _echoInt64List(
-            reference.pointer, _id_echoInt64List.pointer, _$js.pointer)
+            _$$selfRef.pointer, _id_echoInt64List.pointer, _$js.pointer)
         .object<jni$_.JLongArray>();
   }
 
@@ -25228,9 +25799,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JDoubleArray echoFloat64List(
     jni$_.JDoubleArray ds,
   ) {
+    final _$$selfRef = reference;
     final _$ds = ds.reference;
     return _echoFloat64List(
-            reference.pointer, _id_echoFloat64List.pointer, _$ds.pointer)
+            _$$selfRef.pointer, _id_echoFloat64List.pointer, _$ds.pointer)
         .object<jni$_.JDoubleArray>();
   }
 
@@ -25256,9 +25828,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JObject echoObject(
     jni$_.JObject object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object.reference;
     return _echoObject(
-            reference.pointer, _id_echoObject.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_echoObject.pointer, _$object.pointer)
         .object<jni$_.JObject>();
   }
 
@@ -25284,8 +25857,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<jni$_.JObject?> echoList(
     jni$_.JList<jni$_.JObject?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _echoList(reference.pointer, _id_echoList.pointer, _$list.pointer)
+    return _echoList(_$$selfRef.pointer, _id_echoList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JObject?>>();
   }
 
@@ -25311,9 +25885,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<jni$_.JString?> echoStringList(
     jni$_.JList<jni$_.JString?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoStringList(
-            reference.pointer, _id_echoStringList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoStringList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JString?>>();
   }
 
@@ -25339,9 +25914,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<jni$_.JLong?> echoIntList(
     jni$_.JList<jni$_.JLong?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoIntList(
-            reference.pointer, _id_echoIntList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoIntList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JLong?>>();
   }
 
@@ -25367,9 +25943,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<jni$_.JDouble?> echoDoubleList(
     jni$_.JList<jni$_.JDouble?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoDoubleList(
-            reference.pointer, _id_echoDoubleList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoDoubleList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JDouble?>>();
   }
 
@@ -25395,9 +25972,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<jni$_.JBoolean?> echoBoolList(
     jni$_.JList<jni$_.JBoolean?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoBoolList(
-            reference.pointer, _id_echoBoolList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoBoolList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JBoolean?>>();
   }
 
@@ -25423,9 +26001,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<NIAnEnum?> echoEnumList(
     jni$_.JList<NIAnEnum?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoEnumList(
-            reference.pointer, _id_echoEnumList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum?>>();
   }
 
@@ -25451,9 +26030,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<NIAllNullableTypes?> echoClassList(
     jni$_.JList<NIAllNullableTypes?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoClassList(
-            reference.pointer, _id_echoClassList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes?>>();
   }
 
@@ -25479,9 +26059,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<NIAnEnum> echoNonNullEnumList(
     jni$_.JList<NIAnEnum> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _echoNonNullEnumList(
-            reference.pointer, _id_echoNonNullEnumList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoNonNullEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum>>();
   }
 
@@ -25507,9 +26088,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<NIAllNullableTypes> echoNonNullClassList(
     jni$_.JList<NIAllNullableTypes> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _echoNonNullClassList(
-            reference.pointer, _id_echoNonNullClassList.pointer, _$list.pointer)
+    return _echoNonNullClassList(_$$selfRef.pointer,
+            _id_echoNonNullClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes>>();
   }
 
@@ -25535,8 +26117,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JObject?, jni$_.JObject?> echoMap(
     jni$_.JMap<jni$_.JObject?, jni$_.JObject?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _echoMap(reference.pointer, _id_echoMap.pointer, _$map.pointer)
+    return _echoMap(_$$selfRef.pointer, _id_echoMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>>();
   }
 
@@ -25562,9 +26145,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JString?, jni$_.JString?> echoStringMap(
     jni$_.JMap<jni$_.JString?, jni$_.JString?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoStringMap(
-            reference.pointer, _id_echoStringMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString?, jni$_.JString?>>();
   }
 
@@ -25590,8 +26174,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JLong?, jni$_.JLong?> echoIntMap(
     jni$_.JMap<jni$_.JLong?, jni$_.JLong?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _echoIntMap(reference.pointer, _id_echoIntMap.pointer, _$map.pointer)
+    return _echoIntMap(
+            _$$selfRef.pointer, _id_echoIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JLong?>>();
   }
 
@@ -25617,9 +26203,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<NIAnEnum?, NIAnEnum?> echoEnumMap(
     jni$_.JMap<NIAnEnum?, NIAnEnum?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoEnumMap(
-            reference.pointer, _id_echoEnumMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum?, NIAnEnum?>>();
   }
 
@@ -25645,9 +26232,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?> echoClassMap(
     jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoClassMap(
-            reference.pointer, _id_echoClassMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>>();
   }
 
@@ -25673,9 +26261,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JString, jni$_.JString> echoNonNullStringMap(
     jni$_.JMap<jni$_.JString, jni$_.JString> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoNonNullStringMap(
-            reference.pointer, _id_echoNonNullStringMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNonNullStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString, jni$_.JString>>();
   }
 
@@ -25701,9 +26290,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JLong, jni$_.JLong> echoNonNullIntMap(
     jni$_.JMap<jni$_.JLong, jni$_.JLong> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoNonNullIntMap(
-            reference.pointer, _id_echoNonNullIntMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNonNullIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, jni$_.JLong>>();
   }
 
@@ -25729,9 +26319,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<NIAnEnum, NIAnEnum> echoNonNullEnumMap(
     jni$_.JMap<NIAnEnum, NIAnEnum> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoNonNullEnumMap(
-            reference.pointer, _id_echoNonNullEnumMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNonNullEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum, NIAnEnum>>();
   }
 
@@ -25757,9 +26348,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JLong, NIAllNullableTypes> echoNonNullClassMap(
     jni$_.JMap<jni$_.JLong, NIAllNullableTypes> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _echoNonNullClassMap(
-            reference.pointer, _id_echoNonNullClassMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNonNullClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, NIAllNullableTypes>>();
   }
 
@@ -25785,8 +26377,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   NIAllClassesWrapper echoClassWrapper(
     NIAllClassesWrapper nIAllClassesWrapper,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllClassesWrapper = nIAllClassesWrapper.reference;
-    return _echoClassWrapper(reference.pointer, _id_echoClassWrapper.pointer,
+    return _echoClassWrapper(_$$selfRef.pointer, _id_echoClassWrapper.pointer,
             _$nIAllClassesWrapper.pointer)
         .object<NIAllClassesWrapper>();
   }
@@ -25813,9 +26406,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   NIAnEnum echoEnum(
     NIAnEnum nIAnEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum.reference;
     return _echoEnum(
-            reference.pointer, _id_echoEnum.pointer, _$nIAnEnum.pointer)
+            _$$selfRef.pointer, _id_echoEnum.pointer, _$nIAnEnum.pointer)
         .object<NIAnEnum>();
   }
 
@@ -25841,8 +26435,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   NIAnotherEnum echoAnotherEnum(
     NIAnotherEnum nIAnotherEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum.reference;
-    return _echoAnotherEnum(reference.pointer, _id_echoAnotherEnum.pointer,
+    return _echoAnotherEnum(_$$selfRef.pointer, _id_echoAnotherEnum.pointer,
             _$nIAnotherEnum.pointer)
         .object<NIAnotherEnum>();
   }
@@ -25869,8 +26464,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JString echoNamedDefaultString(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
-    return _echoNamedDefaultString(reference.pointer,
+    return _echoNamedDefaultString(_$$selfRef.pointer,
             _id_echoNamedDefaultString.pointer, _$string.pointer)
         .object<jni$_.JString>();
   }
@@ -25896,8 +26492,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   core$_.double echoOptionalDefaultDouble(
     core$_.double d,
   ) {
+    final _$$selfRef = reference;
     return _echoOptionalDefaultDouble(
-            reference.pointer, _id_echoOptionalDefaultDouble.pointer, d)
+            _$$selfRef.pointer, _id_echoOptionalDefaultDouble.pointer, d)
         .doubleFloat;
   }
 
@@ -25921,7 +26518,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   core$_.int echoRequiredInt(
     core$_.int j,
   ) {
-    return _echoRequiredInt(reference.pointer, _id_echoRequiredInt.pointer, j)
+    final _$$selfRef = reference;
+    return _echoRequiredInt(_$$selfRef.pointer, _id_echoRequiredInt.pointer, j)
         .long;
   }
 
@@ -25947,9 +26545,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   NIAllNullableTypes? echoAllNullableTypes(
     NIAllNullableTypes? nIAllNullableTypes,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllNullableTypes =
         nIAllNullableTypes?.reference ?? jni$_.jNullReference;
-    return _echoAllNullableTypes(reference.pointer,
+    return _echoAllNullableTypes(_$$selfRef.pointer,
             _id_echoAllNullableTypes.pointer, _$nIAllNullableTypes.pointer)
         .object<NIAllNullableTypes?>();
   }
@@ -25977,10 +26576,11 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   NIAllNullableTypesWithoutRecursion? echoAllNullableTypesWithoutRecursion(
     NIAllNullableTypesWithoutRecursion? nIAllNullableTypesWithoutRecursion,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllNullableTypesWithoutRecursion =
         nIAllNullableTypesWithoutRecursion?.reference ?? jni$_.jNullReference;
     return _echoAllNullableTypesWithoutRecursion(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAllNullableTypesWithoutRecursion.pointer,
             _$nIAllNullableTypesWithoutRecursion.pointer)
         .object<NIAllNullableTypesWithoutRecursion?>();
@@ -26009,9 +26609,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JString? extractNestedNullableString(
     NIAllClassesWrapper nIAllClassesWrapper,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllClassesWrapper = nIAllClassesWrapper.reference;
     return _extractNestedNullableString(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_extractNestedNullableString.pointer,
             _$nIAllClassesWrapper.pointer)
         .object<jni$_.JString?>();
@@ -26040,8 +26641,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   NIAllClassesWrapper createNestedNullableString(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _createNestedNullableString(reference.pointer,
+    return _createNestedNullableString(_$$selfRef.pointer,
             _id_createNestedNullableString.pointer, _$string.pointer)
         .object<NIAllClassesWrapper>();
   }
@@ -26078,11 +26680,12 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     jni$_.JLong? long,
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _sendMultipleNullableTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_sendMultipleNullableTypes.pointer,
             _$boolean.pointer,
             _$long.pointer,
@@ -26123,11 +26726,12 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     jni$_.JLong? long,
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _sendMultipleNullableTypesWithoutRecursion(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_sendMultipleNullableTypesWithoutRecursion.pointer,
             _$boolean.pointer,
             _$long.pointer,
@@ -26157,9 +26761,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JLong? echoNullableInt(
     jni$_.JLong? long,
   ) {
+    final _$$selfRef = reference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     return _echoNullableInt(
-            reference.pointer, _id_echoNullableInt.pointer, _$long.pointer)
+            _$$selfRef.pointer, _id_echoNullableInt.pointer, _$long.pointer)
         .object<jni$_.JLong?>();
   }
 
@@ -26185,9 +26790,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JDouble? echoNullableDouble(
     jni$_.JDouble? double,
   ) {
+    final _$$selfRef = reference;
     final _$double = double?.reference ?? jni$_.jNullReference;
-    return _echoNullableDouble(
-            reference.pointer, _id_echoNullableDouble.pointer, _$double.pointer)
+    return _echoNullableDouble(_$$selfRef.pointer,
+            _id_echoNullableDouble.pointer, _$double.pointer)
         .object<jni$_.JDouble?>();
   }
 
@@ -26213,9 +26819,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JBoolean? echoNullableBool(
     jni$_.JBoolean? boolean,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     return _echoNullableBool(
-            reference.pointer, _id_echoNullableBool.pointer, _$boolean.pointer)
+            _$$selfRef.pointer, _id_echoNullableBool.pointer, _$boolean.pointer)
         .object<jni$_.JBoolean?>();
   }
 
@@ -26241,9 +26848,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JString? echoNullableString(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _echoNullableString(
-            reference.pointer, _id_echoNullableString.pointer, _$string.pointer)
+    return _echoNullableString(_$$selfRef.pointer,
+            _id_echoNullableString.pointer, _$string.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -26269,9 +26877,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JByteArray? echoNullableUint8List(
     jni$_.JByteArray? bs,
   ) {
+    final _$$selfRef = reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
     return _echoNullableUint8List(
-            reference.pointer, _id_echoNullableUint8List.pointer, _$bs.pointer)
+            _$$selfRef.pointer, _id_echoNullableUint8List.pointer, _$bs.pointer)
         .object<jni$_.JByteArray?>();
   }
 
@@ -26297,9 +26906,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JIntArray? echoNullableInt32List(
     jni$_.JIntArray? is$,
   ) {
+    final _$$selfRef = reference;
     final _$is$ = is$?.reference ?? jni$_.jNullReference;
-    return _echoNullableInt32List(
-            reference.pointer, _id_echoNullableInt32List.pointer, _$is$.pointer)
+    return _echoNullableInt32List(_$$selfRef.pointer,
+            _id_echoNullableInt32List.pointer, _$is$.pointer)
         .object<jni$_.JIntArray?>();
   }
 
@@ -26325,9 +26935,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JLongArray? echoNullableInt64List(
     jni$_.JLongArray? js,
   ) {
+    final _$$selfRef = reference;
     final _$js = js?.reference ?? jni$_.jNullReference;
     return _echoNullableInt64List(
-            reference.pointer, _id_echoNullableInt64List.pointer, _$js.pointer)
+            _$$selfRef.pointer, _id_echoNullableInt64List.pointer, _$js.pointer)
         .object<jni$_.JLongArray?>();
   }
 
@@ -26353,8 +26964,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JDoubleArray? echoNullableFloat64List(
     jni$_.JDoubleArray? ds,
   ) {
+    final _$$selfRef = reference;
     final _$ds = ds?.reference ?? jni$_.jNullReference;
-    return _echoNullableFloat64List(reference.pointer,
+    return _echoNullableFloat64List(_$$selfRef.pointer,
             _id_echoNullableFloat64List.pointer, _$ds.pointer)
         .object<jni$_.JDoubleArray?>();
   }
@@ -26381,9 +26993,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JObject? echoNullableObject(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _echoNullableObject(
-            reference.pointer, _id_echoNullableObject.pointer, _$object.pointer)
+    return _echoNullableObject(_$$selfRef.pointer,
+            _id_echoNullableObject.pointer, _$object.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -26409,9 +27022,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<jni$_.JObject?>? echoNullableList(
     jni$_.JList<jni$_.JObject?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     return _echoNullableList(
-            reference.pointer, _id_echoNullableList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_echoNullableList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JObject?>?>();
   }
 
@@ -26437,9 +27051,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<NIAnEnum?>? echoNullableEnumList(
     jni$_.JList<NIAnEnum?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _echoNullableEnumList(
-            reference.pointer, _id_echoNullableEnumList.pointer, _$list.pointer)
+    return _echoNullableEnumList(_$$selfRef.pointer,
+            _id_echoNullableEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum?>?>();
   }
 
@@ -26465,8 +27080,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<NIAllNullableTypes?>? echoNullableClassList(
     jni$_.JList<NIAllNullableTypes?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _echoNullableClassList(reference.pointer,
+    return _echoNullableClassList(_$$selfRef.pointer,
             _id_echoNullableClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes?>?>();
   }
@@ -26494,8 +27110,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<NIAnEnum>? echoNullableNonNullEnumList(
     jni$_.JList<NIAnEnum>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullEnumList(reference.pointer,
+    return _echoNullableNonNullEnumList(_$$selfRef.pointer,
             _id_echoNullableNonNullEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum>?>();
   }
@@ -26523,8 +27140,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<NIAllNullableTypes>? echoNullableNonNullClassList(
     jni$_.JList<NIAllNullableTypes>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullClassList(reference.pointer,
+    return _echoNullableNonNullClassList(_$$selfRef.pointer,
             _id_echoNullableNonNullClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes>?>();
   }
@@ -26551,9 +27169,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JObject?, jni$_.JObject?>? echoNullableMap(
     jni$_.JMap<jni$_.JObject?, jni$_.JObject?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     return _echoNullableMap(
-            reference.pointer, _id_echoNullableMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNullableMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>();
   }
 
@@ -26579,9 +27198,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JString?, jni$_.JString?>? echoNullableStringMap(
     jni$_.JMap<jni$_.JString?, jni$_.JString?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _echoNullableStringMap(
-            reference.pointer, _id_echoNullableStringMap.pointer, _$map.pointer)
+    return _echoNullableStringMap(_$$selfRef.pointer,
+            _id_echoNullableStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString?, jni$_.JString?>?>();
   }
 
@@ -26607,9 +27227,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JLong?, jni$_.JLong?>? echoNullableIntMap(
     jni$_.JMap<jni$_.JLong?, jni$_.JLong?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     return _echoNullableIntMap(
-            reference.pointer, _id_echoNullableIntMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNullableIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JLong?>?>();
   }
 
@@ -26635,9 +27256,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<NIAnEnum?, NIAnEnum?>? echoNullableEnumMap(
     jni$_.JMap<NIAnEnum?, NIAnEnum?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     return _echoNullableEnumMap(
-            reference.pointer, _id_echoNullableEnumMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNullableEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum?, NIAnEnum?>?>();
   }
 
@@ -26663,9 +27285,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>? echoNullableClassMap(
     jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     return _echoNullableClassMap(
-            reference.pointer, _id_echoNullableClassMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_echoNullableClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>?>();
   }
 
@@ -26692,8 +27315,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JString, jni$_.JString>? echoNullableNonNullStringMap(
     jni$_.JMap<jni$_.JString, jni$_.JString>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullStringMap(reference.pointer,
+    return _echoNullableNonNullStringMap(_$$selfRef.pointer,
             _id_echoNullableNonNullStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString, jni$_.JString>?>();
   }
@@ -26720,8 +27344,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JLong, jni$_.JLong>? echoNullableNonNullIntMap(
     jni$_.JMap<jni$_.JLong, jni$_.JLong>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullIntMap(reference.pointer,
+    return _echoNullableNonNullIntMap(_$$selfRef.pointer,
             _id_echoNullableNonNullIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, jni$_.JLong>?>();
   }
@@ -26749,8 +27374,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<NIAnEnum, NIAnEnum>? echoNullableNonNullEnumMap(
     jni$_.JMap<NIAnEnum, NIAnEnum>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullEnumMap(reference.pointer,
+    return _echoNullableNonNullEnumMap(_$$selfRef.pointer,
             _id_echoNullableNonNullEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum, NIAnEnum>?>();
   }
@@ -26778,8 +27404,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JLong, NIAllNullableTypes>? echoNullableNonNullClassMap(
     jni$_.JMap<jni$_.JLong, NIAllNullableTypes>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _echoNullableNonNullClassMap(reference.pointer,
+    return _echoNullableNonNullClassMap(_$$selfRef.pointer,
             _id_echoNullableNonNullClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, NIAllNullableTypes>?>();
   }
@@ -26806,9 +27433,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   NIAnEnum? echoNullableEnum(
     NIAnEnum? nIAnEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum?.reference ?? jni$_.jNullReference;
-    return _echoNullableEnum(
-            reference.pointer, _id_echoNullableEnum.pointer, _$nIAnEnum.pointer)
+    return _echoNullableEnum(_$$selfRef.pointer, _id_echoNullableEnum.pointer,
+            _$nIAnEnum.pointer)
         .object<NIAnEnum?>();
   }
 
@@ -26834,8 +27462,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   NIAnotherEnum? echoAnotherNullableEnum(
     NIAnotherEnum? nIAnotherEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum?.reference ?? jni$_.jNullReference;
-    return _echoAnotherNullableEnum(reference.pointer,
+    return _echoAnotherNullableEnum(_$$selfRef.pointer,
             _id_echoAnotherNullableEnum.pointer, _$nIAnotherEnum.pointer)
         .object<NIAnotherEnum?>();
   }
@@ -26862,8 +27491,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JLong? echoOptionalNullableInt(
     jni$_.JLong? long,
   ) {
+    final _$$selfRef = reference;
     final _$long = long?.reference ?? jni$_.jNullReference;
-    return _echoOptionalNullableInt(reference.pointer,
+    return _echoOptionalNullableInt(_$$selfRef.pointer,
             _id_echoOptionalNullableInt.pointer, _$long.pointer)
         .object<jni$_.JLong?>();
   }
@@ -26890,8 +27520,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JString? echoNamedNullableString(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _echoNamedNullableString(reference.pointer,
+    return _echoNamedNullableString(_$$selfRef.pointer,
             _id_echoNamedNullableString.pointer, _$string.pointer)
         .object<jni$_.JString?>();
   }
@@ -26918,9 +27549,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   core$_.Future<void> noopAsync() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
+    final _$$selfRef = reference;
     final $r = _noopAsync(
-            reference.pointer, _id_noopAsync.pointer, _$continuation.pointer)
+            _$$selfRef.pointer, _id_noopAsync.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
     jni$_.JObject $o;
@@ -26968,8 +27599,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _echoAsyncInt(reference.pointer, _id_echoAsyncInt.pointer, j,
+    final _$$selfRef = reference;
+    final $r = _echoAsyncInt(_$$selfRef.pointer, _id_echoAsyncInt.pointer, j,
             _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -27023,8 +27654,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _echoAsyncDouble(reference.pointer, _id_echoAsyncDouble.pointer,
+    final _$$selfRef = reference;
+    final $r = _echoAsyncDouble(_$$selfRef.pointer, _id_echoAsyncDouble.pointer,
             d, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -27076,8 +27707,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _echoAsyncBool(reference.pointer, _id_echoAsyncBool.pointer,
+    final _$$selfRef = reference;
+    final $r = _echoAsyncBool(_$$selfRef.pointer, _id_echoAsyncBool.pointer,
             z ? 1 : 0, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -27134,8 +27765,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$string = string.reference;
-    final $r = _echoAsyncString(reference.pointer, _id_echoAsyncString.pointer,
+    final $r = _echoAsyncString(_$$selfRef.pointer, _id_echoAsyncString.pointer,
             _$string.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -27192,9 +27824,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$bs = bs.reference;
     final $r = _echoAsyncUint8List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncUint8List.pointer,
             _$bs.pointer,
             _$continuation.pointer)
@@ -27253,9 +27886,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$is$ = is$.reference;
     final $r = _echoAsyncInt32List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncInt32List.pointer,
             _$is$.pointer,
             _$continuation.pointer)
@@ -27314,9 +27948,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$js = js.reference;
     final $r = _echoAsyncInt64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncInt64List.pointer,
             _$js.pointer,
             _$continuation.pointer)
@@ -27375,9 +28010,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$ds = ds.reference;
     final $r = _echoAsyncFloat64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncFloat64List.pointer,
             _$ds.pointer,
             _$continuation.pointer)
@@ -27436,8 +28072,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$object = object.reference;
-    final $r = _echoAsyncObject(reference.pointer, _id_echoAsyncObject.pointer,
+    final $r = _echoAsyncObject(_$$selfRef.pointer, _id_echoAsyncObject.pointer,
             _$object.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -27494,8 +28131,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    final $r = _echoAsyncList(reference.pointer, _id_echoAsyncList.pointer,
+    final $r = _echoAsyncList(_$$selfRef.pointer, _id_echoAsyncList.pointer,
             _$list.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -27552,9 +28190,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _echoAsyncEnumList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncEnumList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -27613,9 +28252,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _echoAsyncClassList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncClassList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -27674,8 +28314,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    final $r = _echoAsyncMap(reference.pointer, _id_echoAsyncMap.pointer,
+    final $r = _echoAsyncMap(_$$selfRef.pointer, _id_echoAsyncMap.pointer,
             _$map.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -27732,9 +28373,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
     final $r = _echoAsyncStringMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncStringMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -27793,8 +28435,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    final $r = _echoAsyncIntMap(reference.pointer, _id_echoAsyncIntMap.pointer,
+    final $r = _echoAsyncIntMap(_$$selfRef.pointer, _id_echoAsyncIntMap.pointer,
             _$map.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -27851,8 +28494,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    final $r = _echoAsyncEnumMap(reference.pointer,
+    final $r = _echoAsyncEnumMap(_$$selfRef.pointer,
             _id_echoAsyncEnumMap.pointer, _$map.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -27910,9 +28554,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
     final $r = _echoAsyncClassMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncClassMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -27971,8 +28616,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum.reference;
-    final $r = _echoAsyncEnum(reference.pointer, _id_echoAsyncEnum.pointer,
+    final $r = _echoAsyncEnum(_$$selfRef.pointer, _id_echoAsyncEnum.pointer,
             _$nIAnEnum.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -28029,9 +28675,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum.reference;
     final $r = _echoAnotherAsyncEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAnotherAsyncEnum.pointer,
             _$nIAnotherEnum.pointer,
             _$continuation.pointer)
@@ -28082,8 +28729,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   core$_.Future<jni$_.JObject?> throwAsyncError() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _throwAsyncError(reference.pointer, _id_throwAsyncError.pointer,
+    final _$$selfRef = reference;
+    final $r = _throwAsyncError(_$$selfRef.pointer, _id_throwAsyncError.pointer,
             _$continuation.pointer)
         .object<jni$_.JObject?>();
     _$continuation.release();
@@ -28134,8 +28781,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   core$_.Future<void> throwAsyncErrorFromVoid() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _throwAsyncErrorFromVoid(reference.pointer,
+    final _$$selfRef = reference;
+    final $r = _throwAsyncErrorFromVoid(_$$selfRef.pointer,
             _id_throwAsyncErrorFromVoid.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -28181,8 +28828,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   core$_.Future<jni$_.JObject?> throwAsyncFlutterError() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _throwAsyncFlutterError(reference.pointer,
+    final _$$selfRef = reference;
+    final $r = _throwAsyncFlutterError(_$$selfRef.pointer,
             _id_throwAsyncFlutterError.pointer, _$continuation.pointer)
         .object<jni$_.JObject?>();
     _$continuation.release();
@@ -28241,9 +28888,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAllTypes = nIAllTypes.reference;
     final $r = _echoAsyncNIAllTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNIAllTypes.pointer,
             _$nIAllTypes.pointer,
             _$continuation.pointer)
@@ -28303,10 +28951,11 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAllNullableTypes =
         nIAllNullableTypes?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableNIAllNullableTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableNIAllNullableTypes.pointer,
             _$nIAllNullableTypes.pointer,
             _$continuation.pointer)
@@ -28369,10 +29018,11 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAllNullableTypesWithoutRecursion =
         nIAllNullableTypesWithoutRecursion?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableNIAllNullableTypesWithoutRecursion(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableNIAllNullableTypesWithoutRecursion.pointer,
             _$nIAllNullableTypesWithoutRecursion.pointer,
             _$continuation.pointer)
@@ -28433,9 +29083,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableInt(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableInt.pointer,
             _$long.pointer,
             _$continuation.pointer)
@@ -28496,9 +29147,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$double = double?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableDouble(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableDouble.pointer,
             _$double.pointer,
             _$continuation.pointer)
@@ -28559,9 +29211,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableBool(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableBool.pointer,
             _$boolean.pointer,
             _$continuation.pointer)
@@ -28622,9 +29275,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableString(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableString.pointer,
             _$string.pointer,
             _$continuation.pointer)
@@ -28686,9 +29340,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableUint8List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableUint8List.pointer,
             _$bs.pointer,
             _$continuation.pointer)
@@ -28750,9 +29405,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$is$ = is$?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableInt32List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableInt32List.pointer,
             _$is$.pointer,
             _$continuation.pointer)
@@ -28814,9 +29470,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$js = js?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableInt64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableInt64List.pointer,
             _$js.pointer,
             _$continuation.pointer)
@@ -28878,9 +29535,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$ds = ds?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableFloat64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableFloat64List.pointer,
             _$ds.pointer,
             _$continuation.pointer)
@@ -28941,9 +29599,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableObject(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableObject.pointer,
             _$object.pointer,
             _$continuation.pointer)
@@ -29004,9 +29663,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -29067,9 +29727,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableEnumList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableEnumList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -29131,9 +29792,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableClassList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableClassList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -29195,9 +29857,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -29260,9 +29923,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableStringMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableStringMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -29324,9 +29988,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableIntMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableIntMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -29387,9 +30052,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableEnumMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableEnumMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -29451,9 +30117,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableClassMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableClassMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -29514,9 +30181,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum?.reference ?? jni$_.jNullReference;
     final $r = _echoAsyncNullableEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAsyncNullableEnum.pointer,
             _$nIAnEnum.pointer,
             _$continuation.pointer)
@@ -29578,9 +30246,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum?.reference ?? jni$_.jNullReference;
     final $r = _echoAnotherAsyncNullableEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_echoAnotherAsyncNullableEnum.pointer,
             _$nIAnotherEnum.pointer,
             _$continuation.pointer)
@@ -29631,7 +30300,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
 
   /// from: `public fun callFlutterNoop(): kotlin.Unit`
   void callFlutterNoop() {
-    _callFlutterNoop(reference.pointer, _id_callFlutterNoop.pointer).check();
+    final _$$selfRef = reference;
+    _callFlutterNoop(_$$selfRef.pointer, _id_callFlutterNoop.pointer).check();
   }
 
   static final _id_callFlutterThrowError =
@@ -29655,8 +30325,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   /// from: `public fun callFlutterThrowError(): kotlin.Any?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? callFlutterThrowError() {
+    final _$$selfRef = reference;
     return _callFlutterThrowError(
-            reference.pointer, _id_callFlutterThrowError.pointer)
+            _$$selfRef.pointer, _id_callFlutterThrowError.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -29681,8 +30352,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
 
   /// from: `public fun callFlutterThrowErrorFromVoid(): kotlin.Unit`
   void callFlutterThrowErrorFromVoid() {
+    final _$$selfRef = reference;
     _callFlutterThrowErrorFromVoid(
-            reference.pointer, _id_callFlutterThrowErrorFromVoid.pointer)
+            _$$selfRef.pointer, _id_callFlutterThrowErrorFromVoid.pointer)
         .check();
   }
 
@@ -29708,8 +30380,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   NIAllTypes callFlutterEchoNIAllTypes(
     NIAllTypes nIAllTypes,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllTypes = nIAllTypes.reference;
-    return _callFlutterEchoNIAllTypes(reference.pointer,
+    return _callFlutterEchoNIAllTypes(_$$selfRef.pointer,
             _id_callFlutterEchoNIAllTypes.pointer, _$nIAllTypes.pointer)
         .object<NIAllTypes>();
   }
@@ -29737,10 +30410,11 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   NIAllNullableTypes? callFlutterEchoNIAllNullableTypes(
     NIAllNullableTypes? nIAllNullableTypes,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllNullableTypes =
         nIAllNullableTypes?.reference ?? jni$_.jNullReference;
     return _callFlutterEchoNIAllNullableTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoNIAllNullableTypes.pointer,
             _$nIAllNullableTypes.pointer)
         .object<NIAllNullableTypes?>();
@@ -29779,11 +30453,12 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     jni$_.JLong? long,
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _callFlutterSendMultipleNullableTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterSendMultipleNullableTypes.pointer,
             _$boolean.pointer,
             _$long.pointer,
@@ -29815,10 +30490,11 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
       callFlutterEchoNIAllNullableTypesWithoutRecursion(
     NIAllNullableTypesWithoutRecursion? nIAllNullableTypesWithoutRecursion,
   ) {
+    final _$$selfRef = reference;
     final _$nIAllNullableTypesWithoutRecursion =
         nIAllNullableTypesWithoutRecursion?.reference ?? jni$_.jNullReference;
     return _callFlutterEchoNIAllNullableTypesWithoutRecursion(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoNIAllNullableTypesWithoutRecursion.pointer,
             _$nIAllNullableTypesWithoutRecursion.pointer)
         .object<NIAllNullableTypesWithoutRecursion?>();
@@ -29858,11 +30534,12 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
     jni$_.JLong? long,
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _callFlutterSendMultipleNullableTypesWithoutRecursion(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterSendMultipleNullableTypesWithoutRecursion.pointer,
             _$boolean.pointer,
             _$long.pointer,
@@ -29891,8 +30568,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   core$_.bool callFlutterEchoBool(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _callFlutterEchoBool(
-            reference.pointer, _id_callFlutterEchoBool.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_callFlutterEchoBool.pointer, z ? 1 : 0)
         .boolean;
   }
 
@@ -29916,8 +30594,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   core$_.int callFlutterEchoInt(
     core$_.int j,
   ) {
+    final _$$selfRef = reference;
     return _callFlutterEchoInt(
-            reference.pointer, _id_callFlutterEchoInt.pointer, j)
+            _$$selfRef.pointer, _id_callFlutterEchoInt.pointer, j)
         .long;
   }
 
@@ -29942,8 +30621,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   core$_.double callFlutterEchoDouble(
     core$_.double d,
   ) {
+    final _$$selfRef = reference;
     return _callFlutterEchoDouble(
-            reference.pointer, _id_callFlutterEchoDouble.pointer, d)
+            _$$selfRef.pointer, _id_callFlutterEchoDouble.pointer, d)
         .doubleFloat;
   }
 
@@ -29969,8 +30649,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JString callFlutterEchoString(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
-    return _callFlutterEchoString(reference.pointer,
+    return _callFlutterEchoString(_$$selfRef.pointer,
             _id_callFlutterEchoString.pointer, _$string.pointer)
         .object<jni$_.JString>();
   }
@@ -29997,8 +30678,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JByteArray callFlutterEchoUint8List(
     jni$_.JByteArray bs,
   ) {
+    final _$$selfRef = reference;
     final _$bs = bs.reference;
-    return _callFlutterEchoUint8List(reference.pointer,
+    return _callFlutterEchoUint8List(_$$selfRef.pointer,
             _id_callFlutterEchoUint8List.pointer, _$bs.pointer)
         .object<jni$_.JByteArray>();
   }
@@ -30025,8 +30707,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JIntArray callFlutterEchoInt32List(
     jni$_.JIntArray is$,
   ) {
+    final _$$selfRef = reference;
     final _$is$ = is$.reference;
-    return _callFlutterEchoInt32List(reference.pointer,
+    return _callFlutterEchoInt32List(_$$selfRef.pointer,
             _id_callFlutterEchoInt32List.pointer, _$is$.pointer)
         .object<jni$_.JIntArray>();
   }
@@ -30053,8 +30736,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JLongArray callFlutterEchoInt64List(
     jni$_.JLongArray js,
   ) {
+    final _$$selfRef = reference;
     final _$js = js.reference;
-    return _callFlutterEchoInt64List(reference.pointer,
+    return _callFlutterEchoInt64List(_$$selfRef.pointer,
             _id_callFlutterEchoInt64List.pointer, _$js.pointer)
         .object<jni$_.JLongArray>();
   }
@@ -30082,8 +30766,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JDoubleArray callFlutterEchoFloat64List(
     jni$_.JDoubleArray ds,
   ) {
+    final _$$selfRef = reference;
     final _$ds = ds.reference;
-    return _callFlutterEchoFloat64List(reference.pointer,
+    return _callFlutterEchoFloat64List(_$$selfRef.pointer,
             _id_callFlutterEchoFloat64List.pointer, _$ds.pointer)
         .object<jni$_.JDoubleArray>();
   }
@@ -30110,9 +30795,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<jni$_.JObject?> callFlutterEchoList(
     jni$_.JList<jni$_.JObject?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _callFlutterEchoList(
-            reference.pointer, _id_callFlutterEchoList.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_callFlutterEchoList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JObject?>>();
   }
 
@@ -30138,8 +30824,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<NIAnEnum?> callFlutterEchoEnumList(
     jni$_.JList<NIAnEnum?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _callFlutterEchoEnumList(reference.pointer,
+    return _callFlutterEchoEnumList(_$$selfRef.pointer,
             _id_callFlutterEchoEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum?>>();
   }
@@ -30166,8 +30853,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<NIAllNullableTypes?> callFlutterEchoClassList(
     jni$_.JList<NIAllNullableTypes?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _callFlutterEchoClassList(reference.pointer,
+    return _callFlutterEchoClassList(_$$selfRef.pointer,
             _id_callFlutterEchoClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes?>>();
   }
@@ -30195,8 +30883,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<NIAnEnum> callFlutterEchoNonNullEnumList(
     jni$_.JList<NIAnEnum> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _callFlutterEchoNonNullEnumList(reference.pointer,
+    return _callFlutterEchoNonNullEnumList(_$$selfRef.pointer,
             _id_callFlutterEchoNonNullEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum>>();
   }
@@ -30224,8 +30913,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<NIAllNullableTypes> callFlutterEchoNonNullClassList(
     jni$_.JList<NIAllNullableTypes> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _callFlutterEchoNonNullClassList(reference.pointer,
+    return _callFlutterEchoNonNullClassList(_$$selfRef.pointer,
             _id_callFlutterEchoNonNullClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes>>();
   }
@@ -30252,9 +30942,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JObject?, jni$_.JObject?> callFlutterEchoMap(
     jni$_.JMap<jni$_.JObject?, jni$_.JObject?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _callFlutterEchoMap(
-            reference.pointer, _id_callFlutterEchoMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_callFlutterEchoMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>>();
   }
 
@@ -30280,8 +30971,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JString?, jni$_.JString?> callFlutterEchoStringMap(
     jni$_.JMap<jni$_.JString?, jni$_.JString?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _callFlutterEchoStringMap(reference.pointer,
+    return _callFlutterEchoStringMap(_$$selfRef.pointer,
             _id_callFlutterEchoStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString?, jni$_.JString?>>();
   }
@@ -30308,9 +31000,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JLong?, jni$_.JLong?> callFlutterEchoIntMap(
     jni$_.JMap<jni$_.JLong?, jni$_.JLong?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _callFlutterEchoIntMap(
-            reference.pointer, _id_callFlutterEchoIntMap.pointer, _$map.pointer)
+    return _callFlutterEchoIntMap(_$$selfRef.pointer,
+            _id_callFlutterEchoIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JLong?>>();
   }
 
@@ -30336,8 +31029,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<NIAnEnum?, NIAnEnum?> callFlutterEchoEnumMap(
     jni$_.JMap<NIAnEnum?, NIAnEnum?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _callFlutterEchoEnumMap(reference.pointer,
+    return _callFlutterEchoEnumMap(_$$selfRef.pointer,
             _id_callFlutterEchoEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum?, NIAnEnum?>>();
   }
@@ -30364,8 +31058,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?> callFlutterEchoClassMap(
     jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _callFlutterEchoClassMap(reference.pointer,
+    return _callFlutterEchoClassMap(_$$selfRef.pointer,
             _id_callFlutterEchoClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>>();
   }
@@ -30393,8 +31088,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JString, jni$_.JString> callFlutterEchoNonNullStringMap(
     jni$_.JMap<jni$_.JString, jni$_.JString> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _callFlutterEchoNonNullStringMap(reference.pointer,
+    return _callFlutterEchoNonNullStringMap(_$$selfRef.pointer,
             _id_callFlutterEchoNonNullStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString, jni$_.JString>>();
   }
@@ -30422,8 +31118,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JLong, jni$_.JLong> callFlutterEchoNonNullIntMap(
     jni$_.JMap<jni$_.JLong, jni$_.JLong> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _callFlutterEchoNonNullIntMap(reference.pointer,
+    return _callFlutterEchoNonNullIntMap(_$$selfRef.pointer,
             _id_callFlutterEchoNonNullIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, jni$_.JLong>>();
   }
@@ -30451,8 +31148,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<NIAnEnum, NIAnEnum> callFlutterEchoNonNullEnumMap(
     jni$_.JMap<NIAnEnum, NIAnEnum> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _callFlutterEchoNonNullEnumMap(reference.pointer,
+    return _callFlutterEchoNonNullEnumMap(_$$selfRef.pointer,
             _id_callFlutterEchoNonNullEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum, NIAnEnum>>();
   }
@@ -30480,8 +31178,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JLong, NIAllNullableTypes> callFlutterEchoNonNullClassMap(
     jni$_.JMap<jni$_.JLong, NIAllNullableTypes> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _callFlutterEchoNonNullClassMap(reference.pointer,
+    return _callFlutterEchoNonNullClassMap(_$$selfRef.pointer,
             _id_callFlutterEchoNonNullClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, NIAllNullableTypes>>();
   }
@@ -30508,8 +31207,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   NIAnEnum callFlutterEchoEnum(
     NIAnEnum nIAnEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum.reference;
-    return _callFlutterEchoEnum(reference.pointer,
+    return _callFlutterEchoEnum(_$$selfRef.pointer,
             _id_callFlutterEchoEnum.pointer, _$nIAnEnum.pointer)
         .object<NIAnEnum>();
   }
@@ -30537,8 +31237,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   NIAnotherEnum callFlutterEchoNIAnotherEnum(
     NIAnotherEnum nIAnotherEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum.reference;
-    return _callFlutterEchoNIAnotherEnum(reference.pointer,
+    return _callFlutterEchoNIAnotherEnum(_$$selfRef.pointer,
             _id_callFlutterEchoNIAnotherEnum.pointer, _$nIAnotherEnum.pointer)
         .object<NIAnotherEnum>();
   }
@@ -30566,8 +31267,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JBoolean? callFlutterEchoNullableBool(
     jni$_.JBoolean? boolean,
   ) {
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableBool(reference.pointer,
+    return _callFlutterEchoNullableBool(_$$selfRef.pointer,
             _id_callFlutterEchoNullableBool.pointer, _$boolean.pointer)
         .object<jni$_.JBoolean?>();
   }
@@ -30595,8 +31297,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JLong? callFlutterEchoNullableInt(
     jni$_.JLong? long,
   ) {
+    final _$$selfRef = reference;
     final _$long = long?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableInt(reference.pointer,
+    return _callFlutterEchoNullableInt(_$$selfRef.pointer,
             _id_callFlutterEchoNullableInt.pointer, _$long.pointer)
         .object<jni$_.JLong?>();
   }
@@ -30624,8 +31327,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JDouble? callFlutterEchoNullableDouble(
     jni$_.JDouble? double,
   ) {
+    final _$$selfRef = reference;
     final _$double = double?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableDouble(reference.pointer,
+    return _callFlutterEchoNullableDouble(_$$selfRef.pointer,
             _id_callFlutterEchoNullableDouble.pointer, _$double.pointer)
         .object<jni$_.JDouble?>();
   }
@@ -30653,8 +31357,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JString? callFlutterEchoNullableString(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableString(reference.pointer,
+    return _callFlutterEchoNullableString(_$$selfRef.pointer,
             _id_callFlutterEchoNullableString.pointer, _$string.pointer)
         .object<jni$_.JString?>();
   }
@@ -30682,8 +31387,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JByteArray? callFlutterEchoNullableUint8List(
     jni$_.JByteArray? bs,
   ) {
+    final _$$selfRef = reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableUint8List(reference.pointer,
+    return _callFlutterEchoNullableUint8List(_$$selfRef.pointer,
             _id_callFlutterEchoNullableUint8List.pointer, _$bs.pointer)
         .object<jni$_.JByteArray?>();
   }
@@ -30711,8 +31417,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JIntArray? callFlutterEchoNullableInt32List(
     jni$_.JIntArray? is$,
   ) {
+    final _$$selfRef = reference;
     final _$is$ = is$?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableInt32List(reference.pointer,
+    return _callFlutterEchoNullableInt32List(_$$selfRef.pointer,
             _id_callFlutterEchoNullableInt32List.pointer, _$is$.pointer)
         .object<jni$_.JIntArray?>();
   }
@@ -30740,8 +31447,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JLongArray? callFlutterEchoNullableInt64List(
     jni$_.JLongArray? js,
   ) {
+    final _$$selfRef = reference;
     final _$js = js?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableInt64List(reference.pointer,
+    return _callFlutterEchoNullableInt64List(_$$selfRef.pointer,
             _id_callFlutterEchoNullableInt64List.pointer, _$js.pointer)
         .object<jni$_.JLongArray?>();
   }
@@ -30769,8 +31477,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JDoubleArray? callFlutterEchoNullableFloat64List(
     jni$_.JDoubleArray? ds,
   ) {
+    final _$$selfRef = reference;
     final _$ds = ds?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableFloat64List(reference.pointer,
+    return _callFlutterEchoNullableFloat64List(_$$selfRef.pointer,
             _id_callFlutterEchoNullableFloat64List.pointer, _$ds.pointer)
         .object<jni$_.JDoubleArray?>();
   }
@@ -30798,8 +31507,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<jni$_.JObject?>? callFlutterEchoNullableList(
     jni$_.JList<jni$_.JObject?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableList(reference.pointer,
+    return _callFlutterEchoNullableList(_$$selfRef.pointer,
             _id_callFlutterEchoNullableList.pointer, _$list.pointer)
         .object<jni$_.JList<jni$_.JObject?>?>();
   }
@@ -30827,8 +31537,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<NIAnEnum?>? callFlutterEchoNullableEnumList(
     jni$_.JList<NIAnEnum?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableEnumList(reference.pointer,
+    return _callFlutterEchoNullableEnumList(_$$selfRef.pointer,
             _id_callFlutterEchoNullableEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum?>?>();
   }
@@ -30856,8 +31567,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<NIAllNullableTypes?>? callFlutterEchoNullableClassList(
     jni$_.JList<NIAllNullableTypes?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableClassList(reference.pointer,
+    return _callFlutterEchoNullableClassList(_$$selfRef.pointer,
             _id_callFlutterEchoNullableClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes?>?>();
   }
@@ -30885,8 +31597,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<NIAnEnum>? callFlutterEchoNullableNonNullEnumList(
     jni$_.JList<NIAnEnum>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableNonNullEnumList(reference.pointer,
+    return _callFlutterEchoNullableNonNullEnumList(_$$selfRef.pointer,
             _id_callFlutterEchoNullableNonNullEnumList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAnEnum>?>();
   }
@@ -30914,8 +31627,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JList<NIAllNullableTypes>? callFlutterEchoNullableNonNullClassList(
     jni$_.JList<NIAllNullableTypes>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableNonNullClassList(reference.pointer,
+    return _callFlutterEchoNullableNonNullClassList(_$$selfRef.pointer,
             _id_callFlutterEchoNullableNonNullClassList.pointer, _$list.pointer)
         .object<jni$_.JList<NIAllNullableTypes>?>();
   }
@@ -30943,8 +31657,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JObject?, jni$_.JObject?>? callFlutterEchoNullableMap(
     jni$_.JMap<jni$_.JObject?, jni$_.JObject?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableMap(reference.pointer,
+    return _callFlutterEchoNullableMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JObject?, jni$_.JObject?>?>();
   }
@@ -30972,8 +31687,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JString?, jni$_.JString?>? callFlutterEchoNullableStringMap(
     jni$_.JMap<jni$_.JString?, jni$_.JString?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableStringMap(reference.pointer,
+    return _callFlutterEchoNullableStringMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString?, jni$_.JString?>?>();
   }
@@ -31001,8 +31717,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JLong?, jni$_.JLong?>? callFlutterEchoNullableIntMap(
     jni$_.JMap<jni$_.JLong?, jni$_.JLong?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableIntMap(reference.pointer,
+    return _callFlutterEchoNullableIntMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, jni$_.JLong?>?>();
   }
@@ -31030,8 +31747,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<NIAnEnum?, NIAnEnum?>? callFlutterEchoNullableEnumMap(
     jni$_.JMap<NIAnEnum?, NIAnEnum?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableEnumMap(reference.pointer,
+    return _callFlutterEchoNullableEnumMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum?, NIAnEnum?>?>();
   }
@@ -31060,8 +31778,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
       callFlutterEchoNullableClassMap(
     jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableClassMap(reference.pointer,
+    return _callFlutterEchoNullableClassMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong?, NIAllNullableTypes?>?>();
   }
@@ -31090,8 +31809,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
       callFlutterEchoNullableNonNullStringMap(
     jni$_.JMap<jni$_.JString, jni$_.JString>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableNonNullStringMap(reference.pointer,
+    return _callFlutterEchoNullableNonNullStringMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableNonNullStringMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JString, jni$_.JString>?>();
   }
@@ -31119,8 +31839,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<jni$_.JLong, jni$_.JLong>? callFlutterEchoNullableNonNullIntMap(
     jni$_.JMap<jni$_.JLong, jni$_.JLong>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableNonNullIntMap(reference.pointer,
+    return _callFlutterEchoNullableNonNullIntMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableNonNullIntMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, jni$_.JLong>?>();
   }
@@ -31148,8 +31869,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   jni$_.JMap<NIAnEnum, NIAnEnum>? callFlutterEchoNullableNonNullEnumMap(
     jni$_.JMap<NIAnEnum, NIAnEnum>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableNonNullEnumMap(reference.pointer,
+    return _callFlutterEchoNullableNonNullEnumMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableNonNullEnumMap.pointer, _$map.pointer)
         .object<jni$_.JMap<NIAnEnum, NIAnEnum>?>();
   }
@@ -31178,8 +31900,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
       callFlutterEchoNullableNonNullClassMap(
     jni$_.JMap<jni$_.JLong, NIAllNullableTypes>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableNonNullClassMap(reference.pointer,
+    return _callFlutterEchoNullableNonNullClassMap(_$$selfRef.pointer,
             _id_callFlutterEchoNullableNonNullClassMap.pointer, _$map.pointer)
         .object<jni$_.JMap<jni$_.JLong, NIAllNullableTypes>?>();
   }
@@ -31207,8 +31930,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   NIAnEnum? callFlutterEchoNullableEnum(
     NIAnEnum? nIAnEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum?.reference ?? jni$_.jNullReference;
-    return _callFlutterEchoNullableEnum(reference.pointer,
+    return _callFlutterEchoNullableEnum(_$$selfRef.pointer,
             _id_callFlutterEchoNullableEnum.pointer, _$nIAnEnum.pointer)
         .object<NIAnEnum?>();
   }
@@ -31236,9 +31960,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   NIAnotherEnum? callFlutterEchoAnotherNullableEnum(
     NIAnotherEnum? nIAnotherEnum,
   ) {
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum?.reference ?? jni$_.jNullReference;
     return _callFlutterEchoAnotherNullableEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAnotherNullableEnum.pointer,
             _$nIAnotherEnum.pointer)
         .object<NIAnotherEnum?>();
@@ -31266,8 +31991,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   core$_.Future<void> callFlutterNoopAsync() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _callFlutterNoopAsync(reference.pointer,
+    final _$$selfRef = reference;
+    final $r = _callFlutterNoopAsync(_$$selfRef.pointer,
             _id_callFlutterNoopAsync.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -31322,9 +32047,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAllTypes = nIAllTypes.reference;
     final $r = _callFlutterEchoAsyncNIAllTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNIAllTypes.pointer,
             _$nIAllTypes.pointer,
             _$continuation.pointer)
@@ -31385,10 +32111,11 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAllNullableTypes =
         nIAllNullableTypes?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableNIAllNullableTypes(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableNIAllNullableTypes.pointer,
             _$nIAllNullableTypes.pointer,
             _$continuation.pointer)
@@ -31451,10 +32178,11 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAllNullableTypesWithoutRecursion =
         nIAllNullableTypesWithoutRecursion?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableNIAllNullableTypesWithoutRecursion(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableNIAllNullableTypesWithoutRecursion
                 .pointer,
             _$nIAllNullableTypesWithoutRecursion.pointer,
@@ -31511,9 +32239,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
+    final _$$selfRef = reference;
     final $r = _callFlutterEchoAsyncBool(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncBool.pointer,
             z ? 1 : 0,
             _$continuation.pointer)
@@ -31567,8 +32295,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _callFlutterEchoAsyncInt(reference.pointer,
+    final _$$selfRef = reference;
+    final $r = _callFlutterEchoAsyncInt(_$$selfRef.pointer,
             _id_callFlutterEchoAsyncInt.pointer, j, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -31626,8 +32354,8 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _callFlutterEchoAsyncDouble(reference.pointer,
+    final _$$selfRef = reference;
+    final $r = _callFlutterEchoAsyncDouble(_$$selfRef.pointer,
             _id_callFlutterEchoAsyncDouble.pointer, d, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -31685,9 +32413,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$string = string.reference;
     final $r = _callFlutterEchoAsyncString(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncString.pointer,
             _$string.pointer,
             _$continuation.pointer)
@@ -31747,9 +32476,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$bs = bs.reference;
     final $r = _callFlutterEchoAsyncUint8List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncUint8List.pointer,
             _$bs.pointer,
             _$continuation.pointer)
@@ -31809,9 +32539,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$is$ = is$.reference;
     final $r = _callFlutterEchoAsyncInt32List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncInt32List.pointer,
             _$is$.pointer,
             _$continuation.pointer)
@@ -31871,9 +32602,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$js = js.reference;
     final $r = _callFlutterEchoAsyncInt64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncInt64List.pointer,
             _$js.pointer,
             _$continuation.pointer)
@@ -31933,9 +32665,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$ds = ds.reference;
     final $r = _callFlutterEchoAsyncFloat64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncFloat64List.pointer,
             _$ds.pointer,
             _$continuation.pointer)
@@ -31995,9 +32728,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$object = object.reference;
     final $r = _callFlutterEchoAsyncObject(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncObject.pointer,
             _$object.pointer,
             _$continuation.pointer)
@@ -32056,9 +32790,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _callFlutterEchoAsyncList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -32118,9 +32853,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _callFlutterEchoAsyncEnumList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncEnumList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -32180,9 +32916,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _callFlutterEchoAsyncClassList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncClassList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -32242,9 +32979,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _callFlutterEchoAsyncNonNullEnumList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNonNullEnumList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -32305,9 +33043,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list.reference;
     final $r = _callFlutterEchoAsyncNonNullClassList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNonNullClassList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -32367,9 +33106,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
     final $r = _callFlutterEchoAsyncMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -32430,9 +33170,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
     final $r = _callFlutterEchoAsyncStringMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncStringMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -32493,9 +33234,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
     final $r = _callFlutterEchoAsyncIntMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncIntMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -32555,9 +33297,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
     final $r = _callFlutterEchoAsyncEnumMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncEnumMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -32618,9 +33361,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map.reference;
     final $r = _callFlutterEchoAsyncClassMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncClassMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -32679,9 +33423,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum.reference;
     final $r = _callFlutterEchoAsyncEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncEnum.pointer,
             _$nIAnEnum.pointer,
             _$continuation.pointer)
@@ -32741,9 +33486,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum.reference;
     final $r = _callFlutterEchoAnotherAsyncEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAnotherAsyncEnum.pointer,
             _$nIAnotherEnum.pointer,
             _$continuation.pointer)
@@ -32803,9 +33549,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$boolean = boolean?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableBool(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableBool.pointer,
             _$boolean.pointer,
             _$continuation.pointer)
@@ -32867,9 +33614,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$long = long?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableInt(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableInt.pointer,
             _$long.pointer,
             _$continuation.pointer)
@@ -32931,9 +33679,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$double = double?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableDouble(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableDouble.pointer,
             _$double.pointer,
             _$continuation.pointer)
@@ -32995,9 +33744,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableString(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableString.pointer,
             _$string.pointer,
             _$continuation.pointer)
@@ -33059,9 +33809,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$bs = bs?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableUint8List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableUint8List.pointer,
             _$bs.pointer,
             _$continuation.pointer)
@@ -33123,9 +33874,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$is$ = is$?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableInt32List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableInt32List.pointer,
             _$is$.pointer,
             _$continuation.pointer)
@@ -33187,9 +33939,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$js = js?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableInt64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableInt64List.pointer,
             _$js.pointer,
             _$continuation.pointer)
@@ -33251,9 +34004,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$ds = ds?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableFloat64List(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableFloat64List.pointer,
             _$ds.pointer,
             _$continuation.pointer)
@@ -33307,9 +34061,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   core$_.Future<jni$_.JObject?> callFlutterThrowFlutterErrorAsync() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
+    final _$$selfRef = reference;
     final $r = _callFlutterThrowFlutterErrorAsync(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterThrowFlutterErrorAsync.pointer,
             _$continuation.pointer)
         .object<jni$_.JObject?>();
@@ -33370,9 +34124,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableObject(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableObject.pointer,
             _$object.pointer,
             _$continuation.pointer)
@@ -33434,9 +34189,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -33498,9 +34254,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableEnumList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableEnumList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -33563,9 +34320,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableClassList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableClassList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -33628,9 +34386,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableNonNullEnumList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableNonNullEnumList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -33693,9 +34452,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableNonNullClassList(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableNonNullClassList.pointer,
             _$list.pointer,
             _$continuation.pointer)
@@ -33758,9 +34518,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -33823,9 +34584,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableStringMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableStringMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -33888,9 +34650,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableIntMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableIntMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -33953,9 +34716,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableEnumMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableEnumMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -34018,9 +34782,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableClassMap(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableClassMap.pointer,
             _$map.pointer,
             _$continuation.pointer)
@@ -34082,9 +34847,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnEnum = nIAnEnum?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAsyncNullableEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAsyncNullableEnum.pointer,
             _$nIAnEnum.pointer,
             _$continuation.pointer)
@@ -34146,9 +34912,10 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$nIAnotherEnum = nIAnotherEnum?.reference ?? jni$_.jNullReference;
     final $r = _callFlutterEchoAnotherAsyncNullableEnum(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterEchoAnotherAsyncNullableEnum.pointer,
             _$nIAnotherEnum.pointer,
             _$continuation.pointer)
@@ -34199,8 +34966,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
 
   /// from: `public fun defaultIsMainThread(): kotlin.Boolean`
   core$_.bool defaultIsMainThread() {
+    final _$$selfRef = reference;
     return _defaultIsMainThread(
-            reference.pointer, _id_defaultIsMainThread.pointer)
+            _$$selfRef.pointer, _id_defaultIsMainThread.pointer)
         .boolean;
   }
 
@@ -34227,9 +34995,9 @@ extension NIHostIntegrationCoreApiRegistrar$$Methods
   core$_.Future<jni$_.JBoolean> callFlutterNoopOnBackgroundThread() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
+    final _$$selfRef = reference;
     final $r = _callFlutterNoopOnBackgroundThread(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_callFlutterNoopOnBackgroundThread.pointer,
             _$continuation.pointer)
         .object<jni$_.JObject>();
@@ -34298,9 +35066,10 @@ extension type NIUnusedClass$Companion._(jni$_.JObject _$this)
   factory NIUnusedClass$Companion(
     jni$_.JObject? defaultConstructorMarker,
   ) {
+    final _$$classRef = _class.reference;
     final _$defaultConstructorMarker =
         defaultConstructorMarker?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer,
+    return _new$(_$$classRef.pointer, _id_new$.pointer,
             _$defaultConstructorMarker.pointer)
         .object<NIUnusedClass$Companion>();
   }
@@ -34328,8 +35097,9 @@ extension NIUnusedClass$Companion$$Methods on NIUnusedClass$Companion {
   NIUnusedClass fromList(
     jni$_.JList<jni$_.JObject?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _fromList(reference.pointer, _id_fromList.pointer, _$list.pointer)
+    return _fromList(_$$selfRef.pointer, _id_fromList.pointer, _$list.pointer)
         .object<NIUnusedClass>();
   }
 }
@@ -34383,8 +35153,9 @@ extension type NIUnusedClass._(jni$_.JObject _$this) implements jni$_.JObject {
   factory NIUnusedClass(
     jni$_.JObject? object,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer, _$object.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$object.pointer)
         .object<NIUnusedClass>();
   }
 
@@ -34418,11 +35189,12 @@ extension type NIUnusedClass._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     jni$_.JObject? defaultConstructorMarker,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$defaultConstructorMarker =
         defaultConstructorMarker?.reference ?? jni$_.jNullReference;
-    return _new$1(_class.reference.pointer, _id_new$1.pointer, _$object.pointer,
-            i, _$defaultConstructorMarker.pointer)
+    return _new$1(_$$classRef.pointer, _id_new$1.pointer, _$object.pointer, i,
+            _$defaultConstructorMarker.pointer)
         .object<NIUnusedClass>();
   }
 
@@ -34445,7 +35217,8 @@ extension type NIUnusedClass._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory NIUnusedClass.new$2() {
-    return _new$2(_class.reference.pointer, _id_new$2.pointer)
+    final _$$classRef = _class.reference;
+    return _new$2(_$$classRef.pointer, _id_new$2.pointer)
         .object<NIUnusedClass>();
   }
 }
@@ -34471,7 +35244,8 @@ extension NIUnusedClass$$Methods on NIUnusedClass {
   /// from: `public final java.lang.Object getAField()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? get aField {
-    return _get$aField(reference.pointer, _id_get$aField.pointer)
+    final _$$selfRef = reference;
+    return _get$aField(_$$selfRef.pointer, _id_get$aField.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -34495,7 +35269,8 @@ extension NIUnusedClass$$Methods on NIUnusedClass {
   /// from: `public fun toList(): kotlin.collections.List<kotlin.Any?>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject?> toList() {
-    return _toList(reference.pointer, _id_toList.pointer)
+    final _$$selfRef = reference;
+    return _toList(_$$selfRef.pointer, _id_toList.pointer)
         .object<jni$_.JList<jni$_.JObject?>>();
   }
 
@@ -34519,8 +35294,9 @@ extension NIUnusedClass$$Methods on NIUnusedClass {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -34543,7 +35319,8 @@ extension NIUnusedClass$$Methods on NIUnusedClass {
 
   /// from: `public fun hashCode(): kotlin.Int`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_component1 = NIUnusedClass._class.instanceMethodId(
@@ -34566,7 +35343,8 @@ extension NIUnusedClass$$Methods on NIUnusedClass {
   /// from: `public operator fun component1(): kotlin.Any?`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? component1() {
-    return _component1(reference.pointer, _id_component1.pointer)
+    final _$$selfRef = reference;
+    return _component1(_$$selfRef.pointer, _id_component1.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -34591,8 +35369,9 @@ extension NIUnusedClass$$Methods on NIUnusedClass {
   NIUnusedClass copy(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _copy(reference.pointer, _id_copy.pointer, _$object.pointer)
+    return _copy(_$$selfRef.pointer, _id_copy.pointer, _$object.pointer)
         .object<NIUnusedClass>();
   }
 
@@ -34616,7 +35395,8 @@ extension NIUnusedClass$$Methods on NIUnusedClass {
   /// from: `public fun toString(): kotlin.String`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<jni$_.JString>();
   }
 }
@@ -34667,10 +35447,11 @@ extension type NiTestsError._(jni$_.JObject _$this) implements jni$_.JObject {
     jni$_.JString? string1,
     jni$_.JObject? object,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string.reference;
     final _$string1 = string1?.reference ?? jni$_.jNullReference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer, _$string.pointer,
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$string.pointer,
             _$string1.pointer, _$object.pointer)
         .object<NiTestsError>();
   }
@@ -34711,13 +35492,14 @@ extension type NiTestsError._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     jni$_.JObject? defaultConstructorMarker,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$string1 = string1?.reference ?? jni$_.jNullReference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$defaultConstructorMarker =
         defaultConstructorMarker?.reference ?? jni$_.jNullReference;
     return _new$1(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_new$1.pointer,
             _$string.pointer,
             _$string1.pointer,
@@ -34749,7 +35531,8 @@ extension NiTestsError$$Methods on NiTestsError {
   /// from: `public final java.lang.String getCode()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString get code {
-    return _get$code(reference.pointer, _id_get$code.pointer)
+    final _$$selfRef = reference;
+    return _get$code(_$$selfRef.pointer, _id_get$code.pointer)
         .object<jni$_.JString>();
   }
 
@@ -34773,7 +35556,8 @@ extension NiTestsError$$Methods on NiTestsError {
   /// from: `public java.lang.String getMessage()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? get message {
-    return _get$message(reference.pointer, _id_get$message.pointer)
+    final _$$selfRef = reference;
+    return _get$message(_$$selfRef.pointer, _id_get$message.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -34797,7 +35581,8 @@ extension NiTestsError$$Methods on NiTestsError {
   /// from: `public final java.lang.Object getDetails()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? get details {
-    return _get$details(reference.pointer, _id_get$details.pointer)
+    final _$$selfRef = reference;
+    return _get$details(_$$selfRef.pointer, _id_get$details.pointer)
         .object<jni$_.JObject?>();
   }
 }
@@ -34841,9 +35626,9 @@ extension type Nullability$InnerClass<$T extends jni$_.JObject?,
   factory Nullability$InnerClass(
     Nullability<$T?, $U> $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<Nullability$InnerClass<$T, $U, $V>>();
   }
 }
@@ -34882,10 +35667,11 @@ extension Nullability$InnerClass$$Methods<
     $U object1,
     $V? object2,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1.reference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
-    _f(reference.pointer, _id_f.pointer, _$object.pointer, _$object1.pointer,
+    _f(_$$selfRef.pointer, _id_f.pointer, _$object.pointer, _$object1.pointer,
             _$object2.pointer)
         .check();
   }
@@ -34940,10 +35726,11 @@ extension type Nullability<$T extends jni$_.JObject?,
     $U object1,
     $U? object2,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1.reference;
     final _$object2 = object2?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer, _$object.pointer,
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$object.pointer,
             _$object1.pointer, _$object2.pointer)
         .object<Nullability<$T, $U>>();
   }
@@ -34971,7 +35758,8 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   /// from: `public final T getT()`
   /// The returned object must be released after use, by calling the [release] method.
   $T? get t {
-    return _get$t(reference.pointer, _id_get$t.pointer).object<$T?>();
+    final _$$selfRef = reference;
+    return _get$t(_$$selfRef.pointer, _id_get$t.pointer).object<$T?>();
   }
 
   static final _id_get$u = Nullability._class.instanceMethodId(
@@ -34994,7 +35782,8 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   /// from: `public final U getU()`
   /// The returned object must be released after use, by calling the [release] method.
   $U get u {
-    return _get$u(reference.pointer, _id_get$u.pointer).object<$U>();
+    final _$$selfRef = reference;
+    return _get$u(_$$selfRef.pointer, _id_get$u.pointer).object<$U>();
   }
 
   static final _id_get$nullableU = Nullability._class.instanceMethodId(
@@ -35017,7 +35806,8 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   /// from: `public final U getNullableU()`
   /// The returned object must be released after use, by calling the [release] method.
   $U? get nullableU {
-    return _get$nullableU(reference.pointer, _id_get$nullableU.pointer)
+    final _$$selfRef = reference;
+    return _get$nullableU(_$$selfRef.pointer, _id_get$nullableU.pointer)
         .object<$U?>();
   }
 
@@ -35039,9 +35829,10 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public final void setNullableU(U object)`
   set nullableU($U? object) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     _set$nullableU(
-            reference.pointer, _id_set$nullableU.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_set$nullableU.pointer, _$object.pointer)
         .check();
   }
 
@@ -35065,7 +35856,8 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   /// from: `public fun self(): com.github.dart_lang.jnigen.Nullability<*, *>`
   /// The returned object must be released after use, by calling the [release] method.
   Nullability<jni$_.JObject?, jni$_.JObject> self() {
-    return _self(reference.pointer, _id_self.pointer)
+    final _$$selfRef = reference;
+    return _self(_$$selfRef.pointer, _id_self.pointer)
         .object<Nullability<jni$_.JObject?, jni$_.JObject>>();
   }
 
@@ -35089,7 +35881,9 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   /// from: `public fun hello(): kotlin.String`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString hello() {
-    return _hello(reference.pointer, _id_hello.pointer).object<jni$_.JString>();
+    final _$$selfRef = reference;
+    return _hello(_$$selfRef.pointer, _id_hello.pointer)
+        .object<jni$_.JString>();
   }
 
   static final _id_nullableHello = Nullability._class.instanceMethodId(
@@ -35112,8 +35906,9 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   jni$_.JString? nullableHello(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _nullableHello(
-            reference.pointer, _id_nullableHello.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_nullableHello.pointer, z ? 1 : 0)
         .object<jni$_.JString?>();
   }
 
@@ -35137,7 +35932,8 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   /// from: `public fun list(): kotlin.collections.List<*>`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JObject?> list() {
-    return _list(reference.pointer, _id_list.pointer)
+    final _$$selfRef = reference;
+    return _list(_$$selfRef.pointer, _id_list.pointer)
         .object<jni$_.JList<jni$_.JObject?>>();
   }
 
@@ -35162,9 +35958,10 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   $V methodGenericEcho<$V extends jni$_.JObject>(
     $V object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object.reference;
     return _methodGenericEcho(
-            reference.pointer, _id_methodGenericEcho.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_methodGenericEcho.pointer, _$object.pointer)
         .object<$V>();
   }
 
@@ -35190,8 +35987,9 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   $V? methodGenericNullableEcho<$V extends jni$_.JObject?>(
     $V? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _methodGenericNullableEcho(reference.pointer,
+    return _methodGenericNullableEcho(_$$selfRef.pointer,
             _id_methodGenericNullableEcho.pointer, _$object.pointer)
         .object<$V?>();
   }
@@ -35217,9 +36015,10 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   $U classGenericEcho(
     $U object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object.reference;
     return _classGenericEcho(
-            reference.pointer, _id_classGenericEcho.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_classGenericEcho.pointer, _$object.pointer)
         .object<$U>();
   }
 
@@ -35245,8 +36044,9 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   $T? classGenericNullableEcho(
     $T? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _classGenericNullableEcho(reference.pointer,
+    return _classGenericNullableEcho(_$$selfRef.pointer,
             _id_classGenericNullableEcho.pointer, _$object.pointer)
         .object<$T?>();
   }
@@ -35272,8 +36072,9 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   jni$_.JString firstOf(
     jni$_.JList<jni$_.JString> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _firstOf(reference.pointer, _id_firstOf.pointer, _$list.pointer)
+    return _firstOf(_$$selfRef.pointer, _id_firstOf.pointer, _$list.pointer)
         .object<jni$_.JString>();
   }
 
@@ -35298,9 +36099,10 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   jni$_.JString? firstOfNullable(
     jni$_.JList<jni$_.JString?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _firstOfNullable(
-            reference.pointer, _id_firstOfNullable.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_firstOfNullable.pointer, _$list.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -35325,9 +36127,10 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   $U classGenericFirstOf(
     jni$_.JList<$U> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
     return _classGenericFirstOf(
-            reference.pointer, _id_classGenericFirstOf.pointer, _$list.pointer)
+            _$$selfRef.pointer, _id_classGenericFirstOf.pointer, _$list.pointer)
         .object<$U>();
   }
 
@@ -35354,8 +36157,9 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   $T? classGenericFirstOfNullable(
     jni$_.JList<$T> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _classGenericFirstOfNullable(reference.pointer,
+    return _classGenericFirstOfNullable(_$$selfRef.pointer,
             _id_classGenericFirstOfNullable.pointer, _$list.pointer)
         .object<$T?>();
   }
@@ -35381,9 +36185,10 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   $V methodGenericFirstOf<$V extends jni$_.JObject>(
     jni$_.JList<$V> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _methodGenericFirstOf(
-            reference.pointer, _id_methodGenericFirstOf.pointer, _$list.pointer)
+    return _methodGenericFirstOf(_$$selfRef.pointer,
+            _id_methodGenericFirstOf.pointer, _$list.pointer)
         .object<$V>();
   }
 
@@ -35410,8 +36215,9 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   $V? methodGenericFirstOfNullable<$V extends jni$_.JObject?>(
     jni$_.JList<$V> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _methodGenericFirstOfNullable(reference.pointer,
+    return _methodGenericFirstOfNullable(_$$selfRef.pointer,
             _id_methodGenericFirstOfNullable.pointer, _$list.pointer)
         .object<$V?>();
   }
@@ -35437,9 +36243,10 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   jni$_.JList<jni$_.JString> stringListOf(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
     return _stringListOf(
-            reference.pointer, _id_stringListOf.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_stringListOf.pointer, _$string.pointer)
         .object<jni$_.JList<jni$_.JString>>();
   }
 
@@ -35464,9 +36271,10 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   jni$_.JList<jni$_.JString?> nullableListOf(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _nullableListOf(
-            reference.pointer, _id_nullableListOf.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_nullableListOf.pointer, _$string.pointer)
         .object<jni$_.JList<jni$_.JString?>>();
   }
 
@@ -35491,9 +36299,10 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   jni$_.JList<$U> classGenericListOf(
     $U object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object.reference;
-    return _classGenericListOf(
-            reference.pointer, _id_classGenericListOf.pointer, _$object.pointer)
+    return _classGenericListOf(_$$selfRef.pointer,
+            _id_classGenericListOf.pointer, _$object.pointer)
         .object<jni$_.JList<$U>>();
   }
 
@@ -35520,8 +36329,9 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   jni$_.JList<$T?> classGenericNullableListOf(
     $T? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _classGenericNullableListOf(reference.pointer,
+    return _classGenericNullableListOf(_$$selfRef.pointer,
             _id_classGenericNullableListOf.pointer, _$object.pointer)
         .object<jni$_.JList<$T?>>();
   }
@@ -35547,8 +36357,9 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   jni$_.JList<$V> methodGenericListOf<$V extends jni$_.JObject>(
     $V object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object.reference;
-    return _methodGenericListOf(reference.pointer,
+    return _methodGenericListOf(_$$selfRef.pointer,
             _id_methodGenericListOf.pointer, _$object.pointer)
         .object<jni$_.JList<$V>>();
   }
@@ -35576,8 +36387,9 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   jni$_.JList<$V?> methodGenericNullableListOf<$V extends jni$_.JObject?>(
     $V? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _methodGenericNullableListOf(reference.pointer,
+    return _methodGenericNullableListOf(_$$selfRef.pointer,
             _id_methodGenericNullableListOf.pointer, _$object.pointer)
         .object<jni$_.JList<$V?>>();
   }
@@ -35602,9 +36414,10 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   core$_.int methodWithVarArgs(
     jni$_.JArray<jni$_.JString> strings,
   ) {
+    final _$$selfRef = reference;
     final _$strings = strings.reference;
-    return _methodWithVarArgs(
-            reference.pointer, _id_methodWithVarArgs.pointer, _$strings.pointer)
+    return _methodWithVarArgs(_$$selfRef.pointer, _id_methodWithVarArgs.pointer,
+            _$strings.pointer)
         .integer;
   }
 
@@ -35628,9 +36441,10 @@ extension Nullability$$Methods<$T extends jni$_.JObject?,
   core$_.int methodWithWhere<$V extends jni$_.JObject>(
     $V canDoA,
   ) {
+    final _$$selfRef = reference;
     final _$canDoA = canDoA.reference;
     return _methodWithWhere(
-            reference.pointer, _id_methodWithWhere.pointer, _$canDoA.pointer)
+            _$$selfRef.pointer, _id_methodWithWhere.pointer, _$canDoA.pointer)
         .integer;
   }
 }
@@ -35670,8 +36484,8 @@ extension type Operators._(jni$_.JObject _$this) implements jni$_.JObject {
   factory Operators(
     core$_.int i,
   ) {
-    return _new$(_class.reference.pointer, _id_new$.pointer, i)
-        .object<Operators>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer, i).object<Operators>();
   }
 }
 
@@ -35695,7 +36509,8 @@ extension Operators$$Methods on Operators {
 
   /// from: `public final int getValue()`
   core$_.int get value {
-    return _get$value(reference.pointer, _id_get$value.pointer).integer;
+    final _$$selfRef = reference;
+    return _get$value(_$$selfRef.pointer, _id_get$value.pointer).integer;
   }
 
   static final _id_set$value = Operators._class.instanceMethodId(
@@ -35715,7 +36530,8 @@ extension Operators$$Methods on Operators {
 
   /// from: `public final void setValue(int i)`
   set value(core$_.int i) {
-    _set$value(reference.pointer, _id_set$value.pointer, i).check();
+    final _$$selfRef = reference;
+    _set$value(_$$selfRef.pointer, _id_set$value.pointer, i).check();
   }
 
   static final _id_plus = Operators._class.instanceMethodId(
@@ -35739,8 +36555,9 @@ extension Operators$$Methods on Operators {
   Operators plus(
     Operators operators,
   ) {
+    final _$$selfRef = reference;
     final _$operators = operators.reference;
-    return _plus(reference.pointer, _id_plus.pointer, _$operators.pointer)
+    return _plus(_$$selfRef.pointer, _id_plus.pointer, _$operators.pointer)
         .object<Operators>();
   }
 
@@ -35764,7 +36581,8 @@ extension Operators$$Methods on Operators {
   Operators plus$1(
     core$_.int i,
   ) {
-    return _plus$1(reference.pointer, _id_plus$1.pointer, i)
+    final _$$selfRef = reference;
+    return _plus$1(_$$selfRef.pointer, _id_plus$1.pointer, i)
         .object<Operators>();
   }
 
@@ -35789,8 +36607,9 @@ extension Operators$$Methods on Operators {
   Operators minus(
     Operators operators,
   ) {
+    final _$$selfRef = reference;
     final _$operators = operators.reference;
-    return _minus(reference.pointer, _id_minus.pointer, _$operators.pointer)
+    return _minus(_$$selfRef.pointer, _id_minus.pointer, _$operators.pointer)
         .object<Operators>();
   }
 
@@ -35815,8 +36634,9 @@ extension Operators$$Methods on Operators {
   Operators times(
     Operators operators,
   ) {
+    final _$$selfRef = reference;
     final _$operators = operators.reference;
-    return _times(reference.pointer, _id_times.pointer, _$operators.pointer)
+    return _times(_$$selfRef.pointer, _id_times.pointer, _$operators.pointer)
         .object<Operators>();
   }
 
@@ -35841,8 +36661,9 @@ extension Operators$$Methods on Operators {
   Operators div(
     Operators operators,
   ) {
+    final _$$selfRef = reference;
     final _$operators = operators.reference;
-    return _div(reference.pointer, _id_div.pointer, _$operators.pointer)
+    return _div(_$$selfRef.pointer, _id_div.pointer, _$operators.pointer)
         .object<Operators>();
   }
 
@@ -35867,8 +36688,9 @@ extension Operators$$Methods on Operators {
   Operators rem(
     Operators operators,
   ) {
+    final _$$selfRef = reference;
     final _$operators = operators.reference;
-    return _rem(reference.pointer, _id_rem.pointer, _$operators.pointer)
+    return _rem(_$$selfRef.pointer, _id_rem.pointer, _$operators.pointer)
         .object<Operators>();
   }
 
@@ -35892,7 +36714,8 @@ extension Operators$$Methods on Operators {
   core$_.bool get(
     core$_.int i,
   ) {
-    return _get(reference.pointer, _id_get.pointer, i).boolean;
+    final _$$selfRef = reference;
+    return _get(_$$selfRef.pointer, _id_get.pointer, i).boolean;
   }
 
   static final _id_set = Operators._class.instanceMethodId(
@@ -35916,7 +36739,8 @@ extension Operators$$Methods on Operators {
     core$_.int i,
     core$_.bool z,
   ) {
-    _set(reference.pointer, _id_set.pointer, i, z ? 1 : 0).check();
+    final _$$selfRef = reference;
+    _set(_$$selfRef.pointer, _id_set.pointer, i, z ? 1 : 0).check();
   }
 
   static final _id_compareTo = Operators._class.instanceMethodId(
@@ -35939,9 +36763,10 @@ extension Operators$$Methods on Operators {
   core$_.int compareTo(
     Operators operators,
   ) {
+    final _$$selfRef = reference;
     final _$operators = operators.reference;
     return _compareTo(
-            reference.pointer, _id_compareTo.pointer, _$operators.pointer)
+            _$$selfRef.pointer, _id_compareTo.pointer, _$operators.pointer)
         .integer;
   }
 
@@ -36036,8 +36861,8 @@ final _get$nIHostIntegrationCoreApiInstances =
 /// The returned object must be released after use, by calling the [release] method.
 jni$_.JMap<jni$_.JString, NIHostIntegrationCoreApiRegistrar>
     get nIHostIntegrationCoreApiInstances {
-  return _get$nIHostIntegrationCoreApiInstances(
-          _Regress3235KtClass.reference.pointer,
+  final _$$classRef = _Regress3235KtClass.reference;
+  return _get$nIHostIntegrationCoreApiInstances(_$$classRef.pointer,
           _id_get$nIHostIntegrationCoreApiInstances.pointer)
       .object<jni$_.JMap<jni$_.JString, NIHostIntegrationCoreApiRegistrar>>();
 }
@@ -36065,8 +36890,8 @@ final _get$registeredNIFlutterIntegrationCoreApi =
 /// The returned object must be released after use, by calling the [release] method.
 jni$_.JMap<jni$_.JString, NIFlutterIntegrationCoreApi>
     get registeredNIFlutterIntegrationCoreApi {
-  return _get$registeredNIFlutterIntegrationCoreApi(
-          _Regress3235KtClass.reference.pointer,
+  final _$$classRef = _Regress3235KtClass.reference;
+  return _get$registeredNIFlutterIntegrationCoreApi(_$$classRef.pointer,
           _id_get$registeredNIFlutterIntegrationCoreApi.pointer)
       .object<jni$_.JMap<jni$_.JString, NIFlutterIntegrationCoreApi>>();
 }
@@ -36102,9 +36927,9 @@ extension type Speed._(jni$_.JObject _$this) implements Measure<SpeedUnit> {
     core$_.double f,
     SpeedUnit speedUnit,
   ) {
+    final _$$classRef = _class.reference;
     final _$speedUnit = speedUnit.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, f, _$speedUnit.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, f, _$speedUnit.pointer)
         .object<Speed>();
   }
 }
@@ -36129,7 +36954,8 @@ extension Speed$$Methods on Speed {
 
   /// from: `public float getValue()`
   core$_.double get value {
-    return _get$value(reference.pointer, _id_get$value.pointer).float;
+    final _$$selfRef = reference;
+    return _get$value(_$$selfRef.pointer, _id_get$value.pointer).float;
   }
 
   static final _id_get$unit$1 = Speed._class.instanceMethodId(
@@ -36152,7 +36978,8 @@ extension Speed$$Methods on Speed {
   /// from: `public com.github.dart_lang.jnigen.SpeedUnit getUnit()`
   /// The returned object must be released after use, by calling the [release] method.
   SpeedUnit get unit$1 {
-    return _get$unit$1(reference.pointer, _id_get$unit$1.pointer)
+    final _$$selfRef = reference;
+    return _get$unit$1(_$$selfRef.pointer, _id_get$unit$1.pointer)
         .object<SpeedUnit>();
   }
 
@@ -36176,7 +37003,8 @@ extension Speed$$Methods on Speed {
   /// from: `public fun toString(): kotlin.String`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString toString$1() {
-    return _toString$1(reference.pointer, _id_toString$1.pointer)
+    final _$$selfRef = reference;
+    return _toString$1(_$$selfRef.pointer, _id_toString$1.pointer)
         .object<jni$_.JString>();
   }
 
@@ -36199,7 +37027,8 @@ extension Speed$$Methods on Speed {
 
   /// from: `public operator fun component1(): kotlin.Float`
   core$_.double component1() {
-    return _component1(reference.pointer, _id_component1.pointer).float;
+    final _$$selfRef = reference;
+    return _component1(_$$selfRef.pointer, _id_component1.pointer).float;
   }
 
   static final _id_component2 = Speed._class.instanceMethodId(
@@ -36222,7 +37051,8 @@ extension Speed$$Methods on Speed {
   /// from: `public operator fun component2(): com.github.dart_lang.jnigen.SpeedUnit`
   /// The returned object must be released after use, by calling the [release] method.
   SpeedUnit component2() {
-    return _component2(reference.pointer, _id_component2.pointer)
+    final _$$selfRef = reference;
+    return _component2(_$$selfRef.pointer, _id_component2.pointer)
         .object<SpeedUnit>();
   }
 
@@ -36251,8 +37081,9 @@ extension Speed$$Methods on Speed {
     core$_.double f,
     SpeedUnit speedUnit,
   ) {
+    final _$$selfRef = reference;
     final _$speedUnit = speedUnit.reference;
-    return _copy(reference.pointer, _id_copy.pointer, f, _$speedUnit.pointer)
+    return _copy(_$$selfRef.pointer, _id_copy.pointer, f, _$speedUnit.pointer)
         .object<Speed>();
   }
 
@@ -36275,7 +37106,8 @@ extension Speed$$Methods on Speed {
 
   /// from: `public fun hashCode(): kotlin.Int`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 
   static final _id_equals = Speed._class.instanceMethodId(
@@ -36298,8 +37130,9 @@ extension Speed$$Methods on Speed {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 }
@@ -36361,7 +37194,8 @@ extension type SpeedUnit._(jni$_.JObject _$this)
   /// from: `static public com.github.dart_lang.jnigen.SpeedUnit[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<SpeedUnit?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<SpeedUnit?>?>();
   }
 
@@ -36386,9 +37220,9 @@ extension type SpeedUnit._(jni$_.JObject _$this)
   static SpeedUnit? valueOf(
     jni$_.JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$string.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$string.pointer)
         .object<SpeedUnit?>();
   }
 }
@@ -36414,7 +37248,8 @@ extension SpeedUnit$$Methods on SpeedUnit {
   /// from: `public java.lang.String getSign()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString get sign {
-    return _get$sign(reference.pointer, _id_get$sign.pointer)
+    final _$$selfRef = reference;
+    return _get$sign(_$$selfRef.pointer, _id_get$sign.pointer)
         .object<jni$_.JString>();
   }
 
@@ -36437,7 +37272,8 @@ extension SpeedUnit$$Methods on SpeedUnit {
 
   /// from: `public float getCoefficient()`
   core$_.double get coefficient {
-    return _get$coefficient(reference.pointer, _id_get$coefficient.pointer)
+    final _$$selfRef = reference;
+    return _get$coefficient(_$$selfRef.pointer, _id_get$coefficient.pointer)
         .float;
   }
 }
@@ -36477,8 +37313,8 @@ extension type SuspendFun._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory SuspendFun() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<SuspendFun>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<SuspendFun>();
   }
 }
 
@@ -36504,8 +37340,8 @@ extension SuspendFun$$Methods on SuspendFun {
   core$_.Future<jni$_.JString> sayHelloWithoutDelay() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _sayHelloWithoutDelay(reference.pointer,
+    final _$$selfRef = reference;
+    final $r = _sayHelloWithoutDelay(_$$selfRef.pointer,
             _id_sayHelloWithoutDelay.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -36553,8 +37389,8 @@ extension SuspendFun$$Methods on SuspendFun {
   core$_.Future<jni$_.JString> failWithoutDelay() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _failWithoutDelay(reference.pointer,
+    final _$$selfRef = reference;
+    final $r = _failWithoutDelay(_$$selfRef.pointer,
             _id_failWithoutDelay.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -36602,9 +37438,9 @@ extension SuspendFun$$Methods on SuspendFun {
   core$_.Future<jni$_.JString> fail() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
+    final _$$selfRef = reference;
     final $r =
-        _fail(reference.pointer, _id_fail.pointer, _$continuation.pointer)
+        _fail(_$$selfRef.pointer, _id_fail.pointer, _$continuation.pointer)
             .object<jni$_.JObject>();
     _$continuation.release();
     jni$_.JObject $o;
@@ -36651,9 +37487,9 @@ extension SuspendFun$$Methods on SuspendFun {
   core$_.Future<jni$_.JString> sayHello() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
+    final _$$selfRef = reference;
     final $r = _sayHello(
-            reference.pointer, _id_sayHello.pointer, _$continuation.pointer)
+            _$$selfRef.pointer, _id_sayHello.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
     jni$_.JObject $o;
@@ -36708,8 +37544,9 @@ extension SuspendFun$$Methods on SuspendFun {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$string = string.reference;
-    final $r = _sayHello$1(reference.pointer, _id_sayHello$1.pointer,
+    final $r = _sayHello$1(_$$selfRef.pointer, _id_sayHello$1.pointer,
             _$string.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -36760,8 +37597,8 @@ extension SuspendFun$$Methods on SuspendFun {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _nullableHello(reference.pointer, _id_nullableHello.pointer,
+    final _$$selfRef = reference;
+    final $r = _nullableHello(_$$selfRef.pointer, _id_nullableHello.pointer,
             z ? 1 : 0, _$continuation.pointer)
         .object<jni$_.JObject?>();
     _$continuation.release();
@@ -36815,9 +37652,9 @@ extension SuspendFun$$Methods on SuspendFun {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
+    final _$$selfRef = reference;
     final $r = _nullableHelloWithoutDelay(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_nullableHelloWithoutDelay.pointer,
             z ? 1 : 0,
             _$continuation.pointer)
@@ -36877,8 +37714,9 @@ extension SuspendFun$$Methods on SuspendFun {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    final $r = _nullableList(reference.pointer, _id_nullableList.pointer,
+    final $r = _nullableList(_$$selfRef.pointer, _id_nullableList.pointer,
             _$list.pointer, _$continuation.pointer)
         .object<jni$_.JObject?>();
     _$continuation.release();
@@ -36926,7 +37764,8 @@ extension SuspendFun$$Methods on SuspendFun {
 
   /// from: `public final int getResult()`
   core$_.int get result {
-    return _get$result(reference.pointer, _id_get$result.pointer).integer;
+    final _$$selfRef = reference;
+    return _get$result(_$$selfRef.pointer, _id_get$result.pointer).integer;
   }
 
   static final _id_set$result = SuspendFun._class.instanceMethodId(
@@ -36946,7 +37785,8 @@ extension SuspendFun$$Methods on SuspendFun {
 
   /// from: `public final void setResult(int i)`
   set result(core$_.int i) {
-    _set$result(reference.pointer, _id_set$result.pointer, i).check();
+    final _$$selfRef = reference;
+    _set$result(_$$selfRef.pointer, _id_set$result.pointer, i).check();
   }
 
   static final _id_noReturn = SuspendFun._class.instanceMethodId(
@@ -36970,9 +37810,9 @@ extension SuspendFun$$Methods on SuspendFun {
   core$_.Future<void> noReturn() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
+    final _$$selfRef = reference;
     final $r = _noReturn(
-            reference.pointer, _id_noReturn.pointer, _$continuation.pointer)
+            _$$selfRef.pointer, _id_noReturn.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
     jni$_.JObject $o;
@@ -37034,9 +37874,10 @@ core$_.Future<jni$_.JString> consumeOnAnotherThread(
 ) async {
   final $p = jni$_.ReceivePort();
   final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+  final _$$classRef = _SuspendFunKtClass.reference;
   final _$suspendInterface = suspendInterface.reference;
   final $r = _consumeOnAnotherThread(
-          _SuspendFunKtClass.reference.pointer,
+          _$$classRef.pointer,
           _id_consumeOnAnotherThread.pointer,
           _$suspendInterface.pointer,
           _$continuation.pointer)
@@ -37091,9 +37932,10 @@ core$_.Future<jni$_.JString> consumeOnSameThread(
 ) async {
   final $p = jni$_.ReceivePort();
   final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+  final _$$classRef = _SuspendFunKtClass.reference;
   final _$suspendInterface = suspendInterface.reference;
   final $r = _consumeOnSameThread(
-          _SuspendFunKtClass.reference.pointer,
+          _$$classRef.pointer,
           _id_consumeOnSameThread.pointer,
           _$suspendInterface.pointer,
           _$continuation.pointer)
@@ -37320,9 +38162,9 @@ extension SuspendInterface$$Methods on SuspendInterface {
   core$_.Future<jni$_.JString> sayHello() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
+    final _$$selfRef = reference;
     final $r = _sayHello(
-            reference.pointer, _id_sayHello.pointer, _$continuation.pointer)
+            _$$selfRef.pointer, _id_sayHello.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
     jni$_.JObject $o;
@@ -37377,8 +38219,9 @@ extension SuspendInterface$$Methods on SuspendInterface {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$string = string.reference;
-    final $r = _sayHello$1(reference.pointer, _id_sayHello$1.pointer,
+    final $r = _sayHello$1(_$$selfRef.pointer, _id_sayHello$1.pointer,
             _$string.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -37429,8 +38272,8 @@ extension SuspendInterface$$Methods on SuspendInterface {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _nullableHello(reference.pointer, _id_nullableHello.pointer,
+    final _$$selfRef = reference;
+    final $r = _nullableHello(_$$selfRef.pointer, _id_nullableHello.pointer,
             z ? 1 : 0, _$continuation.pointer)
         .object<jni$_.JObject?>();
     _$continuation.release();
@@ -37480,9 +38323,9 @@ extension SuspendInterface$$Methods on SuspendInterface {
   core$_.Future<jni$_.JInteger> sayInt() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
+    final _$$selfRef = reference;
     final $r =
-        _sayInt(reference.pointer, _id_sayInt.pointer, _$continuation.pointer)
+        _sayInt(_$$selfRef.pointer, _id_sayInt.pointer, _$continuation.pointer)
             .object<jni$_.JObject>();
     _$continuation.release();
     jni$_.JObject $o;
@@ -37537,8 +38380,9 @@ extension SuspendInterface$$Methods on SuspendInterface {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$integer = integer.reference;
-    final $r = _sayInt$1(reference.pointer, _id_sayInt$1.pointer,
+    final $r = _sayInt$1(_$$selfRef.pointer, _id_sayInt$1.pointer,
             _$integer.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
@@ -37589,8 +38433,8 @@ extension SuspendInterface$$Methods on SuspendInterface {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
-    final $r = _nullableInt(reference.pointer, _id_nullableInt.pointer,
+    final _$$selfRef = reference;
+    final $r = _nullableInt(_$$selfRef.pointer, _id_nullableInt.pointer,
             z ? 1 : 0, _$continuation.pointer)
         .object<jni$_.JObject?>();
     _$continuation.release();
@@ -37648,8 +38492,9 @@ extension SuspendInterface$$Methods on SuspendInterface {
   ) async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    final $r = _nullableList(reference.pointer, _id_nullableList.pointer,
+    final $r = _nullableList(_$$selfRef.pointer, _id_nullableList.pointer,
             _$list.pointer, _$continuation.pointer)
         .object<jni$_.JObject?>();
     _$continuation.release();
@@ -37699,9 +38544,9 @@ extension SuspendInterface$$Methods on SuspendInterface {
   core$_.Future<void> noReturn() async {
     final $p = jni$_.ReceivePort();
     final _$continuation = jni$_.ProtectedJniExtensions.newPortContinuation($p);
-
+    final _$$selfRef = reference;
     final $r = _noReturn(
-            reference.pointer, _id_noReturn.pointer, _$continuation.pointer)
+            _$$selfRef.pointer, _id_noReturn.pointer, _$continuation.pointer)
         .object<jni$_.JObject>();
     _$continuation.release();
     jni$_.JObject $o;
@@ -37853,8 +38698,8 @@ final _get$topLevelField = jni$_.ProtectedJniExtensions.lookup<
 
 /// from: `static public final int getTopLevelField()`
 core$_.int get topLevelField {
-  return _get$topLevelField(
-          _TopLevelKtClass.reference.pointer, _id_get$topLevelField.pointer)
+  final _$$classRef = _TopLevelKtClass.reference;
+  return _get$topLevelField(_$$classRef.pointer, _id_get$topLevelField.pointer)
       .integer;
 }
 
@@ -37874,8 +38719,8 @@ final _set$topLevelField = jni$_.ProtectedJniExtensions.lookup<
 
 /// from: `static public final void setTopLevelField(int i)`
 set topLevelField(core$_.int i) {
-  _set$topLevelField(
-          _TopLevelKtClass.reference.pointer, _id_set$topLevelField.pointer, i)
+  final _$$classRef = _TopLevelKtClass.reference;
+  _set$topLevelField(_$$classRef.pointer, _id_set$topLevelField.pointer, i)
       .check();
 }
 
@@ -37898,8 +38743,8 @@ final _topLevel = jni$_.ProtectedJniExtensions.lookup<
 
 /// from: `public fun topLevel(): kotlin.Int`
 core$_.int topLevel() {
-  return _topLevel(_TopLevelKtClass.reference.pointer, _id_topLevel.pointer)
-      .integer;
+  final _$$classRef = _TopLevelKtClass.reference;
+  return _topLevel(_$$classRef.pointer, _id_topLevel.pointer).integer;
 }
 
 final _id_topLevelSum = _TopLevelKtClass.staticMethodId(
@@ -37923,8 +38768,8 @@ core$_.int topLevelSum(
   core$_.int i,
   core$_.int i1,
 ) {
-  return _topLevelSum(
-          _TopLevelKtClass.reference.pointer, _id_topLevelSum.pointer, i, i1)
+  final _$$classRef = _TopLevelKtClass.reference;
+  return _topLevelSum(_$$classRef.pointer, _id_topLevelSum.pointer, i, i1)
       .integer;
 }
 
@@ -37950,8 +38795,9 @@ final _get$topLevelField$1 = jni$_.ProtectedJniExtensions.lookup<
 
 /// from: `static public final int getTopLevelField()`
 core$_.int get topLevelField$1 {
+  final _$$classRef = _TopLevelKt$1Class.reference;
   return _get$topLevelField$1(
-          _TopLevelKt$1Class.reference.pointer, _id_get$topLevelField$1.pointer)
+          _$$classRef.pointer, _id_get$topLevelField$1.pointer)
       .integer;
 }
 
@@ -37971,8 +38817,8 @@ final _set$topLevelField$1 = jni$_.ProtectedJniExtensions.lookup<
 
 /// from: `static public final void setTopLevelField(int i)`
 set topLevelField$1(core$_.int i) {
-  _set$topLevelField$1(_TopLevelKt$1Class.reference.pointer,
-          _id_set$topLevelField$1.pointer, i)
+  final _$$classRef = _TopLevelKt$1Class.reference;
+  _set$topLevelField$1(_$$classRef.pointer, _id_set$topLevelField$1.pointer, i)
       .check();
 }
 
@@ -37995,7 +38841,6 @@ final _topLevel$1 = jni$_.ProtectedJniExtensions.lookup<
 
 /// from: `public fun topLevel(): kotlin.Int`
 core$_.int topLevel$1() {
-  return _topLevel$1(
-          _TopLevelKt$1Class.reference.pointer, _id_topLevel$1.pointer)
-      .integer;
+  final _$$classRef = _TopLevelKt$1Class.reference;
+  return _topLevel$1(_$$classRef.pointer, _id_topLevel$1.pointer).integer;
 }

--- a/pkgs/jnigen/test/large_java_test/lib/large_bindings.dart
+++ b/pkgs/jnigen/test/large_java_test/lib/large_bindings.dart
@@ -144,7 +144,8 @@ extension BaseInterface$$Methods on BaseInterface {
 
   /// from: `public abstract void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 }
 
@@ -225,7 +226,8 @@ extension type CustomEnum._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public com.example.CustomEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<CustomEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<CustomEnum?>?>();
   }
 
@@ -250,9 +252,9 @@ extension type CustomEnum._(jni$_.JObject _$this) implements jni$_.JObject {
   static CustomEnum? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<CustomEnum?>();
   }
 }
@@ -374,7 +376,8 @@ extension CustomInterface$$Methods<$T extends jni$_.JObject?>
   /// from: `public abstract T getValue()`
   /// The returned object must be released after use, by calling the [release] method.
   $T? getValue() {
-    return _getValue(reference.pointer, _id_getValue.pointer).object<$T?>();
+    final _$$selfRef = reference;
+    return _getValue(_$$selfRef.pointer, _id_getValue.pointer).object<$T?>();
   }
 }
 
@@ -435,8 +438,9 @@ extension type CustomObject<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   factory CustomObject(
     $T? value,
   ) {
+    final _$$classRef = _class.reference;
     final _$value = value?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer, _$value.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$value.pointer)
         .object<CustomObject<$T>>();
   }
 }
@@ -571,7 +575,8 @@ extension DagA$$Methods on DagA {
 
   /// from: `public abstract void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 }
 
@@ -719,7 +724,8 @@ extension DagB$$Methods on DagB {
 
   /// from: `public abstract void bMethod()`
   void bMethod() {
-    _bMethod(reference.pointer, _id_bMethod.pointer).check();
+    final _$$selfRef = reference;
+    _bMethod(_$$selfRef.pointer, _id_bMethod.pointer).check();
   }
 
   static final _id_aMethod = DagB._class.instanceMethodId(
@@ -741,7 +747,8 @@ extension DagB$$Methods on DagB {
 
   /// from: `public abstract void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 }
 
@@ -908,7 +915,8 @@ extension DagC$$Methods on DagC {
 
   /// from: `public abstract void cMethod()`
   void cMethod() {
-    _cMethod(reference.pointer, _id_cMethod.pointer).check();
+    final _$$selfRef = reference;
+    _cMethod(_$$selfRef.pointer, _id_cMethod.pointer).check();
   }
 
   static final _id_aMethod = DagC._class.instanceMethodId(
@@ -930,7 +938,8 @@ extension DagC$$Methods on DagC {
 
   /// from: `public abstract void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 
   static final _id_bMethod = DagC._class.instanceMethodId(
@@ -952,7 +961,8 @@ extension DagC$$Methods on DagC {
 
   /// from: `public abstract void bMethod()`
   void bMethod() {
-    _bMethod(reference.pointer, _id_bMethod.pointer).check();
+    final _$$selfRef = reference;
+    _bMethod(_$$selfRef.pointer, _id_bMethod.pointer).check();
   }
 }
 
@@ -1137,7 +1147,8 @@ extension DagD$$Methods on DagD {
 
   /// from: `public abstract void dMethod()`
   void dMethod() {
-    _dMethod(reference.pointer, _id_dMethod.pointer).check();
+    final _$$selfRef = reference;
+    _dMethod(_$$selfRef.pointer, _id_dMethod.pointer).check();
   }
 
   static final _id_aMethod = DagD._class.instanceMethodId(
@@ -1159,7 +1170,8 @@ extension DagD$$Methods on DagD {
 
   /// from: `public abstract void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 
   static final _id_bMethod = DagD._class.instanceMethodId(
@@ -1181,7 +1193,8 @@ extension DagD$$Methods on DagD {
 
   /// from: `public abstract void bMethod()`
   void bMethod() {
-    _bMethod(reference.pointer, _id_bMethod.pointer).check();
+    final _$$selfRef = reference;
+    _bMethod(_$$selfRef.pointer, _id_bMethod.pointer).check();
   }
 
   static final _id_cMethod = DagD._class.instanceMethodId(
@@ -1203,7 +1216,8 @@ extension DagD$$Methods on DagD {
 
   /// from: `public abstract void cMethod()`
   void cMethod() {
-    _cMethod(reference.pointer, _id_cMethod.pointer).check();
+    final _$$selfRef = reference;
+    _cMethod(_$$selfRef.pointer, _id_cMethod.pointer).check();
   }
 }
 
@@ -1406,7 +1420,8 @@ extension DagE$$Methods on DagE {
 
   /// from: `public abstract void eMethod()`
   void eMethod() {
-    _eMethod(reference.pointer, _id_eMethod.pointer).check();
+    final _$$selfRef = reference;
+    _eMethod(_$$selfRef.pointer, _id_eMethod.pointer).check();
   }
 
   static final _id_bMethod = DagE._class.instanceMethodId(
@@ -1428,7 +1443,8 @@ extension DagE$$Methods on DagE {
 
   /// from: `public abstract void bMethod()`
   void bMethod() {
-    _bMethod(reference.pointer, _id_bMethod.pointer).check();
+    final _$$selfRef = reference;
+    _bMethod(_$$selfRef.pointer, _id_bMethod.pointer).check();
   }
 
   static final _id_aMethod = DagE._class.instanceMethodId(
@@ -1450,7 +1466,8 @@ extension DagE$$Methods on DagE {
 
   /// from: `public abstract void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 
   static final _id_dMethod = DagE._class.instanceMethodId(
@@ -1472,7 +1489,8 @@ extension DagE$$Methods on DagE {
 
   /// from: `public abstract void dMethod()`
   void dMethod() {
-    _dMethod(reference.pointer, _id_dMethod.pointer).check();
+    final _$$selfRef = reference;
+    _dMethod(_$$selfRef.pointer, _id_dMethod.pointer).check();
   }
 
   static final _id_cMethod = DagE._class.instanceMethodId(
@@ -1494,7 +1512,8 @@ extension DagE$$Methods on DagE {
 
   /// from: `public abstract void cMethod()`
   void cMethod() {
-    _cMethod(reference.pointer, _id_cMethod.pointer).check();
+    final _$$selfRef = reference;
+    _cMethod(_$$selfRef.pointer, _id_cMethod.pointer).check();
   }
 }
 
@@ -1695,7 +1714,8 @@ extension DiamondLeft$$Methods on DiamondLeft {
 
   /// from: `public abstract void leftMethod()`
   void leftMethod() {
-    _leftMethod(reference.pointer, _id_leftMethod.pointer).check();
+    final _$$selfRef = reference;
+    _leftMethod(_$$selfRef.pointer, _id_leftMethod.pointer).check();
   }
 
   static final _id_baseMethod = DiamondLeft._class.instanceMethodId(
@@ -1717,7 +1737,8 @@ extension DiamondLeft$$Methods on DiamondLeft {
 
   /// from: `default public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 }
 
@@ -1879,7 +1900,8 @@ extension DiamondRight$$Methods on DiamondRight {
 
   /// from: `public abstract void rightMethod()`
   void rightMethod() {
-    _rightMethod(reference.pointer, _id_rightMethod.pointer).check();
+    final _$$selfRef = reference;
+    _rightMethod(_$$selfRef.pointer, _id_rightMethod.pointer).check();
   }
 
   static final _id_baseMethod = DiamondRight._class.instanceMethodId(
@@ -1901,7 +1923,8 @@ extension DiamondRight$$Methods on DiamondRight {
 
   /// from: `default public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 }
 
@@ -2064,9 +2087,10 @@ extension GenericInterface$$Methods<$T extends jni$_.JObject?>
   $T? genericInterfaceMethod(
     $T? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     return _genericInterfaceMethod(
-            reference.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
         .object<$T?>();
   }
 }
@@ -2127,7 +2151,8 @@ extension type GenericParent<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory GenericParent() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<GenericParent<$T>>();
   }
 }
@@ -2154,9 +2179,10 @@ extension GenericParent$$Methods<$T extends jni$_.JObject?>
   void genericParentMethod(
     $T? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod(
-            reference.pointer, _id_genericParentMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod.pointer, _$t.pointer)
         .check();
   }
 }
@@ -2195,8 +2221,8 @@ extension type GrandParent._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory GrandParent() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<GrandParent>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<GrandParent>();
   }
 }
 
@@ -2220,7 +2246,8 @@ extension GrandParent$$Methods on GrandParent {
 
   /// from: `public void grandParentMethod()`
   void grandParentMethod() {
-    _grandParentMethod(reference.pointer, _id_grandParentMethod.pointer)
+    final _$$selfRef = reference;
+    _grandParentMethod(_$$selfRef.pointer, _id_grandParentMethod.pointer)
         .check();
   }
 }
@@ -2261,7 +2288,8 @@ extension type NestedCustom<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory NestedCustom() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<NestedCustom<$T, $U>>();
   }
 }
@@ -2305,9 +2333,9 @@ extension type NestedCustom$Nested<$T extends jni$_.JObject?,
   factory NestedCustom$Nested(
     NestedCustom<$T?, $U?> $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<NestedCustom$Nested<$T, $U, $V>>();
   }
 }
@@ -2470,7 +2498,8 @@ extension OtherInterface$$Methods on OtherInterface {
 
   /// from: `public abstract void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 }
@@ -2535,7 +2564,8 @@ extension type TestClass000<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass000() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass000<$T, $U>>();
   }
 }
@@ -2561,7 +2591,8 @@ extension TestClass000$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -2586,8 +2617,9 @@ extension TestClass000$$Methods<$T extends jni$_.JObject?,
   jni$_.JFloatArray? setFoo<$S extends jni$_.JObject?>(
     jni$_.JFloatArray? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _setFoo(reference.pointer, _id_setFoo.pointer, _$p1.pointer)
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer, _$p1.pointer)
         .object<jni$_.JFloatArray?>();
   }
 }
@@ -2629,7 +2661,8 @@ extension type TestClass000$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass000$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass000$Nested>();
   }
 }
@@ -2757,8 +2790,9 @@ extension TestClass001$$Methods<$T extends jni$_.JObject> on TestClass001<$T> {
     jni$_.JSet<$T>? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _isFoo(reference.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JSet<$T>?>();
   }
 }
@@ -2825,7 +2859,8 @@ extension type TestClass001$Sub<$T extends jni$_.JObject>._(
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass001$Sub() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass001$Sub<$T>>();
   }
 }
@@ -2855,8 +2890,9 @@ extension TestClass001$Sub$$Methods<$T extends jni$_.JObject>
     jni$_.JSet<$T>? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _isFoo(reference.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JSet<$T>?>();
   }
 }
@@ -3090,7 +3126,8 @@ extension TestClass002$$Methods on TestClass002 {
 
   /// from: `default public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_leftMethod = TestClass002._class.instanceMethodId(
@@ -3112,7 +3149,8 @@ extension TestClass002$$Methods on TestClass002 {
 
   /// from: `default public void leftMethod()`
   void leftMethod() {
-    _leftMethod(reference.pointer, _id_leftMethod.pointer).check();
+    final _$$selfRef = reference;
+    _leftMethod(_$$selfRef.pointer, _id_leftMethod.pointer).check();
   }
 
   static final _id_rightMethod = TestClass002._class.instanceMethodId(
@@ -3134,7 +3172,8 @@ extension TestClass002$$Methods on TestClass002 {
 
   /// from: `default public void rightMethod()`
   void rightMethod() {
-    _rightMethod(reference.pointer, _id_rightMethod.pointer).check();
+    final _$$selfRef = reference;
+    _rightMethod(_$$selfRef.pointer, _id_rightMethod.pointer).check();
   }
 
   static final _id_myMethod = TestClass002._class.instanceMethodId(
@@ -3158,7 +3197,8 @@ extension TestClass002$$Methods on TestClass002 {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JArray<jni$_.JMap<$S, $S>>?
       myMethod<$S extends jni$_.JObject, $V extends jni$_.JObject>() {
-    return _myMethod(reference.pointer, _id_myMethod.pointer)
+    final _$$selfRef = reference;
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer)
         .object<jni$_.JArray<jni$_.JMap<$S, $S>>?>();
   }
 }
@@ -3278,7 +3318,8 @@ extension type TestClass003._(jni$_.JObject _$this)
   /// from: `static public com.example.TestClass003[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass003?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass003?>?>();
   }
 
@@ -3303,9 +3344,9 @@ extension type TestClass003._(jni$_.JObject _$this)
   static TestClass003? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass003?>();
   }
 }
@@ -3330,7 +3371,8 @@ extension TestClass003$$Methods on TestClass003 {
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -3357,8 +3399,9 @@ extension TestClass003$$Methods on TestClass003 {
     $S? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _getFoo(reference.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
         .object<$S?>();
   }
 }
@@ -3401,9 +3444,9 @@ extension type TestClass003$Nested._(jni$_.JObject _$this)
   factory TestClass003$Nested(
     TestClass003 $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass003$Nested>();
   }
 }
@@ -3448,9 +3491,9 @@ extension type TestClass004<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
     jni$_.JIntArray p1,
     core$_.int p2,
   ) {
+    final _$$classRef = _class.reference;
     final _$p1 = p1.reference;
-    return _setFoo(
-            _class.reference.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
+    return _setFoo(_$$classRef.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JIntArray>();
   }
 
@@ -3581,7 +3624,8 @@ extension TestClass004$$Methods<$T extends jni$_.JObject?> on TestClass004<$T> {
 
   /// from: `default public void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 
   static final _id_bMethod = TestClass004._class.instanceMethodId(
@@ -3603,7 +3647,8 @@ extension TestClass004$$Methods<$T extends jni$_.JObject?> on TestClass004<$T> {
 
   /// from: `default public void bMethod()`
   void bMethod() {
-    _bMethod(reference.pointer, _id_bMethod.pointer).check();
+    final _$$selfRef = reference;
+    _bMethod(_$$selfRef.pointer, _id_bMethod.pointer).check();
   }
 
   static final _id_cMethod = TestClass004._class.instanceMethodId(
@@ -3625,7 +3670,8 @@ extension TestClass004$$Methods<$T extends jni$_.JObject?> on TestClass004<$T> {
 
   /// from: `default public void cMethod()`
   void cMethod() {
-    _cMethod(reference.pointer, _id_cMethod.pointer).check();
+    final _$$selfRef = reference;
+    _cMethod(_$$selfRef.pointer, _id_cMethod.pointer).check();
   }
 
   static final _id_dMethod = TestClass004._class.instanceMethodId(
@@ -3647,7 +3693,8 @@ extension TestClass004$$Methods<$T extends jni$_.JObject?> on TestClass004<$T> {
 
   /// from: `default public void dMethod()`
   void dMethod() {
-    _dMethod(reference.pointer, _id_dMethod.pointer).check();
+    final _$$selfRef = reference;
+    _dMethod(_$$selfRef.pointer, _id_dMethod.pointer).check();
   }
 
   static final _id_eMethod = TestClass004._class.instanceMethodId(
@@ -3669,7 +3716,8 @@ extension TestClass004$$Methods<$T extends jni$_.JObject?> on TestClass004<$T> {
 
   /// from: `default public void eMethod()`
   void eMethod() {
-    _eMethod(reference.pointer, _id_eMethod.pointer).check();
+    final _$$selfRef = reference;
+    _eMethod(_$$selfRef.pointer, _id_eMethod.pointer).check();
   }
 }
 
@@ -3807,7 +3855,8 @@ extension type TestClass004$NestedEnum._(jni$_.JObject _$this)
   /// from: `static public com.example.TestClass004$NestedEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass004$NestedEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass004$NestedEnum?>?>();
   }
 
@@ -3832,9 +3881,9 @@ extension type TestClass004$NestedEnum._(jni$_.JObject _$this)
   static TestClass004$NestedEnum? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass004$NestedEnum?>();
   }
 }
@@ -3876,7 +3925,8 @@ extension type TestClass005<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass005() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass005<$T, $U>>();
   }
 }
@@ -3903,9 +3953,10 @@ extension TestClass005$$Methods<$T extends jni$_.JObject?,
   void genericParentMethod$1(
     jni$_.JString? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod$1(
-            reference.pointer, _id_genericParentMethod$1.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod$1.pointer, _$t.pointer)
         .check();
   }
 
@@ -3930,8 +3981,9 @@ extension TestClass005$$Methods<$T extends jni$_.JObject?,
   jni$_.JString setFoo<$S extends jni$_.JObject?>(
     jni$_.JString p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1.reference;
-    return _setFoo(reference.pointer, _id_setFoo.pointer, _$p1.pointer)
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer, _$p1.pointer)
         .object<jni$_.JString>();
   }
 }
@@ -3970,8 +4022,8 @@ extension type TestClass006._(jni$_.JObject _$this) implements GrandParent {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass006() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<TestClass006>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<TestClass006>();
   }
 }
 
@@ -3995,7 +4047,8 @@ extension TestClass006$$Methods on TestClass006 {
 
   /// from: `public void grandParentMethod()`
   void grandParentMethod() {
-    _grandParentMethod(reference.pointer, _id_grandParentMethod.pointer)
+    final _$$selfRef = reference;
+    _grandParentMethod(_$$selfRef.pointer, _id_grandParentMethod.pointer)
         .check();
   }
 
@@ -4020,8 +4073,9 @@ extension TestClass006$$Methods on TestClass006 {
   jni$_.JBooleanArray? setFoo<$S extends jni$_.JObject?>(
     jni$_.JBooleanArray? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _setFoo(reference.pointer, _id_setFoo.pointer, _$p1.pointer)
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer, _$p1.pointer)
         .object<jni$_.JBooleanArray?>();
   }
 }
@@ -4064,9 +4118,9 @@ extension type TestClass006$Nested._(jni$_.JObject _$this)
   factory TestClass006$Nested(
     TestClass006 $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass006$Nested>();
   }
 }
@@ -4107,7 +4161,8 @@ extension type TestClass007<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass007() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass007<$T>>();
   }
 }
@@ -4132,7 +4187,8 @@ extension TestClass007$$Methods<$T extends jni$_.JObject?> on TestClass007<$T> {
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -4155,7 +4211,8 @@ extension TestClass007$$Methods<$T extends jni$_.JObject?> on TestClass007<$T> {
 
   /// from: `public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_getFoo = TestClass007._class.instanceMethodId(
@@ -4181,8 +4238,9 @@ extension TestClass007$$Methods<$T extends jni$_.JObject?> on TestClass007<$T> {
     jni$_.JObject p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1.reference;
-    return _getFoo(reference.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JObject>();
   }
 }
@@ -4225,9 +4283,9 @@ extension type TestClass007$Nested<$T extends jni$_.JObject?>._(
   factory TestClass007$Nested(
     TestClass007<$T?> $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass007$Nested<$T>>();
   }
 }
@@ -4272,9 +4330,10 @@ extension TestClass008$$Methods<$T extends jni$_.JObject> on TestClass008<$T> {
   void genericParentMethod(
     jni$_.JObject? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod(
-            reference.pointer, _id_genericParentMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod.pointer, _$t.pointer)
         .check();
   }
 
@@ -4297,7 +4356,8 @@ extension TestClass008$$Methods<$T extends jni$_.JObject> on TestClass008<$T> {
 
   /// from: `public abstract void myMethod()`
   void myMethod() {
-    _myMethod(reference.pointer, _id_myMethod.pointer).check();
+    final _$$selfRef = reference;
+    _myMethod(_$$selfRef.pointer, _id_myMethod.pointer).check();
   }
 }
 
@@ -4434,7 +4494,8 @@ extension type TestClass009<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass009() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass009<$T>>();
   }
 }
@@ -4460,9 +4521,10 @@ extension TestClass009$$Methods<$T extends jni$_.JObject> on TestClass009<$T> {
   void genericParentMethod$1(
     jni$_.JString? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod$1(
-            reference.pointer, _id_genericParentMethod$1.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod$1.pointer, _$t.pointer)
         .check();
   }
 
@@ -4487,7 +4549,8 @@ extension TestClass009$$Methods<$T extends jni$_.JObject> on TestClass009<$T> {
     core$_.int p1,
     core$_.int p2,
   ) {
-    return _getFoo(reference.pointer, _id_getFoo.pointer, p1, p2).char;
+    final _$$selfRef = reference;
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer, p1, p2).char;
   }
 }
 
@@ -4526,7 +4589,8 @@ extension type TestClass011<$T extends jni$_.JObject,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass011() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass011<$T, $U>>();
   }
 }
@@ -4587,7 +4651,8 @@ extension type TestClass011$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass011$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass011$Nested>();
   }
 }
@@ -4724,7 +4789,8 @@ extension TestClass012$$Methods<$T extends jni$_.JObject,
 
   /// from: `default public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -4747,7 +4813,8 @@ extension TestClass012$$Methods<$T extends jni$_.JObject,
 
   /// from: `default public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_isFoo = TestClass012._class.instanceMethodId(
@@ -4773,8 +4840,9 @@ extension TestClass012$$Methods<$T extends jni$_.JObject,
     jni$_.JArray<CustomEnum?>? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _isFoo(reference.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JArray<CustomEnum?>?>();
   }
 }
@@ -4871,7 +4939,8 @@ extension type TestClass012$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass012$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass012$Nested>();
   }
 }
@@ -4912,7 +4981,8 @@ extension type TestClass013<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass013() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass013<$T>>();
   }
 }
@@ -4937,7 +5007,8 @@ extension TestClass013$$Methods<$T extends jni$_.JObject> on TestClass013<$T> {
 
   /// from: `public void grandParentMethod()`
   void grandParentMethod() {
-    _grandParentMethod(reference.pointer, _id_grandParentMethod.pointer)
+    final _$$selfRef = reference;
+    _grandParentMethod(_$$selfRef.pointer, _id_grandParentMethod.pointer)
         .check();
   }
 
@@ -4964,8 +5035,9 @@ extension TestClass013$$Methods<$T extends jni$_.JObject> on TestClass013<$T> {
     jni$_.JDoubleArray? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _setFoo(reference.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JDoubleArray?>();
   }
 }
@@ -5008,7 +5080,8 @@ extension TestClass014$$Methods<$T extends jni$_.JObject> on TestClass014<$T> {
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -5033,8 +5106,9 @@ extension TestClass014$$Methods<$T extends jni$_.JObject> on TestClass014<$T> {
   jni$_.JByteArray? getFoo<$S extends jni$_.JObject, $V extends jni$_.JObject>(
     jni$_.JByteArray? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _getFoo(reference.pointer, _id_getFoo.pointer, _$p1.pointer)
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer, _$p1.pointer)
         .object<jni$_.JByteArray?>();
   }
 }
@@ -5088,7 +5162,8 @@ extension type TestClass014$NestedEnum._(jni$_.JObject _$this)
   /// from: `static public com.example.TestClass014$NestedEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass014$NestedEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass014$NestedEnum?>?>();
   }
 
@@ -5113,9 +5188,9 @@ extension type TestClass014$NestedEnum._(jni$_.JObject _$this)
   static TestClass014$NestedEnum? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass014$NestedEnum?>();
   }
 }
@@ -5155,8 +5230,8 @@ extension type TestClass015._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass015() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<TestClass015>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<TestClass015>();
   }
 }
 
@@ -5184,8 +5259,9 @@ extension TestClass015$$Methods on TestClass015 {
     jni$_.JList<jni$_.JString?>? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _getFoo(reference.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JList<jni$_.JString?>?>();
   }
 }
@@ -5225,7 +5301,8 @@ extension type TestClass015$Sub._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass015$Sub() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass015$Sub>();
   }
 }
@@ -5268,9 +5345,9 @@ extension type TestClass015$Nested._(jni$_.JObject _$this)
   factory TestClass015$Nested(
     TestClass015 $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass015$Nested>();
   }
 }
@@ -5311,7 +5388,8 @@ extension type TestClass016<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass016() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass016<$T>>();
   }
 }
@@ -5337,7 +5415,8 @@ extension TestClass016$$Methods<$T extends jni$_.JObject?> on TestClass016<$T> {
   /// from: `synchronized public T[] getFoo()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JArray<$T?>? getFoo<$S extends jni$_.JObject?>() {
-    return _getFoo(reference.pointer, _id_getFoo.pointer)
+    final _$$selfRef = reference;
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer)
         .object<jni$_.JArray<$T?>?>();
   }
 }
@@ -5573,9 +5652,10 @@ extension TestClass017$$Methods<$T extends jni$_.JObject> on TestClass017<$T> {
   jni$_.JObject? genericInterfaceMethod(
     jni$_.JObject? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     return _genericInterfaceMethod(
-            reference.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -5602,8 +5682,9 @@ extension TestClass017$$Methods<$T extends jni$_.JObject> on TestClass017<$T> {
     CustomObject<$S> p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1.reference;
-    return _setFoo(reference.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
         .object<CustomObject<$S>>();
   }
 }
@@ -5778,7 +5859,8 @@ extension type TestClass018<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass018() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass018<$T, $U>>();
   }
 }
@@ -5805,9 +5887,10 @@ extension TestClass018$$Methods<$T extends jni$_.JObject?,
   void genericParentMethod(
     jni$_.JObject? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod(
-            reference.pointer, _id_genericParentMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod.pointer, _$t.pointer)
         .check();
   }
 
@@ -5835,8 +5918,9 @@ extension TestClass018$$Methods<$T extends jni$_.JObject?,
     jni$_.JArray<CustomInterface<$S?>>? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _setFoo(reference.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JArray<CustomInterface<$S?>>?>();
   }
 }
@@ -5890,7 +5974,8 @@ extension type TestClass018$NestedEnum._(jni$_.JObject _$this)
   /// from: `static public com.example.TestClass018$NestedEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass018$NestedEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass018$NestedEnum?>?>();
   }
 
@@ -5915,9 +6000,9 @@ extension type TestClass018$NestedEnum._(jni$_.JObject _$this)
   static TestClass018$NestedEnum? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass018$NestedEnum?>();
   }
 }
@@ -5958,7 +6043,8 @@ extension type TestClass019<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass019() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass019<$T>>();
   }
 }
@@ -5987,8 +6073,9 @@ extension TestClass019$$Methods<$T extends jni$_.JObject?> on TestClass019<$T> {
     jni$_.JArray<jni$_.JObject?>? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _getFoo(reference.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JArray<jni$_.JObject?>?>();
   }
 }
@@ -6109,7 +6196,8 @@ extension TestClass020$$Methods<$T extends jni$_.JObject> on TestClass020<$T> {
   /// from: `public abstract com.example.NestedCustom$Nested<S, S, S> isFoo()`
   /// The returned object must be released after use, by calling the [release] method.
   NestedCustom$Nested<$S, $S, $S>? isFoo<$S extends jni$_.JObject>() {
-    return _isFoo(reference.pointer, _id_isFoo.pointer)
+    final _$$selfRef = reference;
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer)
         .object<NestedCustom$Nested<$S, $S, $S>?>();
   }
 }
@@ -6176,7 +6264,8 @@ extension type TestClass020$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass020$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass020$Nested>();
   }
 }
@@ -6217,8 +6306,8 @@ extension type TestClass021._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass021() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<TestClass021>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<TestClass021>();
   }
 }
 
@@ -6242,7 +6331,8 @@ extension TestClass021$$Methods on TestClass021 {
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -6267,8 +6357,9 @@ extension TestClass021$$Methods on TestClass021 {
   jni$_.JMap<$S?, $S?>? setFoo<$S extends jni$_.JObject?>(
     jni$_.JMap<$S?, $S?>? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _setFoo(reference.pointer, _id_setFoo.pointer, _$p1.pointer)
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer, _$p1.pointer)
         .object<jni$_.JMap<$S?, $S?>?>();
   }
 }
@@ -6309,7 +6400,8 @@ extension type TestClass022<$T extends jni$_.JObject,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass022() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass022<$T, $U>>();
   }
 }
@@ -6335,7 +6427,8 @@ extension TestClass022$$Methods<$T extends jni$_.JObject,
 
   /// from: `public void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 
   static final _id_bMethod = TestClass022._class.instanceMethodId(
@@ -6357,7 +6450,8 @@ extension TestClass022$$Methods<$T extends jni$_.JObject,
 
   /// from: `public void bMethod()`
   void bMethod() {
-    _bMethod(reference.pointer, _id_bMethod.pointer).check();
+    final _$$selfRef = reference;
+    _bMethod(_$$selfRef.pointer, _id_bMethod.pointer).check();
   }
 
   static final _id_cMethod = TestClass022._class.instanceMethodId(
@@ -6379,7 +6473,8 @@ extension TestClass022$$Methods<$T extends jni$_.JObject,
 
   /// from: `public void cMethod()`
   void cMethod() {
-    _cMethod(reference.pointer, _id_cMethod.pointer).check();
+    final _$$selfRef = reference;
+    _cMethod(_$$selfRef.pointer, _id_cMethod.pointer).check();
   }
 
   static final _id_dMethod = TestClass022._class.instanceMethodId(
@@ -6401,7 +6496,8 @@ extension TestClass022$$Methods<$T extends jni$_.JObject,
 
   /// from: `public void dMethod()`
   void dMethod() {
-    _dMethod(reference.pointer, _id_dMethod.pointer).check();
+    final _$$selfRef = reference;
+    _dMethod(_$$selfRef.pointer, _id_dMethod.pointer).check();
   }
 
   static final _id_eMethod = TestClass022._class.instanceMethodId(
@@ -6423,7 +6519,8 @@ extension TestClass022$$Methods<$T extends jni$_.JObject,
 
   /// from: `public void eMethod()`
   void eMethod() {
-    _eMethod(reference.pointer, _id_eMethod.pointer).check();
+    final _$$selfRef = reference;
+    _eMethod(_$$selfRef.pointer, _id_eMethod.pointer).check();
   }
 
   static final _id_isFoo = TestClass022._class.instanceMethodId(
@@ -6447,7 +6544,8 @@ extension TestClass022$$Methods<$T extends jni$_.JObject,
     core$_.int p1,
     core$_.int p2,
   ) {
-    return _isFoo(reference.pointer, _id_isFoo.pointer, p1, p2).short;
+    final _$$selfRef = reference;
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, p1, p2).short;
   }
 }
 
@@ -6588,7 +6686,8 @@ extension TestClass023$$Methods<$T extends jni$_.JObject,
 
   /// from: `default public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_leftMethod = TestClass023._class.instanceMethodId(
@@ -6610,7 +6709,8 @@ extension TestClass023$$Methods<$T extends jni$_.JObject,
 
   /// from: `default public void leftMethod()`
   void leftMethod() {
-    _leftMethod(reference.pointer, _id_leftMethod.pointer).check();
+    final _$$selfRef = reference;
+    _leftMethod(_$$selfRef.pointer, _id_leftMethod.pointer).check();
   }
 
   static final _id_rightMethod = TestClass023._class.instanceMethodId(
@@ -6632,7 +6732,8 @@ extension TestClass023$$Methods<$T extends jni$_.JObject,
 
   /// from: `default public void rightMethod()`
   void rightMethod() {
-    _rightMethod(reference.pointer, _id_rightMethod.pointer).check();
+    final _$$selfRef = reference;
+    _rightMethod(_$$selfRef.pointer, _id_rightMethod.pointer).check();
   }
 
   static final _id_getFoo = TestClass023._class.instanceMethodId(
@@ -6658,8 +6759,9 @@ extension TestClass023$$Methods<$T extends jni$_.JObject,
     jni$_.JArray<CustomObject<$S>>? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _getFoo(reference.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JArray<CustomObject<$S>>?>();
   }
 }
@@ -6767,8 +6869,8 @@ extension type TestClass024._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass024() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<TestClass024>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<TestClass024>();
   }
 
   static final _id_myMethod = _class.staticMethodId(
@@ -6792,7 +6894,8 @@ extension type TestClass024._(jni$_.JObject _$this)
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JShortArray?
       myMethod<$S extends jni$_.JObject, $V extends jni$_.JObject>() {
-    return _myMethod(_class.reference.pointer, _id_myMethod.pointer)
+    final _$$classRef = _class.reference;
+    return _myMethod(_$$classRef.pointer, _id_myMethod.pointer)
         .object<jni$_.JShortArray?>();
   }
 }
@@ -6817,7 +6920,8 @@ extension TestClass024$$Methods on TestClass024 {
 
   /// from: `public void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 
   static final _id_bMethod = TestClass024._class.instanceMethodId(
@@ -6839,7 +6943,8 @@ extension TestClass024$$Methods on TestClass024 {
 
   /// from: `public void bMethod()`
   void bMethod() {
-    _bMethod(reference.pointer, _id_bMethod.pointer).check();
+    final _$$selfRef = reference;
+    _bMethod(_$$selfRef.pointer, _id_bMethod.pointer).check();
   }
 
   static final _id_cMethod = TestClass024._class.instanceMethodId(
@@ -6861,7 +6966,8 @@ extension TestClass024$$Methods on TestClass024 {
 
   /// from: `public void cMethod()`
   void cMethod() {
-    _cMethod(reference.pointer, _id_cMethod.pointer).check();
+    final _$$selfRef = reference;
+    _cMethod(_$$selfRef.pointer, _id_cMethod.pointer).check();
   }
 
   static final _id_dMethod = TestClass024._class.instanceMethodId(
@@ -6883,7 +6989,8 @@ extension TestClass024$$Methods on TestClass024 {
 
   /// from: `public void dMethod()`
   void dMethod() {
-    _dMethod(reference.pointer, _id_dMethod.pointer).check();
+    final _$$selfRef = reference;
+    _dMethod(_$$selfRef.pointer, _id_dMethod.pointer).check();
   }
 
   static final _id_eMethod = TestClass024._class.instanceMethodId(
@@ -6905,7 +7012,8 @@ extension TestClass024$$Methods on TestClass024 {
 
   /// from: `public void eMethod()`
   void eMethod() {
-    _eMethod(reference.pointer, _id_eMethod.pointer).check();
+    final _$$selfRef = reference;
+    _eMethod(_$$selfRef.pointer, _id_eMethod.pointer).check();
   }
 }
 
@@ -6958,7 +7066,8 @@ extension type TestClass024$NestedEnum._(jni$_.JObject _$this)
   /// from: `static public com.example.TestClass024$NestedEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass024$NestedEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass024$NestedEnum?>?>();
   }
 
@@ -6983,9 +7092,9 @@ extension type TestClass024$NestedEnum._(jni$_.JObject _$this)
   static TestClass024$NestedEnum? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass024$NestedEnum?>();
   }
 }
@@ -7112,7 +7221,8 @@ extension TestClass025$$Methods<$T extends jni$_.JObject?> on TestClass025<$T> {
 
   /// from: `default public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -7136,7 +7246,8 @@ extension TestClass025$$Methods<$T extends jni$_.JObject?> on TestClass025<$T> {
   /// from: `public abstract java.util.Set<S> setFoo()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JSet<$S?> setFoo<$S extends jni$_.JObject?>() {
-    return _setFoo(reference.pointer, _id_setFoo.pointer)
+    final _$$selfRef = reference;
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer)
         .object<jni$_.JSet<$S?>>();
   }
 }
@@ -7223,7 +7334,8 @@ extension type TestClass025$NestedEnum._(jni$_.JObject _$this)
   /// from: `static public com.example.TestClass025$NestedEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass025$NestedEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass025$NestedEnum?>?>();
   }
 
@@ -7248,9 +7360,9 @@ extension type TestClass025$NestedEnum._(jni$_.JObject _$this)
   static TestClass025$NestedEnum? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass025$NestedEnum?>();
   }
 }
@@ -7291,7 +7403,8 @@ extension type TestClass026._(jni$_.JObject _$this) implements jni$_.JObject {
   /// The returned object must be released after use, by calling the [release] method.
   static TestClass026
       create<$S extends jni$_.JObject?, $V extends jni$_.JObject?>() {
-    return _create(_class.reference.pointer, _id_create.pointer)
+    final _$$classRef = _class.reference;
+    return _create(_$$classRef.pointer, _id_create.pointer)
         .object<TestClass026>();
   }
 }
@@ -7333,7 +7446,8 @@ extension type TestClass026$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass026$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass026$Nested>();
   }
 }
@@ -7374,7 +7488,8 @@ extension type TestClass027<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass027() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass027<$T, $U>>();
   }
 }
@@ -7400,7 +7515,8 @@ extension TestClass027$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void grandParentMethod()`
   void grandParentMethod() {
-    _grandParentMethod(reference.pointer, _id_grandParentMethod.pointer)
+    final _$$selfRef = reference;
+    _grandParentMethod(_$$selfRef.pointer, _id_grandParentMethod.pointer)
         .check();
   }
 
@@ -7425,8 +7541,9 @@ extension TestClass027$$Methods<$T extends jni$_.JObject?,
   jni$_.JObject? getFoo<$S extends jni$_.JObject?>(
     jni$_.JObject? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _getFoo(reference.pointer, _id_getFoo.pointer, _$p1.pointer)
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer, _$p1.pointer)
         .object<jni$_.JObject?>();
   }
 }
@@ -7565,7 +7682,8 @@ extension type TestClass028<$T extends jni$_.JObject,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass028() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass028<$T, $U>>();
   }
 }
@@ -7591,7 +7709,8 @@ extension TestClass028$$Methods<$T extends jni$_.JObject,
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -7615,7 +7734,8 @@ extension TestClass028$$Methods<$T extends jni$_.JObject,
   /// from: `public final int[] myMethod()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JIntArray? myMethod<$S extends jni$_.JObject>() {
-    return _myMethod(reference.pointer, _id_myMethod.pointer)
+    final _$$selfRef = reference;
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer)
         .object<jni$_.JIntArray?>();
   }
 }
@@ -7748,9 +7868,10 @@ extension TestClass029$$Methods on TestClass029 {
   jni$_.JString? genericInterfaceMethod(
     jni$_.JString? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     return _genericInterfaceMethod(
-            reference.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -7775,7 +7896,8 @@ extension TestClass029$$Methods on TestClass029 {
     core$_.int p1,
     core$_.int p2,
   ) {
-    return _isFoo(reference.pointer, _id_isFoo.pointer, p1, p2).byte;
+    final _$$selfRef = reference;
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, p1, p2).byte;
   }
 }
 
@@ -7845,7 +7967,8 @@ extension type TestClass029$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass029$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass029$Nested>();
   }
 }
@@ -7886,7 +8009,8 @@ extension type TestClass030<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass030() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass030<$T>>();
   }
 }
@@ -7912,7 +8036,8 @@ extension TestClass030$$Methods<$T extends jni$_.JObject?> on TestClass030<$T> {
   /// from: `public boolean[] myMethod()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JBooleanArray myMethod<$S extends jni$_.JObject?>() {
-    return _myMethod(reference.pointer, _id_myMethod.pointer)
+    final _$$selfRef = reference;
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer)
         .object<jni$_.JBooleanArray>();
   }
 }
@@ -7955,9 +8080,9 @@ extension type TestClass030$Nested<$T extends jni$_.JObject?>._(
   factory TestClass030$Nested(
     TestClass030<$T?> $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass030$Nested<$T>>();
   }
 }
@@ -8088,7 +8213,8 @@ extension TestClass031$$Methods on TestClass031 {
 
   /// from: `default public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -8115,8 +8241,9 @@ extension TestClass031$$Methods on TestClass031 {
     jni$_.JArray<CustomInterface<$S>?>? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _myMethod(reference.pointer, _id_myMethod.pointer, _$p1.pointer, p2)
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer, _$p1.pointer, p2)
         .object<jni$_.JArray<CustomInterface<$S>?>?>();
   }
 }
@@ -8198,7 +8325,8 @@ extension type TestClass031$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass031$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass031$Nested>();
   }
 }
@@ -8333,7 +8461,8 @@ extension TestClass032$$Methods<$T extends jni$_.JObject,
 
   /// from: `default public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_leftMethod = TestClass032._class.instanceMethodId(
@@ -8355,7 +8484,8 @@ extension TestClass032$$Methods<$T extends jni$_.JObject,
 
   /// from: `default public void leftMethod()`
   void leftMethod() {
-    _leftMethod(reference.pointer, _id_leftMethod.pointer).check();
+    final _$$selfRef = reference;
+    _leftMethod(_$$selfRef.pointer, _id_leftMethod.pointer).check();
   }
 
   static final _id_rightMethod = TestClass032._class.instanceMethodId(
@@ -8377,7 +8507,8 @@ extension TestClass032$$Methods<$T extends jni$_.JObject,
 
   /// from: `default public void rightMethod()`
   void rightMethod() {
-    _rightMethod(reference.pointer, _id_rightMethod.pointer).check();
+    final _$$selfRef = reference;
+    _rightMethod(_$$selfRef.pointer, _id_rightMethod.pointer).check();
   }
 
   static final _id_isFoo = TestClass032._class.instanceMethodId(
@@ -8399,7 +8530,8 @@ extension TestClass032$$Methods<$T extends jni$_.JObject,
 
   /// from: `public abstract boolean isFoo()`
   core$_.bool isFoo<$S extends jni$_.JObject, $V extends jni$_.JObject>() {
-    return _isFoo(reference.pointer, _id_isFoo.pointer).boolean;
+    final _$$selfRef = reference;
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer).boolean;
   }
 }
 
@@ -8498,7 +8630,8 @@ extension type TestClass033<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   static core$_.int isFoo<$S extends jni$_.JObject?>(
     core$_.int p1,
   ) {
-    return _isFoo(_class.reference.pointer, _id_isFoo.pointer, p1).long;
+    final _$$classRef = _class.reference;
+    return _isFoo(_$$classRef.pointer, _id_isFoo.pointer, p1).long;
   }
 
   /// Maps a specific port to the implemented interface.
@@ -8603,7 +8736,8 @@ extension TestClass033$$Methods<$T extends jni$_.JObject?> on TestClass033<$T> {
 
   /// from: `default public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 }
@@ -8776,9 +8910,10 @@ extension TestClass034$$Methods<$T extends jni$_.JObject?,
   jni$_.JString? genericInterfaceMethod(
     jni$_.JString? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     return _genericInterfaceMethod(
-            reference.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -8805,8 +8940,9 @@ extension TestClass034$$Methods<$T extends jni$_.JObject?,
     CustomObject<$S?>? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _isFoo(reference.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
         .object<CustomObject<$S?>?>();
   }
 }
@@ -8898,7 +9034,8 @@ extension type TestClass034$NestedEnum._(jni$_.JObject _$this)
   /// from: `static public com.example.TestClass034$NestedEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass034$NestedEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass034$NestedEnum?>?>();
   }
 
@@ -8923,9 +9060,9 @@ extension type TestClass034$NestedEnum._(jni$_.JObject _$this)
   static TestClass034$NestedEnum? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass034$NestedEnum?>();
   }
 }
@@ -8970,7 +9107,8 @@ extension TestClass035$$Methods<$T extends jni$_.JObject,
 
   /// from: `public void grandParentMethod()`
   void grandParentMethod() {
-    _grandParentMethod(reference.pointer, _id_grandParentMethod.pointer)
+    final _$$selfRef = reference;
+    _grandParentMethod(_$$selfRef.pointer, _id_grandParentMethod.pointer)
         .check();
   }
 
@@ -8997,8 +9135,9 @@ extension TestClass035$$Methods<$T extends jni$_.JObject,
     jni$_.JList<$S> p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1.reference;
-    return _myMethod(reference.pointer, _id_myMethod.pointer, _$p1.pointer, p2)
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer, _$p1.pointer, p2)
         .object<jni$_.JList<$S>>();
   }
 }
@@ -9040,7 +9179,8 @@ extension type TestClass035$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass035$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass035$Nested>();
   }
 }
@@ -9081,7 +9221,8 @@ extension type TestClass037<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass037() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass037<$T>>();
   }
 }
@@ -9106,7 +9247,8 @@ extension TestClass037$$Methods<$T extends jni$_.JObject?> on TestClass037<$T> {
 
   /// from: `public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_leftMethod = TestClass037._class.instanceMethodId(
@@ -9128,7 +9270,8 @@ extension TestClass037$$Methods<$T extends jni$_.JObject?> on TestClass037<$T> {
 
   /// from: `public void leftMethod()`
   void leftMethod() {
-    _leftMethod(reference.pointer, _id_leftMethod.pointer).check();
+    final _$$selfRef = reference;
+    _leftMethod(_$$selfRef.pointer, _id_leftMethod.pointer).check();
   }
 
   static final _id_rightMethod = TestClass037._class.instanceMethodId(
@@ -9150,7 +9293,8 @@ extension TestClass037$$Methods<$T extends jni$_.JObject?> on TestClass037<$T> {
 
   /// from: `public void rightMethod()`
   void rightMethod() {
-    _rightMethod(reference.pointer, _id_rightMethod.pointer).check();
+    final _$$selfRef = reference;
+    _rightMethod(_$$selfRef.pointer, _id_rightMethod.pointer).check();
   }
 
   static final _id_get$foo = TestClass037._class.instanceMethodId(
@@ -9173,7 +9317,8 @@ extension TestClass037$$Methods<$T extends jni$_.JObject?> on TestClass037<$T> {
   /// from: `public char[] getFoo()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JCharArray get foo {
-    return _get$foo(reference.pointer, _id_get$foo.pointer)
+    final _$$selfRef = reference;
+    return _get$foo(_$$selfRef.pointer, _id_get$foo.pointer)
         .object<jni$_.JCharArray>();
   }
 }
@@ -9215,7 +9360,8 @@ extension type TestClass037$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass037$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass037$Nested>();
   }
 }
@@ -9256,7 +9402,8 @@ extension type TestClass038<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass038() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass038<$T>>();
   }
 
@@ -9281,7 +9428,8 @@ extension type TestClass038<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<jni$_.JString>?
       isFoo<$S extends jni$_.JObject?, $V extends jni$_.JObject?>() {
-    return _isFoo(_class.reference.pointer, _id_isFoo.pointer)
+    final _$$classRef = _class.reference;
+    return _isFoo(_$$classRef.pointer, _id_isFoo.pointer)
         .object<jni$_.JArray<jni$_.JString>?>();
   }
 }
@@ -9306,7 +9454,8 @@ extension TestClass038$$Methods<$T extends jni$_.JObject?> on TestClass038<$T> {
 
   /// from: `public void grandParentMethod()`
   void grandParentMethod() {
-    _grandParentMethod(reference.pointer, _id_grandParentMethod.pointer)
+    final _$$selfRef = reference;
+    _grandParentMethod(_$$selfRef.pointer, _id_grandParentMethod.pointer)
         .check();
   }
 }
@@ -9433,7 +9582,8 @@ extension TestClass039$$Methods<$T extends jni$_.JObject?> on TestClass039<$T> {
 
   /// from: `default public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -9456,7 +9606,8 @@ extension TestClass039$$Methods<$T extends jni$_.JObject?> on TestClass039<$T> {
 
   /// from: `default public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_getFoo = TestClass039._class.instanceMethodId(
@@ -9478,7 +9629,8 @@ extension TestClass039$$Methods<$T extends jni$_.JObject?> on TestClass039<$T> {
 
   /// from: `public abstract int getFoo()`
   core$_.int getFoo<$S extends jni$_.JObject?, $V extends jni$_.JObject?>() {
-    return _getFoo(reference.pointer, _id_getFoo.pointer).integer;
+    final _$$selfRef = reference;
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer).integer;
   }
 }
 
@@ -9565,7 +9717,8 @@ extension type TestClass039$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass039$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass039$Nested>();
   }
 }
@@ -9605,8 +9758,8 @@ extension type TestClass040._(jni$_.JObject _$this) implements GrandParent {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass040() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<TestClass040>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<TestClass040>();
   }
 }
 
@@ -9630,7 +9783,8 @@ extension TestClass040$$Methods on TestClass040 {
 
   /// from: `public void grandParentMethod()`
   void grandParentMethod() {
-    _grandParentMethod(reference.pointer, _id_grandParentMethod.pointer)
+    final _$$selfRef = reference;
+    _grandParentMethod(_$$selfRef.pointer, _id_grandParentMethod.pointer)
         .check();
   }
 
@@ -9654,7 +9808,8 @@ extension TestClass040$$Methods on TestClass040 {
   /// from: `public com.example.CustomInterface[] myMethod()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JArray<CustomInterface<$S?>?>? myMethod<$S extends jni$_.JObject?>() {
-    return _myMethod(reference.pointer, _id_myMethod.pointer)
+    final _$$selfRef = reference;
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer)
         .object<jni$_.JArray<CustomInterface<$S?>?>?>();
   }
 }
@@ -9697,9 +9852,9 @@ extension type TestClass040$Nested._(jni$_.JObject _$this)
   factory TestClass040$Nested(
     TestClass040 $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass040$Nested>();
   }
 }
@@ -9834,7 +9989,8 @@ extension TestClass041$$Methods<$T extends jni$_.JObject,
 
   /// from: `default public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -9857,7 +10013,8 @@ extension TestClass041$$Methods<$T extends jni$_.JObject,
 
   /// from: `default public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 }
 
@@ -9937,8 +10094,9 @@ extension type TestClass042<$T extends jni$_.JObject?,
       $U extends jni$_.JObject?, $S extends jni$_.JObject?>(
     CustomInterface<$S?>? p1,
   ) {
+    final _$$classRef = _class.reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _create(_class.reference.pointer, _id_create.pointer, _$p1.pointer)
+    return _create(_$$classRef.pointer, _id_create.pointer, _$p1.pointer)
         .object<TestClass042<$T, $U>>();
   }
 }
@@ -9964,7 +10122,8 @@ extension TestClass042$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void grandParentMethod()`
   void grandParentMethod() {
-    _grandParentMethod(reference.pointer, _id_grandParentMethod.pointer)
+    final _$$selfRef = reference;
+    _grandParentMethod(_$$selfRef.pointer, _id_grandParentMethod.pointer)
         .check();
   }
 }
@@ -10008,9 +10167,9 @@ extension type TestClass042$Nested<$T extends jni$_.JObject?,
   factory TestClass042$Nested(
     TestClass042<$T?, $U?> $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass042$Nested<$T, $U>>();
   }
 }
@@ -10052,7 +10211,8 @@ extension type TestClass043<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass043() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass043<$T, $U>>();
   }
 }
@@ -10090,9 +10250,10 @@ extension TestClass043$$Methods<$T extends jni$_.JObject?,
   void genericParentMethod(
     jni$_.JObject? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod(
-            reference.pointer, _id_genericParentMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod.pointer, _$t.pointer)
         .check();
   }
 }
@@ -10133,7 +10294,8 @@ extension type TestClass044<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass044() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass044<$T, $U>>();
   }
 }
@@ -10159,7 +10321,8 @@ extension TestClass044$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -10182,7 +10345,8 @@ extension TestClass044$$Methods<$T extends jni$_.JObject?,
   core$_.double isFoo<$S extends jni$_.JObject?>(
     core$_.double p1,
   ) {
-    return _isFoo(reference.pointer, _id_isFoo.pointer, p1).float;
+    final _$$selfRef = reference;
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, p1).float;
   }
 }
 
@@ -10309,7 +10473,8 @@ extension TestClass045$$Methods<$T extends jni$_.JObject?> on TestClass045<$T> {
 
   /// from: `default public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -10334,8 +10499,9 @@ extension TestClass045$$Methods<$T extends jni$_.JObject?> on TestClass045<$T> {
   jni$_.JArray<jni$_.JMap<$T?, $T?>?>? isFoo(
     jni$_.JArray<jni$_.JMap<$T?, $T?>?>? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _isFoo(reference.pointer, _id_isFoo.pointer, _$p1.pointer)
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, _$p1.pointer)
         .object<jni$_.JArray<jni$_.JMap<$T?, $T?>?>?>();
   }
 }
@@ -10413,7 +10579,8 @@ extension type TestClass045$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass045$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass045$Nested>();
   }
 }
@@ -10552,9 +10719,10 @@ extension TestClass046$$Methods<$T extends jni$_.JObject?> on TestClass046<$T> {
   jni$_.JString? genericInterfaceMethod(
     jni$_.JString? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     return _genericInterfaceMethod(
-            reference.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -10581,8 +10749,9 @@ extension TestClass046$$Methods<$T extends jni$_.JObject?> on TestClass046<$T> {
     jni$_.JArray<NestedCustom$Nested<$T?, $T?, $T?>?>? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _getFoo(reference.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JArray<NestedCustom$Nested<$T?, $T?, $T?>?>?>();
   }
 }
@@ -10672,7 +10841,8 @@ extension type TestClass046$NestedEnum._(jni$_.JObject _$this)
   /// from: `static public com.example.TestClass046$NestedEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass046$NestedEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass046$NestedEnum?>?>();
   }
 
@@ -10697,9 +10867,9 @@ extension type TestClass046$NestedEnum._(jni$_.JObject _$this)
   static TestClass046$NestedEnum? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass046$NestedEnum?>();
   }
 }
@@ -10741,7 +10911,8 @@ extension type TestClass047<$T extends jni$_.JObject,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass047() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass047<$T, $U>>();
   }
 }
@@ -10768,9 +10939,10 @@ extension TestClass047$$Methods<$T extends jni$_.JObject,
   void genericParentMethod(
     jni$_.JObject? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod(
-            reference.pointer, _id_genericParentMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod.pointer, _$t.pointer)
         .check();
   }
 
@@ -10797,8 +10969,9 @@ extension TestClass047$$Methods<$T extends jni$_.JObject,
     jni$_.JObject p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1.reference;
-    return _setFoo(reference.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JObject>();
   }
 }
@@ -10838,7 +11011,8 @@ extension type TestClass048<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass048() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass048<$T>>();
   }
 }
@@ -10863,7 +11037,8 @@ extension TestClass048$$Methods<$T extends jni$_.JObject> on TestClass048<$T> {
 
   /// from: `public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_leftMethod = TestClass048._class.instanceMethodId(
@@ -10885,7 +11060,8 @@ extension TestClass048$$Methods<$T extends jni$_.JObject> on TestClass048<$T> {
 
   /// from: `public void leftMethod()`
   void leftMethod() {
-    _leftMethod(reference.pointer, _id_leftMethod.pointer).check();
+    final _$$selfRef = reference;
+    _leftMethod(_$$selfRef.pointer, _id_leftMethod.pointer).check();
   }
 
   static final _id_rightMethod = TestClass048._class.instanceMethodId(
@@ -10907,7 +11083,8 @@ extension TestClass048$$Methods<$T extends jni$_.JObject> on TestClass048<$T> {
 
   /// from: `public void rightMethod()`
   void rightMethod() {
-    _rightMethod(reference.pointer, _id_rightMethod.pointer).check();
+    final _$$selfRef = reference;
+    _rightMethod(_$$selfRef.pointer, _id_rightMethod.pointer).check();
   }
 
   static final _id_myMethod = TestClass048._class.instanceMethodId(
@@ -10930,7 +11107,8 @@ extension TestClass048$$Methods<$T extends jni$_.JObject> on TestClass048<$T> {
   /// from: `public native com.example.CustomEnum myMethod()`
   /// The returned object must be released after use, by calling the [release] method.
   CustomEnum? myMethod() {
-    return _myMethod(reference.pointer, _id_myMethod.pointer)
+    final _$$selfRef = reference;
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer)
         .object<CustomEnum?>();
   }
 }
@@ -10973,9 +11151,9 @@ extension type TestClass048$Nested<$T extends jni$_.JObject>._(
   factory TestClass048$Nested(
     TestClass048<$T> $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass048$Nested<$T>>();
   }
 }
@@ -11017,7 +11195,8 @@ extension type TestClass049<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass049() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass049<$T, $U>>();
   }
 }
@@ -11044,9 +11223,10 @@ extension TestClass049$$Methods<$T extends jni$_.JObject?,
   void genericParentMethod(
     jni$_.JObject? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod(
-            reference.pointer, _id_genericParentMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod.pointer, _$t.pointer)
         .check();
   }
 
@@ -11073,8 +11253,9 @@ extension TestClass049$$Methods<$T extends jni$_.JObject?,
     CustomEnum? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _myMethod(reference.pointer, _id_myMethod.pointer, _$p1.pointer, p2)
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer, _$p1.pointer, p2)
         .object<CustomEnum?>();
   }
 }
@@ -11115,7 +11296,8 @@ extension type TestClass050._(jni$_.JObject _$this) implements GrandParent {
     core$_.double p1,
     core$_.int p2,
   ) {
-    return _create(_class.reference.pointer, _id_create.pointer, p1, p2)
+    final _$$classRef = _class.reference;
+    return _create(_$$classRef.pointer, _id_create.pointer, p1, p2)
         .object<TestClass050>();
   }
 }
@@ -11140,7 +11322,8 @@ extension TestClass050$$Methods on TestClass050 {
 
   /// from: `public void grandParentMethod()`
   void grandParentMethod() {
-    _grandParentMethod(reference.pointer, _id_grandParentMethod.pointer)
+    final _$$selfRef = reference;
+    _grandParentMethod(_$$selfRef.pointer, _id_grandParentMethod.pointer)
         .check();
   }
 }
@@ -11181,7 +11364,8 @@ extension type TestClass051._(jni$_.JObject _$this)
   /// from: `static public char[] myMethod()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JCharArray? myMethod<$S extends jni$_.JObject?>() {
-    return _myMethod(_class.reference.pointer, _id_myMethod.pointer)
+    final _$$classRef = _class.reference;
+    return _myMethod(_$$classRef.pointer, _id_myMethod.pointer)
         .object<jni$_.JCharArray?>();
   }
 
@@ -11289,7 +11473,8 @@ extension TestClass051$$Methods on TestClass051 {
 
   /// from: `default public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 }
@@ -11461,7 +11646,8 @@ extension type TestClass052<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass052() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass052<$T, $U>>();
   }
 
@@ -11485,7 +11671,8 @@ extension type TestClass052<$T extends jni$_.JObject?,
   /// from: `static public boolean[] isFoo()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JBooleanArray? isFoo() {
-    return _isFoo(_class.reference.pointer, _id_isFoo.pointer)
+    final _$$classRef = _class.reference;
+    return _isFoo(_$$classRef.pointer, _id_isFoo.pointer)
         .object<jni$_.JBooleanArray?>();
   }
 }
@@ -11511,7 +11698,8 @@ extension TestClass052$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 
   static final _id_bMethod = TestClass052._class.instanceMethodId(
@@ -11533,7 +11721,8 @@ extension TestClass052$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void bMethod()`
   void bMethod() {
-    _bMethod(reference.pointer, _id_bMethod.pointer).check();
+    final _$$selfRef = reference;
+    _bMethod(_$$selfRef.pointer, _id_bMethod.pointer).check();
   }
 
   static final _id_cMethod = TestClass052._class.instanceMethodId(
@@ -11555,7 +11744,8 @@ extension TestClass052$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void cMethod()`
   void cMethod() {
-    _cMethod(reference.pointer, _id_cMethod.pointer).check();
+    final _$$selfRef = reference;
+    _cMethod(_$$selfRef.pointer, _id_cMethod.pointer).check();
   }
 
   static final _id_dMethod = TestClass052._class.instanceMethodId(
@@ -11577,7 +11767,8 @@ extension TestClass052$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void dMethod()`
   void dMethod() {
-    _dMethod(reference.pointer, _id_dMethod.pointer).check();
+    final _$$selfRef = reference;
+    _dMethod(_$$selfRef.pointer, _id_dMethod.pointer).check();
   }
 
   static final _id_eMethod = TestClass052._class.instanceMethodId(
@@ -11599,7 +11790,8 @@ extension TestClass052$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void eMethod()`
   void eMethod() {
-    _eMethod(reference.pointer, _id_eMethod.pointer).check();
+    final _$$selfRef = reference;
+    _eMethod(_$$selfRef.pointer, _id_eMethod.pointer).check();
   }
 }
 
@@ -11639,7 +11831,8 @@ extension type TestClass054<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass054() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass054<$T, $U>>();
   }
 }
@@ -11665,7 +11858,8 @@ extension TestClass054$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -11688,7 +11882,8 @@ extension TestClass054$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_myMethod = TestClass054._class.instanceMethodId(
@@ -11712,7 +11907,8 @@ extension TestClass054$$Methods<$T extends jni$_.JObject?,
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JDoubleArray?
       myMethod<$S extends jni$_.JObject?, $V extends jni$_.JObject?>() {
-    return _myMethod(reference.pointer, _id_myMethod.pointer)
+    final _$$selfRef = reference;
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer)
         .object<jni$_.JDoubleArray?>();
   }
 }
@@ -11766,7 +11962,8 @@ extension type TestClass054$NestedEnum._(jni$_.JObject _$this)
   /// from: `static public com.example.TestClass054$NestedEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass054$NestedEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass054$NestedEnum?>?>();
   }
 
@@ -11791,9 +11988,9 @@ extension type TestClass054$NestedEnum._(jni$_.JObject _$this)
   static TestClass054$NestedEnum? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass054$NestedEnum?>();
   }
 }
@@ -11834,7 +12031,8 @@ extension type TestClass055<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass055() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass055<$T>>();
   }
 }
@@ -11860,9 +12058,10 @@ extension TestClass055$$Methods<$T extends jni$_.JObject> on TestClass055<$T> {
   void genericParentMethod$1(
     jni$_.JString? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod$1(
-            reference.pointer, _id_genericParentMethod$1.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod$1.pointer, _$t.pointer)
         .check();
   }
 
@@ -11889,8 +12088,9 @@ extension TestClass055$$Methods<$T extends jni$_.JObject> on TestClass055<$T> {
     jni$_.JObject? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _isFoo(reference.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JObject?>();
   }
 }
@@ -11933,9 +12133,9 @@ extension type TestClass055$Nested<$T extends jni$_.JObject>._(
   factory TestClass055$Nested(
     TestClass055<$T> $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass055$Nested<$T>>();
   }
 }
@@ -11976,7 +12176,8 @@ extension type TestClass056<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass056() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass056<$T>>();
   }
 }
@@ -12001,7 +12202,8 @@ extension TestClass056$$Methods<$T extends jni$_.JObject?> on TestClass056<$T> {
 
   /// from: `public void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 
   static final _id_bMethod = TestClass056._class.instanceMethodId(
@@ -12023,7 +12225,8 @@ extension TestClass056$$Methods<$T extends jni$_.JObject?> on TestClass056<$T> {
 
   /// from: `public void bMethod()`
   void bMethod() {
-    _bMethod(reference.pointer, _id_bMethod.pointer).check();
+    final _$$selfRef = reference;
+    _bMethod(_$$selfRef.pointer, _id_bMethod.pointer).check();
   }
 
   static final _id_cMethod = TestClass056._class.instanceMethodId(
@@ -12045,7 +12248,8 @@ extension TestClass056$$Methods<$T extends jni$_.JObject?> on TestClass056<$T> {
 
   /// from: `public void cMethod()`
   void cMethod() {
-    _cMethod(reference.pointer, _id_cMethod.pointer).check();
+    final _$$selfRef = reference;
+    _cMethod(_$$selfRef.pointer, _id_cMethod.pointer).check();
   }
 
   static final _id_dMethod = TestClass056._class.instanceMethodId(
@@ -12067,7 +12271,8 @@ extension TestClass056$$Methods<$T extends jni$_.JObject?> on TestClass056<$T> {
 
   /// from: `public void dMethod()`
   void dMethod() {
-    _dMethod(reference.pointer, _id_dMethod.pointer).check();
+    final _$$selfRef = reference;
+    _dMethod(_$$selfRef.pointer, _id_dMethod.pointer).check();
   }
 
   static final _id_eMethod = TestClass056._class.instanceMethodId(
@@ -12089,7 +12294,8 @@ extension TestClass056$$Methods<$T extends jni$_.JObject?> on TestClass056<$T> {
 
   /// from: `public void eMethod()`
   void eMethod() {
-    _eMethod(reference.pointer, _id_eMethod.pointer).check();
+    final _$$selfRef = reference;
+    _eMethod(_$$selfRef.pointer, _id_eMethod.pointer).check();
   }
 
   static final _id_myMethod = TestClass056._class.instanceMethodId(
@@ -12115,8 +12321,9 @@ extension TestClass056$$Methods<$T extends jni$_.JObject?> on TestClass056<$T> {
     $T? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _myMethod(reference.pointer, _id_myMethod.pointer, _$p1.pointer, p2)
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer, _$p1.pointer, p2)
         .object<$T?>();
   }
 }
@@ -12245,7 +12452,8 @@ extension TestClass058$$Methods<$T extends jni$_.JObject> on TestClass058<$T> {
 
   /// from: `default public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -12272,8 +12480,9 @@ extension TestClass058$$Methods<$T extends jni$_.JObject> on TestClass058<$T> {
     jni$_.JArray<$T?>? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _isFoo(reference.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JArray<$T?>?>();
   }
 }
@@ -12355,7 +12564,8 @@ extension type TestClass058$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass058$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass058$Nested>();
   }
 }
@@ -12396,7 +12606,8 @@ extension type TestClass059<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass059() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass059<$T>>();
   }
 }
@@ -12423,8 +12634,9 @@ extension TestClass059$$Methods<$T extends jni$_.JObject> on TestClass059<$T> {
   jni$_.JArray<jni$_.JString?>? myMethod<$S extends jni$_.JObject>(
     jni$_.JArray<jni$_.JString?>? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _myMethod(reference.pointer, _id_myMethod.pointer, _$p1.pointer)
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer, _$p1.pointer)
         .object<jni$_.JArray<jni$_.JString?>?>();
   }
 }
@@ -12564,7 +12776,8 @@ extension TestClass060$$Methods<$T extends jni$_.JObject> on TestClass060<$T> {
 
   /// from: `default public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_leftMethod = TestClass060._class.instanceMethodId(
@@ -12586,7 +12799,8 @@ extension TestClass060$$Methods<$T extends jni$_.JObject> on TestClass060<$T> {
 
   /// from: `default public void leftMethod()`
   void leftMethod() {
-    _leftMethod(reference.pointer, _id_leftMethod.pointer).check();
+    final _$$selfRef = reference;
+    _leftMethod(_$$selfRef.pointer, _id_leftMethod.pointer).check();
   }
 
   static final _id_rightMethod = TestClass060._class.instanceMethodId(
@@ -12608,7 +12822,8 @@ extension TestClass060$$Methods<$T extends jni$_.JObject> on TestClass060<$T> {
 
   /// from: `default public void rightMethod()`
   void rightMethod() {
-    _rightMethod(reference.pointer, _id_rightMethod.pointer).check();
+    final _$$selfRef = reference;
+    _rightMethod(_$$selfRef.pointer, _id_rightMethod.pointer).check();
   }
 
   static final _id_getFoo = TestClass060._class.instanceMethodId(
@@ -12632,8 +12847,9 @@ extension TestClass060$$Methods<$T extends jni$_.JObject> on TestClass060<$T> {
   NestedCustom$Nested<$S, $S, $S>? getFoo<$S extends jni$_.JObject>(
     NestedCustom$Nested<$S, $S, $S>? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _getFoo(reference.pointer, _id_getFoo.pointer, _$p1.pointer)
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer, _$p1.pointer)
         .object<NestedCustom$Nested<$S, $S, $S>?>();
   }
 }
@@ -12742,7 +12958,8 @@ extension type TestClass061<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass061() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass061<$T>>();
   }
 }
@@ -12767,7 +12984,8 @@ extension TestClass061$$Methods<$T extends jni$_.JObject> on TestClass061<$T> {
 
   /// from: `public void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 
   static final _id_bMethod = TestClass061._class.instanceMethodId(
@@ -12789,7 +13007,8 @@ extension TestClass061$$Methods<$T extends jni$_.JObject> on TestClass061<$T> {
 
   /// from: `public void bMethod()`
   void bMethod() {
-    _bMethod(reference.pointer, _id_bMethod.pointer).check();
+    final _$$selfRef = reference;
+    _bMethod(_$$selfRef.pointer, _id_bMethod.pointer).check();
   }
 
   static final _id_cMethod = TestClass061._class.instanceMethodId(
@@ -12811,7 +13030,8 @@ extension TestClass061$$Methods<$T extends jni$_.JObject> on TestClass061<$T> {
 
   /// from: `public void cMethod()`
   void cMethod() {
-    _cMethod(reference.pointer, _id_cMethod.pointer).check();
+    final _$$selfRef = reference;
+    _cMethod(_$$selfRef.pointer, _id_cMethod.pointer).check();
   }
 
   static final _id_dMethod = TestClass061._class.instanceMethodId(
@@ -12833,7 +13053,8 @@ extension TestClass061$$Methods<$T extends jni$_.JObject> on TestClass061<$T> {
 
   /// from: `public void dMethod()`
   void dMethod() {
-    _dMethod(reference.pointer, _id_dMethod.pointer).check();
+    final _$$selfRef = reference;
+    _dMethod(_$$selfRef.pointer, _id_dMethod.pointer).check();
   }
 
   static final _id_eMethod = TestClass061._class.instanceMethodId(
@@ -12855,7 +13076,8 @@ extension TestClass061$$Methods<$T extends jni$_.JObject> on TestClass061<$T> {
 
   /// from: `public void eMethod()`
   void eMethod() {
-    _eMethod(reference.pointer, _id_eMethod.pointer).check();
+    final _$$selfRef = reference;
+    _eMethod(_$$selfRef.pointer, _id_eMethod.pointer).check();
   }
 
   static final _id_isFoo = TestClass061._class.instanceMethodId(
@@ -12880,8 +13102,9 @@ extension TestClass061$$Methods<$T extends jni$_.JObject> on TestClass061<$T> {
       isFoo<$S extends jni$_.JObject, $V extends jni$_.JObject>(
     jni$_.JArray<NestedCustom$Nested<$S, $S, $S>>? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _isFoo(reference.pointer, _id_isFoo.pointer, _$p1.pointer)
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, _$p1.pointer)
         .object<jni$_.JArray<NestedCustom$Nested<$S, $S, $S>>?>();
   }
 }
@@ -12923,7 +13146,8 @@ extension type TestClass061$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass061$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass061$Nested>();
   }
 }
@@ -12964,7 +13188,8 @@ extension type TestClass062<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass062() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass062<$T>>();
   }
 
@@ -12988,7 +13213,8 @@ extension type TestClass062<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `static public com.example.CustomEnum setFoo()`
   /// The returned object must be released after use, by calling the [release] method.
   static CustomEnum? setFoo<$S extends jni$_.JObject>() {
-    return _setFoo(_class.reference.pointer, _id_setFoo.pointer)
+    final _$$classRef = _class.reference;
+    return _setFoo(_$$classRef.pointer, _id_setFoo.pointer)
         .object<CustomEnum?>();
   }
 }
@@ -13014,9 +13240,10 @@ extension TestClass062$$Methods<$T extends jni$_.JObject> on TestClass062<$T> {
   void genericParentMethod$1(
     jni$_.JString? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod$1(
-            reference.pointer, _id_genericParentMethod$1.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod$1.pointer, _$t.pointer)
         .check();
   }
 }
@@ -13055,8 +13282,8 @@ extension type TestClass063._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass063() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<TestClass063>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<TestClass063>();
   }
 
   static final _id_setFoo = _class.staticMethodId(
@@ -13078,7 +13305,8 @@ extension type TestClass063._(jni$_.JObject _$this) implements jni$_.JObject {
 
   /// from: `static public void setFoo()`
   static void setFoo<$S extends jni$_.JObject?, $V extends jni$_.JObject?>() {
-    _setFoo(_class.reference.pointer, _id_setFoo.pointer).check();
+    final _$$classRef = _class.reference;
+    _setFoo(_$$classRef.pointer, _id_setFoo.pointer).check();
   }
 }
 
@@ -13120,9 +13348,9 @@ extension type TestClass063$Nested._(jni$_.JObject _$this)
   factory TestClass063$Nested(
     TestClass063 $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass063$Nested>();
   }
 }
@@ -13163,7 +13391,8 @@ extension type TestClass064<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass064() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass064<$T, $U>>();
   }
 }
@@ -13189,7 +13418,8 @@ extension TestClass064$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void grandParentMethod()`
   void grandParentMethod() {
-    _grandParentMethod(reference.pointer, _id_grandParentMethod.pointer)
+    final _$$selfRef = reference;
+    _grandParentMethod(_$$selfRef.pointer, _id_grandParentMethod.pointer)
         .check();
   }
 }
@@ -13319,9 +13549,10 @@ extension TestClass065$$Methods<$T extends jni$_.JObject?> on TestClass065<$T> {
   jni$_.JString? genericInterfaceMethod(
     jni$_.JString? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     return _genericInterfaceMethod(
-            reference.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -13344,7 +13575,8 @@ extension TestClass065$$Methods<$T extends jni$_.JObject?> on TestClass065<$T> {
 
   /// from: `public abstract byte setFoo()`
   core$_.int setFoo<$S extends jni$_.JObject?>() {
-    return _setFoo(reference.pointer, _id_setFoo.pointer).byte;
+    final _$$selfRef = reference;
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer).byte;
   }
 }
 
@@ -13413,7 +13645,8 @@ extension type TestClass066<$T extends jni$_.JObject,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass066() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass066<$T, $U>>();
   }
 }
@@ -13440,9 +13673,10 @@ extension TestClass066$$Methods<$T extends jni$_.JObject,
   void genericParentMethod$1(
     jni$_.JString? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod$1(
-            reference.pointer, _id_genericParentMethod$1.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod$1.pointer, _$t.pointer)
         .check();
   }
 
@@ -13465,7 +13699,8 @@ extension TestClass066$$Methods<$T extends jni$_.JObject,
 
   /// from: `public native double isFoo()`
   core$_.double isFoo() {
-    return _isFoo(reference.pointer, _id_isFoo.pointer).doubleFloat;
+    final _$$selfRef = reference;
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer).doubleFloat;
   }
 }
 
@@ -13524,7 +13759,8 @@ extension type TestClass067._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public com.example.TestClass067[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass067?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass067?>?>();
   }
 
@@ -13549,9 +13785,9 @@ extension type TestClass067._(jni$_.JObject _$this) implements jni$_.JObject {
   static TestClass067? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass067?>();
   }
 }
@@ -13577,7 +13813,8 @@ extension TestClass067$$Methods on TestClass067 {
   /// from: `public char[] isFoo()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JCharArray? isFoo<$S extends jni$_.JObject?>() {
-    return _isFoo(reference.pointer, _id_isFoo.pointer)
+    final _$$selfRef = reference;
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer)
         .object<jni$_.JCharArray?>();
   }
 }
@@ -13619,7 +13856,8 @@ extension type TestClass067$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass067$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass067$Nested>();
   }
 }
@@ -13662,8 +13900,9 @@ extension type TestClass068._(jni$_.JObject _$this)
   static jni$_.JLongArray? isFoo<$S extends jni$_.JObject?>(
     jni$_.JLongArray? p1,
   ) {
+    final _$$classRef = _class.reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _isFoo(_class.reference.pointer, _id_isFoo.pointer, _$p1.pointer)
+    return _isFoo(_$$classRef.pointer, _id_isFoo.pointer, _$p1.pointer)
         .object<jni$_.JLongArray?>();
   }
 
@@ -13783,7 +14022,8 @@ extension TestClass068$$Methods on TestClass068 {
 
   /// from: `default public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_leftMethod = TestClass068._class.instanceMethodId(
@@ -13805,7 +14045,8 @@ extension TestClass068$$Methods on TestClass068 {
 
   /// from: `default public void leftMethod()`
   void leftMethod() {
-    _leftMethod(reference.pointer, _id_leftMethod.pointer).check();
+    final _$$selfRef = reference;
+    _leftMethod(_$$selfRef.pointer, _id_leftMethod.pointer).check();
   }
 
   static final _id_rightMethod = TestClass068._class.instanceMethodId(
@@ -13827,7 +14068,8 @@ extension TestClass068$$Methods on TestClass068 {
 
   /// from: `default public void rightMethod()`
   void rightMethod() {
-    _rightMethod(reference.pointer, _id_rightMethod.pointer).check();
+    final _$$selfRef = reference;
+    _rightMethod(_$$selfRef.pointer, _id_rightMethod.pointer).check();
   }
 }
 
@@ -13939,7 +14181,8 @@ extension type TestClass068$NestedEnum._(jni$_.JObject _$this)
   /// from: `static public com.example.TestClass068$NestedEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass068$NestedEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass068$NestedEnum?>?>();
   }
 
@@ -13964,9 +14207,9 @@ extension type TestClass068$NestedEnum._(jni$_.JObject _$this)
   static TestClass068$NestedEnum? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass068$NestedEnum?>();
   }
 }
@@ -14100,9 +14343,10 @@ extension TestClass069$$Methods<$T extends jni$_.JObject?> on TestClass069<$T> {
   jni$_.JString? genericInterfaceMethod(
     jni$_.JString? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     return _genericInterfaceMethod(
-            reference.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -14127,7 +14371,8 @@ extension TestClass069$$Methods<$T extends jni$_.JObject?> on TestClass069<$T> {
     core$_.int p1,
     core$_.int p2,
   ) {
-    return _myMethod(reference.pointer, _id_myMethod.pointer, p1, p2).short;
+    final _$$selfRef = reference;
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer, p1, p2).short;
   }
 }
 
@@ -14197,7 +14442,8 @@ extension type TestClass069$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass069$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass069$Nested>();
   }
 }
@@ -14239,7 +14485,8 @@ extension type TestClass070<$T extends jni$_.JObject,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass070() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass070<$T, $U>>();
   }
 
@@ -14266,9 +14513,9 @@ extension type TestClass070<$T extends jni$_.JObject,
     jni$_.JIntArray? p1,
     core$_.int p2,
   ) {
+    final _$$classRef = _class.reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _getFoo(
-            _class.reference.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
+    return _getFoo(_$$classRef.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JIntArray?>();
   }
 }
@@ -14294,7 +14541,8 @@ extension TestClass070$$Methods<$T extends jni$_.JObject,
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -14317,7 +14565,8 @@ extension TestClass070$$Methods<$T extends jni$_.JObject,
 
   /// from: `public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 }
 
@@ -14445,7 +14694,8 @@ extension TestClass071$$Methods<$T extends jni$_.JObject?> on TestClass071<$T> {
 
   /// from: `default public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -14470,8 +14720,9 @@ extension TestClass071$$Methods<$T extends jni$_.JObject?> on TestClass071<$T> {
   jni$_.JArray<CustomInterface<$T?>?>? myMethod(
     jni$_.JArray<CustomInterface<$T?>?>? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _myMethod(reference.pointer, _id_myMethod.pointer, _$p1.pointer)
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer, _$p1.pointer)
         .object<jni$_.JArray<CustomInterface<$T?>?>?>();
   }
 }
@@ -14643,9 +14894,10 @@ extension TestClass072$$Methods on TestClass072 {
   jni$_.JString? genericInterfaceMethod(
     jni$_.JString? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     return _genericInterfaceMethod(
-            reference.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -14669,7 +14921,8 @@ extension TestClass072$$Methods on TestClass072 {
   /// from: `public abstract S getFoo()`
   /// The returned object must be released after use, by calling the [release] method.
   $S? getFoo<$S extends jni$_.JObject?, $V extends jni$_.JObject?>() {
-    return _getFoo(reference.pointer, _id_getFoo.pointer).object<$S?>();
+    final _$$selfRef = reference;
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer).object<$S?>();
   }
 }
 
@@ -14739,7 +14992,8 @@ extension type TestClass072$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass072$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass072$Nested>();
   }
 }
@@ -14800,7 +15054,8 @@ extension type TestClass073._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public com.example.TestClass073[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass073?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass073?>?>();
   }
 
@@ -14825,9 +15080,9 @@ extension type TestClass073._(jni$_.JObject _$this) implements jni$_.JObject {
   static TestClass073? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass073?>();
   }
 }
@@ -14867,7 +15122,8 @@ extension type TestClass074<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass074() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass074<$T>>();
   }
 }
@@ -14892,7 +15148,8 @@ extension TestClass074$$Methods<$T extends jni$_.JObject?> on TestClass074<$T> {
 
   /// from: `public void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 
   static final _id_bMethod = TestClass074._class.instanceMethodId(
@@ -14914,7 +15171,8 @@ extension TestClass074$$Methods<$T extends jni$_.JObject?> on TestClass074<$T> {
 
   /// from: `public void bMethod()`
   void bMethod() {
-    _bMethod(reference.pointer, _id_bMethod.pointer).check();
+    final _$$selfRef = reference;
+    _bMethod(_$$selfRef.pointer, _id_bMethod.pointer).check();
   }
 
   static final _id_cMethod = TestClass074._class.instanceMethodId(
@@ -14936,7 +15194,8 @@ extension TestClass074$$Methods<$T extends jni$_.JObject?> on TestClass074<$T> {
 
   /// from: `public void cMethod()`
   void cMethod() {
-    _cMethod(reference.pointer, _id_cMethod.pointer).check();
+    final _$$selfRef = reference;
+    _cMethod(_$$selfRef.pointer, _id_cMethod.pointer).check();
   }
 
   static final _id_dMethod = TestClass074._class.instanceMethodId(
@@ -14958,7 +15217,8 @@ extension TestClass074$$Methods<$T extends jni$_.JObject?> on TestClass074<$T> {
 
   /// from: `public void dMethod()`
   void dMethod() {
-    _dMethod(reference.pointer, _id_dMethod.pointer).check();
+    final _$$selfRef = reference;
+    _dMethod(_$$selfRef.pointer, _id_dMethod.pointer).check();
   }
 
   static final _id_eMethod = TestClass074._class.instanceMethodId(
@@ -14980,7 +15240,8 @@ extension TestClass074$$Methods<$T extends jni$_.JObject?> on TestClass074<$T> {
 
   /// from: `public void eMethod()`
   void eMethod() {
-    _eMethod(reference.pointer, _id_eMethod.pointer).check();
+    final _$$selfRef = reference;
+    _eMethod(_$$selfRef.pointer, _id_eMethod.pointer).check();
   }
 
   static final _id_getFoo = TestClass074._class.instanceMethodId(
@@ -15007,8 +15268,9 @@ extension TestClass074$$Methods<$T extends jni$_.JObject?> on TestClass074<$T> {
     jni$_.JArray<jni$_.JSet<$S?>?>? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _getFoo(reference.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JArray<jni$_.JSet<$S?>?>?>();
   }
 }
@@ -15051,9 +15313,9 @@ extension type TestClass074$Nested<$T extends jni$_.JObject?>._(
   factory TestClass074$Nested(
     TestClass074<$T?> $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass074$Nested<$T>>();
   }
 }
@@ -15174,7 +15436,8 @@ extension TestClass075$$Methods on TestClass075 {
   /// from: `default public java.util.Set[] isFoo()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JArray<jni$_.JSet<$S?>?>? isFoo<$S extends jni$_.JObject?>() {
-    return _isFoo(reference.pointer, _id_isFoo.pointer)
+    final _$$selfRef = reference;
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer)
         .object<jni$_.JArray<jni$_.JSet<$S?>?>?>();
   }
 }
@@ -15234,7 +15497,8 @@ extension type TestClass076<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass076() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass076<$T>>();
   }
 }
@@ -15260,9 +15524,10 @@ extension TestClass076$$Methods<$T extends jni$_.JObject?> on TestClass076<$T> {
   void genericParentMethod(
     jni$_.JObject? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod(
-            reference.pointer, _id_genericParentMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod.pointer, _$t.pointer)
         .check();
   }
 
@@ -15287,8 +15552,9 @@ extension TestClass076$$Methods<$T extends jni$_.JObject?> on TestClass076<$T> {
   jni$_.JArray<jni$_.JString?>? myMethod(
     jni$_.JArray<jni$_.JString?>? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _myMethod(reference.pointer, _id_myMethod.pointer, _$p1.pointer)
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer, _$p1.pointer)
         .object<jni$_.JArray<jni$_.JString?>?>();
   }
 }
@@ -15425,9 +15691,10 @@ extension TestClass077$$Methods<$T extends jni$_.JObject?> on TestClass077<$T> {
   jni$_.JObject? genericInterfaceMethod(
     jni$_.JObject? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     return _genericInterfaceMethod(
-            reference.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -15454,8 +15721,9 @@ extension TestClass077$$Methods<$T extends jni$_.JObject?> on TestClass077<$T> {
     jni$_.JShortArray p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1.reference;
-    return _myMethod(reference.pointer, _id_myMethod.pointer, _$p1.pointer, p2)
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer, _$p1.pointer, p2)
         .object<jni$_.JShortArray>();
   }
 }
@@ -15529,7 +15797,8 @@ extension type TestClass077$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass077$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass077$Nested>();
   }
 }
@@ -15570,7 +15839,8 @@ extension type TestClass078<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass078() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass078<$T>>();
   }
 }
@@ -15596,9 +15866,10 @@ extension TestClass078$$Methods<$T extends jni$_.JObject> on TestClass078<$T> {
   void genericParentMethod(
     jni$_.JObject? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod(
-            reference.pointer, _id_genericParentMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod.pointer, _$t.pointer)
         .check();
   }
 
@@ -15624,8 +15895,9 @@ extension TestClass078$$Methods<$T extends jni$_.JObject> on TestClass078<$T> {
       getFoo<$S extends jni$_.JObject, $V extends jni$_.JObject>(
     jni$_.JArray<jni$_.JList<$S>>? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _getFoo(reference.pointer, _id_getFoo.pointer, _$p1.pointer)
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer, _$p1.pointer)
         .object<jni$_.JArray<jni$_.JList<$S>>?>();
   }
 }
@@ -15666,7 +15938,8 @@ extension type TestClass079<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass079() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass079<$T, $U>>();
   }
 }
@@ -15692,7 +15965,8 @@ extension TestClass079$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -15716,7 +15990,8 @@ extension TestClass079$$Methods<$T extends jni$_.JObject?,
   /// from: `public native com.example.CustomObject[] setFoo()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JArray<CustomObject<$T?>?>? setFoo() {
-    return _setFoo(reference.pointer, _id_setFoo.pointer)
+    final _$$selfRef = reference;
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer)
         .object<jni$_.JArray<CustomObject<$T?>?>?>();
   }
 }
@@ -15854,7 +16129,8 @@ extension type TestClass080<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass080() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass080<$T>>();
   }
 }
@@ -15883,8 +16159,9 @@ extension TestClass080$$Methods<$T extends jni$_.JObject?> on TestClass080<$T> {
     jni$_.JArray<CustomInterface<$T?>?>? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _setFoo(reference.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JArray<CustomInterface<$T?>?>?>();
   }
 }
@@ -15924,7 +16201,8 @@ extension type TestClass080$Sub<$T extends jni$_.JObject?>._(
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass080$Sub() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass080$Sub<$T>>();
   }
 }
@@ -15966,7 +16244,8 @@ extension type TestClass080$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass080$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass080$Nested>();
   }
 }
@@ -16112,7 +16391,8 @@ extension TestClass081$$Methods on TestClass081 {
 
   /// from: `default public void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 
   static final _id_bMethod = TestClass081._class.instanceMethodId(
@@ -16134,7 +16414,8 @@ extension TestClass081$$Methods on TestClass081 {
 
   /// from: `default public void bMethod()`
   void bMethod() {
-    _bMethod(reference.pointer, _id_bMethod.pointer).check();
+    final _$$selfRef = reference;
+    _bMethod(_$$selfRef.pointer, _id_bMethod.pointer).check();
   }
 
   static final _id_cMethod = TestClass081._class.instanceMethodId(
@@ -16156,7 +16437,8 @@ extension TestClass081$$Methods on TestClass081 {
 
   /// from: `default public void cMethod()`
   void cMethod() {
-    _cMethod(reference.pointer, _id_cMethod.pointer).check();
+    final _$$selfRef = reference;
+    _cMethod(_$$selfRef.pointer, _id_cMethod.pointer).check();
   }
 
   static final _id_dMethod = TestClass081._class.instanceMethodId(
@@ -16178,7 +16460,8 @@ extension TestClass081$$Methods on TestClass081 {
 
   /// from: `default public void dMethod()`
   void dMethod() {
-    _dMethod(reference.pointer, _id_dMethod.pointer).check();
+    final _$$selfRef = reference;
+    _dMethod(_$$selfRef.pointer, _id_dMethod.pointer).check();
   }
 
   static final _id_eMethod = TestClass081._class.instanceMethodId(
@@ -16200,7 +16483,8 @@ extension TestClass081$$Methods on TestClass081 {
 
   /// from: `default public void eMethod()`
   void eMethod() {
-    _eMethod(reference.pointer, _id_eMethod.pointer).check();
+    final _$$selfRef = reference;
+    _eMethod(_$$selfRef.pointer, _id_eMethod.pointer).check();
   }
 
   static final _id_getFoo = TestClass081._class.instanceMethodId(
@@ -16224,7 +16508,8 @@ extension TestClass081$$Methods on TestClass081 {
     core$_.double p1,
     core$_.int p2,
   ) {
-    return _getFoo(reference.pointer, _id_getFoo.pointer, p1, p2).doubleFloat;
+    final _$$selfRef = reference;
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer, p1, p2).doubleFloat;
   }
 }
 
@@ -16355,8 +16640,9 @@ extension TestClass082$$Methods<$T extends jni$_.JObject> on TestClass082<$T> {
     jni$_.JArray<jni$_.JObject>? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _getFoo(reference.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JArray<jni$_.JObject>?>();
   }
 }
@@ -16399,9 +16685,9 @@ extension type TestClass082$Nested<$T extends jni$_.JObject>._(
   factory TestClass082$Nested(
     TestClass082<$T> $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass082$Nested<$T>>();
   }
 }
@@ -16531,7 +16817,8 @@ extension TestClass083$$Methods on TestClass083 {
 
   /// from: `default public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -16558,8 +16845,9 @@ extension TestClass083$$Methods on TestClass083 {
     jni$_.JArray<jni$_.JMap<$S?, $S?>?>? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _isFoo(reference.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JArray<jni$_.JMap<$S?, $S?>?>?>();
   }
 }
@@ -16733,9 +17021,10 @@ extension TestClass084$$Methods<$T extends jni$_.JObject> on TestClass084<$T> {
   jni$_.JObject? genericInterfaceMethod(
     jni$_.JObject? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     return _genericInterfaceMethod(
-            reference.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericInterfaceMethod.pointer, _$t.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -16759,7 +17048,8 @@ extension TestClass084$$Methods<$T extends jni$_.JObject> on TestClass084<$T> {
   /// from: `public abstract S setFoo()`
   /// The returned object must be released after use, by calling the [release] method.
   $S? setFoo<$S extends jni$_.JObject>() {
-    return _setFoo(reference.pointer, _id_setFoo.pointer).object<$S?>();
+    final _$$selfRef = reference;
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer).object<$S?>();
   }
 }
 
@@ -16926,7 +17216,8 @@ extension type TestClass085<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass085() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass085<$T, $U>>();
   }
 }
@@ -16952,7 +17243,8 @@ extension TestClass085$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -16975,7 +17267,8 @@ extension TestClass085$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 }
 
@@ -17018,9 +17311,9 @@ extension type TestClass085$Nested<$T extends jni$_.JObject?,
   factory TestClass085$Nested(
     TestClass085<$T?, $U?> $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass085$Nested<$T, $U>>();
   }
 }
@@ -17061,7 +17354,8 @@ extension type TestClass086<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass086() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass086<$T>>();
   }
 }
@@ -17088,8 +17382,9 @@ extension TestClass086$$Methods<$T extends jni$_.JObject> on TestClass086<$T> {
   jni$_.JList<$T>? setFoo(
     jni$_.JList<$T>? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _setFoo(reference.pointer, _id_setFoo.pointer, _$p1.pointer)
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer, _$p1.pointer)
         .object<jni$_.JList<$T>?>();
   }
 }
@@ -17129,7 +17424,8 @@ extension type TestClass086$Sub<$T extends jni$_.JObject>._(
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass086$Sub() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass086$Sub<$T>>();
   }
 }
@@ -17278,7 +17574,8 @@ extension TestClass087$$Methods<$T extends jni$_.JObject?> on TestClass087<$T> {
 
   /// from: `default public void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 
   static final _id_bMethod = TestClass087._class.instanceMethodId(
@@ -17300,7 +17597,8 @@ extension TestClass087$$Methods<$T extends jni$_.JObject?> on TestClass087<$T> {
 
   /// from: `default public void bMethod()`
   void bMethod() {
-    _bMethod(reference.pointer, _id_bMethod.pointer).check();
+    final _$$selfRef = reference;
+    _bMethod(_$$selfRef.pointer, _id_bMethod.pointer).check();
   }
 
   static final _id_cMethod = TestClass087._class.instanceMethodId(
@@ -17322,7 +17620,8 @@ extension TestClass087$$Methods<$T extends jni$_.JObject?> on TestClass087<$T> {
 
   /// from: `default public void cMethod()`
   void cMethod() {
-    _cMethod(reference.pointer, _id_cMethod.pointer).check();
+    final _$$selfRef = reference;
+    _cMethod(_$$selfRef.pointer, _id_cMethod.pointer).check();
   }
 
   static final _id_dMethod = TestClass087._class.instanceMethodId(
@@ -17344,7 +17643,8 @@ extension TestClass087$$Methods<$T extends jni$_.JObject?> on TestClass087<$T> {
 
   /// from: `default public void dMethod()`
   void dMethod() {
-    _dMethod(reference.pointer, _id_dMethod.pointer).check();
+    final _$$selfRef = reference;
+    _dMethod(_$$selfRef.pointer, _id_dMethod.pointer).check();
   }
 
   static final _id_eMethod = TestClass087._class.instanceMethodId(
@@ -17366,7 +17666,8 @@ extension TestClass087$$Methods<$T extends jni$_.JObject?> on TestClass087<$T> {
 
   /// from: `default public void eMethod()`
   void eMethod() {
-    _eMethod(reference.pointer, _id_eMethod.pointer).check();
+    final _$$selfRef = reference;
+    _eMethod(_$$selfRef.pointer, _id_eMethod.pointer).check();
   }
 
   static final _id_isFoo = TestClass087._class.instanceMethodId(
@@ -17392,8 +17693,9 @@ extension TestClass087$$Methods<$T extends jni$_.JObject?> on TestClass087<$T> {
     jni$_.JByteArray p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1.reference;
-    return _isFoo(reference.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JByteArray>();
   }
 }
@@ -17522,7 +17824,8 @@ extension type TestClass087$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass087$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass087$Nested>();
   }
 }
@@ -17568,9 +17871,9 @@ extension type TestClass088<$T extends jni$_.JObject?,
     jni$_.JFloatArray? p1,
     core$_.int p2,
   ) {
+    final _$$classRef = _class.reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _create(
-            _class.reference.pointer, _id_create.pointer, _$p1.pointer, p2)
+    return _create(_$$classRef.pointer, _id_create.pointer, _$p1.pointer, p2)
         .object<TestClass088<$T, $U>>();
   }
 }
@@ -17596,7 +17899,8 @@ extension TestClass088$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -17619,7 +17923,8 @@ extension TestClass088$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 }
 
@@ -17662,9 +17967,9 @@ extension type TestClass088$Nested<$T extends jni$_.JObject?,
   factory TestClass088$Nested(
     TestClass088<$T?, $U?> $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass088$Nested<$T, $U>>();
   }
 }
@@ -17705,8 +18010,8 @@ extension type TestClass089._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass089() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<TestClass089>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<TestClass089>();
   }
 }
 
@@ -17730,7 +18035,8 @@ extension TestClass089$$Methods on TestClass089 {
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -17753,7 +18059,8 @@ extension TestClass089$$Methods on TestClass089 {
 
   /// from: `public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_isFoo = TestClass089._class.instanceMethodId(
@@ -17776,7 +18083,8 @@ extension TestClass089$$Methods on TestClass089 {
   /// from: `synchronized public java.lang.Object isFoo()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? isFoo<$S extends jni$_.JObject?, $V extends jni$_.JObject?>() {
-    return _isFoo(reference.pointer, _id_isFoo.pointer)
+    final _$$selfRef = reference;
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer)
         .object<jni$_.JObject?>();
   }
 }
@@ -17917,7 +18225,8 @@ extension TestClass090$$Methods<$T extends jni$_.JObject?,
 
   /// from: `default public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_leftMethod = TestClass090._class.instanceMethodId(
@@ -17939,7 +18248,8 @@ extension TestClass090$$Methods<$T extends jni$_.JObject?,
 
   /// from: `default public void leftMethod()`
   void leftMethod() {
-    _leftMethod(reference.pointer, _id_leftMethod.pointer).check();
+    final _$$selfRef = reference;
+    _leftMethod(_$$selfRef.pointer, _id_leftMethod.pointer).check();
   }
 
   static final _id_rightMethod = TestClass090._class.instanceMethodId(
@@ -17961,7 +18271,8 @@ extension TestClass090$$Methods<$T extends jni$_.JObject?,
 
   /// from: `default public void rightMethod()`
   void rightMethod() {
-    _rightMethod(reference.pointer, _id_rightMethod.pointer).check();
+    final _$$selfRef = reference;
+    _rightMethod(_$$selfRef.pointer, _id_rightMethod.pointer).check();
   }
 
   static final _id_setFoo = TestClass090._class.instanceMethodId(
@@ -17987,8 +18298,9 @@ extension TestClass090$$Methods<$T extends jni$_.JObject?,
     jni$_.JObject? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _setFoo(reference.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JObject?>();
   }
 }
@@ -18091,7 +18403,8 @@ extension type TestClass090$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass090$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass090$Nested>();
   }
 }
@@ -18132,7 +18445,8 @@ extension type TestClass091<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass091() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass091<$T>>();
   }
 }
@@ -18157,7 +18471,8 @@ extension TestClass091$$Methods<$T extends jni$_.JObject> on TestClass091<$T> {
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -18180,7 +18495,8 @@ extension TestClass091$$Methods<$T extends jni$_.JObject> on TestClass091<$T> {
 
   /// from: `public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_myMethod = TestClass091._class.instanceMethodId(
@@ -18204,8 +18520,9 @@ extension TestClass091$$Methods<$T extends jni$_.JObject> on TestClass091<$T> {
   $T myMethod<$S extends jni$_.JObject>(
     $T p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1.reference;
-    return _myMethod(reference.pointer, _id_myMethod.pointer, _$p1.pointer)
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer, _$p1.pointer)
         .object<$T>();
   }
 }
@@ -18247,7 +18564,8 @@ extension type TestClass091$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass091$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass091$Nested>();
   }
 }
@@ -18376,7 +18694,8 @@ extension TestClass092$$Methods on TestClass092 {
 
   /// from: `default public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -18401,8 +18720,9 @@ extension TestClass092$$Methods on TestClass092 {
   jni$_.JLongArray? isFoo<$S extends jni$_.JObject?, $V extends jni$_.JObject?>(
     jni$_.JLongArray? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _isFoo(reference.pointer, _id_isFoo.pointer, _$p1.pointer)
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, _$p1.pointer)
         .object<jni$_.JLongArray?>();
   }
 }
@@ -18573,7 +18893,8 @@ extension type TestClass093<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass093() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass093<$T, $U>>();
   }
 }
@@ -18599,7 +18920,8 @@ extension TestClass093$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void grandParentMethod()`
   void grandParentMethod() {
-    _grandParentMethod(reference.pointer, _id_grandParentMethod.pointer)
+    final _$$selfRef = reference;
+    _grandParentMethod(_$$selfRef.pointer, _id_grandParentMethod.pointer)
         .check();
   }
 
@@ -18626,8 +18948,9 @@ extension TestClass093$$Methods<$T extends jni$_.JObject?,
     CustomObject<$S?>? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _isFoo(reference.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, _$p1.pointer, p2)
         .object<CustomObject<$S?>?>();
   }
 }
@@ -18667,7 +18990,8 @@ extension type TestClass094<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass094() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass094<$T>>();
   }
 }
@@ -18692,7 +19016,8 @@ extension TestClass094$$Methods<$T extends jni$_.JObject?> on TestClass094<$T> {
 
   /// from: `public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_leftMethod = TestClass094._class.instanceMethodId(
@@ -18714,7 +19039,8 @@ extension TestClass094$$Methods<$T extends jni$_.JObject?> on TestClass094<$T> {
 
   /// from: `public void leftMethod()`
   void leftMethod() {
-    _leftMethod(reference.pointer, _id_leftMethod.pointer).check();
+    final _$$selfRef = reference;
+    _leftMethod(_$$selfRef.pointer, _id_leftMethod.pointer).check();
   }
 
   static final _id_rightMethod = TestClass094._class.instanceMethodId(
@@ -18736,7 +19062,8 @@ extension TestClass094$$Methods<$T extends jni$_.JObject?> on TestClass094<$T> {
 
   /// from: `public void rightMethod()`
   void rightMethod() {
-    _rightMethod(reference.pointer, _id_rightMethod.pointer).check();
+    final _$$selfRef = reference;
+    _rightMethod(_$$selfRef.pointer, _id_rightMethod.pointer).check();
   }
 
   static final _id_setFoo = TestClass094._class.instanceMethodId(
@@ -18760,7 +19087,8 @@ extension TestClass094$$Methods<$T extends jni$_.JObject?> on TestClass094<$T> {
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JFloatArray?
       setFoo<$S extends jni$_.JObject?, $V extends jni$_.JObject?>() {
-    return _setFoo(reference.pointer, _id_setFoo.pointer)
+    final _$$selfRef = reference;
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer)
         .object<jni$_.JFloatArray?>();
   }
 }
@@ -18898,7 +19226,8 @@ extension type TestClass095<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass095() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass095<$T>>();
   }
 }
@@ -18924,7 +19253,8 @@ extension TestClass095$$Methods<$T extends jni$_.JObject> on TestClass095<$T> {
   /// from: `public final java.util.List[] isFoo()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JArray<jni$_.JList<$S>>? isFoo<$S extends jni$_.JObject>() {
-    return _isFoo(reference.pointer, _id_isFoo.pointer)
+    final _$$selfRef = reference;
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer)
         .object<jni$_.JArray<jni$_.JList<$S>>?>();
   }
 }
@@ -18964,8 +19294,8 @@ extension type TestClass096._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass096() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<TestClass096>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<TestClass096>();
   }
 }
 
@@ -18989,7 +19319,8 @@ extension TestClass096$$Methods on TestClass096 {
 
   /// from: `public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_leftMethod = TestClass096._class.instanceMethodId(
@@ -19011,7 +19342,8 @@ extension TestClass096$$Methods on TestClass096 {
 
   /// from: `public void leftMethod()`
   void leftMethod() {
-    _leftMethod(reference.pointer, _id_leftMethod.pointer).check();
+    final _$$selfRef = reference;
+    _leftMethod(_$$selfRef.pointer, _id_leftMethod.pointer).check();
   }
 
   static final _id_rightMethod = TestClass096._class.instanceMethodId(
@@ -19033,7 +19365,8 @@ extension TestClass096$$Methods on TestClass096 {
 
   /// from: `public void rightMethod()`
   void rightMethod() {
-    _rightMethod(reference.pointer, _id_rightMethod.pointer).check();
+    final _$$selfRef = reference;
+    _rightMethod(_$$selfRef.pointer, _id_rightMethod.pointer).check();
   }
 }
 
@@ -19170,7 +19503,8 @@ extension type TestClass097<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass097() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass097<$T>>();
   }
 }
@@ -19196,9 +19530,10 @@ extension TestClass097$$Methods<$T extends jni$_.JObject> on TestClass097<$T> {
   void genericParentMethod(
     jni$_.JObject? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod(
-            reference.pointer, _id_genericParentMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod.pointer, _$t.pointer)
         .check();
   }
 
@@ -19225,8 +19560,9 @@ extension TestClass097$$Methods<$T extends jni$_.JObject> on TestClass097<$T> {
     jni$_.JObject? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _getFoo(reference.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JObject?>();
   }
 }
@@ -19364,8 +19700,8 @@ extension type TestClass098._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass098() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<TestClass098>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<TestClass098>();
   }
 }
 
@@ -19390,9 +19726,10 @@ extension TestClass098$$Methods on TestClass098 {
   void genericParentMethod(
     jni$_.JObject? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod(
-            reference.pointer, _id_genericParentMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod.pointer, _$t.pointer)
         .check();
   }
 
@@ -19415,7 +19752,8 @@ extension TestClass098$$Methods on TestClass098 {
 
   /// from: `public final void getFoo()`
   void getFoo<$S extends jni$_.JObject?>() {
-    _getFoo(reference.pointer, _id_getFoo.pointer).check();
+    final _$$selfRef = reference;
+    _getFoo(_$$selfRef.pointer, _id_getFoo.pointer).check();
   }
 }
 
@@ -19468,7 +19806,8 @@ extension type TestClass098$NestedEnum._(jni$_.JObject _$this)
   /// from: `static public com.example.TestClass098$NestedEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass098$NestedEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass098$NestedEnum?>?>();
   }
 
@@ -19493,9 +19832,9 @@ extension type TestClass098$NestedEnum._(jni$_.JObject _$this)
   static TestClass098$NestedEnum? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass098$NestedEnum?>();
   }
 }
@@ -19536,7 +19875,8 @@ extension type TestClass099<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass099() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass099<$T>>();
   }
 }
@@ -19563,8 +19903,9 @@ extension TestClass099$$Methods<$T extends jni$_.JObject?> on TestClass099<$T> {
   jni$_.JSet<$S?>? isFoo<$S extends jni$_.JObject?>(
     jni$_.JSet<$S?>? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _isFoo(reference.pointer, _id_isFoo.pointer, _$p1.pointer)
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, _$p1.pointer)
         .object<jni$_.JSet<$S?>?>();
   }
 }
@@ -19607,9 +19948,9 @@ extension type TestClass099$Nested<$T extends jni$_.JObject?>._(
   factory TestClass099$Nested(
     TestClass099<$T?> $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass099$Nested<$T>>();
   }
 }
@@ -19650,7 +19991,8 @@ extension type TestClass100<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass100() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass100<$T>>();
   }
 }
@@ -19686,9 +20028,10 @@ extension TestClass100$$Methods<$T extends jni$_.JObject> on TestClass100<$T> {
   void genericParentMethod$1(
     jni$_.JString? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod$1(
-            reference.pointer, _id_genericParentMethod$1.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod$1.pointer, _$t.pointer)
         .check();
   }
 }
@@ -19731,9 +20074,9 @@ extension type TestClass100$Nested<$T extends jni$_.JObject>._(
   factory TestClass100$Nested(
     TestClass100<$T> $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass100$Nested<$T>>();
   }
 }
@@ -19774,8 +20117,8 @@ extension type TestClass101._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass101() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<TestClass101>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<TestClass101>();
   }
 }
 
@@ -19799,7 +20142,8 @@ extension TestClass101$$Methods on TestClass101 {
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -19822,7 +20166,8 @@ extension TestClass101$$Methods on TestClass101 {
 
   /// from: `public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_setFoo = TestClass101._class.instanceMethodId(
@@ -19848,8 +20193,9 @@ extension TestClass101$$Methods on TestClass101 {
     jni$_.JObject? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _setFoo(reference.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JObject?>();
   }
 }
@@ -19890,7 +20236,8 @@ extension type TestClass102<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass102() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass102<$T, $U>>();
   }
 }
@@ -19916,7 +20263,8 @@ extension TestClass102$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -19939,7 +20287,8 @@ extension TestClass102$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_getFoo = TestClass102._class.instanceMethodId(
@@ -19965,8 +20314,9 @@ extension TestClass102$$Methods<$T extends jni$_.JObject?,
     jni$_.JString? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _getFoo(reference.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JString?>();
   }
 }
@@ -20187,8 +20537,9 @@ extension TestClass103$$Methods on TestClass103 {
   jni$_.JArray<CustomEnum?>? setFoo<$S extends jni$_.JObject?>(
     jni$_.JArray<CustomEnum?>? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _setFoo(reference.pointer, _id_setFoo.pointer, _$p1.pointer)
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer, _$p1.pointer)
         .object<jni$_.JArray<CustomEnum?>?>();
   }
 }
@@ -20251,7 +20602,8 @@ extension type TestClass104<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass104() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass104<$T>>();
   }
 }
@@ -20276,7 +20628,8 @@ extension TestClass104$$Methods<$T extends jni$_.JObject> on TestClass104<$T> {
 
   /// from: `public void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 
   static final _id_bMethod = TestClass104._class.instanceMethodId(
@@ -20298,7 +20651,8 @@ extension TestClass104$$Methods<$T extends jni$_.JObject> on TestClass104<$T> {
 
   /// from: `public void bMethod()`
   void bMethod() {
-    _bMethod(reference.pointer, _id_bMethod.pointer).check();
+    final _$$selfRef = reference;
+    _bMethod(_$$selfRef.pointer, _id_bMethod.pointer).check();
   }
 
   static final _id_cMethod = TestClass104._class.instanceMethodId(
@@ -20320,7 +20674,8 @@ extension TestClass104$$Methods<$T extends jni$_.JObject> on TestClass104<$T> {
 
   /// from: `public void cMethod()`
   void cMethod() {
-    _cMethod(reference.pointer, _id_cMethod.pointer).check();
+    final _$$selfRef = reference;
+    _cMethod(_$$selfRef.pointer, _id_cMethod.pointer).check();
   }
 
   static final _id_dMethod = TestClass104._class.instanceMethodId(
@@ -20342,7 +20697,8 @@ extension TestClass104$$Methods<$T extends jni$_.JObject> on TestClass104<$T> {
 
   /// from: `public void dMethod()`
   void dMethod() {
-    _dMethod(reference.pointer, _id_dMethod.pointer).check();
+    final _$$selfRef = reference;
+    _dMethod(_$$selfRef.pointer, _id_dMethod.pointer).check();
   }
 
   static final _id_eMethod = TestClass104._class.instanceMethodId(
@@ -20364,7 +20720,8 @@ extension TestClass104$$Methods<$T extends jni$_.JObject> on TestClass104<$T> {
 
   /// from: `public void eMethod()`
   void eMethod() {
-    _eMethod(reference.pointer, _id_eMethod.pointer).check();
+    final _$$selfRef = reference;
+    _eMethod(_$$selfRef.pointer, _id_eMethod.pointer).check();
   }
 
   static final _id_isFoo = TestClass104._class.instanceMethodId(
@@ -20387,7 +20744,8 @@ extension TestClass104$$Methods<$T extends jni$_.JObject> on TestClass104<$T> {
   /// from: `synchronized public com.example.CustomInterface<S> isFoo()`
   /// The returned object must be released after use, by calling the [release] method.
   CustomInterface<$S>? isFoo<$S extends jni$_.JObject>() {
-    return _isFoo(reference.pointer, _id_isFoo.pointer)
+    final _$$selfRef = reference;
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer)
         .object<CustomInterface<$S>?>();
   }
 }
@@ -20429,7 +20787,8 @@ extension type TestClass104$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass104$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass104$Nested>();
   }
 }
@@ -20471,8 +20830,9 @@ extension type TestClass105<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   factory TestClass105(
     jni$_.JArray<CustomInterface<$T>>? p1,
   ) {
+    final _$$classRef = _class.reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer, _$p1.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$p1.pointer)
         .object<TestClass105<$T>>();
   }
 }
@@ -20497,7 +20857,8 @@ extension TestClass105$$Methods<$T extends jni$_.JObject> on TestClass105<$T> {
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -20520,7 +20881,8 @@ extension TestClass105$$Methods<$T extends jni$_.JObject> on TestClass105<$T> {
 
   /// from: `public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 }
 
@@ -20573,7 +20935,8 @@ extension type TestClass105$NestedEnum._(jni$_.JObject _$this)
   /// from: `static public com.example.TestClass105$NestedEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass105$NestedEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass105$NestedEnum?>?>();
   }
 
@@ -20598,9 +20961,9 @@ extension type TestClass105$NestedEnum._(jni$_.JObject _$this)
   static TestClass105$NestedEnum? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass105$NestedEnum?>();
   }
 }
@@ -20641,7 +21004,8 @@ extension type TestClass106<$T extends jni$_.JObject,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass106() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass106<$T, $U>>();
   }
 }
@@ -20682,7 +21046,8 @@ extension type TestClass106$Sub<$T extends jni$_.JObject,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass106$Sub() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass106$Sub<$T, $U>>();
   }
 }
@@ -20819,8 +21184,8 @@ extension type TestClass107._(jni$_.JObject _$this) implements GrandParent {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass107() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<TestClass107>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<TestClass107>();
   }
 
   static final _id_getFoo = _class.staticMethodId(
@@ -20845,8 +21210,9 @@ extension type TestClass107._(jni$_.JObject _$this) implements GrandParent {
       getFoo<$S extends jni$_.JObject?, $V extends jni$_.JObject?>(
     jni$_.JFloatArray? p1,
   ) {
+    final _$$classRef = _class.reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _getFoo(_class.reference.pointer, _id_getFoo.pointer, _$p1.pointer)
+    return _getFoo(_$$classRef.pointer, _id_getFoo.pointer, _$p1.pointer)
         .object<jni$_.JFloatArray?>();
   }
 }
@@ -20871,7 +21237,8 @@ extension TestClass107$$Methods on TestClass107 {
 
   /// from: `public void grandParentMethod()`
   void grandParentMethod() {
-    _grandParentMethod(reference.pointer, _id_grandParentMethod.pointer)
+    final _$$selfRef = reference;
+    _grandParentMethod(_$$selfRef.pointer, _id_grandParentMethod.pointer)
         .check();
   }
 }
@@ -21095,7 +21462,8 @@ extension TestClass108$$Methods<$T extends jni$_.JObject> on TestClass108<$T> {
 
   /// from: `default public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 
@@ -21119,7 +21487,8 @@ extension TestClass108$$Methods<$T extends jni$_.JObject> on TestClass108<$T> {
   /// from: `default public T setFoo()`
   /// The returned object must be released after use, by calling the [release] method.
   $T setFoo<$S extends jni$_.JObject, $V extends jni$_.JObject>() {
-    return _setFoo(reference.pointer, _id_setFoo.pointer).object<$T>();
+    final _$$selfRef = reference;
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer).object<$T>();
   }
 }
 
@@ -21191,7 +21560,8 @@ extension type TestClass109<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass109() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass109<$T>>();
   }
 }
@@ -21217,9 +21587,10 @@ extension TestClass109$$Methods<$T extends jni$_.JObject> on TestClass109<$T> {
   void genericParentMethod(
     jni$_.JObject? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod(
-            reference.pointer, _id_genericParentMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod.pointer, _$t.pointer)
         .check();
   }
 
@@ -21243,7 +21614,9 @@ extension TestClass109$$Methods<$T extends jni$_.JObject> on TestClass109<$T> {
   /// from: `public final com.example.CustomEnum getFoo()`
   /// The returned object must be released after use, by calling the [release] method.
   CustomEnum? getFoo<$S extends jni$_.JObject>() {
-    return _getFoo(reference.pointer, _id_getFoo.pointer).object<CustomEnum?>();
+    final _$$selfRef = reference;
+    return _getFoo(_$$selfRef.pointer, _id_getFoo.pointer)
+        .object<CustomEnum?>();
   }
 }
 
@@ -21285,9 +21658,9 @@ extension type TestClass109$Nested<$T extends jni$_.JObject>._(
   factory TestClass109$Nested(
     TestClass109<$T> $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass109$Nested<$T>>();
   }
 }
@@ -21328,7 +21701,8 @@ extension type TestClass110<$T extends jni$_.JObject>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass110() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass110<$T>>();
   }
 }
@@ -21390,9 +21764,9 @@ extension type TestClass111<$T extends jni$_.JObject>._(jni$_.JObject _$this)
     jni$_.JArray<jni$_.JObject?>? p1,
     core$_.int p2,
   ) {
+    final _$$classRef = _class.reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _create(
-            _class.reference.pointer, _id_create.pointer, _$p1.pointer, p2)
+    return _create(_$$classRef.pointer, _id_create.pointer, _$p1.pointer, p2)
         .object<TestClass111<$T>>();
   }
 }
@@ -21418,9 +21792,10 @@ extension TestClass111$$Methods<$T extends jni$_.JObject> on TestClass111<$T> {
   void genericParentMethod(
     jni$_.JObject? t,
   ) {
+    final _$$selfRef = reference;
     final _$t = t?.reference ?? jni$_.jNullReference;
     _genericParentMethod(
-            reference.pointer, _id_genericParentMethod.pointer, _$t.pointer)
+            _$$selfRef.pointer, _id_genericParentMethod.pointer, _$t.pointer)
         .check();
   }
 }
@@ -21474,7 +21849,8 @@ extension type TestClass111$NestedEnum._(jni$_.JObject _$this)
   /// from: `static public com.example.TestClass111$NestedEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass111$NestedEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass111$NestedEnum?>?>();
   }
 
@@ -21499,9 +21875,9 @@ extension type TestClass111$NestedEnum._(jni$_.JObject _$this)
   static TestClass111$NestedEnum? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass111$NestedEnum?>();
   }
 }
@@ -21544,8 +21920,9 @@ extension type TestClass113._(jni$_.JObject _$this)
       create<$S extends jni$_.JObject?, $V extends jni$_.JObject?>(
     jni$_.JShortArray? p1,
   ) {
+    final _$$classRef = _class.reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _create(_class.reference.pointer, _id_create.pointer, _$p1.pointer)
+    return _create(_$$classRef.pointer, _id_create.pointer, _$p1.pointer)
         .object<TestClass113>();
   }
 }
@@ -21570,7 +21947,8 @@ extension TestClass113$$Methods on TestClass113 {
 
   /// from: `public void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 
   static final _id_bMethod = TestClass113._class.instanceMethodId(
@@ -21592,7 +21970,8 @@ extension TestClass113$$Methods on TestClass113 {
 
   /// from: `public void bMethod()`
   void bMethod() {
-    _bMethod(reference.pointer, _id_bMethod.pointer).check();
+    final _$$selfRef = reference;
+    _bMethod(_$$selfRef.pointer, _id_bMethod.pointer).check();
   }
 
   static final _id_cMethod = TestClass113._class.instanceMethodId(
@@ -21614,7 +21993,8 @@ extension TestClass113$$Methods on TestClass113 {
 
   /// from: `public void cMethod()`
   void cMethod() {
-    _cMethod(reference.pointer, _id_cMethod.pointer).check();
+    final _$$selfRef = reference;
+    _cMethod(_$$selfRef.pointer, _id_cMethod.pointer).check();
   }
 
   static final _id_dMethod = TestClass113._class.instanceMethodId(
@@ -21636,7 +22016,8 @@ extension TestClass113$$Methods on TestClass113 {
 
   /// from: `public void dMethod()`
   void dMethod() {
-    _dMethod(reference.pointer, _id_dMethod.pointer).check();
+    final _$$selfRef = reference;
+    _dMethod(_$$selfRef.pointer, _id_dMethod.pointer).check();
   }
 
   static final _id_eMethod = TestClass113._class.instanceMethodId(
@@ -21658,7 +22039,8 @@ extension TestClass113$$Methods on TestClass113 {
 
   /// from: `public void eMethod()`
   void eMethod() {
-    _eMethod(reference.pointer, _id_eMethod.pointer).check();
+    final _$$selfRef = reference;
+    _eMethod(_$$selfRef.pointer, _id_eMethod.pointer).check();
   }
 }
 
@@ -21699,7 +22081,8 @@ extension type TestClass113$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass113$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass113$Nested>();
   }
 }
@@ -21740,8 +22123,8 @@ extension type TestClass115._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass115() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<TestClass115>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<TestClass115>();
   }
 }
 
@@ -21765,7 +22148,8 @@ extension TestClass115$$Methods on TestClass115 {
 
   /// from: `public void aMethod()`
   void aMethod() {
-    _aMethod(reference.pointer, _id_aMethod.pointer).check();
+    final _$$selfRef = reference;
+    _aMethod(_$$selfRef.pointer, _id_aMethod.pointer).check();
   }
 
   static final _id_bMethod = TestClass115._class.instanceMethodId(
@@ -21787,7 +22171,8 @@ extension TestClass115$$Methods on TestClass115 {
 
   /// from: `public void bMethod()`
   void bMethod() {
-    _bMethod(reference.pointer, _id_bMethod.pointer).check();
+    final _$$selfRef = reference;
+    _bMethod(_$$selfRef.pointer, _id_bMethod.pointer).check();
   }
 
   static final _id_cMethod = TestClass115._class.instanceMethodId(
@@ -21809,7 +22194,8 @@ extension TestClass115$$Methods on TestClass115 {
 
   /// from: `public void cMethod()`
   void cMethod() {
-    _cMethod(reference.pointer, _id_cMethod.pointer).check();
+    final _$$selfRef = reference;
+    _cMethod(_$$selfRef.pointer, _id_cMethod.pointer).check();
   }
 
   static final _id_dMethod = TestClass115._class.instanceMethodId(
@@ -21831,7 +22217,8 @@ extension TestClass115$$Methods on TestClass115 {
 
   /// from: `public void dMethod()`
   void dMethod() {
-    _dMethod(reference.pointer, _id_dMethod.pointer).check();
+    final _$$selfRef = reference;
+    _dMethod(_$$selfRef.pointer, _id_dMethod.pointer).check();
   }
 
   static final _id_eMethod = TestClass115._class.instanceMethodId(
@@ -21853,7 +22240,8 @@ extension TestClass115$$Methods on TestClass115 {
 
   /// from: `public void eMethod()`
   void eMethod() {
-    _eMethod(reference.pointer, _id_eMethod.pointer).check();
+    final _$$selfRef = reference;
+    _eMethod(_$$selfRef.pointer, _id_eMethod.pointer).check();
   }
 
   static final _id_myMethod = TestClass115._class.instanceMethodId(
@@ -21875,7 +22263,8 @@ extension TestClass115$$Methods on TestClass115 {
 
   /// from: `synchronized public void myMethod()`
   void myMethod<$S extends jni$_.JObject>() {
-    _myMethod(reference.pointer, _id_myMethod.pointer).check();
+    final _$$selfRef = reference;
+    _myMethod(_$$selfRef.pointer, _id_myMethod.pointer).check();
   }
 }
 
@@ -21917,9 +22306,9 @@ extension type TestClass115$Nested._(jni$_.JObject _$this)
   factory TestClass115$Nested(
     TestClass115 $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<TestClass115$Nested>();
   }
 }
@@ -21961,7 +22350,8 @@ extension type TestClass116<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass116() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass116<$T, $U>>();
   }
 }
@@ -22000,7 +22390,8 @@ extension TestClass116$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void otherInterfaceMethod()`
   void otherInterfaceMethod() {
-    _otherInterfaceMethod(reference.pointer, _id_otherInterfaceMethod.pointer)
+    final _$$selfRef = reference;
+    _otherInterfaceMethod(_$$selfRef.pointer, _id_otherInterfaceMethod.pointer)
         .check();
   }
 }
@@ -22042,7 +22433,8 @@ extension type TestClass116$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass116$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass116$Nested>();
   }
 }
@@ -22103,7 +22495,8 @@ extension type TestClass117._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public com.example.TestClass117[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass117?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass117?>?>();
   }
 
@@ -22128,9 +22521,9 @@ extension type TestClass117._(jni$_.JObject _$this) implements jni$_.JObject {
   static TestClass117? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass117?>();
   }
 }
@@ -22159,8 +22552,9 @@ extension TestClass117$$Methods on TestClass117 {
     jni$_.JObject p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1.reference;
-    return _myMethod(reference.pointer, _id_myMethod.pointer, _$p1.pointer, p2)
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer, _$p1.pointer, p2)
         .object<jni$_.JObject>();
   }
 }
@@ -22318,7 +22712,8 @@ extension type TestClass118._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public com.example.TestClass118[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass118?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass118?>?>();
   }
 
@@ -22343,9 +22738,9 @@ extension type TestClass118._(jni$_.JObject _$this) implements jni$_.JObject {
   static TestClass118? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass118?>();
   }
 }
@@ -22372,8 +22767,9 @@ extension TestClass118$$Methods on TestClass118 {
   jni$_.JArray<jni$_.JMap<$S?, $S?>?>? isFoo<$S extends jni$_.JObject?>(
     jni$_.JArray<jni$_.JMap<$S?, $S?>?>? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _isFoo(reference.pointer, _id_isFoo.pointer, _$p1.pointer)
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, _$p1.pointer)
         .object<jni$_.JArray<jni$_.JMap<$S?, $S?>?>?>();
   }
 }
@@ -22412,8 +22808,8 @@ extension type TestClass119._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass119() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<TestClass119>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<TestClass119>();
   }
 }
 
@@ -22441,8 +22837,9 @@ extension TestClass119$$Methods on TestClass119 {
     jni$_.JBooleanArray? p1,
     core$_.int p2,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _setFoo(reference.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
+    return _setFoo(_$$selfRef.pointer, _id_setFoo.pointer, _$p1.pointer, p2)
         .object<jni$_.JBooleanArray?>();
   }
 }
@@ -22482,7 +22879,8 @@ extension type TestClass119$Sub._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass119$Sub() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass119$Sub>();
   }
 }
@@ -22522,7 +22920,8 @@ extension type TestClass120<$T extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass120() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass120<$T, $U>>();
   }
 }
@@ -22558,7 +22957,8 @@ extension TestClass120$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void grandParentMethod()`
   void grandParentMethod() {
-    _grandParentMethod(reference.pointer, _id_grandParentMethod.pointer)
+    final _$$selfRef = reference;
+    _grandParentMethod(_$$selfRef.pointer, _id_grandParentMethod.pointer)
         .check();
   }
 }
@@ -22698,8 +23098,9 @@ extension type TestClass121<$T extends jni$_.JObject?,
       $U extends jni$_.JObject?, $S extends jni$_.JObject?>(
     CustomObject<$S?>? p1,
   ) {
+    final _$$classRef = _class.reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _create(_class.reference.pointer, _id_create.pointer, _$p1.pointer)
+    return _create(_$$classRef.pointer, _id_create.pointer, _$p1.pointer)
         .object<TestClass121<$T, $U>>();
   }
 }
@@ -22725,7 +23126,8 @@ extension TestClass121$$Methods<$T extends jni$_.JObject?,
 
   /// from: `public void grandParentMethod()`
   void grandParentMethod() {
-    _grandParentMethod(reference.pointer, _id_grandParentMethod.pointer)
+    final _$$selfRef = reference;
+    _grandParentMethod(_$$selfRef.pointer, _id_grandParentMethod.pointer)
         .check();
   }
 }
@@ -22779,7 +23181,8 @@ extension type TestClass121$NestedEnum._(jni$_.JObject _$this)
   /// from: `static public com.example.TestClass121$NestedEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass121$NestedEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass121$NestedEnum?>?>();
   }
 
@@ -22804,9 +23207,9 @@ extension type TestClass121$NestedEnum._(jni$_.JObject _$this)
   static TestClass121$NestedEnum? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass121$NestedEnum?>();
   }
 }
@@ -22849,7 +23252,8 @@ extension type TestClass122._(jni$_.JObject _$this)
     core$_.int p1,
     core$_.int p2,
   ) {
-    return _create(_class.reference.pointer, _id_create.pointer, p1, p2)
+    final _$$classRef = _class.reference;
+    return _create(_$$classRef.pointer, _id_create.pointer, p1, p2)
         .object<TestClass122>();
   }
 }
@@ -22874,7 +23278,8 @@ extension TestClass122$$Methods on TestClass122 {
 
   /// from: `public void baseMethod()`
   void baseMethod() {
-    _baseMethod(reference.pointer, _id_baseMethod.pointer).check();
+    final _$$selfRef = reference;
+    _baseMethod(_$$selfRef.pointer, _id_baseMethod.pointer).check();
   }
 
   static final _id_leftMethod = TestClass122._class.instanceMethodId(
@@ -22896,7 +23301,8 @@ extension TestClass122$$Methods on TestClass122 {
 
   /// from: `public void leftMethod()`
   void leftMethod() {
-    _leftMethod(reference.pointer, _id_leftMethod.pointer).check();
+    final _$$selfRef = reference;
+    _leftMethod(_$$selfRef.pointer, _id_leftMethod.pointer).check();
   }
 
   static final _id_rightMethod = TestClass122._class.instanceMethodId(
@@ -22918,7 +23324,8 @@ extension TestClass122$$Methods on TestClass122 {
 
   /// from: `public void rightMethod()`
   void rightMethod() {
-    _rightMethod(reference.pointer, _id_rightMethod.pointer).check();
+    final _$$selfRef = reference;
+    _rightMethod(_$$selfRef.pointer, _id_rightMethod.pointer).check();
   }
 }
 
@@ -23057,8 +23464,8 @@ extension type TestClass123<$T extends jni$_.JObject,
     core$_.int p1,
     core$_.int p2,
   ) {
-    return _setFoo(_class.reference.pointer, _id_setFoo.pointer, p1, p2)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _setFoo(_$$classRef.pointer, _id_setFoo.pointer, p1, p2).integer;
   }
 
   /// Maps a specific port to the implemented interface.
@@ -23196,7 +23603,8 @@ extension type TestClass123$Sub<$T extends jni$_.JObject,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass123$Sub() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass123$Sub<$T, $U>>();
   }
 
@@ -23221,8 +23629,8 @@ extension type TestClass123$Sub<$T extends jni$_.JObject,
     core$_.int p1,
     core$_.int p2,
   ) {
-    return _setFoo(_class.reference.pointer, _id_setFoo.pointer, p1, p2)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _setFoo(_$$classRef.pointer, _id_setFoo.pointer, p1, p2).integer;
   }
 }
 
@@ -23263,7 +23671,8 @@ extension type TestClass123$Nested._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass123$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass123$Nested>();
   }
 }
@@ -23324,7 +23733,8 @@ extension type TestClass124._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public com.example.TestClass124[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass124?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass124?>?>();
   }
 
@@ -23349,9 +23759,9 @@ extension type TestClass124._(jni$_.JObject _$this) implements jni$_.JObject {
   static TestClass124? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass124?>();
   }
 }
@@ -23378,8 +23788,9 @@ extension TestClass124$$Methods on TestClass124 {
   jni$_.JString? isFoo<$S extends jni$_.JObject?>(
     jni$_.JString? p1,
   ) {
+    final _$$selfRef = reference;
     final _$p1 = p1?.reference ?? jni$_.jNullReference;
-    return _isFoo(reference.pointer, _id_isFoo.pointer, _$p1.pointer)
+    return _isFoo(_$$selfRef.pointer, _id_isFoo.pointer, _$p1.pointer)
         .object<jni$_.JString?>();
   }
 }
@@ -23433,7 +23844,8 @@ extension type TestClass124$NestedEnum._(jni$_.JObject _$this)
   /// from: `static public com.example.TestClass124$NestedEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass124$NestedEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass124$NestedEnum?>?>();
   }
 
@@ -23458,9 +23870,9 @@ extension type TestClass124$NestedEnum._(jni$_.JObject _$this)
   static TestClass124$NestedEnum? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass124$NestedEnum?>();
   }
 }
@@ -23501,7 +23913,8 @@ extension type TestClass125<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass125() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass125<$T>>();
   }
 }
@@ -23527,7 +23940,8 @@ extension TestClass125$$Methods<$T extends jni$_.JObject?> on TestClass125<$T> {
   /// from: `public short[] myMethod()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JShortArray? myMethod() {
-    return _myMethod(reference.pointer, _id_myMethod.pointer)
+    final _$$selfRef = reference;
+    return _myMethod(_$$selfRef.pointer, _id_myMethod.pointer)
         .object<jni$_.JShortArray?>();
   }
 }
@@ -23567,7 +23981,8 @@ extension type TestClass125$Sub<$T extends jni$_.JObject?>._(
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory TestClass125$Sub() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<TestClass125$Sub<$T>>();
   }
 }
@@ -23621,7 +24036,8 @@ extension type TestClass125$NestedEnum._(jni$_.JObject _$this)
   /// from: `static public com.example.TestClass125$NestedEnum[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<TestClass125$NestedEnum?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<TestClass125$NestedEnum?>?>();
   }
 
@@ -23646,9 +24062,9 @@ extension type TestClass125$NestedEnum._(jni$_.JObject _$this)
   static TestClass125$NestedEnum? valueOf(
     jni$_.JString? name,
   ) {
+    final _$$classRef = _class.reference;
     final _$name = name?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$name.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$name.pointer)
         .object<TestClass125$NestedEnum?>();
   }
 }

--- a/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
+++ b/pkgs/jnigen/test/simple_package_test/bindings/simple_package.dart
@@ -83,7 +83,8 @@ extension type Example$Nested$NestedTwice._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory Example$Nested$NestedTwice() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<Example$Nested$NestedTwice>();
   }
 }
@@ -125,7 +126,8 @@ extension type Example$Nested._(jni$_.JObject _$this) implements jni$_.JObject {
   factory Example$Nested(
     core$_.bool z,
   ) {
-    return _new$(_class.reference.pointer, _id_new$.pointer, z ? 1 : 0)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer, z ? 1 : 0)
         .object<Example$Nested>();
   }
 }
@@ -151,8 +153,9 @@ extension Example$Nested$$Methods on Example$Nested {
 
   /// from: `public void usesAnonymousInnerClass()`
   void usesAnonymousInnerClass() {
+    final _$$selfRef = reference;
     _usesAnonymousInnerClass(
-            reference.pointer, _id_usesAnonymousInnerClass.pointer)
+            _$$selfRef.pointer, _id_usesAnonymousInnerClass.pointer)
         .check();
   }
 
@@ -175,7 +178,8 @@ extension Example$Nested$$Methods on Example$Nested {
 
   /// from: `public boolean getValue()`
   core$_.bool get value {
-    return _get$value(reference.pointer, _id_get$value.pointer).boolean;
+    final _$$selfRef = reference;
+    return _get$value(_$$selfRef.pointer, _id_get$value.pointer).boolean;
   }
 
   static final _id_set$value = Example$Nested._class.instanceMethodId(
@@ -195,7 +199,8 @@ extension Example$Nested$$Methods on Example$Nested {
 
   /// from: `public void setValue(boolean z)`
   set value(core$_.bool z) {
-    _set$value(reference.pointer, _id_set$value.pointer, z ? 1 : 0).check();
+    final _$$selfRef = reference;
+    _set$value(_$$selfRef.pointer, _id_set$value.pointer, z ? 1 : 0).check();
   }
 }
 
@@ -238,9 +243,9 @@ extension type Example$NonStaticNested._(jni$_.JObject _$this)
   factory Example$NonStaticNested(
     Example $outerClass,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$$outerClass.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer)
         .object<Example$NonStaticNested>();
   }
 }
@@ -330,8 +335,8 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
 
   /// from: `static public int getAmount()`
   static core$_.int get amount {
-    return _get$amount(_class.reference.pointer, _id_get$amount.pointer)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _get$amount(_$$classRef.pointer, _id_get$amount.pointer).integer;
   }
 
   static final _id_get$pi = _class.staticMethodId(
@@ -353,7 +358,8 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
 
   /// from: `static public double getPi()`
   static core$_.double get pi {
-    return _get$pi(_class.reference.pointer, _id_get$pi.pointer).doubleFloat;
+    final _$$classRef = _class.reference;
+    return _get$pi(_$$classRef.pointer, _id_get$pi.pointer).doubleFloat;
   }
 
   static final _id_get$asterisk = _class.staticMethodId(
@@ -375,8 +381,8 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
 
   /// from: `static public char getAsterisk()`
   static core$_.int get asterisk {
-    return _get$asterisk(_class.reference.pointer, _id_get$asterisk.pointer)
-        .char;
+    final _$$classRef = _class.reference;
+    return _get$asterisk(_$$classRef.pointer, _id_get$asterisk.pointer).char;
   }
 
   static final _id_get$name = _class.staticMethodId(
@@ -399,7 +405,8 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public java.lang.String getName()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString? get name {
-    return _get$name(_class.reference.pointer, _id_get$name.pointer)
+    final _$$classRef = _class.reference;
+    return _get$name(_$$classRef.pointer, _id_get$name.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -423,8 +430,9 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public com.github.dart_lang.jnigen.simple_package.Example$Nested getNestedInstance()`
   /// The returned object must be released after use, by calling the [release] method.
   static Example$Nested? get nestedInstance {
+    final _$$classRef = _class.reference;
     return _get$nestedInstance(
-            _class.reference.pointer, _id_get$nestedInstance.pointer)
+            _$$classRef.pointer, _id_get$nestedInstance.pointer)
         .object<Example$Nested?>();
   }
 
@@ -444,7 +452,8 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
 
   /// from: `static public void setAmount(int i)`
   static set amount(core$_.int i) {
-    _set$amount(_class.reference.pointer, _id_set$amount.pointer, i).check();
+    final _$$classRef = _class.reference;
+    _set$amount(_$$classRef.pointer, _id_set$amount.pointer, i).check();
   }
 
   static final _id_set$name = _class.staticMethodId(
@@ -465,8 +474,9 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
 
   /// from: `static public void setName(java.lang.String string)`
   static set name(jni$_.JString? string) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    _set$name(_class.reference.pointer, _id_set$name.pointer, _$string.pointer)
+    _set$name(_$$classRef.pointer, _id_set$name.pointer, _$string.pointer)
         .check();
   }
 
@@ -488,9 +498,10 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
 
   /// from: `static public void setNestedInstance(com.github.dart_lang.jnigen.simple_package.Example$Nested nested)`
   static set nestedInstance(Example$Nested? nested) {
+    final _$$classRef = _class.reference;
     final _$nested = nested?.reference ?? jni$_.jNullReference;
-    _set$nestedInstance(_class.reference.pointer,
-            _id_set$nestedInstance.pointer, _$nested.pointer)
+    _set$nestedInstance(_$$classRef.pointer, _id_set$nestedInstance.pointer,
+            _$nested.pointer)
         .check();
   }
 
@@ -527,8 +538,8 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i2,
     core$_.int i3,
   ) {
-    return _max4(_class.reference.pointer, _id_max4.pointer, i, i1, i2, i3)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _max4(_$$classRef.pointer, _id_max4.pointer, i, i1, i2, i3).integer;
   }
 
   static final _id_max8 = _class.staticMethodId(
@@ -576,8 +587,9 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i6,
     core$_.int i7,
   ) {
-    return _max8(_class.reference.pointer, _id_max8.pointer, i, i1, i2, i3, i4,
-            i5, i6, i7)
+    final _$$classRef = _class.reference;
+    return _max8(_$$classRef.pointer, _id_max8.pointer, i, i1, i2, i3, i4, i5,
+            i6, i7)
         .integer;
   }
 
@@ -600,7 +612,8 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory Example() {
-    return _new$(_class.reference.pointer, _id_new$.pointer).object<Example>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<Example>();
   }
 
   static final _id_new$1 = _class.constructorId(
@@ -622,8 +635,8 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
   factory Example.new$1(
     core$_.int i,
   ) {
-    return _new$1(_class.reference.pointer, _id_new$1.pointer, i)
-        .object<Example>();
+    final _$$classRef = _class.reference;
+    return _new$1(_$$classRef.pointer, _id_new$1.pointer, i).object<Example>();
   }
 
   static final _id_new$2 = _class.constructorId(
@@ -647,7 +660,8 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     core$_.bool z,
   ) {
-    return _new$2(_class.reference.pointer, _id_new$2.pointer, i, z ? 1 : 0)
+    final _$$classRef = _class.reference;
+    return _new$2(_$$classRef.pointer, _id_new$2.pointer, i, z ? 1 : 0)
         .object<Example>();
   }
 
@@ -681,8 +695,9 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.bool z,
     jni$_.JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _new$3(_class.reference.pointer, _id_new$3.pointer, i, z ? 1 : 0,
+    return _new$3(_$$classRef.pointer, _id_new$3.pointer, i, z ? 1 : 0,
             _$string.pointer)
         .object<Example>();
   }
@@ -732,8 +747,9 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i6,
     core$_.int i7,
   ) {
-    return _new$4(_class.reference.pointer, _id_new$4.pointer, i, i1, i2, i3,
-            i4, i5, i6, i7)
+    final _$$classRef = _class.reference;
+    return _new$4(_$$classRef.pointer, _id_new$4.pointer, i, i1, i2, i3, i4, i5,
+            i6, i7)
         .object<Example>();
   }
 
@@ -758,8 +774,8 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i,
     core$_.int i1,
   ) {
-    return _addInts(_class.reference.pointer, _id_addInts.pointer, i, i1)
-        .integer;
+    final _$$classRef = _class.reference;
+    return _addInts(_$$classRef.pointer, _id_addInts.pointer, i, i1).integer;
   }
 
   static final _id_get$arr = _class.staticMethodId(
@@ -782,7 +798,8 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public int[] getArr()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JIntArray? get arr {
-    return _get$arr(_class.reference.pointer, _id_get$arr.pointer)
+    final _$$classRef = _class.reference;
+    return _get$arr(_$$classRef.pointer, _id_get$arr.pointer)
         .object<jni$_.JIntArray?>();
   }
 
@@ -806,8 +823,9 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
   static core$_.int addAll(
     jni$_.JIntArray? is$,
   ) {
+    final _$$classRef = _class.reference;
     final _$is$ = is$?.reference ?? jni$_.jNullReference;
-    return _addAll(_class.reference.pointer, _id_addAll.pointer, _$is$.pointer)
+    return _addAll(_$$classRef.pointer, _id_addAll.pointer, _$is$.pointer)
         .integer;
   }
 
@@ -830,8 +848,8 @@ extension type Example._(jni$_.JObject _$this) implements jni$_.JObject {
 
   /// from: `static public void throwException()`
   static void throwException() {
-    _throwException(_class.reference.pointer, _id_throwException.pointer)
-        .check();
+    final _$$classRef = _class.reference;
+    _throwException(_$$classRef.pointer, _id_throwException.pointer).check();
   }
 }
 
@@ -855,7 +873,8 @@ extension Example$$Methods on Example {
 
   /// from: `public int getNumber()`
   core$_.int get number {
-    return _get$number(reference.pointer, _id_get$number.pointer).integer;
+    final _$$selfRef = reference;
+    return _get$number(_$$selfRef.pointer, _id_get$number.pointer).integer;
   }
 
   static final _id_set$number = Example._class.instanceMethodId(
@@ -875,7 +894,8 @@ extension Example$$Methods on Example {
 
   /// from: `public void setNumber(int i)`
   set number(core$_.int i) {
-    _set$number(reference.pointer, _id_set$number.pointer, i).check();
+    final _$$selfRef = reference;
+    _set$number(_$$selfRef.pointer, _id_set$number.pointer, i).check();
   }
 
   static final _id_get$isUp = Example._class.instanceMethodId(
@@ -897,7 +917,8 @@ extension Example$$Methods on Example {
 
   /// from: `public boolean getIsUp()`
   core$_.bool get isUp {
-    return _get$isUp(reference.pointer, _id_get$isUp.pointer).boolean;
+    final _$$selfRef = reference;
+    return _get$isUp(_$$selfRef.pointer, _id_get$isUp.pointer).boolean;
   }
 
   static final _id_set$up = Example._class.instanceMethodId(
@@ -917,7 +938,8 @@ extension Example$$Methods on Example {
 
   /// from: `public void setUp(boolean z)`
   set up(core$_.bool z) {
-    _set$up(reference.pointer, _id_set$up.pointer, z ? 1 : 0).check();
+    final _$$selfRef = reference;
+    _set$up(_$$selfRef.pointer, _id_set$up.pointer, z ? 1 : 0).check();
   }
 
   static final _id_get$codename = Example._class.instanceMethodId(
@@ -940,7 +962,8 @@ extension Example$$Methods on Example {
   /// from: `public java.lang.String getCodename()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? get codename {
-    return _get$codename(reference.pointer, _id_get$codename.pointer)
+    final _$$selfRef = reference;
+    return _get$codename(_$$selfRef.pointer, _id_get$codename.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -962,8 +985,10 @@ extension Example$$Methods on Example {
 
   /// from: `public void setCodename(java.lang.String string)`
   set codename(jni$_.JString? string) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    _set$codename(reference.pointer, _id_set$codename.pointer, _$string.pointer)
+    _set$codename(
+            _$$selfRef.pointer, _id_set$codename.pointer, _$string.pointer)
         .check();
   }
 
@@ -987,7 +1012,8 @@ extension Example$$Methods on Example {
   /// from: `public java.util.Random getRandom()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? get random {
-    return _get$random(reference.pointer, _id_get$random.pointer)
+    final _$$selfRef = reference;
+    return _get$random(_$$selfRef.pointer, _id_get$random.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1009,8 +1035,9 @@ extension Example$$Methods on Example {
 
   /// from: `public void setRandom(java.util.Random random)`
   set random(jni$_.JObject? random) {
+    final _$$selfRef = reference;
     final _$random = random?.reference ?? jni$_.jNullReference;
-    _set$random(reference.pointer, _id_set$random.pointer, _$random.pointer)
+    _set$random(_$$selfRef.pointer, _id_set$random.pointer, _$random.pointer)
         .check();
   }
 
@@ -1033,7 +1060,8 @@ extension Example$$Methods on Example {
 
   /// from: `public long getRandomLong()`
   core$_.int get randomLong {
-    return _get$randomLong(reference.pointer, _id_get$randomLong.pointer).long;
+    final _$$selfRef = reference;
+    return _get$randomLong(_$$selfRef.pointer, _id_get$randomLong.pointer).long;
   }
 
   static final _id_add4Longs = Example._class.instanceMethodId(
@@ -1069,7 +1097,8 @@ extension Example$$Methods on Example {
     core$_.int j2,
     core$_.int j3,
   ) {
-    return _add4Longs(reference.pointer, _id_add4Longs.pointer, j, j1, j2, j3)
+    final _$$selfRef = reference;
+    return _add4Longs(_$$selfRef.pointer, _id_add4Longs.pointer, j, j1, j2, j3)
         .long;
   }
 
@@ -1118,7 +1147,8 @@ extension Example$$Methods on Example {
     core$_.int j6,
     core$_.int j7,
   ) {
-    return _add8Longs(reference.pointer, _id_add8Longs.pointer, j, j1, j2, j3,
+    final _$$selfRef = reference;
+    return _add8Longs(_$$selfRef.pointer, _id_add8Longs.pointer, j, j1, j2, j3,
             j4, j5, j6, j7)
         .long;
   }
@@ -1144,8 +1174,9 @@ extension Example$$Methods on Example {
   jni$_.JString? getRandomNumericString(
     jni$_.JObject? random,
   ) {
+    final _$$selfRef = reference;
     final _$random = random?.reference ?? jni$_.jNullReference;
-    return _getRandomNumericString(reference.pointer,
+    return _getRandomNumericString(_$$selfRef.pointer,
             _id_getRandomNumericString.pointer, _$random.pointer)
         .object<jni$_.JString?>();
   }
@@ -1169,7 +1200,8 @@ extension Example$$Methods on Example {
 
   /// from: `public final void finalMethod()`
   void finalMethod() {
-    _finalMethod(reference.pointer, _id_finalMethod.pointer).check();
+    final _$$selfRef = reference;
+    _finalMethod(_$$selfRef.pointer, _id_finalMethod.pointer).check();
   }
 
   static final _id_get$list = Example._class.instanceMethodId(
@@ -1192,7 +1224,8 @@ extension Example$$Methods on Example {
   /// from: `public java.util.List<java.lang.String> getList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JString?>? get list {
-    return _get$list(reference.pointer, _id_get$list.pointer)
+    final _$$selfRef = reference;
+    return _get$list(_$$selfRef.pointer, _id_get$list.pointer)
         .object<jni$_.JList<jni$_.JString?>?>();
   }
 
@@ -1224,9 +1257,10 @@ extension Example$$Methods on Example {
     jni$_.JList<jni$_.JString?>? list,
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _joinStrings(reference.pointer, _id_joinStrings.pointer,
+    return _joinStrings(_$$selfRef.pointer, _id_joinStrings.pointer,
             _$list.pointer, _$string.pointer)
         .object<jni$_.JString?>();
   }
@@ -1270,13 +1304,14 @@ extension Example$$Methods on Example {
     jni$_.JList<$T?>? list,
     jni$_.JMap<jni$_.JString?, jni$_.JObject?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$is$ = is$?.reference ?? jni$_.jNullReference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     _methodWithSeveralParams(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_methodWithSeveralParams.pointer,
             c,
             _$string.pointer,
@@ -1306,7 +1341,8 @@ extension Example$$Methods on Example {
 
   /// from: `public int whichExample()`
   core$_.int whichExample() {
-    return _whichExample(reference.pointer, _id_whichExample.pointer).integer;
+    final _$$selfRef = reference;
+    return _whichExample(_$$selfRef.pointer, _id_whichExample.pointer).integer;
   }
 
   static final _id_get$self = Example._class.instanceMethodId(
@@ -1329,7 +1365,8 @@ extension Example$$Methods on Example {
   /// from: `public com.github.dart_lang.jnigen.simple_package.Example getSelf()`
   /// The returned object must be released after use, by calling the [release] method.
   Example? get self {
-    return _get$self(reference.pointer, _id_get$self.pointer)
+    final _$$selfRef = reference;
+    return _get$self(_$$selfRef.pointer, _id_get$self.pointer)
         .object<Example?>();
   }
 
@@ -1352,7 +1389,8 @@ extension Example$$Methods on Example {
 
   /// from: `public void overloaded()`
   void overloaded() {
-    _overloaded(reference.pointer, _id_overloaded.pointer).check();
+    final _$$selfRef = reference;
+    _overloaded(_$$selfRef.pointer, _id_overloaded.pointer).check();
   }
 
   static final _id_overloaded$1 = Example._class.instanceMethodId(
@@ -1377,9 +1415,10 @@ extension Example$$Methods on Example {
     core$_.int i,
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     _overloaded$1(
-            reference.pointer, _id_overloaded$1.pointer, i, _$string.pointer)
+            _$$selfRef.pointer, _id_overloaded$1.pointer, i, _$string.pointer)
         .check();
   }
 
@@ -1402,7 +1441,8 @@ extension Example$$Methods on Example {
   void overloaded$2(
     core$_.int i,
   ) {
-    _overloaded$2(reference.pointer, _id_overloaded$2.pointer, i).check();
+    final _$$selfRef = reference;
+    _overloaded$2(_$$selfRef.pointer, _id_overloaded$2.pointer, i).check();
   }
 
   static final _id_overloaded$3 = Example._class.instanceMethodId(
@@ -1432,9 +1472,10 @@ extension Example$$Methods on Example {
     jni$_.JList<jni$_.JInteger?>? list,
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    _overloaded$3(reference.pointer, _id_overloaded$3.pointer, _$list.pointer,
+    _overloaded$3(_$$selfRef.pointer, _id_overloaded$3.pointer, _$list.pointer,
             _$string.pointer)
         .check();
   }
@@ -1459,8 +1500,9 @@ extension Example$$Methods on Example {
   void overloaded$4(
     jni$_.JList<jni$_.JInteger?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    _overloaded$4(reference.pointer, _id_overloaded$4.pointer, _$list.pointer)
+    _overloaded$4(_$$selfRef.pointer, _id_overloaded$4.pointer, _$list.pointer)
         .check();
   }
 
@@ -1484,7 +1526,8 @@ extension Example$$Methods on Example {
   core$_.bool bool(
     core$_.bool z,
   ) {
-    return _bool(reference.pointer, _id_bool.pointer, z ? 1 : 0).boolean;
+    final _$$selfRef = reference;
+    return _bool(_$$selfRef.pointer, _id_bool.pointer, z ? 1 : 0).boolean;
   }
 
   static final _id_num = Example._class.instanceMethodId(
@@ -1507,7 +1550,8 @@ extension Example$$Methods on Example {
   core$_.double num(
     core$_.double d,
   ) {
-    return _num(reference.pointer, _id_num.pointer, d).doubleFloat;
+    final _$$selfRef = reference;
+    return _num(_$$selfRef.pointer, _id_num.pointer, d).doubleFloat;
   }
 }
 
@@ -1552,9 +1596,9 @@ extension type Exceptions$MyException._(jni$_.JObject _$this)
     jni$_.JString? string,
     core$_.int i,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$string.pointer, i)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$string.pointer, i)
         .object<Exceptions$MyException>();
   }
 }
@@ -1611,8 +1655,8 @@ extension type Exceptions._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory Exceptions() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<Exceptions>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<Exceptions>();
   }
 
   static final _id_new$1 = _class.constructorId(
@@ -1634,7 +1678,8 @@ extension type Exceptions._(jni$_.JObject _$this) implements jni$_.JObject {
   factory Exceptions.new$1(
     core$_.double f,
   ) {
-    return _new$1(_class.reference.pointer, _id_new$1.pointer, f)
+    final _$$classRef = _class.reference;
+    return _new$1(_$$classRef.pointer, _id_new$1.pointer, f)
         .object<Exceptions>();
   }
 
@@ -1677,8 +1722,8 @@ extension type Exceptions._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i4,
     core$_.int i5,
   ) {
-    return _new$2(
-            _class.reference.pointer, _id_new$2.pointer, i, i1, i2, i3, i4, i5)
+    final _$$classRef = _class.reference;
+    return _new$2(_$$classRef.pointer, _id_new$2.pointer, i, i1, i2, i3, i4, i5)
         .object<Exceptions>();
   }
 
@@ -1702,8 +1747,9 @@ extension type Exceptions._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public java.lang.Object staticObjectMethod()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JObject? staticObjectMethod() {
+    final _$$classRef = _class.reference;
     return _staticObjectMethod(
-            _class.reference.pointer, _id_staticObjectMethod.pointer)
+            _$$classRef.pointer, _id_staticObjectMethod.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1726,8 +1772,8 @@ extension type Exceptions._(jni$_.JObject _$this) implements jni$_.JObject {
 
   /// from: `static public int staticIntMethod()`
   static core$_.int staticIntMethod() {
-    return _staticIntMethod(
-            _class.reference.pointer, _id_staticIntMethod.pointer)
+    final _$$classRef = _class.reference;
+    return _staticIntMethod(_$$classRef.pointer, _id_staticIntMethod.pointer)
         .integer;
   }
 
@@ -1751,8 +1797,9 @@ extension type Exceptions._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public java.lang.Object[] staticObjectArrayMethod()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<jni$_.JObject?>? staticObjectArrayMethod() {
+    final _$$classRef = _class.reference;
     return _staticObjectArrayMethod(
-            _class.reference.pointer, _id_staticObjectArrayMethod.pointer)
+            _$$classRef.pointer, _id_staticObjectArrayMethod.pointer)
         .object<jni$_.JArray<jni$_.JObject?>?>();
   }
 
@@ -1776,8 +1823,9 @@ extension type Exceptions._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public int[] staticIntArrayMethod()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JIntArray? staticIntArrayMethod() {
+    final _$$classRef = _class.reference;
     return _staticIntArrayMethod(
-            _class.reference.pointer, _id_staticIntArrayMethod.pointer)
+            _$$classRef.pointer, _id_staticIntArrayMethod.pointer)
         .object<jni$_.JIntArray?>();
   }
 
@@ -1800,8 +1848,8 @@ extension type Exceptions._(jni$_.JObject _$this) implements jni$_.JObject {
 
   /// from: `static public void throwLoremIpsum()`
   static void throwLoremIpsum() {
-    _throwLoremIpsum(_class.reference.pointer, _id_throwLoremIpsum.pointer)
-        .check();
+    final _$$classRef = _class.reference;
+    _throwLoremIpsum(_$$classRef.pointer, _id_throwLoremIpsum.pointer).check();
   }
 
   static final _id_throwMyException = _class.staticMethodId(
@@ -1823,7 +1871,8 @@ extension type Exceptions._(jni$_.JObject _$this) implements jni$_.JObject {
 
   /// from: `static public void throwMyException()`
   static void throwMyException() {
-    _throwMyException(_class.reference.pointer, _id_throwMyException.pointer)
+    final _$$classRef = _class.reference;
+    _throwMyException(_$$classRef.pointer, _id_throwMyException.pointer)
         .check();
   }
 }
@@ -1849,7 +1898,8 @@ extension Exceptions$$Methods on Exceptions {
   /// from: `public java.lang.Object objectMethod()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? objectMethod() {
-    return _objectMethod(reference.pointer, _id_objectMethod.pointer)
+    final _$$selfRef = reference;
+    return _objectMethod(_$$selfRef.pointer, _id_objectMethod.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1872,7 +1922,8 @@ extension Exceptions$$Methods on Exceptions {
 
   /// from: `public int intMethod()`
   core$_.int intMethod() {
-    return _intMethod(reference.pointer, _id_intMethod.pointer).integer;
+    final _$$selfRef = reference;
+    return _intMethod(_$$selfRef.pointer, _id_intMethod.pointer).integer;
   }
 
   static final _id_objectArrayMethod = Exceptions._class.instanceMethodId(
@@ -1895,7 +1946,8 @@ extension Exceptions$$Methods on Exceptions {
   /// from: `public java.lang.Object[] objectArrayMethod()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JArray<jni$_.JObject?>? objectArrayMethod() {
-    return _objectArrayMethod(reference.pointer, _id_objectArrayMethod.pointer)
+    final _$$selfRef = reference;
+    return _objectArrayMethod(_$$selfRef.pointer, _id_objectArrayMethod.pointer)
         .object<jni$_.JArray<jni$_.JObject?>?>();
   }
 
@@ -1919,7 +1971,8 @@ extension Exceptions$$Methods on Exceptions {
   /// from: `public int[] intArrayMethod()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JIntArray? intArrayMethod() {
-    return _intArrayMethod(reference.pointer, _id_intArrayMethod.pointer)
+    final _$$selfRef = reference;
+    return _intArrayMethod(_$$selfRef.pointer, _id_intArrayMethod.pointer)
         .object<jni$_.JIntArray?>();
   }
 
@@ -1943,8 +1996,9 @@ extension Exceptions$$Methods on Exceptions {
 
   /// from: `public int throwNullPointerException()`
   core$_.int throwNullPointerException() {
+    final _$$selfRef = reference;
     return _throwNullPointerException(
-            reference.pointer, _id_throwNullPointerException.pointer)
+            _$$selfRef.pointer, _id_throwNullPointerException.pointer)
         .integer;
   }
 
@@ -1970,8 +2024,9 @@ extension Exceptions$$Methods on Exceptions {
   /// from: `public java.io.InputStream throwFileNotFoundException()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? throwFileNotFoundException() {
+    final _$$selfRef = reference;
     return _throwFileNotFoundException(
-            reference.pointer, _id_throwFileNotFoundException.pointer)
+            _$$selfRef.pointer, _id_throwFileNotFoundException.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -1995,8 +2050,9 @@ extension Exceptions$$Methods on Exceptions {
   /// from: `public java.io.FileInputStream throwClassCastException()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JObject? throwClassCastException() {
+    final _$$selfRef = reference;
     return _throwClassCastException(
-            reference.pointer, _id_throwClassCastException.pointer)
+            _$$selfRef.pointer, _id_throwClassCastException.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -2020,8 +2076,9 @@ extension Exceptions$$Methods on Exceptions {
 
   /// from: `public int throwArrayIndexException()`
   core$_.int throwArrayIndexException() {
+    final _$$selfRef = reference;
     return _throwArrayIndexException(
-            reference.pointer, _id_throwArrayIndexException.pointer)
+            _$$selfRef.pointer, _id_throwArrayIndexException.pointer)
         .integer;
   }
 
@@ -2045,8 +2102,9 @@ extension Exceptions$$Methods on Exceptions {
 
   /// from: `public int throwArithmeticException()`
   core$_.int throwArithmeticException() {
+    final _$$selfRef = reference;
     return _throwArithmeticException(
-            reference.pointer, _id_throwArithmeticException.pointer)
+            _$$selfRef.pointer, _id_throwArithmeticException.pointer)
         .integer;
   }
 }
@@ -2102,8 +2160,8 @@ extension type Fields$Nested._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory Fields$Nested() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<Fields$Nested>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<Fields$Nested>();
   }
 }
 
@@ -2225,7 +2283,8 @@ extension type Fields._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory Fields() {
-    return _new$(_class.reference.pointer, _id_new$.pointer).object<Fields>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<Fields>();
   }
 }
 
@@ -2351,7 +2410,8 @@ extension type C2._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory C2() {
-    return _new$(_class.reference.pointer, _id_new$.pointer).object<C2>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<C2>();
   }
 }
 
@@ -2390,8 +2450,8 @@ extension type Example$1._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory Example$1() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<Example$1>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<Example$1>();
   }
 }
 
@@ -2415,7 +2475,8 @@ extension Example$1$$Methods on Example$1 {
 
   /// from: `public int whichExample()`
   core$_.int whichExample() {
-    return _whichExample(reference.pointer, _id_whichExample.pointer).integer;
+    final _$$selfRef = reference;
+    return _whichExample(_$$selfRef.pointer, _id_whichExample.pointer).integer;
   }
 }
 
@@ -2457,7 +2518,8 @@ extension type Colors$RGB._(jni$_.JObject _$this) implements jni$_.JObject {
     core$_.int i1,
     core$_.int i2,
   ) {
-    return _new$(_class.reference.pointer, _id_new$.pointer, i, i1, i2)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer, i, i1, i2)
         .object<Colors$RGB>();
   }
 }
@@ -2519,8 +2581,9 @@ extension Colors$RGB$$Methods on Colors$RGB {
   core$_.bool equals(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _equals(reference.pointer, _id_equals.pointer, _$object.pointer)
+    return _equals(_$$selfRef.pointer, _id_equals.pointer, _$object.pointer)
         .boolean;
   }
 
@@ -2543,7 +2606,8 @@ extension Colors$RGB$$Methods on Colors$RGB {
 
   /// from: `public int hashCode()`
   core$_.int hashCode$1() {
-    return _hashCode$1(reference.pointer, _id_hashCode$1.pointer).integer;
+    final _$$selfRef = reference;
+    return _hashCode$1(_$$selfRef.pointer, _id_hashCode$1.pointer).integer;
   }
 }
 
@@ -2610,7 +2674,8 @@ extension type Colors._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `static public com.github.dart_lang.jnigen.enums.Colors[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<Colors?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<Colors?>?>();
   }
 
@@ -2635,9 +2700,9 @@ extension type Colors._(jni$_.JObject _$this) implements jni$_.JObject {
   static Colors? valueOf(
     jni$_.JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$string.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$string.pointer)
         .object<Colors?>();
   }
 }
@@ -2672,7 +2737,8 @@ extension Colors$$Methods on Colors {
   /// from: `public com.github.dart_lang.jnigen.enums.Colors$RGB toRGB()`
   /// The returned object must be released after use, by calling the [release] method.
   Colors$RGB? toRGB() {
-    return _toRGB(reference.pointer, _id_toRGB.pointer).object<Colors$RGB?>();
+    final _$$selfRef = reference;
+    return _toRGB(_$$selfRef.pointer, _id_toRGB.pointer).object<Colors$RGB?>();
   }
 }
 
@@ -2715,9 +2781,9 @@ extension type GenericConstructor<$T extends jni$_.JObject?>._(
       create<$T extends jni$_.JObject?, $S extends jni$_.JObject?>(
     jni$_.JArray<$S?>? objects,
   ) {
+    final _$$classRef = _class.reference;
     final _$objects = objects?.reference ?? jni$_.jNullReference;
-    return _create(
-            _class.reference.pointer, _id_create.pointer, _$objects.pointer)
+    return _create(_$$classRef.pointer, _id_create.pointer, _$objects.pointer)
         .object<GenericConstructor<$T>>();
   }
 }
@@ -2760,8 +2826,9 @@ extension GenericConstructor$$Methods<$T extends jni$_.JObject?>
   $T? identity(
     $T? number,
   ) {
+    final _$$selfRef = reference;
     final _$number = number?.reference ?? jni$_.jNullReference;
-    return _identity(reference.pointer, _id_identity.pointer, _$number.pointer)
+    return _identity(_$$selfRef.pointer, _id_identity.pointer, _$number.pointer)
         .object<$T?>();
   }
 }
@@ -2804,7 +2871,8 @@ extension type GenericTypeParams<$S extends jni$_.JObject?,
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory GenericTypeParams() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<GenericTypeParams<$S, $K>>();
   }
 }
@@ -2856,10 +2924,11 @@ extension type GrandParent$Parent$Child<$T extends jni$_.JObject?,
     GrandParent$Parent<$T?, $S?> $outerClass,
     $U? object,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer,
-            _$$outerClass.pointer, _$object.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer,
+            _$object.pointer)
         .object<GrandParent$Parent$Child<$T, $S, $U>>();
   }
 }
@@ -2962,10 +3031,11 @@ extension type GrandParent$Parent<$T extends jni$_.JObject?,
     GrandParent<$T?> $outerClass,
     $S? object,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer,
-            _$$outerClass.pointer, _$object.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer,
+            _$object.pointer)
         .object<GrandParent$Parent<$T, $S>>();
   }
 }
@@ -3051,11 +3121,12 @@ extension type GrandParent$StaticParent$Child<$S extends jni$_.JObject?,
     $S? object,
     $U? object1,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer,
-            _$$outerClass.pointer, _$object.pointer, _$object1.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer,
+            _$object.pointer, _$object1.pointer)
         .object<GrandParent$StaticParent$Child<$S, $U>>();
   }
 }
@@ -3133,8 +3204,9 @@ extension type GrandParent$StaticParent<$S extends jni$_.JObject?>._(
   factory GrandParent$StaticParent(
     $S? object,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer, _$object.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$object.pointer)
         .object<GrandParent$StaticParent<$S>>();
   }
 }
@@ -3194,8 +3266,9 @@ extension type GrandParent<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   factory GrandParent(
     $T? object,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer, _$object.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$object.pointer)
         .object<GrandParent<$T>>();
   }
 
@@ -3219,8 +3292,9 @@ extension type GrandParent<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `static public com.github.dart_lang.jnigen.generics.GrandParent$StaticParent<java.lang.String> stringStaticParent()`
   /// The returned object must be released after use, by calling the [release] method.
   static GrandParent$StaticParent<jni$_.JString?>? stringStaticParent() {
+    final _$$classRef = _class.reference;
     return _stringStaticParent(
-            _class.reference.pointer, _id_stringStaticParent.pointer)
+            _$$classRef.pointer, _id_stringStaticParent.pointer)
         .object<GrandParent$StaticParent<jni$_.JString?>?>();
   }
 
@@ -3246,9 +3320,10 @@ extension type GrandParent<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
       varStaticParent<$S extends jni$_.JObject?>(
     $S? object,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _varStaticParent(_class.reference.pointer,
-            _id_varStaticParent.pointer, _$object.pointer)
+    return _varStaticParent(
+            _$$classRef.pointer, _id_varStaticParent.pointer, _$object.pointer)
         .object<GrandParent$StaticParent<$S?>?>();
   }
 }
@@ -3287,7 +3362,8 @@ extension GrandParent$$Methods<$T extends jni$_.JObject?> on GrandParent<$T> {
   /// from: `public com.github.dart_lang.jnigen.generics.GrandParent$Parent<T, java.lang.String> stringParent()`
   /// The returned object must be released after use, by calling the [release] method.
   GrandParent$Parent<$T?, jni$_.JString?>? stringParent() {
-    return _stringParent(reference.pointer, _id_stringParent.pointer)
+    final _$$selfRef = reference;
+    return _stringParent(_$$selfRef.pointer, _id_stringParent.pointer)
         .object<GrandParent$Parent<$T?, jni$_.JString?>?>();
   }
 
@@ -3312,9 +3388,10 @@ extension GrandParent$$Methods<$T extends jni$_.JObject?> on GrandParent<$T> {
   GrandParent$Parent<$T?, $S?>? varParent<$S extends jni$_.JObject?>(
     $S? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _varParent(
-            reference.pointer, _id_varParent.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_varParent.pointer, _$object.pointer)
         .object<GrandParent$Parent<$T?, $S?>?>();
   }
 
@@ -3339,8 +3416,9 @@ extension GrandParent$$Methods<$T extends jni$_.JObject?> on GrandParent<$T> {
   /// from: `public com.github.dart_lang.jnigen.generics.GrandParent$StaticParent<T> staticParentWithSameType()`
   /// The returned object must be released after use, by calling the [release] method.
   GrandParent$StaticParent<$T?>? staticParentWithSameType() {
+    final _$$selfRef = reference;
     return _staticParentWithSameType(
-            reference.pointer, _id_staticParentWithSameType.pointer)
+            _$$selfRef.pointer, _id_staticParentWithSameType.pointer)
         .object<GrandParent$StaticParent<$T?>?>();
   }
 }
@@ -3393,11 +3471,12 @@ extension type MyMap$MyEntry<$K extends jni$_.JObject?,
     $K? object,
     $V? object1,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer,
-            _$$outerClass.pointer, _$object.pointer, _$object1.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer,
+            _$object.pointer, _$object1.pointer)
         .object<MyMap$MyEntry<$K, $V>>();
   }
 }
@@ -3468,8 +3547,8 @@ extension type MyMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory MyMap() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<MyMap<$K, $V>>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<MyMap<$K, $V>>();
   }
 }
 
@@ -3496,8 +3575,9 @@ extension MyMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   $V? get(
     $K? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _get(reference.pointer, _id_get.pointer, _$object.pointer)
+    return _get(_$$selfRef.pointer, _id_get.pointer, _$object.pointer)
         .object<$V?>();
   }
 
@@ -3529,9 +3609,10 @@ extension MyMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
     $K? object,
     $V? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _put(reference.pointer, _id_put.pointer, _$object.pointer,
+    return _put(_$$selfRef.pointer, _id_put.pointer, _$object.pointer,
             _$object1.pointer)
         .object<$V?>();
   }
@@ -3556,7 +3637,8 @@ extension MyMap$$Methods<$K extends jni$_.JObject?, $V extends jni$_.JObject?>
   /// from: `public com.github.dart_lang.jnigen.generics.MyStack<com.github.dart_lang.jnigen.generics.MyMap$MyEntry<K, V>> entryStack()`
   /// The returned object must be released after use, by calling the [release] method.
   MyStack<MyMap$MyEntry<$K?, $V?>?>? entryStack() {
-    return _entryStack(reference.pointer, _id_entryStack.pointer)
+    final _$$selfRef = reference;
+    return _entryStack(_$$selfRef.pointer, _id_entryStack.pointer)
         .object<MyStack<MyMap$MyEntry<$K?, $V?>?>?>();
   }
 }
@@ -3597,8 +3679,8 @@ extension type MyStack<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory MyStack() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<MyStack<$T>>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<MyStack<$T>>();
   }
 
   static final _id_fromArray = _class.staticMethodId(
@@ -3622,9 +3704,10 @@ extension type MyStack<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   static MyStack<$T?>? fromArray<$T extends jni$_.JObject?>(
     jni$_.JArray<$T?>? objects,
   ) {
+    final _$$classRef = _class.reference;
     final _$objects = objects?.reference ?? jni$_.jNullReference;
     return _fromArray(
-            _class.reference.pointer, _id_fromArray.pointer, _$objects.pointer)
+            _$$classRef.pointer, _id_fromArray.pointer, _$objects.pointer)
         .object<MyStack<$T?>?>();
   }
 
@@ -3651,8 +3734,9 @@ extension type MyStack<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
       fromArrayOfArrayOfGrandParents<$S extends jni$_.JObject?>(
     jni$_.JArray<jni$_.JArray<GrandParent<$S?>?>?>? grandParents,
   ) {
+    final _$$classRef = _class.reference;
     final _$grandParents = grandParents?.reference ?? jni$_.jNullReference;
-    return _fromArrayOfArrayOfGrandParents(_class.reference.pointer,
+    return _fromArrayOfArrayOfGrandParents(_$$classRef.pointer,
             _id_fromArrayOfArrayOfGrandParents.pointer, _$grandParents.pointer)
         .object<MyStack<$S?>?>();
   }
@@ -3677,8 +3761,8 @@ extension type MyStack<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `static public com.github.dart_lang.jnigen.generics.MyStack<T> of()`
   /// The returned object must be released after use, by calling the [release] method.
   static MyStack<$T?>? of<$T extends jni$_.JObject?>() {
-    return _of(_class.reference.pointer, _id_of.pointer)
-        .object<MyStack<$T?>?>();
+    final _$$classRef = _class.reference;
+    return _of(_$$classRef.pointer, _id_of.pointer).object<MyStack<$T?>?>();
   }
 
   static final _id_of$1 = _class.staticMethodId(
@@ -3702,8 +3786,9 @@ extension type MyStack<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   static MyStack<$T?>? of$1<$T extends jni$_.JObject?>(
     $T? object,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _of$1(_class.reference.pointer, _id_of$1.pointer, _$object.pointer)
+    return _of$1(_$$classRef.pointer, _id_of$1.pointer, _$object.pointer)
         .object<MyStack<$T?>?>();
   }
 
@@ -3735,9 +3820,10 @@ extension type MyStack<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
     $T? object,
     $T? object1,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _of$2(_class.reference.pointer, _id_of$2.pointer, _$object.pointer,
+    return _of$2(_$$classRef.pointer, _id_of$2.pointer, _$object.pointer,
             _$object1.pointer)
         .object<MyStack<$T?>?>();
   }
@@ -3764,8 +3850,9 @@ extension MyStack$$Methods<$T extends jni$_.JObject?> on MyStack<$T> {
   void push(
     $T? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    _push(reference.pointer, _id_push.pointer, _$object.pointer).check();
+    _push(_$$selfRef.pointer, _id_push.pointer, _$object.pointer).check();
   }
 
   static final _id_pop = MyStack._class.instanceMethodId(
@@ -3788,7 +3875,8 @@ extension MyStack$$Methods<$T extends jni$_.JObject?> on MyStack<$T> {
   /// from: `public T pop()`
   /// The returned object must be released after use, by calling the [release] method.
   $T? pop() {
-    return _pop(reference.pointer, _id_pop.pointer).object<$T?>();
+    final _$$selfRef = reference;
+    return _pop(_$$selfRef.pointer, _id_pop.pointer).object<$T?>();
   }
 
   static final _id_size = MyStack._class.instanceMethodId(
@@ -3810,7 +3898,8 @@ extension MyStack$$Methods<$T extends jni$_.JObject?> on MyStack<$T> {
 
   /// from: `public int size()`
   core$_.int size() {
-    return _size(reference.pointer, _id_size.pointer).integer;
+    final _$$selfRef = reference;
+    return _size(_$$selfRef.pointer, _id_size.pointer).integer;
   }
 }
 
@@ -3850,7 +3939,8 @@ extension type StringKeyedMap<$V extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory StringKeyedMap() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<StringKeyedMap<$V>>();
   }
 }
@@ -3892,8 +3982,8 @@ extension type StringMap._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory StringMap() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<StringMap>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<StringMap>();
   }
 }
 
@@ -3933,8 +4023,8 @@ extension type StringStack._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory StringStack() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<StringStack>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<StringStack>();
   }
 }
 
@@ -3974,7 +4064,8 @@ extension type StringValuedMap<$K extends jni$_.JObject?>._(
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory StringValuedMap() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<StringValuedMap<$K>>();
   }
 }
@@ -4162,9 +4253,10 @@ extension GenericInterface$$Methods<$T extends jni$_.JObject?>
   jni$_.JArray<$U?>? genericArrayOf<$U extends jni$_.JObject?>(
     $U? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _genericArrayOf(
-            reference.pointer, _id_genericArrayOf.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_genericArrayOf.pointer, _$object.pointer)
         .object<jni$_.JArray<$U?>?>();
   }
 
@@ -4189,8 +4281,9 @@ extension GenericInterface$$Methods<$T extends jni$_.JObject?>
   jni$_.JArray<$T?>? arrayOf(
     $T? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _arrayOf(reference.pointer, _id_arrayOf.pointer, _$object.pointer)
+    return _arrayOf(_$$selfRef.pointer, _id_arrayOf.pointer, _$object.pointer)
         .object<jni$_.JArray<$T?>?>();
   }
 
@@ -4222,9 +4315,10 @@ extension GenericInterface$$Methods<$T extends jni$_.JObject?>
     $T? object,
     $U? object1,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1?.reference ?? jni$_.jNullReference;
-    return _mapOf(reference.pointer, _id_mapOf.pointer, _$object.pointer,
+    return _mapOf(_$$selfRef.pointer, _id_mapOf.pointer, _$object.pointer,
             _$object1.pointer)
         .object<jni$_.JMap<$T?, $U?>?>();
   }
@@ -4251,8 +4345,9 @@ extension GenericInterface$$Methods<$T extends jni$_.JObject?>
   $U? firstOfGenericArray<$U extends jni$_.JObject?>(
     jni$_.JArray<$U?>? objects,
   ) {
+    final _$$selfRef = reference;
     final _$objects = objects?.reference ?? jni$_.jNullReference;
-    return _firstOfGenericArray(reference.pointer,
+    return _firstOfGenericArray(_$$selfRef.pointer,
             _id_firstOfGenericArray.pointer, _$objects.pointer)
         .object<$U?>();
   }
@@ -4278,9 +4373,10 @@ extension GenericInterface$$Methods<$T extends jni$_.JObject?>
   $T? firstOfArray(
     jni$_.JArray<$T?>? objects,
   ) {
+    final _$$selfRef = reference;
     final _$objects = objects?.reference ?? jni$_.jNullReference;
     return _firstOfArray(
-            reference.pointer, _id_firstOfArray.pointer, _$objects.pointer)
+            _$$selfRef.pointer, _id_firstOfArray.pointer, _$objects.pointer)
         .object<$T?>();
   }
 
@@ -4305,8 +4401,10 @@ extension GenericInterface$$Methods<$T extends jni$_.JObject?>
   $T? firstKeyOf<$U extends jni$_.JObject?>(
     jni$_.JMap<$T?, $U?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
-    return _firstKeyOf(reference.pointer, _id_firstKeyOf.pointer, _$map.pointer)
+    return _firstKeyOf(
+            _$$selfRef.pointer, _id_firstKeyOf.pointer, _$map.pointer)
         .object<$T?>();
   }
 
@@ -4331,9 +4429,10 @@ extension GenericInterface$$Methods<$T extends jni$_.JObject?>
   $U? firstValueOf<$U extends jni$_.JObject?>(
     jni$_.JMap<$T?, $U?>? map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map?.reference ?? jni$_.jNullReference;
     return _firstValueOf(
-            reference.pointer, _id_firstValueOf.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_firstValueOf.pointer, _$map.pointer)
         .object<$U?>();
   }
 }
@@ -4583,8 +4682,10 @@ extension InheritedFromMyInterface$$Methods on InheritedFromMyInterface {
   void voidCallback(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    _voidCallback(reference.pointer, _id_voidCallback.pointer, _$string.pointer)
+    _voidCallback(
+            _$$selfRef.pointer, _id_voidCallback.pointer, _$string.pointer)
         .check();
   }
 
@@ -4610,9 +4711,10 @@ extension InheritedFromMyInterface$$Methods on InheritedFromMyInterface {
   jni$_.JString? stringCallback(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _stringCallback(
-            reference.pointer, _id_stringCallback.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_stringCallback.pointer, _$string.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -4638,9 +4740,10 @@ extension InheritedFromMyInterface$$Methods on InheritedFromMyInterface {
   jni$_.JString? varCallback(
     jni$_.JString? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _varCallback(
-            reference.pointer, _id_varCallback.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_varCallback.pointer, _$object.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -4678,8 +4781,9 @@ extension InheritedFromMyInterface$$Methods on InheritedFromMyInterface {
     core$_.int c,
     core$_.double d,
   ) {
+    final _$$selfRef = reference;
     return _manyPrimitives(
-            reference.pointer, _id_manyPrimitives.pointer, i, z ? 1 : 0, c, d)
+            _$$selfRef.pointer, _id_manyPrimitives.pointer, i, z ? 1 : 0, c, d)
         .long;
   }
 }
@@ -4860,7 +4964,8 @@ extension InheritedFromMyRunnable$$Methods on InheritedFromMyRunnable {
 
   /// from: `public abstract void run()`
   void run() {
-    _run(reference.pointer, _id_run.pointer).check();
+    final _$$selfRef = reference;
+    _run(_$$selfRef.pointer, _id_run.pointer).check();
   }
 }
 
@@ -5037,8 +5142,10 @@ extension MyInterface$$Methods<$T extends jni$_.JObject?> on MyInterface<$T> {
   void voidCallback(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    _voidCallback(reference.pointer, _id_voidCallback.pointer, _$string.pointer)
+    _voidCallback(
+            _$$selfRef.pointer, _id_voidCallback.pointer, _$string.pointer)
         .check();
   }
 
@@ -5063,9 +5170,10 @@ extension MyInterface$$Methods<$T extends jni$_.JObject?> on MyInterface<$T> {
   jni$_.JString? stringCallback(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _stringCallback(
-            reference.pointer, _id_stringCallback.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_stringCallback.pointer, _$string.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -5090,9 +5198,10 @@ extension MyInterface$$Methods<$T extends jni$_.JObject?> on MyInterface<$T> {
   $T? varCallback(
     $T? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _varCallback(
-            reference.pointer, _id_varCallback.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_varCallback.pointer, _$object.pointer)
         .object<$T?>();
   }
 
@@ -5129,8 +5238,9 @@ extension MyInterface$$Methods<$T extends jni$_.JObject?> on MyInterface<$T> {
     core$_.int c,
     core$_.double d,
   ) {
+    final _$$selfRef = reference;
     return _manyPrimitives(
-            reference.pointer, _id_manyPrimitives.pointer, i, z ? 1 : 0, c, d)
+            _$$selfRef.pointer, _id_manyPrimitives.pointer, i, z ? 1 : 0, c, d)
         .long;
   }
 }
@@ -5232,7 +5342,8 @@ extension type MyInterfaceConsumer._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory MyInterfaceConsumer() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<MyInterfaceConsumer>();
   }
 
@@ -5278,11 +5389,12 @@ extension type MyInterfaceConsumer._(jni$_.JObject _$this)
     core$_.double d,
     $T? object,
   ) {
+    final _$$classRef = _class.reference;
     final _$myInterface = myInterface?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     _consumeOnAnotherThread(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_consumeOnAnotherThread.pointer,
             _$myInterface.pointer,
             _$string.pointer,
@@ -5336,11 +5448,12 @@ extension type MyInterfaceConsumer._(jni$_.JObject _$this)
     core$_.double d,
     $T? object,
   ) {
+    final _$$classRef = _class.reference;
     final _$myInterface = myInterface?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     _consumeOnSameThread(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_consumeOnSameThread.pointer,
             _$myInterface.pointer,
             _$string.pointer,
@@ -5469,7 +5582,8 @@ extension MyRunnable$$Methods on MyRunnable {
 
   /// from: `public abstract void run()`
   void run() {
-    _run(reference.pointer, _id_run.pointer).check();
+    final _$$selfRef = reference;
+    _run(_$$selfRef.pointer, _id_run.pointer).check();
   }
 }
 
@@ -5535,9 +5649,9 @@ extension type MyRunnableRunner._(jni$_.JObject _$this)
   factory MyRunnableRunner(
     MyRunnable? myRunnable,
   ) {
+    final _$$classRef = _class.reference;
     final _$myRunnable = myRunnable?.reference ?? jni$_.jNullReference;
-    return _new$(
-            _class.reference.pointer, _id_new$.pointer, _$myRunnable.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$myRunnable.pointer)
         .object<MyRunnableRunner>();
   }
 }
@@ -5577,7 +5691,8 @@ extension MyRunnableRunner$$Methods on MyRunnableRunner {
 
   /// from: `public void runOnSameThread()`
   void runOnSameThread() {
-    _runOnSameThread(reference.pointer, _id_runOnSameThread.pointer).check();
+    final _$$selfRef = reference;
+    _runOnSameThread(_$$selfRef.pointer, _id_runOnSameThread.pointer).check();
   }
 
   static final _id_runOnAnotherThread =
@@ -5600,7 +5715,8 @@ extension MyRunnableRunner$$Methods on MyRunnableRunner {
 
   /// from: `public void runOnAnotherThread()`
   void runOnAnotherThread() {
-    _runOnAnotherThread(reference.pointer, _id_runOnAnotherThread.pointer)
+    final _$$selfRef = reference;
+    _runOnAnotherThread(_$$selfRef.pointer, _id_runOnAnotherThread.pointer)
         .check();
   }
 
@@ -5624,8 +5740,9 @@ extension MyRunnableRunner$$Methods on MyRunnableRunner {
 
   /// from: `public void runOnAnotherThreadAndJoin()`
   void runOnAnotherThreadAndJoin() {
+    final _$$selfRef = reference;
     _runOnAnotherThreadAndJoin(
-            reference.pointer, _id_runOnAnotherThreadAndJoin.pointer)
+            _$$selfRef.pointer, _id_runOnAnotherThreadAndJoin.pointer)
         .check();
   }
 }
@@ -5669,8 +5786,9 @@ extension type StringConversionException._(jni$_.JObject _$this)
   factory StringConversionException(
     jni$_.JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer, _$string.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$string.pointer)
         .object<StringConversionException>();
   }
 }
@@ -5792,9 +5910,10 @@ extension StringConverter$$Methods on StringConverter {
   core$_.int parseToInt(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _parseToInt(
-            reference.pointer, _id_parseToInt.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_parseToInt.pointer, _$string.pointer)
         .integer;
   }
 }
@@ -5857,7 +5976,8 @@ extension type StringConverterConsumer._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory StringConverterConsumer() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<StringConverterConsumer>();
   }
 
@@ -5889,11 +6009,12 @@ extension type StringConverterConsumer._(jni$_.JObject _$this)
     StringConverter? stringConverter,
     jni$_.JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$stringConverter =
         stringConverter?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _consumeOnSameThread(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_consumeOnSameThread.pointer,
             _$stringConverter.pointer,
             _$string.pointer)
@@ -5928,11 +6049,12 @@ extension type StringConverterConsumer._(jni$_.JObject _$this)
     StringConverter? stringConverter,
     jni$_.JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$stringConverter =
         stringConverter?.reference ?? jni$_.jNullReference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _consumeOnAnotherThread(
-            _class.reference.pointer,
+            _$$classRef.pointer,
             _id_consumeOnAnotherThread.pointer,
             _$stringConverter.pointer,
             _$string.pointer)
@@ -6061,8 +6183,9 @@ extension Animal$$Methods on Animal {
   jni$_.JString eat(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
-    return _eat(reference.pointer, _id_eat.pointer, _$string.pointer)
+    return _eat(_$$selfRef.pointer, _id_eat.pointer, _$string.pointer)
         .object<jni$_.JString>();
   }
 }
@@ -6123,8 +6246,8 @@ extension type BaseClass<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory BaseClass() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<BaseClass<$T>>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<BaseClass<$T>>();
   }
 }
 
@@ -6150,9 +6273,10 @@ extension BaseClass$$Methods<$T extends jni$_.JObject?> on BaseClass<$T> {
   $T? someMethod(
     $T? charSequence,
   ) {
+    final _$$selfRef = reference;
     final _$charSequence = charSequence?.reference ?? jni$_.jNullReference;
     return _someMethod(
-            reference.pointer, _id_someMethod.pointer, _$charSequence.pointer)
+            _$$selfRef.pointer, _id_someMethod.pointer, _$charSequence.pointer)
         .object<$T?>();
   }
 }
@@ -6277,7 +6401,8 @@ extension BaseGenericInterface$$Methods<$T extends jni$_.JObject?>
   /// from: `public abstract T foo()`
   /// The returned object must be released after use, by calling the [release] method.
   $T? foo() {
-    return _foo(reference.pointer, _id_foo.pointer).object<$T?>();
+    final _$$selfRef = reference;
+    return _foo(_$$selfRef.pointer, _id_foo.pointer).object<$T?>();
   }
 }
 
@@ -6430,7 +6555,8 @@ extension BaseInterface$$Methods on BaseInterface {
   /// from: `public abstract java.lang.String foo()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? foo() {
-    return _foo(reference.pointer, _id_foo.pointer).object<jni$_.JString?>();
+    final _$$selfRef = reference;
+    return _foo(_$$selfRef.pointer, _id_foo.pointer).object<jni$_.JString?>();
   }
 
   static final _id_someMethod = BaseInterface._class.instanceMethodId(
@@ -6454,9 +6580,10 @@ extension BaseInterface$$Methods on BaseInterface {
   jni$_.JString? someMethod(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _someMethod(
-            reference.pointer, _id_someMethod.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_someMethod.pointer, _$string.pointer)
         .object<jni$_.JString?>();
   }
 }
@@ -6527,7 +6654,8 @@ extension type Child._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory Child() {
-    return _new$(_class.reference.pointer, _id_new$.pointer).object<Child>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<Child>();
   }
 }
 
@@ -6552,7 +6680,8 @@ extension Child$$Methods on Child {
   /// from: `public java.lang.String foo()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? foo() {
-    return _foo(reference.pointer, _id_foo.pointer).object<jni$_.JString?>();
+    final _$$selfRef = reference;
+    return _foo(_$$selfRef.pointer, _id_foo.pointer).object<jni$_.JString?>();
   }
 
   static final _id_someMethod$1 = Child._class.instanceMethodId(
@@ -6576,9 +6705,10 @@ extension Child$$Methods on Child {
   jni$_.JString? someMethod$1(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _someMethod$1(
-            reference.pointer, _id_someMethod$1.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_someMethod$1.pointer, _$string.pointer)
         .object<jni$_.JString?>();
   }
 }
@@ -6713,7 +6843,8 @@ extension DerivedInterface$$Methods on DerivedInterface {
   /// from: `public abstract java.lang.String foo()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString? foo() {
-    return _foo(reference.pointer, _id_foo.pointer).object<jni$_.JString?>();
+    final _$$selfRef = reference;
+    return _foo(_$$selfRef.pointer, _id_foo.pointer).object<jni$_.JString?>();
   }
 
   static final _id_someMethod = DerivedInterface._class.instanceMethodId(
@@ -6737,9 +6868,10 @@ extension DerivedInterface$$Methods on DerivedInterface {
   jni$_.JString? someMethod(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _someMethod(
-            reference.pointer, _id_someMethod.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_someMethod.pointer, _$string.pointer)
         .object<jni$_.JString?>();
   }
 }
@@ -6917,7 +7049,8 @@ extension Dog$$Methods on Dog {
   /// from: `public abstract java.lang.String bark()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString bark() {
-    return _bark(reference.pointer, _id_bark.pointer).object<jni$_.JString>();
+    final _$$selfRef = reference;
+    return _bark(_$$selfRef.pointer, _id_bark.pointer).object<jni$_.JString>();
   }
 
   static final _id_giveBirth = Dog._class.instanceMethodId(
@@ -6940,7 +7073,8 @@ extension Dog$$Methods on Dog {
   jni$_.JString? giveBirth(
     core$_.bool z,
   ) {
-    return _giveBirth(reference.pointer, _id_giveBirth.pointer, z ? 1 : 0)
+    final _$$selfRef = reference;
+    return _giveBirth(_$$selfRef.pointer, _id_giveBirth.pointer, z ? 1 : 0)
         .object<jni$_.JString?>();
   }
 
@@ -6965,8 +7099,9 @@ extension Dog$$Methods on Dog {
   jni$_.JString eat(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
-    return _eat(reference.pointer, _id_eat.pointer, _$string.pointer)
+    return _eat(_$$selfRef.pointer, _id_eat.pointer, _$string.pointer)
         .object<jni$_.JString>();
   }
 
@@ -6989,7 +7124,8 @@ extension Dog$$Methods on Dog {
   core$_.int walk(
     core$_.int i,
   ) {
-    return _walk(reference.pointer, _id_walk.pointer, i).integer;
+    final _$$selfRef = reference;
+    return _walk(_$$selfRef.pointer, _id_walk.pointer, i).integer;
   }
 }
 
@@ -7164,7 +7300,8 @@ extension FourLegged$$Methods on FourLegged {
   core$_.int walk(
     core$_.int i,
   ) {
-    return _walk(reference.pointer, _id_walk.pointer, i).integer;
+    final _$$selfRef = reference;
+    return _walk(_$$selfRef.pointer, _id_walk.pointer, i).integer;
   }
 
   static final _id_eat = FourLegged._class.instanceMethodId(
@@ -7188,8 +7325,9 @@ extension FourLegged$$Methods on FourLegged {
   jni$_.JString eat(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
-    return _eat(reference.pointer, _id_eat.pointer, _$string.pointer)
+    return _eat(_$$selfRef.pointer, _id_eat.pointer, _$string.pointer)
         .object<jni$_.JString>();
   }
 }
@@ -7360,7 +7498,9 @@ extension Furry$$Methods on Furry {
   /// from: `public abstract java.lang.String groom()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString groom() {
-    return _groom(reference.pointer, _id_groom.pointer).object<jni$_.JString>();
+    final _$$selfRef = reference;
+    return _groom(_$$selfRef.pointer, _id_groom.pointer)
+        .object<jni$_.JString>();
   }
 
   static final _id_giveBirth = Furry._class.instanceMethodId(
@@ -7383,7 +7523,8 @@ extension Furry$$Methods on Furry {
   jni$_.JString? giveBirth(
     core$_.bool z,
   ) {
-    return _giveBirth(reference.pointer, _id_giveBirth.pointer, z ? 1 : 0)
+    final _$$selfRef = reference;
+    return _giveBirth(_$$selfRef.pointer, _id_giveBirth.pointer, z ? 1 : 0)
         .object<jni$_.JString?>();
   }
 
@@ -7408,8 +7549,9 @@ extension Furry$$Methods on Furry {
   jni$_.JString eat(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
-    return _eat(reference.pointer, _id_eat.pointer, _$string.pointer)
+    return _eat(_$$selfRef.pointer, _id_eat.pointer, _$string.pointer)
         .object<jni$_.JString>();
   }
 }
@@ -7489,7 +7631,8 @@ extension type GenericDerivedClass<$T extends jni$_.JObject?>._(
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory GenericDerivedClass() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<GenericDerivedClass<$T>>();
   }
 }
@@ -7624,7 +7767,8 @@ extension Mammal$$Methods on Mammal {
   jni$_.JString? giveBirth(
     core$_.bool z,
   ) {
-    return _giveBirth(reference.pointer, _id_giveBirth.pointer, z ? 1 : 0)
+    final _$$selfRef = reference;
+    return _giveBirth(_$$selfRef.pointer, _id_giveBirth.pointer, z ? 1 : 0)
         .object<jni$_.JString?>();
   }
 
@@ -7649,8 +7793,9 @@ extension Mammal$$Methods on Mammal {
   jni$_.JString eat(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
-    return _eat(reference.pointer, _id_eat.pointer, _$string.pointer)
+    return _eat(_$$selfRef.pointer, _id_eat.pointer, _$string.pointer)
         .object<jni$_.JString>();
   }
 }
@@ -7720,7 +7865,8 @@ extension type ShibaInu._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory ShibaInu() {
-    return _new$(_class.reference.pointer, _id_new$.pointer).object<ShibaInu>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<ShibaInu>();
   }
 }
 
@@ -7746,8 +7892,9 @@ extension ShibaInu$$Methods on ShibaInu {
   jni$_.JString eat(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
-    return _eat(reference.pointer, _id_eat.pointer, _$string.pointer)
+    return _eat(_$$selfRef.pointer, _id_eat.pointer, _$string.pointer)
         .object<jni$_.JString>();
   }
 
@@ -7771,7 +7918,8 @@ extension ShibaInu$$Methods on ShibaInu {
   jni$_.JString? giveBirth(
     core$_.bool z,
   ) {
-    return _giveBirth(reference.pointer, _id_giveBirth.pointer, z ? 1 : 0)
+    final _$$selfRef = reference;
+    return _giveBirth(_$$selfRef.pointer, _id_giveBirth.pointer, z ? 1 : 0)
         .object<jni$_.JString?>();
   }
 
@@ -7794,7 +7942,8 @@ extension ShibaInu$$Methods on ShibaInu {
   core$_.int walk(
     core$_.int i,
   ) {
-    return _walk(reference.pointer, _id_walk.pointer, i).integer;
+    final _$$selfRef = reference;
+    return _walk(_$$selfRef.pointer, _id_walk.pointer, i).integer;
   }
 
   static final _id_bark = ShibaInu._class.instanceMethodId(
@@ -7817,7 +7966,8 @@ extension ShibaInu$$Methods on ShibaInu {
   /// from: `public java.lang.String bark()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString bark() {
-    return _bark(reference.pointer, _id_bark.pointer).object<jni$_.JString>();
+    final _$$selfRef = reference;
+    return _bark(_$$selfRef.pointer, _id_bark.pointer).object<jni$_.JString>();
   }
 
   static final _id_groom = ShibaInu._class.instanceMethodId(
@@ -7840,7 +7990,9 @@ extension ShibaInu$$Methods on ShibaInu {
   /// from: `public java.lang.String groom()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString groom() {
-    return _groom(reference.pointer, _id_groom.pointer).object<jni$_.JString>();
+    final _$$selfRef = reference;
+    return _groom(_$$selfRef.pointer, _id_groom.pointer)
+        .object<jni$_.JString>();
   }
 }
 
@@ -7881,7 +8033,8 @@ extension type SpecificDerivedClass._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory SpecificDerivedClass() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer)
         .object<SpecificDerivedClass>();
   }
 }
@@ -7908,9 +8061,10 @@ extension SpecificDerivedClass$$Methods on SpecificDerivedClass {
   jni$_.JString? someMethod$1(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _someMethod$1(
-            reference.pointer, _id_someMethod$1.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_someMethod$1.pointer, _$string.pointer)
         .object<jni$_.JString?>();
   }
 }
@@ -7965,10 +8119,11 @@ extension type Annotated$Nested<
     Annotated<$T?, $U, $W> $outerClass,
     $V? object,
   ) {
+    final _$$classRef = _class.reference;
     final _$$outerClass = $outerClass.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _new$(_class.reference.pointer, _id_new$.pointer,
-            _$$outerClass.pointer, _$object.pointer)
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$$outerClass.pointer,
+            _$object.pointer)
         .object<Annotated$Nested<$T, $U, $W, $V>>();
   }
 }
@@ -8053,10 +8208,11 @@ extension type Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
     $U object1,
     $W object2,
   ) {
+    final _$$classRef = _class.reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     final _$object1 = object1.reference;
     final _$object2 = object2.reference;
-    return _new$(_class.reference.pointer, _id_new$.pointer, _$object.pointer,
+    return _new$(_$$classRef.pointer, _id_new$.pointer, _$object.pointer,
             _$object1.pointer, _$object2.pointer)
         .object<Annotated<$T, $U, $W>>();
   }
@@ -8081,7 +8237,8 @@ extension type Annotated<$T extends jni$_.JObject?, $U extends jni$_.JObject,
   /// from: `static public java.lang.String staticHello()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JString staticHello() {
-    return _staticHello(_class.reference.pointer, _id_staticHello.pointer)
+    final _$$classRef = _class.reference;
+    return _staticHello(_$$classRef.pointer, _id_staticHello.pointer)
         .object<jni$_.JString>();
   }
 }
@@ -8149,7 +8306,9 @@ extension Annotated$$Methods<
   /// from: `public java.lang.String hello()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString hello() {
-    return _hello(reference.pointer, _id_hello.pointer).object<jni$_.JString>();
+    final _$$selfRef = reference;
+    return _hello(_$$selfRef.pointer, _id_hello.pointer)
+        .object<jni$_.JString>();
   }
 
   static final _id_nullableHello = Annotated._class.instanceMethodId(
@@ -8172,8 +8331,9 @@ extension Annotated$$Methods<
   jni$_.JString? nullableHello(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _nullableHello(
-            reference.pointer, _id_nullableHello.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_nullableHello.pointer, z ? 1 : 0)
         .object<jni$_.JString?>();
   }
 
@@ -8198,8 +8358,9 @@ extension Annotated$$Methods<
   jni$_.JString echo(
     jni$_.JString string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string.reference;
-    return _echo(reference.pointer, _id_echo.pointer, _$string.pointer)
+    return _echo(_$$selfRef.pointer, _id_echo.pointer, _$string.pointer)
         .object<jni$_.JString>();
   }
 
@@ -8224,9 +8385,10 @@ extension Annotated$$Methods<
   jni$_.JString? nullableEcho(
     jni$_.JString? string,
   ) {
+    final _$$selfRef = reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
     return _nullableEcho(
-            reference.pointer, _id_nullableEcho.pointer, _$string.pointer)
+            _$$selfRef.pointer, _id_nullableEcho.pointer, _$string.pointer)
         .object<jni$_.JString?>();
   }
 
@@ -8250,7 +8412,8 @@ extension Annotated$$Methods<
   /// from: `public java.lang.String[] array()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JArray<jni$_.JString> array() {
-    return _array(reference.pointer, _id_array.pointer)
+    final _$$selfRef = reference;
+    return _array(_$$selfRef.pointer, _id_array.pointer)
         .object<jni$_.JArray<jni$_.JString>>();
   }
 
@@ -8274,7 +8437,8 @@ extension Annotated$$Methods<
   /// from: `public java.lang.String[] arrayOfNullable()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JArray<jni$_.JString?> arrayOfNullable() {
-    return _arrayOfNullable(reference.pointer, _id_arrayOfNullable.pointer)
+    final _$$selfRef = reference;
+    return _arrayOfNullable(_$$selfRef.pointer, _id_arrayOfNullable.pointer)
         .object<jni$_.JArray<jni$_.JString?>>();
   }
 
@@ -8298,8 +8462,9 @@ extension Annotated$$Methods<
   jni$_.JArray<jni$_.JString>? nullableArray(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _nullableArray(
-            reference.pointer, _id_nullableArray.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_nullableArray.pointer, z ? 1 : 0)
         .object<jni$_.JArray<jni$_.JString>?>();
   }
 
@@ -8323,8 +8488,9 @@ extension Annotated$$Methods<
   jni$_.JArray<jni$_.JString?>? nullableArrayOfNullable(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _nullableArrayOfNullable(
-            reference.pointer, _id_nullableArrayOfNullable.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_nullableArrayOfNullable.pointer, z ? 1 : 0)
         .object<jni$_.JArray<jni$_.JString?>?>();
   }
 
@@ -8348,7 +8514,8 @@ extension Annotated$$Methods<
   /// from: `public java.util.List<java.lang.String> list()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JString> list() {
-    return _list(reference.pointer, _id_list.pointer)
+    final _$$selfRef = reference;
+    return _list(_$$selfRef.pointer, _id_list.pointer)
         .object<jni$_.JList<jni$_.JString>>();
   }
 
@@ -8372,7 +8539,8 @@ extension Annotated$$Methods<
   /// from: `public java.util.List<java.lang.String> listOfNullable()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JString?> listOfNullable() {
-    return _listOfNullable(reference.pointer, _id_listOfNullable.pointer)
+    final _$$selfRef = reference;
+    return _listOfNullable(_$$selfRef.pointer, _id_listOfNullable.pointer)
         .object<jni$_.JList<jni$_.JString?>>();
   }
 
@@ -8396,7 +8564,9 @@ extension Annotated$$Methods<
   jni$_.JList<jni$_.JString>? nullableList(
     core$_.bool z,
   ) {
-    return _nullableList(reference.pointer, _id_nullableList.pointer, z ? 1 : 0)
+    final _$$selfRef = reference;
+    return _nullableList(
+            _$$selfRef.pointer, _id_nullableList.pointer, z ? 1 : 0)
         .object<jni$_.JList<jni$_.JString>?>();
   }
 
@@ -8420,8 +8590,9 @@ extension Annotated$$Methods<
   jni$_.JList<jni$_.JString?>? nullableListOfNullable(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _nullableListOfNullable(
-            reference.pointer, _id_nullableListOfNullable.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_nullableListOfNullable.pointer, z ? 1 : 0)
         .object<jni$_.JList<jni$_.JString?>?>();
   }
 
@@ -8446,9 +8617,10 @@ extension Annotated$$Methods<
   $T? classGenericEcho(
     $T? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _classGenericEcho(
-            reference.pointer, _id_classGenericEcho.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_classGenericEcho.pointer, _$object.pointer)
         .object<$T?>();
   }
 
@@ -8473,8 +8645,9 @@ extension Annotated$$Methods<
   $T? nullableClassGenericEcho(
     $T? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _nullableClassGenericEcho(reference.pointer,
+    return _nullableClassGenericEcho(_$$selfRef.pointer,
             _id_nullableClassGenericEcho.pointer, _$object.pointer)
         .object<$T?>();
   }
@@ -8500,9 +8673,10 @@ extension Annotated$$Methods<
   $V? methodGenericEcho<$V extends jni$_.JObject?>(
     $V? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _methodGenericEcho(
-            reference.pointer, _id_methodGenericEcho.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_methodGenericEcho.pointer, _$object.pointer)
         .object<$V?>();
   }
 
@@ -8527,9 +8701,10 @@ extension Annotated$$Methods<
   $V methodGenericEcho2<$V extends jni$_.JObject>(
     $V object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object.reference;
-    return _methodGenericEcho2(
-            reference.pointer, _id_methodGenericEcho2.pointer, _$object.pointer)
+    return _methodGenericEcho2(_$$selfRef.pointer,
+            _id_methodGenericEcho2.pointer, _$object.pointer)
         .object<$V>();
   }
 
@@ -8554,9 +8729,10 @@ extension Annotated$$Methods<
   $V methodGenericEcho3<$V extends jni$_.JObject>(
     $V object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object.reference;
-    return _methodGenericEcho3(
-            reference.pointer, _id_methodGenericEcho3.pointer, _$object.pointer)
+    return _methodGenericEcho3(_$$selfRef.pointer,
+            _id_methodGenericEcho3.pointer, _$object.pointer)
         .object<$V>();
   }
 
@@ -8587,9 +8763,10 @@ extension Annotated$$Methods<
     $V? object,
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _nullableReturnMethodGenericEcho(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_nullableReturnMethodGenericEcho.pointer,
             _$object.pointer,
             z ? 1 : 0)
@@ -8623,9 +8800,10 @@ extension Annotated$$Methods<
     $V object,
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     final _$object = object.reference;
     return _nullableReturnMethodGenericEcho2(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_nullableReturnMethodGenericEcho2.pointer,
             _$object.pointer,
             z ? 1 : 0)
@@ -8654,8 +8832,9 @@ extension Annotated$$Methods<
   $V? nullableMethodGenericEcho<$V extends jni$_.JObject?>(
     $V? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _nullableMethodGenericEcho(reference.pointer,
+    return _nullableMethodGenericEcho(_$$selfRef.pointer,
             _id_nullableMethodGenericEcho.pointer, _$object.pointer)
         .object<$V?>();
   }
@@ -8683,8 +8862,9 @@ extension Annotated$$Methods<
   $V? noAnnotationMethodGenericEcho<$V extends jni$_.JObject?>(
     $V? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _noAnnotationMethodGenericEcho(reference.pointer,
+    return _noAnnotationMethodGenericEcho(_$$selfRef.pointer,
             _id_noAnnotationMethodGenericEcho.pointer, _$object.pointer)
         .object<$V?>();
   }
@@ -8712,8 +8892,9 @@ extension Annotated$$Methods<
   $V nullableArgMethodGenericEcho<$V extends jni$_.JObject>(
     $V? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _nullableArgMethodGenericEcho(reference.pointer,
+    return _nullableArgMethodGenericEcho(_$$selfRef.pointer,
             _id_nullableArgMethodGenericEcho.pointer, _$object.pointer)
         .object<$V>();
   }
@@ -8738,7 +8919,8 @@ extension Annotated$$Methods<
   /// from: `public java.util.List<T> classGenericList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<$T?> classGenericList() {
-    return _classGenericList(reference.pointer, _id_classGenericList.pointer)
+    final _$$selfRef = reference;
+    return _classGenericList(_$$selfRef.pointer, _id_classGenericList.pointer)
         .object<jni$_.JList<$T?>>();
   }
 
@@ -8764,8 +8946,9 @@ extension Annotated$$Methods<
   /// from: `public java.util.List<T> classGenericListOfNullable()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<$T?> classGenericListOfNullable() {
+    final _$$selfRef = reference;
     return _classGenericListOfNullable(
-            reference.pointer, _id_classGenericListOfNullable.pointer)
+            _$$selfRef.pointer, _id_classGenericListOfNullable.pointer)
         .object<jni$_.JList<$T?>>();
   }
 
@@ -8789,8 +8972,9 @@ extension Annotated$$Methods<
   jni$_.JList<$T?>? nullableClassGenericList(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _nullableClassGenericList(
-            reference.pointer, _id_nullableClassGenericList.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_nullableClassGenericList.pointer, z ? 1 : 0)
         .object<jni$_.JList<$T?>?>();
   }
 
@@ -8815,7 +8999,8 @@ extension Annotated$$Methods<
   jni$_.JList<$T?>? nullableClassGenericListOfNullable(
     core$_.bool z,
   ) {
-    return _nullableClassGenericListOfNullable(reference.pointer,
+    final _$$selfRef = reference;
+    return _nullableClassGenericListOfNullable(_$$selfRef.pointer,
             _id_nullableClassGenericListOfNullable.pointer, z ? 1 : 0)
         .object<jni$_.JList<$T?>?>();
   }
@@ -8841,9 +9026,10 @@ extension Annotated$$Methods<
   jni$_.JList<$V?> methodGenericList<$V extends jni$_.JObject?>(
     $V? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
     return _methodGenericList(
-            reference.pointer, _id_methodGenericList.pointer, _$object.pointer)
+            _$$selfRef.pointer, _id_methodGenericList.pointer, _$object.pointer)
         .object<jni$_.JList<$V?>>();
   }
 
@@ -8869,8 +9055,9 @@ extension Annotated$$Methods<
   /// from: `public java.util.List<V> methodGenericListOfNullable()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<$V?> methodGenericListOfNullable<$V extends jni$_.JObject?>() {
+    final _$$selfRef = reference;
     return _methodGenericListOfNullable(
-            reference.pointer, _id_methodGenericListOfNullable.pointer)
+            _$$selfRef.pointer, _id_methodGenericListOfNullable.pointer)
         .object<jni$_.JList<$V?>>();
   }
 
@@ -8898,8 +9085,9 @@ extension Annotated$$Methods<
     $V? object,
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _nullableMethodGenericList(reference.pointer,
+    return _nullableMethodGenericList(_$$selfRef.pointer,
             _id_nullableMethodGenericList.pointer, _$object.pointer, z ? 1 : 0)
         .object<jni$_.JList<$V?>?>();
   }
@@ -8926,7 +9114,8 @@ extension Annotated$$Methods<
       nullableMethodGenericListOfNullable<$V extends jni$_.JObject?>(
     core$_.bool z,
   ) {
-    return _nullableMethodGenericListOfNullable(reference.pointer,
+    final _$$selfRef = reference;
+    return _nullableMethodGenericListOfNullable(_$$selfRef.pointer,
             _id_nullableMethodGenericListOfNullable.pointer, z ? 1 : 0)
         .object<jni$_.JList<$V?>?>();
   }
@@ -8952,8 +9141,9 @@ extension Annotated$$Methods<
   $T? firstOfClassGenericList(
     jni$_.JList<$T?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _firstOfClassGenericList(reference.pointer,
+    return _firstOfClassGenericList(_$$selfRef.pointer,
             _id_firstOfClassGenericList.pointer, _$list.pointer)
         .object<$T?>();
   }
@@ -8981,8 +9171,9 @@ extension Annotated$$Methods<
   $T? firstOfClassGenericNullableList(
     jni$_.JList<$T?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _firstOfClassGenericNullableList(reference.pointer,
+    return _firstOfClassGenericNullableList(_$$selfRef.pointer,
             _id_firstOfClassGenericNullableList.pointer, _$list.pointer)
         .object<$T?>();
   }
@@ -9010,8 +9201,9 @@ extension Annotated$$Methods<
   $T? firstOfClassGenericListOfNullable(
     jni$_.JList<$T?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _firstOfClassGenericListOfNullable(reference.pointer,
+    return _firstOfClassGenericListOfNullable(_$$selfRef.pointer,
             _id_firstOfClassGenericListOfNullable.pointer, _$list.pointer)
         .object<$T?>();
   }
@@ -9039,9 +9231,10 @@ extension Annotated$$Methods<
   $T? firstOfClassGenericNullableListOfNullable(
     jni$_.JList<$T?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     return _firstOfClassGenericNullableListOfNullable(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_firstOfClassGenericNullableListOfNullable.pointer,
             _$list.pointer)
         .object<$T?>();
@@ -9068,8 +9261,9 @@ extension Annotated$$Methods<
   $V? firstOfMethodGenericList<$V extends jni$_.JObject?>(
     jni$_.JList<$V?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _firstOfMethodGenericList(reference.pointer,
+    return _firstOfMethodGenericList(_$$selfRef.pointer,
             _id_firstOfMethodGenericList.pointer, _$list.pointer)
         .object<$V?>();
   }
@@ -9097,8 +9291,9 @@ extension Annotated$$Methods<
   $V? firstOfMethodGenericNullableList<$V extends jni$_.JObject?>(
     jni$_.JList<$V?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
-    return _firstOfMethodGenericNullableList(reference.pointer,
+    return _firstOfMethodGenericNullableList(_$$selfRef.pointer,
             _id_firstOfMethodGenericNullableList.pointer, _$list.pointer)
         .object<$V?>();
   }
@@ -9126,8 +9321,9 @@ extension Annotated$$Methods<
   $V? firstOfMethodGenericListOfNullable<$V extends jni$_.JObject?>(
     jni$_.JList<$V?> list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list.reference;
-    return _firstOfMethodGenericListOfNullable(reference.pointer,
+    return _firstOfMethodGenericListOfNullable(_$$selfRef.pointer,
             _id_firstOfMethodGenericListOfNullable.pointer, _$list.pointer)
         .object<$V?>();
   }
@@ -9155,9 +9351,10 @@ extension Annotated$$Methods<
   $V? firstOfMethodGenericNullableListOfNullable<$V extends jni$_.JObject?>(
     jni$_.JList<$V?>? list,
   ) {
+    final _$$selfRef = reference;
     final _$list = list?.reference ?? jni$_.jNullReference;
     return _firstOfMethodGenericNullableListOfNullable(
-            reference.pointer,
+            _$$selfRef.pointer,
             _id_firstOfMethodGenericNullableListOfNullable.pointer,
             _$list.pointer)
         .object<$V?>();
@@ -9184,9 +9381,10 @@ extension Annotated$$Methods<
   $T? firstKeyOfComboMap<$V extends jni$_.JObject?>(
     jni$_.JMap<$T?, $V?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _firstKeyOfComboMap(
-            reference.pointer, _id_firstKeyOfComboMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_firstKeyOfComboMap.pointer, _$map.pointer)
         .object<$T?>();
   }
 
@@ -9211,9 +9409,10 @@ extension Annotated$$Methods<
   $V? firstValueOfComboMap<$V extends jni$_.JObject?>(
     jni$_.JMap<$T?, $V?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _firstValueOfComboMap(
-            reference.pointer, _id_firstValueOfComboMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_firstValueOfComboMap.pointer, _$map.pointer)
         .object<$V?>();
   }
 
@@ -9240,8 +9439,9 @@ extension Annotated$$Methods<
   $T? firstKeyOfComboMapNullableKey<$V extends jni$_.JObject?>(
     jni$_.JMap<$T?, $V?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _firstKeyOfComboMapNullableKey(reference.pointer,
+    return _firstKeyOfComboMapNullableKey(_$$selfRef.pointer,
             _id_firstKeyOfComboMapNullableKey.pointer, _$map.pointer)
         .object<$T?>();
   }
@@ -9269,8 +9469,9 @@ extension Annotated$$Methods<
   $V? firstValueOfComboMapNullableKey<$V extends jni$_.JObject?>(
     jni$_.JMap<$T?, $V?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _firstValueOfComboMapNullableKey(reference.pointer,
+    return _firstValueOfComboMapNullableKey(_$$selfRef.pointer,
             _id_firstValueOfComboMapNullableKey.pointer, _$map.pointer)
         .object<$V?>();
   }
@@ -9298,8 +9499,9 @@ extension Annotated$$Methods<
   $T? firstKeyOfComboMapNullableValue<$V extends jni$_.JObject?>(
     jni$_.JMap<$T?, $V?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _firstKeyOfComboMapNullableValue(reference.pointer,
+    return _firstKeyOfComboMapNullableValue(_$$selfRef.pointer,
             _id_firstKeyOfComboMapNullableValue.pointer, _$map.pointer)
         .object<$T?>();
   }
@@ -9327,8 +9529,9 @@ extension Annotated$$Methods<
   $V? firstValueOfComboMapNullableValue<$V extends jni$_.JObject?>(
     jni$_.JMap<$T?, $V?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _firstValueOfComboMapNullableValue(reference.pointer,
+    return _firstValueOfComboMapNullableValue(_$$selfRef.pointer,
             _id_firstValueOfComboMapNullableValue.pointer, _$map.pointer)
         .object<$V?>();
   }
@@ -9356,8 +9559,9 @@ extension Annotated$$Methods<
   $T? firstKeyOfComboMapNullableKeyAndValue<$V extends jni$_.JObject?>(
     jni$_.JMap<$T?, $V?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _firstKeyOfComboMapNullableKeyAndValue(reference.pointer,
+    return _firstKeyOfComboMapNullableKeyAndValue(_$$selfRef.pointer,
             _id_firstKeyOfComboMapNullableKeyAndValue.pointer, _$map.pointer)
         .object<$T?>();
   }
@@ -9385,8 +9589,9 @@ extension Annotated$$Methods<
   $V? firstValueOfComboMapNullableKeyAndValue<$V extends jni$_.JObject?>(
     jni$_.JMap<$T?, $V?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
-    return _firstValueOfComboMapNullableKeyAndValue(reference.pointer,
+    return _firstValueOfComboMapNullableKeyAndValue(_$$selfRef.pointer,
             _id_firstValueOfComboMapNullableKeyAndValue.pointer, _$map.pointer)
         .object<$V?>();
   }
@@ -9412,9 +9617,10 @@ extension Annotated$$Methods<
   jni$_.JObject? firstEntryOfComboMap<$V extends jni$_.JObject?>(
     jni$_.JMap<$T?, $V?> map,
   ) {
+    final _$$selfRef = reference;
     final _$map = map.reference;
     return _firstEntryOfComboMap(
-            reference.pointer, _id_firstEntryOfComboMap.pointer, _$map.pointer)
+            _$$selfRef.pointer, _id_firstEntryOfComboMap.pointer, _$map.pointer)
         .object<jni$_.JObject?>();
   }
 
@@ -9438,7 +9644,8 @@ extension Annotated$$Methods<
   /// from: `public W getW()`
   /// The returned object must be released after use, by calling the [release] method.
   $W get w$1 {
-    return _get$w$1(reference.pointer, _id_get$w$1.pointer).object<$W>();
+    final _$$selfRef = reference;
+    return _get$w$1(_$$selfRef.pointer, _id_get$w$1.pointer).object<$W>();
   }
 
   static final _id_nullableGetW = Annotated._class.instanceMethodId(
@@ -9461,7 +9668,9 @@ extension Annotated$$Methods<
   $W? nullableGetW(
     core$_.bool z,
   ) {
-    return _nullableGetW(reference.pointer, _id_nullableGetW.pointer, z ? 1 : 0)
+    final _$$selfRef = reference;
+    return _nullableGetW(
+            _$$selfRef.pointer, _id_nullableGetW.pointer, z ? 1 : 0)
         .object<$W?>();
   }
 
@@ -9485,7 +9694,8 @@ extension Annotated$$Methods<
   /// from: `public java.util.List<java.util.List<java.util.List<T>>> list3dOfT()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JList<jni$_.JList<$T?>>> list3dOfT() {
-    return _list3dOfT(reference.pointer, _id_list3dOfT.pointer)
+    final _$$selfRef = reference;
+    return _list3dOfT(_$$selfRef.pointer, _id_list3dOfT.pointer)
         .object<jni$_.JList<jni$_.JList<jni$_.JList<$T?>>>>();
   }
 
@@ -9509,7 +9719,8 @@ extension Annotated$$Methods<
   /// from: `public java.util.List<java.util.List<java.util.List<U>>> list3dOfU()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JList<jni$_.JList<$U>>> list3dOfU() {
-    return _list3dOfU(reference.pointer, _id_list3dOfU.pointer)
+    final _$$selfRef = reference;
+    return _list3dOfU(_$$selfRef.pointer, _id_list3dOfU.pointer)
         .object<jni$_.JList<jni$_.JList<jni$_.JList<$U>>>>();
   }
 
@@ -9533,7 +9744,8 @@ extension Annotated$$Methods<
   /// from: `public java.util.List<java.util.List<java.util.List<W>>> list3dOfW()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JList<jni$_.JList<$W>>> list3dOfW() {
-    return _list3dOfW(reference.pointer, _id_list3dOfW.pointer)
+    final _$$selfRef = reference;
+    return _list3dOfW(_$$selfRef.pointer, _id_list3dOfW.pointer)
         .object<jni$_.JList<jni$_.JList<jni$_.JList<$W>>>>();
   }
 
@@ -9557,8 +9769,9 @@ extension Annotated$$Methods<
   jni$_.JList<jni$_.JList<jni$_.JList<$U?>>> list3dOfNullableU(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _list3dOfNullableU(
-            reference.pointer, _id_list3dOfNullableU.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_list3dOfNullableU.pointer, z ? 1 : 0)
         .object<jni$_.JList<jni$_.JList<jni$_.JList<$U?>>>>();
   }
 
@@ -9582,8 +9795,9 @@ extension Annotated$$Methods<
   jni$_.JList<jni$_.JList<jni$_.JList<$W?>>> list3dOfNullableW(
     core$_.bool z,
   ) {
+    final _$$selfRef = reference;
     return _list3dOfNullableW(
-            reference.pointer, _id_list3dOfNullableW.pointer, z ? 1 : 0)
+            _$$selfRef.pointer, _id_list3dOfNullableW.pointer, z ? 1 : 0)
         .object<jni$_.JList<jni$_.JList<jni$_.JList<$W?>>>>();
   }
 
@@ -9607,7 +9821,8 @@ extension Annotated$$Methods<
   /// from: `public com.github.dart_lang.jnigen.annotations.Annotated$Nested<T, U, W, java.lang.Integer> nested()`
   /// The returned object must be released after use, by calling the [release] method.
   Annotated$Nested<$T?, $U, $W, jni$_.JInteger>? nested() {
-    return _nested(reference.pointer, _id_nested.pointer)
+    final _$$selfRef = reference;
+    return _nested(_$$selfRef.pointer, _id_nested.pointer)
         .object<Annotated$Nested<$T?, $U, $W, jni$_.JInteger>?>();
   }
 
@@ -9631,7 +9846,8 @@ extension Annotated$$Methods<
   /// from: `public java.util.List<? extends java.lang.Integer> intList()`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JList<jni$_.JInteger> intList() {
-    return _intList(reference.pointer, _id_intList.pointer)
+    final _$$selfRef = reference;
+    return _intList(_$$selfRef.pointer, _id_intList.pointer)
         .object<jni$_.JList<jni$_.JInteger>>();
   }
 }
@@ -9708,7 +9924,8 @@ extension type JsonSerializable$Case._(jni$_.JObject _$this)
   /// from: `static public com.github.dart_lang.jnigen.annotations.JsonSerializable$Case[] values()`
   /// The returned object must be released after use, by calling the [release] method.
   static jni$_.JArray<JsonSerializable$Case?>? values() {
-    return _values(_class.reference.pointer, _id_values.pointer)
+    final _$$classRef = _class.reference;
+    return _values(_$$classRef.pointer, _id_values.pointer)
         .object<jni$_.JArray<JsonSerializable$Case?>?>();
   }
 
@@ -9733,9 +9950,9 @@ extension type JsonSerializable$Case._(jni$_.JObject _$this)
   static JsonSerializable$Case? valueOf(
     jni$_.JString? string,
   ) {
+    final _$$classRef = _class.reference;
     final _$string = string?.reference ?? jni$_.jNullReference;
-    return _valueOf(
-            _class.reference.pointer, _id_valueOf.pointer, _$string.pointer)
+    return _valueOf(_$$classRef.pointer, _id_valueOf.pointer, _$string.pointer)
         .object<JsonSerializable$Case?>();
   }
 }
@@ -9860,7 +10077,8 @@ extension JsonSerializable$$Methods on JsonSerializable {
   /// from: `public abstract com.github.dart_lang.jnigen.annotations.JsonSerializable$Case value()`
   /// The returned object must be released after use, by calling the [release] method.
   JsonSerializable$Case? value() {
-    return _value(reference.pointer, _id_value.pointer)
+    final _$$selfRef = reference;
+    return _value(_$$selfRef.pointer, _id_value.pointer)
         .object<JsonSerializable$Case?>();
   }
 }
@@ -9921,8 +10139,8 @@ extension type MyDataClass._(jni$_.JObject _$this) implements jni$_.JObject {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory MyDataClass() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<MyDataClass>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<MyDataClass>();
   }
 }
 
@@ -10232,8 +10450,9 @@ extension R2250$Child$$Methods on R2250$Child {
   core$_.int foo(
     jni$_.JObject? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _foo(reference.pointer, _id_foo.pointer, _$object.pointer).integer;
+    return _foo(_$$selfRef.pointer, _id_foo.pointer, _$object.pointer).integer;
   }
 }
 
@@ -10373,8 +10592,9 @@ extension R2250$$Methods<$T extends jni$_.JObject?> on R2250<$T> {
   core$_.int foo(
     $T? object,
   ) {
+    final _$$selfRef = reference;
     final _$object = object?.reference ?? jni$_.jNullReference;
-    return _foo(reference.pointer, _id_foo.pointer, _$object.pointer).integer;
+    return _foo(_$$selfRef.pointer, _id_foo.pointer, _$object.pointer).integer;
   }
 }
 
@@ -10433,8 +10653,8 @@ extension type R693$Child._(jni$_.JObject _$this) implements R693<R693$Child?> {
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory R693$Child() {
-    return _new$(_class.reference.pointer, _id_new$.pointer)
-        .object<R693$Child>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<R693$Child>();
   }
 }
 
@@ -10475,7 +10695,8 @@ extension type R693<$T extends jni$_.JObject?>._(jni$_.JObject _$this)
   /// from: `public void <init>()`
   /// The returned object must be released after use, by calling the [release] method.
   factory R693() {
-    return _new$(_class.reference.pointer, _id_new$.pointer).object<R693<$T>>();
+    final _$$classRef = _class.reference;
+    return _new$(_$$classRef.pointer, _id_new$.pointer).object<R693<$T>>();
   }
 }
 


### PR DESCRIPTION
For the most part, JNIgen was already storing all `foo.reference.pointer`s in a local variable. There were just a few remaining cases: the class reference for static methods, the self reference for non-static methods, and one other random case in kotlin suspend functions. Not sure if these cases can hit the same GC issue, but I'm switching them to locals just to be safe.

Fixes https://github.com/dart-lang/native/issues/3346